### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.1.0"
+version = "0.1.1"
 description = "Declarative YAML-based framework for orchestrating LLM workflows with batch processing"
 authors = [
     {name = "Muizz Kolapo"},


### PR DESCRIPTION
## Summary
- Bump version from `0.1.0` to `0.1.1` in `pyproject.toml` and `__version__.py`
- After merge, create GitHub Release `v0.1.1` to trigger PyPI publish

## Test plan
- [ ] Verify `pyproject.toml` version is `0.1.1`
- [ ] Verify `__version__.py` version is `0.1.1`
- [ ] After release: `pip install agent-actions==0.1.1 && agac --help`