### PR TITLE
fix: warn when json_mode=false drops compiled schema

### DIFF
--- a/agent_actions/llm/providers/batch_base.py
+++ b/agent_actions/llm/providers/batch_base.py
@@ -84,6 +84,13 @@ class BaseBatchClient(ABC):
 
         tasks = []
         json_mode = agent_config.get("json_mode", get_default("json_mode"))
+        if not json_mode and agent_config.get("compiled_schema") is not None:
+            logger.warning(
+                "json_mode=false but schema was compiled for action '%s'. "
+                "The schema will not be sent to the LLM. "
+                "Set json_mode=true to enable schema enforcement.",
+                agent_config.get("agent_type", agent_config.get("name", "unknown")),
+            )
         schema = agent_config.get("compiled_schema") if json_mode else None
 
         for row in data:

--- a/agent_actions/llm/providers/client_base.py
+++ b/agent_actions/llm/providers/client_base.py
@@ -5,12 +5,15 @@ Provides common functionality for all LLM clients including API key management,
 data redaction, and invocation dispatch to JSON or non-JSON modes.
 """
 
+import logging
 import os
 import re
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from agent_actions.utils.constants import API_KEY_KEY, JSON_MODE_KEY
+
+logger = logging.getLogger(__name__)
 
 
 class BaseClient(ABC):
@@ -178,4 +181,11 @@ class BaseClient(ABC):
         json_mode: bool = agent_config.get(JSON_MODE_KEY, True)
         if json_mode:
             return cls.call_json(api_key, agent_config, prompt_config, context_data, schema)
+        if schema is not None:
+            logger.warning(
+                "json_mode=false but schema was compiled for action '%s'. "
+                "The schema will not be sent to the LLM. "
+                "Set json_mode=true to enable schema enforcement.",
+                agent_config.get("agent_type", "unknown"),
+            )
         return cls.call_non_json(api_key, agent_config, prompt_config, context_data)

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -181,6 +181,10 @@ class WorkflowStaticAnalyzer:
         for error in self._check_reprompt_udf_references():
             result.add_error(error)
 
+        # Step 5: Warn when json_mode=false but schema is defined
+        for warning in self._check_json_mode_schema_mismatch():
+            result.add_warning(warning)
+
         return result
 
     def _build_graph(self) -> None:
@@ -906,6 +910,62 @@ class WorkflowStaticAnalyzer:
                     )
 
         return errors, warnings
+
+    # ── json_mode / schema mismatch ─────────────────────────────────
+
+    def _check_json_mode_schema_mismatch(self) -> list[StaticTypeWarning]:
+        """Warn when json_mode=false but a schema is defined.
+
+        The schema will be compiled but never sent to the LLM because
+        ``BaseClient.invoke()`` routes to ``call_non_json()`` which does
+        not accept a schema parameter.  The user likely expects schema
+        enforcement but will silently get free-form text.
+        """
+        warnings: list[StaticTypeWarning] = []
+        actions = self.workflow_config.get("actions", [])
+
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+
+            name = action.get("name", "<unnamed>")
+            kind = action.get("kind", DEFAULT_ACTION_KIND)
+            if kind != "llm":
+                continue
+
+            json_mode = action.get("json_mode", True)
+            if json_mode:
+                continue
+
+            has_schema = bool(
+                action.get("schema") or action.get("output_schema") or action.get("schema_name")
+            )
+            if not has_schema:
+                continue
+
+            warnings.append(
+                StaticTypeWarning(
+                    message=(
+                        f"Action '{name}' has json_mode=false but defines a schema. "
+                        f"The schema will be compiled but not sent to the LLM. "
+                        f"Set json_mode=true to enable schema enforcement, or "
+                        f"remove the schema if text output is intended."
+                    ),
+                    location=FieldLocation(
+                        agent_name=name,
+                        config_field="json_mode",
+                        raw_reference="json_mode: false",
+                    ),
+                    referenced_agent=name,
+                    referenced_field="json_mode",
+                    hint=(
+                        "json_mode=false routes to call_non_json() which does not "
+                        "forward the schema. The LLM will return free-form text."
+                    ),
+                )
+            )
+
+        return warnings
 
     def _check_guard_nullable_fields(self) -> list[StaticTypeWarning]:
         """Detect fields that may be None due to upstream guard filtering.

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -13,9 +13,13 @@ from agent_actions.input.context.normalizer import (
     detect_orphaned_directives,
     normalize_context_scope,
 )
+from agent_actions.output.response.config_fields import get_default
 from agent_actions.utils.constants import (
     DEFAULT_ACTION_KIND,
+    JSON_MODE_KEY,
     RESERVED_AGENT_NAMES,
+    SCHEMA_KEY,
+    SCHEMA_NAME_KEY,
     SPECIAL_NAMESPACES,
 )
 
