### PR TITLE
feat: pause-and-surface on partial failure with on_partial_failure config

### DIFF
--- a/docs.agent-actions/docs/reference/configuration/defaults.md
+++ b/docs.agent-actions/docs/reference/configuration/defaults.md
@@ -54,6 +54,7 @@ actions:
 | `stop` | string/list | Stop sequence(s) to end generation |
 | `record_limit` | integer | Max records per file at start nodes (default: unlimited) |
 | `file_limit` | integer | Max files to walk per action (default: unlimited) |
+| `on_partial_failure` | string | Behavior when action has partial item failures: `continue` (default) or `pause` (see [Failure Handling](../execution/failure-handling.md)) |
 
 :::note Schema vs Runtime
 The `DefaultsConfig` schema defines only the core defaultable fields above. Additional fields like `api_key`, `context_scope`, `is_operational`, and `prompt_debug` are resolved at runtime through configuration merging and may not be explicitly defined in the defaults schema.

--- a/docs.agent-actions/docs/reference/execution/failure-handling.md
+++ b/docs.agent-actions/docs/reference/execution/failure-handling.md
@@ -1,0 +1,132 @@
+---
+title: Failure Handling
+sidebar_position: 7
+---
+
+# Failure Handling
+
+What happens when some records succeed and others fail? Consider a workflow extracting claims from 100 reviews — 97 process fine, but 3 hit a rate limit. Agent Actions doesn't treat this as a total failure. Instead, it tracks exactly what happened, tells you about it, and lets downstream actions continue on the successful records.
+
+## Partial Failures
+
+When an action processes N items and some fail while others succeed, the action is marked `completed_with_failures`. This is distinct from `completed` (everything worked) and `failed` (nothing worked).
+
+```
+Action 0 complete (4.2s)           # 97/100 items OK, 3 failed
+Action 1 complete (2.1s)           # Runs on the 97 successful records
+07:45:35 | Completed in 6.31s | 1 OK | 1 PARTIAL | 0 SKIP | 0 ERROR
+```
+
+### What Gets Tracked
+
+For each failed item, Agent Actions persists:
+
+| Field | Description |
+|-------|-------------|
+| `source_guid` | Unique identifier of the failed record |
+| `reason` | Error message (e.g., "groq API error: 429 rate limit") |
+| `input_snapshot` | JSON snapshot of the original input record (for future retry) |
+
+This data lives in the storage backend's disposition table — not in temporary logs.
+
+### How Downstream Actions Behave
+
+`completed_with_failures` does **not** trigger the circuit breaker. Downstream actions receive the successful records and process them normally. The failed records are simply absent from the output.
+
+:::info
+This is different from `failed` status, which triggers the circuit breaker and skips all downstream actions that depend on it.
+:::
+
+## Pausing on Partial Failure
+
+By default, the workflow continues when partial failures occur. If you want the workflow to pause and show you what failed before proceeding, use `on_partial_failure: pause`.
+
+### Configuration
+
+```yaml
+defaults:
+  on_partial_failure: pause    # Pause for all actions
+
+actions:
+  - name: extract_claims
+    on_partial_failure: continue  # Override: this action continues
+  - name: score_quality
+    # Inherits "pause" from defaults
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `on_partial_failure` | `"continue"` \| `"pause"` | `"continue"` | Behavior when the action has partial item failures |
+
+`on_partial_failure` follows the standard [defaults inheritance](../configuration/defaults.md) pattern — set it once in defaults, override per-action where needed.
+
+### What Happens When Paused
+
+When a level contains an action with partial failures and `on_partial_failure: pause`:
+
+1. The level completes and prints a yellow completion line
+2. A failure summary is printed with action names, failed item counts, and truncated error reasons
+3. The workflow exits cleanly
+
+```
+Action 0 complete (4.2s)
+Workflow paused — partial failure(s) detected:
+  extract_claims: 3 item(s) failed
+    - groq API error: Error code: 429 rate limit exceeded
+    - groq API error: Error code: 429 rate limit exceeded
+    - groq API error: Error code: 500 internal server error
+Run 'agac run' again to continue with partial results.
+```
+
+### Resuming After a Pause
+
+Run `agac run` again. Actions that already completed (including those with partial failures) are skipped — the workflow picks up where it left off. The successful records from the paused action are still available to downstream actions.
+
+:::tip
+Use `on_partial_failure: pause` during development to catch issues early. Use `continue` (the default) in automated pipelines where you want the workflow to finish without manual intervention.
+:::
+
+## Execution Tally
+
+The workflow completion summary shows four categories:
+
+```
+07:45:35 | Completed in 31.17s | 7 OK | 1 PARTIAL | 2 SKIP | 1 ERROR
+```
+
+| Status | Meaning | Level Line Color |
+|--------|---------|-----------------|
+| **OK** | Action completed successfully | Green |
+| **PARTIAL** | Action completed but some items failed | Yellow |
+| **SKIP** | Action skipped because an upstream dependency failed | Yellow |
+| **ERROR** | Action failed entirely (all items) | Red |
+
+### Circuit Breaker Behavior
+
+When an action fails entirely (`ERROR`), the circuit breaker kicks in:
+
+```mermaid
+flowchart LR
+    A[extract_claims] -->|fails| CB{Circuit Breaker}
+    CB -->|SKIP| B[score_quality]
+    CB -->|SKIP| C[aggregate_scores]
+    CB -->|SKIP| D[generate_response]
+```
+
+All downstream dependents are marked `SKIP` — they don't execute, don't make API calls, and don't produce output. The tally reflects this accurately.
+
+When an action partially fails (`PARTIAL`), no circuit breaker triggers. Downstream actions run on the successful records:
+
+```mermaid
+flowchart LR
+    A["extract_claims<br/>(9/10 OK)"] -->|9 records| B[score_quality]
+    B --> C[aggregate_scores]
+    C --> D[generate_response]
+```
+
+## See Also
+
+- [Retry & Error Handling](./retry.md) — Automatic retry for transient errors
+- [Guards](./guards.md) — Conditional action execution
+- [Defaults](../configuration/defaults.md) — Setting `on_partial_failure` globally
+- [Run Modes](./run-modes.md) — Batch vs online execution

--- a/docs.agent-actions/docs/reference/execution/retry.md
+++ b/docs.agent-actions/docs/reference/execution/retry.md
@@ -74,5 +74,6 @@ retry:
 
 ## See Also
 
+- [Failure Handling](./failure-handling.md) - Partial failures, `on_partial_failure`, and the execution tally
 - [Reprompting](../validation/reprompting.md) - Handling invalid LLM outputs
 - [Run Modes](./run-modes.md) - Batch vs online execution

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -653,6 +653,4 @@ class TestPauseOnPartialFailure:
         from agent_actions.config.schema import ActionConfig
 
         with pytest.raises(ValidationError):
-            ActionConfig(
-                name="test", prompt="x", intent="x", on_partial_failure="invalid"
-            )
+            ActionConfig(name="test", prompt="x", intent="x", on_partial_failure="invalid")


### PR DESCRIPTION
## Summary
- Adds `on_partial_failure` config (`"continue"` | `"pause"`, default `"continue"`) following the standard defaults/per-action inheritance pattern
- When set to `"pause"`, workflow halts after a level with partial failures, prints a summary of failed items, and exits cleanly
- CLI distinguishes partial-failure pauses from batch-pending pauses via `WorkflowState.pause_reason`
- Works in both async (parallel) and sequential execution paths
- Adds documentation page covering partial failures, tally, and circuit breaker behavior

## Changes
- **Config**: `on_partial_failure` on `ActionConfig`, `DefaultsConfig`, `SIMPLE_CONFIG_FIELDS`, `ActionConfigDict`
- **WorkflowState**: `pause_reason` field (`"partial_failure"` | `"batch_pending"` | None)
- **Async path**: `execute_level_async` detects partial + pause → shared `_print_failure_summary()` → returns False
- **Sequential path**: `_run_single_action` same logic → returns True (stop)
- **CLI**: checks `pause_reason` before `is_workflow_complete` (correct precedence)
- **Rich safety**: error reasons escaped via `rich.markup.escape()`
- **Docs**: new `reference/execution/failure-handling.md`, updated defaults + retry cross-refs

## Usage
```yaml
defaults:
  on_partial_failure: pause

actions:
  - name: extract_claims
    on_partial_failure: continue  # Override for this action
```

## Test plan
- [x] `ruff check .` — clean
- [x] `ruff format --check` — clean
- [x] `pytest` — 4301 passed, 2 skipped, 0 failures
- [ ] Manual: `on_partial_failure: pause` → item failure → workflow pauses with summary
- [ ] Manual: default → workflow continues as today