### PR TITLE
fix: place example READMEs where docs scanner expects them

### DIFF
--- a/examples/contract_reviewer/agent_workflow/contract_reviewer/README.md
+++ b/examples/contract_reviewer/agent_workflow/contract_reviewer/README.md
@@ -1,0 +1,283 @@
+# Contract Reviewer
+
+<p align="center"><img src="docs/flow.png" width="700"/></p>
+
+## What You'll Learn
+
+This is the **only example** in the repository that demonstrates the **Map-Reduce pattern** and **FILE granularity**. You'll learn how to:
+
+- **Split one input record into many** (the "map" step) using a Tool action that returns a list.
+- **Process each fragment independently** with per-record LLM actions.
+- **Collect all fragments back into one** (the "reduce" step) using a Tool action with `granularity: File`, which receives every record from the file at once instead of one at a time.
+- **Filter records with a guard** so that an expensive LLM action only runs on records that match a condition.
+- **Mix model vendors in a single workflow** -- Anthropic for legal reasoning, OpenAI for executive summarization.
+
+---
+
+## The Problem
+
+A legal team needs to review contracts before signing. Each contract contains many clauses -- payment, IP, liability, termination -- and each clause carries different risk. Reviewing a whole contract in a single LLM call works poorly. The model loses focus. The output is unstructured. And you can't selectively deep-dive into the dangerous parts.
+
+The Map-Reduce pattern solves this naturally:
+
+1. **Map** -- split the contract into individual clauses so each one is analyzed in isolation with full attention.
+2. **Process** -- run each clause through a risk-analysis prompt that scores it against seed-data criteria.
+3. **Filter** -- only send high-risk clauses to an expensive deep-analysis step.
+4. **Reduce** -- aggregate all clause-level results into a single contract-level risk report.
+5. **Summarize** -- generate a plain-language executive summary from the aggregated report.
+
+---
+
+## How It Works
+
+The workflow contains five actions executed in sequence. Here's what each one does and which YAML settings matter.
+
+### 1. `split_into_clauses` (Tool)
+
+Parses the contract's `full_text` field and emits **one record per clause**. One contract goes in, N clause records come out.
+
+- **Kind**: `tool` -- Python function, no LLM call.
+- **Impl**: `split_contract_by_clause` -- regex finds numbered headings (`1. DEFINITIONS`, `Section 2: ...`, etc.) and slices the text.
+- **Output fields**: `clause_number`, `clause_title`, `clause_text`
+- **Context scope**: observes only `source.full_text`, `source.contract_id`, and `source.title`; passes through metadata (`contract_id`, `title`, `parties`) so downstream actions can reference the contract.
+
+### 2. `analyze_clause` (LLM / Anthropic)
+
+Analyzes **each** clause against the risk criteria from seed data. The default granularity is `Record`, so the framework invokes this action once per clause.
+
+- **Model**: `claude-sonnet-4-20250514` via Anthropic -- chosen for strong legal reasoning.
+- **Prompt**: classify risk as high/medium/low, extract obligations and deadlines, recommend an action (accept, negotiate, reject, or flag_for_legal).
+- **Seed data**: `risk_criteria.json` is injected through `context_scope.observe`, giving the model a rubric with concrete indicators for each risk level.
+- **Output fields**: `risk_level`, `risk_score`, `risk_indicators`, `obligations`, `deadlines`, `reasoning`, `recommended_action`
+
+### 3. `flag_high_risk` (LLM / Anthropic, guarded)
+
+Deep legal analysis **only on clauses classified as high-risk**. Clauses that don't match the guard are silently filtered out.
+
+- **Guard**: `risk_level == "high"` with `on_false: filter` -- non-matching records drop entirely.
+- **Model**: same Anthropic model as the previous step.
+- **Context**: observes the full `analyze_clause.*` output plus `source.full_text` (the entire original contract) for cross-referencing, and `seed.risk_criteria`.
+- **Output fields**: `severity`, `legal_exposure`, `financial_impact`, `cross_references`, `negotiation_points`, `precedent_concerns`, `mitigation_strategy`
+
+### 4. `aggregate_risk_summary` (Tool, FILE granularity)
+
+The reduce step. Collects **all** clause-level analyses into a single contract-level risk report. FILE granularity is essential here -- without it, the framework passes records one at a time and the tool can't compute cross-clause aggregates.
+
+- **Kind**: `tool` -- Python function.
+- **Granularity**: `File` -- input is a `list[dict]` of every record, not a single record.
+- **Impl**: `aggregate_clause_analyses` -- counts risk levels, computes average risk scores, collects obligations and deadlines, builds a prioritized negotiation list.
+- **Output fields**: `overall_risk_level`, `overall_risk_score`, `risk_distribution`, `high_risk_clauses`, `total_obligations`, `key_deadlines`, `negotiation_priority`
+
+### 5. `generate_executive_summary` (LLM / OpenAI)
+
+Plain-language summary for VP/C-level stakeholders. It deliberately **doesn't** see individual clause analyses -- only the aggregated report -- keeping context tight.
+
+- **Model**: `gpt-4o-mini` via OpenAI (the workflow default).
+- **Context scope**: observes only `aggregate_risk_summary.*`; explicitly drops `analyze_clause.*`, `flag_high_risk.*`, and `split_into_clauses.*`.
+- **Output fields**: `executive_summary`, `risk_verdict`, `top_concerns`, `recommended_next_steps`, `approval_conditions`, `estimated_negotiation_effort`
+
+---
+
+## Key Patterns Explained
+
+### Map-Reduce Pattern
+
+Split a large document into pieces, process each piece independently, then combine the results. In AGAC: a Tool action returns a list (the map step), normal per-record actions process each element, and a `granularity: File` action merges everything back (the reduce step).
+
+**Map step** -- the tool returns a Python `list[dict]`, and the framework automatically fans out one record per list element:
+
+```yaml
+- name: split_into_clauses
+  kind: tool
+  impl: split_contract_by_clause
+  intent: "Split contract full_text into individual numbered clauses"
+  schema: split_into_clauses
+  context_scope:
+    observe:
+      - source.full_text
+      - source.contract_id
+      - source.title
+    passthrough:
+      - source.contract_id
+      - source.title
+      - source.parties
+```
+
+After this action, the workflow has N records (one per clause) where before it had 1. Every subsequent action (until the reduce step) runs once per clause.
+
+**Reduce step** -- the `granularity: File` setting tells the framework to batch all records from the same file back into a single call:
+
+```yaml
+- name: aggregate_risk_summary
+  dependencies: [analyze_clause]
+  kind: tool
+  impl: aggregate_clause_analyses
+  intent: "Aggregate all clause analyses into a unified contract risk report"
+  schema: aggregate_risk_summary
+  granularity: File
+  context_scope:
+    observe:
+      - analyze_clause.*
+      - flag_high_risk.*
+      - source.contract_id
+      - source.title
+      - source.parties
+```
+
+### FILE Granularity
+
+By default, every action uses `granularity: Record` -- one record at a time. Set `granularity: File`, and the action receives **all records from the input file in a single call**.
+
+This matters whenever your logic needs a cross-record view: computing averages, counting distributions, sorting by priority, producing one output from many inputs. Without it, the aggregation tool would see one clause at a time and could never build a contract-level summary.
+
+A FILE granularity tool in Python receives a `list[dict]` and returns a `FileUDFResult`:
+
+```python
+from agent_actions import udf_tool
+from agent_actions.config.types import Granularity
+from agent_actions.utils.udf_management.registry import FileUDFResult
+
+@udf_tool(granularity=Granularity.FILE)
+def aggregate_clause_analyses(data: list[dict[str, Any]]) -> FileUDFResult:
+    # data contains ALL clause records at once
+    # ... aggregate logic ...
+    return FileUDFResult(
+        outputs=[single_summary_dict],
+        input_count=len(data),
+    )
+```
+
+### Guard as Filter
+
+The `flag_high_risk` action uses a guard to skip clauses that aren't high-risk. The key setting is `on_false: filter` -- records that fail the condition are **dropped from the pipeline entirely** for this action. They aren't passed through unchanged; they simply don't reach it.
+
+```yaml
+- name: flag_high_risk
+  dependencies: [analyze_clause]
+  intent: "Perform deep legal analysis of high-risk clauses with full contract context"
+  schema: flag_high_risk
+  prompt: $contract_reviewer.Flag_High_Risk
+  model_vendor: anthropic
+  model_name: claude-sonnet-4-20250514
+  api_key: ANTHROPIC_API_KEY
+  guard:
+    condition: 'risk_level == "high"'
+    on_false: "filter"
+```
+
+A cost and latency win. Eight clauses, two high-risk? The expensive deep-analysis LLM call runs twice, not eight times.
+
+### Multi-Vendor
+
+Two LLM providers in one workflow. The `defaults` block sets OpenAI as the baseline; individual actions override to Anthropic where legal reasoning quality matters more:
+
+```yaml
+defaults:
+  model_vendor: openai
+  model_name: gpt-4o-mini
+  api_key: OPENAI_API_KEY
+
+actions:
+  - name: analyze_clause
+    model_vendor: anthropic
+    model_name: claude-sonnet-4-20250514
+    api_key: ANTHROPIC_API_KEY
+    # ...
+
+  - name: flag_high_risk
+    model_vendor: anthropic
+    model_name: claude-sonnet-4-20250514
+    api_key: ANTHROPIC_API_KEY
+    # ...
+
+  - name: generate_executive_summary
+    # inherits defaults: openai / gpt-4o-mini
+    # ...
+```
+
+Balance cost and quality stage by stage. Legal clause analysis benefits from a stronger model; the executive summary, operating on already-structured data, works fine with a lighter one.
+
+### Retry and Reprompt
+
+All LLM actions inherit retry from defaults -- transient API errors (rate limits, timeouts) are retried up to 2 times with backoff:
+
+```yaml
+defaults:
+  retry:
+    enabled: true
+    max_attempts: 2
+```
+
+`analyze_clause` also has reprompt validation. If the LLM returns null values for `risk_score` or other required fields, the framework rejects the output and reprompts automatically:
+
+```yaml
+reprompt:
+  validation: check_required_fields    # Rejects any response with null values
+  max_attempts: 2
+  on_exhausted: return_last            # Accept best attempt if retries fail
+```
+
+The `check_required_fields` UDF in `tools/shared/reprompt_validations.py` is generic -- it checks that no field in the response is null, without hardcoding field names.
+
+---
+
+## Quick Start
+
+Install the CLI:
+
+```bash
+pip install agent-actions-cli
+```
+
+Copy the environment sample and fill in your API keys:
+
+```bash
+cp .env.sample .env
+# Edit .env with your OPENAI_API_KEY and ANTHROPIC_API_KEY
+```
+
+Run the workflow:
+
+```bash
+agac run -a contract_reviewer
+```
+
+By default the workflow processes 2 records (`record_limit: 2` in the config). Remove or increase that setting to process the full dataset.
+
+The sample input (`agent_io/staging/contracts.json`) includes three contracts of varying risk levels. After the run completes, check the output database for per-clause analyses, high-risk flags, aggregated risk summaries, and executive summaries.
+
+---
+
+## Project Structure
+
+```
+contract_reviewer/
+├── README.md
+├── docs/
+├── agent_actions.yml
+├── agent_workflow/
+│   └── contract_reviewer/
+│       ├── agent_config/
+│       │   └── contract_reviewer.yml
+│       ├── agent_io/
+│       │   ├── staging/
+│       │   │   └── contracts.json
+│       │   └── target/
+│       └── seed_data/
+│           └── risk_criteria.json
+├── prompt_store/
+│   └── contract_reviewer.md
+├── schema/
+│   └── contract_reviewer/
+│       ├── split_into_clauses.yml
+│       ├── analyze_clause.yml
+│       ├── flag_high_risk.yml
+│       ├── aggregate_risk_summary.yml
+│       └── generate_executive_summary.yml
+└── tools/
+    ├── contract_reviewer/
+    │   ├── split_contract_by_clause.py
+    │   └── aggregate_clause_analyses.py
+    └── shared/
+        └── reprompt_validations.py
+```