@@ -933,12 +937,12 @@ class WorkflowStaticAnalyzer:
             if kind != "llm":
                 continue
 
-            json_mode = action.get("json_mode", True)
+            json_mode = action.get(JSON_MODE_KEY, get_default(JSON_MODE_KEY))
             if json_mode:
                 continue
 
             has_schema = bool(
-                action.get("schema") or action.get("output_schema") or action.get("schema_name")
+                action.get(SCHEMA_KEY) or action.get("output_schema") or action.get(SCHEMA_NAME_KEY)
             )
             if not has_schema:
                 continue
@@ -947,9 +951,9 @@ class WorkflowStaticAnalyzer:
                 StaticTypeWarning(
                     message=(
                         f"Action '{name}' has json_mode=false but defines a schema. "
-                        f"The schema will be compiled but not sent to the LLM. "
-                        f"Set json_mode=true to enable schema enforcement, or "
-                        f"remove the schema if text output is intended."
+                        "The schema will be compiled but not sent to the LLM. "
+                        "Set json_mode=true to enable schema enforcement, or "
+                        "remove the schema if text output is intended."
                     ),
                     location=FieldLocation(
                         agent_name=name,
@@ -959,8 +963,9 @@ class WorkflowStaticAnalyzer:
                     referenced_agent=name,
                     referenced_field="json_mode",
                     hint=(
-                        "json_mode=false routes to call_non_json() which does not "
-                        "forward the schema. The LLM will return free-form text."
+                        "When json_mode is false, the schema is not included in the "
+                        "LLM request. The LLM will return free-form text instead of "
+                        "structured output."
                     ),
                 )
             )

