### PR TITLE
docs: add Project Surface to prompt, llm, processing manifests

### DIFF
--- a/agent_actions/llm/_MANIFEST.md
+++ b/agent_actions/llm/_MANIFEST.md
@@ -14,3 +14,30 @@ Cohere, etc.).
 | [config](config/_MANIFEST.md) | Shared vendor configuration utilities. |
 | [providers](providers/_MANIFEST.md) | Provider-specific clients, failure injection, usage tracking, and tooling. |
 | [realtime](realtime/_MANIFEST.md) | Online runner utilities, context handlers, and invocation services. |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `ClientInvocationService.invoke_client()` | — | Reads | `actions[].model_vendor`, `actions[].model_name` |
+| `AgentManager.get_agent_paths()` | `agent_config/{workflow}.yml` | Reads | — |
+| `AgentManager.get_agent_paths()` | `agent_io/` | Reads | — |
+| `BatchSubmissionService` | `agent_io/target/{action}/batch/.batch_registry.json` | Reads/Writes | — |
+| `BatchRetrievalService` | `agent_io/target/{action}/batch/` | Reads | — |
+| `BatchRegistryManager` | `agent_io/target/{action}/batch/.batch_registry.json` | Reads/Writes | — |
+| `extract_generation_params()` | — | Reads | `actions[].temperature`, `actions[].max_tokens`, `actions[].top_p` |
+| `VendorType` | — | Validates | `actions[].model_vendor` |
+| `ToolClient` | `tools/{workflow}/{tool}.py` | Reads | `actions[].impl`, `tool_path` |
+| `batch_cli.status()` | `agent_io/target/{action}/batch/` | Reads | — |
+| `batch_cli.retrieve()` | `agent_io/target/{action}/batch/` | Reads | — |
+| `AgentManager.clean_directory()` | `agent_io/target/{action}/` | Writes | — |
+
+**Internal only**: `_resolve_client()`, `CLIENT_REGISTRY`, `PROVIDER_MESSAGE_CONFIGS`, `_VENDOR_PACKAGES`, `PromptService.debug_print_prompt()`, `BaseVendorConfig` and per-vendor config classes, `error_wrapper`, `failure_injection`, `usage_tracker`, `mixins` — no direct project surface.
+
+**Examples** — see this module in action:
+- [`examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) — multi-vendor workflow using `groq`, `openai`, `ollama`, and `anthropic` providers with per-action `model_vendor` / `model_name` / `api_key` overrides
+- [`examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py`](../../examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py) — tool implementation invoked by `ToolClient` via `kind: tool` + `impl:` config
+- [`examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml`](../../examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml) — workflow with tool actions using FILE granularity (map-reduce pattern)
+- [`examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) — workflow demonstrating `reprompt` config with `validation` and `max_attempts` keys consumed by the online invocation path

--- a/agent_actions/processing/_MANIFEST.md
+++ b/agent_actions/processing/_MANIFEST.md
@@ -26,3 +26,29 @@ lineage helpers, recovery flows, and transformation pipelines.
 | `prepared_task.py` | Module | `GuardStatus` enum (PASSED, SKIPPED, FILTERED, UPSTREAM_UNPROCESSED), `PreparedTask` dataclass, and `PreparationContext` (carries `mode: RunMode` directly). | `typing` |
 | `task_preparer.py` | Module | Unified task preparation (normalize, prompt, guard) for batch/online. Short-circuits upstream-unprocessed records before context loading. | `input`, `prompt` |
 | `types.py` | Module | `ProcessingStatus` enum (SUCCESS, SKIPPED, FILTERED, FAILED, EXHAUSTED, DEFERRED, UNPROCESSED), `ProcessingResult` factories, and `ProcessingContext` (uses `RunMode` for mode). | `typing` |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `RecordProcessor.__init__()` | — | Reads | `actions[].granularity`, `actions[].kind` |
