### PR TITLE
fix: resolve false-positive StaticTypeError for Jinja loop variables

### DIFF
--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -211,7 +211,7 @@ def extract_action_names_from_template(template: str | None) -> set:
             return
 
         if isinstance(node, nodes.Getattr):
-            current = node
+            current: nodes.Node = node
             while isinstance(current, nodes.Getattr):
                 current = current.node
             if isinstance(current, nodes.Name):

--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -126,12 +126,31 @@ def extract_action_names_from_context_scope(context_scope: dict | None) -> set:
     return referenced_actions
 
 
+def _extract_action_names_regex(template: str) -> set:
+    """Regex fallback for action name extraction (used when AST parse fails)."""
+    referenced_actions: set[str] = set()
+    _JINJA_KEYWORDS = frozenset({"loop", "range", "true", "false", "none", "self", "version"})
+
+    pattern = r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*[\.\[]"
+    matches = re.findall(pattern, template)
+
+    for namespace in matches:
+        if namespace in SPECIAL_NAMESPACES:
+            continue
+        if namespace in _JINJA_KEYWORDS:
+            continue
+        referenced_actions.add(namespace)
+
+    return referenced_actions
+
+
 def extract_action_names_from_template(template: str | None) -> set:
     """
     Extract unique action names referenced in a Jinja2 template.
 
-    Parses template for {{ namespace.field }} patterns and extracts namespace names.
-    Filters out special namespaces (source, version, workflow) and common Jinja2 filters.
+    Parses template AST to extract namespace names, excluding variables scoped
+    by {% for %}, {% set %}, and {% macro %} constructs. Falls back to regex
+    if the template has syntax errors.
 
     Args:
         template: Jinja2 template string
@@ -146,21 +165,69 @@ def extract_action_names_from_template(template: str | None) -> set:
     if not template or not isinstance(template, str):
         return set()
 
-    referenced_actions = set()
+    from jinja2 import Environment, nodes
+    from jinja2.exceptions import TemplateSyntaxError
 
-    # Match {{ namespace.field }} or {{ namespace['field'] }} patterns
-    # This regex captures the namespace (first identifier before . or [)
-    pattern = r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*[\.\[]"
-    matches = re.findall(pattern, template)
+    _JINJA_KEYWORDS = frozenset({"loop", "range", "true", "false", "none", "self", "version"})
 
-    for namespace in matches:
-        # Filter out special namespaces and common Jinja2 variables
-        if namespace in SPECIAL_NAMESPACES:
-            continue
-        if namespace in ("loop", "range", "true", "false", "none", "self", "version"):
-            continue
-        referenced_actions.add(namespace)
+    try:
+        env = Environment()
+        ast = env.parse(template)
+    except TemplateSyntaxError:
+        return _extract_action_names_regex(template)
 
+    referenced_actions: set[str] = set()
+
+    def _walk(node: nodes.Node, local_vars: set[str]) -> None:
+        # {% for %} and {% macro %} create child scopes — copy the set
+        if isinstance(node, nodes.For):
+            new_locals = local_vars.copy()
+            if isinstance(node.target, nodes.Name):
+                new_locals.add(node.target.name)
+            elif isinstance(node.target, nodes.Tuple):
+                for item in node.target.items:
+                    if isinstance(item, nodes.Name):
+                        new_locals.add(item.name)
+            for child in node.iter_child_nodes():
+                _walk(child, new_locals)
+            return
+
+        if isinstance(node, nodes.Macro):
+            new_locals = local_vars.copy()
+            for arg in node.args:
+                if isinstance(arg, nodes.Name):
+                    new_locals.add(arg.name)
+            for child in node.iter_child_nodes():
+                _walk(child, new_locals)
+            return
+
+        # {% set %} introduces a name at the current scope level — mutate in place
+        # so subsequent siblings (processed by the parent's loop) see it
+        if isinstance(node, nodes.Assign):
+            if isinstance(node.target, nodes.Name):
+                local_vars.add(node.target.name)
+            for child in node.iter_child_nodes():
+                _walk(child, local_vars)
+            return
+
+        if isinstance(node, nodes.Getattr):
+            current = node
+            while isinstance(current, nodes.Getattr):
+                current = current.node
+            if isinstance(current, nodes.Name):
+                root = current.name
+                if (
+                    root not in local_vars
+                    and root not in SPECIAL_NAMESPACES
+                    and root not in _JINJA_KEYWORDS
+                ):
+                    referenced_actions.add(root)
+            return
+
+        for child in node.iter_child_nodes():
+            _walk(child, local_vars)
+
+    _walk(ast, set())
     return referenced_actions
 
 

--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -1,7 +1,5 @@
 """Field reference parsing and action name extraction utilities."""
 
-import re
-
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
@@ -126,31 +124,13 @@ def extract_action_names_from_context_scope(context_scope: dict | None) -> set:
     return referenced_actions
 
 
-def _extract_action_names_regex(template: str) -> set:
-    """Regex fallback for action name extraction (used when AST parse fails)."""
-    referenced_actions: set[str] = set()
-    _JINJA_KEYWORDS = frozenset({"loop", "range", "true", "false", "none", "self", "version"})
-
-    pattern = r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*[\.\[]"
-    matches = re.findall(pattern, template)
-
-    for namespace in matches:
-        if namespace in SPECIAL_NAMESPACES:
-            continue
-        if namespace in _JINJA_KEYWORDS:
-            continue
-        referenced_actions.add(namespace)
-
-    return referenced_actions
-
-
 def extract_action_names_from_template(template: str | None) -> set:
     """
     Extract unique action names referenced in a Jinja2 template.
 
     Parses template AST to extract namespace names, excluding variables scoped
-    by {% for %}, {% set %}, and {% macro %} constructs. Falls back to regex
-    if the template has syntax errors.
+    by {% for %}, {% set %}, and {% macro %} constructs. Returns empty set
+    if the template has syntax errors (broken templates fail at render time).
 
     Args:
         template: Jinja2 template string
@@ -174,7 +154,7 @@ def extract_action_names_from_template(template: str | None) -> set:
         env = Environment()
         ast = env.parse(template)
     except TemplateSyntaxError:
-        return _extract_action_names_regex(template)
+        return set()
 
     referenced_actions: set[str] = set()
 

--- a/agent_actions/validation/static_analyzer/reference_extractor.py
+++ b/agent_actions/validation/static_analyzer/reference_extractor.py
@@ -166,6 +166,24 @@ class ReferenceExtractor:
                 self._walk_ast(child, references, new_locals)
             return
 
+        # {% set %} introduces a name at the current scope level — mutate in place
+        # so subsequent siblings (processed by the parent's loop) see it
+        if isinstance(node, nodes.Assign):
+            if isinstance(node.target, nodes.Name):
+                local_vars.add(node.target.name)
+            for child in node.iter_child_nodes():
+                self._walk_ast(child, references, local_vars)
+            return
+
+        if isinstance(node, nodes.Macro):
+            new_locals = local_vars.copy()
+            for arg in node.args:
+                if isinstance(arg, nodes.Name):
+                    new_locals.add(arg.name)
+            for child in node.iter_child_nodes():
+                self._walk_ast(child, references, new_locals)
+            return
+
         if isinstance(node, nodes.Getattr):
             ref = self._extract_getattr_chain(node)
             if ref:

--- a/tests/validation/static_analyzer/test_reference_extractor.py
+++ b/tests/validation/static_analyzer/test_reference_extractor.py
@@ -373,3 +373,55 @@ class TestReferenceExtractor:
         assert "resp" not in agent_names
         # Real external references should be present
         assert "extractor" in agent_names
+
+    def test_set_variable_skipped(self):
+        """Test {% set %} variables are not treated as external references."""
+        config = {
+            "name": "agent",
+            "prompt": """
+            {% set summary = source.text %}
+            Result: {{ summary.truncated }}
+            Real ref: {{ action.extractor.data }}
+            """,
+        }
+        refs = self.extractor.extract_from_agent(config)
+
+        agent_names = {r.source_agent for r in refs}
+        assert "summary" not in agent_names
+        assert "extractor" in agent_names
+
+    def test_macro_param_skipped(self):
+        """Test {% macro %} parameters are not treated as external references."""
+        config = {
+            "name": "agent",
+            "prompt": """
+            {% macro render_item(item) %}
+            Name: {{ item.name }}
+            Score: {{ item.score }}
+            {% endmacro %}
+            Real ref: {{ action.extractor.data }}
+            """,
+        }
+        refs = self.extractor.extract_from_agent(config)
+
+        agent_names = {r.source_agent for r in refs}
+        assert "item" not in agent_names
+        assert "extractor" in agent_names
+
+    def test_tuple_unpacking_in_loop_skipped(self):
+        """Test tuple unpacking in for-loops skips all loop variables."""
+        config = {
+            "name": "agent",
+            "prompt": """
+            {% for key, value in source.items %}
+            {{ key.name }}: {{ value.data }}
+            {% endfor %}
+            Real ref: {{ action.extractor.data }}
+            """,
+        }
+        refs = self.extractor.extract_from_agent(config)
+
+        agent_names = {r.source_agent for r in refs}
+        assert "key" not in agent_names
+        assert "value" not in agent_names
+        assert "extractor" in agent_names

--- a/tests/validation/static_analyzer/test_template_scope_coverage.py
+++ b/tests/validation/static_analyzer/test_template_scope_coverage.py
@@ -256,10 +256,7 @@ class TestTemplateScopeCoverage:
                 {
                     "name": "processor",
                     "context_scope": {"observe": ["source.*"]},
-                    "prompt": (
-                        "{% set total = source.metadata %}"
-                        "Count: {{ total.count }}"
-                    ),
+                    "prompt": ("{% set total = source.metadata %}Count: {{ total.count }}"),
                 },
             ]
         }
