### PR TITLE
fix: bump __version__.py to 0.1.8

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"


### PR DESCRIPTION
## Summary
- Missed bumping `agent_actions/__version__.py` in the version bump PR (#218)
- PyPI publish CI failed because tag version (0.1.8) didn't match `__version__.py` (0.1.7)