### PR TITLE
chore: bump version to 0.1.8 (python) and 0.1.16 (extension)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.1.7"
+version = "0.1.8"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-actions",
   "displayName": "Agent Actions",
   "description": "Language support and workflow navigation for Agent Actions projects",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "publisher": "runagac",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump Python package version from 0.1.7 → 0.1.8
- Bump VS Code extension version from 0.1.15 → 0.1.16