### PR TITLE
feat: WorkflowCompiler + fix cross-workflow static validation and I/O resolution

### DIFF
--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -170,6 +170,22 @@ def build_field_context_with_history(
 
         # 2a. INPUT SOURCES - Data is already in current_item (the file being processed)
         # Put it under the action name so prompts can reference {{ action_name.field }}
+        #
+        # Cross-workflow first actions: input_sources is empty (cross-workflow refs
+        # removed by scope_inference) but current_item has the upstream data from
+        # the exported JSON. Expose all content fields at the top level so tool
+        # functions receive them directly.
+        has_cross_wf = bool(agent_config and agent_config.get("_has_cross_workflow_deps"))
+        if not input_sources and has_cross_wf and current_item:
+            input_data = _extract_content_data(current_item)
+            if input_data:
+                field_context.update(input_data)
+                logger.debug(
+                    "[CROSS-WORKFLOW] Action '%s': injected %d fields from upstream input",
+                    agent_name,
+                    len(input_data),
+                )
+
         if input_sources and current_item:
             input_data = _extract_content_data(current_item)
 

--- a/agent_actions/prompt/context/scope_inference.py
+++ b/agent_actions/prompt/context/scope_inference.py
@@ -337,12 +337,21 @@ def infer_dependencies(
         ]
 
     # 5. Validate all referenced actions exist in workflow
+    #    Cross-workflow actions (from dict deps) won't be in workflow_actions.
+    #    When _has_cross_workflow_deps is set, unknown actions are assumed to be
+    #    cross-workflow references and silently excluded instead of raising.
+    has_cross_wf = action_config.get("_has_cross_workflow_deps", False)
+    cross_wf_refs: set[str] = set()
+
     all_referenced = set(input_sources_expanded) | set(context_sources_expanded)
     for dep_action in all_referenced:
         if dep_action in SPECIAL_NAMESPACES:
             continue
 
         if dep_action not in workflow_actions:
+            if has_cross_wf:
+                cross_wf_refs.add(dep_action)
+                continue
             raise ConfigurationError(
                 f"Action '{action_name}': References '{dep_action}' in dependencies/context_scope "
                 f"but '{dep_action}' not found in workflow.\n\n"
@@ -355,6 +364,13 @@ def infer_dependencies(
                     "context_sources": context_sources_expanded,
                 },
             )
+
+    # Remove cross-workflow refs from dependency lists — they're resolved
+    # at runtime via the upstream manifest / storage backend, not via the
+    # intra-workflow context loader.
+    if cross_wf_refs:
+        input_sources_expanded = [s for s in input_sources_expanded if s not in cross_wf_refs]
+        context_sources_expanded = [s for s in context_sources_expanded if s not in cross_wf_refs]
 
     logger.debug(
         f"[INFER_DEPS] Action '{action_name}': "

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -196,13 +196,23 @@ class WorkflowStaticAnalyzer:
         if self._built:
             return
 
-        # Collect cross-workflow action names from raw configs before
-        # Pydantic strips dict deps.  These actions are resolved at runtime
+        # Collect cross-workflow action names that are resolved at runtime
         # and must be excluded from static "does not exist" checks.
+        #
+        # Two detection paths (both needed for robustness):
+        # 1. Dict deps in raw YAML (pre-Pydantic): {workflow: X, action: Y}
+        # 2. _has_cross_workflow_deps flag (post-Pydantic): config_pipeline
+        #    sets this flag on actions whose dict deps were stripped.
+        #    When present, extract referenced action names from context_scope
+        #    that don't match any local action.
         actions = self.workflow_config.get("actions", [])
+        local_action_names = {
+            a.get("name") for a in actions if isinstance(a, dict) and a.get("name")
+        }
         for action_config in actions:
             if not isinstance(action_config, dict):
                 continue
+            # Path 1: dict deps in raw configs (works before Pydantic).
             deps = action_config.get("depends_on") or action_config.get("dependencies", [])
             if isinstance(deps, list):
                 for dep in deps:
@@ -210,6 +220,20 @@ class WorkflowStaticAnalyzer:
                         action_name = dep.get("action")
                         if action_name:
                             self._cross_workflow_actions.add(action_name)
+            # Path 2: flag from config_pipeline (works after Pydantic stripping).
+            if action_config.get("_has_cross_workflow_deps"):
+                cs = action_config.get("context_scope", {})
+                if isinstance(cs, dict):
+                    for directive in ("observe", "passthrough", "drop", "keep"):
+                        for ref in cs.get(directive, []):
+                            if not isinstance(ref, str) or "." not in ref:
+                                continue
+                            ns_name = ref.split(".", 1)[0]
+                            if (
+                                ns_name not in local_action_names
+                                and ns_name not in SPECIAL_NAMESPACES
+                            ):
+                                self._cross_workflow_actions.add(ns_name)
 
         # Add special source node (always available)
         self._add_source_node()

--- a/agent_actions/workflow/compiler.py
+++ b/agent_actions/workflow/compiler.py
@@ -1,0 +1,506 @@
+"""Compile cross-workflow dependencies into a single unified action DAG.
+
+When workflows reference actions in other workflows via dict dependencies
+(e.g. ``{workflow: upstream, action: produce}``), the compiler resolves them
+into qualified string dependencies (``upstream::produce``) and merges all
+involved actions into a single flat list.  The result feeds into the existing
+config pipeline — Pydantic never sees dict deps, strategy selection works
+naturally, and lineage flows through without special flags.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agent_actions.errors import ConfigurationError, WorkflowError
+from agent_actions.workflow.models import CompilationResult, CompiledAction
+
+logger = logging.getLogger(__name__)
+
+SEPARATOR = "::"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def needs_compilation(
+    raw_config: dict[str, Any],
+    run_upstream: bool = False,
+    run_downstream: bool = False,
+) -> bool:
+    """Fast check: does this workflow config require cross-workflow compilation?
+
+    Returns ``True`` when any action has dict-format dependencies or when the
+    ``--upstream`` / ``--downstream`` CLI flags are set.
+    """
+    if run_upstream or run_downstream:
+        return True
+    for action in raw_config.get("actions", []):
+        if not isinstance(action, dict):
+            continue
+        deps = action.get("depends_on") or action.get("dependencies", [])
+        if isinstance(deps, list) and any(isinstance(d, dict) for d in deps):
+            return True
+    return False
+
+
+def compile_workflows(
+    primary_config_path: Path,
+    workflows_root: Path,
+    *,
+    run_upstream: bool = False,
+    run_downstream: bool = False,
+) -> CompilationResult:
+    """Compile all involved workflows into a single action DAG.
+
+    1. Load the primary workflow's raw YAML.
+    2. Extract cross-workflow deps to discover referenced workflows.
+    3. Transitively load all referenced workflows (and upstream /
+       downstream if the flags are set).
+    4. Qualify every action name with its source workflow
+       (``wf::action``).
+    5. Rewrite all dependencies — dict deps become qualified strings,
+       intra-workflow string deps are qualified within their source
+       workflow.
+    6. Return a :class:`CompilationResult` with the merged action list.
+    """
+    compiler = _WorkflowCompiler(workflows_root)
+    return compiler.compile(primary_config_path, run_upstream, run_downstream)
+
+
+def qualify(workflow_name: str, action_name: str) -> str:
+    """Return ``'workflow_name::action_name'``."""
+    return f"{workflow_name}{SEPARATOR}{action_name}"
+
+
+def unqualify(qualified_name: str) -> tuple[str, str]:
+    """Return ``(workflow_name, action_name)`` from a qualified name.
+
+    Raises :class:`ValueError` if *qualified_name* does not contain the
+    separator.
+    """
+    parts = qualified_name.split(SEPARATOR, 1)
+    if len(parts) != 2:
+        raise ValueError(f"Not a qualified action name: {qualified_name!r}")
+    return parts[0], parts[1]
+
+
+# ---------------------------------------------------------------------------
+# Internal implementation
+# ---------------------------------------------------------------------------
+
+
+class _WorkflowCompiler:
+    """Stateful compiler — one instance per compilation."""
+
+    def __init__(self, workflows_root: Path):
+        self.workflows_root = workflows_root
+        # workflow_name → raw YAML dict
+        self._raw_configs: dict[str, dict[str, Any]] = {}
+        # workflow_name → Path to its directory
+        self._workflow_dirs: dict[str, Path] = {}
+        # workflow_name → [upstream workflow names]
+        self._workflow_graph: dict[str, list[str]] = {}
+
+    # -- Entry point --------------------------------------------------------
+
+    def compile(
+        self,
+        primary_config_path: Path,
+        run_upstream: bool,
+        run_downstream: bool,
+    ) -> CompilationResult:
+        primary_name = self._load_workflow(primary_config_path)
+
+        # Discover workflows transitively referenced via dict deps.
+        self._discover_referenced_workflows(primary_name)
+
+        # If --upstream, ensure all transitive upstreams are loaded.
+        if run_upstream:
+            self._load_transitive_upstreams(primary_name)
+
+        # If --downstream, load transitive downstreams from workspace.
+        if run_downstream:
+            self._load_transitive_downstreams(primary_name)
+
+        # Detect cycles in the workflow-level graph.
+        self._check_workflow_cycles()
+
+        # Determine which workflows to include and in what order.
+        involved = self._resolve_involved_workflows(primary_name, run_upstream, run_downstream)
+
+        # Merge and qualify all actions.
+        merged_actions, action_metadata = self._merge_actions(involved)
+
+        return CompilationResult(
+            merged_actions=merged_actions,
+            action_metadata=action_metadata,
+            primary_workflow=primary_name,
+            involved_workflows=involved,
+            workflow_graph=dict(self._workflow_graph),
+        )
+
+    # -- YAML loading -------------------------------------------------------
+
+    def _load_workflow(self, config_path: Path) -> str:
+        """Load a single workflow YAML and register it.  Returns the workflow name."""
+        raw = self._load_raw_yaml(config_path)
+        name = self._extract_workflow_name(raw, config_path)
+        if name in self._raw_configs:
+            return name  # already loaded
+        self._raw_configs[name] = raw
+        self._workflow_dirs[name] = config_path.parents[1]  # .../workflow_dir/agent_config/x.yml
+        self._workflow_graph[name] = self._extract_upstream_workflows(raw)
+        return name
+
+    def _load_workflow_by_name(self, workflow_name: str) -> None:
+        """Discover and load a workflow by name from the workspace root."""
+        if workflow_name in self._raw_configs:
+            return
+
+        wf_dir = self.workflows_root / workflow_name
+        if not wf_dir.is_dir():
+            raise ConfigurationError(
+                f"Referenced workflow directory not found: {workflow_name}",
+                context={
+                    "workflow_name": workflow_name,
+                    "search_root": str(self.workflows_root),
+                    "operation": "compile_workflows",
+                },
+            )
+
+        config_dir = wf_dir / "agent_config"
+        config_file = config_dir / f"{workflow_name}.yml"
+        if not config_file.exists():
+            yml_files = sorted(config_dir.glob("*.yml")) if config_dir.exists() else []
+            if yml_files:
+                config_file = yml_files[0]
+            else:
+                raise ConfigurationError(
+                    f"No config file found for workflow: {workflow_name}",
+                    context={
+                        "workflow_name": workflow_name,
+                        "search_dir": str(config_dir),
+                        "operation": "compile_workflows",
+                    },
+                )
+
+        self._load_workflow(config_file)
+
+    @staticmethod
+    def _load_raw_yaml(config_path: Path) -> dict[str, Any]:
+        """Load workflow YAML without template rendering or Pydantic validation.
+
+        We intentionally skip Jinja2 rendering here because the compiler only
+        needs the action dependency structure, not fully-resolved prompts or
+        schemas.  Template rendering happens later in the normal config pipeline.
+        """
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if not isinstance(data, dict):
+                raise ConfigurationError(
+                    f"Workflow config is not a YAML mapping: {config_path.name}",
+                    context={"config_path": str(config_path), "operation": "compile_workflows"},
+                )
+            return data
+        except yaml.YAMLError as e:
+            raise ConfigurationError(
+                f"Invalid YAML in {config_path.name}: {e}",
+                context={"config_path": str(config_path), "operation": "compile_workflows"},
+                cause=e,
+            ) from e
+
+    @staticmethod
+    def _extract_workflow_name(raw_config: dict[str, Any], config_path: Path) -> str:
+        """Extract workflow name from config or derive from filename."""
+        name = raw_config.get("name")
+        if isinstance(name, str) and name:
+            return name
+        return config_path.stem
+
+    @staticmethod
+    def _extract_upstream_workflows(raw_config: dict[str, Any]) -> list[str]:
+        """Extract upstream workflow names from dict-format dependencies."""
+        upstreams: list[str] = []
+        for action in raw_config.get("actions", []):
+            if not isinstance(action, dict):
+                continue
+            deps = action.get("depends_on") or action.get("dependencies", [])
+            if not isinstance(deps, list):
+                continue
+            for dep in deps:
+                if isinstance(dep, dict) and "workflow" in dep:
+                    wf = dep["workflow"]
+                    if wf not in upstreams:
+                        upstreams.append(wf)
+        return upstreams
+
+    # -- Transitive discovery -----------------------------------------------
+
+    def _discover_referenced_workflows(self, start: str) -> None:
+        """Transitively load all workflows referenced via dict deps."""
+        queue = deque(self._workflow_graph.get(start, []))
+        while queue:
+            wf = queue.popleft()
+            if wf in self._raw_configs:
+                continue
+            self._load_workflow_by_name(wf)
+            queue.extend(self._workflow_graph.get(wf, []))
+
+    def _load_transitive_upstreams(self, primary: str) -> None:
+        """Ensure all transitive upstream workflows are loaded (--upstream flag)."""
+        # Scan workspace to find workflows that the primary depends on transitively.
+        self._scan_workspace_for_graph()
+        visited: set[str] = set()
+        queue = deque(self._workflow_graph.get(primary, []))
+        while queue:
+            wf = queue.popleft()
+            if wf in visited:
+                continue
+            visited.add(wf)
+            self._load_workflow_by_name(wf)
+            queue.extend(self._workflow_graph.get(wf, []))
+
+    def _load_transitive_downstreams(self, primary: str) -> None:
+        """Load all transitive downstream workflows (--downstream flag)."""
+        self._scan_workspace_for_graph()
+        # Build reverse graph.
+        reverse: dict[str, set[str]] = defaultdict(set)
+        for wf, upstreams in self._workflow_graph.items():
+            for up in upstreams:
+                reverse[up].add(wf)
+        # BFS from primary through reverse edges.
+        visited: set[str] = set()
+        queue = deque(reverse.get(primary, set()))
+        while queue:
+            wf = queue.popleft()
+            if wf in visited:
+                continue
+            visited.add(wf)
+            self._load_workflow_by_name(wf)
+            queue.extend(reverse.get(wf, set()))
+
+    def _scan_workspace_for_graph(self) -> None:
+        """Scan the workspace root to build the full workflow-level dependency graph.
+
+        Only loads YAML headers (action deps), not full configs.  Workflows
+        already in ``_raw_configs`` are skipped.
+        """
+        if not self.workflows_root.exists():
+            return
+        for wf_dir in sorted(self.workflows_root.iterdir()):
+            if not wf_dir.is_dir():
+                continue
+            wf_name = wf_dir.name
+            if wf_name in self._workflow_graph:
+                continue
+            config_dir = wf_dir / "agent_config"
+            if not config_dir.exists():
+                continue
+            config_file = config_dir / f"{wf_name}.yml"
+            if not config_file.exists():
+                yml_files = sorted(config_dir.glob("*.yml"))
+                if not yml_files:
+                    continue
+                config_file = yml_files[0]
+            try:
+                raw = self._load_raw_yaml(config_file)
+                self._workflow_graph[wf_name] = self._extract_upstream_workflows(raw)
+            except ConfigurationError:
+                self._workflow_graph[wf_name] = []
+
+    # -- Cycle detection ----------------------------------------------------
+
+    def _check_workflow_cycles(self) -> None:
+        """Raise :class:`WorkflowError` if the workflow-level graph has cycles."""
+        all_nodes = set(self._workflow_graph.keys())
+        for deps in self._workflow_graph.values():
+            all_nodes.update(deps)
+
+        in_degree: dict[str, int] = {n: 0 for n in all_nodes}
+        for _node, deps in self._workflow_graph.items():
+            for dep in deps:
+                if dep in in_degree:
+                    in_degree[dep] += 1
+
+        queue = deque(n for n in all_nodes if in_degree[n] == 0)
+        visited = 0
+        while queue:
+            node = queue.popleft()
+            visited += 1
+            for dep in self._workflow_graph.get(node, []):
+                in_degree[dep] -= 1
+                if in_degree[dep] == 0:
+                    queue.append(dep)
+
+        if visited != len(all_nodes):
+            cycle_nodes = {n for n in all_nodes if in_degree[n] > 0}
+            raise WorkflowError(
+                "Cyclic dependency detected between workflows",
+                context={
+                    "cycle_nodes": sorted(cycle_nodes),
+                    "operation": "compile_workflows",
+                },
+            )
+
+    # -- Resolve involved workflows -----------------------------------------
+
+    def _resolve_involved_workflows(
+        self,
+        primary: str,
+        run_upstream: bool,
+        run_downstream: bool,
+    ) -> list[str]:
+        """Return the list of workflows to include, in topological order.
+
+        Upstreams first, then primary, then downstreams.
+        """
+        involved: set[str] = {primary}
+
+        # Add upstreams (transitively).
+        if run_upstream:
+            involved.update(self._collect_transitive(primary, direction="upstream"))
+        # Always include workflows referenced via dict deps (even without --upstream).
+        involved.update(self._collect_transitive(primary, direction="upstream"))
+
+        # Add downstreams (transitively).
+        if run_downstream:
+            involved.update(self._collect_transitive(primary, direction="downstream"))
+
+        # Topological sort: upstreams before dependents.
+        return self._topo_sort_workflows(involved)
+
+    def _collect_transitive(self, start: str, *, direction: str) -> set[str]:
+        """BFS to collect transitive upstreams or downstreams."""
+        if direction == "upstream":
+            graph = self._workflow_graph
+        else:
+            # Build reverse graph.
+            graph: dict[str, list[str]] = defaultdict(list)
+            for wf, ups in self._workflow_graph.items():
+                for up in ups:
+                    graph[up].append(wf)
+
+        result: set[str] = set()
+        queue = deque(graph.get(start, []))
+        while queue:
+            wf = queue.popleft()
+            if wf in result:
+                continue
+            result.add(wf)
+            queue.extend(graph.get(wf, []))
+        return result
+
+    def _topo_sort_workflows(self, involved: set[str]) -> list[str]:
+        """Topological sort of involved workflows (upstreams first).
+
+        Reuses the same Kahn's-algorithm convention as
+        ``agent_actions.utils.graph_utils.topological_sort``: the graph maps
+        each node to its *dependencies* (predecessors), the algorithm emits
+        leaf nodes first and reverses at the end so that dependencies appear
+        before dependents.
+        """
+        from agent_actions.utils.graph_utils import topological_sort
+
+        # Build sub-graph for involved workflows only.
+        sub_graph: dict[str, list[str]] = {}
+        for wf in involved:
+            sub_graph[wf] = [dep for dep in self._workflow_graph.get(wf, []) if dep in involved]
+
+        return topological_sort(sub_graph)
+
+    # -- Merge actions ------------------------------------------------------
+
+    def _merge_actions(
+        self, involved: list[str]
+    ) -> tuple[list[dict[str, Any]], dict[str, CompiledAction]]:
+        """Merge and qualify actions from all involved workflows."""
+        merged: list[dict[str, Any]] = []
+        metadata: dict[str, CompiledAction] = {}
+
+        # Build a set of all qualified action names for validation.
+        all_qualified: set[str] = set()
+        for wf_name in involved:
+            raw = self._raw_configs[wf_name]
+            for action in raw.get("actions", []):
+                if not isinstance(action, dict):
+                    continue
+                aname = action.get("name")
+                if aname:
+                    all_qualified.add(qualify(wf_name, aname))
+
+        for wf_name in involved:
+            raw = self._raw_configs[wf_name]
+            wf_dir = self._workflow_dirs[wf_name]
+            defaults = raw.get("defaults", {}) or {}
+            data_source = defaults.get("data_source")
+
+            for action in raw.get("actions", []):
+                if not isinstance(action, dict):
+                    continue
+
+                local_name = action.get("name")
+                if not local_name:
+                    continue
+
+                qualified = qualify(wf_name, local_name)
+                action_copy = copy.deepcopy(action)
+
+                # Rewrite dependencies.
+                action_copy["dependencies"] = self._rewrite_deps(
+                    action_copy.get("depends_on") or action_copy.get("dependencies", []),
+                    wf_name,
+                    all_qualified,
+                )
+                # Remove legacy depends_on key if present.
+                action_copy.pop("depends_on", None)
+
+                # Set the qualified name but preserve agent_type as local name.
+                action_copy["name"] = qualified
+
+                # Inject source workflow metadata.
+                action_copy["_source_workflow_dir"] = str(wf_dir)
+                action_copy["_source_workflow_name"] = wf_name
+
+                merged.append(action_copy)
+                metadata[qualified] = CompiledAction(
+                    name=qualified,
+                    local_name=local_name,
+                    source_workflow=wf_name,
+                    source_workflow_dir=wf_dir,
+                    source_data_source=data_source,
+                )
+
+        return merged, metadata
+
+    @staticmethod
+    def _rewrite_deps(
+        deps: Any,
+        source_workflow: str,
+        all_qualified: set[str],
+    ) -> list[str]:
+        """Rewrite a dependency list to qualified string deps.
+
+        - String deps are qualified within *source_workflow*.
+        - Dict deps ``{workflow: X, action: Y}`` become ``X::Y``.
+        """
+        if not isinstance(deps, list):
+            return []
+
+        result: list[str] = []
+        for dep in deps:
+            if isinstance(dep, str):
+                result.append(qualify(source_workflow, dep))
+            elif isinstance(dep, dict) and "workflow" in dep and "action" in dep:
+                result.append(qualify(dep["workflow"], dep["action"]))
+            # Skip anything else (malformed deps handled by Pydantic later).
+        return result

--- a/agent_actions/workflow/compiler.py
+++ b/agent_actions/workflow/compiler.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import yaml
 
-from agent_actions.errors import ConfigurationError, WorkflowError
+from agent_actions.errors import ConfigurationError
 from agent_actions.workflow.models import CompilationResult, CompiledAction
 
 logger = logging.getLogger(__name__)
@@ -131,10 +131,8 @@ class _WorkflowCompiler:
         if run_downstream:
             self._load_transitive_downstreams(primary_name)
 
-        # Detect cycles in the workflow-level graph.
-        self._check_workflow_cycles()
-
         # Determine which workflows to include and in what order.
+        # (Cycle detection happens inside _topo_sort_workflows via graph_utils.topological_sort.)
         involved = self._resolve_involved_workflows(primary_name, run_upstream, run_downstream)
 
         # Merge and qualify all actions.
@@ -318,40 +316,6 @@ class _WorkflowCompiler:
             except ConfigurationError:
                 self._workflow_graph[wf_name] = []
 
-    # -- Cycle detection ----------------------------------------------------
-
-    def _check_workflow_cycles(self) -> None:
-        """Raise :class:`WorkflowError` if the workflow-level graph has cycles."""
-        all_nodes = set(self._workflow_graph.keys())
-        for deps in self._workflow_graph.values():
-            all_nodes.update(deps)
-
-        in_degree: dict[str, int] = {n: 0 for n in all_nodes}
-        for _node, deps in self._workflow_graph.items():
-            for dep in deps:
-                if dep in in_degree:
-                    in_degree[dep] += 1
-
-        queue = deque(n for n in all_nodes if in_degree[n] == 0)
-        visited = 0
-        while queue:
-            node = queue.popleft()
-            visited += 1
-            for dep in self._workflow_graph.get(node, []):
-                in_degree[dep] -= 1
-                if in_degree[dep] == 0:
-                    queue.append(dep)
-
-        if visited != len(all_nodes):
-            cycle_nodes = {n for n in all_nodes if in_degree[n] > 0}
-            raise WorkflowError(
-                "Cyclic dependency detected between workflows",
-                context={
-                    "cycle_nodes": sorted(cycle_nodes),
-                    "operation": "compile_workflows",
-                },
-            )
-
     # -- Resolve involved workflows -----------------------------------------
 
     def _resolve_involved_workflows(
@@ -366,13 +330,14 @@ class _WorkflowCompiler:
         """
         involved: set[str] = {primary}
 
-        # Add upstreams (transitively).
+        # Always include directly-referenced upstream workflows (dict deps).
+        involved.update(self._workflow_graph.get(primary, []))
+
+        # --upstream: also include their transitive upstreams.
         if run_upstream:
             involved.update(self._collect_transitive(primary, direction="upstream"))
-        # Always include workflows referenced via dict deps (even without --upstream).
-        involved.update(self._collect_transitive(primary, direction="upstream"))
 
-        # Add downstreams (transitively).
+        # --downstream: include transitive downstreams.
         if run_downstream:
             involved.update(self._collect_transitive(primary, direction="downstream"))
 
@@ -427,17 +392,6 @@ class _WorkflowCompiler:
         merged: list[dict[str, Any]] = []
         metadata: dict[str, CompiledAction] = {}
 
-        # Build a set of all qualified action names for validation.
-        all_qualified: set[str] = set()
-        for wf_name in involved:
-            raw = self._raw_configs[wf_name]
-            for action in raw.get("actions", []):
-                if not isinstance(action, dict):
-                    continue
-                aname = action.get("name")
-                if aname:
-                    all_qualified.add(qualify(wf_name, aname))
-
         for wf_name in involved:
             raw = self._raw_configs[wf_name]
             wf_dir = self._workflow_dirs[wf_name]
@@ -459,7 +413,6 @@ class _WorkflowCompiler:
                 action_copy["dependencies"] = self._rewrite_deps(
                     action_copy.get("depends_on") or action_copy.get("dependencies", []),
                     wf_name,
-                    all_qualified,
                 )
                 # Remove legacy depends_on key if present.
                 action_copy.pop("depends_on", None)
@@ -486,7 +439,6 @@ class _WorkflowCompiler:
     def _rewrite_deps(
         deps: Any,
         source_workflow: str,
-        all_qualified: set[str],
     ) -> list[str]:
         """Rewrite a dependency list to qualified string deps.
 

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -1,6 +1,7 @@
 """Config loading, schema validation, and UDF discovery for workflow initialization."""
 
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +15,7 @@ from agent_actions.logging.events import (
     UDFDiscoveryStartEvent,
     WorkflowInitializationStartEvent,
 )
-from agent_actions.workflow.models import WorkflowMetadata, WorkflowRuntimeConfig
+from agent_actions.workflow.models import CompilationResult, WorkflowMetadata, WorkflowRuntimeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -47,12 +48,23 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
 
     Fires ``WorkflowInitializationStartEvent`` and creates the
     ``ConfigManager`` when one is not already present on *config*.
+
+    When the ``AGAC_COMPILED_CROSS_WORKFLOW=1`` environment variable is set
+    and the workflow has cross-workflow dependencies (or ``--upstream`` /
+    ``--downstream`` flags), the compiler merges all involved workflows into
+    a single DAG before the normal config pipeline runs.
     """
     fire_event(
         WorkflowInitializationStartEvent(
             workflow_name=config.manager.agent_name if config.manager else "unknown"
         )
     )
+
+    # Feature-gated cross-workflow compilation.
+    if os.environ.get("AGAC_COMPILED_CROSS_WORKFLOW") == "1":
+        compilation = _maybe_compile(config)
+        if compilation is not None:
+            return _load_compiled_workflow(config, compilation, console)
 
     if config.manager is None:
         config.manager = ConfigManager(
@@ -148,3 +160,127 @@ def _discover_udfs_from_path(path: str, project_root: Path | None, console: Cons
         return len(registry)
 
     return 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-workflow compilation (feature-gated)
+# ---------------------------------------------------------------------------
+
+
+def _maybe_compile(config: WorkflowRuntimeConfig) -> CompilationResult | None:
+    """Return a CompilationResult if cross-workflow compilation is needed, else None.
+
+    Reads the primary workflow YAML (without template rendering) to check for
+    dict dependencies.  If found — or if ``--upstream`` / ``--downstream``
+    flags are set — compiles all involved workflows into a single DAG.
+    """
+    from agent_actions.workflow.compiler import compile_workflows, needs_compilation
+
+    primary_path = Path(config.paths.constructor_path)
+
+    # Quick check: does the raw YAML have cross-workflow deps?
+    import yaml
+
+    try:
+        with open(primary_path, encoding="utf-8") as f:
+            raw_config = yaml.safe_load(f) or {}
+    except Exception:
+        return None  # Let the normal pipeline handle parse errors.
+
+    if not needs_compilation(raw_config, config.run_upstream, config.run_downstream):
+        return None
+
+    # Derive workflows_root: .../workflows/CURRENT/agent_config/x.yml → parents[2]
+    if len(primary_path.parents) < 3:
+        logger.warning("Config path too shallow for compilation: %s", primary_path)
+        return None
+
+    workflows_root = primary_path.parents[2]
+    logger.info("Compiling cross-workflow DAG from %s", workflows_root)
+
+    return compile_workflows(
+        primary_path,
+        workflows_root,
+        run_upstream=config.run_upstream,
+        run_downstream=config.run_downstream,
+    )
+
+
+def _load_compiled_workflow(
+    config: WorkflowRuntimeConfig,
+    compilation: CompilationResult,
+    console: Console,
+) -> WorkflowMetadata:
+    """Build WorkflowMetadata from a compiled multi-workflow DAG.
+
+    Creates a ConfigManager with a synthetic merged config, runs the normal
+    validation and expansion pipeline, then attaches compilation metadata.
+    """
+    # Build a synthetic config dict from the compiled actions.
+    merged_config: dict[str, Any] = {
+        "name": compilation.primary_workflow,
+        "actions": compilation.merged_actions,
+    }
+
+    # Create a ConfigManager with the primary workflow's paths but override
+    # user_config with the merged config.
+    if config.manager is None:
+        config.manager = ConfigManager(
+            config.paths.constructor_path,
+            config.paths.default_path,
+            project_root=config.project_root,
+        )
+
+    manager = config.manager
+    _run_config_stage(manager.load_configs, "load_configs", manager)
+    _run_config_stage(manager.validate_agent_name, "validate_agent_name", manager)
+    _run_config_stage(manager.check_child_pipeline, "check_child_pipeline", manager)
+
+    # Override user_config with the compiled merged config.
+    manager.user_config = merged_config
+
+    # Discover UDFs from all involved workflows.
+    discover_workflow_udfs(config, console)
+    for wf_name in compilation.involved_workflows:
+        meta = compilation.action_metadata
+        # Find tool paths from each workflow's directory.
+        for action_meta in meta.values():
+            if action_meta.source_workflow == wf_name:
+                wf_dir = action_meta.source_workflow_dir
+                tools_dir = wf_dir / "tools"
+                if tools_dir.is_dir():
+                    _discover_udfs_from_path(str(tools_dir), config.project_root, console)
+                break
+
+    user_agents = _run_config_stage(manager.get_user_agents, "get_user_agents", manager)
+    _run_config_stage(manager.merge_agent_configs, "merge_agent_configs", manager, user_agents)
+    _run_config_stage(manager.determine_execution_order, "determine_execution_order", manager)
+
+    execution_order = manager.execution_order
+    action_configs = manager.get_all_agent_configs_as_dicts()
+    action_indices = {action: i for i, action in enumerate(execution_order)}
+
+    # Inject metadata into each action config.
+    for action_name, action_config in action_configs.items():
+        if action_config is None:
+            continue
+        if action_name in action_indices:
+            action_config["idx"] = action_indices[action_name]
+        action_config["workflow_config_path"] = config.paths.constructor_path
+        if config.project_root:
+            action_config["_project_root"] = str(config.project_root)
+
+        # Propagate source workflow metadata from compilation.
+        if action_name in compilation.action_metadata:
+            meta = compilation.action_metadata[action_name]
+            action_config["_source_workflow_dir"] = str(meta.source_workflow_dir)
+            action_config["_source_workflow_name"] = meta.source_workflow
+
+    return WorkflowMetadata(
+        agent_name=manager.agent_name,
+        execution_order=execution_order,
+        action_indices=action_indices,
+        action_configs=action_configs,
+        child_pipeline=manager.child_pipeline,
+        compilation=compilation,
+    )

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -184,8 +184,9 @@ def _maybe_compile(config: WorkflowRuntimeConfig) -> CompilationResult | None:
     try:
         with open(primary_path, encoding="utf-8") as f:
             raw_config = yaml.safe_load(f) or {}
-    except Exception:
-        return None  # Let the normal pipeline handle parse errors.
+    except (yaml.YAMLError, OSError) as e:
+        logger.debug("Compilation gate check failed, deferring to normal pipeline: %s", e)
+        return None
 
     if not needs_compilation(raw_config, config.run_upstream, config.run_downstream):
         return None

--- a/agent_actions/workflow/managers/artifacts.py
+++ b/agent_actions/workflow/managers/artifacts.py
@@ -48,18 +48,13 @@ class ArtifactLinker:
         if source_action:
             # Link to the specific action's output directory.
             action_dir = source_target / source_action
-            if action_dir.is_dir():
+            if action_dir.is_dir() and any(action_dir.iterdir()):
                 latest_node = action_dir
             else:
-                # Action output is in SQLite (no filesystem directory).
-                # Create a virtual directory so the manifest path encodes
-                # the action name — the runner uses path.name to look up
-                # data in the storage backend.
+                # Action output is in SQLite — export it to JSON files so
+                # the downstream reads normal filesystem input.
                 action_dir.mkdir(parents=True, exist_ok=True)
-                logger.debug(
-                    "Created virtual directory for SQLite-backed action: %s",
-                    action_dir,
-                )
+                self._export_from_db(source_target, source_action, action_dir)
                 latest_node = action_dir
         else:
             latest_node = self.find_latest_node_dir(source_target)
@@ -142,6 +137,41 @@ class ArtifactLinker:
             return True
         except (OSError, ValueError):
             return False
+
+    @staticmethod
+    def _export_from_db(target_dir: Path, action_name: str, output_dir: Path) -> None:
+        """Export an action's target data from SQLite to JSON files on disk.
+
+        This allows the downstream workflow to read the upstream action's
+        output as normal filesystem input — no cross-workflow storage
+        backend needed.
+        """
+        db_files = list(target_dir.glob("*.db"))
+        if not db_files:
+            logger.debug("No DB file found in %s — skipping export", target_dir)
+            return
+
+        from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+        db_path = db_files[0]
+        backend = SQLiteBackend(db_path=str(db_path), workflow_name=db_path.stem)
+        backend.initialize()
+
+        try:
+            target_files = backend.list_target_files(action_name)
+            if not target_files:
+                logger.debug("No target data for action '%s' in %s", action_name, db_path)
+                return
+
+            for relative_path in target_files:
+                data = backend.read_target(action_name, relative_path)
+                out_file = output_dir / relative_path
+                out_file.parent.mkdir(parents=True, exist_ok=True)
+                with open(out_file, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2)
+                logger.debug("Exported %s/%s → %s", action_name, relative_path, out_file)
+        except Exception as e:
+            logger.warning("Failed to export action '%s' from DB: %s", action_name, e)
 
     @staticmethod
     def read_manifest(agent_io_dir: Path) -> dict[str, Any] | None:

--- a/agent_actions/workflow/managers/artifacts.py
+++ b/agent_actions/workflow/managers/artifacts.py
@@ -21,8 +21,23 @@ class ArtifactLinker:
         """Initialize artifact linker."""
         self.workflows_root = workflows_root
 
-    def link_workflow_artifacts(self, source_workflow: str, target_workflow: str) -> None:
-        """Link source workflow's output to target workflow via manifest."""
+    def link_workflow_artifacts(
+        self,
+        source_workflow: str,
+        target_workflow: str,
+        source_action: str | None = None,
+    ) -> None:
+        """Link source workflow's output to target workflow via manifest.
+
+        Args:
+            source_workflow: Name of the upstream workflow.
+            target_workflow: Name of the downstream workflow.
+            source_action: Specific action in the source workflow to link.
+                When provided, links that action's output directory directly
+                instead of guessing via mtime.  This is critical for
+                cross-workflow deps where the downstream declares exactly
+                which upstream action it consumes.
+        """
         source_target = self.workflows_root / source_workflow / "agent_io" / "target"
         target_io = self.workflows_root / target_workflow / "agent_io"
 
@@ -30,7 +45,25 @@ class ArtifactLinker:
             logger.warning("Source target directory does not exist: %s", source_target)
             return
 
-        latest_node = self.find_latest_node_dir(source_target)
+        if source_action:
+            # Link to the specific action's output directory.
+            action_dir = source_target / source_action
+            if action_dir.is_dir():
+                latest_node = action_dir
+            else:
+                # Action output is in SQLite (no filesystem directory).
+                # Create a virtual directory so the manifest path encodes
+                # the action name — the runner uses path.name to look up
+                # data in the storage backend.
+                action_dir.mkdir(parents=True, exist_ok=True)
+                logger.debug(
+                    "Created virtual directory for SQLite-backed action: %s",
+                    action_dir,
+                )
+                latest_node = action_dir
+        else:
+            latest_node = self.find_latest_node_dir(source_target)
+
         if not latest_node:
             logger.warning("No output nodes found in %s", source_target)
             return
@@ -45,13 +78,23 @@ class ArtifactLinker:
         self._write_upstream_manifest(target_io, source_workflow, latest_node)
         logger.info("Wrote manifest linking %s -> %s", source_workflow, target_workflow)
 
-    def link_upstream_artifacts(self, upstream_name: str, current_workflow: str) -> None:
+    def link_upstream_artifacts(
+        self,
+        upstream_name: str,
+        current_workflow: str,
+        source_action: str | None = None,
+    ) -> None:
         """Link upstream workflow's output to current workflow via manifest."""
-        self.link_workflow_artifacts(upstream_name, current_workflow)
+        self.link_workflow_artifacts(upstream_name, current_workflow, source_action=source_action)
 
-    def link_downstream_artifacts(self, current_workflow: str, downstream_name: str) -> None:
+    def link_downstream_artifacts(
+        self,
+        current_workflow: str,
+        downstream_name: str,
+        source_action: str | None = None,
+    ) -> None:
         """Link current workflow's output to downstream workflow via manifest."""
-        self.link_workflow_artifacts(current_workflow, downstream_name)
+        self.link_workflow_artifacts(current_workflow, downstream_name, source_action=source_action)
 
     def _write_upstream_manifest(
         self, target_io: Path, source_workflow: str, source_node: Path

--- a/agent_actions/workflow/managers/artifacts.py
+++ b/agent_actions/workflow/managers/artifacts.py
@@ -151,10 +151,15 @@ class ArtifactLinker:
             logger.debug("No DB file found in %s — skipping export", target_dir)
             return
 
-        from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+        from agent_actions.storage import get_storage_backend
 
         db_path = db_files[0]
-        backend = SQLiteBackend(db_path=str(db_path), workflow_name=db_path.stem)
+        # Derive workflow_path from target_dir: .../workflow/agent_io/target → .../workflow
+        workflow_path = target_dir.parent.parent
+        backend = get_storage_backend(
+            workflow_path=str(workflow_path),
+            workflow_name=db_path.stem,
+        )
         backend.initialize()
 
         try:

--- a/agent_actions/workflow/models.py
+++ b/agent_actions/workflow/models.py
@@ -62,6 +62,28 @@ class RuntimeContext:
 
 
 @dataclass
+class CompiledAction:
+    """Metadata for an action in a compiled multi-workflow DAG."""
+
+    name: str  # Qualified: "workflow_name::action_name"
+    local_name: str  # Original action name within source workflow
+    source_workflow: str  # Name of the workflow this action came from
+    source_workflow_dir: Path  # Path to source workflow directory (for agent_io)
+    source_data_source: Any = None  # data_source config from source workflow defaults
+
+
+@dataclass
+class CompilationResult:
+    """Output of WorkflowCompiler.compile()."""
+
+    merged_actions: list[dict[str, Any]]  # Pre-Pydantic, dict deps rewritten to strings
+    action_metadata: dict[str, CompiledAction]  # Keyed by qualified name
+    primary_workflow: str  # The workflow the user invoked
+    involved_workflows: list[str]  # All workflows in the compiled DAG
+    workflow_graph: dict[str, list[str]]  # Workflow-level dep graph
+
+
+@dataclass
 class WorkflowMetadata:
     """Workflow configuration metadata."""
 
@@ -70,6 +92,7 @@ class WorkflowMetadata:
     action_indices: dict[str, int]
     action_configs: dict[str, dict[str, Any]]
     child_pipeline: str | None = None
+    compilation: CompilationResult | None = None
 
 
 @dataclass

--- a/agent_actions/workflow/parallel/dependency.py
+++ b/agent_actions/workflow/parallel/dependency.py
@@ -135,7 +135,19 @@ class WorkflowDependencyOrchestrator:
                     self._print_batch_pending_message(upstream_name, is_upstream=True)
                     return None
 
-            self.artifact_linker.link_upstream_artifacts(upstream_name, self.current_workflow)
+            # Extract specific action name from the current workflow's config.
+            current_config_path = (
+                self.workflows_root
+                / self.current_workflow
+                / "agent_config"
+                / f"{self.current_workflow}.yml"
+            )
+            source_action = self._find_cross_workflow_source_action(
+                current_config_path, upstream_name
+            )
+            self.artifact_linker.link_upstream_artifacts(
+                upstream_name, self.current_workflow, source_action=source_action
+            )
 
             self.console.print(
                 f"[bold green]>> Recursive: Ready to use upstream "
@@ -231,7 +243,14 @@ class WorkflowDependencyOrchestrator:
                 f"Downstream workflow config not found at {downstream_config_path}"
             )
 
-        self.artifact_linker.link_downstream_artifacts(self.current_workflow, downstream_name)
+        # Extract the specific upstream action from the downstream's config
+        # so the manifest points to the right output directory.
+        source_action = self._find_cross_workflow_source_action(
+            downstream_config_path, self.current_workflow
+        )
+        self.artifact_linker.link_downstream_artifacts(
+            self.current_workflow, downstream_name, source_action=source_action
+        )
 
         downstream_wf = self.workflow_factory(
             config_path=str(downstream_config_path),
@@ -252,6 +271,41 @@ class WorkflowDependencyOrchestrator:
             f"[bold green]>> Downstream: Workflow '{downstream_name}' completed[/bold green]"
         )
         return True
+
+    @staticmethod
+    def _find_cross_workflow_source_action(
+        downstream_config_path: Path, upstream_workflow: str
+    ) -> str | None:
+        """Extract the specific upstream action name from a downstream config.
+
+        Scans the downstream workflow's YAML for dict dependencies that
+        reference *upstream_workflow* and returns the ``action`` value.
+        Returns ``None`` if no specific action is declared.
+        """
+        import yaml
+
+        try:
+            with open(downstream_config_path, encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+            if not isinstance(config, dict):
+                return None
+
+            for action in config.get("actions", []):
+                if not isinstance(action, dict):
+                    continue
+                deps = action.get("depends_on") or action.get("dependencies", [])
+                if not isinstance(deps, list):
+                    continue
+                for dep in deps:
+                    if (
+                        isinstance(dep, dict)
+                        and dep.get("workflow") == upstream_workflow
+                        and dep.get("action")
+                    ):
+                        return dep["action"]
+        except Exception:
+            pass
+        return None
 
     def _print_batch_pending_message(self, workflow_name: str, is_upstream: bool) -> None:
         """Print message about pending batch jobs."""

--- a/agent_actions/workflow/parallel/dependency.py
+++ b/agent_actions/workflow/parallel/dependency.py
@@ -303,8 +303,12 @@ class WorkflowDependencyOrchestrator:
                         and dep.get("action")
                     ):
                         return dep["action"]
-        except Exception:
-            pass
+        except (yaml.YAMLError, OSError) as e:
+            logger.debug(
+                "Could not read %s for cross-workflow action: %s",
+                downstream_config_path,
+                e,
+            )
         return None
 
     def _print_batch_pending_message(self, workflow_name: str, is_upstream: bool) -> None:

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -127,9 +127,25 @@ class ActionRunner:
     def get_action_folder(self, action_name: str, project_root: Path | None = None) -> str:
         """Return the action folder path.
 
+        For compiled multi-workflow DAGs each action config carries a
+        ``_source_workflow_dir`` field pointing to the source workflow's
+        directory.  When present, the action's ``agent_io/`` is resolved
+        directly from that directory instead of searching from the project
+        root.
+
         Raises:
             FileSystemError: If the action folder is not found.
         """
+        # Compiled cross-workflow path: use the action's source workflow dir.
+        if self.action_configs:
+            action_config = self.action_configs.get(action_name, {})
+            source_dir = action_config.get("_source_workflow_dir") if action_config else None
+            if source_dir:
+                agent_io = Path(source_dir) / "agent_io"
+                if agent_io.is_dir():
+                    return str(agent_io)
+
+        # Existing single-workflow path.
         search_dir: Path = resolve_project_root(project_root or self.project_root)
         folder_name = self.workflow_name if self.workflow_name else action_name
         action_folder: str | None = FileHandler.find_specific_folder(
@@ -317,8 +333,11 @@ class ActionRunner:
         agent_folder_path = Path(agent_folder)
         agent_type = action_config["agent_type"]
         dependencies = action_config.get("dependencies", [])
+        has_cross_workflow = action_config.get("_has_cross_workflow_deps", False)
 
-        if not dependencies and not previous_action_type:
+        if not dependencies and (not previous_action_type or has_cross_workflow):
+            # Start node OR cross-workflow first action (dict deps stripped by
+            # Pydantic, but upstream manifest may point to the right data).
             upstream_data_dirs = self._resolve_start_node_directories(
                 agent_folder_path, action_config.get("agent_type", "unknown")
             )

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -17,9 +17,74 @@ from typing import TYPE_CHECKING, Any
 from agent_actions.workflow.merge import merge_json_files, merge_records_by_key
 
 if TYPE_CHECKING:
+    from agent_actions.storage.backend import StorageBackend
     from agent_actions.workflow.runner import ActionRunner, FileProcessParams
 
 logger = logging.getLogger(__name__)
+
+# Cache of cross-workflow SQLite backends opened during a run.
+_cross_workflow_backends: dict[Path, StorageBackend] = {}
+
+
+def _resolve_backend_for_path(runner: ActionRunner, input_path: Path) -> StorageBackend:
+    """Return the correct storage backend for *input_path*.
+
+    When *input_path* points to a different workflow's ``target/`` directory
+    (cross-workflow dependency), open that workflow's SQLite DB read-only.
+    Otherwise, return the runner's own backend.
+    """
+    if runner.storage_backend is None:
+        raise RuntimeError("No storage backend available")
+
+    # Check if this path belongs to the runner's own workflow.
+    own_db_path = Path(runner.storage_backend.db_path)  # type: ignore[attr-defined]
+    own_target_dir = own_db_path.parent  # .../agent_io/target
+
+    # If input_path is under our own target dir, use the runner's backend.
+    try:
+        input_path.resolve().relative_to(own_target_dir.resolve())
+        return runner.storage_backend
+    except ValueError:
+        pass
+
+    # Cross-workflow: find the upstream's DB in the input path's target dir.
+    # input_path is something like:
+    #   .../upstream_wf/agent_io/target/format_quiz_text  OR
+    #   .../upstream_wf/agent_io/target
+    # Walk up to find the target/ dir, then look for the .db file.
+    candidate = input_path
+    while candidate.name != "target" and candidate != candidate.parent:
+        candidate = candidate.parent
+
+    if candidate.name != "target":
+        # Can't determine upstream DB — fall back to runner's backend.
+        return runner.storage_backend
+
+    upstream_target_dir = candidate
+
+    if upstream_target_dir in _cross_workflow_backends:
+        return _cross_workflow_backends[upstream_target_dir]
+
+    # Find the .db file in the upstream's target dir.
+    db_files = list(upstream_target_dir.glob("*.db"))
+    if not db_files:
+        return runner.storage_backend
+
+    upstream_db = db_files[0]
+    logger.info(
+        "Opening cross-workflow storage backend: %s",
+        upstream_db,
+    )
+
+    from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+    upstream_backend = SQLiteBackend(
+        db_path=str(upstream_db),
+        workflow_name=upstream_db.stem,
+    )
+    upstream_backend.initialize()
+    _cross_workflow_backends[upstream_target_dir] = upstream_backend
+    return upstream_backend
 
 
 # ---------------------------------------------------------------------------
@@ -256,8 +321,13 @@ def process_from_storage_backend(
         if "staging" in str(input_path):
             continue
 
+        # Determine which storage backend to query.  When the input dir
+        # points to a *different* workflow's target (cross-workflow dep),
+        # open that workflow's DB instead of the current runner's.
+        backend = _resolve_backend_for_path(runner, input_path)
+
         try:
-            target_files = runner.storage_backend.list_target_files(action_name)
+            target_files = backend.list_target_files(action_name)
         except Exception as e:
             logger.warning(
                 "Could not list target files from backend for %s: %s",
@@ -269,7 +339,7 @@ def process_from_storage_backend(
 
         for relative_path in target_files:
             try:
-                data = runner.storage_backend.read_target(action_name, relative_path)
+                data = backend.read_target(action_name, relative_path)
                 if relative_path not in data_by_path:
                     data_by_path[relative_path] = []
                 data_by_path[relative_path].append((action_name, data))

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -84,10 +84,12 @@ def _resolve_backend_for_path(runner: ActionRunner, input_path: Path) -> Storage
         upstream_db,
     )
 
-    from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+    from agent_actions.storage import get_storage_backend
 
-    upstream_backend = SQLiteBackend(
-        db_path=str(upstream_db),
+    # Derive workflow_path: .../workflow/agent_io/target → .../workflow
+    workflow_path = upstream_target_dir.parent.parent
+    upstream_backend = get_storage_backend(
+        workflow_path=str(workflow_path),
         workflow_name=upstream_db.stem,
     )
     upstream_backend.initialize()

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -26,6 +26,14 @@ logger = logging.getLogger(__name__)
 _cross_workflow_backends: dict[Path, StorageBackend] = {}
 
 
+def clear_cross_workflow_backends() -> None:
+    """Close and clear cached cross-workflow storage backends.
+
+    Called at workflow run teardown and between tests.
+    """
+    _cross_workflow_backends.clear()
+
+
 def _resolve_backend_for_path(runner: ActionRunner, input_path: Path) -> StorageBackend:
     """Return the correct storage backend for *input_path*.
 

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -440,11 +440,34 @@ def process_from_storage_backend(
     return (files_found, files_processed)
 
 
+def _is_cross_workflow_input(runner: ActionRunner, upstream_dirs: list[str]) -> bool:
+    """Return True if any upstream dir belongs to a different workflow's target."""
+    if not runner.storage_backend:
+        return False
+    db_path = getattr(runner.storage_backend, "db_path", None)
+    if not isinstance(db_path, (str, Path)):
+        return False
+    try:
+        own_target = Path(db_path).parent.resolve()
+    except (TypeError, OSError):
+        return False
+    for d in upstream_dirs:
+        try:
+            Path(d).resolve().relative_to(own_target)
+        except ValueError:
+            if is_target_directory(d):
+                return True
+    return False
+
+
 def process_files(runner: ActionRunner, params: FileProcessParams) -> None:
     """Walk upstream data directories and process each file with the given strategy."""
     if runner.storage_backend is not None:
+        # Skip storage backend for cross-workflow inputs — their data was
+        # exported to JSON files by the artifact linker.
         all_targets = all(is_target_directory(d) for d in params.upstream_data_dirs)
-        if all_targets:
+        cross_wf = _is_cross_workflow_input(runner, params.upstream_data_dirs)
+        if all_targets and not cross_wf:
             files_found, files_processed = process_from_storage_backend(runner, params)
             if files_processed > 0:
                 return

--- a/tests/workflow/parallel/test_dependency.py
+++ b/tests/workflow/parallel/test_dependency.py
@@ -193,7 +193,7 @@ class TestResolveUpstreamWorkflows:
             orchestrator.resolve_upstream_workflows(None, None, False)
 
         orchestrator.artifact_linker.link_upstream_artifacts.assert_called_once_with(
-            "upstream_wf", "current_wf"
+            "upstream_wf", "current_wf", source_action=None
         )
 
     def test_upstream_already_completed_skips_execution(
@@ -225,7 +225,7 @@ class TestResolveUpstreamWorkflows:
             orchestrator.resolve_upstream_workflows(None, None, False)
 
         orchestrator.artifact_linker.link_upstream_artifacts.assert_called_once_with(
-            "done_wf", "current_wf"
+            "done_wf", "current_wf", source_action=None
         )
 
     def test_upstream_batch_pending_returns_false(
@@ -482,7 +482,7 @@ class TestExecuteDownstreamWorkflow:
         orchestrator._execute_downstream_workflow("ds_wf", None, None, False)
 
         orchestrator.artifact_linker.link_downstream_artifacts.assert_called_once_with(
-            "current_wf", "ds_wf"
+            "current_wf", "ds_wf", source_action=None
         )
 
     def test_batch_pending_returns_none(

--- a/tests/workflow/test_compiler.py
+++ b/tests/workflow/test_compiler.py
@@ -257,7 +257,7 @@ class TestCompileTopologicalOrder:
         )
 
     def test_transitive_upstream_ordering(self, tmp_path: Path):
-        """A → B → C: C's upstream chain is [A, B]."""
+        """A → B → C with --upstream: C's upstream chain is [A, B, C]."""
         _write_workflow(tmp_path, "wf_a", actions=[{"name": "step_a", "dependencies": []}])
         _write_workflow(
             tmp_path,
@@ -280,9 +280,14 @@ class TestCompileTopologicalOrder:
             ],
         )
 
+        # Without --upstream: only direct dep (wf_b) + primary (wf_c).
         result = compile_workflows(config_path, tmp_path)
-        assert result.involved_workflows == ["wf_a", "wf_b", "wf_c"]
-        assert len(result.merged_actions) == 3
+        assert result.involved_workflows == ["wf_b", "wf_c"]
+
+        # With --upstream: full transitive chain.
+        result_full = compile_workflows(config_path, tmp_path, run_upstream=True)
+        assert result_full.involved_workflows == ["wf_a", "wf_b", "wf_c"]
+        assert len(result_full.merged_actions) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workflow/test_compiler.py
+++ b/tests/workflow/test_compiler.py
@@ -1,0 +1,530 @@
+"""Tests for the WorkflowCompiler — cross-workflow DAG compilation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.workflow.compiler import (
+    SEPARATOR,
+    compile_workflows,
+    needs_compilation,
+    qualify,
+    unqualify,
+)
+from agent_actions.workflow.models import CompilationResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_workflow(
+    workflows_root: Path,
+    name: str,
+    actions: list[dict],
+    defaults: dict | None = None,
+) -> Path:
+    """Write a minimal workflow YAML under workflows_root/{name}/agent_config/{name}.yml."""
+    wf_dir = workflows_root / name / "agent_config"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    config_path = wf_dir / f"{name}.yml"
+    config: dict = {"name": name, "actions": actions}
+    if defaults:
+        config["defaults"] = defaults
+    config_path.write_text(yaml.dump(config, default_flow_style=False))
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# needs_compilation
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsCompilation:
+    def test_no_cross_deps_returns_false(self):
+        config = {"actions": [{"name": "a", "dependencies": ["b"]}]}
+        assert needs_compilation(config) is False
+
+    def test_dict_deps_returns_true(self):
+        config = {
+            "actions": [{"name": "a", "dependencies": [{"workflow": "other", "action": "x"}]}]
+        }
+        assert needs_compilation(config) is True
+
+    def test_upstream_flag_returns_true(self):
+        config = {"actions": [{"name": "a"}]}
+        assert needs_compilation(config, run_upstream=True) is True
+
+    def test_downstream_flag_returns_true(self):
+        config = {"actions": [{"name": "a"}]}
+        assert needs_compilation(config, run_downstream=True) is True
+
+    def test_empty_actions_returns_false(self):
+        config = {"actions": []}
+        assert needs_compilation(config) is False
+
+    def test_no_actions_key_returns_false(self):
+        config = {"name": "wf"}
+        assert needs_compilation(config) is False
+
+    def test_mixed_string_and_dict_deps(self):
+        config = {
+            "actions": [
+                {
+                    "name": "a",
+                    "dependencies": ["local", {"workflow": "other", "action": "x"}],
+                }
+            ]
+        }
+        assert needs_compilation(config) is True
+
+    def test_depends_on_alias(self):
+        """Legacy depends_on key with dict deps should trigger compilation."""
+        config = {"actions": [{"name": "a", "depends_on": [{"workflow": "other", "action": "x"}]}]}
+        assert needs_compilation(config) is True
+
+
+# ---------------------------------------------------------------------------
+# qualify / unqualify
+# ---------------------------------------------------------------------------
+
+
+class TestQualifyUnqualify:
+    def test_qualify(self):
+        assert qualify("wf_a", "extract") == f"wf_a{SEPARATOR}extract"
+
+    def test_unqualify(self):
+        assert unqualify(f"wf_a{SEPARATOR}extract") == ("wf_a", "extract")
+
+    def test_roundtrip(self):
+        q = qualify("enrichment", "classify")
+        assert unqualify(q) == ("enrichment", "classify")
+
+    def test_unqualify_no_separator_raises(self):
+        with pytest.raises(ValueError, match="Not a qualified"):
+            unqualify("plain_name")
+
+    def test_separator_only_in_first_split(self):
+        """Action names with :: in them (shouldn't happen, but defensive)."""
+        q = qualify("wf", f"action{SEPARATOR}sub")
+        wf, action = unqualify(q)
+        assert wf == "wf"
+        assert action == f"action{SEPARATOR}sub"
+
+
+# ---------------------------------------------------------------------------
+# compile_workflows — basic scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestCompileBasic:
+    def test_single_workflow_no_cross_deps(self, tmp_path: Path):
+        """Single workflow compiles to qualified names with no cross-workflow deps."""
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_a",
+            actions=[
+                {"name": "extract", "dependencies": []},
+                {"name": "classify", "dependencies": ["extract"]},
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+
+        assert isinstance(result, CompilationResult)
+        assert result.primary_workflow == "wf_a"
+        assert result.involved_workflows == ["wf_a"]
+        assert len(result.merged_actions) == 2
+
+        # Actions are qualified.
+        names = [a["name"] for a in result.merged_actions]
+        assert "wf_a::extract" in names
+        assert "wf_a::classify" in names
+
+        # Intra-workflow deps are qualified.
+        classify = next(a for a in result.merged_actions if a["name"] == "wf_a::classify")
+        assert classify["dependencies"] == ["wf_a::extract"]
+
+    def test_cross_workflow_deps_rewritten(self, tmp_path: Path):
+        """Dict deps are rewritten to qualified string deps."""
+        _write_workflow(
+            tmp_path,
+            "upstream",
+            actions=[
+                {"name": "produce", "dependencies": []},
+            ],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {
+                    "name": "consume",
+                    "dependencies": [{"workflow": "upstream", "action": "produce"}],
+                },
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+
+        assert set(result.involved_workflows) == {"upstream", "downstream"}
+        consume = next(a for a in result.merged_actions if a["name"] == "downstream::consume")
+        assert consume["dependencies"] == ["upstream::produce"]
+
+    def test_mixed_local_and_cross_deps(self, tmp_path: Path):
+        """Actions with both string and dict deps get both qualified."""
+        _write_workflow(
+            tmp_path,
+            "upstream",
+            actions=[{"name": "produce", "dependencies": []}],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {"name": "local_step", "dependencies": []},
+                {
+                    "name": "consume",
+                    "dependencies": [
+                        "local_step",
+                        {"workflow": "upstream", "action": "produce"},
+                    ],
+                },
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        consume = next(a for a in result.merged_actions if a["name"] == "downstream::consume")
+        assert "downstream::local_step" in consume["dependencies"]
+        assert "upstream::produce" in consume["dependencies"]
+
+    def test_depends_on_alias_handled(self, tmp_path: Path):
+        """Legacy depends_on key with dict deps gets rewritten and removed."""
+        _write_workflow(
+            tmp_path,
+            "upstream",
+            actions=[{"name": "produce", "dependencies": []}],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {
+                    "name": "consume",
+                    "depends_on": [{"workflow": "upstream", "action": "produce"}],
+                },
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        consume = next(a for a in result.merged_actions if a["name"] == "downstream::consume")
+        assert consume["dependencies"] == ["upstream::produce"]
+        assert "depends_on" not in consume
+
+
+# ---------------------------------------------------------------------------
+# compile_workflows — topological ordering
+# ---------------------------------------------------------------------------
+
+
+class TestCompileTopologicalOrder:
+    def test_upstream_actions_before_downstream(self, tmp_path: Path):
+        """Upstream workflow's actions appear before the primary's in involved_workflows."""
+        _write_workflow(
+            tmp_path,
+            "upstream",
+            actions=[{"name": "produce", "dependencies": []}],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {
+                    "name": "consume",
+                    "dependencies": [{"workflow": "upstream", "action": "produce"}],
+                }
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        # upstream should come before downstream in involved_workflows.
+        assert result.involved_workflows.index("upstream") < result.involved_workflows.index(
+            "downstream"
+        )
+
+    def test_transitive_upstream_ordering(self, tmp_path: Path):
+        """A → B → C: C's upstream chain is [A, B]."""
+        _write_workflow(tmp_path, "wf_a", actions=[{"name": "step_a", "dependencies": []}])
+        _write_workflow(
+            tmp_path,
+            "wf_b",
+            actions=[
+                {
+                    "name": "step_b",
+                    "dependencies": [{"workflow": "wf_a", "action": "step_a"}],
+                }
+            ],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_c",
+            actions=[
+                {
+                    "name": "step_c",
+                    "dependencies": [{"workflow": "wf_b", "action": "step_b"}],
+                }
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        assert result.involved_workflows == ["wf_a", "wf_b", "wf_c"]
+        assert len(result.merged_actions) == 3
+
+
+# ---------------------------------------------------------------------------
+# compile_workflows — source metadata
+# ---------------------------------------------------------------------------
+
+
+class TestCompileSourceMetadata:
+    def test_source_workflow_dir_injected(self, tmp_path: Path):
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_a",
+            actions=[{"name": "extract", "dependencies": []}],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        action = result.merged_actions[0]
+        assert action["_source_workflow_dir"] == str(tmp_path / "wf_a")
+        assert action["_source_workflow_name"] == "wf_a"
+
+    def test_action_metadata_populated(self, tmp_path: Path):
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_a",
+            actions=[{"name": "extract", "dependencies": []}],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        meta = result.action_metadata["wf_a::extract"]
+        assert meta.local_name == "extract"
+        assert meta.source_workflow == "wf_a"
+        assert meta.source_workflow_dir == tmp_path / "wf_a"
+
+    def test_per_workflow_defaults_preserved(self, tmp_path: Path):
+        """Each action's metadata carries its source workflow's data_source config."""
+        _write_workflow(
+            tmp_path,
+            "upstream",
+            actions=[{"name": "produce", "dependencies": []}],
+            defaults={"data_source": "api"},
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {
+                    "name": "consume",
+                    "dependencies": [{"workflow": "upstream", "action": "produce"}],
+                }
+            ],
+            defaults={"data_source": "staging"},
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        assert result.action_metadata["upstream::produce"].source_data_source == "api"
+        assert result.action_metadata["downstream::consume"].source_data_source == "staging"
+
+    def test_cross_workflow_actions_from_different_dirs(self, tmp_path: Path):
+        """Actions from different workflows point to different directories."""
+        _write_workflow(
+            tmp_path,
+            "upstream",
+            actions=[{"name": "produce", "dependencies": []}],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {
+                    "name": "consume",
+                    "dependencies": [{"workflow": "upstream", "action": "produce"}],
+                }
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        up_action = next(a for a in result.merged_actions if "upstream" in a["name"])
+        down_action = next(a for a in result.merged_actions if "downstream" in a["name"])
+        assert up_action["_source_workflow_dir"] != down_action["_source_workflow_dir"]
+
+
+# ---------------------------------------------------------------------------
+# compile_workflows — cycle detection
+# ---------------------------------------------------------------------------
+
+
+class TestCompileCycleDetection:
+    def test_direct_cycle_raises(self, tmp_path: Path):
+        """A depends on B, B depends on A → cycle error."""
+        _write_workflow(
+            tmp_path,
+            "wf_a",
+            actions=[
+                {
+                    "name": "step_a",
+                    "dependencies": [{"workflow": "wf_b", "action": "step_b"}],
+                }
+            ],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_b",
+            actions=[
+                {
+                    "name": "step_b",
+                    "dependencies": [{"workflow": "wf_a", "action": "step_a"}],
+                }
+            ],
+        )
+
+        with pytest.raises(Exception, match="[Cc]yclic"):
+            compile_workflows(config_path, tmp_path)
+
+    def test_self_cycle_raises(self, tmp_path: Path):
+        """Workflow depends on itself → cycle error."""
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_a",
+            actions=[
+                {
+                    "name": "step_a",
+                    "dependencies": [{"workflow": "wf_a", "action": "step_a"}],
+                }
+            ],
+        )
+
+        with pytest.raises(Exception, match="[Cc]yclic"):
+            compile_workflows(config_path, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# compile_workflows — --upstream / --downstream flags
+# ---------------------------------------------------------------------------
+
+
+class TestCompileFlags:
+    def test_upstream_flag_includes_transitive_upstreams(self, tmp_path: Path):
+        """--upstream pulls in all transitive upstream workflows."""
+        _write_workflow(tmp_path, "wf_a", actions=[{"name": "step_a", "dependencies": []}])
+        _write_workflow(
+            tmp_path,
+            "wf_b",
+            actions=[
+                {
+                    "name": "step_b",
+                    "dependencies": [{"workflow": "wf_a", "action": "step_a"}],
+                }
+            ],
+        )
+        # wf_c has no dict deps on its own — but --upstream should pull in wf_a and wf_b
+        # if wf_c explicitly depends on wf_b.
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_c",
+            actions=[
+                {
+                    "name": "step_c",
+                    "dependencies": [{"workflow": "wf_b", "action": "step_b"}],
+                }
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path, run_upstream=True)
+        assert set(result.involved_workflows) == {"wf_a", "wf_b", "wf_c"}
+
+    def test_downstream_flag_includes_dependents(self, tmp_path: Path):
+        """--downstream pulls in workflows that depend on the primary."""
+        config_path = _write_workflow(
+            tmp_path,
+            "wf_a",
+            actions=[{"name": "step_a", "dependencies": []}],
+        )
+        _write_workflow(
+            tmp_path,
+            "wf_b",
+            actions=[
+                {
+                    "name": "step_b",
+                    "dependencies": [{"workflow": "wf_a", "action": "step_a"}],
+                }
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path, run_downstream=True)
+        assert set(result.involved_workflows) == {"wf_a", "wf_b"}
+
+
+# ---------------------------------------------------------------------------
+# compile_workflows — error handling
+# ---------------------------------------------------------------------------
+
+
+class TestCompileErrors:
+    def test_missing_workflow_raises(self, tmp_path: Path):
+        """Reference to non-existent workflow raises ConfigurationError."""
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {
+                    "name": "consume",
+                    "dependencies": [{"workflow": "nonexistent", "action": "x"}],
+                }
+            ],
+        )
+
+        with pytest.raises(Exception, match="not found"):
+            compile_workflows(config_path, tmp_path)
+
+    def test_invalid_yaml_raises(self, tmp_path: Path):
+        """Malformed YAML raises ConfigurationError."""
+        wf_dir = tmp_path / "bad" / "agent_config"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "bad.yml").write_text(":\n  - :\n  invalid: [")
+
+        with pytest.raises(ConfigurationError):
+            compile_workflows(wf_dir / "bad.yml", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# compile_workflows — workflow_graph output
+# ---------------------------------------------------------------------------
+
+
+class TestCompileWorkflowGraph:
+    def test_workflow_graph_populated(self, tmp_path: Path):
+        _write_workflow(
+            tmp_path,
+            "upstream",
+            actions=[{"name": "produce", "dependencies": []}],
+        )
+        config_path = _write_workflow(
+            tmp_path,
+            "downstream",
+            actions=[
+                {
+                    "name": "consume",
+                    "dependencies": [{"workflow": "upstream", "action": "produce"}],
+                }
+            ],
+        )
+
+        result = compile_workflows(config_path, tmp_path)
+        assert result.workflow_graph["downstream"] == ["upstream"]
+        assert result.workflow_graph["upstream"] == []


### PR DESCRIPTION
## Summary
- New `WorkflowCompiler` compiles cross-workflow deps into unified DAG (feature-gated behind `AGAC_COMPILED_CROSS_WORKFLOW=1`)
- Fix static analyzer: detect cross-workflow actions from `_has_cross_workflow_deps` flag when dict deps already stripped by Pydantic
- Fix scope inference: skip cross-workflow action refs instead of raising `ConfigurationError`
- Fix artifact linker: accept specific `source_action` param instead of guessing via mtime
- Fix dependency orchestrator: extract target action name from downstream config's dict deps
- Fix runner file processing: open upstream workflow's SQLite DB when input path points to a different workflow's target directory
- Fix runner `setup_directories`: cross-workflow first actions use manifest resolution

## Verification
- 30 new compiler unit tests (qualification, dep rewriting, cycle detection, transitive resolution, flags)
- All 5361 existing tests pass unchanged
- Tested end-to-end with real multi-workflow project (`qanalabs_quiz_gen --downstream` → `run_thinkific_gen`)