### PR TITLE
docs: add Project Surface to input, output, storage manifests

### DIFF
--- a/agent_actions/input/_MANIFEST.md
+++ b/agent_actions/input/_MANIFEST.md
@@ -13,3 +13,38 @@ and chunking/lineage support).
 | [context](context/_MANIFEST.md) | Context normalization, historical node retrieval, and context_scope expansion helpers. |
 | [loaders](loaders/_MANIFEST.md) | File loaders for JSON/XML/text/tabular/UDF discovery and asynchronous base classes. |
 | [preprocessing](preprocessing/_MANIFEST.md) | Chunking, filter parsing, field resolution, stage bootstrapping, and transformation helper packages. |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `resolve_start_node_data_source()` | `agent_io/staging/` | Reads | `data_source` |
+| `resolve_start_node_data_source()` | `{local_folder}/` | Reads | `data_source.folder` |
+| `FileReader.read()` | `agent_io/staging/*.json` | Reads | — |
+| `FileReader.read()` | `agent_io/staging/*.csv` | Reads | — |
+| `FileReader.read()` | `agent_io/staging/*.xml` | Reads | — |
+| `FileReader.read()` | `agent_io/staging/*.pdf` | Reads | — |
+| `FileReader.read()` | `agent_io/staging/*.docx` | Reads | — |
+| `FileReader.read()` | `agent_io/staging/*.xlsx` | Reads | — |
+| `JsonLoader.process()` | `agent_io/staging/*.json` | Reads | — |
+| `TabularLoader.process()` | `agent_io/staging/*.csv` | Reads | — |
+| `XmlLoader.process()` | `agent_io/staging/*.xml` | Reads | — |
+| `SourceDataLoader.load_source_data()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `SourceDataLoader.save_source_data()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `discover_udfs()` | `user_code/**/*.py` | Reads | — |
+| `validate_udf_references()` | `agent_config/{workflow}.yml` | Validates | `impl` |
+| `normalize_all_agent_configs()` | `agent_config/{workflow}.yml` | Transforms | `context_scope` |
+| `HistoricalNodeDataLoader.load_historical_node_data()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `process_initial_stage()` | `agent_io/staging/*` | Reads | `run_mode`, `record_limit` |
+| `Tokenizer.split_text_content()` | `agent_io/staging/*.txt` | Transforms | `chunk_config.chunk_size`, `chunk_config.overlap` |
+| `GuardFilter.evaluate()` | `agent_config/{workflow}.yml` | Validates | `where_clause` |
+| `GuardEvaluator.evaluate()` | `agent_config/{workflow}.yml` | Validates | `guards` |
+
+**Internal only**: `ContextPreprocessor.extract_guid_and_content()` — extracts metadata from inter-node context payloads, no direct project file surface. `_expand_list_directive()` — internal helper for `normalize_context_scope()`.
+
+**Examples** — see this module in action:
+- [`examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_io/staging/`](../../examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_io/staging/) — staging input files read by `FileReader` and loaders
+- [`examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_io/staging/`](../../examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_io/staging/) — staging directory resolved by `resolve_start_node_data_source()`
+- [`examples/support_resolution/agent_workflow/support_resolution/agent_io/staging/`](../../examples/support_resolution/agent_workflow/support_resolution/agent_io/staging/) — staging input files demonstrating multi-format loading

--- a/agent_actions/output/_MANIFEST.md
+++ b/agent_actions/output/_MANIFEST.md
@@ -52,3 +52,29 @@ When `output_directory` is provided, `write_target()` computes the relative path
 - Stored as: `subdir/file.json` (not just `file.json`)
 
 This prevents file collisions when multiple files share the same name but live in different subdirectories.
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `FileWriter.write_staging()` | `agent_io/staging/*.json` | Writes | — |
+| `FileWriter.write_staging()` | `agent_io/staging/*.txt` | Writes | — |
+| `FileWriter.write_staging()` | `agent_io/staging/*.csv` | Writes | — |
+| `FileWriter.write_target()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `FileWriter.write_source()` | `agent_io/source/*.json` | Writes | — |
+| `UnifiedSourceDataSaver.save_source_items()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `SchemaLoader.discover_schema_files()` | `schema/{workflow}/*.yml` | Reads | `schema_path` |
+| `SchemaLoader.load_schema()` | `schema/{workflow}/{schema_name}.yml` | Reads | `schema_name` |
+| `ResponseSchemaCompiler.compile()` | `schema/{workflow}/{schema_name}.yml` | Reads | `schema_name`, `schema` |
+| `ActionExpander.expand()` | `agent_config/{workflow}.yml` | Transforms | `kind`, `model_vendor`, `schema_name`, `context_scope` |
+| `inherit_simple_fields()` | `agent_config/{workflow}.yml` | Reads | all keys in `SIMPLE_CONFIG_FIELDS` |
+| `ResponseBuilder.build()` | `agent_io/target/{action}/*.json` | Transforms | `output_field` |
+
+**Internal only**: `_convert_json_schema_to_unified()`, `compile_field()`, `compile_unified_schema()` — internal schema conversion with no direct project file surface. `_inject_functions_into_schema()`, `_resolve_dispatch_in_schema()` — dispatch resolution internals.
+
+**Examples** — see this module in action:
+- [`examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_io/target/`](../../examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_io/target/) — target output directory written by `FileWriter.write_target()`
+- [`examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/schema/`](../../examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/schema/) — response schemas loaded by `SchemaLoader`
+- [`examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_io/source/`](../../examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_io/source/) — source data persisted by `UnifiedSourceDataSaver`

--- a/agent_actions/storage/_MANIFEST.md
+++ b/agent_actions/storage/_MANIFEST.md
@@ -35,3 +35,30 @@ backends (S3, DuckDB, etc.). One database per workflow stored at
 - **input/context/historical.py**: Queries backend for historical node data lookups
 - **prompt/context/scope.py**: Passes `output_directory` for backend data resolution
 - **processing/processor.py**: Threads `output_directory` through prompt preparation
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `get_storage_backend()` | `agent_io/target/{workflow}.db` | Writes | `storage_backend` |
+| `SQLiteBackend.initialize()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `SQLiteBackend.write_target()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `SQLiteBackend.read_target()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `SQLiteBackend.write_source()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `SQLiteBackend.read_source()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `SQLiteBackend.list_target_files()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `SQLiteBackend.list_source_files()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `SQLiteBackend.set_disposition()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `SQLiteBackend.get_disposition()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `SQLiteBackend.delete_target()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `SQLiteBackend.preview_target()` | `agent_io/target/{workflow}.db` | Reads | — |
+| `SQLiteBackend.get_storage_stats()` | `agent_io/target/{workflow}.db` | Reads | — |
+
+**Internal only**: `StorageBackend` (ABC) — abstract interface, no direct file interaction. `Disposition` enum, `VALID_DISPOSITIONS`, `NODE_LEVEL_RECORD_ID` — constants consumed by workflow/processing modules, no project file surface. `SQLiteBackend._validate_identifier()` — internal security helper.
+
+**Examples** — see this module in action:
+- [`examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_io/target/`](../../examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_io/target/) — target directory containing `{workflow}.db` created by `get_storage_backend()`
+- [`examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_io/target/`](../../examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_io/target/) — SQLite database storing source/target data and disposition records
+- [`examples/support_resolution/agent_workflow/support_resolution/agent_io/target/`](../../examples/support_resolution/agent_workflow/support_resolution/agent_io/target/) — multi-action workflow demonstrating `list_target_files()` for dependency resolution


### PR DESCRIPTION
## Summary
- Append `## Project Surface` sections to `input`, `output`, and `storage` module manifests
- Maps exported symbols to user project files (reads, writes, validates, transforms) with specific YAML config keys
- Links to real example files for navigation

## Verification
- All table paths are generic, not example-specific
- Example links use correct relative paths
- No existing manifest content modified