### PR TITLE
docs: document agac init --example flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ pip install agent-actions
 ## Quick start
 
 ```bash
-agac init my-project && cd my-project   # scaffold a project
-agac run -a my_workflow                  # execute
+agac init my-project && cd my-project                # scaffold a project
+agac init --example contract_reviewer my-project     # or start from an example
+agac run -a my_workflow                              # execute
 ```
 
 ## Why not just write Python?

--- a/docs.agent-actions/docs/reference/cli/utilities.md
+++ b/docs.agent-actions/docs/reference/cli/utilities.md
@@ -77,6 +77,8 @@ Think of this like `npm init` or `git init` - it gives you a working starting po
 |--------|-------------|
 | `-o, --output-dir` | Directory to create the project in (default: current directory) |
 | `-t, --template` | Template to use for project initialization (default: `default`) |
+| `-e, --example` | Scaffold from a built-in example (fetched from GitHub) |
+| `--list-examples` | List available example names and exit |
 | `-f, --force` | Force project creation even if directory exists |
 
 **Examples:**
@@ -90,9 +92,19 @@ agac init my_project -o ~/projects
 # Use a specific template
 agac init my_project -t advanced
 
+# Scaffold from a built-in example
+agac init my_project --example contract_reviewer
+
+# See all available examples
+agac init --list-examples
+
 # Force overwrite existing files
 agac init my_project -f
 ```
+
+:::tip Start from an Example
+Use `--example` to scaffold a fully working project you can run immediately. Examples are fetched from GitHub so the package stays lightweight. Available examples: `book_catalog_enrichment`, `contract_reviewer`, `incident_triage`, `product_listing_enrichment`, `review_analyzer`.
+:::
 
 ## clean
 

--- a/docs.agent-actions/docs/tutorials/index.md
+++ b/docs.agent-actions/docs/tutorials/index.md
@@ -34,6 +34,10 @@ agac init my_workflow
 cd my_workflow
 ```
 
+:::tip
+Want a fully working example instead? Run `agac init --example contract_reviewer my_workflow` to scaffold a complete project you can run immediately. See all examples with `agac init --list-examples`.
+:::
+
 This creates the standard project structure:
 
 ```


### PR DESCRIPTION
## Summary
- Add `--example` and `--list-examples` to CLI reference options table and examples
- Add `--example` to README quick start section
- Add tip callout in getting started tutorial pointing users to examples
- Documents the feature added in #18

## Files changed
- `README.md` — quick start now shows `--example` usage
- `docs.agent-actions/docs/reference/cli/utilities.md` — options table, examples, tip callout
- `docs.agent-actions/docs/tutorials/index.md` — tip callout