### PR TITLE
feat: surface runtime warnings and errors in docs site logs screen

### DIFF
--- a/agent_actions/tooling/docs/frontend/components/screens/logs-screen.tsx
+++ b/agent_actions/tooling/docs/frontend/components/screens/logs-screen.tsx
@@ -20,7 +20,7 @@ import type { ValidationGroup } from "@/lib/mock-data"
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-type LogTab = "errors" | "warnings"
+type LogTab = "errors" | "warnings" | "runtime"
 type SortDir = "asc" | "desc"
 
 interface SortState<K extends string> {
@@ -211,7 +211,7 @@ const warningsChartConfig = {
 // ─── Main Component ──────────────────────────────────────────────────────────
 
 export function LogsScreen() {
-  const { validationErrorGroups, validationWarningGroups, stats } = useCatalogData()
+  const { validationErrorGroups, validationWarningGroups, runtimeErrorGroups, runtimeWarningGroups, stats } = useCatalogData()
   const [activeTab, setActiveTab] = useState<LogTab>("errors")
   const [focusedTarget, setFocusedTarget] = useState<string | null>(null)
   const [selectedGroup, setSelectedGroup] = useState<ValidationGroup | null>(null)
@@ -227,9 +227,11 @@ export function LogsScreen() {
   const errorSparkData = useMemo(() => buildSparkData(validationErrorGroups.flatMap((g) => g.timestamps)), [validationErrorGroups])
   const warningSparkData = useMemo(() => buildSparkData(validationWarningGroups.flatMap((g) => g.timestamps)), [validationWarningGroups])
 
+  const runtimeCount = runtimeErrorGroups.reduce((s, g) => s + g.count, 0) + runtimeWarningGroups.reduce((s, g) => s + g.count, 0)
   const tabs: { id: LogTab; label: string; count: number; icon: React.ReactNode; color: string }[] = [
     { id: "errors", label: "Errors", count: stats.validation_errors, icon: <AlertCircle className="h-3 w-3" />, color: "hsl(var(--destructive))" },
     { id: "warnings", label: "Warnings", count: stats.validation_warnings, icon: <AlertTriangle className="h-3 w-3" />, color: "hsl(var(--warning))" },
+    { id: "runtime", label: "Runtime", count: runtimeCount, icon: <Flame className="h-3 w-3" />, color: "hsl(var(--warning))" },
   ]
 
   // Stable reference for clearing focus (avoids re-triggering useEffect)
@@ -242,9 +244,20 @@ export function LogsScreen() {
     setSelectedGroup(null)
   }, [])
 
+  const runtimeAllGroups = useMemo(
+    () => [...runtimeErrorGroups, ...runtimeWarningGroups].sort((a, b) => b.count - a.count),
+    [runtimeErrorGroups, runtimeWarningGroups],
+  )
+
+  const activeGroups = useMemo(() => {
+    if (activeTab === "errors") return validationErrorGroups
+    if (activeTab === "warnings") return validationWarningGroups
+    return runtimeAllGroups
+  }, [activeTab, validationErrorGroups, validationWarningGroups, runtimeAllGroups])
+
   const totalForActiveTab = useMemo(
-    () => (activeTab === "errors" ? validationErrorGroups : validationWarningGroups).reduce((s, g) => s + g.count, 0),
-    [activeTab, validationErrorGroups, validationWarningGroups],
+    () => activeGroups.reduce((s, g) => s + g.count, 0),
+    [activeGroups],
   )
 
   // L3: SourceDetail view replaces the entire dashboard
@@ -407,6 +420,18 @@ export function LogsScreen() {
             seriesKey="warnings"
             chartConfig={warningsChartConfig}
             emptyLabel="No warnings"
+            focusedTarget={focusedTarget}
+            onClearFocus={clearFocus}
+            onViewDetail={setSelectedGroup}
+          />
+        )}
+        {activeTab === "runtime" && (
+          <ValidationBreakdown
+            groups={runtimeAllGroups}
+            colorVar="--warning"
+            seriesKey="warnings"
+            chartConfig={warningsChartConfig}
+            emptyLabel="No runtime warnings or errors"
             focusedTarget={focusedTarget}
             onClearFocus={clearFocus}
             onViewDetail={setSelectedGroup}

--- a/agent_actions/tooling/docs/frontend/lib/catalog-client.ts
+++ b/agent_actions/tooling/docs/frontend/lib/catalog-client.ts
@@ -20,6 +20,8 @@ export interface RawCatalogJson {
     recent_invocations: unknown[]
     validation_errors: RawValidationEntry[]
     validation_warnings: RawValidationEntry[]
+    runtime_warnings?: RawValidationEntry[]
+    runtime_errors?: RawValidationEntry[]
   }
   stats: {
     total_workflows: number

--- a/agent_actions/tooling/docs/frontend/lib/mock-data.ts
+++ b/agent_actions/tooling/docs/frontend/lib/mock-data.ts
@@ -15,6 +15,8 @@ export interface Stats {
   total_runs: number
   validation_errors: number
   validation_warnings: number
+  runtime_warnings?: number
+  runtime_errors?: number
 }
 
 export interface WorkflowDefaults {

--- a/agent_actions/tooling/docs/frontend/lib/transformers.ts
+++ b/agent_actions/tooling/docs/frontend/lib/transformers.ts
@@ -398,6 +398,8 @@ export interface CatalogData {
   toolFunctions: ToolFunction[]
   validationErrorGroups: ValidationGroup[]
   validationWarningGroups: ValidationGroup[]
+  runtimeErrorGroups: ValidationGroup[]
+  runtimeWarningGroups: ValidationGroup[]
   workflowData: WorkflowDataSummary[]
   generatedAt: string
   projectName: string | null
@@ -415,6 +417,8 @@ export function transformAll(catalog: RawCatalogJson, runs: RawRunsJson): Catalo
     toolFunctions: transformToolFunctions(catalog),
     validationErrorGroups: errors,
     validationWarningGroups: warnings,
+    runtimeErrorGroups: groupValidationEntries(catalog.logs?.runtime_errors ?? []),
+    runtimeWarningGroups: groupValidationEntries(catalog.logs?.runtime_warnings ?? []),
     workflowData: transformWorkflowData(catalog),
     generatedAt: catalog.metadata?.generated_at ?? "",
     projectName: catalog.metadata?.project_name ?? null,

--- a/agent_actions/tooling/docs/generator.py
+++ b/agent_actions/tooling/docs/generator.py
@@ -283,10 +283,26 @@ class CatalogGenerator:
         )
         catalog["stats"]["total_runs"] = len(runs_data) if runs_data else 0
 
+        # Merge runtime warnings/errors from all workflows into catalog logs
+        all_runtime_warnings: list[dict] = []
+        all_runtime_errors: list[dict] = []
+        if runs_data:
+            for wf_run in runs_data.values():
+                all_runtime_warnings.extend(wf_run.get("runtime_warnings", []))
+                all_runtime_errors.extend(wf_run.get("runtime_errors", []))
+
+        if not isinstance(catalog.get("logs"), dict):
+            catalog["logs"] = {}
+        catalog["logs"]["runtime_warnings"] = all_runtime_warnings
+        catalog["logs"]["runtime_errors"] = all_runtime_errors
+
         # Update validation stats from logs
         if logs_data:
             catalog["stats"]["validation_errors"] = len(logs_data.get("validation_errors", []))
             catalog["stats"]["validation_warnings"] = len(logs_data.get("validation_warnings", []))
+
+        catalog["stats"]["runtime_warnings"] = len(all_runtime_warnings)
+        catalog["stats"]["runtime_errors"] = len(all_runtime_errors)
 
         # Update stats for new categories
         catalog["stats"]["total_vendors"] = len(vendors_data) if vendors_data else 0

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -300,6 +300,14 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
                     exc_info=True,
                 )
 
+        # Extract runtime warnings/errors from events.json
+        runtime_events: dict[str, list[dict[str, Any]]] = {}
+        if events_path.exists():
+            try:
+                runtime_events = extract_runtime_warnings(events_path)
+            except (OSError, ValueError) as e:
+                logger.debug("Failed to extract runtime warnings from %s: %s", events_path, e)
+
         # Load .manifest.json for execution plan and per-action status
         manifest_path = target_dir / ".manifest.json"
         manifest_data = None
@@ -314,6 +322,8 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
             "workflow_name": workflow_name,
             "latest_run": latest_run,
             "action_metrics": action_metrics,
+            "runtime_warnings": runtime_events.get("runtime_warnings", []),
+            "runtime_errors": runtime_events.get("runtime_errors", []),
             "manifest": manifest_data,
             "run_results_path": str(run_results_path) if run_results_path.exists() else None,
             "events_path": str(events_path) if events_path.exists() else None,
@@ -490,3 +500,61 @@ def extract_action_metrics(events_path: Path) -> dict[str, Any]:
         logger.debug("Could not read action metrics from %s: %s", events_path, e)
 
     return action_metrics
+
+
+def extract_runtime_warnings(events_path: Path) -> dict[str, list[dict[str, Any]]]:
+    """Extract runtime warn/error events from a per-workflow events.json.
+
+    Returns:
+        {"runtime_warnings": [...], "runtime_errors": [...]} where each entry
+        has {target, message, timestamp, category, action_name, event_type}.
+    """
+    import json
+
+    warnings: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    _LOG_LINE_LIMIT = 100_000
+    try:
+        with open(events_path, encoding="utf-8") as f:
+            for line in itertools.islice(f, _LOG_LINE_LIMIT):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                level = event.get("level")
+                if level not in ("warn", "error"):
+                    continue
+
+                # Skip validation events — they're already captured by scan_logs()
+                event_type = event.get("event_type", "")
+                if event_type in ("ValidationErrorEvent", "ValidationWarningEvent"):
+                    continue
+
+                meta = event.get("meta", {})
+                action_name = meta.get("action_name", "")
+                workflow_name = meta.get("workflow_name", "")
+                target = action_name or workflow_name or event.get("category", "unknown")
+
+                entry = {
+                    "target": target,
+                    "message": event.get("message", ""),
+                    "timestamp": meta.get("timestamp", ""),
+                    "category": event.get("category", ""),
+                    "action_name": action_name,
+                    "event_type": event_type,
+                }
+
+                if level == "warn":
+                    warnings.append(entry)
+                else:
+                    errors.append(entry)
+
+    except OSError as e:
+        logger.debug("Could not read runtime warnings from %s: %s", events_path, e)
+
+    return {"runtime_warnings": warnings, "runtime_errors": errors}

--- a/tests/unit/tooling/docs/test_runtime_warnings_scanner.py
+++ b/tests/unit/tooling/docs/test_runtime_warnings_scanner.py
@@ -1,0 +1,173 @@
+"""Tests for extract_runtime_warnings scanner function."""
+
+import json
+
+import pytest
+
+from agent_actions.tooling.docs.scanner.data_scanners import extract_runtime_warnings
+
+
+@pytest.fixture
+def events_file(tmp_path):
+    """Create a temporary events.json file."""
+    path = tmp_path / "events.json"
+
+    def _write(events):
+        path.write_text("\n".join(json.dumps(e) for e in events))
+        return path
+
+    return _write
+
+
+class TestExtractRuntimeWarnings:
+    def test_extracts_warn_events(self, events_file):
+        path = events_file(
+            [
+                {
+                    "event_type": "LogEvent",
+                    "level": "warn",
+                    "category": "processing",
+                    "message": "All records filtered by guard",
+                    "meta": {
+                        "timestamp": "2026-04-03T09:44:13Z",
+                        "action_name": "generate_summary",
+                        "workflow_name": "incident_triage",
+                    },
+                    "data": {},
+                },
+            ]
+        )
+        result = extract_runtime_warnings(path)
+        assert len(result["runtime_warnings"]) == 1
+        assert result["runtime_warnings"][0]["target"] == "generate_summary"
+        assert "filtered by guard" in result["runtime_warnings"][0]["message"]
+        assert len(result["runtime_errors"]) == 0
+
+    def test_extracts_error_events(self, events_file):
+        path = events_file(
+            [
+                {
+                    "event_type": "ActionFailedEvent",
+                    "level": "error",
+                    "category": "action",
+                    "message": "Action failed: 401 Unauthorized",
+                    "meta": {
+                        "timestamp": "2026-04-03T10:00:00Z",
+                        "action_name": "extract_claims",
+                        "workflow_name": "review_analyzer",
+                    },
+                    "data": {},
+                },
+            ]
+        )
+        result = extract_runtime_warnings(path)
+        assert len(result["runtime_errors"]) == 1
+        assert result["runtime_errors"][0]["target"] == "extract_claims"
+        assert len(result["runtime_warnings"]) == 0
+
+    def test_skips_info_and_debug(self, events_file):
+        path = events_file(
+            [
+                {"event_type": "X", "level": "info", "message": "ok", "meta": {}, "data": {}},
+                {"event_type": "X", "level": "debug", "message": "trace", "meta": {}, "data": {}},
+            ]
+        )
+        result = extract_runtime_warnings(path)
+        assert len(result["runtime_warnings"]) == 0
+        assert len(result["runtime_errors"]) == 0
+
+    def test_skips_validation_events(self, events_file):
+        """Validation events are already captured by scan_logs — don't duplicate."""
+        path = events_file(
+            [
+                {
+                    "event_type": "ValidationErrorEvent",
+                    "level": "error",
+                    "message": "Missing field",
+                    "meta": {"action_name": "act"},
+                    "data": {},
+                },
+                {
+                    "event_type": "ValidationWarningEvent",
+                    "level": "warn",
+                    "message": "Unused dep",
+                    "meta": {"action_name": "act"},
+                    "data": {},
+                },
+            ]
+        )
+        result = extract_runtime_warnings(path)
+        assert len(result["runtime_warnings"]) == 0
+        assert len(result["runtime_errors"]) == 0
+
+    def test_target_fallback_to_workflow_name(self, events_file):
+        path = events_file(
+            [
+                {
+                    "event_type": "WorkflowFailedEvent",
+                    "level": "error",
+                    "message": "Workflow failed",
+                    "meta": {"workflow_name": "my_workflow"},
+                    "data": {},
+                },
+            ]
+        )
+        result = extract_runtime_warnings(path)
+        assert result["runtime_errors"][0]["target"] == "my_workflow"
+
+    def test_target_fallback_to_category(self, events_file):
+        path = events_file(
+            [
+                {
+                    "event_type": "SomeEvent",
+                    "level": "warn",
+                    "category": "cache",
+                    "message": "Cache miss",
+                    "meta": {},
+                    "data": {},
+                },
+            ]
+        )
+        result = extract_runtime_warnings(path)
+        assert result["runtime_warnings"][0]["target"] == "cache"
+
+    def test_empty_file(self, events_file):
+        path = events_file([])
+        result = extract_runtime_warnings(path)
+        assert result == {"runtime_warnings": [], "runtime_errors": []}
+
+    def test_nonexistent_file(self, tmp_path):
+        result = extract_runtime_warnings(tmp_path / "missing.json")
+        assert result == {"runtime_warnings": [], "runtime_errors": []}
+
+    def test_mixed_events(self, events_file):
+        path = events_file(
+            [
+                {"event_type": "X", "level": "info", "message": "ok", "meta": {}, "data": {}},
+                {
+                    "event_type": "X",
+                    "level": "warn",
+                    "message": "w1",
+                    "meta": {"action_name": "a"},
+                    "data": {},
+                },
+                {
+                    "event_type": "X",
+                    "level": "error",
+                    "message": "e1",
+                    "meta": {"action_name": "b"},
+                    "data": {},
+                },
+                {
+                    "event_type": "X",
+                    "level": "warn",
+                    "message": "w2",
+                    "meta": {"action_name": "c"},
+                    "data": {},
+                },
+                {"event_type": "X", "level": "debug", "message": "d", "meta": {}, "data": {}},
+            ]
+        )
+        result = extract_runtime_warnings(path)
+        assert len(result["runtime_warnings"]) == 2
+        assert len(result["runtime_errors"]) == 1


### PR DESCRIPTION
## Summary
Runtime warn/error events from workflow executions (guard filtering, action failures, API errors) were only visible in raw `events.json` files. Now they surface in the docs site's Logs screen as a new "Runtime" tab, using the same grouped-by-source UI that validation events already use.

## Data pipeline
```
events.json (per-workflow, NDJSON)
  → extract_runtime_warnings() (new scanner function)
    → scan_runs() merges into runs_data[wf].runtime_warnings/errors
      → generator.py aggregates into catalog.logs.runtime_warnings/errors + stats
        → catalog-client.ts (new optional fields on logs type)
          → transformers.ts groups via existing groupValidationEntries()
            → CatalogData.runtimeErrorGroups / runtimeWarningGroups
              → LogsScreen "Runtime" tab (reuses ValidationBreakdown component)
```

## What changed

### Python (scanner + generator)
- **`data_scanners.py`** — New `extract_runtime_warnings(events_path)`: reads per-workflow events.json, collects events where `level in ("warn", "error")`, skips validation events (already captured by `scan_logs()`). Target falls back: action_name → workflow_name → category.
- **`data_scanners.py`** — `scan_runs()` now calls `extract_runtime_warnings()` and includes `runtime_warnings`/`runtime_errors` in each workflow's run data.
- **`generator.py`** — Merges runtime events from all workflows into `catalog["logs"]` and adds `runtime_warnings`/`runtime_errors` stats.

### Frontend (source only, no out/ rebuild)
- **`catalog-client.ts`** — Added `runtime_warnings?` and `runtime_errors?` optional fields to logs type.
- **`mock-data.ts`** — Added `runtime_warnings?` and `runtime_errors?` to Stats interface.
- **`transformers.ts`** — Added `runtimeErrorGroups` and `runtimeWarningGroups` to CatalogData, grouped via existing `groupValidationEntries()`.
- **`logs-screen.tsx`** — New "Runtime" tab combining runtime errors and warnings, rendered via existing `ValidationBreakdown` component.

### Tests
- **`test_runtime_warnings_scanner.py`** — 9 tests: warn extraction, error extraction, skips info/debug, skips validation events, target fallbacks (action → workflow → category), empty file, missing file, mixed events.

## Test plan
- [x] 4505 passed, 2 skipped — full suite
- [x] Ruff lint and format clean
- [x] 9 new scanner tests cover all branches
- [x] No `frontend/out/` rebuild (per shared memory — Clone 4 will do final rebuild)