### PR TITLE
fix(tests): rewrite smoke test checks to use real verification

### DIFF
--- a/tests/manual/smoke_test/checks/guards.py
+++ b/tests/manual/smoke_test/checks/guards.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
 
 from tests.manual.smoke_test.checks import Check
@@ -10,9 +11,12 @@ from tests.manual.smoke_test.context import CheckResult, RunContext
 class GuardCheck(Check):
     """Verify a guarded action produced correct dispositions.
 
+    Queries the record_disposition table in the SQLite DB for evidence
+    that the guard evaluated correctly.
+
     Args:
         action: action name that has a guard
-        behavior: expected guard behavior — "filter" or "skip"
+        behavior: expected guard behavior -- "filter" or "skip"
     """
 
     action: str
@@ -27,103 +31,84 @@ class GuardCheck(Check):
                 CheckResult(
                     False,
                     f"guard({self.action}): pipeline completed",
-                    f"exit code {ctx.exit_code} — cannot verify guard behavior",
+                    f"exit code {ctx.exit_code} -- cannot verify guard behavior",
                 )
             )
             return results
 
-        action_dir = ctx.target_dir / self.action
-
-        # Look for guard-related evidence in stdout/stderr
-        combined_output = ctx.stdout + ctx.stderr
-        guard_mentioned = "guard" in combined_output.lower() or self.action in combined_output
+        db_path = ctx.db_path
+        if db_path is None:
+            results.append(
+                CheckResult(
+                    False,
+                    f"guard({self.action}): storage DB exists",
+                    "no storage DB found in target dir",
+                )
+            )
+            return results
 
         if self.behavior == "filter":
-            # For "filter" behavior: the action should still run but some records
-            # may get disposition "filtered". At minimum, the pipeline should not
-            # crash and the action directory or DB should exist.
-            if action_dir.exists():
-                results.append(
-                    CheckResult(
-                        True,
-                        f"guard({self.action}): action dir exists",
-                        "guard evaluated — action directory present",
-                    )
-                )
-            else:
-                # Action dir might not exist if all records were filtered,
-                # which is valid guard behavior
-                results.append(
-                    CheckResult(
-                        True,
-                        f"guard({self.action}): all records filtered",
-                        "action directory absent — guard may have filtered all records",
-                    )
-                )
+            with sqlite3.connect(str(db_path)) as conn:
+                dispositions = conn.execute(
+                    "SELECT disposition FROM record_disposition WHERE action_name = ?",
+                    (self.action,),
+                ).fetchall()
 
-            # Check for filter disposition evidence in logs
-            filter_evidence = (
-                "filter" in combined_output.lower()
-                or "disposition" in combined_output.lower()
-                or "guard" in combined_output.lower()
-            )
-            results.append(
-                CheckResult(
-                    True,
-                    f"guard({self.action}): filter behavior configured",
-                    "guard log evidence found"
-                    if filter_evidence
-                    else "no crash — guard did not break pipeline",
-                )
-            )
+                filtered = [d for d in dispositions if d[0] == "filtered"]
+                if filtered:
+                    results.append(
+                        CheckResult(
+                            True,
+                            f"guard({self.action}): filtered records found",
+                            f"{len(filtered)} records with disposition 'filtered'",
+                        )
+                    )
+                else:
+                    results.append(
+                        CheckResult(
+                            False,
+                            f"guard({self.action}): filtered records found",
+                            "no records with disposition 'filtered' in record_disposition",
+                        )
+                    )
 
         elif self.behavior == "skip":
-            # For "skip" behavior: the guard may skip the entire action.
-            # The action directory may or may not exist depending on guard evaluation.
-            skip_evidence = "skip" in combined_output.lower() or "guard" in combined_output.lower()
+            with sqlite3.connect(str(db_path)) as conn:
+                # For skip behavior, the action should have no target_data rows
+                target_count = conn.execute(
+                    "SELECT COUNT(*) FROM target_data WHERE action_name = ?",
+                    (self.action,),
+                ).fetchone()[0]
 
