### PR TITLE
chore: bump version to 0.1.10 (python) and 0.1.18 (extension)

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.1.9"
+version = "0.1.10"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-actions",
   "displayName": "Agent Actions",
   "description": "Language support and workflow navigation for Agent Actions projects",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "publisher": "runagac",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Python: 0.1.9 → 0.1.10
- VS Code extension: 0.1.17 → 0.1.18 (0.1.17 published to marketplace)

### Changes included in this release (since v0.1.9):
- fix: HITL FILE granularity + guard pre-filter for FILE mode (#229)
- fix: HITL FILE mode truncates lineage to just its own node_id (#231)
- fix: resolve false-positive StaticTypeError for Jinja loop variables (#232)
- fix: accept cross-workflow dependency syntax, fix 4 crash sites
- fix: improve VS Code data card indentation, grammar, and rendering (#223)
- fix: improve docs data card indentation, contrast, and grammar (#224)
- test: deterministic lineage integrity tests (#221)
- test: context scope integration tests (#222)
- docs: update HITL, granularity, and guards docs (#230)

## Verification
- `pyproject.toml`, `__version__.py`, and `package.json` all updated
- VS Code extension 0.1.17 published to marketplace