### PR TITLE
chore: bump vscode extension to 0.1.5

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-actions",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-actions",
-      "version": "0.1.2",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-actions",
   "displayName": "Agent Actions",
   "description": "YAML language support for Agent Actions workflows — autocomplete, validation, and go-to-definition.",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "publisher": "runagac",
   "license": "Apache-2.0",
   "repository": {
@@ -49,7 +49,9 @@
         "agentActions.interpreter": {
           "type": "array",
           "default": [],
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "scope": "resource",
           "description": "Path to the Python interpreter used to run the LSP server. If empty, the interpreter from the Python extension is used."
         },


### PR DESCRIPTION
## Summary
- Bumps VS Code extension version from 0.1.2 to 0.1.5 to match what's published on the marketplace
- Syncs `package-lock.json` with current `package.json`

## Context
Versions 0.1.3 and 0.1.4 were published to the marketplace but the version bump commits never landed on `main`. This PR brings the repo in sync with the published 0.1.5 release.

## Test plan
- [ ] `npm install` succeeds in `vscode-extension/`
- [ ] `npm run typecheck && npm run build` passes