-            if action_dir.exists():
-                results.append(
-                    CheckResult(
-                        True,
-                        f"guard({self.action}): action ran (guard passed)",
-                        "guard condition was true — action executed",
-                    )
-                )
-            else:
-                results.append(
-                    CheckResult(
-                        True,
-                        f"guard({self.action}): action skipped (guard triggered)",
-                        "action directory absent — guard skip behavior applied",
-                    )
-                )
+                # Also check for a skipped disposition
+                skip_dispositions = conn.execute(
+                    "SELECT disposition FROM record_disposition WHERE action_name = ?",
+                    (self.action,),
+                ).fetchall()
+                skipped = [d for d in skip_dispositions if d[0] == "skipped"]
 
-            results.append(
-                CheckResult(
-                    True,
-                    f"guard({self.action}): skip behavior configured",
-                    "guard log evidence found"
-                    if skip_evidence
-                    else "no crash — guard did not break pipeline",
-                )
-            )
+                if target_count == 0:
+                    results.append(
+                        CheckResult(
+                            True,
+                            f"guard({self.action}): action skipped (no output)",
+                            f"0 rows in target_data, {len(skipped)} skip dispositions",
+                        )
+                    )
+                else:
+                    results.append(
+                        CheckResult(
+                            False,
+                            f"guard({self.action}): action skipped (no output)",
+                            f"expected 0 target_data rows but found {target_count}",
+                        )
+                    )
         else:
             results.append(
                 CheckResult(
                     False,
-                    f"guard({self.action}): unknown behavior",
-                    f"unexpected behavior '{self.behavior}' — expected 'filter' or 'skip'",
-                )
-            )
-
-        # Verify the guard didn't cause downstream actions to fail silently
-        if guard_mentioned:
-            results.append(
-                CheckResult(
-                    True,
-                    f"guard({self.action}): pipeline healthy after guard",
-                    "guard evaluation did not crash the pipeline",
+                    f"guard({self.action}): valid behavior",
+                    f"unexpected behavior '{self.behavior}' -- expected 'filter' or 'skip'",
                 )
             )
 

--- a/tests/manual/smoke_test/checks/parallel.py
+++ b/tests/manual/smoke_test/checks/parallel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import json
+import sqlite3
 from dataclasses import dataclass
 
 from tests.manual.smoke_test.checks import Check
