### PR TITLE
fix: expand [start, end] version ranges in VS Code extension

### DIFF
--- a/vscode-extension/src/model/yamlParser.ts
+++ b/vscode-extension/src/model/yamlParser.ts
@@ -103,8 +103,11 @@ function parseActionEntry(entry: unknown): ParsedAction[] | null {
 }
 
 /**
- * Expand a versioned action into multiple concrete actions
- * Handles versions.range: [1, 2, 3] -> action_1, action_2, action_3
+ * Expand a versioned action into multiple concrete actions.
+ *
+ * Supports two range formats (mirroring the core engine in expander.py):
+ *   - Pair: [start, end] → expands to start..end inclusive
+ *   - Explicit list: [1, 2, 3] → used as-is
  */
 function expandVersions(
     baseName: string,
@@ -118,7 +121,18 @@ function expandVersions(
         return [];
     }
 
-    return range.map((version) => {
+    // When range is a [start, end] pair, expand to the full sequence.
+    // This matches the core engine: range(start, end + 1).
+    let rangeValues: (number | string)[] = range;
+    if (range.length === 2 && typeof range[0] === 'number' && typeof range[1] === 'number') {
+        const [start, end] = range as [number, number];
+        rangeValues = [];
+        for (let v = start; v <= end; v++) {
+            rangeValues.push(v);
+        }
+    }
+
+    return rangeValues.map((version) => {
         const versionSuffix = `_${version}`;
         const versionedName = `${baseName}${versionSuffix}`;
 


### PR DESCRIPTION
## Summary

The VS Code extension's `expandVersions()` in `yamlParser.ts` treated `versions.range: [0, 3]` as a literal two-element list, creating only `action_0` and `action_3`. The core engine (`expander.py:191-195`) treats `[0, 3]` as a `[start, end]` pair and expands to `[0, 1, 2, 3]`.

This caused the sidebar to show "2 versions" instead of 4, which led to users writing `context_scope.observe` refs that missed intermediate versions.

## Root cause

`yamlParser.ts:121` did `range.map(...)` directly on the array. The core engine checks `if len(range) == 2` and expands with `range(start, end + 1)`.

## Fix

When `range` is a 2-element numeric array, expand it as `[start..end]` inclusive. Explicit lists (3+ elements or non-numeric) are still used as-is.

## Changes

- `vscode-extension/src/model/yamlParser.ts` — `expandVersions()` now mirrors core engine range expansion logic

## Test plan

- [x] Manual: `versions: {range: [0, 3]}` now shows 4 versions in sidebar
- [x] Explicit lists like `range: [1, 2, 3]` still work (3+ elements bypass pair expansion)