### PR TITLE
docs: add Project Surface to cli, logging, models manifests

### DIFF
--- a/agent_actions/cli/_MANIFEST.md
+++ b/agent_actions/cli/_MANIFEST.md
@@ -84,3 +84,40 @@
 | `PreviewCommand` | Class | Implementation of the preview command. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the preview command. | - |
 | `preview` | Function | Preview data stored in the SQLite storage backend. | - |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `main_entrypoint()` | `.env` | Reads | — |
+| `requires_project()` | `agent_actions.yml` | Reads | — |
+| `RunCommand.execute()` | `agent_config/{workflow}.yml` | Reads | — |
+| `RunCommand.execute()` | `agent_io/staging/*.json` | Reads | `defaults.data_source` |
+| `RunCommand.execute()` | `agent_io/target/` | Writes | — |
+| `RunCommand.execute()` | `prompt_store/{workflow}.md` | Reads | `actions[].prompt` |
+| `RunCommand.execute()` | `templates/` | Reads | — |
+| `RenderCommand.execute()` | `agent_config/{workflow}.yml` | Reads | — |
+| `RenderCommand.execute()` | `templates/` | Reads | — |
+| `InitCommand.execute()` | `agent_actions.yml` | Writes | `project_name` |
+| `InitCommand.execute()` | `agent_config/`, `agent_io/`, `prompt_store/` | Writes | — |
+| `init_example()` | `agent_actions.yml` | Writes | `project_name` |
+| `StatusCommand.execute()` | `agent_io/.agent_status.json` | Reads | — |
+| `SchemaCommand.execute()` | `agent_config/{workflow}.yml` | Reads | — |
+| `SchemaCommand.execute()` | `schema/{workflow}/*.yml` | Reads | `schema_path` |
+| `PreviewCommand.execute()` | `agent_io/target/{workflow}.db` | Reads | `output_storage.backend` |
+| `ListUDFsCommand.execute()` | `tools/{workflow}/*.py` | Reads | `tool_path` |
+| `clean_cli()` | `agent_io/source/`, `agent_io/target/` | Writes | — |
+| `skills install` | `.claude/skills/`, `.codex/skills/` | Writes | — |
+| `docs()` | `artefact/catalog.json`, `artefact/runs.json` | Writes | — |
+
+**Internal only**: `handles_user_errors()`, `_LazyCLI`, `CLI._configure_logging()`, `CLI._register_signal_handlers()` — no direct project surface.
+
+**Examples** — see this module in action:
+- [`examples/support_resolution/agent_actions.yml`](../../examples/support_resolution/agent_actions.yml) — project config with Ollama vendor, consumed by `main_entrypoint()` and `requires_project()`
+- [`examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml`](../../examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml) — workflow config read by `RunCommand`, `SchemaCommand`, and `RenderCommand`
+- [`examples/support_resolution/agent_workflow/support_resolution/agent_io/staging/issues.json`](../../examples/support_resolution/agent_workflow/support_resolution/agent_io/staging/issues.json) — input data loaded during `agac run`
+- [`examples/support_resolution/tools/support_resolution/package_triage_result.py`](../../examples/support_resolution/tools/support_resolution/package_triage_result.py) — UDF discovered by `list-udfs` command
+- [`examples/book_catalog_enrichment/agent_actions.yml`](../../examples/book_catalog_enrichment/agent_actions.yml) — project config with SQLite storage backend, exercising `preview` command
+- [`examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml`](../../examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml) — multi-action workflow exercising `inspect` and `schema` commands

--- a/agent_actions/logging/_MANIFEST.md
+++ b/agent_actions/logging/_MANIFEST.md
@@ -24,3 +24,25 @@ factories, filters, formatters, and the event-driven error/reporting plumbing.
 | `LoggerFactory` | Class | Manage logger creation, level setting, and debug state. | `logging` |
 | `filters.py` | Module | Custom filters (e.g., `RedactingFilter`) to sanitize sensitive payloads. | `logging` |
 | `formatters.py` | Module | Formatter helpers such as `JSONFormatter` used across services. | `logging` |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `LoggingConfig.from_project_config()` | `agent_actions.yml` | Reads | `logging.level`, `logging.file.*`, `logging.module_levels`, `logging.include_timestamps`, `logging.include_source_location` |
