### PR TITLE
audit: consolidate preflight validation — close all detection gaps

### DIFF
--- a/agent_actions/validation/action_validators/granularity_output_field_validator.py
+++ b/agent_actions/validation/action_validators/granularity_output_field_validator.py
@@ -1,7 +1,7 @@
 """Validator for granularity and output_field configuration."""
 
 from agent_actions.output.response.config_fields import get_default
-from agent_actions.utils.constants import JSON_MODE_KEY
+from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR, JSON_MODE_KEY
 from agent_actions.validation.action_validators.base_action_validator import (
     ActionEntryValidationResult,
     BaseActionEntryValidator,
@@ -35,12 +35,7 @@ class GranularityAndOutputFieldValidator(BaseActionEntryValidator):
             elif granularity == "record":
                 kind = str(normalized_entry.get("kind", "")).lower()
                 if kind == "hitl":
-                    errors.append(
-                        f"{desc} HITL actions require FILE granularity. "
-                        "Record granularity launches a separate approval UI per record. "
-                        "Set 'granularity: file' or remove the granularity field "
-                        "(HITL defaults to file)."
-                    )
+                    errors.append(f"{desc} {HITL_FILE_GRANULARITY_ERROR}")
 
         if "output_field" in normalized_entry:
             json_mode = normalized_entry.get(JSON_MODE_KEY, True)
@@ -48,7 +43,6 @@ class GranularityAndOutputFieldValidator(BaseActionEntryValidator):
             if json_mode:
                 errors.append(f"{desc} 'output_field' can only be used when 'json_mode' is false.")
 
-        # on_schema_mismatch=reprompt requires reprompt config
         on_mismatch = normalized_entry.get("on_schema_mismatch")
         if isinstance(on_mismatch, str) and on_mismatch.lower() == "reprompt":
             reprompt = normalized_entry.get("reprompt")

--- a/agent_actions/validation/action_validators/granularity_output_field_validator.py
+++ b/agent_actions/validation/action_validators/granularity_output_field_validator.py
@@ -12,7 +12,7 @@ from agent_actions.validation.utils.action_config_validation_utilities import (
 
 
 class GranularityAndOutputFieldValidator(BaseActionEntryValidator):
-    """Validates granularity enum and output_field compatibility."""
+    """Validates granularity enum, output_field compatibility, and kind-granularity rules."""
 
     def validate(self, context) -> ActionEntryValidationResult:
         """Validate granularity and output_field configuration."""
@@ -32,12 +32,32 @@ class GranularityAndOutputFieldValidator(BaseActionEntryValidator):
             if granularity not in valid_granularity_values:
                 valid_values_str = "' or '".join(sorted(valid_granularity_values))
                 errors.append(f"{desc} 'granularity' must be '{valid_values_str}'.")
+            elif granularity == "record":
+                kind = str(normalized_entry.get("kind", "")).lower()
+                if kind == "hitl":
+                    errors.append(
+                        f"{desc} HITL actions require FILE granularity. "
+                        "Record granularity launches a separate approval UI per record. "
+                        "Set 'granularity: file' or remove the granularity field "
+                        "(HITL defaults to file)."
+                    )
 
         if "output_field" in normalized_entry:
             json_mode = normalized_entry.get(JSON_MODE_KEY, True)
 
             if json_mode:
                 errors.append(f"{desc} 'output_field' can only be used when 'json_mode' is false.")
+
+        # on_schema_mismatch=reprompt requires reprompt config
+        on_mismatch = normalized_entry.get("on_schema_mismatch")
+        if isinstance(on_mismatch, str) and on_mismatch.lower() == "reprompt":
+            reprompt = normalized_entry.get("reprompt")
+            if not reprompt:
+                errors.append(
+                    f"{desc} 'on_schema_mismatch: reprompt' requires a 'reprompt' "
+                    "configuration block. Add reprompt: {{validation: your_udf_name}} "
+                    "or change on_schema_mismatch to 'warn' or 'reject'."
+                )
 
         if errors:
             return ActionEntryValidationResult.with_errors(errors)

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -5,6 +5,7 @@ similar to TypeScript's compile-time type checking.
 """
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import ConfigurationError
@@ -175,6 +176,10 @@ class WorkflowStaticAnalyzer:
         # Step 3b: Check lineage reachability for observe/passthrough references
         for warning in self._check_lineage_reachability():
             result.add_warning(warning)
+
+        # Step 4: Validate reprompt UDF references exist
+        for error in self._check_reprompt_udf_references():
+            result.add_error(error)
 
         return result
 
@@ -1191,6 +1196,115 @@ class WorkflowStaticAnalyzer:
                         queue.append(dep)
 
         return False
+
+    def _check_reprompt_udf_references(self) -> list[StaticTypeError]:
+        """Validate that reprompt.validation UDF names reference discoverable functions.
+
+        Scans the project's tool directories for ``@reprompt_validation``-decorated
+        functions and checks that every ``reprompt.validation`` reference in the
+        workflow config matches a known function name.
+        """
+        errors: list[StaticTypeError] = []
+        actions = self.workflow_config.get("actions", [])
+
+        # Collect actions that reference a reprompt validation UDF.
+        udf_refs: list[tuple[str, str]] = []  # (action_name, udf_name)
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            name = action.get("name", "unknown")
+            reprompt = action.get("reprompt")
+            if not isinstance(reprompt, dict):
+                continue
+            validation = reprompt.get("validation")
+            if isinstance(validation, str) and validation:
+                udf_refs.append((name, validation))
+
+        if not udf_refs:
+            return errors
+
+        # Discover available reprompt validation UDFs by scanning tool files
+        # for @reprompt_validation decorators via AST.
+        available_udfs = self._scan_reprompt_validation_udfs()
+
+        for action_name, udf_name in udf_refs:
+            if available_udfs is None:
+                # Could not scan — emit warning-level skip (no project_root).
+                continue
+            if udf_name not in available_udfs:
+                hint_parts = []
+                if available_udfs:
+                    hint_parts.append(
+                        f"Available reprompt validators: {', '.join(sorted(available_udfs))}"
+                    )
+                hint_parts.append(
+                    "Define a function decorated with @reprompt_validation in your tools directory."
+                )
+                errors.append(
+                    StaticTypeError(
+                        message=(
+                            f"Action '{action_name}': reprompt.validation references "
+                            f"UDF '{udf_name}' which was not found in the project's "
+                            f"tool directories."
+                        ),
+                        location=FieldLocation(
+                            agent_name=action_name,
+                            config_field="reprompt.validation",
+                            raw_reference=udf_name,
+                        ),
+                        referenced_agent=action_name,
+                        referenced_field="reprompt.validation",
+                        available_fields=available_udfs or set(),
+                        hint=" ".join(hint_parts),
+                    )
+                )
+
+        return errors
+
+    def _scan_reprompt_validation_udfs(self) -> set[str] | None:
+        """Scan tool directories for @reprompt_validation decorated functions.
+
+        Returns set of function names, or None if scanning is not possible
+        (e.g., no project_root configured).
+        """
+        import ast
+
+        from agent_actions.config.path_config import get_tool_dirs, resolve_project_root
+
+        project_root = resolve_project_root(self.schema_extractor.project_root)
+        if not project_root or not project_root.exists():
+            return None
+
+        tool_dirs = get_tool_dirs(project_root)
+        found: set[str] = set()
+
+        for tool_dir in tool_dirs:
+            tool_path = (
+                project_root / tool_dir if not Path(tool_dir).is_absolute() else Path(tool_dir)
+            )
+            if not tool_path.exists():
+                continue
+            for py_file in tool_path.rglob("*.py"):
+                try:
+                    tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+                except (SyntaxError, UnicodeDecodeError):
+                    continue
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.FunctionDef):
+                        continue
+                    for decorator in node.decorator_list:
+                        dec_name = ""
+                        if isinstance(decorator, ast.Name):
+                            dec_name = decorator.id
+                        elif isinstance(decorator, ast.Call):
+                            if isinstance(decorator.func, ast.Name):
+                                dec_name = decorator.func.id
+                            elif isinstance(decorator.func, ast.Attribute):
+                                dec_name = decorator.func.attr
+                        if dec_name == "reprompt_validation":
+                            found.add(node.name)
+
+        return found
 
     def _add_source_node(self) -> None:
         """Add the special source node for workflow input."""

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -5,7 +5,6 @@ similar to TypeScript's compile-time type checking.
 """
 
 import logging
-from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import ConfigurationError
@@ -1226,11 +1225,10 @@ class WorkflowStaticAnalyzer:
         # Discover available reprompt validation UDFs by scanning tool files
         # for @reprompt_validation decorators via AST.
         available_udfs = self._scan_reprompt_validation_udfs()
+        if available_udfs is None:
+            return errors
 
         for action_name, udf_name in udf_refs:
-            if available_udfs is None:
-                # Could not scan — emit warning-level skip (no project_root).
-                continue
             if udf_name not in available_udfs:
                 hint_parts = []
                 if available_udfs:
@@ -1269,9 +1267,10 @@ class WorkflowStaticAnalyzer:
         """
         import ast
 
-        from agent_actions.config.path_config import get_tool_dirs, resolve_project_root
+        from agent_actions.config.path_config import get_tool_dirs
+        from agent_actions.utils.path_utils import resolve_relative_to
 
-        project_root = resolve_project_root(self.schema_extractor.project_root)
+        project_root = self.schema_extractor.project_root
         if not project_root or not project_root.exists():
             return None
 
@@ -1279,9 +1278,7 @@ class WorkflowStaticAnalyzer:
         found: set[str] = set()
 
         for tool_dir in tool_dirs:
-            tool_path = (
-                project_root / tool_dir if not Path(tool_dir).is_absolute() else Path(tool_dir)
-            )
+            tool_path = resolve_relative_to(tool_dir, project_root)
             if not tool_path.exists():
                 continue
             for py_file in tool_path.rglob("*.py"):

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -1,0 +1,509 @@
+"""Preflight consolidation tests.
+
+Ensures every detectable misconfiguration is caught before execution.
+Organized by category of misconfiguration.
+"""
+
+import pytest
+
+from agent_actions.config.schema import ActionConfig, WorkflowConfig
+from agent_actions.validation.orchestration.action_entry_validation_orchestrator import (
+    ActionEntryValidationOrchestrator,
+)
+from agent_actions.validation.static_analyzer import (
+    WorkflowStaticAnalyzer,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _validate_entry(entry: dict, agent_name: str = "test_workflow") -> tuple[list, list]:
+    """Run orchestrator on a single action entry, return (errors, warnings)."""
+    orch = ActionEntryValidationOrchestrator()
+    orch.validate_action_entry(entry, agent_name)
+    return orch.get_validation_errors(), orch.get_validation_warnings()
+
+
+def _make_workflow(actions: list[dict]) -> dict:
+    """Build a minimal workflow config dict."""
+    return {"name": "test_workflow", "description": "test", "actions": actions}
+
+
+def _analyze(actions: list[dict], **kwargs):
+    """Run static analysis on a list of action dicts."""
+    config = _make_workflow(actions)
+    analyzer = WorkflowStaticAnalyzer(config, **kwargs)
+    return analyzer.analyze()
+
+
+# ── TestDependencyValidation ─────────────────────────────────────────
+
+
+class TestDependencyValidation:
+    """Validates dependency references are caught at preflight."""
+
+    def test_dangling_depends_on_reference(self):
+        """Dangling dependency (non-existent action) raises at Pydantic level."""
+        with pytest.raises(ValueError, match="depend.*nonexistent|not defined"):
+            WorkflowConfig(
+                name="wf",
+                description="test",
+                actions=[
+                    ActionConfig(name="a", intent="do", kind="llm"),
+                    ActionConfig(name="b", intent="do", kind="llm", dependencies=["nonexistent"]),
+                ],
+            )
+
+    def test_circular_dependency_detected(self):
+        """Circular dependency chain is caught by Pydantic model validator."""
+        with pytest.raises(ValueError, match="[Cc]ircular|cycle"):
+            WorkflowConfig(
+                name="wf",
+                description="test",
+                actions=[
+                    ActionConfig(name="a", intent="do", kind="llm", dependencies=["b"]),
+                    ActionConfig(name="b", intent="do", kind="llm", dependencies=["a"]),
+                ],
+            )
+
+    def test_cross_workflow_dep_not_false_positive(self):
+        """Cross-workflow deps (dict format) are stripped, not rejected."""
+        # Should not raise — dict deps are silently stripped
+        config = ActionConfig(
+            name="a",
+            intent="do",
+            kind="llm",
+            dependencies=[{"workflow": "other", "action": "x"}, "local_dep"],
+        )
+        # Only string deps survive
+        assert config.dependencies == ["local_dep"]
+
+    def test_primary_dependency_references_valid_action(self):
+        """primary_dependency referencing non-existent action is caught."""
+        with pytest.raises(ValueError, match="primary_dependency.*ghost|not defined"):
+            WorkflowConfig(
+                name="wf",
+                description="test",
+                actions=[
+                    ActionConfig(name="a", intent="do", kind="llm"),
+                    ActionConfig(
+                        name="b",
+                        intent="do",
+                        kind="llm",
+                        dependencies=["a"],
+                        primary_dependency="ghost",
+                    ),
+                ],
+            )
+
+
+# ── TestGuardValidation ──────────────────────────────────────────────
+
+
+class TestGuardValidation:
+    """Validates guard expressions are checked at preflight."""
+
+    def test_invalid_guard_type_detected(self):
+        """Non-string/dict guard raises at Pydantic level."""
+        with pytest.raises(ValueError):
+            ActionConfig(
+                name="a",
+                intent="do",
+                kind="llm",
+                guard=12345,
+            )
+
+    def test_guard_dict_with_condition(self):
+        """Valid guard dict config is accepted."""
+        config = ActionConfig(
+            name="a",
+            intent="do",
+            kind="llm",
+            guard={"condition": "score >= 85", "on_false": "filter"},
+        )
+        assert config.guard is not None
+
+    def test_guard_references_valid_fields_via_static(self):
+        """Static analyzer catches guard references to non-existent fields."""
+        result = _analyze(
+            [
+                {
+                    "name": "scorer",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"score": {"type": "number"}},
+                    },
+                },
+                {
+                    "name": "consumer",
+                    "depends_on": ["scorer"],
+                    "guard": {"condition": "nonexistent_field > 5", "on_false": "filter"},
+                    "context_scope": {"observe": ["scorer.score"]},
+                    "schema": {
+                        "type": "object",
+                        "properties": {"result": {"type": "string"}},
+                    },
+                },
+            ]
+        )
+        # The guard references nonexistent_field which isn't in any upstream schema.
+        # Static analysis should flag this (bare identifier warning or missing field).
+        assert len(result.errors) >= 0 or len(result.warnings) >= 0
+
+
+# ── TestSchemaValidation ─────────────────────────────────────────────
+
+
+class TestSchemaValidation:
+    """Validates schema structures are checked at preflight."""
+
+    def test_inline_schema_structure_valid(self):
+        """Valid inline schema passes validation."""
+        errors, _ = _validate_entry(
+            {
+                "name": "test",
+                "agent_type": "llm",
+                "model_name": "gpt-4",
+                "schema": {"summary": "string", "score": "number"},
+            }
+        )
+        schema_errors = [e for e in errors if "schema" in e.lower()]
+        assert len(schema_errors) == 0
+
+    def test_invalid_field_type_detected(self):
+        """Invalid type in inline schema is caught."""
+        errors, _ = _validate_entry(
+            {
+                "name": "test",
+                "agent_type": "llm",
+                "model_name": "gpt-4",
+                "schema": {"summary": "string", "bad_field": "foobar_type"},
+            }
+        )
+        assert any("foobar_type" in e for e in errors)
+
+    def test_duplicate_field_ids_detected(self):
+        """Duplicate field IDs in unified schema are caught by static analyzer."""
+        result = _analyze(
+            [
+                {
+                    "name": "extractor",
+                    "schema": {
+                        "fields": [
+                            {"id": "name", "type": "string"},
+                            {"id": "name", "type": "number"},
+                        ],
+                    },
+                },
+            ]
+        )
+        assert any("duplicate" in e.message.lower() for e in result.errors)
+
+    def test_schema_and_schema_name_conflict_warned(self):
+        """Having both schema and schema_name produces a warning."""
+        _, warnings = _validate_entry(
+            {
+                "name": "test",
+                "agent_type": "llm",
+                "model_name": "gpt-4",
+                "schema": {"summary": "string"},
+                "schema_name": "my_schema",
+            }
+        )
+        assert any("schema" in w.lower() and "schema_name" in w.lower() for w in warnings)
+
+
+# ── TestContextScopeValidation ───────────────────────────────────────
+
+
+class TestContextScopeValidation:
+    """Validates context_scope references are checked at preflight."""
+
+    def test_observe_references_valid_action(self):
+        """Observe referencing non-existent action is caught."""
+        result = _analyze(
+            [
+                {
+                    "name": "consumer",
+                    "depends_on": ["ghost"],
+                    "context_scope": {"observe": ["ghost.field"]},
+                    "schema": {
+                        "type": "object",
+                        "properties": {"out": {"type": "string"}},
+                    },
+                },
+            ]
+        )
+        assert not result.is_valid
+        assert any("ghost" in e.message for e in result.errors)
+
+    def test_observe_field_exists_in_upstream_schema(self):
+        """Observe referencing non-existent field in upstream schema is caught."""
+        result = _analyze(
+            [
+                {
+                    "name": "extractor",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                    },
+                },
+                {
+                    "name": "consumer",
+                    "depends_on": ["extractor"],
+                    "context_scope": {"observe": ["extractor.nonexistent"]},
+                    "schema": {
+                        "type": "object",
+                        "properties": {"out": {"type": "string"}},
+                    },
+                },
+            ]
+        )
+        assert any("nonexistent" in e.message for e in result.errors)
+
+    def test_orphaned_directives_detected(self):
+        """Orphaned observe/passthrough (siblings of context_scope) detected."""
+        result = _analyze(
+            [
+                {
+                    "name": "action_a",
+                    "context_scope": None,
+                    "observe": ["source.field"],
+                    "schema": {
+                        "type": "object",
+                        "properties": {"out": {"type": "string"}},
+                    },
+                },
+            ]
+        )
+        assert any("context_scope" in e.message.lower() for e in result.errors)
+
+
+# ── TestRecoveryValidation ───────────────────────────────────────────
+
+
+class TestRecoveryValidation:
+    """Validates retry/reprompt configs are checked at preflight."""
+
+    def test_retry_config_range_valid(self):
+        """Retry max_attempts outside 1-10 range raises at Pydantic level."""
+        with pytest.raises(ValueError, match="greater than or equal|less than or equal"):
+            ActionConfig(
+                name="a",
+                intent="do",
+                kind="llm",
+                retry={"max_attempts": 99},
+            )
+
+    def test_retry_true_rejected(self):
+        """retry: true (ambiguous) is rejected."""
+        with pytest.raises(ValueError, match="retry: true is not valid"):
+            ActionConfig(name="a", intent="do", kind="llm", retry=True)
+
+    def test_on_exhausted_valid_enum(self):
+        """Invalid on_exhausted value is rejected at Pydantic level."""
+        with pytest.raises(ValueError):
+            ActionConfig(
+                name="a",
+                intent="do",
+                kind="llm",
+                retry={"on_exhausted": "crash"},
+            )
+
+    def test_reprompt_udf_exists(self):
+        """Reprompt validation referencing non-existent UDF caught by static analyzer."""
+        result = _analyze(
+            [
+                {
+                    "name": "llm_action",
+                    "reprompt": {"validation": "totally_nonexistent_validator_xyz"},
+                    "context_scope": {"observe": ["source.*"]},
+                    "schema": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                    },
+                },
+            ]
+        )
+        # The static analyzer should flag the missing UDF
+        assert any("totally_nonexistent_validator_xyz" in e.message for e in result.errors)
+
+    def test_on_schema_mismatch_reprompt_requires_reprompt_config(self):
+        """on_schema_mismatch: reprompt without reprompt block is caught."""
+        errors, _ = _validate_entry(
+            {
+                "name": "test",
+                "agent_type": "llm",
+                "model_name": "gpt-4",
+                "on_schema_mismatch": "reprompt",
+                # no reprompt config
+            }
+        )
+        assert any("reprompt" in e.lower() and "on_schema_mismatch" in e.lower() for e in errors)
+
+    def test_on_schema_mismatch_reprompt_with_reprompt_config_passes(self):
+        """on_schema_mismatch: reprompt with reprompt block passes validation."""
+        errors, _ = _validate_entry(
+            {
+                "name": "test",
+                "agent_type": "llm",
+                "model_name": "gpt-4",
+                "on_schema_mismatch": "reprompt",
+                "reprompt": {"validation": "my_validator"},
+            }
+        )
+        mismatch_errors = [
+            e for e in errors if "on_schema_mismatch" in e.lower() and "reprompt" in e.lower()
+        ]
+        assert len(mismatch_errors) == 0
+
+
+# ── TestTypeSpecificValidation ───────────────────────────────────────
+
+
+class TestTypeSpecificValidation:
+    """Validates kind-specific rules are enforced at preflight."""
+
+    def test_tool_impl_exists(self):
+        """Tool action without impl raises at Pydantic level."""
+        with pytest.raises(ValueError, match="impl"):
+            ActionConfig(name="t", intent="do", kind="tool")
+
+    def test_hitl_requires_file_granularity(self):
+        """HITL action with granularity: record is caught by action validator."""
+        errors, _ = _validate_entry(
+            {
+                "name": "review",
+                "agent_type": "llm",
+                "model_name": "n/a",
+                "kind": "hitl",
+                "granularity": "record",
+                "hitl": {"instructions": "Review these records"},
+            }
+        )
+        assert any("hitl" in e.lower() and "file" in e.lower() for e in errors)
+
+    def test_hitl_file_granularity_passes(self):
+        """HITL action with granularity: file passes validation."""
+        errors, _ = _validate_entry(
+            {
+                "name": "review",
+                "agent_type": "llm",
+                "model_name": "n/a",
+                "kind": "hitl",
+                "granularity": "file",
+                "hitl": {"instructions": "Review these records"},
+            }
+        )
+        hitl_errors = [e for e in errors if "hitl" in e.lower() and "granularity" in e.lower()]
+        assert len(hitl_errors) == 0
+
+    def test_hitl_without_granularity_passes(self):
+        """HITL action without explicit granularity passes (runtime defaults to file)."""
+        errors, _ = _validate_entry(
+            {
+                "name": "review",
+                "agent_type": "llm",
+                "model_name": "n/a",
+                "kind": "hitl",
+                "hitl": {"instructions": "Review these records"},
+            }
+        )
+        hitl_errors = [e for e in errors if "hitl" in e.lower() and "granularity" in e.lower()]
+        assert len(hitl_errors) == 0
+
+    def test_hitl_requires_hitl_config(self):
+        """HITL action without hitl config block raises at Pydantic level."""
+        with pytest.raises(ValueError, match="hitl.*configuration"):
+            ActionConfig(name="h", intent="do", kind="hitl")
+
+    def test_llm_requires_model_name(self):
+        """LLM action without model_name is caught by entry validator."""
+        errors, _ = _validate_entry(
+            {
+                "name": "test",
+                "agent_type": "llm",
+            }
+        )
+        assert any("model_name" in e.lower() for e in errors)
+
+
+# ── TestActionableErrors ─────────────────────────────────────────────
+
+
+class TestActionableErrors:
+    """Validates error messages are actionable and include context."""
+
+    def test_every_error_includes_action_name(self):
+        """Errors from action validators include action name context."""
+        errors, _ = _validate_entry(
+            {
+                "name": "my_special_action",
+                "agent_type": "llm",
+                # missing model_name
+            }
+        )
+        assert len(errors) > 0
+        # At least one error should include the context (agent type + name)
+        assert any("my_special_action" in e or "llm" in e.lower() for e in errors)
+
+    def test_every_error_suggests_fix(self):
+        """Static analyzer errors include hints for fixing."""
+        result = _analyze(
+            [
+                {
+                    "name": "extractor",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                    },
+                },
+                {
+                    "name": "consumer",
+                    "depends_on": ["extractor"],
+                    "context_scope": {"observe": ["extractor.nonexistent"]},
+                    "schema": {
+                        "type": "object",
+                        "properties": {"out": {"type": "string"}},
+                    },
+                },
+            ]
+        )
+        # At least one error should have a hint
+        errors_with_hint = [e for e in result.errors if e.hint]
+        assert len(errors_with_hint) > 0
+
+    def test_granularity_error_is_actionable(self):
+        """HITL granularity error message tells the user how to fix it."""
+        errors, _ = _validate_entry(
+            {
+                "name": "review",
+                "agent_type": "llm",
+                "model_name": "n/a",
+                "kind": "hitl",
+                "granularity": "record",
+                "hitl": {"instructions": "Review these records"},
+            }
+        )
+        hitl_errors = [e for e in errors if "hitl" in e.lower()]
+        assert len(hitl_errors) > 0
+        # Error message should tell user how to fix
+        assert any("granularity: file" in e.lower() or "remove" in e.lower() for e in hitl_errors)
+
+    def test_reprompt_mismatch_error_is_actionable(self):
+        """on_schema_mismatch error tells the user what to add."""
+        errors, _ = _validate_entry(
+            {
+                "name": "test",
+                "agent_type": "llm",
+                "model_name": "gpt-4",
+                "on_schema_mismatch": "reprompt",
+            }
+        )
+        reprompt_errors = [e for e in errors if "on_schema_mismatch" in e.lower()]
+        assert len(reprompt_errors) > 0
+        # Should suggest adding reprompt block or changing the mode
+        assert any(
+            "reprompt:" in e.lower() or "warn" in e.lower() or "reject" in e.lower()
+            for e in reprompt_errors
+        )

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -148,7 +148,7 @@ class TestGuardValidation:
         )
         # The guard references nonexistent_field which isn't in any upstream schema.
         # Static analysis should flag this (bare identifier warning or missing field).
-        assert len(result.errors) >= 0 or len(result.warnings) >= 0
+        assert result.errors or result.warnings
 
 
 # ── TestSchemaValidation ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Audited all preflight validators, static analyzer, and action validators for detection gaps
- Added 3 checks that previously only failed at runtime (wasted LLM calls / silent failures):
  - **HITL + record granularity**: now caught at config validation (was only caught in RecordProcessor.__init__)
  - **on_schema_mismatch: reprompt without reprompt config**: now caught at config validation (was unchecked)
  - **reprompt.validation UDF existence**: static analyzer scans tool dirs via AST (was only caught at runtime with silent skip)
- All error messages include action name, what's wrong, and how to fix
- 30 new tests covering all spec categories

## Verification
- `ruff format --check` passes on changed files
- `ruff check` passes on changed files
- All 30 new tests pass
- Full suite: 4902 passed, 2 skipped