### PR TITLE
fix: HITL FILE mode lineage truncation — all ancestor references lost

### DIFF
--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -561,6 +561,10 @@ class ProcessingPipeline:
                 original_data=data,
             )
 
+            # Align context.source_data with the guard-passing subset so the
+            # enricher's source_mapping indices resolve to the correct parents.
+            context.source_data = original_passing
+
             if not passing:
                 results = _build_skipped_results(skipped)
             else:

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -299,12 +299,15 @@ def process_file_mode_hitl(
                             structured_item[field] = item[field]
                 structured_data.append(structured_item)
 
+        # HITL FILE mode is always 1:1 — identity source_mapping ensures the
+        # enricher extends parent lineage rather than truncating to [node_id].
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=structured_data,
             source_guid=None,
             raw_response=raw_response,
             executed=executed,
+            source_mapping={i: i for i in range(len(structured_data))},
         )
 
         result = pipeline.record_processor.enrichment_pipeline.enrich(result, context)

--- a/tests/integration/test_lineage_integrity.py
+++ b/tests/integration/test_lineage_integrity.py
@@ -721,6 +721,122 @@ class TestLineageFileMode:
         assert result.error == "Tool returned empty output"
 
 
+class TestLineageHitlFileMode:
+    """HITL FILE-mode lineage integrity.
+
+    HITL FILE mode is always 1:1 — output[i] comes from original_data[i].
+    The identity source_mapping must cause the enricher to extend lineage
+    from the parent record rather than truncating to [node_id].
+    """
+
+    def test_hitl_file_mode_extends_parent_lineage(self):
+        """HITL output should contain parent lineage + HITL node_id."""
+        guid_a = _uuid()
+        guid_b = _uuid()
+        parent_node_a = f"extract_{_uuid()}"
+        parent_node_b = f"extract_{_uuid()}"
+        # Simulate upstream records with deep lineage chains
+        ancestor_node = f"ingest_{_uuid()}"
+        source_items = [
+            _make_source_item(
+                guid_a,
+                parent_node_a,
+                lineage=[ancestor_node, parent_node_a],
+                target_id=_uuid(),
+            ),
+            _make_source_item(
+                guid_b,
+                parent_node_b,
+                lineage=[ancestor_node, parent_node_b],
+                target_id=_uuid(),
+            ),
+        ]
+
+        # HITL output: 1:1 identity mapping (same as process_file_mode_hitl builds)
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[
+                {"content": {"hitl_status": "approved"}, "source_guid": guid_a},
+                {"content": {"hitl_status": "rejected"}, "source_guid": guid_b},
+            ],
+            source_guid=None,
+            source_mapping={0: 0, 1: 1},
+        )
+        context = _make_context(
+            source_data=source_items,
+            is_first_stage=False,
+            action_name="review_data",
+        )
+
+        enriched = LineageEnricher().enrich(result, context)
+
+        for i in range(2):
+            lineage = enriched.data[i]["lineage"]
+            # Lineage must include ALL ancestors plus the new HITL node_id
+            assert ancestor_node in lineage, "Ancestor node lost from lineage"
+            assert source_items[i]["node_id"] in lineage, "Parent node lost from lineage"
+            assert enriched.data[i]["node_id"] in lineage, "HITL node_id not appended"
+            # Parent ancestry preserved
+            assert enriched.data[i]["parent_target_id"] == source_items[i]["target_id"]
+
+    def test_hitl_file_mode_single_record_no_index_suffix(self):
+        """Single HITL output gets node_id without _0 suffix."""
+        guid = _uuid()
+        parent_node = f"extract_{_uuid()}"
+        source_item = _make_source_item(guid, parent_node, target_id=_uuid())
+
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": {"hitl_status": "approved"}, "source_guid": guid}],
+            source_guid=None,
+            source_mapping={0: 0},
+        )
+        context = _make_context(
+            source_data=[source_item],
+            is_first_stage=False,
+            action_name="review_data",
+        )
+
+        enriched = LineageEnricher().enrich(result, context)
+
+        node_id = enriched.data[0]["node_id"]
+        assert node_id.startswith("review_data_")
+        assert not node_id.endswith("_0")
+        assert parent_node in enriched.data[0]["lineage"]
+        assert node_id in enriched.data[0]["lineage"]
+
+    def test_hitl_file_mode_without_source_mapping_truncates(self):
+        """Without source_mapping, HITL lineage falls back to per-item lookup.
+
+        This test documents the bug: when source_mapping is missing and
+        source_guid lookup fails, lineage is truncated to just [node_id].
+        """
+        guid = _uuid()
+        parent_node = f"extract_{_uuid()}"
+        # Source item has a DIFFERENT source_guid than the output — simulates
+        # the case where source_guid gets corrupted or overwritten.
+        source_item = _make_source_item(_uuid(), parent_node, target_id=_uuid())
+
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": {"hitl_status": "approved"}, "source_guid": guid}],
+            source_guid=None,
+            # NO source_mapping — this is the bug condition
+        )
+        context = _make_context(
+            source_data=[source_item],
+            is_first_stage=False,
+            action_name="review_data",
+        )
+
+        enriched = LineageEnricher().enrich(result, context)
+
+        # Without source_mapping AND mismatched source_guid, lineage is truncated
+        lineage = enriched.data[0]["lineage"]
+        assert parent_node not in lineage, "Parent should be lost without source_mapping"
+        assert len(lineage) == 1, "Lineage should be truncated to just [node_id]"
+
+
 class TestLineageVersionParallel:
     """Version/parallel actions: same input processed by multiple agents."""
 

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -263,6 +263,41 @@ def test_file_mode_hitl_preserves_target_id():
     assert result.data[0]["source_guid"] == "sg-1"
 
 
