### PR TITLE
feat: redesign data card with 5-section tree view and action info

### DIFF
--- a/agent_actions/tooling/docs/frontend/app/globals.css
+++ b/agent_actions/tooling/docs/frontend/app/globals.css
@@ -209,9 +209,6 @@
     overflow: hidden;
   }
 
-  /* ─── Section styling ─── */
-  .dc-section { border-left: none; }
-
   .dc-section-header {
     @apply flex items-center gap-2 w-full text-left transition-colors cursor-pointer;
     padding: 0.625rem 1rem;

--- a/agent_actions/tooling/docs/frontend/app/globals.css
+++ b/agent_actions/tooling/docs/frontend/app/globals.css
@@ -209,11 +209,8 @@
     overflow: hidden;
   }
 
-  /* ─── Section accent bars ─── */
-  .dc-section-purple { border-left: 3px solid #c084fc; }
-  .dc-section-blue   { border-left: 3px solid #7dd3fc; }
-  .dc-section-pink   { border-left: 3px solid #f9a8d4; }
-  .dc-section-gray   { border-left: 3px solid #71717a; }
+  /* ─── Section styling ─── */
+  .dc-section { border-left: none; }
 
   .dc-section-header {
     @apply flex items-center gap-2 w-full text-left transition-colors cursor-pointer;

--- a/agent_actions/tooling/docs/frontend/app/globals.css
+++ b/agent_actions/tooling/docs/frontend/app/globals.css
@@ -137,13 +137,11 @@
 @layer components {
   .data-card {
     @apply relative rounded-lg border bg-card text-card-foreground overflow-hidden;
-    border-left: 4px solid #534AB7;
     box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.04), 0 1px 2px -1px rgb(0 0 0 / 0.04);
     transition: transform 150ms ease, box-shadow 150ms ease;
     background-image: none;
   }
   .dark .data-card {
-    border-left-color: #7F77DD;
     box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.2), 0 1px 2px -1px rgb(0 0 0 / 0.15);
   }
   .data-card:hover {
@@ -211,138 +209,151 @@
     overflow: hidden;
   }
 
-  /* ─── Prompt Trace drawer ─── */
-  .trace-section {
-    @apply border-t mt-0;
-    border-color: hsl(250 25% 85%);
-    background: linear-gradient(180deg, hsl(250 30% 96%), transparent 100%);
-  }
-  .dark .trace-section {
-    border-color: hsl(250 25% 20%);
-    background: linear-gradient(180deg, hsl(250 30% 12%), transparent 100%);
-  }
+  /* ─── Section accent bars ─── */
+  .dc-section-purple { border-left: 3px solid #c084fc; }
+  .dc-section-blue   { border-left: 3px solid #7dd3fc; }
+  .dc-section-pink   { border-left: 3px solid #f9a8d4; }
+  .dc-section-gray   { border-left: 3px solid #71717a; }
 
-  .trace-trigger {
-    @apply flex items-center gap-1.5 py-2 px-4 w-full text-left transition-colors cursor-pointer;
-    font-size: 10px;
-    color: hsl(250 40% 50%);
+  .dc-section-header {
+    @apply flex items-center gap-2 w-full text-left transition-colors cursor-pointer;
+    padding: 0.625rem 1rem;
+    border-top: 1px solid hsl(var(--border) / 0.4);
     background: none;
-    border: none;
+    border-right: none;
+    border-bottom: none;
     font-family: inherit;
   }
-  .dark .trace-trigger {
-    color: hsl(250 45% 72%);
-  }
-  .trace-trigger:hover {
-    @apply text-foreground;
+  .dc-section-header:hover {
+    background: hsl(var(--accent) / 0.08);
   }
 
-  .trace-label {
-    @apply uppercase tracking-wider font-semibold;
-  }
-  .trace-badges {
-    @apply flex gap-1.5 ml-auto;
-  }
-  .trace-badge {
+  /* Badge styles (kept from trace design) */
+  .dc-badge {
     @apply font-mono rounded;
     font-size: 9px;
     padding: 1px 6px;
     font-weight: 500;
     letter-spacing: 0.3px;
   }
-  .trace-badge-model {
+  .dc-badge-model {
     background: hsl(225 20% 92%);
     color: hsl(225 15% 40%);
     border: 1px solid hsl(225 16% 86%);
   }
-  .dark .trace-badge-model {
+  .dark .dc-badge-model {
     background: hsl(225 20% 14%);
     color: hsl(210 15% 55%);
     border: 1px solid hsl(225 16% 18%);
   }
-  .trace-badge-mode {
+  .dc-badge-mode {
     background: hsl(174 30% 92%);
     color: hsl(174 50% 35%);
     border: 1px solid hsl(174 30% 85%);
   }
-  .dark .trace-badge-mode {
+  .dark .dc-badge-mode {
     background: hsl(174 30% 12%);
     color: hsl(174 50% 60%);
     border: 1px solid hsl(174 30% 18%);
   }
-  .trace-badge-mode.batch {
-    background: hsl(38 30% 92%);
-    color: hsl(38 60% 38%);
-    border: 1px solid hsl(38 30% 85%);
+
+  /* ─── Notion-style prose (for prompt trace + long text in tree) ─── */
+  .dc-prose {
+    font-size: 13px;
+    line-height: 1.7;
+    color: hsl(var(--foreground) / 0.85);
+    padding: 0.75rem 1rem;
   }
-  .dark .trace-badge-mode.batch {
-    background: hsl(38 30% 12%);
-    color: hsl(38 60% 60%);
-    border: 1px solid hsl(38 30% 18%);
+  .dc-prose h1,
+  .dc-prose h2,
+  .dc-prose h3 {
+    @apply font-semibold;
+    color: hsl(var(--foreground) / 0.95);
+    margin-top: 1.25em;
+    margin-bottom: 0.5em;
+  }
+  .dc-prose h1 { font-size: 1.15em; }
+  .dc-prose h2 { font-size: 1.05em; }
+  .dc-prose h3 { font-size: 1em; }
+  .dc-prose p { margin: 0.4em 0; }
+  .dc-prose strong { color: hsl(var(--foreground) / 0.95); font-weight: 600; }
+  .dc-prose blockquote {
+    border-left: 3px solid hsl(250 60% 70%);
+    padding-left: 0.75em;
+    margin: 0.5em 0;
+    color: hsl(var(--foreground) / 0.7);
+    font-style: normal;
+  }
+  .dc-prose ul, .dc-prose ol {
+    padding-left: 1.5em;
+    margin: 0.4em 0;
+  }
+  .dc-prose li { margin: 0.2em 0; }
+  .dc-prose code {
+    @apply font-mono text-xs rounded px-1 py-0.5;
+    background: hsl(var(--secondary) / 0.6);
+    color: hsl(250 60% 70%);
+  }
+  .dc-prose pre {
+    @apply font-mono text-xs rounded-md overflow-x-auto;
+    background: hsl(225 24% 7%);
+    padding: 0.75em 1em;
+    margin: 0.5em 0;
   }
 
-  .trace-content {
-    @apply px-4 pb-3.5;
+  /* ─── JSON syntax highlighting ─── */
+  .dc-json {
+    @apply font-mono text-xs leading-relaxed rounded-md overflow-x-auto;
+    background: hsl(225 24% 5%);
+    border: 1px solid hsl(225 16% 14%);
+    padding: 0.75rem 0;
   }
-  .trace-panels {
-    @apply flex flex-col gap-2.5;
+  .dc-json-line { display: flex; }
+  .dc-json-gutter {
+    @apply select-none shrink-0 text-right;
+    min-width: 2.5rem;
+    padding-right: 0.75rem;
+    color: hsl(var(--foreground) / 0.15);
   }
-  .trace-panel {
-    @apply rounded-md border overflow-hidden;
-    border-color: hsl(225 16% 86%);
+  .dc-json-code { white-space: pre-wrap; word-break: break-all; }
+  .dc-json-key { color: #7dd3fc; }
+  .dc-json-string { color: #fdba74; }
+  .dc-json-number { color: #c084fc; }
+  .dc-json-brace { color: #6ee7b7; }
+  .dc-json-bool { color: #c084fc; }
+  .dc-json-null { color: #c084fc; font-style: italic; }
+
+  /* ─── Source quote blockquote in tree ─── */
+  .dc-source-quote {
+    border-left: 3px solid hsl(250 60% 70%);
+    padding-left: 0.75rem;
+    color: hsl(var(--foreground) / 0.75);
+    font-style: italic;
+    font-size: 0.92em;
+    line-height: 1.6;
   }
-  .dark .trace-panel {
-    border-color: hsl(225 16% 14%);
+
+  /* ─── Long text prose block in tree ─── */
+  .dc-tree-prose {
+    @apply rounded-md border px-3 py-2;
+    border-color: hsl(var(--border) / 0.3);
+    background: hsl(var(--secondary) / 0.3);
+    font-size: 13px;
+    line-height: 1.65;
+    color: hsl(var(--foreground) / 0.85);
   }
-  .trace-panel-header {
-    @apply flex items-center justify-between px-3 py-1.5 uppercase tracking-wider font-semibold;
-    font-size: 9px;
+
+  /* ─── Copy button ─── */
+  .dc-copy-btn {
+    @apply ml-auto shrink-0 rounded-md p-1 transition-colors;
+    color: hsl(var(--foreground) / 0.3);
   }
-  .trace-panel-size {
-    @apply font-mono font-normal normal-case tracking-normal;
-    opacity: 0.5;
+  .dc-copy-btn:hover {
+    color: hsl(var(--foreground) / 0.7);
+    background: hsl(var(--accent) / 0.1);
   }
-  .trace-panel-prompt .trace-panel-header {
-    background: hsl(250 30% 96%);
-    color: hsl(250 40% 50%);
-    border-bottom: 1px solid hsl(250 20% 90%);
-  }
-  .dark .trace-panel-prompt .trace-panel-header {
-    background: hsl(225 20% 7%);
-    color: hsl(250 45% 72%);
-    border-bottom: 1px solid hsl(250 20% 15%);
-  }
-  .trace-panel-response .trace-panel-header {
-    background: hsl(170 30% 96%);
-    color: hsl(174 50% 35%);
-    border-bottom: 1px solid hsl(174 20% 88%);
-  }
-  .dark .trace-panel-response .trace-panel-header {
-    background: hsl(170 20% 7%);
-    color: hsl(174 50% 65%);
-    border-bottom: 1px solid hsl(174 20% 13%);
-  }
-  .trace-panel-body {
-    @apply font-mono leading-relaxed;
-    padding: 10px 12px;
-    font-size: 11px;
-    color: hsl(var(--foreground));
-    opacity: 0.82;
-    white-space: pre-wrap;
-    word-break: break-word;
-    max-height: 240px;
-    overflow-y: auto;
-    background: hsl(225 10% 97%);
-  }
-  .dark .trace-panel-body {
-    background: hsl(225 24% 7%);
-  }
-  .trace-panel-response .trace-panel-body {
-    font-size: 12px;
-    max-height: 120px;
-  }
-  .dark .trace-panel-response .trace-panel-body {
-    color: hsl(174 30% 75%);
+  .dc-copy-btn.copied {
+    color: hsl(var(--success));
   }
 
   /* Typography control pill (font/width stepper) */

--- a/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
+++ b/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
-import { CellValue, DataCard } from "@/components/ui/data-card"
+import { CellValue, DataCard, type ActionInfo } from "@/components/ui/data-card"
 import { useCatalogData } from "@/lib/catalog-context"
 import type { DataNode, WorkflowDataSummary } from "@/lib/mock-data"
 
@@ -419,9 +419,22 @@ function NodeDetail({
   workflow: WorkflowDataSummary
   onBack: () => void
 }) {
+  const { actions } = useCatalogData()
   const [page, setPage] = useState(0)
   const [viewMode, setViewMode] = useState<ViewMode>("card")
   const typo = useTypographyPrefs()
+
+  // Look up action config for the card info section
+  const actionConfig = actions[node.node] || actions[`${node.workflow}__${node.node}`]
+  const actionInfo: ActionInfo | undefined = actionConfig
+    ? {
+        name: node.node,
+        kind: actionConfig.type || "unknown",
+        impl: actionConfig.impl || undefined,
+        intent: actionConfig.intent || undefined,
+        dependencies: actionConfig.deps || [],
+      }
+    : undefined
 
   const columns = useMemo(() => {
     if (node.preview.length === 0) return []
@@ -568,6 +581,7 @@ function NodeDetail({
                   index={idx + 1}
                   fontSize={typo.fontSize}
                   defaultOpen={i === 0}
+                  actionInfo={actionInfo}
                 />
               )
             })}

--- a/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
+++ b/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
@@ -567,6 +567,7 @@ function NodeDetail({
                   record={row}
                   index={idx + 1}
                   fontSize={typo.fontSize}
+                  defaultOpen={i === 0}
                 />
               )
             })}

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -436,11 +436,20 @@ function useSectionState(nodeKey: string) {
 
 // ── DataCard ──────────────────────────────────────────────────────────────
 
+export interface ActionInfo {
+  name: string
+  kind: string
+  impl?: string
+  intent?: string
+  dependencies: string[]
+}
+
 export interface DataCardProps {
   record: Record<string, unknown>
   index?: number
   fontSize?: number
   defaultOpen?: boolean
+  actionInfo?: ActionInfo
 }
 
 function getDisplayFields(record: Record<string, unknown>): Record<string, unknown> {
@@ -451,7 +460,7 @@ function getDisplayFields(record: Record<string, unknown>): Record<string, unkno
   return record
 }
 
-export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCardProps) {
+export function DataCard({ record, index, fontSize, defaultOpen = true, actionInfo }: DataCardProps) {
   const [recordOpen, setRecordOpen] = useState(defaultOpen)
   const displayRecord = getDisplayFields(record)
   const { identity, metadata } = classifyRecord(record)
@@ -532,6 +541,30 @@ export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCa
 
       <div className="data-card-drawer" data-open={recordOpen}>
         <div>
+
+      {/* Action info bar */}
+      {actionInfo && (
+        <div className="px-4 py-2 flex items-center gap-2 flex-wrap border-t border-border/30">
+          <span className="text-[10px] font-mono font-medium px-1.5 py-0.5 rounded bg-secondary text-foreground/70">
+            {actionInfo.kind}
+          </span>
+          {actionInfo.impl && (
+            <span className="text-[10px] font-mono text-muted-foreground/60">
+              fn: {actionInfo.impl}
+            </span>
+          )}
+          {actionInfo.dependencies.length > 0 && (
+            <span className="text-[10px] font-mono text-muted-foreground/50">
+              deps: {actionInfo.dependencies.join(", ")}
+            </span>
+          )}
+          {actionInfo.intent && (
+            <span className="text-[10px] text-muted-foreground/50 truncate" title={actionInfo.intent}>
+              {actionInfo.intent}
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Section 1: Prompt Trace */}
       {trace?.compiled_prompt && (

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -45,16 +45,12 @@ export function CellValue({ value }: { value: unknown }) {
   if (typeof value === "object") {
     const str = JSON.stringify(value)
     return (
-      <span className="font-mono text-muted-foreground truncate block max-w-[300px]" title={str}>
-        {str.length > 80 ? str.slice(0, 80) + "\u2026" : str}
-      </span>
+      <span className="font-mono text-muted-foreground break-all">{str}</span>
     )
   }
   const str = String(value)
   return (
-    <span className="font-mono text-foreground truncate block max-w-[300px]" title={str}>
-      {str.length > 120 ? str.slice(0, 120) + "\u2026" : str}
-    </span>
+    <span className="font-mono text-foreground break-all">{str}</span>
   )
 }
 
@@ -294,25 +290,29 @@ function FieldValue({ fieldKey, value }: { fieldKey: string; value: unknown }) {
 
 // ── Tree components ────────────────────────────────────────────────────────
 
-function TreeField({ fieldKey, value }: { fieldKey: string; value: unknown }) {
-  const short = isShortValue(value) && !isLongFormField(fieldKey) && !isSourceQuoteField(fieldKey)
-
-  if (short) {
-    return (
-      <div className="flex items-baseline gap-3 min-w-0 py-0.5 pl-6">
-        <span className="text-[0.85em] font-mono text-[#7dd3fc] shrink-0">{fieldKey}</span>
-        <div className="min-w-0 flex-1 text-[0.9em]">
-          <FieldValue fieldKey={fieldKey} value={value} />
-        </div>
-      </div>
-    )
-  }
+function TreeField({ fieldKey, value, defaultOpen = true }: { fieldKey: string; value: unknown; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen)
+  const valStr = typeof value === "string" ? value : typeof value === "object" ? JSON.stringify(value) : String(value ?? "")
+  const preview = valStr.length > 60 ? valStr.slice(0, 60) + "\u2026" : valStr
 
   return (
-    <div className="flex flex-col gap-1 py-0.5 pl-6">
-      <span className="text-[0.85em] font-mono text-[#7dd3fc]">{fieldKey}</span>
-      <div className="text-[0.9em]">
-        <FieldValue fieldKey={fieldKey} value={value} />
+    <div className="py-0.5 pl-4">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 min-w-0 w-full text-left hover:bg-accent/10 rounded-sm py-0.5 px-2 transition-colors"
+      >
+        <ChevronRight
+          className={`h-2.5 w-2.5 shrink-0 text-muted-foreground/40 transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span className="text-[0.85em] font-mono text-[#7dd3fc] shrink-0">{fieldKey}</span>
+        {!open && (
+          <span className="text-[0.8em] font-mono text-muted-foreground/40 truncate">{preview}</span>
+        )}
+      </button>
+      <div className="data-card-drawer" data-open={open}>
+        <div className="pl-7 pr-2 pb-1">
+          <FieldValue fieldKey={fieldKey} value={value} />
+        </div>
       </div>
     </div>
   )
@@ -401,6 +401,7 @@ function ArrayItemNode({
 
 const DEFAULT_SECTION_STATE = {
   promptTrace: false,
+  inputData: false,
   rawResponse: false,
   actionOutput: true,
   metadata: false,
@@ -440,6 +441,7 @@ export interface DataCardProps {
   record: Record<string, unknown>
   index?: number
   fontSize?: number
+  defaultOpen?: boolean
 }
 
 function getDisplayFields(record: Record<string, unknown>): Record<string, unknown> {
@@ -450,7 +452,8 @@ function getDisplayFields(record: Record<string, unknown>): Record<string, unkno
   return record
 }
 
-export function DataCard({ record, index, fontSize }: DataCardProps) {
+export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCardProps) {
+  const [recordOpen, setRecordOpen] = useState(defaultOpen)
   const displayRecord = getDisplayFields(record)
   const { identity, metadata } = classifyRecord(record)
 
@@ -462,6 +465,19 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
     record._trace && typeof record._trace === "object" && "compiled_prompt" in record._trace
       ? (record._trace as PromptTrace)
       : null
+
+  // Parse input data from trace's llm_context (JSON string → namespaced object)
+  let inputData: Record<string, unknown> | null = null
+  if (trace?.llm_context) {
+    try {
+      const parsed = JSON.parse(trace.llm_context)
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        inputData = parsed as Record<string, unknown>
+      }
+    } catch {
+      // Not valid JSON — skip input data section
+    }
+  }
 
   // Derive a stable node key for section state persistence
   const nodeKey =
@@ -478,39 +494,50 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
 
   return (
     <div className="data-card" style={fontSize ? { fontSize: `${fontSize}px` } : undefined}>
-      {/* Identity header */}
-      <div className="px-4 pt-3 pb-1">
-        <div className="flex items-center gap-2 flex-wrap">
-          {typeof index === "number" && (
-            <span className="text-[10px] font-mono text-muted-foreground/40 tabular-nums">
-              #{index}
-            </span>
-          )}
-          {identity.map((f) => (
-            <span
-              key={f.key}
-              className="text-[10px] font-mono text-muted-foreground/60 truncate"
-              title={`${f.key}: ${formatValue(f.value, 0)}`}
-            >
-              {formatValue(f.value, 32)}
-            </span>
-          ))}
-          {typeof record._file === "string" && (
-            <span
-              className="text-[10px] font-mono text-muted-foreground/50 truncate"
-              title={record._file}
-            >
-              {record._file}
-            </span>
-          )}
-        </div>
-      </div>
+      {/* Identity header — click to expand/collapse record */}
+      <button
+        onClick={() => setRecordOpen(!recordOpen)}
+        className="flex items-center gap-2 flex-wrap px-4 pt-3 pb-1 w-full text-left hover:bg-accent/5 transition-colors"
+      >
+        <ChevronRight
+          className={`h-3.5 w-3.5 shrink-0 text-muted-foreground/40 transition-transform ${recordOpen ? "rotate-90" : ""}`}
+        />
+        {typeof index === "number" && (
+          <span className="text-[10px] font-mono text-muted-foreground/40 tabular-nums">
+            #{index}
+          </span>
+        )}
+        {identity.map((f) => (
+          <span
+            key={f.key}
+            className="text-[10px] font-mono text-muted-foreground/60 truncate"
+            title={`${f.key}: ${formatValue(f.value, 0)}`}
+          >
+            {formatValue(f.value, 32)}
+          </span>
+        ))}
+        {typeof record._file === "string" && (
+          <span
+            className="text-[10px] font-mono text-muted-foreground/50 truncate"
+            title={record._file}
+          >
+            {record._file}
+          </span>
+        )}
+        {!recordOpen && (
+          <span className="text-[10px] text-muted-foreground/40 ml-auto">
+            {trace ? "trace + " : ""}{outputFields.length} fields
+          </span>
+        )}
+      </button>
+
+      <div className="data-card-drawer" data-open={recordOpen}><div>
 
       {/* Section 1: Prompt Trace */}
       {trace?.compiled_prompt && (
         <CollapsibleSection
           label="Prompt Trace"
-          accentClass="dc-section-purple"
+          accentClass="dc-section"
           badge={
             <div className="flex gap-1.5">
               {trace.model_name && (
@@ -532,11 +559,46 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
         </CollapsibleSection>
       )}
 
-      {/* Section 2: Raw Response */}
+      {/* Section 2: Input Data */}
+      {inputData && Object.keys(inputData).length > 0 && (
+        <CollapsibleSection
+          label="Input Data"
+          accentClass="dc-section"
+          hint={`${Object.keys(inputData).length} namespaces`}
+          open={sec.inputData}
+          onToggle={() => toggle("inputData")}
+          copyText={JSON.stringify(inputData, null, 2)}
+        >
+          <div className="pb-2">
+            {Object.entries(inputData).map(([nsName, nsData]) => {
+              if (typeof nsData !== "object" || nsData === null) {
+                return (
+                  <TreeField key={nsName} fieldKey={nsName} value={nsData} />
+                )
+              }
+              const fields = nsData as Record<string, unknown>
+              return (
+                <TreeNode
+                  key={nsName}
+                  label={nsName}
+                  badge={`${Object.keys(fields).length} fields`}
+                  defaultOpen={false}
+                >
+                  {Object.entries(fields).map(([k, v]) => (
+                    <TreeField key={k} fieldKey={k} value={v} />
+                  ))}
+                </TreeNode>
+              )
+            })}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Section 3: Raw Response */}
       {trace?.response_text && (
         <CollapsibleSection
           label="Raw Response"
-          accentClass="dc-section-blue"
+          accentClass="dc-section"
           hint={
             trace.response_length
               ? `${trace.response_length.toLocaleString()} chars`
@@ -556,7 +618,7 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
       {outputFields.length > 0 && (
         <CollapsibleSection
           label="Action Output"
-          accentClass="dc-section-pink"
+          accentClass="dc-section"
           hint={`${outputFields.length} fields`}
           open={sec.actionOutput}
           onToggle={() => toggle("actionOutput")}
@@ -598,7 +660,7 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
       {metadata.length > 0 && (
         <CollapsibleSection
           label="Metadata"
-          accentClass="dc-section-gray"
+          accentClass="dc-section"
           hint={`${metadata.length} fields`}
           open={sec.metadata}
           onToggle={() => toggle("metadata")}
@@ -622,6 +684,8 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
           </div>
         </CollapsibleSection>
       )}
+
+      </div></div>{/* close record drawer */}
     </div>
   )
 }

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -1,7 +1,9 @@
 "use client"
 
-import React, { useState } from "react"
-import { ChevronRight } from "lucide-react"
+import React, { useState, useCallback, useEffect } from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { ChevronRight, Copy, Check } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import {
   classifyField,
@@ -10,6 +12,7 @@ import {
   isInlineArray,
   isLongFormField,
   isShortValue,
+  isSourceQuoteField,
   getValueType,
   formatValue,
   type ClassifiedField,
@@ -55,13 +58,204 @@ export function CellValue({ value }: { value: unknown }) {
   )
 }
 
+// ── Copy button ────────────────────────────────────────────────────────────
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      navigator.clipboard.writeText(text).then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      })
+    },
+    [text],
+  )
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={`dc-copy-btn ${copied ? "copied" : ""}`}
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  )
+}
+
+// ── Markdown prose renderer ────────────────────────────────────────────────
+
+function MarkdownProse({ text }: { text: string }) {
+  return (
+    <article className="dc-prose">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+    </article>
+  )
+}
+
+// ── JSON syntax highlighter ────────────────────────────────────────────────
+
+function highlightJsonLine(line: string): React.ReactNode[] {
+  const tokens: React.ReactNode[] = []
+  let i = 0
+
+  while (i < line.length) {
+    // Whitespace
+    if (/\s/.test(line[i])) {
+      let ws = ""
+      while (i < line.length && /\s/.test(line[i])) ws += line[i++]
+      tokens.push(ws)
+      continue
+    }
+    // Braces / brackets / colon / comma
+    if ("{[}]:,".includes(line[i])) {
+      tokens.push(
+        <span key={`b${i}`} className="dc-json-brace">
+          {line[i]}
+        </span>,
+      )
+      i++
+      continue
+    }
+    // String
+    if (line[i] === '"') {
+      let str = '"'
+      i++
+      while (i < line.length && line[i] !== '"') {
+        if (line[i] === "\\") {
+          str += line[i++]
+        }
+        if (i < line.length) str += line[i++]
+      }
+      if (i < line.length) str += line[i++]
+
+      // Determine if this is a key (followed by :) or a value
+      let j = i
+      while (j < line.length && /\s/.test(line[j])) j++
+      const isKey = j < line.length && line[j] === ":"
+      tokens.push(
+        <span key={`s${i}`} className={isKey ? "dc-json-key" : "dc-json-string"}>
+          {str}
+        </span>,
+      )
+      continue
+    }
+    // Number / boolean / null
+    const rest = line.slice(i)
+    const numMatch = rest.match(/^-?\d+(\.\d+)?([eE][+-]?\d+)?/)
+    if (numMatch) {
+      tokens.push(
+        <span key={`n${i}`} className="dc-json-number">
+          {numMatch[0]}
+        </span>,
+      )
+      i += numMatch[0].length
+      continue
+    }
+    const kwMatch = rest.match(/^(true|false)/)
+    if (kwMatch) {
+      tokens.push(
+        <span key={`k${i}`} className="dc-json-bool">
+          {kwMatch[0]}
+        </span>,
+      )
+      i += kwMatch[0].length
+      continue
+    }
+    const nullMatch = rest.match(/^null/)
+    if (nullMatch) {
+      tokens.push(
+        <span key={`x${i}`} className="dc-json-null">
+          null
+        </span>,
+      )
+      i += 4
+      continue
+    }
+    // Fallback
+    tokens.push(line[i])
+    i++
+  }
+  return tokens
+}
+
+function JsonHighlighter({ text }: { text: string }) {
+  let formatted: string
+  try {
+    formatted = JSON.stringify(JSON.parse(text), null, 2)
+  } catch {
+    // Not valid JSON — render as plain monospace
+    return (
+      <pre className="dc-json px-3 py-2 whitespace-pre-wrap break-all">
+        {text}
+      </pre>
+    )
+  }
+
+  const lines = formatted.split("\n")
+
+  return (
+    <div className="dc-json">
+      {lines.map((line, i) => (
+        <div key={i} className="dc-json-line">
+          <span className="dc-json-gutter">{i + 1}</span>
+          <span className="dc-json-code">{highlightJsonLine(line)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Collapsible section ────────────────────────────────────────────────────
+
+function CollapsibleSection({
+  label,
+  accentClass,
+  badge,
+  hint,
+  open,
+  onToggle,
+  copyText,
+  children,
+}: {
+  label: string
+  accentClass: string
+  badge?: React.ReactNode
+  hint?: string
+  open: boolean
+  onToggle: () => void
+  copyText?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className={accentClass}>
+      <button onClick={onToggle} className="dc-section-header">
+        <ChevronRight
+          className={`h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span className="text-[0.85em] font-semibold text-foreground/90">{label}</span>
+        {badge}
+        {hint && <span className="text-[0.75em] text-muted-foreground/50 ml-auto">{hint}</span>}
+        {copyText && <CopyButton text={copyText} />}
+      </button>
+      <div className="data-card-drawer" data-open={open}>
+        <div>{children}</div>
+      </div>
+    </div>
+  )
+}
+
 // ── Field renderers ────────────────────────────────────────────────────────
 
 function InlinePills({ items }: { items: (string | number)[] }) {
   return (
     <div className="flex flex-wrap gap-1.5">
       {items.map((item, i) => (
-        <span key={i} className="data-card-pill">{String(item)}</span>
+        <span key={i} className="data-card-pill">
+          {String(item)}
+        </span>
       ))}
     </div>
   )
@@ -75,51 +269,6 @@ function CodeBlock({ value }: { value: unknown }) {
   )
 }
 
-/** Render an array of objects as structured sub-cards instead of raw JSON. */
-function ObjectArrayBlock({ items, fieldKey }: { items: Record<string, unknown>[]; fieldKey: string }) {
-  const [expanded, setExpanded] = useState(false)
-  const visibleCount = expanded ? items.length : 2
-  const hasMore = items.length > 2
-
-  return (
-    <div className="flex flex-col gap-2">
-      {items.slice(0, visibleCount).map((item, i) => (
-        <div
-          key={i}
-          className="rounded-md border border-border/40 bg-secondary/20 px-3 py-2.5 flex flex-col gap-1.5"
-        >
-          <span className="text-[9px] font-mono text-muted-foreground/40 tabular-nums">
-            {humanizeKey(fieldKey)} [{i + 1}/{items.length}]
-          </span>
-          {Object.entries(item).map(([k, v]) => {
-            const valStr = typeof v === "object" && v !== null ? JSON.stringify(v) : String(v ?? "")
-            const isLong = valStr.length > 100
-            return (
-              <div key={k} className={isLong ? "flex flex-col gap-0.5" : "flex items-baseline gap-2 min-w-0"}>
-                <span className="text-[10px] uppercase tracking-wider font-semibold text-muted-foreground/70 shrink-0">
-                  {humanizeKey(k)}
-                </span>
-                <span className={`text-[0.9em] ${isLong ? "data-card-prose" : "font-mono text-foreground/80"}`}>
-                  {valStr}
-                </span>
-              </div>
-            )
-          })}
-        </div>
-      ))}
-      {hasMore && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="text-[10px] text-[hsl(var(--primary))] hover:underline self-start"
-        >
-          {expanded ? "Show less" : `Show ${items.length - 2} more`}
-        </button>
-      )}
-    </div>
-  )
-}
-
-/** True when value is an array of plain objects (not nested arrays). */
 function isArrayOfObjects(value: unknown): value is Record<string, unknown>[] {
   if (!Array.isArray(value) || value.length === 0) return false
   return value.every((v) => typeof v === "object" && v !== null && !Array.isArray(v))
@@ -129,49 +278,30 @@ function FieldValue({ fieldKey, value }: { fieldKey: string; value: unknown }) {
   if (isInlineArray(value)) {
     return <InlinePills items={value as (string | number)[]} />
   }
-  if (isArrayOfObjects(value)) {
-    return <ObjectArrayBlock items={value} fieldKey={fieldKey} />
-  }
-  if (getValueType(value) === "object") {
+  if (getValueType(value) === "object" && !isArrayOfObjects(value)) {
     return <CodeBlock value={value} />
   }
-  if (typeof value === "string" && (isLongFormField(fieldKey) ? value.length > 80 : value.length > 120)) {
-    return <ProseBlock text={value} />
+  // Source quote — blockquote treatment
+  if (isSourceQuoteField(fieldKey) && typeof value === "string") {
+    return <div className="dc-source-quote">{value}</div>
+  }
+  // Long text — Notion prose block
+  if (typeof value === "string" && value.length > 80) {
+    return <div className="dc-tree-prose">{value}</div>
   }
   return <CellValue value={value} />
 }
 
-function ProseBlock({ text }: { text: string }) {
-  const [expanded, setExpanded] = useState(false)
-  const needsClamp = text.length > 200
+// ── Tree components ────────────────────────────────────────────────────────
 
-  return (
-    <div>
-      <p className={`data-card-prose ${needsClamp && !expanded ? "clamped" : ""}`}>
-        {text}
-      </p>
-      {needsClamp && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="text-[10px] text-[hsl(var(--primary))] hover:underline mt-1"
-        >
-          {expanded ? "Show less" : "Show more"}
-        </button>
-      )}
-    </div>
-  )
-}
-
-// ── Field row ─────────────────────────────────────────────────────────────
-
-function FieldRow({ fieldKey, value }: { fieldKey: string; value: unknown }) {
-  const short = isShortValue(value) && !isLongFormField(fieldKey)
+function TreeField({ fieldKey, value }: { fieldKey: string; value: unknown }) {
+  const short = isShortValue(value) && !isLongFormField(fieldKey) && !isSourceQuoteField(fieldKey)
 
   if (short) {
     return (
-      <div className="flex items-baseline gap-3 min-w-0">
-        <span className="data-card-label shrink-0 min-w-[80px]">{humanizeKey(fieldKey)}</span>
-        <div className="min-w-0 flex-1 text-[1em] text-foreground">
+      <div className="flex items-baseline gap-3 min-w-0 py-0.5 pl-6">
+        <span className="text-[0.85em] font-mono text-[#7dd3fc] shrink-0">{fieldKey}</span>
+        <div className="min-w-0 flex-1 text-[0.9em]">
           <FieldValue fieldKey={fieldKey} value={value} />
         </div>
       </div>
@@ -179,41 +309,39 @@ function FieldRow({ fieldKey, value }: { fieldKey: string; value: unknown }) {
   }
 
   return (
-    <div className="flex flex-col gap-1">
-      <span className="data-card-label">{humanizeKey(fieldKey)}</span>
-      <div className="text-[1em] text-foreground">
+    <div className="flex flex-col gap-1 py-0.5 pl-6">
+      <span className="text-[0.85em] font-mono text-[#7dd3fc]">{fieldKey}</span>
+      <div className="text-[0.9em]">
         <FieldValue fieldKey={fieldKey} value={value} />
       </div>
     </div>
   )
 }
 
-// ── Collapsible section (shared by structured fields, metadata, trace) ───
-
-function CollapsibleSection({
+function TreeNode({
   label,
-  badgeText,
-  children,
+  badge,
   defaultOpen = false,
-  className = "",
+  children,
 }: {
   label: string
-  badgeText?: string
-  children: React.ReactNode
+  badge?: string
   defaultOpen?: boolean
-  className?: string
+  children: React.ReactNode
 }) {
   const [open, setOpen] = useState(defaultOpen)
 
   return (
-    <div className={`border-t border-border/50 mt-1 ${className}`}>
+    <div>
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-1.5 py-2 px-4 text-[10px] text-muted-foreground hover:text-foreground transition-colors w-full"
+        className="flex items-center gap-1.5 py-1.5 px-4 w-full text-left hover:bg-accent/20 transition-colors rounded-sm"
       >
-        <ChevronRight className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`} />
-        <span className="uppercase tracking-wider font-semibold">{label}</span>
-        {badgeText && <span className="text-muted-foreground/50 ml-1">{badgeText}</span>}
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-muted-foreground/60 transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span className="text-[0.9em] font-mono font-semibold text-[#c084fc]">{label}</span>
+        {badge && <span className="text-[0.75em] font-mono text-[#6ee7b7]">{badge}</span>}
       </button>
       <div className="data-card-drawer" data-open={open}>
         <div>{children}</div>
@@ -222,83 +350,88 @@ function CollapsibleSection({
   )
 }
 
-// ── Metadata drawer ───────────────────────────────────────────────────────
+function ArrayItemNode({
+  item,
+  index,
+  defaultOpen = false,
+}: {
+  item: Record<string, unknown>
+  index: number
+  defaultOpen?: boolean
+}) {
+  const [open, setOpen] = useState(defaultOpen)
 
-function MetadataDrawer({ fields }: { fields: ClassifiedField[] }) {
-  if (fields.length === 0) return null
-
-  return (
-    <CollapsibleSection label="Metadata" badgeText={`${fields.length} fields`}>
-      <div className="px-4 pb-3 flex flex-col gap-1.5">
-        {fields.map((f) => (
-          <div key={f.key} className="flex items-baseline gap-2 min-w-0">
-            <span className="text-[9px] uppercase tracking-wider text-muted-foreground/60 font-medium shrink-0 min-w-[60px]">
-              {humanizeKey(f.key)}
-            </span>
-            <span className="text-[11px] font-mono text-muted-foreground break-all">
-              {formatValue(f.value, 120)}
-            </span>
-          </div>
-        ))}
-      </div>
-    </CollapsibleSection>
+  const previewField = Object.entries(item).find(
+    ([, v]) => typeof v === "string" && (v as string).length > 10,
   )
-}
-
-// ── Prompt Trace drawer ──────────────────────────────────────────────────
-
-function PromptTraceDrawer({ trace }: { trace: PromptTrace }) {
-  const [open, setOpen] = useState(false)
-
-  const modelLabel = trace.model_name || "unknown"
-  const modeLabel = trace.run_mode || "online"
-  const isBatch = modeLabel === "batch"
+  const preview = previewField
+    ? (previewField[1] as string).slice(0, 80) +
+      ((previewField[1] as string).length > 80 ? "\u2026" : "")
+    : `${Object.keys(item).length} fields`
 
   return (
-    <div className="trace-section">
+    <div>
       <button
         onClick={() => setOpen(!open)}
-        className={`trace-trigger ${open ? "open" : ""}`}
+        className="flex items-center gap-1.5 py-1 px-4 pl-8 w-full text-left hover:bg-accent/20 transition-colors rounded-sm"
       >
-        <ChevronRight className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`} />
-        <span className="trace-label">Prompt Trace</span>
-        <div className="trace-badges">
-          <span className="trace-badge trace-badge-model">{modelLabel}</span>
-          <span className={`trace-badge trace-badge-mode ${isBatch ? "batch" : ""}`}>{modeLabel}</span>
-        </div>
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-muted-foreground/60 transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span className="text-[0.85em] font-mono text-[#7dd3fc]">[{index}]</span>
+        <span className="text-[0.75em] font-mono text-[#6ee7b7]">object</span>
+        {!open && (
+          <span className="text-[0.8em] text-muted-foreground/50 truncate ml-1 italic">
+            {preview}
+          </span>
+        )}
       </button>
       <div className="data-card-drawer" data-open={open}>
-        <div>
-          <div className="trace-content">
-            <div className="trace-panels">
-              <div className="trace-panel trace-panel-prompt">
-                <div className="trace-panel-header">
-                  <span>Compiled Prompt</span>
-                  {trace.prompt_length != null && (
-                    <span className="trace-panel-size">{trace.prompt_length.toLocaleString()} chars</span>
-                  )}
-                </div>
-                <div className="trace-panel-body">
-                  {trace.compiled_prompt}
-                </div>
-              </div>
-              <div className="trace-panel trace-panel-response">
-                <div className="trace-panel-header">
-                  <span>LLM Response</span>
-                  {trace.response_length != null && (
-                    <span className="trace-panel-size">{trace.response_length.toLocaleString()} chars</span>
-                  )}
-                </div>
-                <div className="trace-panel-body">
-                  {trace.response_text || <span className="text-muted-foreground/50 italic text-[10px]">Response pending</span>}
-                </div>
-              </div>
-            </div>
-          </div>
+        <div className="pl-4">
+          {Object.entries(item).map(([k, v]) => (
+            <TreeField key={k} fieldKey={k} value={v} />
+          ))}
         </div>
       </div>
     </div>
   )
+}
+
+// ── Section state persistence ──────────────────────────────────────────────
+
+const DEFAULT_SECTION_STATE = {
+  promptTrace: false,
+  rawResponse: false,
+  actionOutput: true,
+  metadata: false,
+}
+
+let _cachedNodeKey: string | null = null
+let _cachedState: typeof DEFAULT_SECTION_STATE | null = null
+
+function useSectionState(nodeKey: string) {
+  const [state, setState] = useState(() => {
+    if (_cachedNodeKey === nodeKey && _cachedState) return _cachedState
+    return { ...DEFAULT_SECTION_STATE }
+  })
+
+  useEffect(() => {
+    if (_cachedNodeKey !== nodeKey) {
+      _cachedNodeKey = nodeKey
+      _cachedState = { ...DEFAULT_SECTION_STATE }
+      setState({ ...DEFAULT_SECTION_STATE })
+    }
+  }, [nodeKey])
+
+  const toggle = useCallback((key: keyof typeof DEFAULT_SECTION_STATE) => {
+    setState((prev) => {
+      const next = { ...prev, [key]: !prev[key] }
+      _cachedState = next
+      return next
+    })
+  }, [])
+
+  return { state, toggle }
 }
 
 // ── DataCard ──────────────────────────────────────────────────────────────
@@ -321,26 +454,31 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
   const displayRecord = getDisplayFields(record)
   const { identity, metadata } = classifyRecord(record)
 
-  const displayFields = Object.entries(displayRecord)
+  const outputFields = Object.entries(displayRecord)
     .filter(([key]) => classifyField(key) === "content")
-    .map(([key, value]) => ({ key, value, role: "content" as const }))
+    .map(([key, value]) => ({ key, value }))
 
-  // Split into scalar (simple) vs structured (complex) fields
-  const scalarFields = displayFields.filter(
-    (f) => !isArrayOfObjects(f.value) && (getValueType(f.value) !== "object" || isInlineArray(f.value)),
-  )
-  const structuredFields = displayFields.filter(
-    (f) => isArrayOfObjects(f.value) || (getValueType(f.value) === "object" && !isInlineArray(f.value)),
-  )
+  const trace =
+    record._trace && typeof record._trace === "object" && "compiled_prompt" in record._trace
+      ? (record._trace as PromptTrace)
+      : null
 
-  const hasTrace = record._trace && typeof record._trace === "object" && "compiled_prompt" in record._trace
+  // Derive a stable node key for section state persistence
+  const nodeKey =
+    typeof record._file === "string"
+      ? record._file
+      : typeof record.node_id === "string"
+        ? record.node_id
+        : "default"
+
+  const { state: sec, toggle } = useSectionState(nodeKey)
+
+  // Prepare copy text for output section
+  const outputJson = JSON.stringify(displayRecord, null, 2)
 
   return (
-    <div
-      className="data-card"
-      style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
-    >
-      {/* 1. Identity header */}
+    <div className="data-card" style={fontSize ? { fontSize: `${fontSize}px` } : undefined}>
+      {/* Identity header */}
       <div className="px-4 pt-3 pb-1">
         <div className="flex items-center gap-2 flex-wrap">
           {typeof index === "number" && (
@@ -358,44 +496,132 @@ export function DataCard({ record, index, fontSize }: DataCardProps) {
             </span>
           ))}
           {typeof record._file === "string" && (
-            <span className="text-[10px] font-mono text-muted-foreground/50 truncate" title={record._file}>
+            <span
+              className="text-[10px] font-mono text-muted-foreground/50 truncate"
+              title={record._file}
+            >
               {record._file}
             </span>
           )}
         </div>
       </div>
 
-      {/* 2. Prompt Trace (input data — what was sent to the LLM) */}
-      {hasTrace && (
-        <PromptTraceDrawer trace={record._trace as PromptTrace} />
+      {/* Section 1: Prompt Trace */}
+      {trace?.compiled_prompt && (
+        <CollapsibleSection
+          label="Prompt Trace"
+          accentClass="dc-section-purple"
+          badge={
+            <div className="flex gap-1.5">
+              {trace.model_name && (
+                <span className="dc-badge dc-badge-model">{trace.model_name}</span>
+              )}
+              {trace.run_mode && (
+                <span className="dc-badge dc-badge-mode">{trace.run_mode}</span>
+              )}
+            </div>
+          }
+          hint={trace.prompt_length ? `${trace.prompt_length.toLocaleString()} chars` : undefined}
+          open={sec.promptTrace}
+          onToggle={() => toggle("promptTrace")}
+          copyText={trace.compiled_prompt}
+        >
+          <div className="px-2 pb-3">
+            <MarkdownProse text={trace.compiled_prompt} />
+          </div>
+        </CollapsibleSection>
       )}
 
-      {/* 3. Action Output — scalar fields inline, then structured fields */}
-      {(scalarFields.length > 0 || structuredFields.length > 0) && (
-        <div className="px-4 pb-3 pt-1 flex flex-col gap-2.5">
-          {/* Section label */}
-          {hasTrace && (
-            <span className="text-[9px] uppercase tracking-wider font-semibold text-muted-foreground/50 pt-1">
-              Output
-            </span>
+      {/* Section 2: Raw Response */}
+      {trace?.response_text && (
+        <CollapsibleSection
+          label="Raw Response"
+          accentClass="dc-section-blue"
+          hint={
+            trace.response_length
+              ? `${trace.response_length.toLocaleString()} chars`
+              : undefined
+          }
+          open={sec.rawResponse}
+          onToggle={() => toggle("rawResponse")}
+          copyText={trace.response_text}
+        >
+          <div className="px-4 pb-3">
+            <JsonHighlighter text={trace.response_text} />
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Section 3: Action Output */}
+      {outputFields.length > 0 && (
+        <CollapsibleSection
+          label="Action Output"
+          accentClass="dc-section-pink"
+          hint={`${outputFields.length} fields`}
+          open={sec.actionOutput}
+          onToggle={() => toggle("actionOutput")}
+          copyText={outputJson}
+        >
+          <div className="pb-2">
+            {outputFields.map((f) => {
+              if (isArrayOfObjects(f.value)) {
+                const items = f.value as Record<string, unknown>[]
+                return (
+                  <TreeNode
+                    key={f.key}
+                    label={f.key}
+                    badge={`array[${items.length}]`}
+                    defaultOpen={true}
+                  >
+                    {items.map((item, i) => (
+                      <ArrayItemNode
+                        key={i}
+                        item={item}
+                        index={i}
+                        defaultOpen={i === 0}
+                      />
+                    ))}
+                  </TreeNode>
+                )
+              }
+              return <TreeField key={f.key} fieldKey={f.key} value={f.value} />
+            })}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {outputFields.length === 0 && (
+        <div className="px-4 pb-3 text-xs text-muted-foreground italic">No content fields</div>
+      )}
+
+      {/* Section 4: Metadata */}
+      {metadata.length > 0 && (
+        <CollapsibleSection
+          label="Metadata"
+          accentClass="dc-section-gray"
+          hint={`${metadata.length} fields`}
+          open={sec.metadata}
+          onToggle={() => toggle("metadata")}
+          copyText={JSON.stringify(
+            Object.fromEntries(metadata.map((f) => [f.key, f.value])),
+            null,
+            2,
           )}
-          {scalarFields.map((f) => (
-            <FieldRow key={f.key} fieldKey={f.key} value={f.value} />
-          ))}
-          {structuredFields.map((f) => (
-            <FieldRow key={f.key} fieldKey={f.key} value={f.value} />
-          ))}
-        </div>
+        >
+          <div className="px-4 pb-3 flex flex-col gap-1">
+            {metadata.map((f) => (
+              <div key={f.key} className="flex items-baseline gap-2 min-w-0 py-0.5">
+                <span className="text-[0.8em] font-mono text-muted-foreground/50 shrink-0 min-w-[80px]">
+                  {f.key}
+                </span>
+                <span className="text-[0.8em] font-mono text-muted-foreground/70 break-all">
+                  {formatValue(f.value, 120)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
       )}
-
-      {scalarFields.length === 0 && structuredFields.length === 0 && (
-        <div className="px-4 pb-3 text-xs text-muted-foreground italic">
-          No content fields
-        </div>
-      )}
-
-      {/* 4. Metadata (last — collapsible) */}
-      <MetadataDrawer fields={metadata} />
     </div>
   )
 }

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -217,7 +217,6 @@ function CollapsibleSection({
   children,
 }: {
   label: string
-  accentClass: string
   badge?: React.ReactNode
   hint?: string
   open: boolean
@@ -226,7 +225,7 @@ function CollapsibleSection({
   children: React.ReactNode
 }) {
   return (
-    <div className={accentClass}>
+    <div>
       <button onClick={onToggle} className="dc-section-header">
         <ChevronRight
           className={`h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform ${open ? "rotate-90" : ""}`}
@@ -531,13 +530,14 @@ export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCa
         )}
       </button>
 
-      <div className="data-card-drawer" data-open={recordOpen}><div>
+      <div className="data-card-drawer" data-open={recordOpen}>
+        <div>
 
       {/* Section 1: Prompt Trace */}
       {trace?.compiled_prompt && (
         <CollapsibleSection
           label="Prompt Trace"
-          accentClass="dc-section"
+
           badge={
             <div className="flex gap-1.5">
               {trace.model_name && (
@@ -563,7 +563,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCa
       {inputData && Object.keys(inputData).length > 0 && (
         <CollapsibleSection
           label="Input Data"
-          accentClass="dc-section"
+
           hint={`${Object.keys(inputData).length} namespaces`}
           open={sec.inputData}
           onToggle={() => toggle("inputData")}
@@ -598,7 +598,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCa
       {trace?.response_text && (
         <CollapsibleSection
           label="Raw Response"
-          accentClass="dc-section"
+
           hint={
             trace.response_length
               ? `${trace.response_length.toLocaleString()} chars`
@@ -618,7 +618,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCa
       {outputFields.length > 0 && (
         <CollapsibleSection
           label="Action Output"
-          accentClass="dc-section"
+
           hint={`${outputFields.length} fields`}
           open={sec.actionOutput}
           onToggle={() => toggle("actionOutput")}
@@ -660,7 +660,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCa
       {metadata.length > 0 && (
         <CollapsibleSection
           label="Metadata"
-          accentClass="dc-section"
+
           hint={`${metadata.length} fields`}
           open={sec.metadata}
           onToggle={() => toggle("metadata")}
@@ -685,7 +685,8 @@ export function DataCard({ record, index, fontSize, defaultOpen = true }: DataCa
         </CollapsibleSection>
       )}
 
-      </div></div>{/* close record drawer */}
+        </div>
+      </div>
     </div>
   )
 }

--- a/agent_actions/tooling/docs/frontend/lib/data-card-utils.ts
+++ b/agent_actions/tooling/docs/frontend/lib/data-card-utils.ts
@@ -38,7 +38,13 @@ const LONG_FORM_HINTS = new Set([
   "rationale",
   "comment",
   "notes",
+  "source_quote",
 ])
+
+/** True when a field key represents a source quote (gets blockquote rendering). */
+export function isSourceQuoteField(key: string): boolean {
+  return key.toLowerCase().includes("source_quote")
+}
 
 export type FieldRole = "identity" | "content" | "metadata"
 

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -227,11 +227,12 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
         # The prompt_trace table was added in v0.1.6; older DBs won't have it.
         try:
             for action_name, node_data in nodes.items():
-                guid_map: dict[str, dict] = {}
+                # Map source_guid → list of records (multiple records can share a guid)
+                guid_map: dict[str, list[dict]] = {}
                 for rec in node_data["preview"]:
                     sg = rec.get("source_guid")
                     if sg:
-                        guid_map[sg] = rec
+                        guid_map.setdefault(sg, []).append(rec)
 
                 if not guid_map:
                     continue
@@ -252,18 +253,19 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
                     if rid in seen:
                         continue
                     seen.add(rid)
-                    if rid in guid_map:
-                        guid_map[rid]["_trace"] = {
-                            "compiled_prompt": trace_row["compiled_prompt"],
-                            "llm_context": trace_row["llm_context"],
-                            "response_text": trace_row["response_text"],
-                            "model_name": trace_row["model_name"],
-                            "model_vendor": trace_row["model_vendor"],
-                            "run_mode": trace_row["run_mode"],
-                            "prompt_length": trace_row["prompt_length"],
-                            "response_length": trace_row["response_length"],
-                            "attempt": trace_row["attempt"],
-                        }
+                    trace_data = {
+                        "compiled_prompt": trace_row["compiled_prompt"],
+                        "llm_context": trace_row["llm_context"],
+                        "response_text": trace_row["response_text"],
+                        "model_name": trace_row["model_name"],
+                        "model_vendor": trace_row["model_vendor"],
+                        "run_mode": trace_row["run_mode"],
+                        "prompt_length": trace_row["prompt_length"],
+                        "response_length": trace_row["response_length"],
+                        "attempt": trace_row["attempt"],
+                    }
+                    for rec in guid_map.get(rid, []):
+                        rec["_trace"] = trace_data
         except sqlite3.OperationalError:
             logger.debug("No prompt_trace table in %s — skipping trace attachment", db_file)
 


### PR DESCRIPTION
## Summary
- 5 ordered sections: Prompt Trace, Input Data, Raw Response, Action Output, Metadata
- Prompt rendered as Notion-style prose via react-markdown + remark-gfm
- Raw response as syntax-highlighted JSON with line numbers
- Action output as collapsible tree with prose blocks for long text
- Input data parsed from _trace.llm_context as namespaced tree
- Action info bar on every card: kind badge, tool function, dependencies, intent
- Every field individually collapsible with chevron and inline preview
- Records collapsible (first expanded, rest collapsed)
- Copy-to-clipboard on each section
- Monochrome engineering aesthetic, no rainbow accent bars
- Fix catalog scanner: attach traces to ALL records sharing a source_guid

## Verification
- npm run build passes
- 4732 Python tests pass
- Tested with LLM actions (all 5 sections) and tool actions (action info + output + metadata)
- JSON and Table views unchanged
- Typography controls still work