### PR TITLE
docs: add Project Surface to workflow, guards, skills manifests

### DIFF
--- a/agent_actions/guards/_MANIFEST.md
+++ b/agent_actions/guards/_MANIFEST.md
@@ -26,3 +26,23 @@ Only depends on `errors` and `utils.constants` (leaf packages).
 The original modules under `output/response/` are now re-export shims pointing here:
 - `output/response/guard_parser.py` → `guards.guard_parser`
 - `output/response/consolidated_guard.py` → `guards.consolidated_guard`
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `GuardParser.parse()` | `agent_config/{workflow}.yml` | Validates | `actions[].guard.condition` |
+| `parse_guard_config()` | `agent_config/{workflow}.yml` | Validates | `actions[].guard` |
+| `GuardConfig.from_dict()` | `agent_config/{workflow}.yml` | Reads | `actions[].guard.condition`, `actions[].guard.on_false` |
+| `GuardBehavior` | `agent_config/{workflow}.yml` | Validates | `actions[].guard.on_false` |
+| `GuardParser._validate_sql_expression()` | `agent_config/{workflow}.yml` | Validates | `actions[].guard.condition` (SQL expressions) |
+| `GuardParser._validate_udf_expression()` | `tools/{workflow}/*.py` | Validates | `actions[].guard.condition` (UDF references via `udf:module.function`) |
+
+**Internal only**: `GuardExpression.__init__()`, `GuardConfig.__repr__()` — no direct project surface.
+
+**Examples** — see this module in action:
+- [`examples/incident_triage/.../incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) — SQL guard on `final_severity` for conditional executive escalation (`guard.condition: 'final_severity == "SEV1" or final_severity == "SEV2"'`, `on_false: "filter"`)
+- [`examples/review_analyzer/.../review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) — numeric threshold guard gating two parallel branches (`guard.condition: 'consensus_score >= 6'`, `on_false: "filter"`)
+- [`examples/contract_reviewer/.../contract_reviewer.yml`](../../examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml) — string equality guard for risk-level filtering (`guard.condition: 'risk_level == "high"'`, `on_false: "filter"`)

--- a/agent_actions/skills/_MANIFEST.md
+++ b/agent_actions/skills/_MANIFEST.md
@@ -10,3 +10,25 @@ per provider (Claude/Codex). This package ships the `agent-actions-workflow` ski
 | Sub-Module | Description |
 |------------|-------------|
 | [agent-actions-workflow](agent-actions-workflow/scripts/_MANIFEST.md) | Scripts that help analyze field flow, generate TypedDicts, and initialize workflows. |
+
+## Project Surface
+
+> How this module interacts with the user's project files. The skills package is a **content-only** module (no Python source) that ships templates, reference docs, and a SKILL.md descriptor. It produces user project files via template instantiation; it does not read or validate them at runtime.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `workflow.yml.template` | `agent_config/{workflow}.yml` | Writes (scaffolds) | `name`, `defaults`, `actions` |
+| `udf_tool.py.template` | `tools/{workflow}/{tool_name}.py` | Writes (scaffolds) | — |
+| `SKILL.md` | `agent_config/{workflow}.yml` | Reads (instructs AI to read workflow before editing) | — |
+| `SKILL.md` | `agent_io/target/{action}/` | Reads (instructs AI to inspect action output) | — |
+| `SKILL.md` | `prompt_store/{workflow}.md` | Writes (instructs AI to create prompt templates) | — |
+| `SKILL.md` | `schema/` | Writes (instructs AI to create schema files) | — |
+
+**Internal only**: `references/*.md` — reference documentation for AI consumption; no direct file I/O.
+
+**Examples** — see this module in action:
+- [`examples/incident_triage/.../incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) — production workflow following the structure defined by `workflow.yml.template`
+- [`examples/incident_triage/tools/incident_triage/aggregate_severity_votes.py`](../../examples/incident_triage/tools/incident_triage/aggregate_severity_votes.py) — UDF tool following the `@udf_tool()` pattern from `udf_tool.py.template`
+- [`examples/incident_triage/prompt_store/incident_triage.md`](../../examples/incident_triage/prompt_store/incident_triage.md) — prompt store following the `{prompt Name}...{end_prompt}` pattern described in SKILL.md
+- [`examples/contract_reviewer/tools/contract_reviewer/split_contract_by_clause.py`](../../examples/contract_reviewer/tools/contract_reviewer/split_contract_by_clause.py) — map-step UDF showing the content-wrapper + list-return pattern from the template
+- [`examples/review_analyzer/.../review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) — multi-vendor workflow demonstrating advanced patterns (versions, guards, seed_data) covered in SKILL.md references

