### PR TITLE
chore: bump vscode extension to 0.1.7

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-actions",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-actions",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-actions",
   "displayName": "Agent Actions",
   "description": "YAML language support for Agent Actions workflows — autocomplete, validation, and go-to-definition.",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "publisher": "runagac",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump vscode extension version from 0.1.5 to 0.1.7
- Update package-lock.json with installed dependencies