@@ -277,11 +274,7 @@ class TestTemplateScopeCoverage:
                 {
                     "name": "processor",
                     "context_scope": {"observe": ["source.*"]},
-                    "prompt": (
-                        "{% macro render_item(item) %}"
-                        "Name: {{ item.name }}"
-                        "{% endmacro %}"
-                    ),
+                    "prompt": ("{% macro render_item(item) %}Name: {{ item.name }}{% endmacro %}"),
                 },
             ]
         }
@@ -306,9 +299,7 @@ class TestTemplateScopeCoverage:
                     "name": "writer",
                     "context_scope": {"observe": ["source.*"]},
                     "prompt": (
-                        "{% for classify in seed.items %}"
-                        "Item: {{ classify.label }}"
-                        "{% endfor %}"
+                        "{% for classify in seed.items %}Item: {{ classify.label }}{% endfor %}"
                     ),
                 },
             ]

--- a/tests/validation/static_analyzer/test_template_scope_coverage.py
+++ b/tests/validation/static_analyzer/test_template_scope_coverage.py
@@ -200,3 +200,158 @@ class TestTemplateScopeCoverage:
         uncovered_ns = {e.referenced_agent for e in coverage_errors}
         assert "classify" in uncovered_ns
         assert "summarize" in uncovered_ns