--- a/agent_actions/workflow/_MANIFEST.md
+++ b/agent_actions/workflow/_MANIFEST.md
@@ -45,3 +45,33 @@ This intentionally overrides `on_exhausted="return_last"` when ALL records exhau
 tombstones. When zero records succeed, tombstone-only output is not useful and downstream
 actions would produce garbage. `_check_exhausted_raise` in `ResultCollector` handles
 `on_exhausted="raise"` independently (runs before collection).
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `load_workflow_configs()` | `agent_config/{workflow}.yml` | Reads | `name`, `actions`, `defaults` |
+| `load_workflow_configs()` | `agent_config/{workflow}.yml` | Validates | `actions[].dependencies`, `actions[].context_scope` |
+| `discover_workflow_udfs()` | `tools/{workflow}/*.py` | Reads | `defaults.tool_path` |
+| `AgentWorkflow.__init__()` | `agent_io/target/{workflow}.db` | Writes | — |
+| `AgentWorkflow.run()` | `agent_io/target/{action}/` | Writes | `actions[].name` |
+| `AgentWorkflow.run()` | `agent_io/staging/` | Reads | `defaults.data_source` |
+| `AgentWorkflow._run_static_validation()` | `agent_config/{workflow}.yml` | Validates | `actions[].schema`, `actions[].context_scope` |
+| `ActionRunner.setup_directories()` | `agent_io/target/{action}/` | Writes | `actions[].name` |
+| `ActionRunner._resolve_start_node_directories()` | `agent_io/staging/` | Reads | `defaults.data_source` |
+| `ActionRunner._resolve_dependency_directories()` | `agent_io/target/{dependency}/` | Reads | `actions[].dependencies` |
+| `WorkflowSchemaService.validate()` | `schema/{workflow}/{schema_name}.yml` | Reads | `actions[].schema` |
+| `WorkspaceIndex.scan_workspace()` | `agent_config/{workflow}.yml` | Reads | `actions[].dependencies[*].workflow` |
+| `ActionExecutor.execute_action_sync()` | `agent_io/target/{action}/` | Writes | `actions[].name` |
+| `ActionStateManager` | `agent_io/.agent_status.json` | Writes | — |
+
+**Internal only**: `_run_config_stage()`, `_strip_unreachable_drops()`, `_get_reachable_actions()`, `_generate_workflow_session_id()` — no direct project surface.
+
+**Examples** — see this module in action:
+- [`examples/incident_triage/.../incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) — workflow with parallel versioned classifiers, fan-in aggregation, guard-based conditional escalation, and seed data injection
+- [`examples/review_analyzer/.../review_analyzer.yml`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml) — multi-vendor model selection, parallel consensus scoring with version_consumption merge, and pre-check quality gates
+- [`examples/contract_reviewer/.../contract_reviewer.yml`](../../examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml) — map-reduce pattern with FILE granularity aggregation, guard-based deep analysis for high-risk clauses
+- [`examples/incident_triage/tools/incident_triage/aggregate_severity_votes.py`](../../examples/incident_triage/tools/incident_triage/aggregate_severity_votes.py) — UDF tool discovered by `discover_workflow_udfs()` at startup
+- [`examples/incident_triage/.../seed_data/team_roster.json`](../../examples/incident_triage/agent_workflow/incident_triage/seed_data/team_roster.json) — seed data loaded via `defaults.context_scope.seed_path`


### PR DESCRIPTION
## Summary
- Append `## Project Surface` sections to `workflow`, `guards`, and `skills` module manifests
- Maps exported symbols to user project files (reads, writes, validates, transforms) with specific YAML config keys
- Links to real example files for navigation

## Verification
- All table paths are generic, not example-specific
- Example links use correct relative paths
- No existing manifest content modified