### PR TITLE
fix: accept cross-workflow dependency syntax, fix crash sites

### DIFF
--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -291,13 +291,9 @@ class ActionConfig(BaseModel):
         """Strip cross-workflow dict deps (e.g. {workflow: X, action: Y}).
 
         Cross-workflow deps are for execution ordering between workflows, handled
-        by WorkspaceIndex at runtime. They must not reach intra-workflow code
-        (scope inference, DAG traversal, context loading) which expects strings.
-
-        Runs after validate_kind_requirements (which does not inspect dependencies).
-        By stripping here, WorkflowConfig.validate_workflow_invariants sees only
-        intra-workflow string deps — cross-workflow names would otherwise be
-        rejected as dangling dependencies.
+        by WorkspaceIndex at runtime. Intra-workflow code (scope inference, DAG
+        traversal) expects string deps only. Pre-Pydantic callers (docs parser,
+        CLI inspect) also filter independently in infer_dependencies().
         """
         self.dependencies = [d for d in self.dependencies if isinstance(d, str)]
         return self

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -181,7 +181,7 @@ class ActionConfig(BaseModel):
     )
     idempotency_key: str | None = Field(default=None, description="Idempotency key template")
     prompt: str | None = Field(default=None, description="Prompt template or reference")
-    dependencies: list[str | dict[str, Any]] = Field(
+    dependencies: list[str] = Field(
         default_factory=list, description="List of upstream dependencies"
     )
     primary_dependency: str | None = Field(
@@ -286,8 +286,9 @@ class ActionConfig(BaseModel):
             raise ValueError(f"Tool action '{self.name}' requires 'impl' (implementation path)")
         return self
 
-    @model_validator(mode="after")
-    def strip_cross_workflow_deps(self):
+    @field_validator("dependencies", mode="before")
+    @classmethod
+    def strip_cross_workflow_deps(cls, v: Any) -> Any:
         """Strip cross-workflow dict deps (e.g. {workflow: X, action: Y}).
 
         Cross-workflow deps are for execution ordering between workflows, handled
@@ -295,8 +296,9 @@ class ActionConfig(BaseModel):
         traversal) expects string deps only. Pre-Pydantic callers (docs parser,
         CLI inspect) also filter independently in infer_dependencies().
         """
-        self.dependencies = [d for d in self.dependencies if isinstance(d, str)]
-        return self
+        if isinstance(v, list):
+            return [d for d in v if isinstance(d, str)]
+        return v
 
     @field_validator("guard")
     @classmethod

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -181,7 +181,7 @@ class ActionConfig(BaseModel):
     )
     idempotency_key: str | None = Field(default=None, description="Idempotency key template")
     prompt: str | None = Field(default=None, description="Prompt template or reference")
-    dependencies: list[str] = Field(
+    dependencies: list[str | dict[str, Any]] = Field(
         default_factory=list, description="List of upstream dependencies"
     )
     primary_dependency: str | None = Field(
@@ -284,6 +284,22 @@ class ActionConfig(BaseModel):
             raise ValueError(f"HITL action '{self.name}' requires 'hitl' configuration block")
         if self.kind == ActionKind.TOOL and not self.impl:
             raise ValueError(f"Tool action '{self.name}' requires 'impl' (implementation path)")
+        return self
+
+    @model_validator(mode="after")
+    def strip_cross_workflow_deps(self):
+        """Strip cross-workflow dict deps (e.g. {workflow: X, action: Y}).
+
+        Cross-workflow deps are for execution ordering between workflows, handled
+        by WorkspaceIndex at runtime. They must not reach intra-workflow code
+        (scope inference, DAG traversal, context loading) which expects strings.
+
+        Runs after validate_kind_requirements (which does not inspect dependencies).
+        By stripping here, WorkflowConfig.validate_workflow_invariants sees only
+        intra-workflow string deps — cross-workflow names would otherwise be
+        rejected as dangling dependencies.
+        """
+        self.dependencies = [d for d in self.dependencies if isinstance(d, str)]
         return self
 
     @field_validator("guard")

--- a/agent_actions/input/preprocessing/field_resolution/validator.py
+++ b/agent_actions/input/preprocessing/field_resolution/validator.py
@@ -35,7 +35,7 @@ class ReferenceValidator:
 
         current_idx = agent_indices.get(current_agent_name, 999)
 
-        declared_deps = set(agent_config.get("dependencies", []))
+        declared_deps = {d for d in agent_config.get("dependencies", []) if isinstance(d, str)}
 
         # Also include namespaces from context_scope (auto-inferred dependencies)
         context_scope = agent_config.get("context_scope", {})

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -249,7 +249,7 @@ def apply_observe_for_file_mode(
             if isinstance(deps, str):
                 input_source_names = {deps}
             else:
-                input_source_names = set(deps)
+                input_source_names = {d for d in deps if isinstance(d, str)}
             has_reliable_ns = True
         elif data and isinstance(data[0], dict):
             # Best-effort heuristic: treat all top-level keys in record

--- a/agent_actions/prompt/context/scope_inference.py
+++ b/agent_actions/prompt/context/scope_inference.py
@@ -195,6 +195,8 @@ def infer_dependencies(
         all_deps = [deps]
     else:
         all_deps = list(deps)
+    # Filter cross-workflow dict deps — they don't participate in intra-workflow scope
+    all_deps = [d for d in all_deps if isinstance(d, str)]
 
     # 1b. Handle fan-in pattern: multiple DIFFERENT dependencies
     # For fan-in, only the primary dependency is an input source

--- a/agent_actions/prompt/context/scope_inference.py
+++ b/agent_actions/prompt/context/scope_inference.py
@@ -195,7 +195,7 @@ def infer_dependencies(
         all_deps = [deps]
     else:
         all_deps = list(deps)
-    # Filter cross-workflow dict deps — they don't participate in intra-workflow scope
+    # Defensive: docs parser and CLI inspect call this with raw YAML that bypasses ActionConfig
     all_deps = [d for d in all_deps if isinstance(d, str)]
 
     # 1b. Handle fan-in pattern: multiple DIFFERENT dependencies

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -411,7 +411,6 @@ class AgentWorkflow:
         if not self.config.run_upstream:
             return True
         return self.dependency_orchestrator.resolve_upstream_workflows(
-            agent_configs=self.action_configs,
             user_code_path=self.config.paths.user_code_path,
             default_path=self.config.paths.default_path,
             use_tools=self.config.use_tools,

--- a/agent_actions/workflow/parallel/dependency.py
+++ b/agent_actions/workflow/parallel/dependency.py
@@ -48,7 +48,6 @@ class WorkflowDependencyOrchestrator:
 
     def resolve_upstream_workflows(
         self,
-        agent_configs: dict,
         user_code_path: str | None,
         default_path: str | None,
         use_tools: bool,

--- a/agent_actions/workflow/parallel/dependency.py
+++ b/agent_actions/workflow/parallel/dependency.py
@@ -63,22 +63,20 @@ class WorkflowDependencyOrchestrator:
             self.current_workflow,
             extra={"operation": "resolve_upstream"},
         )
-        processed_upstreams = set()
+        upstream_workflows = self.workspace_index.dependency_graph.get(self.current_workflow, [])
+        processed_upstreams: set[str] = set()
 
-        for config in agent_configs.values():
-            for dep in config.get("dependencies", []):
-                if isinstance(dep, dict) and "workflow" in dep:
-                    upstream_name = dep["workflow"]
-                    if upstream_name in processed_upstreams:
-                        continue
+        for upstream_name in upstream_workflows:
+            if upstream_name in processed_upstreams:
+                continue
 
-                    result = self._execute_upstream_workflow(
-                        upstream_name, user_code_path, default_path, use_tools
-                    )
-                    if result is None:
-                        # Upstream has pending batch jobs, exit gracefully
-                        return False
-                    processed_upstreams.add(upstream_name)
+            result = self._execute_upstream_workflow(
+                upstream_name, user_code_path, default_path, use_tools
+            )
+            if result is None:
+                # Upstream has pending batch jobs, exit gracefully
+                return False
+            processed_upstreams.add(upstream_name)
 
         return True
 

--- a/tests/unit/config/test_cross_workflow_deps.py
+++ b/tests/unit/config/test_cross_workflow_deps.py
@@ -1,0 +1,92 @@
+"""Tests for cross-workflow dependency handling in ActionConfig and WorkflowConfig."""
+
+from __future__ import annotations
+
+from agent_actions.config.schema import ActionConfig, ActionKind, WorkflowConfig
+
+
+class TestActionConfigCrossWorkflowDeps:
+    """ActionConfig accepts dict deps at validation and strips them post-validation."""
+
+    def test_string_deps_preserved(self):
+        cfg = ActionConfig(name="a", intent="test", dependencies=["action_a", "action_b"])
+        assert cfg.dependencies == ["action_a", "action_b"]
+
+    def test_dict_deps_stripped(self):
+        cfg = ActionConfig(
+            name="a",
+            intent="test",
+            dependencies=[{"workflow": "upstream", "action": "x"}],
+        )
+        assert cfg.dependencies == []
+
+    def test_mixed_deps_keep_strings_only(self):
+        cfg = ActionConfig(
+            name="a",
+            intent="test",
+            dependencies=[
+                "local_action",
+                {"workflow": "upstream", "action": "remote_action"},
+                "another_local",
+            ],
+        )
+        assert cfg.dependencies == ["local_action", "another_local"]
+
+    def test_model_dump_has_no_dicts(self):
+        cfg = ActionConfig(
+            name="a",
+            intent="test",
+            dependencies=["local", {"workflow": "X"}],
+        )
+        dumped = cfg.model_dump()
+        assert dumped["dependencies"] == ["local"]
+        assert all(isinstance(d, str) for d in dumped["dependencies"])
+
+
+class TestWorkflowConfigCrossWorkflowDeps:
+    """WorkflowConfig validates without error when actions have cross-workflow deps."""
+
+    def test_workflow_with_cross_workflow_deps_validates(self):
+        wf = WorkflowConfig(
+            name="test_wf",
+            description="test",
+            actions=[
+                ActionConfig(
+                    name="consume_upstream",
+                    intent="test",
+                    kind=ActionKind.TOOL,
+                    impl="process",
+                    dependencies=[{"workflow": "other_wf", "action": "produce"}],
+                ),
+            ],
+        )
+        assert len(wf.actions) == 1
+        assert wf.actions[0].dependencies == []
+
+    def test_workflow_invariants_ignore_stripped_cross_deps(self):
+        """Cross-workflow deps are stripped before validate_workflow_invariants runs,
+        so they don't trigger 'dangling dependency' errors."""
+        wf = WorkflowConfig(
+            name="test_wf",
+            description="test",
+            actions=[
+                ActionConfig(
+                    name="first",
+                    intent="produces data",
+                    kind=ActionKind.TOOL,
+                    impl="produce",
+                ),
+                ActionConfig(
+                    name="second",
+                    intent="consumes",
+                    kind=ActionKind.TOOL,
+                    impl="consume",
+                    dependencies=[
+                        "first",
+                        {"workflow": "external_wf", "action": "external_action"},
+                    ],
+                ),
+            ],
+        )
+        # Should not raise — "first" exists, dict dep is stripped
+        assert wf.actions[1].dependencies == ["first"]

--- a/tests/unit/config/test_cross_workflow_deps.py
+++ b/tests/unit/config/test_cross_workflow_deps.py
@@ -40,7 +40,6 @@ class TestActionConfigCrossWorkflowDeps:
         )
         dumped = cfg.model_dump()
         assert dumped["dependencies"] == ["local"]
-        assert all(isinstance(d, str) for d in dumped["dependencies"])
 
 
 class TestWorkflowConfigCrossWorkflowDeps:

--- a/tests/unit/prompt/test_infer_dependencies_cross_workflow.py
+++ b/tests/unit/prompt/test_infer_dependencies_cross_workflow.py
@@ -1,0 +1,45 @@
+"""Tests for infer_dependencies handling of cross-workflow dict dependencies."""
+
+from __future__ import annotations
+
+from agent_actions.prompt.context.scope_inference import infer_dependencies
+
+
+class TestInferDependenciesCrossWorkflow:
+    """infer_dependencies filters out cross-workflow dict deps from raw configs."""
+
+    def test_dict_deps_filtered_from_input_sources(self):
+        config = {
+            "dependencies": [
+                "local_action",
+                {"workflow": "upstream", "action": "remote"},
+            ],
+        }
+        input_sources, context_sources = infer_dependencies(
+            config, ["local_action"], "test_action"
+        )
+        assert input_sources == ["local_action"]
+        assert context_sources == []
+
+    def test_all_dict_deps_produces_empty_sources(self):
+        config = {
+            "dependencies": [{"workflow": "upstream"}],
+        }
+        input_sources, context_sources = infer_dependencies(config, [], "test_action")
+        assert input_sources == []
+        assert context_sources == []
+
+    def test_string_only_deps_unchanged(self):
+        config = {
+            "dependencies": ["action_a"],
+        }
+        input_sources, context_sources = infer_dependencies(
+            config, ["action_a"], "test_action"
+        )
+        assert input_sources == ["action_a"]
+
+    def test_no_deps_unchanged(self):
+        config = {}
+        input_sources, context_sources = infer_dependencies(config, [], "test_action")
+        assert input_sources == []
+        assert context_sources == []

--- a/tests/unit/prompt/test_infer_dependencies_cross_workflow.py
+++ b/tests/unit/prompt/test_infer_dependencies_cross_workflow.py
@@ -15,9 +15,7 @@ class TestInferDependenciesCrossWorkflow:
                 {"workflow": "upstream", "action": "remote"},
             ],
         }
-        input_sources, context_sources = infer_dependencies(
-            config, ["local_action"], "test_action"
-        )
+        input_sources, context_sources = infer_dependencies(config, ["local_action"], "test_action")
         assert input_sources == ["local_action"]
         assert context_sources == []
 
@@ -33,9 +31,7 @@ class TestInferDependenciesCrossWorkflow:
         config = {
             "dependencies": ["action_a"],
         }
-        input_sources, context_sources = infer_dependencies(
-            config, ["action_a"], "test_action"
-        )
+        input_sources, context_sources = infer_dependencies(config, ["action_a"], "test_action")
         assert input_sources == ["action_a"]
 
     def test_no_deps_unchanged(self):

--- a/tests/unit/workflow/test_rename_regression.py
+++ b/tests/unit/workflow/test_rename_regression.py
@@ -239,7 +239,8 @@ class TestCoordinatorUpstreamKwargs:
 
         call_kwargs = mock_orchestrator.resolve_upstream_workflows.call_args.kwargs
 
-        # Must use agent_configs=, not action_configs=
-        assert "agent_configs" in call_kwargs, "Should pass 'agent_configs=', not 'action_configs='"
-        assert "action_configs" not in call_kwargs, "Should not pass 'action_configs=' (old name)"
-        assert call_kwargs["agent_configs"] == {"action_a": {"model_vendor": "openai"}}
+        # agent_configs was removed — upstream resolution uses workspace_index now
+        assert "agent_configs" not in call_kwargs, "agent_configs parameter was removed"
+        assert "action_configs" not in call_kwargs, "action_configs parameter was removed"
+        assert call_kwargs["user_code_path"] == "/tmp/user_code"
+        assert call_kwargs["use_tools"] is False

--- a/tests/workflow/parallel/test_dependency.py
+++ b/tests/workflow/parallel/test_dependency.py
@@ -283,13 +283,7 @@ class TestResolveUpstreamWorkflows:
         orchestrator: WorkflowDependencyOrchestrator,
         mock_factory: MagicMock,
     ):
-        # workspace_index has no entry for current_workflow
-        with patch.object(
-            type(orchestrator),
-            "workspace_index",
-            new_callable=PropertyMock,
-            return_value=MagicMock(dependency_graph={}),
-        ):
+        with self._mock_upstream_index(orchestrator, []):
             configs = {"agent1": {}}
             result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
             assert result is True

--- a/tests/workflow/parallel/test_dependency.py
+++ b/tests/workflow/parallel/test_dependency.py
@@ -152,8 +152,7 @@ class TestResolveUpstreamWorkflows:
 
     def test_no_dependencies(self, orchestrator: WorkflowDependencyOrchestrator):
         with self._mock_upstream_index(orchestrator, []):
-            configs = {"agent1": {"some_key": "val"}}
-            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            result = orchestrator.resolve_upstream_workflows(None, None, False)
             assert result is True
             orchestrator.workflow_factory.assert_not_called()
 
@@ -169,8 +168,7 @@ class TestResolveUpstreamWorkflows:
         mock_factory.return_value = mock_wf
 
         with self._mock_upstream_index(orchestrator, ["upstream_wf"]):
-            configs = {"agent1": {}}
-            result = orchestrator.resolve_upstream_workflows(configs, "/code", "/def", True)
+            result = orchestrator.resolve_upstream_workflows("/code", "/def", True)
 
         assert result is True
         mock_factory.assert_called_once()
@@ -192,8 +190,7 @@ class TestResolveUpstreamWorkflows:
         orchestrator.artifact_linker = MagicMock()
 
         with self._mock_upstream_index(orchestrator, ["upstream_wf"]):
-            configs = {"agent1": {}}
-            orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            orchestrator.resolve_upstream_workflows(None, None, False)
 
         orchestrator.artifact_linker.link_upstream_artifacts.assert_called_once_with(
             "upstream_wf", "current_wf"
@@ -209,8 +206,7 @@ class TestResolveUpstreamWorkflows:
         _create_status_file(workflows_root, "done_wf", {"a": {"status": "completed"}})
 
         with self._mock_upstream_index(orchestrator, ["done_wf"]):
-            configs = {"agent1": {}}
-            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            result = orchestrator.resolve_upstream_workflows(None, None, False)
 
         assert result is True
         # Factory should NOT be called since workflow is already complete
@@ -226,8 +222,7 @@ class TestResolveUpstreamWorkflows:
         orchestrator.artifact_linker = MagicMock()
 
         with self._mock_upstream_index(orchestrator, ["done_wf"]):
-            configs = {"agent1": {}}
-            orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            orchestrator.resolve_upstream_workflows(None, None, False)
 
         orchestrator.artifact_linker.link_upstream_artifacts.assert_called_once_with(
             "done_wf", "current_wf"
@@ -245,8 +240,7 @@ class TestResolveUpstreamWorkflows:
         mock_factory.return_value = mock_wf
 
         with self._mock_upstream_index(orchestrator, ["pending_wf"]):
-            configs = {"agent1": {}}
-            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            result = orchestrator.resolve_upstream_workflows(None, None, False)
 
         assert result is False
 
@@ -255,9 +249,8 @@ class TestResolveUpstreamWorkflows:
         orchestrator: WorkflowDependencyOrchestrator,
     ):
         with self._mock_upstream_index(orchestrator, ["missing_wf"]):
-            configs = {"agent1": {}}
             with pytest.raises(RuntimeError, match="Recursive execution failed"):
-                orchestrator.resolve_upstream_workflows(configs, None, None, False)
+                orchestrator.resolve_upstream_workflows(None, None, False)
 
     def test_duplicate_upstream_processed_once(
         self,
@@ -272,8 +265,7 @@ class TestResolveUpstreamWorkflows:
 
         # workspace_index deduplicates at scan time, but test the runtime guard too
         with self._mock_upstream_index(orchestrator, ["shared_wf", "shared_wf"]):
-            configs = {"agent1": {}}
-            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            result = orchestrator.resolve_upstream_workflows(None, None, False)
 
         assert result is True
         assert mock_factory.call_count == 1
@@ -284,8 +276,7 @@ class TestResolveUpstreamWorkflows:
         mock_factory: MagicMock,
     ):
         with self._mock_upstream_index(orchestrator, []):
-            configs = {"agent1": {}}
-            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            result = orchestrator.resolve_upstream_workflows(None, None, False)
             assert result is True
             mock_factory.assert_not_called()
 
@@ -301,9 +292,8 @@ class TestResolveUpstreamWorkflows:
         mock_factory.return_value = mock_wf
 
         with self._mock_upstream_index(orchestrator, ["fail_wf"]):
-            configs = {"agent1": {}}
             with pytest.raises(RuntimeError, match=r"Recursive execution failed.*ValueError.*boom"):
-                orchestrator.resolve_upstream_workflows(configs, None, None, False)
+                orchestrator.resolve_upstream_workflows(None, None, False)
 
 
 # ===========================================================================

--- a/tests/workflow/parallel/test_dependency.py
+++ b/tests/workflow/parallel/test_dependency.py
@@ -139,11 +139,23 @@ class TestCheckWorkflowComplete:
 class TestResolveUpstreamWorkflows:
     """Tests for upstream dependency resolution."""
 
+    def _mock_upstream_index(self, orchestrator, upstreams: list[str]):
+        """Helper: mock workspace_index.dependency_graph for upstream tests."""
+        return patch.object(
+            type(orchestrator),
+            "workspace_index",
+            new_callable=PropertyMock,
+            return_value=MagicMock(
+                dependency_graph={orchestrator.current_workflow: upstreams},
+            ),
+        )
+
     def test_no_dependencies(self, orchestrator: WorkflowDependencyOrchestrator):
-        configs = {"agent1": {"some_key": "val"}}
-        result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
-        assert result is True
-        orchestrator.workflow_factory.assert_not_called()
+        with self._mock_upstream_index(orchestrator, []):
+            configs = {"agent1": {"some_key": "val"}}
+            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            assert result is True
+            orchestrator.workflow_factory.assert_not_called()
 
     def test_single_upstream_runs_successfully(
         self,
@@ -156,8 +168,9 @@ class TestResolveUpstreamWorkflows:
         mock_wf.run.return_value = True
         mock_factory.return_value = mock_wf
 
-        configs = {"agent1": {"dependencies": [{"workflow": "upstream_wf"}]}}
-        result = orchestrator.resolve_upstream_workflows(configs, "/code", "/def", True)
+        with self._mock_upstream_index(orchestrator, ["upstream_wf"]):
+            configs = {"agent1": {}}
+            result = orchestrator.resolve_upstream_workflows(configs, "/code", "/def", True)
 
         assert result is True
         mock_factory.assert_called_once()
@@ -178,8 +191,9 @@ class TestResolveUpstreamWorkflows:
         mock_factory.return_value = mock_wf
         orchestrator.artifact_linker = MagicMock()
 
-        configs = {"agent1": {"dependencies": [{"workflow": "upstream_wf"}]}}
-        orchestrator.resolve_upstream_workflows(configs, None, None, False)
+        with self._mock_upstream_index(orchestrator, ["upstream_wf"]):
+            configs = {"agent1": {}}
+            orchestrator.resolve_upstream_workflows(configs, None, None, False)
 
         orchestrator.artifact_linker.link_upstream_artifacts.assert_called_once_with(
             "upstream_wf", "current_wf"
@@ -194,8 +208,9 @@ class TestResolveUpstreamWorkflows:
         _create_config_file(workflows_root, "done_wf")
         _create_status_file(workflows_root, "done_wf", {"a": {"status": "completed"}})
 
-        configs = {"agent1": {"dependencies": [{"workflow": "done_wf"}]}}
-        result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+        with self._mock_upstream_index(orchestrator, ["done_wf"]):
+            configs = {"agent1": {}}
+            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
 
         assert result is True
         # Factory should NOT be called since workflow is already complete
@@ -210,8 +225,9 @@ class TestResolveUpstreamWorkflows:
         _create_status_file(workflows_root, "done_wf", {"a": {"status": "completed"}})
         orchestrator.artifact_linker = MagicMock()
 
-        configs = {"agent1": {"dependencies": [{"workflow": "done_wf"}]}}
-        orchestrator.resolve_upstream_workflows(configs, None, None, False)
+        with self._mock_upstream_index(orchestrator, ["done_wf"]):
+            configs = {"agent1": {}}
+            orchestrator.resolve_upstream_workflows(configs, None, None, False)
 
         orchestrator.artifact_linker.link_upstream_artifacts.assert_called_once_with(
             "done_wf", "current_wf"
@@ -228,8 +244,9 @@ class TestResolveUpstreamWorkflows:
         mock_wf.run.return_value = None
         mock_factory.return_value = mock_wf
 
-        configs = {"agent1": {"dependencies": [{"workflow": "pending_wf"}]}}
-        result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+        with self._mock_upstream_index(orchestrator, ["pending_wf"]):
+            configs = {"agent1": {}}
+            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
 
         assert result is False
 
@@ -237,9 +254,10 @@ class TestResolveUpstreamWorkflows:
         self,
         orchestrator: WorkflowDependencyOrchestrator,
     ):
-        configs = {"agent1": {"dependencies": [{"workflow": "missing_wf"}]}}
-        with pytest.raises(RuntimeError, match="Recursive execution failed"):
-            orchestrator.resolve_upstream_workflows(configs, None, None, False)
+        with self._mock_upstream_index(orchestrator, ["missing_wf"]):
+            configs = {"agent1": {}}
+            with pytest.raises(RuntimeError, match="Recursive execution failed"):
+                orchestrator.resolve_upstream_workflows(configs, None, None, False)
 
     def test_duplicate_upstream_processed_once(
         self,
@@ -252,31 +270,30 @@ class TestResolveUpstreamWorkflows:
         mock_wf.run.return_value = True
         mock_factory.return_value = mock_wf
 
-        configs = {
-            "agent1": {"dependencies": [{"workflow": "shared_wf"}]},
-            "agent2": {"dependencies": [{"workflow": "shared_wf"}]},
-        }
-        result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+        # workspace_index deduplicates at scan time, but test the runtime guard too
+        with self._mock_upstream_index(orchestrator, ["shared_wf", "shared_wf"]):
+            configs = {"agent1": {}}
+            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
 
         assert result is True
         assert mock_factory.call_count == 1
 
-    def test_non_workflow_dependencies_skipped(
+    def test_no_upstream_in_dependency_graph(
         self,
         orchestrator: WorkflowDependencyOrchestrator,
         mock_factory: MagicMock,
     ):
-        configs = {
-            "agent1": {
-                "dependencies": [
-                    {"file": "data.csv"},
-                    "some_string_dep",
-                ]
-            }
-        }
-        result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
-        assert result is True
-        mock_factory.assert_not_called()
+        # workspace_index has no entry for current_workflow
+        with patch.object(
+            type(orchestrator),
+            "workspace_index",
+            new_callable=PropertyMock,
+            return_value=MagicMock(dependency_graph={}),
+        ):
+            configs = {"agent1": {}}
+            result = orchestrator.resolve_upstream_workflows(configs, None, None, False)
+            assert result is True
+            mock_factory.assert_not_called()
 
     def test_upstream_execution_raises_wraps_in_runtime_error(
         self,
@@ -289,9 +306,10 @@ class TestResolveUpstreamWorkflows:
         mock_wf.run.side_effect = ValueError("boom")
         mock_factory.return_value = mock_wf
 
-        configs = {"agent1": {"dependencies": [{"workflow": "fail_wf"}]}}
-        with pytest.raises(RuntimeError, match=r"Recursive execution failed.*ValueError.*boom"):
-            orchestrator.resolve_upstream_workflows(configs, None, None, False)
+        with self._mock_upstream_index(orchestrator, ["fail_wf"]):
+            configs = {"agent1": {}}
+            with pytest.raises(RuntimeError, match=r"Recursive execution failed.*ValueError.*boom"):
+                orchestrator.resolve_upstream_workflows(configs, None, None, False)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Accept documented `dependencies: [{workflow: X, action: Y}]` syntax that was rejected by Pydantic schema (`list[str]`)
- Fix 4 crash sites where dict-type dependency entries caused `TypeError` or `AttributeError` in scope inference, field resolution, and file-mode context building
- Redirect upstream workflow resolution to use `WorkspaceIndex.dependency_graph` (reads raw YAML) instead of scanning post-Pydantic configs for dict deps

### Approach

Cross-workflow deps are for execution ordering between workflows — they don't participate in intra-workflow scope resolution. The fix accepts them at the Pydantic gate, strips them via `model_validator` before they reach intra-workflow code, and lets the existing `WorkspaceIndex` handle cross-workflow orchestration from raw YAML (which it already does).

### Audit: 11 unsafe locations, 4 fixed, 7 safe via upstream fixes

| Fixed directly | How |
|----------------|-----|
| `config/schema.py:184` | Accept `list[str \| dict]`, strip dicts in model_validator |
| `scope_inference.py:197` | Filter dicts before `_is_parallel_branches`/`set()` calls |
| `scope_file_mode.py:252` | Filter dicts in `set(deps)` fallback |
| `field_resolution/validator.py:38` | Filter dicts in `set(deps)` |

| Safe via upstream | Why |
|-------------------|-----|
| `runner.py:319,427,456` | Post-Pydantic — deps are strings-only after model_validator |
| `manifest.py:96` | Post-Pydantic — deps are strings-only |
| `scope_builder.py:429` | Calls `infer_dependencies` which now filters |
| `docs/parser.py:148` | Calls `infer_dependencies` which now filters |
| `cli/inspect_base.py:83` | Calls `infer_dependencies` which now filters |
| `static_analyzer.py:1160` | Calls `infer_dependencies` which now filters |
| `parallel/dependency.py:69` | Now uses `workspace_index` instead of agent_configs |

## Verification

- `ruff check` + `ruff format --check`: clean
- `pytest`: 4851 passed, 0 failed
- New tests: `test_cross_workflow_deps.py` (Pydantic acceptance + stripping), `test_infer_dependencies_cross_workflow.py` (scope inference filtering)
- Updated tests: `test_dependency.py` (upstream resolution via workspace_index)