### PR TITLE
fix: remove spurious ConfigValidator call that logs error on every run

### DIFF
--- a/agent_actions/config/manager.py
+++ b/agent_actions/config/manager.py
@@ -307,13 +307,6 @@ class ConfigManager:
         from agent_actions.output.response.config_schema import AgentConfig
         from agent_actions.prompt.context.scope_inference import infer_dependencies
         from agent_actions.utils.graph_utils import topological_sort
-        from agent_actions.validation.config_validator import ConfigValidator
-
-        instance_config = ConfigValidator()
-        agent_configs_dict = {
-            agent_type: config.model_dump() for agent_type, config in self.agent_configs.items()
-        }
-        instance_config.validate(agent_configs_dict)
 
         workflow_actions = list(self.agent_configs.keys())
 


### PR DESCRIPTION
## Summary
`ConfigManager.determine_execution_order()` called `ConfigValidator.validate()` with the raw agent configs dict, but the validator expects `{"operation": "...", ...}`. This produced:

```
An 'operation' must be specified in the input 'data'.
```

in the validation log on **every single run**, even when the workflow is perfectly valid.

By this point in the pipeline, configs have already been validated by `WorkflowConfig` (Pydantic) and the renderer's `_run_config_validator()` (which passes the correct operation payload). The call was redundant.

**Root cause**: The legacy `ConfigManager` code path predated the operation-based validator interface. The renderer (`prompt/renderer.py:294`) does it correctly.

**No other callers have this issue** — searched all `ConfigValidator().validate()` call sites.

## Test plan
- [x] `pytest tests/ -x -q` — 4138 passed, 2 skipped
- [x] Grepped for other bad `ConfigValidator.validate()` calls — none found