--- a/examples/incident_triage/agent_workflow/incident_triage/README.md
+++ b/examples/incident_triage/agent_workflow/incident_triage/README.md
@@ -1,0 +1,405 @@
+# Incident Triage
+
+An automated incident triage workflow that classifies severity through parallel consensus voting, assesses customer and system impact in parallel, dynamically assigns response teams using seed data, and conditionally escalates to leadership for high-severity incidents.
+
+<p align="center"><img src="docs/flow.png" width="700"/></p>
+
+## What You'll Learn
+
+This example demonstrates several intermediate-to-advanced agac patterns:
+
+- **Parallel versioned actions** -- running multiple instances of the same LLM action concurrently with distinct personas
+- **Version merge/aggregation** -- consuming parallel version outputs into a single tool action using the `merge` pattern
+- **Conditional execution with guards** -- skipping actions based on runtime data (severity level)
+- **Multi-seed data injection** -- loading external JSON files (team roster, service catalog, runbooks) into the workflow context
+- **Parallel branching** -- running independent LLM actions concurrently when they share the same dependency
+- **Tool actions** -- using deterministic Python functions alongside LLM actions for aggregation, routing, and formatting
+- **Context scoping with `observe` and `passthrough`** -- controlling exactly which upstream fields each action can see
+
+## The Problem
+
+When a production incident hits, the first 15 minutes matter most. Human triage is slow, inconsistent, and often bottlenecked on a single on-call engineer's judgment. This workflow automates the entire triage process: it extracts structured details from a raw incident report, classifies severity through a three-voter ensemble (reducing single-classifier bias), assesses both customer and system impact simultaneously, assigns the right response team based on real organizational data, and generates a response plan -- all in seconds.
+
+## How It Works
+
+The workflow is defined in a single YAML config with 8 actions arranged across 8 stages. Each action is either an LLM call or a deterministic tool.
+
+### Stage 1: extract_incident_details (LLM)
+
+**Model**: Groq (`llama-3.1-8b-instant`) -- simple structured extraction, fast and cheap.
+
+```yaml
+- name: extract_incident_details
+  intent: "Extract structured information from raw incident report"
+  schema: extract_incident_details
+  prompt: $incident_triage.Extract_Incident_Details
+  model_vendor: groq
+  model_name: llama-3.1-8b-instant
+  api_key: GROQ_API_KEY
+  context_scope:
+    observe:
+      - source.incident_report
+      - source.monitoring_data
+      - source.timestamp
+```
+
+The entry point. It reads the raw incident report and monitoring data from the input record and produces a structured JSON object: title, description, affected systems, error messages, impact signals.
+
+The input record may contain fields irrelevant to extraction. Listing only `source.incident_report`, `source.monitoring_data`, and `source.timestamp` in `observe` limits the LLM's context window to exactly the data it needs. Narrow observation reduces noise and token cost.
+
+### Stage 2: classify_severity (LLM, x3 parallel)
+
+**Model**: Ollama (`llama3.2:latest`) -- classification task; parallel voting compensates for the weaker model.
+
+```yaml
+- name: classify_severity
+  dependencies: [extract_incident_details]
+  intent: "Classify incident severity using multiple independent evaluators"
+  versions:
+    range: [1, 3]
+    mode: parallel
+  schema: classify_severity
+  prompt: $incident_triage.Classify_Severity
+  context_scope:
+    observe:
+      - extract_incident_details.*
+      - source.incident_report
+```
+
+This is the core pattern. Instead of asking one LLM call to classify severity, we run three independent classifiers in parallel. Each version gets a different persona -- conservative, balanced, thorough -- injected through the prompt template using `{{ i }}`, `{{ version.first }}`, and `{{ version.last }}`.
+
+A single classifier can be overconfident or miss edge cases. Three independent votes with different risk perspectives produce a more robust severity rating. The `parallel` mode means all three run concurrently -- no time penalty. Outputs land as `classify_severity_1`, `classify_severity_2`, and `classify_severity_3` in the context.
+
+### Stage 3: aggregate_severity (Tool, merge pattern)
+
+```yaml
+- name: aggregate_severity
+  dependencies: [classify_severity]
+  kind: tool
+  impl: aggregate_severity_votes
+  schema: aggregate_severity
+  intent: "Aggregate severity classifications using weighted consensus"
+  version_consumption:
+    source: classify_severity
+    pattern: merge
+  context_scope:
+    observe:
+      - classify_severity_1.*
+      - classify_severity_2.*
+      - classify_severity_3.*
+    passthrough:
+      - extract_incident_details.*
+```
+
+This tool action consumes all three classifier outputs and produces a single final severity rating via weighted voting. `version_consumption` with `pattern: merge` tells agac this is the aggregation point for the parallel versions from Stage 2.
+
+Aggregation logic -- weighted vote, tie-breaking -- is deterministic. A Python function (`aggregate_severity_votes`) is faster, cheaper, and fully reproducible. Reserve LLM actions for tasks that actually require judgment.
+
+The `passthrough` list forwards `extract_incident_details.*` downstream without the aggregate action itself needing those fields. Context keeps flowing through the pipeline; intermediate actions don't have to re-observe everything.
+
+### Stage 4: assess_customer_impact and assess_system_impact (LLM, parallel branches)
+
+```yaml
+- name: assess_customer_impact
+  dependencies: [aggregate_severity]
+  intent: "Assess impact on customers and revenue"
+  schema: assess_customer_impact
+  prompt: $incident_triage.Assess_Customer_Impact
+  context_scope:
+    observe:
+      - extract_incident_details.*
+      - aggregate_severity.*
+
+- name: assess_system_impact
+  dependencies: [aggregate_severity]
+  intent: "Assess technical system impact and blast radius"
+  schema: assess_system_impact
+  prompt: $incident_triage.Assess_System_Impact
+  context_scope:
+    observe:
+      - extract_incident_details.*
+      - aggregate_severity.*
+```
+
+These two actions share the same dependency (`aggregate_severity`) and don't depend on each other. agac runs them in parallel automatically. One focuses on customer/revenue impact; the other on technical blast radius and cascading failure risk.
+
+Each assessment requires a different analytical lens. Separating them produces more focused, higher-quality outputs -- and parallel execution means there's no latency cost for the split.
+
+### Stage 5: assign_response_team (Tool, seed data)
+
+```yaml
+- name: assign_response_team
+  dependencies: [assess_customer_impact, assess_system_impact]
+  kind: tool
+  impl: assign_team_based_on_impact
+  schema: assign_response_team
+  intent: "Dynamically assign response team based on affected systems and severity"
+  context_scope:
+    observe:
+      - aggregate_severity.final_severity
+      - assess_system_impact.affected_services
+      - seed.team_roster
+      - seed.service_catalog
+    passthrough:
+      - aggregate_severity.*
+      - assess_customer_impact.*
+      - assess_system_impact.*
+```
+
+This tool action reads the severity level and affected services, then looks up the correct response team from the seed data. The `seed.team_roster` and `seed.service_catalog` references pull in the JSON files declared in the `defaults.context_scope.seed_path` block at the top of the config.
+
+Team rosters and service ownership change frequently. Loading them from external JSON files lets you update routing logic without modifying the workflow config or redeploying. The tool function receives the full roster and catalog as context, then makes a deterministic routing decision.
+
+### Stage 6: generate_response_plan (LLM)
+
+```yaml
+- name: generate_response_plan
+  dependencies: [assign_response_team]
+  intent: "Generate initial incident response plan with action items"
+  schema: generate_response_plan
+  prompt: $incident_triage.Generate_Response_Plan
+  context_scope:
+    observe:
+      - assign_response_team.*
+      - extract_incident_details.*
+      - assess_customer_impact.customer_impact_level
+```
+
+With the severity classified, impact assessed, and team assigned, this LLM action generates concrete immediate actions, investigation steps, a communication plan, and escalation criteria.
+
+The response plan only needs the impact level -- not the full breakdown of estimated customer counts and revenue figures. Selecting `assess_customer_impact.customer_impact_level` instead of the wildcard keeps the prompt focused.
+
+### Stage 7: generate_executive_summary (LLM, guarded)
+
+```yaml
+- name: generate_executive_summary
+  dependencies: [generate_response_plan]
+  intent: "Generate executive summary for high-severity incidents"
+  guard:
+    condition: 'aggregate_severity.final_severity == "SEV1" or aggregate_severity.final_severity == "SEV2"'
+    on_false: "filter"
+  schema: generate_executive_summary
+  prompt: $incident_triage.Generate_Executive_Summary
+  context_scope:
+    observe:
+      - aggregate_severity.*
+      - assess_customer_impact.*
+      - generate_response_plan.*
+```
+
+This action only runs for SEV1 and SEV2 incidents. The `guard` block evaluates a condition against runtime context. SEV3 or lower? The action gets filtered -- skipped entirely -- saving LLM cost and avoiding unnecessary leadership notifications.
+
+With `"filter"`, the action is silently skipped and downstream actions proceed without its output. `"block"` would halt the entire pipeline instead. The final formatting stage still needs to run for lower-severity incidents, so `"filter"` is correct here.
+
+### Stage 8: format_triage_output (Tool)
+
+```yaml
+- name: format_triage_output
+  dependencies: [generate_response_plan, generate_executive_summary]
+  kind: tool
+  impl: format_incident_triage
+  schema: format_triage_output
+  intent: "Format complete triage output with all assessments"
+  context_scope:
+    observe:
+      - extract_incident_details.*
+      - aggregate_severity.*
+      - assess_customer_impact.*
+      - assess_system_impact.*
+      - assign_response_team.*
+      - generate_response_plan.*
+      - generate_executive_summary.*
+      - source.timestamp
+```
+
+The final tool action assembles all upstream outputs into a single structured triage record. It observes every prior action's output. When the executive summary was filtered (SEV3+), `generate_executive_summary.*` is simply absent from context -- the tool handles that gracefully.
+
+## Key Patterns Explained
+
+### Parallel Voting with Versions
+
+The `versions` block creates multiple instances of the same action. Each instance gets a unique index (`{{ i }}`), and the prompt template uses `{{ version.first }}` and `{{ version.last }}` to assign different personas:
+
+```yaml
+versions:
+  range: [1, 3]
+  mode: parallel
+```
+
+This produces three concurrent LLM calls: `classify_severity_1`, `classify_severity_2`, and `classify_severity_3`. `range: [1, 3]` means versions 1 through 3 inclusive. `mode: parallel` means they run concurrently, not sequentially.
+
+In the prompt, version-aware templating assigns each classifier a distinct perspective:
+
+```
+You are classifier {{ i }} of {{ version.length }} in a severity classification ensemble.
+
+{% if version.first %}
+**Your role**: Be CONSERVATIVE. When in doubt, classify higher severity.
+{% elif version.last %}
+**Your role**: Be THOROUGH. Consider all possible impacts comprehensively.
+{% else %}
+**Your role**: Be BALANCED. Focus on evidence-based assessment.
+{% endif %}
+```
+
+### Version Merge (Aggregation)
+
+After parallel versions complete, a downstream action consumes them using `version_consumption`:
+
+```yaml
+version_consumption:
+  source: classify_severity
+  pattern: merge
+```
+
+`pattern: merge` tells agac to wait for all versions of `classify_severity` to finish, then expose their outputs as `classify_severity_1.*`, `classify_severity_2.*`, and `classify_severity_3.*` in the consuming action's context. Standard fan-in after a fan-out.
+
+### Conditional Escalation with Guards
+
+Guards let you skip actions based on runtime values:
+
+```yaml
+guard:
+  condition: 'aggregate_severity.final_severity == "SEV1" or aggregate_severity.final_severity == "SEV2"'
+  on_false: "filter"
+```
+
+The `condition` is evaluated against the accumulated context. If it returns false, `on_false` determines the behavior:
+- `"filter"` -- skip this action silently; downstream actions still run
+- `"block"` -- halt the pipeline at this point
+
+This avoids wasting LLM calls on low-severity incidents that don't need executive attention.
+
+### Multi-Seed Data Loading
+
+Seed data is declared once in `defaults` and made available across all actions:
+
+```yaml
+defaults:
+  context_scope:
+    seed_path:
+      team_roster: $file:team_roster.json
+      service_catalog: $file:service_catalog.json
+      runbook_catalog: $file:runbook_catalog.json
+```
+
+Individual actions reference seed data via the `seed.` prefix in their `observe` lists:
+
+```yaml
+context_scope:
+  observe:
+    - seed.team_roster
+    - seed.service_catalog
+```
+
+The `$file:` prefix tells agac to load the JSON file from the `seed_data/` directory -- that's how organizational knowledge (team rosters, service ownership maps, runbook catalogs) gets into tool actions without being hardcoded in the workflow config.
+
+### Parallel Branches (Implicit)
+
+When two actions share the same dependency and don't depend on each other, agac runs them in parallel automatically:
+
+```yaml
+- name: assess_customer_impact
+  dependencies: [aggregate_severity]
+  # ...
+
+- name: assess_system_impact
+  dependencies: [aggregate_severity]
+  # ...
+```
+
+No special keyword needed. The DAG scheduler detects that both actions become runnable at the same time and executes them concurrently. `assign_response_team` lists both as dependencies, so it waits for both to finish:
+
+```yaml
+- name: assign_response_team
+  dependencies: [assess_customer_impact, assess_system_impact]
+```
+
+### Retry and Reprompt
+
+All LLM actions inherit retry from defaults -- transient API errors (rate limits, timeouts) are retried up to 2 times with backoff:
+
+```yaml
+defaults:
+  retry:
+    enabled: true
+    max_attempts: 2
+```
+
+`extract_incident_details` and `classify_severity` also have reprompt validation. If the LLM returns null fields or incomplete structured output, the framework rejects the response and reprompts automatically:
+
+```yaml
+reprompt:
+  validation: check_required_fields    # Rejects any response with null values
+  max_attempts: 2
+  on_exhausted: return_last            # Accept best attempt if retries fail
+```
+
+The `check_required_fields` UDF in `tools/shared/reprompt_validations.py` is generic -- it checks that no field in the response is null, without hardcoding field names.
+
+## Quick Start
+
+Install the CLI:
+
+```bash
+pip install agent-actions-cli
+```
+
+Set your environment variables:
+
+```bash
+export OPENAI_API_KEY=...
+export GROQ_API_KEY=...
+# Ollama must be running locally (no API key needed)
+```
+
+Run the workflow:
+
+```bash
+agac run -a incident_triage
+```
+
+By default the workflow processes 2 records (`record_limit: 2` in the config). Remove or increase that setting to process the full dataset.
+
+The input data lives in `agent_workflow/incident_triage/agent_io/staging/incidents.json` and contains three sample incidents (checkout 502 errors, auth service failure, Elasticsearch cluster outage). Results are written to `agent_workflow/incident_triage/agent_io/target/`.
+
+## Project Structure
+
+```
+incident_triage/
+├── README.md
+├── docs/
+├── agent_actions.yml
+├── agent_workflow/
+│   └── incident_triage/
+│       ├── agent_config/
+│       │   └── incident_triage.yml
+│       ├── agent_io/
+│       │   ├── staging/
+│       │   │   └── incidents.json
+│       │   └── target/
+│       └── seed_data/
+│           ├── team_roster.json
+│           ├── service_catalog.json
+│           └── runbook_catalog.json
+├── prompt_store/
+│   └── incident_triage.md
+├── schema/
+│   └── incident_triage/
+│       ├── extract_incident_details.yml
+│       ├── classify_severity.yml
+│       ├── aggregate_severity.yml
+│       ├── assess_customer_impact.yml
+│       ├── assess_system_impact.yml
+│       ├── assign_response_team.yml
+│       ├── generate_response_plan.yml
+│       ├── generate_executive_summary.yml
+│       └── format_triage_output.yml
+└── tools/
+    ├── incident_triage/
+    │   ├── aggregate_severity_votes.py
+    │   ├── assign_team_based_on_impact.py
+    │   └── format_incident_triage.py
+    └── shared/
+        └── reprompt_validations.py
+```