--- a/tests/unit/llm/test_json_mode_schema_warning.py
+++ b/tests/unit/llm/test_json_mode_schema_warning.py
@@ -1,0 +1,326 @@
+"""Tests for json_mode=false + schema mismatch warnings.
+
+Validates that:
+- Preflight: static analyzer warns when json_mode=false + schema defined
+- Runtime: BaseClient.invoke() logs warning when schema is dropped
+- Runtime: BaseBatchClient.prepare_tasks() logs warning when schema is dropped
+- No false positives for valid configs
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+from agent_actions.llm.providers.batch_base import BaseBatchClient, BatchTask
+from agent_actions.llm.providers.client_base import BaseClient
+from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+    WorkflowStaticAnalyzer,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_workflow(actions: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a minimal workflow config for static analysis."""
+    return {"actions": actions}
+
+
+def _make_action(
+    name: str = "test_action",
+    json_mode: bool = True,
+    schema: dict | str | None = None,
+    schema_name: str | None = None,
+    output_schema: dict | None = None,
+    kind: str = "llm",
+    depends_on: list[str] | None = None,
+) -> dict[str, Any]:
+    action: dict[str, Any] = {
+        "name": name,
+        "kind": kind,
+        "json_mode": json_mode,
+        "model_vendor": "openai",
+        "model_name": "gpt-4",
+        "api_key": "${OPENAI_API_KEY}",
+    }
+    if schema is not None:
+        action["schema"] = schema
+    if schema_name is not None:
+        action["schema_name"] = schema_name
+    if output_schema is not None:
+        action["output_schema"] = output_schema
+    if depends_on is not None:
+        action["depends_on"] = depends_on
+    return action
+
+
+class ConcreteClient(BaseClient):
+    """Minimal concrete client for testing invoke() dispatch."""
+
+    CAPABILITIES = {"json_mode": True}
+
+    @staticmethod
+    def call_json(api_key, agent_config, prompt_config, context_data, schema):
+        return [{"content": "json"}]
+
+    @staticmethod
+    def call_non_json(api_key, agent_config, prompt_config, context_data):
+        return [{"content": "text"}]
+
+
+class ConcreteBatchClient(BaseBatchClient):
+    """Minimal concrete batch client for testing prepare_tasks()."""
+
+    def _get_default_model(self) -> str:
+        return "gpt-4"
+
+    def format_task_for_provider(self, batch_task: BatchTask, schema=None) -> dict:
+        return {"id": batch_task.custom_id, "schema": schema}
+
+    def _fetch_status(self, batch_id: str) -> str:
+        return "completed"
+
+    def _normalize_status(self, raw_status: str) -> str:
+        return raw_status
+
+    def _extract_error_from_response(self, raw_response) -> str | None:
+        return None
+
+    def _extract_content_from_response(self, raw_response) -> Any:
+        return raw_response
+
+    def _extract_metadata_from_response(self, raw_response) -> dict:
+        return {}
+
+    def _extract_usage_from_response(self, raw_response) -> dict | None:
+        return None
+
+    def _fetch_raw_results(self, batch_id: str) -> bytes:
+        return b""
+
+    def _get_result_file_name(self, batch_id: str) -> str:
+        return f"{batch_id}.jsonl"
+
+    def _prepare_batch_input_file(self, tasks, batch_dir, batch_name):
+        return batch_dir / "input.jsonl"
+
+    def _submit_to_provider_api(self, input_file, batch_name):
+        return ("batch_123", "submitted")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Preflight: static analyzer warnings
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestPreflightJsonModeSchemaWarning:
+    """Static analyzer warns when json_mode=false + schema is defined."""
+
+    def test_json_mode_false_with_schema_warns(self):
+        """json_mode=false + schema dict → warning."""
+        action = _make_action(
+            json_mode=False,
+            schema={"type": "object", "properties": {"summary": {"type": "string"}}},
+        )
+        workflow = _make_workflow([action])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        assert len(json_mode_warnings) == 1
+        assert "schema will be compiled but not sent" in json_mode_warnings[0].message
+
+    def test_json_mode_false_with_schema_name_warns(self):
+        """json_mode=false + schema_name → warning."""
+        action = _make_action(json_mode=False, schema_name="summary_schema")
+        workflow = _make_workflow([action])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        assert len(json_mode_warnings) == 1
+
+    def test_json_mode_false_with_output_schema_warns(self):
+        """json_mode=false + output_schema → warning."""
+        action = _make_action(
+            json_mode=False,
+            output_schema={"type": "object", "properties": {"result": {"type": "string"}}},
+        )
+        workflow = _make_workflow([action])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        assert len(json_mode_warnings) == 1
+
+    def test_json_mode_true_with_schema_no_warning(self):
+        """json_mode=true + schema → no warning (correct config)."""
+        action = _make_action(
+            json_mode=True,
+            schema={"type": "object", "properties": {"summary": {"type": "string"}}},
+        )
+        workflow = _make_workflow([action])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        assert len(json_mode_warnings) == 0
+
+    def test_json_mode_false_no_schema_no_warning(self):
+        """json_mode=false + no schema → no warning (valid text output)."""
+        action = _make_action(json_mode=False)
+        workflow = _make_workflow([action])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        assert len(json_mode_warnings) == 0
+
+    def test_tool_action_skipped(self):
+        """Tool actions don't get json_mode/schema check."""
+        action = _make_action(
+            kind="tool",
+            json_mode=False,
+            schema={"type": "object"},
+        )
+        workflow = _make_workflow([action])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        assert len(json_mode_warnings) == 0
+
+    def test_warning_is_non_blocking(self):
+        """json_mode mismatch warning does not block execution."""
+        action = _make_action(
+            json_mode=False,
+            schema={"type": "object", "properties": {"x": {"type": "string"}}},
+        )
+        workflow = _make_workflow([action])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        # Warning exists but result is still valid (not blocked)
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        assert len(json_mode_warnings) == 1
+        # No errors from the mismatch check itself
+        json_mode_errors = [e for e in result.errors if "json_mode" in e.message]
+        assert len(json_mode_errors) == 0
+
+    def test_multiple_actions_each_warned(self):
+        """Each misconfigured action gets its own warning."""
+        a1 = _make_action(name="action_a", json_mode=False, schema={"type": "object"})
+        a2 = _make_action(name="action_b", json_mode=False, schema_name="schema_b")
+        a3 = _make_action(name="action_c", json_mode=True, schema={"type": "object"})
+        workflow = _make_workflow([a1, a2, a3])
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        json_mode_warnings = [w for w in result.warnings if "json_mode=false" in w.message]
+        warned_names = {w.location.agent_name for w in json_mode_warnings}
+        assert warned_names == {"action_a", "action_b"}
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Runtime: BaseClient.invoke() warning
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestRuntimeInvokeWarning:
+    """BaseClient.invoke() logs warning when schema is dropped."""
+
+    @patch("agent_actions.llm.providers.client_base.logger")
+    @patch.object(BaseClient, "get_api_key", return_value="sk-test")
+    def test_invoke_json_false_with_schema_warns(self, _mock_key, mock_logger):
+        """invoke() with json_mode=false + schema logs a warning."""
+        config = {"json_mode": False, "agent_type": "summarize"}
+        schema = {"type": "object", "properties": {"summary": {"type": "string"}}}
+
+        ConcreteClient.invoke(config, "prompt", {}, schema)
+
+        mock_logger.warning.assert_called_once()
+        msg = mock_logger.warning.call_args[0][0]
+        assert "json_mode=false" in msg
+        assert "summarize" in mock_logger.warning.call_args[0][1]
+
+    @patch("agent_actions.llm.providers.client_base.logger")
+    @patch.object(BaseClient, "get_api_key", return_value="sk-test")
+    def test_invoke_json_false_no_schema_no_warning(self, _mock_key, mock_logger):
+        """invoke() with json_mode=false + no schema → no warning."""
+        config = {"json_mode": False, "agent_type": "summarize"}
+
+        ConcreteClient.invoke(config, "prompt", {}, None)
+
+        mock_logger.warning.assert_not_called()
+
+    @patch("agent_actions.llm.providers.client_base.logger")
+    @patch.object(BaseClient, "get_api_key", return_value="sk-test")
+    def test_invoke_json_true_with_schema_no_warning(self, _mock_key, mock_logger):
+        """invoke() with json_mode=true + schema → no warning (normal path)."""
+        config = {"json_mode": True, "agent_type": "summarize"}
+        schema = {"type": "object"}
+
+        ConcreteClient.invoke(config, "prompt", {}, schema)
+
+        mock_logger.warning.assert_not_called()
+
+    @patch.object(BaseClient, "get_api_key", return_value="sk-test")
+    def test_invoke_still_returns_result(self, _mock_key):
+        """invoke() still calls call_non_json and returns result even with warning."""
+        config = {"json_mode": False, "agent_type": "summarize"}
+        schema = {"type": "object"}
+
+        result = ConcreteClient.invoke(config, "prompt", {}, schema)
+        assert result == [{"content": "text"}]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Runtime: BaseBatchClient.prepare_tasks() warning
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestRuntimeBatchWarning:
+    """BaseBatchClient.prepare_tasks() logs warning when schema is dropped."""
+
+    @patch("agent_actions.llm.providers.batch_base.logger")
+    def test_batch_json_false_with_compiled_schema_warns(self, mock_logger):
+        """prepare_tasks() with json_mode=false + compiled_schema logs warning."""
+        config = {
+            "json_mode": False,
+            "compiled_schema": {"type": "object"},
+            "agent_type": "summarize",
+            "model_name": "gpt-4",
+        }
+        data = [{"target_id": "row1", "content": {"text": "hello"}}]
+
+        client = ConcreteBatchClient()
+        tasks = client.prepare_tasks(data, config)
+
+        mock_logger.warning.assert_called_once()
+        msg = mock_logger.warning.call_args[0][0]
+        assert "json_mode=false" in msg
+        # Schema should be None in formatted task (not forwarded)
+        assert tasks[0]["schema"] is None
+
+    @patch("agent_actions.llm.providers.batch_base.logger")
+    def test_batch_json_false_no_schema_no_warning(self, mock_logger):
+        """prepare_tasks() with json_mode=false + no schema → no warning."""
+        config = {
+            "json_mode": False,
+            "agent_type": "summarize",
+            "model_name": "gpt-4",
+        }
+        data = [{"target_id": "row1", "content": {"text": "hello"}}]
+
+        client = ConcreteBatchClient()
+        client.prepare_tasks(data, config)
+
+        mock_logger.warning.assert_not_called()
+
+    @patch("agent_actions.llm.providers.batch_base.logger")
+    def test_batch_json_true_with_schema_no_warning(self, mock_logger):
+        """prepare_tasks() with json_mode=true + schema → no warning."""
+        config = {
+            "json_mode": True,
+            "compiled_schema": {"type": "object"},
+            "agent_type": "summarize",
+            "model_name": "gpt-4",
+        }
+        data = [{"target_id": "row1", "content": {"text": "hello"}}]
+
+        client = ConcreteBatchClient()
+        tasks = client.prepare_tasks(data, config)
+
+        mock_logger.warning.assert_not_called()
+        # Schema IS forwarded when json_mode=true
+        assert tasks[0]["schema"] == {"type": "object"}


### PR DESCRIPTION
## Summary
- Preflight warning: json_mode=false + schema defined → warning about schema not being sent
- Runtime warning: BaseClient.invoke() logs when schema is compiled but not forwarded
- Runtime warning: BaseBatchClient.prepare_tasks() logs same for batch path
- Fixes: specs/bugs/pending/bug_json_mode_false_drops_schema.md

## Verification
- Warning emitted for json_mode=false + schema (all 3 schema keys: schema, schema_name, output_schema)
- No warning for json_mode=true + schema (normal)
- No warning for json_mode=false + no schema (valid text output)
- Tool actions skipped (not applicable)
- Both online and batch paths covered
- 15 regression tests, 5267 total tests pass, 0 regressions