+| `LoggingConfig.from_environment()` | `.env` | Reads | `AGENT_ACTIONS_DEBUG`, `AGENT_ACTIONS_LOG_LEVEL`, `AGENT_ACTIONS_LOG_FORMAT`, `AGENT_ACTIONS_LOG_FILE`, `AGENT_ACTIONS_LOG_DIR`, `AGENT_ACTIONS_NO_LOG_FILE`, `AGENT_ACTIONS_FILE_LOG_LEVEL` |
+| `LoggerFactory.initialize()` | `agent_io/target/events.json` | Writes | — |
+| `LoggerFactory.initialize()` | `agent_io/target/errors.json` | Writes | — |
+| `LoggerFactory._get_log_file_path()` | `logs/events.json` | Writes | `logging.file.path` |
+| `RunResultsCollector.flush()` | `agent_io/target/run_results.json` | Writes | — |
+| `RedactingFilter.filter()` | `agent_io/target/events.json` | Transforms | — |
+
+**Internal only**: `JSONFormatter`, `ConsoleEventHandler`, `LoggingBridgeHandler`, `EventManager`, `fire_event()` — no direct project surface (internal plumbing between handlers).
+
+**Examples** — see this module in action:
+- [`examples/support_resolution/agent_actions.yml`](../../examples/support_resolution/agent_actions.yml) — project config read by `LoggingConfig.from_project_config()`; `model_vendor: ollama` triggers logging of LLM events
+- [`examples/support_resolution/.env.example`](../../examples/support_resolution/.env.example) — environment file loaded before `LoggingConfig.from_environment()` runs
+- [`examples/book_catalog_enrichment/agent_actions.yml`](../../examples/book_catalog_enrichment/agent_actions.yml) — project config with `output_storage: sqlite`, exercising the `events.json` and `errors.json` file handlers
+- [`examples/incident_triage/agent_actions.yml`](../../examples/incident_triage/agent_actions.yml) — multi-action workflow generating `run_results.json` via `RunResultsCollector`

--- a/agent_actions/models/_MANIFEST.md
+++ b/agent_actions/models/_MANIFEST.md
@@ -18,3 +18,23 @@
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `optional_inputs` | Method | Optional input field names (for tools). | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `uses_fields` | Method | Unique 'agent.field' references from upstream. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `to_dict` | Method | Convert to dictionary for JSON serialization. | - |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `ActionKind` | `agent_config/{workflow}.yml` | Validates | `actions[].kind` |
+| `ActionSchema` | `agent_config/{workflow}.yml` | Transforms | `actions[]` |
+| `ActionSchema` | `schema/{workflow}/{action}.yml` | Transforms | `actions[].schema` |
+| `FieldInfo` | `schema/{workflow}/{action}.yml` | Transforms | `fields[]` |
+| `UpstreamReference` | `agent_config/{workflow}.yml` | Transforms | `actions[].context_scope.observe` |
+
+**Internal only**: `FieldSource` enum, `to_dict()` methods — used for serialization within `schema` and `inspect` CLI commands but do not directly read or write user files.
+
+**Examples** — see this module in action:
+- [`examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml`](../../examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml) — workflow config whose `actions[].kind` values are parsed into `ActionKind`; `output_field` and `context_scope.observe` become `FieldInfo` and `UpstreamReference` instances
+- [`examples/support_resolution/schema/support_resolution/format_output.yml`](../../examples/support_resolution/schema/support_resolution/format_output.yml) — schema file transformed into `ActionSchema.output_fields`
+- [`examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml`](../../examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml) — complex multi-action workflow with tool/llm/source kinds exercising `ActionKind` enum variants
+- [`examples/incident_triage/schema/incident_triage/extract_incident_details.yml`](../../examples/incident_triage/schema/incident_triage/extract_incident_details.yml) — schema with multiple fields demonstrating `FieldInfo` and `FieldSource` usage


### PR DESCRIPTION
## Summary
- Append `## Project Surface` sections to `cli`, `logging`, and `models` module manifests
- Maps exported symbols to user project files (reads, writes, validates, transforms) with specific YAML config keys
- Links to real example files for navigation

## Verification
- All table paths are generic, not example-specific
- Example links use correct relative paths
- No existing manifest content modified