### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.1.4"
+version = "0.1.5"
 description = "Declarative YAML-based framework for orchestrating LLM workflows with batch processing"
 authors = [
     {name = "Muizz Kolapo"},

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-actions"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Bump version in `pyproject.toml`, `__version__.py`, and `uv.lock` from 0.1.4 → 0.1.5
- Required for the v0.1.5 release CI version gate