### PR TITLE
fix: add JSON rule to Groq prompt to satisfy json_object requirement

### DIFF
--- a/agent_actions/prompt/message_builder.py
+++ b/agent_actions/prompt/message_builder.py
@@ -172,6 +172,7 @@ PROVIDER_MESSAGE_CONFIGS: dict[str, ProviderMessageConfig] = {
         json_role=MessageRole.SYSTEM_ONLY,
         non_json_role=MessageRole.SYSTEM_ONLY,
         schema_injection=SchemaInjection.NONE,
+        json_rules=("RULES: Respond in valid JSON format.",),
     ),
     "cohere": ProviderMessageConfig(
         json_prompt_style=PromptStyle.TAGGED,
@@ -338,6 +339,9 @@ class MessageBuilder:
                 "",  # blank line between tags
                 f"<|begin_of_text|>:: {context_str} :<|end_of_text|>",
             ]
+            if rules:
+                parts.append("")
+                parts.extend(rules)
             joined = "\n".join(parts)
             return f"\n{joined}\n"
 

--- a/tests/unit/prompt/test_message_builder.py
+++ b/tests/unit/prompt/test_message_builder.py
@@ -154,9 +154,12 @@ class TestStringEquivalence:
         assert env.prompt_body == expected
 
     def test_groq_json(self):
-        expected = _original_groq_json(PROMPT, CONTEXT_STR)
+        base = _original_groq_json(PROMPT, CONTEXT_STR)
         env = MessageBuilder.build("groq", PROMPT, CONTEXT_STR, json_mode=True)
-        assert env.messages[0].content == expected
+        content = env.messages[0].content
+        # Base Groq format is preserved; json rule is appended
+        assert base.strip() in content
+        assert "JSON" in content
 
     def test_groq_non_json(self):
         expected = _original_groq_non_json(PROMPT, CONTEXT_STR)


### PR DESCRIPTION
## Summary
Groq's API requires the word "json" to appear somewhere in the messages when `response_format: {"type": "json_object"}` is set. Without it, every request fails with:
```
'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'.
```

## Root cause
The `TAGGED_GROQ` prompt style in `MessageBuilder._assemble_body()` returned early (line 343) before reaching the rules injection point (line 362). So `json_rules` configured on the Groq provider were silently ignored.

## Fix
- Append rules inside the `TAGGED_GROQ` block before returning
- Added `json_rules=("RULES: Respond in valid JSON format.",)` to Groq's `ProviderMessageConfig` — same pattern used by OpenAI, Mistral, Gemini, and Cohere

## Test plan
- [x] `pytest tests/unit/prompt/test_message_builder.py` — 69 passed
- [x] Verified "json" appears in assembled Groq messages
- [ ] Manual: run workflow with Groq + json_mode → no 400 error