+| `RecordProcessor.process()` | `agent_io/target/{action}/` | Transforms | — |
+| `TaskPreparer.prepare()` | — | Reads | `actions[].guard`, `actions[].conditional_clause` |
+| `TaskPreparer._render_prompt()` | `prompt_store/{workflow}.md` | Reads | `actions[].prompt` |
+| `ResultCollector.collect()` | `agent_io/target/{action}/` | Writes | — |
+| `EnrichmentPipeline.enrich()` | `agent_io/target/{action}/` | Transforms | — |
+| `OnlineStrategy.invoke()` | — | Transforms | `actions[].retry`, `actions[].reprompt` |
+| `BatchContextAdapter.to_processing_context()` | — | Reads | `actions[].agent_type` |
+| `UdfValidator.__init__()` | `tools/shared/reprompt_validations.py` | Reads | `actions[].reprompt.validation` |
+| `ResponseValidator.validate()` | — | Validates | `actions[].reprompt.validation` |
+| `ExhaustedRecordBuilder` | `agent_io/target/{action}/` | Writes | `actions[].retry.max_attempts` |
+
+**Internal only**: `ProcessingStatus`, `ProcessingResult`, `ProcessingContext`, `PreparedTask`, `GuardStatus`, `PreparationContext`, `RecoveryMetadata`, `RetryMetadata`, `RepromptMetadata`, `RetryState`, `InvocationResult`, `InvocationStrategy`, `InvocationStrategyFactory`, `BatchProvider`, `LineageEnricher`, `MetadataEnricher`, `VersionIdEnricher`, `PassthroughEnricher`, `RequiredFieldsEnricher`, `RecoveryEnricher`, `helpers`, `error_handling` — no direct project surface.
+
+**Examples** — see this module in action:
+- [`examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) — workflow using `retry` with `max_attempts`, `reprompt` with `validation` and `on_exhausted`, guards with `condition` / `on_false`, and `granularity: Record`
+- [`examples/review_analyzer/tools/shared/reprompt_validations.py`](../../examples/review_analyzer/tools/shared/reprompt_validations.py) — `@reprompt_validation` UDF loaded by `UdfValidator` at runtime for response validation
+- [`examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml`](../../examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml) — FILE granularity tool actions demonstrating the map-reduce processing pattern with `version_consumption`
+- [`examples/incident_triage/tools/shared/reprompt_validations.py`](../../examples/incident_triage/tools/shared/reprompt_validations.py) — shared reprompt validation UDF used across multiple actions in the triage workflow

--- a/agent_actions/prompt/_MANIFEST.md
+++ b/agent_actions/prompt/_MANIFEST.md
@@ -23,3 +23,38 @@ and service wiring used by CLI commands and runtime agents.
 | `renderer.py` | Module | `JinjaTemplateRenderer` for Jinja rendering, `ConfigRenderingService` for config loading. | `cli`, `validation` |
 | `message_builder.py` | Module | `MessageBuilder` — unified message assembly for all LLM providers. `LLMMessageEnvelope`, `ProviderMessageConfig`, `PROVIDER_MESSAGE_CONFIGS` registry. | `llm`, `prompt_generation` |
 | `service.py` | Module | `PromptService` used by CLI/tests for retrieving prompt definitions. | `logging`, `prompt_generation` |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `PromptLoader.discover_prompt_files()` | `prompt_store/{workflow}.md` | Reads | — |
+| `PromptLoader.load_prompt()` | `prompt_store/{workflow}.md` | Reads | `actions[].prompt` (`$file.block` syntax) |
+| `PromptLoader.validate_prompt_blocks()` | `prompt_store/{workflow}.md` | Validates | — |
+| `PromptLoader.validate_unique_prompts()` | `prompt_store/{workflow}.md` | Validates | — |
+| `render_pipeline_with_templates()` | `agent_config/{workflow}.yml` | Reads | — |
+| `render_pipeline_with_templates()` | `templates/*.j2` | Reads | — |
+| `_resolve_prompt_fields()` | `prompt_store/{workflow}.md` | Reads | `actions[].prompt` |
+| `_compile_action_schemas()` | `schema/{workflow}/{action}.yml` | Reads | `actions[].schema`, `actions[].schema_name` |
+| `_save_failed_render()` | `.agent-actions/cache/rendered_workflows/{workflow}_failed.yml` | Writes | — |
+| `JinjaTemplateRenderer.render()` | `agent_config/{workflow}.yml` | Reads | — |
+| `ConfigRenderingService.render_and_load_config()` | `agent_config/{workflow}.yml` | Reads | — |
+| `ConfigRenderingService.render_and_load_config()` | `schema/{workflow}/` | Validates | `schema_path` |
+| `PromptFormatter.get_raw_prompt()` | `prompt_store/{workflow}.md` | Reads | `actions[].prompt` |
+| `PromptPreparationService._load_seed_data()` | `seed_data/{file}.json` | Reads | `context_scope.seed_path` |
+| `PromptPreparationService._render_prompt_template()` | `prompt_store/{workflow}.md` | Transforms | `actions[].prompt` |
+| `PromptUtils.inject_function_outputs_into_prompt()` | `tools/{workflow}/{tool}.py` | Reads | `tool_path` |
+| `StaticDataLoader.load_static_data()` | `seed_data/{file}.{json,yml,csv,md,txt}` | Reads | `context_scope.seed_path` |
+| `MessageBuilder.build()` | — | Transforms | `actions[].model_vendor` |
+
+**Internal only**: `_apply_version_template()`, `_expand_versioned_action()`, `_expand_workflow_versions()`, `_expand_inline_schema()`, `_is_inline_schema_dict()`, `PromptUtils.parse_field_references()`, `PromptUtils.resolve_field_reference()`, `PromptUtils.replace_field_references()`, `LLMContextBuilder`, `PromptPreparationRequest`, `PromptPreparationResult` — no direct project surface.
+
+**Examples** — see this module in action:
+- [`examples/review_analyzer/prompt_store/review_analyzer.md`](../../examples/review_analyzer/prompt_store/review_analyzer.md) — prompt template with multiple `{prompt}` / `{end_prompt}` blocks, Jinja2 variables (`{{ source.* }}`, `{{ seed.* }}`), and version-aware conditionals (`{{ version.first }}`)
+- [`examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) — workflow config using `$review_analyzer.Block` prompt references, `context_scope.seed_path`, `context_scope.observe/drop/passthrough`, and named schema references
+- [`examples/review_analyzer/agent_workflow/review_analyzer/seed_data/evaluation_rubric.json`](../../examples/review_analyzer/agent_workflow/review_analyzer/seed_data/evaluation_rubric.json) — seed data file loaded by `StaticDataLoader` via `context_scope.seed_path`
+- [`examples/review_analyzer/schema/review_analyzer/extract_claims.yml`](../../examples/review_analyzer/schema/review_analyzer/extract_claims.yml) — YAML schema compiled inline by `_compile_action_schemas()`
+- [`examples/contract_reviewer/prompt_store/contract_reviewer.md`](../../examples/contract_reviewer/prompt_store/contract_reviewer.md) — prompt template for a map-reduce workflow pattern
+- [`examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) — workflow with multiple `seed_path` entries and per-action prompt references


### PR DESCRIPTION
## Summary
- Append `## Project Surface` sections to `prompt`, `llm`, and `processing` module manifests
- Maps exported symbols to user project files (reads, writes, validates, transforms) with specific YAML config keys
- Links to real example files for navigation

## Verification
- All table paths are generic, not example-specific
- Example links use correct relative paths
- No existing manifest content modified