### PR TITLE
fix: resolve FileUDFResult lineage by source_mapping index, not source_guid scan

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -40,7 +40,6 @@ class LineageEnricher(Enricher):
         base_node_id = IDGenerator.generate_node_id(context.action_name)
 
         use_per_item_parent_lookup = result.source_guid is None and not context.is_first_stage
-        has_source_mapping = result.source_mapping is not None and context.source_data is not None
 
         parent_item = None
         if not use_per_item_parent_lookup:
@@ -51,7 +50,11 @@ class LineageEnricher(Enricher):
         for i, item in enumerate(result.data):
             node_id = f"{base_node_id}_{i}" if len(result.data) > 1 else base_node_id
 
-            if has_source_mapping and i in result.source_mapping:
+            if (
+                result.source_mapping is not None
+                and context.source_data is not None
+                and i in result.source_mapping
+            ):
                 # Index-based lookup — resolve parent by source_mapping
                 source_idx = result.source_mapping[i]
                 if isinstance(source_idx, list):

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -46,6 +46,8 @@ class LineageEnricher(Enricher):
         if not use_per_item_parent_lookup:
             parent_item = self._get_parent_item(result.source_guid, context)
 
+        source_data_len = len(context.source_data) if context.source_data else 0
+
         for i, item in enumerate(result.data):
             node_id = f"{base_node_id}_{i}" if len(result.data) > 1 else base_node_id
 
@@ -55,40 +57,44 @@ class LineageEnricher(Enricher):
                 if isinstance(source_idx, list):
                     # Many-to-one: multiple input records merged into one output
                     source_items = [
-                        context.source_data[idx]
-                        for idx in source_idx
-                        if idx < len(context.source_data)
+                        context.source_data[idx] for idx in source_idx if idx < source_data_len
                     ]
