### PR TITLE
feat: add Gantt-style execution timeline to runs detail screen

### DIFF
--- a/agent_actions/tooling/docs/frontend/components/screens/runs-screen.tsx
+++ b/agent_actions/tooling/docs/frontend/components/screens/runs-screen.tsx
@@ -446,10 +446,16 @@ function RunStatusBadge({ status }: { status: RunStatus }) {
 
 /* --- Execution timeline (Gantt) --- */
 
+function actionStatusColor(status: string): string {
+  if (status === "success") return "hsl(var(--success))"
+  if (status === "failed") return "hsl(var(--destructive))"
+  if (status === "skipped") return "hsl(var(--muted-foreground))"
+  return "hsl(var(--primary))"
+}
+
 function ExecutionTimeline({ run }: { run: Run }) {
   const entries = Object.entries(run.actions)
   const runStart = new Date(run.started).getTime()
-  const runEnd = run.ended ? new Date(run.ended).getTime() : runStart + run.duration * 1000
 
   // Compute absolute start/end for each action in seconds from run start
   const bars = entries.map(([name, a]) => {
@@ -491,16 +497,13 @@ function ExecutionTimeline({ run }: { run: Run }) {
 
     return (
       <div className="rounded-xl border border-border bg-card p-5">
-        <h3 className="text-sm font-medium text-foreground mb-4">Execution Timeline</h3>
+        <h3 className="text-sm font-medium text-foreground mb-0.5">Execution Timeline</h3>
+        <p className="text-[10px] text-muted-foreground mb-4">by completion time</p>
         <div className="flex flex-col gap-1.5">
           {completionBars.map(({ name, action: a, endSec }) => {
             const pctEnd = (endSec! / maxEnd) * 100
             const barWidth = Math.max(pctEnd, 2)
-            const color =
-              a.status === "success" ? "hsl(var(--success))"
-              : a.status === "failed" ? "hsl(var(--destructive))"
-              : a.status === "skipped" ? "hsl(var(--muted-foreground))"
-              : "hsl(var(--primary))"
+            const color = actionStatusColor(a.status)
 
             return (
               <div key={name} className="flex items-center gap-3 h-7">


### PR DESCRIPTION
## Summary
- Adds a horizontal bar chart timeline to the run detail view showing when each action started/ended relative to the run
- Parallel actions appear side by side, making concurrent execution visible at a glance
- Color-coded by status: green (success), red (failed), gray (skipped), blue (running)
- Handles two data scenarios: full timing data (positioned Gantt bars) and completion-only data (older runs, scaled bars)
- Source-only change — no `frontend/out/` rebuild (per multi-clone plan)

## Files changed
- `frontend/components/screens/runs-screen.tsx` — Added `ExecutionTimeline` component (166 lines)

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Python lint clean (`ruff check .`)
- [x] No changes to mock-data.ts or transformers.ts (timing data already flows through)
- [x] Component handles missing timing data gracefully (returns null or falls back to completion-based layout)