### PR TITLE
docs: add Project Surface to config, validation, errors manifests

### DIFF
--- a/agent_actions/config/_MANIFEST.md
+++ b/agent_actions/config/_MANIFEST.md
@@ -84,3 +84,39 @@ Key Functions
 | `agent_actions/prompt` | Relies on resolved paths and DI wiring for prompt preparation. |
 | `agent_actions/output` | Uses path resolution to locate IO and schema artifacts. |
 | `agent_actions/cli` | Reads config and project paths to render/run workflows. |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `load_project_config()` | `agent_actions.yml` | Reads | `default_agent_config`, `schema_path`, `tool_path`, `seed_data_path`, `project_name` |
+| `get_schema_path()` | `agent_actions.yml` | Reads | `schema_path` |
+| `get_tool_dirs()` | `agent_actions.yml` | Reads | `tool_path` |
+| `get_seed_data_path()` | `agent_actions.yml` | Reads | `seed_data_path` |
+| `get_project_name()` | `agent_actions.yml` | Reads | `project_name` |
+| `ConfigManager._load_single_config()` | `agent_config/{workflow}/{workflow}.yml` | Reads | entire workflow YAML |
+| `ConfigManager.load_configs()` | `agent_config/{workflow}/{workflow}.yml` | Reads | `tool_path`, `actions[]`, `defaults` |
+| `WorkflowConfig.model_validate()` | `agent_config/{workflow}/{workflow}.yml` | Validates | `name`, `actions[]`, `defaults` |
+| `ActionConfig` (schema.py) | `agent_config/{workflow}/{workflow}.yml` | Validates | `actions[].name`, `actions[].kind`, `actions[].impl`, `actions[].schema`, `actions[].guard`, `actions[].dependencies`, `actions[].reprompt`, `actions[].retry`, `actions[].context_scope`, `actions[].versions` |
+| `DefaultsConfig` (schema.py) | `agent_config/{workflow}/{workflow}.yml` | Validates | `defaults.model_vendor`, `defaults.model_name`, `defaults.granularity`, `defaults.run_mode`, `defaults.data_source`, `defaults.context_scope` |
+| `EnvironmentConfig` | `.env` | Reads | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AGENT_ACTIONS_ENV` |
+| `PathManager.get_standard_path()` | `{workflow}/agent_io/target/{action}/` | Resolves | — |
+| `PathManager.get_standard_path()` | `schema/{workflow}/` | Resolves | — |
+| `PathManager.get_standard_path()` | `prompt_store/` | Resolves | — |
+| `PathManager.clean_path()` | `{workflow}/agent_io/target/{action}/` | Writes | — |
+| `ProjectInitializer.init_project()` | `agent_actions.yml` | Writes | `project_name`, `default_agent_config`, `schema_path`, `tool_path`, `seed_data_path` |
+| `ProjectInitializer.init_project()` | `agent_workflow/`, `prompt_store/`, `schema/`, `templates/`, `tools/`, `seed_data/` | Writes | — |
+| `ProjectPathsFactory.create_project_paths()` | `agent_actions.yml`, `{workflow}/agent_config/`, `{workflow}/agent_io/` | Reads | — |
+| `find_config_file()` | `agent_config/{workflow}/{workflow}.yml` | Reads | — |
+
+**Internal only**: `defaults.py` constants, `types.py` type definitions, `interfaces.py` abstract bases, `factory.py` DI wiring -- no direct project file surface.
+
+**Examples** -- see this module in action:
+- [`examples/book_catalog_enrichment/agent_actions.yml`](../../examples/book_catalog_enrichment/agent_actions.yml) -- project config read by `load_project_config()`, keys: `schema_path`, `tool_path`, `seed_data_path`, `default_agent_config`
+- [`examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml`](../../examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml) -- workflow config parsed by `ConfigManager` and validated by `WorkflowConfig`; exercises `defaults`, `actions[].schema`, `actions[].guard`, `actions[].reprompt`, `actions[].versions`, `actions[].kind`, `actions[].impl`, `actions[].context_scope`
+- [`examples/incident_triage/agent_actions.yml`](../../examples/incident_triage/agent_actions.yml) -- project config with `seed_data_path` read by `get_seed_data_path()`
+- [`examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) -- workflow with `actions[].guard.condition` (SEV1/SEV2 filter), `actions[].versions` (parallel severity classifiers), `actions[].version_consumption`
+- [`examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) -- workflow with `defaults.data_source`, multi-vendor model selection, guard pre-check gates, version consumption with merge pattern
+- [`examples/book_catalog_enrichment/.env.example`](../../examples/book_catalog_enrichment/.env.example) -- `.env` file loaded by `EnvironmentConfig` via `ConfigManager._resolve_dotenv()`

--- a/agent_actions/errors/_MANIFEST.md
+++ b/agent_actions/errors/_MANIFEST.md
@@ -60,3 +60,38 @@
 | `PromptValidationError` | Class | Raised when prompt validation fails. | - |
 | `DataValidationError` | Class | Raised when data validation fails. | - |
 | `SchemaValidationError` | Class | Raised when schema validation fails. | - |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+The `errors` module has **zero direct project file surface**. It does not read, write, validate, or transform any user project files. It defines the exception hierarchy used by every other module.
+
+However, several error classes carry project-file context in their `context` dict, making them the user-visible surface when something goes wrong:
+
+| Symbol | Triggered By | User File Context |
+|--------|-------------|-------------------|
+| `ConfigurationError` | Invalid workflow YAML | `agent_config/{workflow}/{workflow}.yml` |
+| `ConfigValidationError` | Schema/key validation failure | `agent_actions.yml`, `agent_config/{workflow}/{workflow}.yml` |
+| `ProjectNotFoundError` | Missing `agent_actions.yml` | `agent_actions.yml` |
+| `AgentNotFoundError` | Missing agent config directory | `agent_config/{workflow}/` |
+| `FileLoadError` | Cannot read a config/schema/prompt file | `agent_config/{workflow}/{workflow}.yml`, `schema/{workflow}/{action}.yml`, `prompt_store/{workflow}.md` |
+| `FileWriteError` | Cannot write to output directory | `agent_io/target/{action}/` |
+| `SchemaValidationError` | LLM output mismatches schema | `schema/{workflow}/{action}.yml` |
+| `TemplateRenderingError` | Jinja2 template error in config | `templates/`, `agent_config/{workflow}/{workflow}.yml` |
+| `TemplateVariableError` | Undefined variable in prompt template | `prompt_store/{workflow}.md` |
+| `DuplicateFunctionError` | Duplicate `@udf_tool` names | `tools/{workflow}/` |
+| `FunctionNotFoundError` | `impl` reference not found | `tools/{workflow}/`, `agent_config/{workflow}/{workflow}.yml` (`actions[].impl`) |
+| `UDFLoadError` | Python import error in tool file | `tools/{workflow}/` |
+| `PreFlightValidationError` | Pre-run checks fail | `agent_config/{workflow}/{workflow}.yml`, `.env` |
+| `VendorConfigError` | Invalid vendor/API key config | `.env`, `agent_config/{workflow}/{workflow}.yml` (`actions[].api_key`, `actions[].model_vendor`) |
+| `EmptyOutputError` | Action produces no output | `agent_config/{workflow}/{workflow}.yml` (`actions[].on_empty`) |
+
+**Consumed by**: `config`, `validation`, `workflow`, `processing`, `cli`, `prompt`, `input`, `output`, `storage`, `llm` -- every module in the framework imports from `errors`.
+
+**Examples** -- see these errors in action:
+- [`examples/book_catalog_enrichment/agent_actions.yml`](../../examples/book_catalog_enrichment/agent_actions.yml) -- `ProjectNotFoundError` raised if this file is missing; `ConfigValidationError` raised if YAML is malformed or `schema_path` is absent
+- [`examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml`](../../examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml) -- `ConfigurationError` raised if workflow validation fails (duplicate actions, dangling deps, circular deps); `TemplateRenderingError` if Jinja2 template rendering fails
+- [`examples/book_catalog_enrichment/tools/book_catalog_enrichment/format_catalog_entry.py`](../../examples/book_catalog_enrichment/tools/book_catalog_enrichment/format_catalog_entry.py) -- `DuplicateFunctionError` if `@udf_tool` name collides; `FunctionNotFoundError` if `impl: format_catalog_entry` cannot resolve
+- [`examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) -- `VendorConfigError` surfaced during preflight if `GROQ_API_KEY` is missing; `ConfigurationError` if version config is invalid
+- [`examples/review_analyzer/schema/review_analyzer/score_quality.yml`](../../examples/review_analyzer/schema/review_analyzer/score_quality.yml) -- `SchemaValidationError` raised at runtime if LLM output does not match this schema's `properties`/`required` fields