+
+    def test_for_loop_vars_not_flagged(self):
+        """Jinja for-loop variables should not be treated as action namespace references."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "processor",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": (
+                        "{% for skill in seed.data.skills %}"
+                        "- {{ skill.name }} ({{ skill.level }})"
+                        "{% endfor %}"
+                    ),
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        coverage_errors = [e for e in result.errors if "template references namespace" in e.message]
+        flagged = {e.referenced_agent for e in coverage_errors}
+        assert "skill" not in flagged
+
+    def test_nested_for_loop_vars_not_flagged(self):
+        """Nested for-loop variables should not be treated as action namespace references."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "processor",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": (
+                        "{% for skill in seed.exam.skills %}"
+                        "### {{ skill.skill_area }}"
+                        "{% for section in skill.sections %}"
+                        "**{{ section.section_name }}**"
+                        "{% endfor %}"
+                        "{% endfor %}"
+                    ),
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        coverage_errors = [e for e in result.errors if "template references namespace" in e.message]
+        flagged = {e.referenced_agent for e in coverage_errors}
+        assert "skill" not in flagged
+        assert "section" not in flagged
+
+    def test_set_vars_not_flagged(self):
+        """{% set %} variables should not be treated as action namespace references."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "processor",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": (
+                        "{% set total = source.metadata %}"
+                        "Count: {{ total.count }}"
+                    ),
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        coverage_errors = [e for e in result.errors if "template references namespace" in e.message]
+        flagged = {e.referenced_agent for e in coverage_errors}
+        assert "total" not in flagged
+
+    def test_macro_params_not_flagged(self):
+        """{% macro %} parameters should not be treated as action namespace references."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "processor",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": (
+                        "{% macro render_item(item) %}"
+                        "Name: {{ item.name }}"
+                        "{% endmacro %}"
+                    ),
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        coverage_errors = [e for e in result.errors if "template references namespace" in e.message]
+        flagged = {e.referenced_agent for e in coverage_errors}
+        assert "item" not in flagged
+
+    def test_loop_var_same_name_as_action_not_flagged(self):
+        """A loop var sharing a name with an action should not be flagged inside its scope."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "classify",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": "Classify this",
+                    "schema": {"category": "string"},
+                },
+                {
+                    "name": "writer",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": (
+                        "{% for classify in seed.items %}"
+                        "Item: {{ classify.label }}"
+                        "{% endfor %}"
+                    ),
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        coverage_errors = [
+            e
+            for e in result.errors
+            if "template references namespace" in e.message and e.location.agent_name == "writer"
+        ]
+        assert len(coverage_errors) == 0
+
+    def test_real_action_ref_outside_loop_still_flagged(self):
+        """Action references outside any loop scope should still be flagged."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "classify",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": "Classify this",
+                    "schema": {"category": "string"},
+                },
+                {
+                    "name": "writer",
+                    "context_scope": {"observe": ["source.*"]},
+                    "prompt": (
+                        "{% for item in seed.items %}"
+                        "Item: {{ item.name }}"
+                        "{% endfor %}"
+                        "Category: {{ classify.category }}"
+                    ),
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        coverage_errors = [
+            e
+            for e in result.errors
+            if "template references namespace 'classify'" in e.message
+            and e.location.agent_name == "writer"
+        ]
+        assert len(coverage_errors) == 1


### PR DESCRIPTION
## Summary
- Static analyzer's `extract_action_names_from_template()` used regex that treated Jinja-scoped variables (`{% for %}`, `{% set %}`, `{% macro %}`) as action namespace references, producing false-positive `StaticTypeError`s that blocked valid workflows
- Replaced regex with Jinja2 AST parsing that tracks scoped variables in `scope_parsing.py` (fixes both `_check_template_scope_coverage()` and `scope_inference.py` phantom dependency injection)
- Added `{% set %}` and `{% macro %}` scope tracking to `ReferenceExtractor._walk_ast()` which only handled `{% for %}` loops
- 9 new regression tests across both code paths

## Verification
- 4831 tests pass, 0 failures
- `ruff check` and `ruff format --check` clean
- End-to-end verified: `{% for skill in seed.data %}{{ skill.name }}{% endfor %}` no longer produces false positives, real action refs still detected, phantom dependency injection via loop var/action name collision eliminated