@@ -10,6 +10,9 @@ from tests.manual.smoke_test.context import CheckResult, RunContext
 @dataclass
 class ParallelVersions(Check):
     """Verify a versioned action produced outputs for all N versions.
+
+    Queries target_data in the SQLite DB for version-tagged action names
+    ({action}_1, {action}_2, etc.).
 
     Args:
         action: action name with versions configured
@@ -28,105 +31,53 @@ class ParallelVersions(Check):
                 CheckResult(
                     False,
                     f"parallel({self.action}): pipeline completed",
-                    f"exit code {ctx.exit_code} — cannot verify parallel versions",
+                    f"exit code {ctx.exit_code} -- cannot verify parallel versions",
                 )
             )
             return results
 
-        # Versioned actions produce output dirs named {action}_1, {action}_2, etc.
-        # or merged into a downstream action via version_consumption.
-        # Check for version-tagged directories first.
-        version_dirs = []
-        for i in range(1, self.versions + 1):
-            version_dir = ctx.target_dir / f"{self.action}_{i}"
-            if version_dir.exists():
-                version_dirs.append(version_dir)
-
-        if len(version_dirs) == self.versions:
+        db_path = ctx.db_path
+        if db_path is None:
             results.append(
                 CheckResult(
-                    True,
-                    f"parallel({self.action}): {self.versions} version dirs found",
-                    ", ".join(d.name for d in version_dirs),
+                    False,
+                    f"parallel({self.action}): storage DB exists",
+                    "no storage DB found in target dir",
                 )
             )
-
-            # Verify each version directory has output files
-            for vdir in version_dirs:
-                json_files = list(vdir.glob("*.json"))
-                results.append(
-                    CheckResult(
-                        len(json_files) > 0,
-                        f"parallel({self.action}): {vdir.name} has output",
-                        f"{len(json_files)} JSON files" if json_files else "no output files",
-                    )
-                )
             return results
 
-        # If version dirs not found, check if the action's own dir contains
-        # merged version data (version_consumption merges results)
-        action_dir = ctx.target_dir / self.action
-        if action_dir.exists():
-            json_files = list(action_dir.glob("*.json"))
-            if json_files:
-                # Check if records contain version-tagged data
-                version_evidence = set()
-                for jf in json_files:
-                    try:
-                        data = json.loads(jf.read_text())
-                        records = data if isinstance(data, list) else [data]
-                        for record in records:
-                            if not isinstance(record, dict):
-                                continue
-                            # Look for version identifiers in record keys or values
-                            record_str = json.dumps(record).lower()
-                            for i in range(1, self.versions + 1):
-                                if "scorer_id" in record_str or "version" in record_str:
-                                    version_evidence.add(i)
-                                # Check for version-numbered keys like score_quality_1
-                                if f"{self.action}_{i}" in record_str:
-                                    version_evidence.add(i)
-                    except (json.JSONDecodeError, UnicodeDecodeError):
-                        pass
+        with sqlite3.connect(str(db_path)) as conn:
+            missing_versions: list[str] = []
+            found_versions: list[str] = []
 
+            for i in range(1, self.versions + 1):
+                version_name = f"{self.action}_{i}"
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM target_data WHERE action_name = ?",
+                    (version_name,),
+                ).fetchone()[0]
+
+                if count == 0:
+                    missing_versions.append(version_name)
+                else:
+                    found_versions.append(version_name)
+
+            if missing_versions:
+                results.append(
+                    CheckResult(
+                        False,
+                        f"parallel({self.action}): all {self.versions} versions have output",
+                        f"missing: {', '.join(missing_versions)}",
+                    )
+                )
+            else:
                 results.append(
                     CheckResult(
                         True,
-                        f"parallel({self.action}): action dir has output",
-                        f"{len(json_files)} JSON files in {self.action}/",
+                        f"parallel({self.action}): all {self.versions} versions have output",
+                        f"found: {', '.join(found_versions)}",
                     )
                 )
-                return results
-
-        # Check combined output for evidence of parallel execution
-        combined_output = ctx.stdout + ctx.stderr
-        version_keywords = []
-        for i in range(1, self.versions + 1):
-            if f"{self.action}_{i}" in combined_output:
-                version_keywords.append(f"{self.action}_{i}")
-
-        if version_keywords:
-            results.append(
-                CheckResult(
-                    True,
-                    f"parallel({self.action}): version evidence in logs",
-                    f"found: {', '.join(version_keywords)}",
-                )
-            )
-        else:
-            # Parallel execution may have run but output merged by version_consumption.
-            # If the pipeline completed successfully, the versions ran.
-            parallel_evidence = (
-                "version" in combined_output.lower() or "parallel" in combined_output.lower()
-            )
-            results.append(
-                CheckResult(
-                    True,
-                    f"parallel({self.action}): pipeline completed with versions configured",
-                    "version/parallel evidence in logs"
-                    if parallel_evidence
-                    else "pipeline completed — versions configured in workflow",
-                )
-            )
 
         return results

--- a/tests/manual/smoke_test/checks/reprompt.py
+++ b/tests/manual/smoke_test/checks/reprompt.py
@@ -11,8 +11,8 @@ from tests.manual.smoke_test.context import CheckResult, RunContext
 class RepromptCheck(Check):
     """Verify a reprompt-enabled action triggered retries.
 
-    AgacClient intentionally produces short responses on attempt 1,
-    which should fail validation and trigger reprompt on attempt 2+.
+    Parses events.json (NDJSON) for retry/reprompt evidence. If the action
+    is configured for reprompt, there MUST be retry evidence -- no excuses.
 
     Args:
         action: action name with reprompt configured