--- a/agent_actions/validation/_MANIFEST.md
+++ b/agent_actions/validation/_MANIFEST.md
@@ -33,3 +33,32 @@ decoders to schema validators and preflight checks.
 | `schema_validator.py` | Module | `SchemaValidator`: validates schema files against JSON Schema meta-schema. Fires a single `ValidationStartEvent` via the base class `_prepare_validation()`; the redundant `DataValidationStartedEvent` at the top of `validate()` has been removed. | `validation` |
 | `status_validator.py` | Module | `StatusCommandArgs` definition. | `validation` |
 | `validate_udfs.py` | Module | Validates that UDFs referenced in configs exist. | `utils.udf_management`, `validation` |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `ConfigValidator.validate()` | `agent_config/{workflow}/{workflow}.yml` | Validates | `actions[]` entries, `dependencies`, `is_operational` |
+| `ConfigValidator._check_agent_name_unique_logic()` | `agent_config/{workflow}/{workflow}.yml` | Validates | file stem must match workflow name |
+| `SchemaValidator.validate()` | `schema/{workflow}/{action}.yml` | Validates | JSON Schema structure, meta-schema compliance |
+| `SchemaValidator._process_schema_file()` | `schema/{workflow}/{action}.yml` | Reads | `type`, `properties`, `required`, `fields` |
+| `validate_output_against_schema()` | `schema/{workflow}/{action}.yml` | Validates | LLM output checked against schema `properties`, `required`, `fields` |
+| `PromptValidator.validate()` | `prompt_store/{workflow}.md` | Validates | prompt ID uniqueness, block structure, file size |
+| `PathValidator.validate()` | `{workflow}/agent_config/`, `{workflow}/agent_io/` | Validates | directory existence, readability, writability |
+| `ValidateUDFsCommand.validate()` | `agent_config/{workflow}/{workflow}.yml` | Reads | `actions[].impl` references |
+| `ValidateUDFsCommand.validate()` | `tools/{workflow}/` | Validates | UDF `@udf_tool` functions match `impl` references |
+| `RunCommandArgs` | — | Validates | CLI `--agent`, `--user-code`, `--execution-mode` arguments |
+| `BaseValidator._prepare_validation()` | — | — | fires `ValidationStartEvent`/`ValidationCompleteEvent` for all validators |
+
+**Internal only**: `base_validator.py` (base class), `batch_validator.py` / `clean_validator.py` / `init_validator.py` / `render_validator.py` / `status_validator.py` (CLI argument models), `prompt_ast.py` (Jinja2 AST internals) -- consumed by other validators or CLI, no direct project file surface.
+
+**Examples** -- see this module in action:
+- [`examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml`](../../examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml) -- validated by `ConfigValidator`; exercises action entry validation, dependency checks, circular dependency detection
+- [`examples/book_catalog_enrichment/schema/book_catalog_enrichment/review_classification.yml`](../../examples/book_catalog_enrichment/schema/book_catalog_enrichment/review_classification.yml) -- fields-format schema validated by `SchemaValidator._is_fields_format()`; also exercised by `validate_output_against_schema()` at runtime
+- [`examples/book_catalog_enrichment/prompt_store/book_catalog_enrichment.md`](../../examples/book_catalog_enrichment/prompt_store/book_catalog_enrichment.md) -- prompt file validated by `PromptValidator` for ID uniqueness and block structure
+- [`examples/book_catalog_enrichment/tools/book_catalog_enrichment/format_catalog_entry.py`](../../examples/book_catalog_enrichment/tools/book_catalog_enrichment/format_catalog_entry.py) -- UDF tool discovered by `ValidateUDFsCommand`, matched against `actions[].impl` in workflow config
+- [`examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) -- `ConfigValidator` validates guard expressions (`actions[].guard.condition`), version config, and cross-action dependency graph
+- [`examples/incident_triage/schema/incident_triage/classify_severity.yml`](../../examples/incident_triage/schema/incident_triage/classify_severity.yml) -- schema validated by `SchemaValidator` for JSON Schema correctness
+- [`examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) -- exercises `ConfigValidator` with guard conditions (`consensus_score >= 6`), version consumption, and multi-vendor model selection


### PR DESCRIPTION
## Summary
- Append `## Project Surface` sections to `config`, `validation`, and `errors` module manifests
- Maps exported symbols to user project files (reads, writes, validates, transforms) with specific YAML config keys
- Links to real example files for navigation

## Verification
- All table paths are generic (`agent_config/{workflow}.yml`, not example-specific)
- Example links use correct relative paths, verified clickable
- No existing manifest content modified