### PR TITLE
docs: add Project Surface to tooling, utils manifests

### DIFF
--- a/agent_actions/tooling/_MANIFEST.md
+++ b/agent_actions/tooling/_MANIFEST.md
@@ -11,3 +11,70 @@ and the language-server experience for workflows, prompts, tools, and schemas.
 |------------|-------------|
 | [docs](docs/_MANIFEST.md) | CLI tooling and servers for generating the docs artefact, catalog, scanner, and static site. |
 | [lsp](lsp/_MANIFEST.md) | Language Server Protocol components (indexer, resolver, navigation) for IDE integration. |
+| rendering | Data-card rendering helpers shared between LSP hover and HITL templates. |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+### docs — Catalog Generation & Scanning
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `scanner.scan_workflows()` | `agent_workflow/{name}/agent_config/*.yml` | Reads | — |
+| `scanner.scan_workflows()` | `artefact/rendered_workflows/*.yml` | Reads | — |
+| `scanner.scan_readmes()` | `agent_workflow/{name}/README.md` | Reads | — |
+| `scanner.scan_prompts()` | `prompt_store/*.md` | Reads | — |
+| `scanner.scan_schemas()` | `schema/{workflow}/*.yml` | Reads | `schema_path` |
+| `scanner.scan_tool_functions()` | `tools/**/*.py` | Reads | `tool_path` |
+| `scanner.scan_runs()` | `agent_io/target/run_results.json` | Reads | — |
+| `scanner.scan_runs()` | `agent_io/target/events.json` | Reads | — |
+| `scanner.scan_runs()` | `agent_io/target/.manifest.json` | Reads | — |
+| `scanner.scan_logs()` | `logs/events.json` | Reads | — |
+| `scanner.scan_workflow_data()` | `agent_io/target/*.db` | Reads | — |
+| `scanner.scan_examples()` | `agent_actions.yml` | Reads | — |
+| `WorkflowParser.parse_workflow()` | `agent_workflow/{name}/agent_config/*.yml` | Reads | — |
+| `generate_docs()` | `artefact/catalog.json` | Writes | — |
+| `generate_docs()` | `artefact/runs.json` | Writes | — |
+| `RunTracker.record_run()` | `artefact/runs.json` | Writes | — |
+| `RunTracker.start_workflow_run()` | `artefact/runs.json` | Writes | — |
+| `serve_docs()` | `artefact/catalog.json` | Reads | — |
+| `serve_docs()` | `artefact/runs.json` | Reads | — |
+
+### docs — Code Scanner (AST Introspection)
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `scan_tool_functions()` | `tools/**/*.py` | Reads | `tool_path` |
+| `extract_function_details()` | `tools/**/*.py` | Reads | `tool_path` |
+| `extract_typed_dicts()` | `tools/**/*.py` | Reads | `tool_path` |
+
+### lsp — IDE Integration
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `build_index()` | `agent_workflow/{name}/agent_config/*.yml` | Reads | — |
+| `_index_prompts()` | `prompt_store/*.md` | Reads | — |
+| `_index_tools()` | `tools/**/*.py` | Reads | `tool_path` |
+| `_index_schemas()` | `schema/{workflow}/*.yml` | Reads | `schema_path` |
+| `find_project_root()` | `agent_actions.yml` | Reads | — |
+| `find_all_project_roots()` | `agent_actions.yml` | Reads | — |
+| `resolve_reference()` | `agent_workflow/`, `prompt_store/`, `tools/`, `schema/` | Reads | — |
+| `collect_diagnostics()` | `agent_workflow/{name}/agent_config/*.yml` | Validates | — |
+
+### rendering — Data Card Formatting
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `render_card_markdown()` | `agent_io/target/` | Transforms | — |
+
+**Internal only**: `_empty_runs_data()`, `_guard_path()`, `_humanize_key()`, `_format_value()`, `_build_action_data_map()` — no direct project surface.
+
+**Examples** — see this module in action:
+- [`examples/contract_reviewer/agent_actions.yml`](../../examples/contract_reviewer/agent_actions.yml) — project config with `tool_path`, `schema_path`, and `seed_data_path` keys consumed by scanner and indexer
+- [`examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml`](../../examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml) — workflow YAML parsed by `WorkflowParser` and indexed by LSP
+- [`examples/contract_reviewer/tools/contract_reviewer/`](../../examples/contract_reviewer/tools/contract_reviewer/) — UDF tool scripts scanned by `scan_tool_functions()` and indexed by `_index_tools()`
+- [`examples/contract_reviewer/schema/contract_reviewer/`](../../examples/contract_reviewer/schema/contract_reviewer/) — schema YAML files scanned by `scan_schemas()` and indexed by `_index_schemas()`
+- [`examples/contract_reviewer/prompt_store/contract_reviewer.md`](../../examples/contract_reviewer/prompt_store/contract_reviewer.md) — prompt file scanned by `scan_prompts()` and indexed by `_index_prompts()`
+- [`examples/product_listing_enrichment/tools/product_listing_enrichment/`](../../examples/product_listing_enrichment/tools/product_listing_enrichment/) — additional UDF tools exercising `scan_tool_functions()` with nested tool directories
+- [`examples/review_analyzer/schema/review_analyzer/`](../../examples/review_analyzer/schema/review_analyzer/) — schema files exercising `scan_schemas()` and `extract_fields_for_docs()`