@@ -29,93 +29,71 @@ class RepromptCheck(Check):
                 CheckResult(
                     False,
                     f"reprompt({self.action}): pipeline completed",
-                    f"exit code {ctx.exit_code} — cannot verify reprompt",
+                    f"exit code {ctx.exit_code} -- cannot verify reprompt",
                 )
             )
             return results
 
-        combined_output = ctx.stdout + ctx.stderr
-
-        # Look for retry/reprompt evidence in logs
-        retry_keywords = ["reprompt", "retry", "attempt", "validation"]
-        evidence_found = [kw for kw in retry_keywords if kw in combined_output.lower()]
-
-        if evidence_found:
-            results.append(
-                CheckResult(
-                    True,
-                    f"reprompt({self.action}): retry evidence in logs",
-                    f"keywords found: {', '.join(evidence_found)}",
-                )
-            )
-        else:
-            # No log evidence, but the action may have passed on attempt 1
-            # (AgacClient behavior is non-deterministic). That is still valid.
-            results.append(
-                CheckResult(
-                    True,
-                    f"reprompt({self.action}): retry evidence in logs",
-                    "no retry keywords in output — action may have passed on first attempt",
-                )
-            )
-
-        # Check events.json for attempt-related entries
+        # Parse events.json (NDJSON format) for retry evidence
         events_path = ctx.target_dir / "events.json"
-        if events_path.exists():
-            try:
-                events_data = json.loads(events_path.read_text())
-                # Events may be a list of dicts or a single dict
-                events_str = json.dumps(events_data).lower()
-                has_attempt_info = (
-                    "attempt" in events_str
-                    or "retry" in events_str
-                    or "reprompt" in events_str
-                    or self.action in events_str
-                )
-                results.append(
-                    CheckResult(
-                        True,
-                        f"reprompt({self.action}): events recorded",
-                        "action referenced in events"
-                        if has_attempt_info
-                        else "events.json present but no attempt details",
-                    )
-                )
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                results.append(
-                    CheckResult(
-                        True,
-                        f"reprompt({self.action}): events recorded",
-                        "events.json not parseable — checked by OutputStructure",
-                    )
-                )
-        else:
+        if not events_path.exists():
             results.append(
                 CheckResult(
-                    True,
-                    f"reprompt({self.action}): events recorded",
-                    "no events.json — events check deferred to OutputStructure",
+                    False,
+                    f"reprompt({self.action}): events.json exists",
+                    "events.json not found -- cannot verify reprompt",
                 )
             )
+            return results
 
-        # Verify the action ultimately produced output (retries recovered)
-        action_dir = ctx.target_dir / self.action
-        if action_dir.exists() and any(action_dir.glob("*.json")):
+        events: list[dict] = []
+        try:
+            for line in events_path.read_text().splitlines():
+                line = line.strip()
+                if line:
+                    events.append(json.loads(line))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            results.append(
+                CheckResult(
+                    False,
+                    f"reprompt({self.action}): events parseable",
+                    f"failed to parse events.json: {e}",
+                )
+            )
+            return results
+
+        # Look for events related to this action that indicate retries
+        retry_events = []
+        for event in events:
+            event_data = event.get("data", {})
+            event_action = event_data.get("action_name", "")
+            event_type = event.get("event_type", "")
+
+            # Match events for this action
+            if event_action != self.action:
+                continue
+
+            # Check for attempt > 1 or reprompt-related event types
+            attempt = event_data.get("attempt", 0)
+            if attempt > 1:
+                retry_events.append(event)
+            elif "Reprompt" in event_type or "Retry" in event_type:
+                retry_events.append(event)
+
+        if retry_events:
             results.append(
                 CheckResult(
                     True,
-                    f"reprompt({self.action}): action produced output",
-                    "output files present — retries recovered successfully",
+                    f"reprompt({self.action}): retry evidence found",
+                    f"{len(retry_events)} retry-related events",
                 )
             )
         else:
-            # The action may not have its own dir if it is part of a versioned
-            # action or output went to DB. Not a failure of reprompt itself.
             results.append(
                 CheckResult(
-                    True,
-                    f"reprompt({self.action}): action completed",
-                    "no action-level output dir — output may be in DB or versioned",
+                    False,
+                    f"reprompt({self.action}): retry evidence found",
+                    "no retry attempts found in events.json",
                 )
             )
 

--- a/tests/manual/smoke_test/checks/schema_conformance.py
+++ b/tests/manual/smoke_test/checks/schema_conformance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 
 import yaml
 
@@ -9,67 +10,125 @@ from tests.manual.smoke_test.context import CheckResult, RunContext
 
 
 class SchemaConformance(Check):
-    """Verify output JSON fields match the action's schema definition."""
+    """Verify output JSON fields match the action's schema definition.
+
+    Reads from the SQLite DB (target_data table) instead of action directories.
+    """
 
     def verify(self, ctx: RunContext) -> list[CheckResult]:
         results: list[CheckResult] = []
+
+        db_path = ctx.db_path
+        if db_path is None:
+            results.append(
+                CheckResult(
+                    passed=False,
+                    name="schema conformance",
+                    message="no storage DB found in target dir",
+                )
+            )
+            return results
 
         # Load workflow config to get action -> schema mapping
         config = yaml.safe_load(ctx.config_path.read_text())
         schema_dir = ctx.project_dir / "schema" / ctx.example.workflow
 
-        # Actions is a list of dicts (each with a "name" key)
         actions = config.get("actions", [])
+
+        # Collect actions that have guards configured (may produce no output)
+        guarded_actions: set[str] = set()
         for action_cfg in actions:
             if not isinstance(action_cfg, dict):
                 continue
+            if action_cfg.get("guard"):
+                guarded_actions.add(action_cfg.get("name", ""))
 
-            action_name = action_cfg.get("name", "")
-            schema_name = action_cfg.get("schema")
-            if not schema_name:
-                continue
+        schema_actions_checked = 0
 
-            schema_path = schema_dir / f"{schema_name}.yml"
-            if not schema_path.exists():
-                continue
+        with sqlite3.connect(str(db_path)) as conn:
+            for action_cfg in actions:
+                if not isinstance(action_cfg, dict):
+                    continue
 
-            schema = yaml.safe_load(schema_path.read_text())
-            required_fields = schema.get("required", [])
-            if not required_fields:
-                continue
+                action_name = action_cfg.get("name", "")
+                schema_name = action_cfg.get("schema")
+                if not schema_name:
+                    continue
 
-            # Check output files for this action
-            action_dir = ctx.target_dir / action_name
-            if not action_dir.exists():
-                continue  # might be guarded/skipped
+                schema_path = schema_dir / f"{schema_name}.yml"
+                if not schema_path.exists():
+                    continue
 
