### PR TITLE
fix: execution summary shows total action count and step count

### DIFF
--- a/agent_actions/workflow/parallel/action_executor.py
+++ b/agent_actions/workflow/parallel/action_executor.py
@@ -151,7 +151,10 @@ class ActionLevelOrchestrator:
 
     def log_execution_levels(self, levels: list[list[str]], action_indices: dict[str, int]):
         """Log execution levels for user transparency."""
-        self.console.print(f"[blue]📊 Execution: {len(levels)} action(s)[/blue]")
+        total_actions = sum(len(level) for level in levels)
+        self.console.print(
+            f"[blue]📊 Execution: {total_actions} action(s) in {len(levels)} step(s)[/blue]"
+        )
 
         for i, level in enumerate(levels):
             if len(level) > 1:


### PR DESCRIPTION
## Summary
- The execution summary header displayed `len(levels)` (step count) labelled as "action(s)", which was misleading for parallel workflows
- A 7-action workflow across 5 parallel-grouped steps now correctly shows `📊 Execution: 7 action(s) in 5 step(s)` instead of `📊 Execution: 5 action(s)`
- Total derived from `sum(len(level) for level in levels)` — the authoritative source

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` — 4262 passed, 2 skipped
- [ ] Manual run of a parallel workflow confirms correct output