--- a/examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/README.md
+++ b/examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/README.md
@@ -1,0 +1,258 @@
+# Product Listing Enrichment
+
+<p align="center"><img src="docs/flow.png" width="700"/></p>
+
+A six-action pipeline that transforms raw product specs into marketplace-ready listings. It alternates strictly between LLM actions (language generation) and Tool actions (deterministic operations), demonstrating how to divide work by capability: LLMs handle language, tools handle data.
+
+## What You'll Learn
+
+This example teaches four patterns that appear repeatedly in production agent workflows:
+
+1. **LLM/Tool hybrid pipeline** -- structuring a workflow so that LLMs and tools alternate, each doing what the other cannot.
+2. **Progressive context disclosure** -- controlling exactly what each action sees, and dropping context once it's been distilled into a better form.
+3. **Guard-based conditional skip** -- making an action run only when a previous action's output meets a condition.
+4. **Seed data injection** -- providing static reference material (brand guidelines, marketplace rules) that shapes LLM behavior without being part of the input records.
+
+## The Problem
+
+A marketplace seller has raw product data -- technical specs, images, a category, and a price. Turning that into a published listing requires several kinds of work:
+
+- **Language work**: describing specs in human terms, writing persuasive copy, optimizing for search. These require understanding nuance, tone, and intent. An LLM is the right tool.
+- **Data work**: looking up competitor prices, checking character limits, assembling final JSON. These are deterministic and exact. A traditional function is the right tool.
+
+Mixing these responsibilities in a single LLM call produces unreliable results -- LLMs miscount characters and hallucinate pricing data. A strict LLM-Tool-LLM-Tool-LLM-Tool pipeline gives you the best of both.
+
+## How It Works
+
+The pipeline has exactly 6 actions in strict alternation:
+
+### Action 1: `generate_description` (LLM)
+
+**Model**: Gemini (`gemini-2.5-flash`) -- cheap extraction from technical specs.
+
+Takes the raw specs, product images description, and brand voice seed data. The LLM translates technical specifications into a benefit-oriented description, key features, search keywords, and use cases. Pure language work. No tool could turn `"driver_size": "40mm"` into "rich, detailed sound from 40mm custom drivers."
+
+It observes (`observe`) `source.raw_specs`, `source.product_images_description`, `source.product_name`, `source.brand`, and `seed.brand_voice`. It passes through `source.product_id`, `source.product_category`, and `source.current_price` unchanged.
+
+### Action 2: `fetch_competitor_prices` (Tool)
+
+A deterministic function that looks up competitor pricing based on category and price. In production this would call a pricing API. No LLM needed -- pure data lookup.
+
+Observes `generate_description.search_keywords`, `source.product_category`, `source.current_price`.
+
+### Action 3: `write_marketing_copy` (LLM)
+
+**Model**: OpenAI (`gpt-4o-mini`) -- creative writing needs stronger reasoning.
+
+Now the LLM has both the product description (from step 1) and competitor pricing (from step 2). It writes marketplace listing copy that positions the product against the competition. This is where `source.raw_specs` gets dropped -- the LLM already distilled it into readable language in step 1, so there's no reason to pass the raw data forward.
+
+It observes `generate_description.*`, `fetch_competitor_prices.competitor_prices`, `fetch_competitor_prices.price_position`, `seed.brand_voice`, and `seed.marketplace_rules`. It drops `source.raw_specs`.
+
+### Action 4: `validate_compliance` (Tool)
+
+Checks the marketing copy against marketplace rules: character limits, required fields, prohibited content. A tool does this perfectly. No ambiguity about whether a string is 200 or 201 characters.
+
+Observes `write_marketing_copy.*` and `seed.marketplace_rules`.
+
+### Action 5: `optimize_seo` (LLM, guarded)
+
+**Model**: OpenAI (`gpt-4o-mini`) -- SEO reasoning benefits from the stronger default model.
+
+Optimizes keywords and titles for search ranking. This action is **guarded**: it only runs if `compliance_passed == true` from the previous step. No point optimizing copy that'll be rejected.
+
+Observes `write_marketing_copy.*`, `validate_compliance.*`, `source.product_category`, `source.brand`.
+
+### Action 6: `format_listing` (Tool)
+
+Assembles all upstream outputs into the final marketplace-ready JSON structure. Just packaging -- no creativity needed.
+
+Sees everything from all prior actions, plus source identifiers.
+
+## Key Patterns Explained
+
+### 1. LLM/Tool Hybrid Pipeline
+
+The core design principle: LLMs do language, tools do data. Every action in this workflow is explicitly typed. LLM actions have a `prompt` reference. Tool actions have `kind: tool` and an `impl` pointing to a Python function.
+
+```yaml
+# LLM action -- has a prompt, uses a per-action model override
+- name: generate_description
+  intent: "Generate a structured product description from raw technical specs and image context"
+  schema: generate_description
+  prompt: $product_listing_enrichment.Generate_Product_Description
+  model_vendor: gemini                # Cheap extraction from specs
+  model_name: gemini-2.5-flash
+  api_key: GEMINI_API_KEY
+
+# Tool action -- has kind: tool and impl, no model involved
+- name: fetch_competitor_prices
+  dependencies: [generate_description]
+  kind: tool
+  impl: fetch_competitor_prices
+  intent: "Look up competitor pricing data for competitive positioning"
+  schema: fetch_competitor_prices
+```
+
+The alternation is strict: LLM, Tool, LLM, Tool, LLM, Tool. Each LLM action generates language that a tool then processes or validates. Each tool action produces structured data that the next LLM action uses as context.
+
+### 2. Progressive Context Disclosure
+
+Each action sees only what it needs. The `context_scope` block controls this with three directives:
+
+- **`observe`** -- the action can read these fields (they appear in the prompt or tool input)
+- **`passthrough`** -- these fields are forwarded to the next action unchanged, without the current action processing them
+- **`drop`** -- these fields are explicitly removed from the context going forward
+
+The most important use of `drop` in this workflow is removing `raw_specs` after the first action:
+
+```yaml
+- name: write_marketing_copy
+  dependencies: [fetch_competitor_prices]
+  context_scope:
+    observe:
+      - generate_description.*
+      - fetch_competitor_prices.competitor_prices
+      - fetch_competitor_prices.price_position
+      - seed.brand_voice
+      - seed.marketplace_rules
+    drop:
+      - source.raw_specs
+    passthrough:
+      - source.product_id
+      - source.product_category
+      - source.current_price
+      - source.brand
+```
+
+Why drop `raw_specs`? Because `generate_description` already distilled the raw technical data into readable language. Passing both the raw specs and the distilled description to `write_marketing_copy` would waste tokens and risk the LLM contradicting its own earlier output. Once information has been transformed into a better form, drop the original.
+
+### 3. Guard-Based Conditional Skip
+
+The `optimize_seo` action uses a guard to skip itself when compliance validation fails:
+
+```yaml
+- name: optimize_seo
+  dependencies: [validate_compliance]
+  guard:
+    condition: 'compliance_passed == true'
+    on_false: "skip"
+  context_scope:
+    observe:
+      - write_marketing_copy.*
+      - validate_compliance.*
+      - source.product_category
+      - source.brand
+```
+
+`condition` references a field from the previous action's output (`validate_compliance.compliance_passed`). When it evaluates to `false`, the entire action is skipped -- no LLM call is made, no tokens are spent. The `on_false: "skip"` directive means downstream actions still run; the pipeline does not abort.
+
+Guards prevent wasting tokens on actions whose preconditions aren't met. Other common examples: skipping translation when the source language already matches the target, or skipping summarization when the input is already short enough.
+
+### 4. Seed Data Injection
+
+Seed data provides static reference material that shapes LLM behavior. It's defined once in `defaults` and made available to any action that lists it in `observe`:
+
+```yaml
+defaults:
+  context_scope:
+    seed_path:
+      brand_voice: $file:brand_voice.json
+      marketplace_rules: $file:marketplace_rules.json
+```
+
+The `brand_voice.json` file contains tone guidelines, prohibited words, preferred phrases, and formatting rules. The `marketplace_rules.json` file defines character limits, required fields, and prohibited content for each listing component.
+
+Actions reference seed data the same way they reference any other context:
+
+```yaml
+context_scope:
+  observe:
+    - seed.brand_voice
+    - seed.marketplace_rules
+```
+
+Configuration stays in JSON files, not prompts. Brand voice changes? Edit `brand_voice.json`. Marketplace updates its rules? Edit `marketplace_rules.json`. No prompt surgery needed.
+
+### 5. Retry and Reprompt
+
+All LLM actions inherit retry from defaults -- transient API errors (rate limits, timeouts) are retried up to 2 times with backoff:
+
+```yaml
+defaults:
+  retry:
+    enabled: true
+    max_attempts: 2
+```
+
+`generate_description` and `write_marketing_copy` also have reprompt validation. If the LLM returns null fields or incomplete structured output, the framework rejects the response and reprompts automatically:
+
+```yaml
+reprompt:
+  validation: check_required_fields    # Rejects any response with null values
+  max_attempts: 2
+  on_exhausted: return_last            # Accept best attempt if retries fail
+```
+
+The `check_required_fields` UDF in `tools/shared/reprompt_validations.py` is generic -- it checks that no field in the response is null, without hardcoding field names.
+
+## Quick Start
+
+Install the CLI:
+
+```bash
+pip install agent-actions-cli
+```
+
+Set your environment variables:
+
+```bash
+export OPENAI_API_KEY=...
+export GEMINI_API_KEY=...
+```
+
+Run the agent:
+
+```bash
+agac run -a product_listing_enrichment
+```
+
+By default the workflow processes 2 records (`record_limit: 2` in the config). Remove or increase that setting to process the full dataset.
+
+The pipeline will process each product record in `agent_io/staging/products.json` through all six actions and write the results to `agent_io/target/`.
+
+## Project Structure
+
+```
+product_listing_enrichment/
+├── README.md
+├── docs/
+├── agent_actions.yml
+├── agent_workflow/
+│   └── product_listing_enrichment/
+│       ├── agent_config/
+│       │   └── product_listing_enrichment.yml
+│       ├── agent_io/
+│       │   ├── staging/
+│       │   │   └── products.json
+│       │   └── target/
+│       └── seed_data/
+│           ├── brand_voice.json
+│           └── marketplace_rules.json
+├── prompt_store/
+│   └── product_listing_enrichment.md
+├── schema/
+│   └── product_listing_enrichment/
+│       ├── generate_description.yml
+│       ├── fetch_competitor_prices.yml
+│       ├── write_marketing_copy.yml
+│       ├── validate_compliance.yml
+│       ├── optimize_seo.yml
+│       └── format_listing.yml
+└── tools/
+    ├── product_listing_enrichment/
+    │   ├── fetch_competitor_prices.py
+    │   ├── validate_marketplace_compliance.py
+    │   └── format_marketplace_listing.py
+    └── shared/
+        └── reprompt_validations.py
+```