-            for jf in action_dir.glob("*.json"):
-                try:
-                    data = json.loads(jf.read_text())
-                    records = data if isinstance(data, list) else [data]
-                    for record in records:
-                        if not isinstance(record, dict):
-                            continue
-                        missing = [f for f in required_fields if f not in record]
+                schema = yaml.safe_load(schema_path.read_text())
+                required_fields = schema.get("required", [])
+                if not required_fields:
+                    continue
+
+                # Query target_data for this action
+                cursor = conn.execute(
+                    "SELECT data FROM target_data WHERE action_name = ?",
+                    (action_name,),
+                )
+                rows = cursor.fetchall()
+
+                if not rows:
+                    if action_name in guarded_actions:
+                        # Guarded actions may legitimately produce no output
+                        continue
+                    results.append(
+                        CheckResult(
+                            passed=False,
+                            name=f"schema({action_name})",
+                            message="no output found in target_data",
+                        )
+                    )
+                    schema_actions_checked += 1
+                    continue
+
+                schema_actions_checked += 1
+
+                for row in rows:
+                    try:
+                        data = json.loads(row[0])
+                        records = data if isinstance(data, list) else [data]
+                        for record in records:
+                            if not isinstance(record, dict):
+                                continue
+                            missing = [f for f in required_fields if f not in record]
+                            results.append(
+                                CheckResult(
+                                    passed=len(missing) == 0,
+                                    name=f"schema({action_name})",
+                                    message=f"missing fields: {missing}"
+                                    if missing
+                                    else "all required fields present",
+                                )
+                            )
+                    except (json.JSONDecodeError, UnicodeDecodeError):
                         results.append(
                             CheckResult(
-                                passed=len(missing) == 0,
-                                name=f"schema: {action_name}/{jf.name}",
-                                message=f"missing fields: {missing}"
-                                if missing
-                                else "all required fields present",
+                                passed=False,
+                                name=f"schema({action_name})",
+                                message="failed to parse target_data JSON",
                             )
                         )
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    pass  # OutputStructure check catches this
 
         if not results:
-            results.append(
-                CheckResult(
-                    True,
-                    "schema conformance",
-                    "no schema-bearing actions with output",
+            if schema_actions_checked == 0:
+                results.append(
+                    CheckResult(
+                        passed=False,
+                        name="schema conformance",
+                        message="no schema-bearing actions found in workflow config",
+                    )
                 )
-            )
+            else:
+                results.append(
+                    CheckResult(
+                        passed=True,
+                        name="schema conformance",
+                        message="all schema-bearing actions validated",
+                    )
+                )
 
         return results

--- a/tests/manual/smoke_test/context.py
+++ b/tests/manual/smoke_test/context.py
@@ -39,6 +39,12 @@ class RunContext:
     def config_path(self) -> Path:
         return self.workflow_dir / "agent_config" / f"{self.example.workflow}.yml"
 
+    @property
+    def db_path(self) -> Path | None:
+        """Path to the SQLite storage DB, if it exists."""
+        dbs = list(self.target_dir.glob("*.db"))
+        return dbs[0] if dbs else None
+
 
 @dataclass
 class Example:

--- a/tests/manual/smoke_test/registry.py
+++ b/tests/manual/smoke_test/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from tests.manual.smoke_test.checks.context_scope import ContextScope
 from tests.manual.smoke_test.checks.guards import GuardCheck
 from tests.manual.smoke_test.checks.output_structure import OutputStructure
 from tests.manual.smoke_test.checks.parallel import ParallelVersions
@@ -60,6 +61,7 @@ EXAMPLES: list[Example] = [
             GuardCheck(action="generate_response", behavior="filter"),
             GuardCheck(action="extract_product_insights", behavior="filter"),
             RepromptCheck(action="score_quality"),
+            ContextScope(action="generate_response", dropped_fields=["source.star_rating"]),
         ],
     ),
     Example(


### PR DESCRIPTION
## Summary
- SchemaConformance: queries SQLite target_data for required fields (was: always pass)
- RepromptCheck: parses events.json for retry attempts (was: always pass)
- GuardCheck: queries record_disposition for filtered/skipped evidence (was: always pass)
- ParallelVersions: queries target_data for version-tagged output (was: always pass)
- ContextScope: registered on review_analyzer (was: defined but unused)

## Known failures (expected)
85 checks now FAIL because AgacClient generates random field names instead of schema-conformant output. This is a real finding — the fake provider needs to be fixed to produce schema-aware responses. That fix belongs in a separate PR to improve AgacClient's FakeDataGenerator.

## Verification
- Before: 75 pass, 0 fail (theater — checks couldn't fail)
- After: 35 pass, 85 fail (real — checks catch actual issues)
- Guard check PASSES where real filtering occurs (incident_triage generate_executive_summary: 2 filtered records found)
- Guard check FAILS where no filtering evidence exists (real finding)