-                    enriched = LineageBuilder.add_lineage_tracking_from_sources(
+                    skipped = len(source_idx) - len(source_items)
+                    if skipped:
+                        logger.warning(
+                            "source_mapping[%d]: %d of %d indices out of bounds (source_data has %d items)",
+                            i,
+                            skipped,
+                            len(source_idx),
+                            source_data_len,
+                        )
+                    result.data[i] = LineageBuilder.add_lineage_tracking_from_sources(
                         obj=item,
                         source_items=source_items,
                         node_id=node_id,
                     )
+                    continue
                 else:
                     # One-to-one: single input record
-                    if source_idx < len(context.source_data):
+                    if source_idx < source_data_len:
                         parent_item = context.source_data[source_idx]
-                    enriched = LineageBuilder.add_unified_lineage(
-                        obj=item,
-                        node_id=node_id,
-                        parent_item=parent_item,
-                    )
+                    else:
+                        logger.warning(
+                            "source_mapping[%d] -> %d is out of bounds (source_data has %d items)",
+                            i,
+                            source_idx,
+                            source_data_len,
+                        )
+                        parent_item = None
             elif use_per_item_parent_lookup:
                 item_source_guid = item.get("source_guid")
                 parent_item = self._get_parent_item(item_source_guid, context)
-                enriched = LineageBuilder.add_unified_lineage(
-                    obj=item,
-                    node_id=node_id,
-                    parent_item=parent_item,
-                )
-            else:
-                enriched = LineageBuilder.add_unified_lineage(
-                    obj=item,
-                    node_id=node_id,
-                    parent_item=parent_item,
-                )
 
-            result.data[i] = enriched
+            result.data[i] = LineageBuilder.add_unified_lineage(
+                obj=item,
+                node_id=node_id,
+                parent_item=parent_item,
+            )
 
         result.node_id = base_node_id
         return result

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -40,6 +40,7 @@ class LineageEnricher(Enricher):
         base_node_id = IDGenerator.generate_node_id(context.action_name)
 
         use_per_item_parent_lookup = result.source_guid is None and not context.is_first_stage
+        has_source_mapping = result.source_mapping is not None and context.source_data is not None
 
         parent_item = None
         if not use_per_item_parent_lookup:
@@ -48,13 +49,45 @@ class LineageEnricher(Enricher):
         for i, item in enumerate(result.data):
             node_id = f"{base_node_id}_{i}" if len(result.data) > 1 else base_node_id
 
-            if use_per_item_parent_lookup:
+            if has_source_mapping and i in result.source_mapping:
+                # Index-based lookup — resolve parent by source_mapping
+                source_idx = result.source_mapping[i]
+                if isinstance(source_idx, list):
+                    # Many-to-one: multiple input records merged into one output
+                    source_items = [
+                        context.source_data[idx]
+                        for idx in source_idx
+                        if idx < len(context.source_data)
+                    ]
+                    enriched = LineageBuilder.add_lineage_tracking_from_sources(
+                        obj=item,
+                        source_items=source_items,
+                        node_id=node_id,
+                    )
+                else:
+                    # One-to-one: single input record
+                    if source_idx < len(context.source_data):
+                        parent_item = context.source_data[source_idx]
+                    enriched = LineageBuilder.add_unified_lineage(
+                        obj=item,
+                        node_id=node_id,
+                        parent_item=parent_item,
+                    )
+            elif use_per_item_parent_lookup:
                 item_source_guid = item.get("source_guid")
                 parent_item = self._get_parent_item(item_source_guid, context)
+                enriched = LineageBuilder.add_unified_lineage(
+                    obj=item,
+                    node_id=node_id,
+                    parent_item=parent_item,
+                )
+            else:
+                enriched = LineageBuilder.add_unified_lineage(
+                    obj=item,
+                    node_id=node_id,
+                    parent_item=parent_item,
+                )
 
-            enriched = LineageBuilder.add_unified_lineage(
-                obj=item, node_id=node_id, parent_item=parent_item
-            )
             result.data[i] = enriched
 
         result.node_id = base_node_id

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -111,6 +111,7 @@ class ProcessingResult:
     recovery_metadata: RecoveryMetadata | None = None
     raw_response: Any | None = None
     pre_extracted_metadata: dict[str, Any] | None = None
+    source_mapping: dict[int, int | list[int]] | None = None
 
     @classmethod
     def success(

--- a/agent_actions/skills/agent-actions-workflow/references/udf-decorator.md
+++ b/agent_actions/skills/agent-actions-workflow/references/udf-decorator.md
@@ -104,12 +104,12 @@ Use FILE for: Aggregation, deduplication, clustering, cross-record analysis.
 `FileUDFResult` wraps FILE-mode output with optional metadata. The runtime
 unwraps it to `.outputs` before structuring records.
 
-**Important:** Lineage is tracked via `source_guid`, not `source_mapping`.
-The pipeline's FILE-mode handler preserves `source_guid` on each output item
-and `LineageEnricher` resolves ancestry from it. `source_mapping` is validated
-at construction time but is **not yet consumed** by the runtime for lineage
-resolution. Always copy `source_guid` from inputs to outputs for correct
-lineage.
+**Lineage resolution:** When `source_mapping` is provided, the runtime uses it
+to resolve each output's parent record by array index into the input data.
+This is the recommended approach for FILE-mode tools that filter, dedup, or
+merge records — it correctly handles multiple input records sharing the same
+`source_guid` (e.g. after a flatten step). When `source_mapping` is omitted,
+the runtime falls back to matching by `source_guid`.
 
 ```python
 from agent_actions import FileUDFResult

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -77,7 +77,9 @@ def process_file_mode_tool(
         # validation is skipped (validate_output=False or no json_output_schema).
         from agent_actions.utils.udf_management.registry import FileUDFResult
 
+        source_mapping = None
         if isinstance(raw_response, FileUDFResult):
+            source_mapping = raw_response.source_mapping
             raw_response = raw_response.outputs
 
         # Tool should return array
@@ -134,6 +136,7 @@ def process_file_mode_tool(
             source_guid=None,  # FILE mode has no single source
             raw_response=raw_response,
             executed=executed,
+            source_mapping=source_mapping,
         )
 
         # Run enrichment on ALL items in result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.1.8"
+version = "0.1.9"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},

--- a/tests/unit/processing/test_enrichment.py
+++ b/tests/unit/processing/test_enrichment.py
@@ -1,0 +1,225 @@
+"""Tests for LineageEnricher index-based parent lookup via source_mapping."""
+
+from agent_actions.processing.enrichment import LineageEnricher
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+)
+
+
+def _make_context(source_data, is_first_stage=False):
+    """Create a ProcessingContext with the given source_data."""
+    return ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file"},
+        agent_name="dedup_tool",
+        is_first_stage=is_first_stage,
+        source_data=source_data,
+    )
+
+
+def _make_source_item(source_guid, node_id, lineage=None):
+    """Create a source data item with lineage."""
+    item = {
+        "source_guid": source_guid,
+        "node_id": node_id,
+        "lineage": lineage if lineage is not None else [node_id],
+        "content": {"data": f"from_{node_id}"},
+    }
+    return item
+
+
+class TestLineageEnricherSourceMapping:
+    """Tests for source_mapping-based lineage resolution."""
+
+    def test_one_to_one_mapping_distinct_lineage(self):
+        """5 inputs sharing source_guid, one-to-one mapping -> 5 distinct lineage chains."""
+        shared_guid = "shared-guid-aaa"
+        source_data = [_make_source_item(shared_guid, f"flatten_node_{i}") for i in range(5)]
+
+        # 5 outputs, each mapped to a different input
+        output_data = [
+            {"content": {"question": f"Q{i}"}, "source_guid": shared_guid} for i in range(5)
+        ]
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=output_data,
+            source_guid=None,
+            source_mapping={0: 0, 1: 1, 2: 2, 3: 3, 4: 4},
+        )
+
+        context = _make_context(source_data)
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        # Each output should have lineage from its specific input, not the first match
+        for i in range(5):
+            item = enriched.data[i]
+            assert "lineage" in item
+            # The lineage should include the specific parent node
+            assert f"flatten_node_{i}" in item["lineage"]
+
+    def test_no_mapping_falls_back_to_source_guid_scan(self):
+        """When source_mapping is None, existing source_guid scan behavior is preserved."""
+        source_data = [
+            _make_source_item("guid-a", "node_a"),
+            _make_source_item("guid-b", "node_b"),
+        ]
+
+        output_data = [
+            {"content": {"val": 1}, "source_guid": "guid-a"},
+            {"content": {"val": 2}, "source_guid": "guid-b"},
+        ]
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=output_data,
+            source_guid=None,
+            source_mapping=None,  # No mapping -> fallback
+        )
+
+        context = _make_context(source_data)
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        # Per-item source_guid lookup should still work
+        assert "node_a" in enriched.data[0]["lineage"]
+        assert "node_b" in enriched.data[1]["lineage"]
+
+    def test_many_to_one_mapping_uses_lineage_tracking_from_sources(self):
+        """3 inputs merged into 1 output -> output gets lineage_sources with all 3 parent node_ids."""
+        source_data = [
+            _make_source_item("guid-a", "input_0"),
+            _make_source_item("guid-b", "input_1"),
+            _make_source_item("guid-c", "input_2"),
+        ]
+
+        output_data = [
+            {"content": {"merged": True}},
+        ]
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=output_data,
+            source_guid=None,
+            source_mapping={0: [0, 1, 2]},
+        )
+
+        context = _make_context(source_data)
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        item = enriched.data[0]
+        assert "lineage" in item
+        # Many-to-one should produce lineage_sources
+        assert "lineage_sources" in item
+        assert len(item["lineage_sources"]) == 3
+        assert "input_0" in item["lineage_sources"]
+        assert "input_1" in item["lineage_sources"]
+        assert "input_2" in item["lineage_sources"]
+
+    def test_out_of_bounds_source_idx_handled_safely(self):
+        """Source index beyond source_data length should not crash."""
+        source_data = [
+            _make_source_item("guid-a", "node_0"),
+        ]
+
+        output_data = [
+            {"content": {"val": 1}},
+        ]
+        # source_mapping points to index 5, which is out of bounds
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=output_data,
+            source_guid=None,
+            source_mapping={0: 5},
+        )
+
+        context = _make_context(source_data)
+        enricher = LineageEnricher()
+        # Should not raise
+        enriched = enricher.enrich(result, context)
+        assert enriched.data[0]["lineage"] is not None
+
+    def test_output_index_not_in_mapping_falls_back(self):
+        """Output index not present in source_mapping falls back to source_guid scan."""
+        source_data = [
+            _make_source_item("guid-a", "node_0"),
+            _make_source_item("guid-b", "node_1"),
+        ]
+
+        output_data = [
+            {"content": {"val": 1}, "source_guid": "guid-a"},
+            {"content": {"val": 2}, "source_guid": "guid-b"},
+        ]
+        # Only map output 0; output 1 should fall back to source_guid scan
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=output_data,
+            source_guid=None,
+            source_mapping={0: 0},
+        )
+
+        context = _make_context(source_data)
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        # Output 0: uses source_mapping -> parent is node_0
+        assert "node_0" in enriched.data[0]["lineage"]
+        # Output 1: not in mapping, falls back to source_guid scan -> parent is node_1
+        assert "node_1" in enriched.data[1]["lineage"]
+
+    def test_source_mapping_with_none_source_data_ignored(self):
+        """When source_data is None, source_mapping is ignored (has_source_mapping = False)."""
+        output_data = [
+            {"content": {"val": 1}},
+        ]
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=output_data,
+            source_guid=None,
+            source_mapping={0: 0},
+        )
+
+        # source_data is empty list (default), context.source_data is not None but empty
+        # has_source_mapping = True but index lookup will just skip (out of bounds)
+        context = _make_context(source_data=[], is_first_stage=True)
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+        assert enriched.data[0]["lineage"] is not None
+
+    def test_filtered_result_unchanged(self):
+        """FILTERED results should pass through without modification."""
+        result = ProcessingResult(
+            status=ProcessingStatus.FILTERED,
+            data=[],
+            source_mapping={0: 0},
+        )
+        context = _make_context(source_data=[])
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+        assert enriched.status == ProcessingStatus.FILTERED
+
+    def test_many_to_one_out_of_bounds_indices_skipped(self):
+        """Many-to-one with some out-of-bounds indices should skip those safely."""
+        source_data = [
+            _make_source_item("guid-a", "input_0"),
+        ]
+
+        output_data = [
+            {"content": {"merged": True}},
+        ]
+        # Index 0 is valid, indices 5 and 10 are out of bounds
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=output_data,
+            source_guid=None,
+            source_mapping={0: [0, 5, 10]},
+        )
+
+        context = _make_context(source_data)
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        item = enriched.data[0]
+        assert "lineage" in item
+        # Only valid index 0 should be in the sources
+        assert item["node_id"] is not None

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -60,6 +60,65 @@ def test_file_udf_result_unwrapped():
     assert result.data[1]["content"]["name"] == "bob"
 
 
+def test_file_udf_result_source_mapping_preserved():
+    """FileUDFResult.source_mapping should be threaded into ProcessingResult."""
+    pipeline, context = _make_pipeline_and_context()
+
+    udf_result = FileUDFResult(
+        outputs=[{"name": "alice"}, {"name": "bob"}],
+        source_mapping={0: 0, 1: 1},
+        input_count=2,
+    )
+
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+    ]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(udf_result, True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    assert results[0].source_mapping == {0: 0, 1: 1}
+
+
+def test_file_tool_plain_list_source_mapping_is_none():
+    """Plain list return should leave source_mapping as None."""
+    pipeline, context = _make_pipeline_and_context()
+
+    input_data = [{"source_guid": "sg-1", "content": {"id": 1}}]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([{"score": 0.9}], True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    assert results[0].source_mapping is None
+
+
+def test_file_udf_result_no_mapping_source_mapping_is_none():
+    """FileUDFResult without source_mapping should leave it as None."""
+    pipeline, context = _make_pipeline_and_context()
+
+    udf_result = FileUDFResult(
+        outputs=[{"name": "alice"}],
+        source_mapping=None,
+    )
+
+    input_data = [{"source_guid": "sg-1", "content": {"id": 1}}]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(udf_result, True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    assert results[0].source_mapping is None
+
+
 def test_file_tool_plain_list_still_works():
     """FILE tool returning a plain list should still work (backwards compat)."""
     pipeline, context = _make_pipeline_and_context()

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-actions",
   "displayName": "Agent Actions",
   "description": "Language support and workflow navigation for Agent Actions projects",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "publisher": "runagac",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Thread `FileUDFResult.source_mapping` through `ProcessingResult` to `LineageEnricher`
- When source_mapping is present, resolve parent record by array index instead of source_guid first-match scan
- Fixes silent data duplication when multiple input records share the same source_guid (common after flatten/split)
- No-mapping case (plain list return, or FileUDFResult without mapping) is unchanged

## Bug
When a FILE-granularity tool processes records that share a source_guid (e.g., after flatten), the lineage builder finds the first input matching that guid for ALL outputs. This causes downstream `context_scope.observe` to load the same ancestor data for every record, producing duplicate output.

## Verification
- New tests cover: one-to-one mapping, many-to-one mapping, no-mapping fallback, out-of-bounds safety
- All existing tests pass unchanged
- ruff format + ruff check clean
- Full pytest suite green