--- a/examples/review_analyzer/agent_workflow/review_analyzer/README.md
+++ b/examples/review_analyzer/agent_workflow/review_analyzer/README.md
@@ -1,0 +1,348 @@
+# Review Analyzer
+
+Multi-model pipeline that scores product review quality via parallel consensus voting, drafts merchant responses, and extracts product insights -- a context engineering showcase for agac.
+
+<p align="center"><img src="docs/flow.png" width="700"/></p>
+
+## What You'll Learn
+
+- **Multi-vendor model selection** -- choosing Groq, OpenAI, or Anthropic per action based on the task's cost/quality tradeoff
+- **Parallel consensus voting** -- running 3 independent scorer versions with context isolation so no scorer can anchor on another
+- **Guard-based conditional execution** -- skipping expensive LLM calls for records that fail a quality threshold
+- **Progressive context disclosure** -- using `observe`, `drop`, and `passthrough` to control exactly which fields each action sees
+- **Seed data injection** -- loading a shared evaluation rubric from JSON so scoring criteria live outside prompts
+- **Version consumption with merge pattern** -- fanning out to 3 parallel versions and deterministically merging them back
+
+## The Problem
+
+E-commerce platforms receive thousands of product reviews daily. Most are low quality -- vague praise, single-sentence complaints, or suspected fakes. Merchants need a system that (1) objectively scores review quality without being biased by the reviewer's star rating, (2) generates thoughtful merchant responses only for reviews worth responding to, and (3) extracts structured product insights for the product team. This pipeline solves all three with minimal token waste.
+
+## How It Works
+
+### 1. extract_claims
+
+**Model**: Groq (`llama-3.1-8b-instant`) -- fast and cheap, because extraction doesn't need expensive reasoning.
+
+Pulls factual claims, product aspects, and sentiment signals from the raw review text. The critical design decision is the `drop` directive on `star_rating`:
+
+```yaml
+context_scope:
+  observe:
+    - source.review_text
+    - source.review_title
+    - source.product_name
+    - source.product_category
+  drop:
+    - source.star_rating          # Excluded: avoid anchoring bias
+    - source.verified_purchase
+  passthrough:
+    - source.review_id            # Flows to output, zero tokens
+    - source.reviewer_name
+    - source.review_date
+    - source.product_name
+    - source.product_category
+```
+
+If the LLM sees a 5-star rating, it unconsciously biases extraction toward positive framing. Dropping `star_rating` forces the model to work from the text alone. `passthrough` fields like `review_id` flow into the output record without ever entering the LLM's context window. Zero tokens, zero cost -- but the data is preserved for downstream actions.
+
+### 2. score_quality (x3 parallel)
+
+**Model**: Ollama (`llama3.2:latest`) -- parallel voting compensates for the weaker model, keeping cost near zero.
+
+Three independent scorers evaluate each review against the same rubric. The entire fan-out is two lines of YAML:
+
+```yaml
+versions:
+  param: scorer_id
+  range: [1, 2, 3]
+  mode: parallel
+```
+
+Each scorer is context-isolated -- it sees the extracted claims and the seed rubric, but never another scorer's output. That prevents herding (scorer 2 anchoring on scorer 1's number). The prompt template uses version metadata to shift each scorer's focus:
+
+```
+You are quality scorer {{ i }} of {{ version.length }}...
+
+{% if version.first %}
+**Your focus**: Prioritize HELPFULNESS.
+{% elif version.last %}
+**Your focus**: Prioritize AUTHENTICITY.
+{% else %}
+**Your focus**: Prioritize SPECIFICITY.
+{% endif %}
+```
+
+The context scope also continues to drop `star_rating`, keeping the scoring unbiased end to end:
+
+```yaml
+context_scope:
+  observe:
+    - extract_claims.factual_claims
+    - extract_claims.product_aspects
+    - extract_claims.sentiment_signals
+    - source.review_text
+    - seed.rubric
+  drop:
+    - source.star_rating          # Still excluded from scoring
+```
+
+### 3. aggregate_scores
+
+**Kind**: Tool (`aggregate_quality_scores`) -- deterministic math, no LLM needed.
+
+Merges the three parallel scorer outputs into a single weighted consensus score via the `version_consumption` directive:
+
+```yaml
+kind: tool
+impl: aggregate_quality_scores
+version_consumption:
+  source: score_quality           # Declarative fan-in
+  pattern: merge                  #   from parallel versions
+context_scope:
+  observe:
+    - score_quality_1.*
+    - score_quality_2.*
+    - score_quality_3.*
+  passthrough:
+    - extract_claims.*
+```
+
+Weighted averaging is deterministic -- an LLM would add latency, cost, and the possibility of arithmetic hallucination. The `merge` pattern collects all three versioned outputs (`score_quality_1`, `score_quality_2`, `score_quality_3`) into a single context so the tool function can access them all.
+
+### 4. generate_response
+
+**Model**: OpenAI (`gpt-4o-mini`) -- needs reasoning for nuanced, empathetic merchant replies.
+
+Drafts a professional merchant response, but only for reviews that scored high enough. The guard prevents wasting tokens on junk reviews:
+
+```yaml
+guard:
+  condition: 'consensus_score >= 6'
+  on_false: "filter"              # LLM never fires for junk reviews
+```
+
+The context scope is deliberately curated. The response writer sees the original review, extracted claims, and aggregate score -- but NOT the individual scorer reasoning. Clean context, better output:
+
+```yaml
+context_scope:
+  observe:
+    - source.review_text
+    - source.review_title
+    - extract_claims.factual_claims
+    - extract_claims.product_aspects
+    - extract_claims.sentiment_signals
+    - aggregate_scores.consensus_score
+    - aggregate_scores.strengths
+    - aggregate_scores.weaknesses
+  drop:
+    - score_quality.*             # Does NOT see individual scorer reasoning
+```
+
+### 5. extract_product_insights
+
+**Model**: OpenAI (`gpt-4o-mini`) -- needs reasoning for structured extraction against known categories.
+
+Classifies actionable feedback into product improvement categories defined in the seed data. Runs in **parallel** with `generate_response` -- both depend only on `aggregate_scores`:
+
+```yaml
+dependencies: [aggregate_scores]  # Same as generate_response
+guard:
+  condition: 'consensus_score >= 6'
+  on_false: "filter"
+context_scope:
+  observe:
+    - source.review_text
+    - extract_claims.factual_claims
+    - extract_claims.product_aspects
+    - seed.rubric.product_feedback_categories
+```
+
+Notice it reaches into a specific nested field of the seed data (`seed.rubric.product_feedback_categories`) rather than loading the entire rubric. The insights extractor doesn't need scoring weights, so why send them?
+
+### 6. format_output
+
+**Kind**: Tool (`format_analysis_output`) -- deterministic packaging, no LLM needed.
+
+Fans in from both parallel branches (`generate_response` and `extract_product_insights`) and assembles the complete output record:
+
+```yaml
+dependencies: [generate_response, extract_product_insights]
+kind: tool
+impl: format_analysis_output
+context_scope:
+  observe:
+    - generate_response.*
+    - extract_product_insights.*
+    - extract_claims.*
+    - aggregate_scores.*
+    - source.*
+```
+
+## Key Patterns Explained
+
+### Multi-Vendor Model Selection
+
+Each action uses the model best suited to its task. The workflow sets a default vendor and overrides per action:
+
+```yaml
+defaults:
+  model_vendor: openai
+  model_name: gpt-4o-mini
+
+actions:
+  - name: extract_claims
+    model_vendor: groq                # Fast, cheap extraction
+    model_name: llama-3.1-8b-instant
+    api_key: GROQ_API_KEY
+
+  - name: score_quality
+    model_vendor: ollama              # Parallel voting compensates for weaker model
+    model_name: llama3.2:latest
+
+  - name: generate_response           # Uses default (OpenAI) -- needs reasoning
+  - name: extract_product_insights    # Uses default (OpenAI) -- needs reasoning
+```
+
+Not every step needs the same model. Extraction is high-volume, low-complexity -- Groq's small Llama handles it at a fraction of the cost. Scoring runs three parallel voters, so the consensus compensates for a weaker local model -- Ollama's Llama 3.2 keeps that cost at zero. Response generation and product insight extraction need reasoning, so they stay on the OpenAI default. Match the model to the task.
+
+### Parallel Consensus Voting
+
+Three independent scorers produce three opinions. None can see the others:
+
+```yaml
+- name: score_quality
+  versions:
+    param: scorer_id
+    range: [1, 2, 3]
+    mode: parallel
+
+- name: aggregate_scores
+  version_consumption:
+    source: score_quality
+    pattern: merge
+```
+
+The `versions` block creates three parallel instances. `merge` in `aggregate_scores` collects all three into a single context for deterministic aggregation. Think of it as an ensemble method: if two out of three scorers flag a review as low quality, the consensus score reflects that regardless of the third.
+
+### Progressive Context Disclosure
+
+Every action gets a precisely scoped context window using three directives:
+
+| Directive     | Effect                                              | Token cost |
+|---------------|-----------------------------------------------------|------------|
+| `observe`     | Field is included in the LLM context                | Tokens consumed |
+| `drop`        | Field is explicitly excluded, even if it exists      | Zero |
+| `passthrough` | Field flows to the output record, never enters LLM  | Zero |
+
+Example from `extract_claims`:
+
+```yaml
+context_scope:
+  observe:
+    - source.review_text          # LLM sees this
+    - source.product_name         # LLM sees this
+  drop:
+    - source.star_rating          # LLM never sees this
+  passthrough:
+    - source.review_id            # Forwarded to output, zero tokens
+```
+
+Uncontrolled context is the #1 cause of poor LLM output. Drop `star_rating` and you prevent anchoring bias. Pass through `review_id` and you preserve traceability without burning tokens. Each action's context should be a deliberate editorial decision, not a dump of everything available.
+
+### Guard-Based Conditional Execution
+
+Guards prevent expensive actions from running on records that don't meet a threshold:
+
+```yaml
+- name: generate_response
+  guard:
+    condition: 'consensus_score >= 6'
+    on_false: "filter"
+```
+
+When `consensus_score` is below 6, the action is skipped entirely. No prompt assembled, no API call, no tokens consumed. The threshold of 6 comes from the seed data (`evaluation_rubric.json`), so business logic stays outside the YAML config.
+
+Both `generate_response` and `extract_product_insights` share the same guard. They run in parallel for records that pass the gate. Records that don't? Both skipped.
+
+### Retry and Reprompt
+
+All LLM actions inherit retry from defaults -- transient API errors (rate limits, timeouts) are retried up to 2 times with backoff:
+
+```yaml
+defaults:
+  retry:
+    enabled: true
+    max_attempts: 2
+```
+
+`score_quality` also has reprompt validation. If the LLM returns null scores or missing fields, the framework rejects the output and reprompts automatically:
+
+```yaml
+reprompt:
+  validation: check_required_fields    # Rejects any response with null values
+  max_attempts: 2
+  on_exhausted: return_last            # Accept best attempt if retries fail
+```
+
+The `check_required_fields` UDF in `tools/shared/reprompt_validations.py` is generic -- it checks that no field in the response is null, without hardcoding field names.
+
+## Quick Start
+
+Install the CLI:
+
+```bash
+pip install agent-actions-cli
+```
+
+Set your environment variables (or copy `.env.sample` to `.env`):
+
+```bash
+export OPENAI_API_KEY=...
+export GROQ_API_KEY=...
+# Ollama must be running locally (no API key needed)
+```
+
+Run the agent:
+
+```bash
+agac run -a review_analyzer
+```
+
+By default the workflow processes 2 records (`record_limit: 2` in the config). Remove or increase that setting to process the full dataset.
+
+Input reviews go in `agent_workflow/review_analyzer/agent_io/staging/reviews.json`. Results appear in `agent_workflow/review_analyzer/agent_io/target/run_results.json`.
+
+## Project Structure
+
+```
+review_analyzer/
+├── README.md
+├── docs/                              # Pipeline diagram
+├── agent_actions.yml                     # Top-level config
+├── agent_workflow/
+│   └── review_analyzer/
+│       ├── agent_config/
+│       │   └── review_analyzer.yml       # Workflow definition (actions, guards, context)
+│       ├── agent_io/
+│       │   ├── staging/
+│       │   │   └── reviews.json          # Input reviews
+│       │   └── target/                   # Output results
+│       └── seed_data/
+│           └── evaluation_rubric.json    # Scoring rubric and feedback categories
+├── prompt_store/
+│   └── review_analyzer.md               # All prompt templates
+├── schema/
+│   └── review_analyzer/
+│       ├── extract_claims.yml
+│       ├── score_quality.yml
+│       ├── aggregate_scores.yml
+│       ├── generate_response.yml
+│       ├── extract_product_insights.yml
+│       └── format_output.yml
+└── tools/
+    ├── review_analyzer/
+    │   ├── aggregate_quality_scores.py
+    │   └── format_analysis_output.py
+    └── shared/
+        └── reprompt_validations.py       # check_required_fields UDF
+```

