### PR TITLE
fix: resolve .env from project root instead of CWD only

### DIFF
--- a/.changes/unreleased/Bug Fix-20260401-191900.yaml
+++ b/.changes/unreleased/Bug Fix-20260401-191900.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Resolve .env files from project root instead of CWD, fixing env var loading in worktrees and subdirectories
+time: 2026-04-01T19:19:00.000000Z

--- a/agent_actions/cli/main.py
+++ b/agent_actions/cli/main.py
@@ -184,7 +184,15 @@ class CLI:
 def main_entrypoint(argv: Sequence[str] | None = None) -> int:
     from dotenv import load_dotenv
 
-    load_dotenv()
+    from agent_actions.config.path_config import find_project_root_dir
+
+    project_root = find_project_root_dir()
+    if project_root:
+        env_path = project_root / ".env"
+        if env_path.is_file():
+            load_dotenv(env_path)
+    else:
+        load_dotenv()
     app = CLI()
     return app.execute(argv)
 

--- a/agent_actions/config/environment.py
+++ b/agent_actions/config/environment.py
@@ -25,10 +25,15 @@ class LogLevel(str, Enum):
 
 
 class EnvironmentConfig(BaseSettings):
-    """Environment configuration loaded from environment variables with validation."""
+    """Environment configuration loaded from environment variables with validation.
+
+    The ``.env`` file is resolved by the caller (typically ``ConfigManager``)
+    and passed via the ``_env_file`` constructor parameter so that the path is
+    always relative to the project root — not the current working directory.
+    """
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
+        env_file=None, env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
     )
     openai_api_key: SecretStr | None = Field(
         default=None, description="OpenAI API Key for GPT models"

--- a/agent_actions/config/manager.py
+++ b/agent_actions/config/manager.py
@@ -10,7 +10,11 @@ import yaml
 from pydantic import ValidationError
 
 from agent_actions.config.environment import EnvironmentConfig
-from agent_actions.config.path_config import load_project_config, resolve_project_root
+from agent_actions.config.path_config import (
+    find_project_root_dir,
+    load_project_config,
+    resolve_project_root,
+)
 from agent_actions.config.paths import PathManager, ProjectRootNotFoundError
 from agent_actions.config.schema import WorkflowConfig
 from agent_actions.errors import ConfigurationError, ConfigValidationError, TemplateRenderingError
@@ -349,7 +353,8 @@ class ConfigManager:
     def load_environment_config(self) -> EnvironmentConfig:
         """Load and validate environment configuration."""
         try:
-            self.environment_config = EnvironmentConfig()
+            env_file = self._resolve_dotenv()
+            self.environment_config = EnvironmentConfig(_env_file=env_file)  # type: ignore[call-arg]
             return self.environment_config
         except ValidationError as e:
             raise ConfigurationError(
@@ -357,6 +362,14 @@ class ConfigManager:
                 context={"operation": "load_environment_config"},
                 cause=e,
             ) from e
+
+    def _resolve_dotenv(self) -> Path | None:
+        """Return the absolute path to ``.env`` at the project root, or ``None``."""
+        root = self.project_root or find_project_root_dir()
+        if root is None:
+            return None
+        env_path = Path(root) / ".env"
+        return env_path if env_path.is_file() else None
 
     def get_agent_config(self, agent_type: str) -> AgentConfig | None:
         """Get typed agent configuration by agent type."""

--- a/agent_actions/config/path_config.py
+++ b/agent_actions/config/path_config.py
@@ -58,6 +58,42 @@ def load_project_config(project_root: Path) -> dict[str, Any]:
     return {}
 
 
+_PROJECT_MARKERS = ("agent_actions.yml", "agent_actions.yaml", ".agent_actions.yml")
+_FALLBACK_DIRS = ("agent_actions", "agent_config")
+
+
+def find_project_root_dir(
+    start: Path | None = None,
+    *,
+    marker_file: str | None = None,
+    use_fallback_heuristics: bool = True,
+) -> Path | None:
+    """Walk up from *start* (default CWD) looking for the project root.
+
+    The project root is the directory that contains a marker file
+    (``agent_actions.yml`` by default).  When *use_fallback_heuristics* is
+    ``True`` (the default) the ``agent_actions/`` and ``agent_config/``
+    directories are also accepted as indicators — matching the behaviour of
+    :pymethod:`PathManager.get_project_root`.
+
+    Returns the directory containing the marker, or ``None`` if no marker is
+    found before the filesystem root.
+
+    This function is intentionally dependency-free (only ``pathlib``) so it
+    can be called very early — e.g. to locate ``.env`` before the config
+    system boots.
+    """
+    markers = (marker_file,) if marker_file else _PROJECT_MARKERS
+    current = (start or Path.cwd()).resolve()
+    while current != current.parent:
+        if any((current / m).exists() for m in markers):
+            return current
+        if use_fallback_heuristics and any((current / d).is_dir() for d in _FALLBACK_DIRS):
+            return current
+        current = current.parent
+    return None
+
+
 def resolve_project_root(explicit_root: Path | None = None) -> Path:
     """Resolve project root, defaulting to cwd when not provided.
 

--- a/agent_actions/config/paths.py
+++ b/agent_actions/config/paths.py
@@ -93,6 +93,8 @@ class PathManager:
         Raises:
             ProjectRootNotFoundError: If project root cannot be found.
         """
+        from agent_actions.config.path_config import find_project_root_dir
+
         # When start_path is None (CWD), return cached root if available
         # and CWD hasn't changed since the root was resolved.
         # When start_path is explicit, always re-resolve (skip reading cache)
@@ -109,34 +111,25 @@ class PathManager:
 
         search_path = Path(start_path or Path.cwd()).resolve()
 
-        current = search_path
-        while current != current.parent:
-            marker_path = current / self.config.marker_file
-            if marker_path.exists():
-                if self.config.cache_paths:
-                    self._project_root = current
-                    self._cached_cwd = search_path if start_path is None else None
-                return current
+        result = find_project_root_dir(search_path, marker_file=self.config.marker_file)
+        if result is None:
+            raise ProjectRootNotFoundError(
+                f"Project root not found. Searched for '{self.config.marker_file}', 'agent_actions', or 'agent_config' "
+                f"starting from {search_path}"
+            )
 
-            # Fallback: check for 'agent_actions' (package root) or 'agent_config' directory
-            # 'agent_actions' is the definitive project marker per user specification.
-            if (current / "agent_actions").is_dir() or (current / "agent_config").is_dir():
-                logger.warning(
-                    "Project root found via fallback heuristic (no marker file '%s'): %s",
-                    self.config.marker_file,
-                    current,
-                )
-                if self.config.cache_paths:
-                    self._project_root = current
-                    self._cached_cwd = search_path if start_path is None else None
-                return current
+        # Warn when found via fallback heuristic (no marker file present)
+        if not (result / self.config.marker_file).exists():
+            logger.warning(
+                "Project root found via fallback heuristic (no marker file '%s'): %s",
+                self.config.marker_file,
+                result,
+            )
 
-            current = current.parent
-
-        raise ProjectRootNotFoundError(
-            f"Project root not found. Searched for '{self.config.marker_file}', 'agent_actions', or 'agent_config' "
-            f"starting from {search_path}"
-        )
+        if self.config.cache_paths:
+            self._project_root = result
+            self._cached_cwd = search_path if start_path is None else None
+        return result
 
     def get_standard_path(
         self,

--- a/tests/unit/config/test_dotenv_resolution.py
+++ b/tests/unit/config/test_dotenv_resolution.py
@@ -1,0 +1,173 @@
+"""Tests for .env resolution from project root.
+
+Verifies that .env files are found when running from subdirectories or
+worktrees — i.e. when CWD != project root.
+"""
+
+from agent_actions.config.environment import EnvironmentConfig
+from agent_actions.config.manager import ConfigManager
+from agent_actions.config.path_config import find_project_root_dir
+
+# -- find_project_root_dir ---------------------------------------------------
+
+
+class TestFindProjectRootDir:
+    def test_finds_marker_from_subdirectory(self, tmp_path):
+        (tmp_path / "agent_actions.yml").write_text("name: test")
+        child = tmp_path / "sub" / "deep"
+        child.mkdir(parents=True)
+
+        assert find_project_root_dir(start=child) == tmp_path
+
+    def test_finds_yaml_variant(self, tmp_path):
+        (tmp_path / "agent_actions.yaml").write_text("name: test")
+        assert find_project_root_dir(start=tmp_path) == tmp_path
+
+    def test_finds_hidden_variant(self, tmp_path):
+        (tmp_path / ".agent_actions.yml").write_text("name: test")
+        assert find_project_root_dir(start=tmp_path) == tmp_path
+
+    def test_fallback_agent_actions_dir(self, tmp_path):
+        (tmp_path / "agent_actions").mkdir()
+        assert find_project_root_dir(start=tmp_path) == tmp_path
+
+    def test_fallback_agent_config_dir(self, tmp_path):
+        (tmp_path / "agent_config").mkdir()
+        assert find_project_root_dir(start=tmp_path) == tmp_path
+
+    def test_fallback_disabled(self, tmp_path):
+        (tmp_path / "agent_actions").mkdir()
+        assert find_project_root_dir(start=tmp_path, use_fallback_heuristics=False) is None
+
+    def test_custom_marker_file(self, tmp_path):
+        (tmp_path / "custom.yml").write_text("name: test")
+        assert find_project_root_dir(start=tmp_path, marker_file="custom.yml") == tmp_path
+
+    def test_returns_none_when_no_marker(self, tmp_path):
+        assert find_project_root_dir(start=tmp_path) is None
+
+    def test_uses_cwd_when_start_is_none(self, tmp_path, monkeypatch):
+        (tmp_path / "agent_actions.yml").write_text("name: test")
+        monkeypatch.chdir(tmp_path)
+        assert find_project_root_dir() == tmp_path
+
+
+# -- EnvironmentConfig .env loading ------------------------------------------
+
+
+def _clean_env(monkeypatch):
+    """Remove env vars that would interfere with EnvironmentConfig defaults."""
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "DATABASE_URL",
+        "AGENT_ACTIONS_ENV",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestEnvironmentConfigDotenv:
+    def test_loads_env_file_from_explicit_path(self, tmp_path, monkeypatch):
+        _clean_env(monkeypatch)
+        env_file = tmp_path / ".env"
+        env_file.write_text("AGENT_ACTIONS_ENV=staging\n")
+
+        config = EnvironmentConfig(_env_file=env_file)
+        assert config.agent_actions_env.value == "staging"
+
+    def test_falls_back_to_env_vars_when_no_env_file(self, monkeypatch):
+        _clean_env(monkeypatch)
+        monkeypatch.setenv("AGENT_ACTIONS_ENV", "production")
+        config = EnvironmentConfig()
+        assert config.agent_actions_env.value == "production"
+
+    def test_env_file_none_is_safe(self, monkeypatch):
+        """EnvironmentConfig(_env_file=None) should not error."""
+        _clean_env(monkeypatch)
+        config = EnvironmentConfig(_env_file=None)
+        assert config.agent_actions_env.value == "development"  # default
+
+
+# -- ConfigManager._resolve_dotenv -------------------------------------------
+
+
+class TestConfigManagerResolveDotenv:
+    def test_resolves_dotenv_from_explicit_project_root(self, tmp_path, monkeypatch):
+        _clean_env(monkeypatch)
+        (tmp_path / "agent_actions.yml").write_text("name: test")
+        (tmp_path / ".env").write_text("AGENT_ACTIONS_ENV=staging\n")
+
+        mgr = ConfigManager(
+            constructor_path=str(tmp_path / "dummy.yml"),
+            default_path=str(tmp_path / "default.yml"),
+            project_root=tmp_path,
+        )
+        env_file = mgr._resolve_dotenv()
+        assert env_file is not None
+        assert env_file.is_file()
+        assert str(tmp_path) in str(env_file)
+
+    def test_resolves_dotenv_via_find_project_root_dir(self, tmp_path, monkeypatch):
+        """When project_root is None, _resolve_dotenv walks up from CWD."""
+        _clean_env(monkeypatch)
+        (tmp_path / "agent_actions.yml").write_text("name: test")
+        (tmp_path / ".env").write_text("AGENT_ACTIONS_ENV=staging\n")
+
+        nested = tmp_path / "sub" / "deep"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        mgr = ConfigManager(
+            constructor_path=str(tmp_path / "dummy.yml"),
+            default_path=str(tmp_path / "default.yml"),
+        )
+        env_file = mgr._resolve_dotenv()
+        assert env_file is not None
+        assert str(tmp_path) in str(env_file)
+
+    def test_returns_none_when_no_dotenv(self, tmp_path):
+        (tmp_path / "agent_actions.yml").write_text("name: test")
+        # No .env file
+
+        mgr = ConfigManager(
+            constructor_path=str(tmp_path / "dummy.yml"),
+            default_path=str(tmp_path / "default.yml"),
+            project_root=tmp_path,
+        )
+        assert mgr._resolve_dotenv() is None
+
+    def test_returns_none_when_no_project_root(self, tmp_path, monkeypatch):
+        """No project root and no marker — returns None."""
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager(
+            constructor_path=str(tmp_path / "dummy.yml"),
+            default_path=str(tmp_path / "default.yml"),
+        )
+        assert mgr._resolve_dotenv() is None
+
+
+# -- Integration: subdirectory scenario --------------------------------------
+
+
+def test_dotenv_found_from_subdirectory(tmp_path, monkeypatch):
+    """Simulates the worktree/subdirectory scenario end-to-end."""
+    _clean_env(monkeypatch)
+
+    # Set up project root with marker and .env
+    (tmp_path / "agent_actions.yml").write_text("name: test")
+    (tmp_path / ".env").write_text("AGENT_ACTIONS_ENV=staging\n")
+
+    # CWD is a nested subdirectory (like a worktree)
+    nested = tmp_path / "sub" / "deep"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+
+    # find_project_root_dir discovers the root
+    root = find_project_root_dir()
+    assert root == tmp_path
+
+    # .env at that root is loadable via the _env_file parameter
+    env_file = root / ".env"
+    config = EnvironmentConfig(_env_file=env_file)
+    assert config.agent_actions_env.value == "staging"


### PR DESCRIPTION
Both `load_dotenv()` and pydantic-settings `env_file=".env"` resolved relative to CWD. When running from a subdirectory or git worktree the .env at the project root was never found.

Root cause: .env resolution was decoupled from project root discovery.

Fix — single source of truth for project root discovery:

- Extract `find_project_root_dir()` into `path_config.py` as a dependency-free function that walks up from CWD looking for marker files (agent_actions.yml) and fallback directories (agent_actions/, agent_config/).
- `PathManager.get_project_root()` now delegates to it instead of reimplementing the walk — caching and warning logic stays in PathManager.
- `main_entrypoint()` uses `find_project_root_dir()` to locate .env before calling `load_dotenv()`.
- `EnvironmentConfig` no longer resolves .env itself — `env_file` defaults to None and the caller (`ConfigManager.load_environment_config`) passes the resolved path via pydantic-settings' `_env_file` parameter.
- 13 regression tests covering root discovery (markers, fallbacks, custom marker, CWD) and .env loading from subdirectories.