### PR TITLE
docs: update Ollama batch support tables

### DIFF
--- a/docs.agent-actions/docs/reference/configuration/index.md
+++ b/docs.agent-actions/docs/reference/configuration/index.md
@@ -195,7 +195,7 @@ Tool actions support both `Record` and `File` granularity. File granularity allo
 | Groq | `groq` | ✅ | llama-3.3-70b-versatile |
 | Mistral | `mistral` | ✅ | mistral-large-latest |
 | Cohere | `cohere` | ❌ | command-r-plus |
-| Ollama | `ollama` | ❌ | llama3, mistral |
+| Ollama | `ollama` | ✅ | llama3, mistral |
 
 ## Environment Variables
 

--- a/docs.agent-actions/docs/reference/execution/run-modes.md
+++ b/docs.agent-actions/docs/reference/execution/run-modes.md
@@ -68,7 +68,7 @@ defaults:
 | Google Gemini | Yes | Varies |
 | Groq | Yes | Varies |
 | Mistral | Yes | Varies |
-| Ollama | No (local) | N/A |
+| Ollama | Yes (local) | N/A |
 
 ### Batch Commands
 

--- a/docs.agent-actions/docs/reference/validation/index.md
+++ b/docs.agent-actions/docs/reference/validation/index.md
@@ -61,7 +61,7 @@ Feature support varies by vendor:
 | Google | ✅ | ✅ | ✅ | ✅ |
 | Groq | ✅ | ✅ | ✅ | ❌ |
 | Mistral | ✅ | ✅ | ✅ | ❌ |
-| Ollama | ✅ | ❌ | ✅ | ✅ |
+| Ollama | ✅ | ✅ | ✅ | ✅ |
 
 ## Schema Validation
 


### PR DESCRIPTION
## Summary

Updates three doc pages to reflect that Ollama now supports batch mode (enabled in PR #130).

- `docs/reference/validation/index.md` — Batch column: ❌ → ✅
- `docs/reference/execution/run-modes.md` — "No (local)" → "Yes (local)"
- `docs/reference/configuration/index.md` — Batch API column: ❌ → ✅