--- a/examples/support_resolution/agent_workflow/support_resolution/README.md
+++ b/examples/support_resolution/agent_workflow/support_resolution/README.md
@@ -1,0 +1,261 @@
+# Support Resolution
+
+<p align="center"><img src="docs/flow.png" width="700"/></p>
+
+## What You'll Learn
+
+This example teaches you how to build an agent workflow that **skips JSON mode entirely**. Every other example in this repository sets `json_mode: true` and asks the model to produce structured JSON. This one turns that off. Instead, each action asks the model for a single plain-text answer, names that answer with `output_field`, and a final tool action assembles everything into a structured record.
+
+Why does this matter? Small and local models -- the kind you run on your own laptop with Ollama -- often can't produce valid JSON reliably. Decomposing a complex task into steps that each require only one word or one sentence makes the pipeline accessible to *any* model that can follow a simple instruction. You'll learn:
+
+- How `output_field` replaces schema-based extraction when JSON mode is off.
+- How to default an entire workflow to a local Ollama model.
+- How to use a guard as a cost-control mechanism (skip expensive LLM calls for low-value tickets).
+- How to override the model on a single action when one step needs more capability than the rest.
+- How seed data (routing rules) works in non-JSON mode.
+
+---
+
+## The Problem
+
+A support team receives tickets with a title, body, labels, and reporter metadata. Each ticket must be triaged: classified by type, assessed for severity, routed to the right team, summarized for a dashboard, and (for non-trivial tickets) given a draft customer response.
+
+A single monolithic prompt that returns a JSON object works fine with GPT-4o or Claude. Smaller models choke on it. The ticket body can be long, the output schema has many fields, and a 3B-parameter model will regularly produce malformed JSON, missing keys, or hallucinated field names.
+
+The fix: break the task into seven narrow steps. Each step receives only the context it needs and produces a single value. The model never juggles multiple fields at once. Even `llama3.2:latest` running locally can answer "classify this ticket into one of five categories" reliably.
+
+---
+
+## How It Works
+
+The workflow has seven actions. They don't all run sequentially -- the DAG allows parallelism where dependencies permit.
+
+### 1. classify_issue (LLM)
+
+Reads the ticket title, body, and labels. Produces a single value for `issue_type` (one of: `bug`, `feature_request`, `question`, `account_issue`, `performance`). Every later step depends on this classification.
+
+### 2. assess_severity (LLM)
+
+Depends on `classify_issue`. Reads the title, body, and the upstream `issue_type`. Produces `severity` (one of: `critical`, `high`, `medium`, `low`). It **drops** `source.labels` to avoid anchoring on the reporter's own priority guess.
+
+### 3. identify_area (LLM) -- parallel with assess_severity
+
+Depends on `classify_issue` but *not* on `assess_severity`, so it runs in parallel with step 2. Produces `product_area` (one of: `authentication`, `api`, `billing`, `reports`, `integrations`, `ui`, `infrastructure`, `documentation`).
+
+### 4. assign_team (LLM)
+
+Depends on both `assess_severity` and `identify_area`. Reads the three upstream fields plus `seed.routing_rules` (a JSON file mapping teams to areas and issue types). Produces `assigned_team`.
+
+### 5. summarize_issue (LLM) -- parallel with assign_team
+
+Also depends on `assess_severity` and `identify_area`, running in parallel with step 4. Produces `summary` -- a single sentence (max 20 words) for the triage dashboard.
+
+### 6. draft_response (LLM, guarded)
+
+Depends on `summarize_issue` and `assign_team`. Produces `suggested_response` -- a short customer-facing reply. If `severity == "low"`, the guard skips this action entirely. The model is never called.
+
+### 7. format_output (Tool)
+
+A Python tool (`package_triage_result`) that collects all upstream `output_field` values and assembles them into a single triage record. No LLM involved. Just deterministic code.
+
+---
+
+## Key Patterns Explained
+
+### Non-JSON Mode + output_field
+
+The defining pattern of this example. In the defaults block:
+
+```yaml
+defaults:
+  json_mode: false                    # Plain text responses, no JSON required
+```
+
+And on every LLM action, instead of pointing to a schema, you name a single field:
+
+```yaml
+- name: classify_issue
+  intent: "Classify the support ticket into a category"
+  output_field: issue_type           # Names the field, no schema needed
+  prompt: $support_resolution.Classify_Issue
+```
+
+The prompt itself reinforces the contract by ending with a directive like:
+
+```
+Answer with the category name only. Nothing else.
+```
+
+The model's entire response becomes the value of `issue_type`. No parsing, no JSON extraction, no schema validation. The framework stores the plain-text response under the field name you specified.
+
+Ask a model for ONE thing and even a small model gets it right. Ask for a JSON object with seven fields and small models break.
+
+---
+
+### Local Model Support
+
+The defaults configure Ollama as the model vendor:
+
+```yaml
+defaults:
+  model_vendor: ollama
+  model_name: llama3.2:latest
+  api_key: OLLAMA_API_KEY
+  run_mode: online                    # Ollama doesn't support batch mode
+```
+
+Every action runs against a model on your local machine. No API keys for hosted services needed. The `run_mode: online` setting is required because Ollama doesn't support batch/async request queuing.
+
+The combination of `json_mode: false` and `output_field` is what makes local models viable. A 3B model prompted with "classify this ticket into one of five categories -- answer with the category name only" succeeds nearly every time. The same model prompted with "return a JSON object with fields issue_type, severity, product_area, assigned_team, summary, and suggested_response" fails frequently.
+
+---
+
+### Guard as Cost Control
+
+The `draft_response` action uses a guard to skip execution for low-severity tickets:
+
+```yaml
+- name: draft_response
+  dependencies: [summarize_issue, assign_team]
+  output_field: suggested_response
+  guard:
+    condition: 'severity != "low"'
+    on_false: "skip"
+```
+
+When `severity` (produced by `assess_severity` earlier in the pipeline) equals `"low"`, the guard evaluates to false and the action is skipped. The model is never called. The downstream `format_output` tool still runs -- it just receives an empty string for `suggested_response`.
+
+Drafting a customer response is the most token-expensive step (it produces multiple sentences, not a single word). Low-severity tickets like typos don't need a crafted response, so skipping the call saves both latency and compute. On a local Ollama setup, that's time. With a hosted model, that's money.
+
+---
+
+### Per-Action Model Override
+
+The workflow config includes a commented-out override on `draft_response`:
+
+```yaml
+- name: draft_response
+  # model_vendor: openai              # Override: use a stronger model here
+  # model_name: gpt-4o-mini
+  # api_key: OPENAI_API_KEY
+```
+
+Most of the pipeline runs on a cheap/local model. One action switches to a stronger hosted model. Classification, severity assessment, and area identification are constrained-choice tasks -- a small model handles them well. Drafting a customer-facing response benefits from better fluency and tone.
+
+To activate this, uncomment the three lines and set `OPENAI_API_KEY` in your environment. Every other action continues to use Ollama locally; only `draft_response` calls OpenAI.
+
+---
+
+### Seed Data
+
+The `assign_team` action uses seed data -- a static JSON file loaded into the context:
+
+```yaml
+defaults:
+  context_scope:
+    seed_path:
+      routing_rules: $file:routing_rules.json
+```
+
+The file `routing_rules.json` maps teams to product areas and issue types:
+
+```json
+{
+  "teams": {
+    "backend": {
+      "areas": ["api", "authentication", "infrastructure"],
+      "handles": ["bug", "performance"]
+    },
+    "billing": {
+      "areas": ["billing", "account_issue"],
+      "handles": ["account_issue", "bug", "question"]
+    }
+  },
+  "escalation": {
+    "critical": "Route to backend regardless of area",
+    "high": "Route to area-specific team"
+  }
+}
+```
+
+The `assign_team` action observes `seed.routing_rules` in its context scope:
+
+```yaml
+- name: assign_team
+  context_scope:
+    observe:
+      - classify_issue.issue_type
+      - assess_severity.severity
+      - identify_area.product_area
+      - seed.routing_rules
+```
+
+The model sees the routing rules as part of its prompt context and follows them to pick the right team. Non-JSON mode doesn't matter here -- the model only outputs a team name. The seed data is input, not output.
+
+---
+
+## Quick Start
+
+**Prerequisites**: Python 3.10+, the `agent-actions-cli` package, and (for the default config) [Ollama](https://ollama.ai) running locally with the `llama3.2:latest` model pulled.
+
+1. Install the CLI:
+
+```bash
+pip install agent-actions-cli
+```
+
+2. Pull the local model (if you haven't already):
+
+```bash
+ollama pull llama3.2:latest
+```
+
+3. Set environment variables:
+
+```bash
+# For the default Ollama setup, no real API key is needed --
+# but the variable must exist:
+export OLLAMA_API_KEY=ollama
+
+# If you uncomment the per-action OpenAI override on draft_response:
+# export OPENAI_API_KEY=sk-...
+```
+
+4. Run the workflow:
+
+```bash
+agac run -a support_resolution
+```
+
+By default the workflow processes 2 records (`record_limit: 2` in the config). Remove or increase that setting to process the full dataset.
+
+The input tickets are in `agent_workflow/support_resolution/agent_io/staging/issues.json`. The pipeline processes each ticket through all seven actions and writes the triage records to the target directory.
+
+---
+
+## Project Structure
+
+```
+support_resolution/
+├── README.md
+├── docs/
+├── agent_actions.yml
+├── agent_workflow/
+│   └── support_resolution/
+│       ├── agent_config/
+│       │   └── support_resolution.yml
+│       ├── agent_io/
+│       │   ├── staging/
+│       │   │   └── issues.json
+│       │   └── target/
+│       └── seed_data/
+│           └── routing_rules.json
+├── prompt_store/
+│   └── support_resolution.md
+├── schema/
+│   └── support_resolution/
+│       └── format_output.yml
+└── tools/
+    └── support_resolution/
+        └── package_triage_result.py
+```


### PR DESCRIPTION
## Summary
- Copy README.md into `agent_workflow/<name>/` (sibling of `agent_config/`) for 5 example projects
- `scan_readmes()` looks for READMEs as parent of `agent_config/`, but they were 2 levels up at the project root
- `book_catalog_enrichment` already had one in the right place

## Test plan
- [x] All 6 examples now have README.md next to their `agent_config/` directory
- Run `agac docs` on any example project to verify the README tab appears