+def test_file_mode_hitl_sets_identity_source_mapping():
+    """HITL result must include identity source_mapping for lineage resolution."""
+    pipeline = ProcessingPipeline(
+        config=PipelineConfig(
+            action_config={"kind": "hitl", "granularity": "file"},
+            action_name="review_data",
+            idx=0,
+        ),
+        processor_factory=object(),
+    )
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+    )
+
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+        {"source_guid": "sg-3", "content": {"id": 3}},
+    ]
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(
+            {"hitl_status": "approved", "user_comment": "", "timestamp": "2026-02-12T10:00:00Z"},
+            True,
+        ),
+    ):
+        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+
+    assert len(results) == 1
+    result = results[0]
+    # source_mapping must be an identity map: output[i] came from input[i]
+    assert result.source_mapping == {0: 0, 1: 1, 2: 2}
+
+
 def test_file_mode_hitl_observe_filters_and_orders_fields():
     """context_scope.observe should filter fields shown to HITL and preserve order."""
     pipeline = ProcessingPipeline(


### PR DESCRIPTION
## Summary
- HITL FILE-mode `ProcessingResult` was missing `source_mapping`, causing `LineageEnricher` to fall back to per-item `source_guid` lookup which silently failed
- When parent lookup returned `None`, `add_unified_lineage` truncated lineage to just `[node_id]` — all 17+ ancestor node_ids dropped
- Every downstream action using `context_scope.observe` to reference pre-HITL data failed with "historical data not found"
- Root cause: `process_file_mode_hitl` was the only FILE-mode processor that didn't communicate the input→output record mapping to the enrichment pipeline (tool path already did this via `FileUDFResult`)

## Changes
- `pipeline_file_mode.py`: Add identity `source_mapping={i: i}` to HITL result — tells enricher to use deterministic index-based parent lookup (same path as tools)
- `pipeline.py`: Align `context.source_data` with guard-passing subset so enricher indices resolve to correct parents
- Integration test: 3 tests proving lineage is extended through HITL (ancestor preserved, single-record suffix, truncation-without-mapping documented)
- Unit test: 1 test verifying `process_file_mode_hitl` sets identity source_mapping

## Verification
- 4845 passed, 0 failed, 2 skipped
- ruff format + ruff check clean
- New `TestLineageHitlFileMode` class proves ancestor nodes survive HITL processing
- Negative test documents the truncation bug (no source_mapping + mismatched source_guid → lineage lost)

Fixes: `specs/bugs/bug_hitl_lineage_truncation`