--- a/agent_actions/utils/_MANIFEST.md
+++ b/agent_actions/utils/_MANIFEST.md
@@ -34,3 +34,75 @@ pathways.
 | `error_wrap.py` | Module | Decorator for wrapping validation errors with additional context. | `errors`, `validation` |
 | `file_handler.py` | Module | `FileHandler` static utility for recursive file/folder discovery (stdlib only: logging, os, pathlib). Moved from `output/`. | `file_io` |
 | `project_root.py` | Module | Project root detection utilities (`find_project_root`, `ensure_in_project`). Moved from `cli/`. | `errors` |
+| `file_utils.py` | Module | `load_structured_file` helper for loading JSON/YAML files by extension. | `file_io` |
+| `schema_utils.py` | Module | Schema format detection (`is_compiled_schema`, `is_inline_schema_shorthand`). | `validation` |
+| `path_security.py` | Module | Path traversal prevention and sandbox validation utilities. | `errors`, `security` |
+
+## Project Surface
+
+> How this module interacts with the user's project files.
+
+### Project Root & Path Resolution
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `project_root.find_project_root()` | `agent_actions.yml` | Reads | — |
+| `project_root.ensure_in_project()` | `agent_actions.yml` | Validates | — |
+| `path_utils.find_project_root()` | `agent_actions.yml` | Reads | — |
+| `path_utils.derive_workflow_root()` | `agent_io/`, `agent_config/` | Reads | — |
+| `path_utils.create_mirror_source_path()` | `agent_io/target/`, `agent_io/source/` | Transforms | — |
+| `path_utils.ensure_directory_exists()` | `agent_io/`, `artefact/` | Writes | — |
+| `path_utils.create_agent_directory_structure()` | `agent_workflow/{name}/` | Writes | — |
+
+### Module Loading & UDF Discovery
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `module_loader.load_module_from_path()` | `tools/**/*.py` | Reads | `tool_path` |
+| `module_loader.discover_and_load_udfs()` | `tools/*.py` | Reads | `tool_path` |
+| `module_loader.discover_and_load_udfs_recursive()` | `tools/**/*.py` | Reads | `tool_path` |
+| `udf_management.registry.udf_tool` | `tools/**/*.py` | Reads | `tool_path` |
+| `udf_management.tooling.load_user_defined_function()` | `tools/**/*.py` | Reads | `tool_path` |
+| `udf_management.tooling.execute_user_defined_function()` | `tools/**/*.py` | Reads | `tool_path` |
+
+### Configuration Resolution
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `tools_resolver.resolve_tools_path()` | `agent_actions.yml` | Reads | `tool_path`, `tools` |
+| `constants.RESERVED_AGENT_NAMES` | `agent_workflow/{name}/agent_config/*.yml` | Validates | — |
+| `constants.SPECIAL_NAMESPACES` | `agent_workflow/{name}/agent_config/*.yml` | Validates | — |
+| `constants.DANGEROUS_PATTERNS` | `agent_workflow/{name}/agent_config/*.yml` | Validates | `guard.condition` |
+
+### Data Processing Helpers
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `file_handler.FileHandler.get_agent_paths()` | `agent_workflow/{name}/agent_config/`, `agent_io/` | Reads | — |
+| `file_handler.FileHandler.find_file_in_directory()` | `agent_workflow/` | Reads | — |
+| `file_handler.FileHandler.get_all_agent_paths()` | `agent_workflow/{name}/agent_config/*.yml` | Reads | — |
+| `file_utils.load_structured_file()` | `schema/{workflow}/*.yml`, `*.json` | Reads | — |
+| `dict.get_nested_value()` | `agent_io/target/` | Transforms | — |
+| `graph_utils.topological_sort()` | `agent_workflow/{name}/agent_config/*.yml` | Transforms | — |
+
+### Lineage, IDs & Metadata
+
+| Symbol | User File | Interaction | Config Key |
+|--------|-----------|-------------|------------|
+| `id_generation.IDGenerator` | `agent_io/target/` | Transforms | — |
+| `lineage.LineageBuilder` | `agent_io/target/` | Transforms | — |
+| `field_management.FieldManager` | `agent_io/target/` | Transforms | — |
+| `metadata.MetadataExtractor` | `agent_io/target/` | Transforms | — |
+| `correlation.VersionIdGenerator` | `agent_io/target/` | Transforms | — |
+| `passthrough_builder.PassthroughItemBuilder` | `agent_io/target/` | Transforms | — |
+| `transformation.PassthroughTransformer` | `agent_io/target/` | Transforms | `context_scope.passthrough` |
+
+**Internal only**: `safe_format.safe_format_error()`, `error_handler.*`, `error_wrap.*`, `schema_utils.*`, `path_security.*` — no direct project surface (consumed by other framework modules).
+
+**Examples** — see this module in action:
+- [`examples/contract_reviewer/tools/contract_reviewer/split_contract_by_clause.py`](../../examples/contract_reviewer/tools/contract_reviewer/split_contract_by_clause.py) — UDF tool using `@udf_tool` decorator from `udf_management.registry`, discovered by `module_loader`
+- [`examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py`](../../examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py) — FILE-granularity UDF exercising `FileUDFResult` from `udf_management.registry`
+- [`examples/contract_reviewer/agent_actions.yml`](../../examples/contract_reviewer/agent_actions.yml) — `tool_path` and `schema_path` keys resolved by `tools_resolver` and `path_utils`
+- [`examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml`](../../examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml) — workflow with `context_scope.passthrough` processed by `transformation.PassthroughTransformer`, dependencies sorted by `graph_utils.topological_sort()`
+- [`examples/product_listing_enrichment/tools/product_listing_enrichment/fetch_competitor_prices.py`](../../examples/product_listing_enrichment/tools/product_listing_enrichment/fetch_competitor_prices.py) — UDF in a nested tool directory discovered by `discover_and_load_udfs_recursive()`
+- [`examples/review_analyzer/agent_workflow/review_analyzer/agent_io/staging/reviews.json`](../../examples/review_analyzer/agent_workflow/review_analyzer/agent_io/staging/reviews.json) — source data in `agent_io/staging/` located by `path_utils.derive_workflow_root()`


### PR DESCRIPTION
## Summary
- Append `## Project Surface` sections to `tooling` and `utils` module manifests
- Maps exported symbols to user project files (reads, writes, validates, transforms) with specific YAML config keys
- Links to real example files for navigation

## Verification
- All table paths are generic, not example-specific
- Example links use correct relative paths
- No existing manifest content modified