### PR TITLE
fix: FILE-mode lineage inference for cardinality-changing tools

### DIFF
--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -7,6 +7,7 @@ looping per-record.
 
 from __future__ import annotations
 
+import json
 import logging
 import warnings
 from hashlib import sha256
@@ -54,30 +55,175 @@ _TOOL_RESERVED_FIELDS = frozenset(
 # ---------------------------------------------------------------------------
 
 
+def _match_by_node_id(
+    raw_outputs: list[dict],
+    input_data: list[dict],
+) -> dict[int, int] | None:
+    """Match outputs to inputs by ``node_id``.
+
+    Works when the tool received full records (no observe filtering) and
+    passed them through with ``node_id`` intact — typical for dedup, filter,
+    and sort tools that don't strip framework fields.
+
+    Returns a complete mapping only when **every** output carries a
+    ``node_id`` that corresponds to exactly one input.  Returns ``None``
+    otherwise so callers fall through to the next strategy.
+    """
+    nid_to_idx: dict[str, int] = {}
+    for i, item in enumerate(input_data):
+        if isinstance(item, dict):
+            nid = item.get("node_id")
+            if isinstance(nid, str):
+                nid_to_idx[nid] = i
+
+    if not nid_to_idx:
+        return None
+
+    mapping: dict[int, int] = {}
+    for i, item in enumerate(raw_outputs):
+        if not isinstance(item, dict):
+            return None
+        nid = item.get("node_id")
+        if not isinstance(nid, str) or nid not in nid_to_idx:
+            return None
+        mapping[i] = nid_to_idx[nid]
+
+    return mapping
+
+
+def _content_fingerprint(d: dict) -> str:
+    """Deterministic fingerprint of a dict's business content.
+
+    Handles two record shapes:
+    - Flat dict (observe-filtered): fingerprint the whole dict minus reserved fields.
+    - Wrapped dict (no observe): fingerprint ``item["content"]`` if it's a dict.
+    """
+    if isinstance(d.get("content"), dict):
+        target = d["content"]
+    else:
+        target = d
+    clean = {k: v for k, v in target.items() if k not in _TOOL_RESERVED_FIELDS}
+    try:
+        return json.dumps(clean, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return ""
+
+
+def _match_by_content(
+    raw_outputs: list[dict],
+    tool_inputs: list[dict],
+) -> dict[int, int] | None:
+    """Match outputs to inputs by content fingerprint.
+
+    Compares output dicts to the observe-filtered input dicts the tool
+    received.  Uses :func:`json.dumps` with ``sort_keys=True`` for
+    deterministic fingerprinting.  Each input is consumed at most once to
+    handle duplicate-content inputs correctly.
+
+    Returns a complete mapping when **every** output matches exactly one
+    unclaimed input.  Returns ``None`` otherwise.
+    """
+    # Build fingerprint → [indices] for inputs (preserves insertion order).
+    fp_to_indices: dict[str, list[int]] = {}
+    for i, item in enumerate(tool_inputs):
+        if not isinstance(item, dict):
+            continue
+        fp = _content_fingerprint(item)
+        if fp:
+            fp_to_indices.setdefault(fp, []).append(i)
+
+    if not fp_to_indices:
+        return None
+
+    mapping: dict[int, int] = {}
+    claimed: set[int] = set()
+
+    for i, item in enumerate(raw_outputs):
+        if not isinstance(item, dict):
+            return None
+        fp = _content_fingerprint(item)
+        if not fp or fp not in fp_to_indices:
+            return None  # Content was transformed — can't match.
+
+        matched = False
+        for idx in fp_to_indices[fp]:
+            if idx not in claimed:
+                mapping[i] = idx
+                claimed.add(idx)
+                matched = True
+                break
+
+        if not matched:
+            return None  # All matching inputs already claimed.
+
+    return mapping
+
+
 def _infer_source_mapping(
     output_count: int,
     input_data: list[dict],
     action_name: str,
+    raw_outputs: list[dict] | None = None,
+    tool_inputs: list[dict] | None = None,
 ) -> dict[int, int | list[int]] | None:
     """Infer source_mapping when the tool does not provide one.
 
-    Priority:
-    1. Identity mapping when output count matches input count (most common).
-    2. Broadcast when all inputs share the same source_guid.
-    3. Fallback broadcast to first input (with warning).
+    Uses a 4-tier cascade — the first tier to produce a complete mapping wins:
+
+    1. **Identity** — output count matches input count → ``{i: i}``.
+    2. **Node-ID matching** — outputs carry ``node_id`` from their inputs
+       (works when observe filtering is inactive).
+    3. **Content fingerprint matching** — output content matches
+       observe-filtered input content (works when observe is active).
+    4. **Heuristic fallback** — positional for reduction with shared
+       ``source_guid``, broadcast-to-first for expansion or mixed guids.
     """
     input_count = len(input_data)
 
+    # 1. Identity (most common — each output[i] from input[i]).
     if output_count == input_count:
         return {i: i for i in range(output_count)}
 
-    # Check if all inputs share the same source_guid
+    # 2. Node-ID matching (dedup/filter tools that pass through records).
+    if raw_outputs:
+        mapping = _match_by_node_id(raw_outputs, input_data)
+        if mapping is not None:
+            logger.debug(
+                "FILE tool '%s': matched %d outputs to inputs by node_id.",
+                action_name,
+                len(mapping),
+            )
+            return mapping
+
+    # 3. Content fingerprint matching (observe-active tools).
+    if raw_outputs and tool_inputs:
+        mapping = _match_by_content(raw_outputs, tool_inputs)
+        if mapping is not None:
+            logger.debug(
+                "FILE tool '%s': matched %d outputs to inputs by content fingerprint.",
+                action_name,
+                len(mapping),
+            )
+            return mapping
+
+    # 4. Heuristic fallback.
     source_guids = {
         item.get("source_guid")
         for item in input_data
         if isinstance(item, dict) and item.get("source_guid")
     }
-    if len(source_guids) == 1:
+    if len(source_guids) <= 1:
+        if output_count < input_count:
+            # Reduction: positional is the best remaining heuristic.
+            logger.debug(
+                "FILE tool '%s': cardinality reduced (%d → %d) with shared source_guid. "
+                "Using positional mapping.",
+                action_name,
+                input_count,
+                output_count,
+            )
+            return {i: i for i in range(output_count)}
+        # Expansion: broadcast from first (can't determine which input spawned extras).
         return {i: 0 for i in range(output_count)}
 
     logger.warning(
@@ -183,6 +329,8 @@ def process_file_mode_tool(
                 output_count=len(raw_response),
                 input_data=original_data,
                 action_name=context.agent_name,
+                raw_outputs=raw_response,
+                tool_inputs=data,
             )
 
         # Separate business data from framework fields in tool output

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -94,9 +94,11 @@ def _match_by_node_id(
 def _content_fingerprint(d: dict) -> str:
     """Deterministic fingerprint of a dict's business content.
 
-    Handles two record shapes:
-    - Flat dict (observe-filtered): fingerprint the whole dict minus reserved fields.
-    - Wrapped dict (no observe): fingerprint ``item["content"]`` if it's a dict.
+    Returns a fixed-length hex digest so dict keys stay small regardless of
+    record size.  Handles two record shapes:
+
+    - Flat dict (observe-filtered): hash the whole dict minus reserved fields.
+    - Wrapped dict (no observe): hash ``item["content"]`` if it's a dict.
     """
     if isinstance(d.get("content"), dict):
         target = d["content"]
@@ -104,9 +106,10 @@ def _content_fingerprint(d: dict) -> str:
         target = d
     clean = {k: v for k, v in target.items() if k not in _TOOL_RESERVED_FIELDS}
     try:
-        return json.dumps(clean, sort_keys=True, default=str)
+        raw = json.dumps(clean, sort_keys=True, default=str)
     except (TypeError, ValueError):
         return ""
+    return sha256(raw.encode()).hexdigest()
 
 
 def _match_by_content(
@@ -116,13 +119,16 @@ def _match_by_content(
     """Match outputs to inputs by content fingerprint.
 
     Compares output dicts to the observe-filtered input dicts the tool
-    received.  Uses :func:`json.dumps` with ``sort_keys=True`` for
-    deterministic fingerprinting.  Each input is consumed at most once to
-    handle duplicate-content inputs correctly.
+    received.  Each input is consumed at most once to handle
+    duplicate-content inputs correctly.
 
     Returns a complete mapping when **every** output matches exactly one
     unclaimed input.  Returns ``None`` otherwise.
     """
+    # More outputs than inputs → at least one output can't be matched.
+    if len(raw_outputs) > len(tool_inputs):
+        return None
+
     # Build fingerprint → [indices] for inputs (preserves insertion order).
     fp_to_indices: dict[str, list[int]] = {}
     for i, item in enumerate(tool_inputs):
@@ -145,15 +151,12 @@ def _match_by_content(
         if not fp or fp not in fp_to_indices:
             return None  # Content was transformed — can't match.
 
-        matched = False
         for idx in fp_to_indices[fp]:
             if idx not in claimed:
                 mapping[i] = idx
                 claimed.add(idx)
-                matched = True
                 break
-
-        if not matched:
+        else:
             return None  # All matching inputs already claimed.
 
     return mapping

--- a/tests/unit/workflow/test_file_mode_source_mapping.py
+++ b/tests/unit/workflow/test_file_mode_source_mapping.py
@@ -1,0 +1,383 @@
+"""Tests for FILE-mode source_mapping inference (4-tier cascade).
+
+Covers the fix for the shared-source_guid lineage bug: when a FILE tool
+changes cardinality and all inputs share the same source_guid, the old
+inference broadcast all outputs to input[0].  The new inference uses
+node_id matching, content fingerprinting, and improved positional fallback.
+"""
+
+from __future__ import annotations
+
+from agent_actions.workflow.pipeline_file_mode import (
+    _content_fingerprint,
+    _infer_source_mapping,
+    _match_by_content,
+    _match_by_node_id,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_input(idx: int, *, source_guid: str = "sg-A", node_id: str | None = None) -> dict:
+    """Build a minimal input record with framework metadata."""
+    item: dict = {
+        "content": {"question": f"Q{idx}", "idx": idx},
+        "source_guid": source_guid,
+        "lineage": [f"upstream_{idx}"],
+    }
+    if node_id is not None:
+        item["node_id"] = node_id
+    return item
+
+
+def _make_flat_input(idx: int) -> dict:
+    """Build a minimal observe-filtered (flat) input dict."""
+    return {"question": f"Q{idx}", "idx": idx}
+
+
+# ===================================================================
+# Tier 1: Identity
+# ===================================================================
+
+
+class TestIdentityMapping:
+    """When output_count == input_count, return {i: i} unconditionally."""
+
+    def test_same_count_returns_identity(self):
+        inputs = [_make_input(i) for i in range(5)]
+        result = _infer_source_mapping(5, inputs, "action")
+        assert result == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4}
+
+    def test_same_count_ignores_raw_outputs(self):
+        """Identity check fires first regardless of node_id availability."""
+        inputs = [_make_input(i, node_id=f"n{i}") for i in range(3)]
+        outputs = [{"node_id": f"n{2 - i}"} for i in range(3)]  # reversed
+        result = _infer_source_mapping(3, inputs, "action", raw_outputs=outputs)
+        # Identity wins because counts match, even though node_ids differ.
+        assert result == {0: 0, 1: 1, 2: 2}
+
+
+# ===================================================================
+# Tier 2: Node-ID matching
+# ===================================================================
+
+
+class TestNodeIdMatching:
+    """Match outputs to inputs by node_id when tool passes records through."""
+
+    def test_dedup_with_node_ids(self):
+        """7 inputs, 6 outputs — dedup drops one record."""
+        inputs = [_make_input(i, node_id=f"n{i}") for i in range(7)]
+        # Tool drops input[3]
+        outputs = [{"node_id": f"n{i}", "question": f"Q{i}"} for i in range(7) if i != 3]
+        result = _infer_source_mapping(6, inputs, "dedup", raw_outputs=outputs)
+        assert result == {0: 0, 1: 1, 2: 2, 3: 4, 4: 5, 5: 6}
+
+    def test_reorder_with_node_ids(self):
+        """Outputs are same records but in different order."""
+        inputs = [_make_input(i, node_id=f"n{i}") for i in range(4)]
+        outputs = [
+            {"node_id": "n3"},
+            {"node_id": "n0"},
+            {"node_id": "n2"},
+        ]
+        result = _infer_source_mapping(3, inputs, "filter", raw_outputs=outputs)
+        assert result == {0: 3, 1: 0, 2: 2}
+
+    def test_partial_node_ids_falls_through(self):
+        """Some outputs missing node_id → returns None."""
+        inputs = [_make_input(i, node_id=f"n{i}") for i in range(4)]
+        outputs = [{"node_id": "n0"}, {"question": "Q2"}, {"node_id": "n3"}]
+        result = _match_by_node_id(outputs, inputs)
+        assert result is None
+
+    def test_no_node_ids_falls_through(self):
+        """No outputs have node_id → returns None."""
+        inputs = [_make_input(i, node_id=f"n{i}") for i in range(3)]
+        outputs = [{"question": "Q0"}, {"question": "Q1"}]
+        result = _match_by_node_id(outputs, inputs)
+        assert result is None
+
+    def test_unknown_node_id_falls_through(self):
+        """Output carries a node_id not in inputs → returns None."""
+        inputs = [_make_input(i, node_id=f"n{i}") for i in range(3)]
+        outputs = [{"node_id": "n0"}, {"node_id": "n_unknown"}]
+        result = _match_by_node_id(outputs, inputs)
+        assert result is None
+
+    def test_inputs_without_node_ids_falls_through(self):
+        """Inputs have no node_ids → returns None."""
+        inputs = [_make_input(i) for i in range(3)]  # no node_id
+        outputs = [{"node_id": "n0"}, {"node_id": "n1"}]
+        result = _match_by_node_id(outputs, inputs)
+        assert result is None
+
+
+# ===================================================================
+# Tier 3: Content fingerprint matching
+# ===================================================================
+
+
+class TestContentMatching:
+    """Match outputs to inputs by content fingerprint."""
+
+    def test_dedup_with_observe_filtered_data(self):
+        """Observe-filtered flat dicts: dedup drops one, content matches."""
+        tool_inputs = [_make_flat_input(i) for i in range(7)]
+        # Tool drops input[4]
+        raw_outputs = [_make_flat_input(i) for i in range(7) if i != 4]
+        result = _match_by_content(raw_outputs, tool_inputs)
+        assert result == {0: 0, 1: 1, 2: 2, 3: 3, 4: 5, 5: 6}
+
+    def test_filter_with_reorder(self):
+        """Outputs are a reordered subset — non-sequential mapping."""
+        tool_inputs = [_make_flat_input(i) for i in range(5)]
+        # Tool returns inputs [3, 0, 4] in that order
+        raw_outputs = [_make_flat_input(3), _make_flat_input(0), _make_flat_input(4)]
+        result = _match_by_content(raw_outputs, tool_inputs)
+        assert result == {0: 3, 1: 0, 2: 4}
+
+    def test_duplicate_content_first_unclaimed_wins(self):
+        """Two inputs with identical content — first unclaimed is used."""
+        tool_inputs = [{"q": "same"}, {"q": "same"}, {"q": "unique"}]
+        raw_outputs = [{"q": "same"}, {"q": "unique"}]
+        result = _match_by_content(raw_outputs, tool_inputs)
+        # First "same" output claims input[0], "unique" claims input[2].
+        assert result == {0: 0, 1: 2}
+
+    def test_transformed_content_falls_through(self):
+        """Tool modified field values — no fingerprint match → None."""
+        tool_inputs = [{"q": "A", "score": 0.9}, {"q": "B", "score": 0.3}]
+        raw_outputs = [{"q": "A", "score": 0.95}]  # score changed
+        result = _match_by_content(raw_outputs, tool_inputs)
+        assert result is None
+
+    def test_new_content_falls_through(self):
+        """Tool generated entirely new content → None."""
+        tool_inputs = [{"q": "A"}, {"q": "B"}]
+        raw_outputs = [{"q": "C"}]  # not from any input
+        result = _match_by_content(raw_outputs, tool_inputs)
+        assert result is None
+
+    def test_all_inputs_claimed_falls_through(self):
+        """More outputs matching same fingerprint than available inputs → None."""
+        tool_inputs = [{"q": "same"}]
+        raw_outputs = [{"q": "same"}, {"q": "same"}]  # 2 outputs but only 1 input
+        result = _match_by_content(raw_outputs, tool_inputs)
+        assert result is None
+
+    def test_empty_outputs(self):
+        """Empty output list → empty mapping."""
+        tool_inputs = [_make_flat_input(0)]
+        result = _match_by_content([], tool_inputs)
+        assert result == {}
+
+    def test_non_dict_output_falls_through(self):
+        """Non-dict in output → None."""
+        tool_inputs = [_make_flat_input(0)]
+        result = _match_by_content(["not a dict"], tool_inputs)  # type: ignore[list-item]
+        assert result is None
+
+
+# ===================================================================
+# Content fingerprint function
+# ===================================================================
+
+
+class TestContentFingerprint:
+    """Unit tests for _content_fingerprint."""
+
+    def test_flat_dict(self):
+        fp = _content_fingerprint({"b": 2, "a": 1})
+        assert fp == '{"a": 1, "b": 2}'
+
+    def test_wrapped_dict(self):
+        """When item has a content dict, fingerprint the content."""
+        fp = _content_fingerprint({"content": {"b": 2, "a": 1}, "node_id": "n0"})
+        assert fp == '{"a": 1, "b": 2}'
+
+    def test_strips_reserved_fields(self):
+        fp = _content_fingerprint({"question": "Q1", "source_guid": "sg", "node_id": "n0"})
+        assert fp == '{"question": "Q1"}'
+
+    def test_deterministic(self):
+        """Same content, different insertion order → same fingerprint."""
+        fp1 = _content_fingerprint({"a": 1, "b": 2})
+        fp2 = _content_fingerprint({"b": 2, "a": 1})
+        assert fp1 == fp2
+
+    def test_empty_dict(self):
+        fp = _content_fingerprint({})
+        assert fp == "{}"
+
+
+# ===================================================================
+# Tier 4: Heuristic fallback
+# ===================================================================
+
+
+class TestHeuristicFallback:
+    """When node_id and content matching both fail."""
+
+    def test_shared_guid_reduction_uses_positional(self):
+        """Reduction with shared source_guid → positional {i: i}."""
+        inputs = [_make_input(i) for i in range(7)]
+        # No node_ids in outputs, content doesn't match (transformed).
+        outputs = [{"transformed": f"T{i}"} for i in range(5)]
+        tool_inputs = [_make_flat_input(i) for i in range(7)]
+        result = _infer_source_mapping(
+            5,
+            inputs,
+            "transform_filter",
+            raw_outputs=outputs,
+            tool_inputs=tool_inputs,
+        )
+        assert result == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4}
+
+    def test_shared_guid_expansion_uses_broadcast(self):
+        """Expansion with shared source_guid → broadcast {i: 0}."""
+        inputs = [_make_input(i) for i in range(3)]
+        outputs = [{"new": f"N{i}"} for i in range(5)]
+        tool_inputs = [_make_flat_input(i) for i in range(3)]
+        result = _infer_source_mapping(
+            5,
+            inputs,
+            "expand",
+            raw_outputs=outputs,
+            tool_inputs=tool_inputs,
+        )
+        assert result == {0: 0, 1: 0, 2: 0, 3: 0, 4: 0}
+
+    def test_no_source_guids_reduction_uses_positional(self):
+        """Reduction with no source_guids → positional."""
+        inputs = [{"content": {"q": f"Q{i}"}} for i in range(5)]
+        outputs = [{"new": f"N{i}"} for i in range(3)]
+        tool_inputs = [{"q": f"Q{i}"} for i in range(5)]
+        result = _infer_source_mapping(
+            3,
+            inputs,
+            "filter",
+            raw_outputs=outputs,
+            tool_inputs=tool_inputs,
+        )
+        assert result == {0: 0, 1: 1, 2: 2}
+
+    def test_mixed_guids_uses_broadcast_with_warning(self, caplog):
+        """Mixed source_guids → broadcast to first."""
+        inputs = [
+            _make_input(0, source_guid="sg-A"),
+            _make_input(1, source_guid="sg-B"),
+            _make_input(2, source_guid="sg-C"),
+        ]
+        outputs = [{"new": "N0"}]
+        tool_inputs = [{"q": "Q0"}, {"q": "Q1"}, {"q": "Q2"}]
+        result = _infer_source_mapping(
+            1,
+            inputs,
+            "aggregate",
+            raw_outputs=outputs,
+            tool_inputs=tool_inputs,
+        )
+        assert result == {0: 0}
+
+
+# ===================================================================
+# Integration: full cascade
+# ===================================================================
+
+
+class TestFullCascade:
+    """End-to-end tests through _infer_source_mapping showing tier priority."""
+
+    def test_node_id_wins_over_content(self):
+        """When both node_id and content could match, node_id is tried first."""
+        inputs = [
+            _make_input(0, node_id="n0"),
+            _make_input(1, node_id="n1"),
+            _make_input(2, node_id="n2"),
+        ]
+        # Output carries node_ids — node_id matching should fire.
+        outputs = [{"node_id": "n2", "question": "Q2"}, {"node_id": "n0", "question": "Q0"}]
+        tool_inputs = [_make_flat_input(0), _make_flat_input(1), _make_flat_input(2)]
+        result = _infer_source_mapping(
+            2,
+            inputs,
+            "filter",
+            raw_outputs=outputs,
+            tool_inputs=tool_inputs,
+        )
+        # node_id matching gives the correct non-sequential mapping.
+        assert result == {0: 2, 1: 0}
+
+    def test_content_fires_when_node_id_absent(self):
+        """Observe-filtered outputs (no node_id) → content matching fires."""
+        inputs = [_make_input(i) for i in range(5)]
+        tool_inputs = [_make_flat_input(i) for i in range(5)]
+        # Tool drops input[2], returns flat dicts without node_id.
+        outputs = [_make_flat_input(i) for i in range(5) if i != 2]
+        result = _infer_source_mapping(
+            4,
+            inputs,
+            "dedup",
+            raw_outputs=outputs,
+            tool_inputs=tool_inputs,
+        )
+        assert result == {0: 0, 1: 1, 2: 3, 3: 4}
+
+    def test_heuristic_fires_when_both_fail(self):
+        """Transformed content + no node_ids → falls to positional."""
+        inputs = [_make_input(i) for i in range(4)]
+        tool_inputs = [_make_flat_input(i) for i in range(4)]
+        # All-new content, no node_ids.
+        outputs = [{"transformed": f"X{i}"} for i in range(3)]
+        result = _infer_source_mapping(
+            3,
+            inputs,
+            "transform",
+            raw_outputs=outputs,
+            tool_inputs=tool_inputs,
+        )
+        assert result == {0: 0, 1: 1, 2: 2}
+
+    def test_backward_compat_no_raw_outputs(self):
+        """When raw_outputs is not provided, falls through to heuristic."""
+        inputs = [_make_input(i) for i in range(5)]
+        result = _infer_source_mapping(3, inputs, "legacy")
+        # Shared guid, reduction → positional.
+        assert result == {0: 0, 1: 1, 2: 2}
+
+    def test_the_reported_bug_scenario(self):
+        """Reproduce the exact bug from the report: 7 in, 6 out, shared guid.
+
+        Before fix: all outputs → input[0].
+        After fix: content matching → each output to its correct input.
+        """
+        questions = [
+            "security isolation violations",
+            "capability negotiation extensibility",
+            "multiple MCP servers",
+            "unique ID in requests",
+            "HTTP vs STDIO",
+            "structure spec compliance",
+            "security isolation violations v2",  # duplicate, from different page
+        ]
+        inputs = [
+            _make_input(i, source_guid="sg-A" if i < 6 else "sg-B", node_id=f"flatten_{i}")
+            for i in range(7)
+        ]
+        # Observe-filtered tool inputs (flat dicts, no node_id).
+        tool_inputs = [{"question": q, "idx": i} for i, q in enumerate(questions)]
+        # Dedup drops the last record (duplicate of [0]).
+        raw_outputs = [{"question": q, "idx": i} for i, q in enumerate(questions[:6])]
+
+        result = _infer_source_mapping(
+            6,
+            inputs,
+            "dedup",
+            raw_outputs=raw_outputs,
+            tool_inputs=tool_inputs,
+        )
+        # Each output maps to its corresponding input — NOT all to input[0].
+        assert result == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}

--- a/tests/unit/workflow/test_file_mode_source_mapping.py
+++ b/tests/unit/workflow/test_file_mode_source_mapping.py
@@ -189,18 +189,21 @@ class TestContentMatching:
 class TestContentFingerprint:
     """Unit tests for _content_fingerprint."""
 
-    def test_flat_dict(self):
+    def test_flat_dict_returns_hex_digest(self):
         fp = _content_fingerprint({"b": 2, "a": 1})
-        assert fp == '{"a": 1, "b": 2}'
+        assert len(fp) == 64  # sha256 hex digest
+        assert all(c in "0123456789abcdef" for c in fp)
 
-    def test_wrapped_dict(self):
-        """When item has a content dict, fingerprint the content."""
-        fp = _content_fingerprint({"content": {"b": 2, "a": 1}, "node_id": "n0"})
-        assert fp == '{"a": 1, "b": 2}'
+    def test_wrapped_dict_fingerprints_content(self):
+        """When item has a content dict, fingerprint the content — not the wrapper."""
+        fp_wrapped = _content_fingerprint({"content": {"b": 2, "a": 1}, "node_id": "n0"})
+        fp_flat = _content_fingerprint({"b": 2, "a": 1})
+        assert fp_wrapped == fp_flat
 
     def test_strips_reserved_fields(self):
-        fp = _content_fingerprint({"question": "Q1", "source_guid": "sg", "node_id": "n0"})
-        assert fp == '{"question": "Q1"}'
+        fp_with = _content_fingerprint({"question": "Q1", "source_guid": "sg", "node_id": "n0"})
+        fp_without = _content_fingerprint({"question": "Q1"})
+        assert fp_with == fp_without
 
     def test_deterministic(self):
         """Same content, different insertion order → same fingerprint."""
@@ -210,7 +213,7 @@ class TestContentFingerprint:
 
     def test_empty_dict(self):
         fp = _content_fingerprint({})
-        assert fp == "{}"
+        assert len(fp) == 64  # valid hash even for empty content
 
 
 # ===================================================================

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -945,3 +945,233 @@ class TestReattachSourceGuid:
 
         # Out of bounds → not set (no crash)
         assert "source_guid" not in structured[0]
+
+
+# ---------------------------------------------------------------------------
+# Integration: dedup with shared source_guid through full pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestDedupSharedGuidLineage:
+    """Deterministic integration tests proving each output record gets distinct
+    lineage after a dedup tool reduces cardinality on shared-source_guid data.
+
+    These tests exercise the full path: process_file_mode_tool → inference →
+    enrichment → lineage assignment. They verify the fix for the bug where
+    all outputs inherited input[0]'s lineage.
+    """
+
+    @staticmethod
+    def _make_dedup_pipeline_and_context(action_name="dedup_tool"):
+        pipeline = ProcessingPipeline(
+            config=PipelineConfig(
+                action_config={"kind": "tool", "granularity": "file"},
+                action_name=action_name,
+                idx=1,
+            ),
+            processor_factory=object(),
+        )
+        context = ProcessingContext(
+            agent_config={"kind": "tool", "granularity": "file"},
+            agent_name=action_name,
+            is_first_stage=False,
+        )
+        return pipeline, context
+
+    def test_dedup_shared_guid_distinct_lineage_via_content_match(self):
+        """7 inputs (shared guid) → 6 outputs via dedup → each output gets
+        its own parent's lineage, not all from input[0].
+
+        This reproduces the exact bug from the report: observe-filtered data
+        (no node_id), content fingerprint matching resolves the correct parent.
+        """
+        pipeline, context = self._make_dedup_pipeline_and_context()
+
+        # 7 input records from the same source page — all share source_guid.
+        # Each has a distinct lineage from a prior flatten step.
+        original_data = [
+            {
+                "source_guid": "sg-page1",
+                "node_id": f"flatten_q{i}",
+                "lineage": [f"flatten_q{i}"],
+                "target_id": f"tid-{i}",
+                "content": {"question": f"Q{i}", "idx": i},
+            }
+            for i in range(7)
+        ]
+        # Observe-filtered data the tool receives (flat dicts, no framework fields).
+        observe_filtered = [{"question": f"Q{i}", "idx": i} for i in range(7)]
+
+        # Dedup tool drops record 6 (duplicate). Returns 6 records.
+        dedup_output = [{"question": f"Q{i}", "idx": i} for i in range(6)]
+
+        context.source_data = original_data
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(dedup_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(observe_filtered, original_data, context)
+
+        result = results[0]
+        assert result.status == ProcessingStatus.SUCCESS
+        assert len(result.data) == 6
+
+        # CRITICAL ASSERTION: each output traces to its CORRECT parent.
+        # Before fix: all outputs had lineage from input[0] (flatten_q0).
+        # After fix: output[i] has lineage from input[i] (flatten_q{i}).
+        for i, item in enumerate(result.data):
+            lineage = item.get("lineage", [])
+            # Lineage must contain the parent's node_id (flatten_q{i}).
+            assert f"flatten_q{i}" in lineage, (
+                f"output[{i}] lineage {lineage} missing expected parent flatten_q{i}"
+            )
+            # Must also contain this action's own node_id.
+            assert any(nid.startswith("dedup_tool_") for nid in lineage), (
+                f"output[{i}] lineage {lineage} missing own node_id"
+            )
+
+        # Verify ALL outputs have distinct lineage (no two share the same chain).
+        lineage_tuples = [tuple(item["lineage"]) for item in result.data]
+        assert len(set(lineage_tuples)) == 6, (
+            f"Expected 6 distinct lineage chains, got {len(set(lineage_tuples))}"
+        )
+
+    def test_dedup_shared_guid_distinct_lineage_via_node_id_match(self):
+        """Same scenario but tool receives full records (no observe filter)
+        and passes them through with node_id intact → node_id matching fires.
+        """
+        pipeline, context = self._make_dedup_pipeline_and_context()
+
+        # Full records with framework metadata.
+        original_data = [
+            {
+                "source_guid": "sg-page1",
+                "node_id": f"flatten_q{i}",
+                "lineage": [f"flatten_q{i}"],
+                "target_id": f"tid-{i}",
+                "content": {"question": f"Q{i}", "idx": i},
+            }
+            for i in range(7)
+        ]
+
+        # Tool receives full records and returns a subset (drops record 3).
+        # Since no observe filter, output carries node_id.
+        dedup_output = [
+            {
+                "node_id": f"flatten_q{i}",
+                "source_guid": "sg-page1",
+                "question": f"Q{i}",
+                "idx": i,
+            }
+            for i in range(7)
+            if i != 3
+        ]
+
+        context.source_data = original_data
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(dedup_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(original_data, original_data, context)
+
+        result = results[0]
+        assert result.status == ProcessingStatus.SUCCESS
+        assert len(result.data) == 6
+
+        # Verify mapping jumped over input[3] correctly.
+        assert result.source_mapping == {0: 0, 1: 1, 2: 2, 3: 4, 4: 5, 5: 6}
+
+        # Each output traces to the correct parent — output[3] → input[4].
+        expected_parents = [0, 1, 2, 4, 5, 6]
+        for out_idx, in_idx in enumerate(expected_parents):
+            lineage = result.data[out_idx].get("lineage", [])
+            assert f"flatten_q{in_idx}" in lineage, (
+                f"output[{out_idx}] lineage {lineage} missing expected parent flatten_q{in_idx}"
+            )
+
+    def test_dedup_reorder_shared_guid_content_match(self):
+        """Dedup reorders output — content matching correctly maps non-sequential."""
+        pipeline, context = self._make_dedup_pipeline_and_context()
+
+        original_data = [
+            {
+                "source_guid": "sg-A",
+                "node_id": f"flatten_{i}",
+                "lineage": [f"flatten_{i}"],
+                "target_id": f"tid-{i}",
+                "content": {"q": f"Q{i}", "score": i * 10},
+            }
+            for i in range(5)
+        ]
+        observe_filtered = [{"q": f"Q{i}", "score": i * 10} for i in range(5)]
+
+        # Tool returns records [4, 1, 0] in that order (dropped 2 and 3).
+        dedup_output = [
+            {"q": "Q4", "score": 40},
+            {"q": "Q1", "score": 10},
+            {"q": "Q0", "score": 0},
+        ]
+
+        context.source_data = original_data
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(dedup_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(observe_filtered, original_data, context)
+
+        result = results[0]
+        assert len(result.data) == 3
+
+        # output[0] ("Q4") → input[4], output[1] ("Q1") → input[1], etc.
+        assert result.source_mapping == {0: 4, 1: 1, 2: 0}
+
+        # Verify lineage reflects the reorder.
+        assert "flatten_4" in result.data[0]["lineage"]
+        assert "flatten_1" in result.data[1]["lineage"]
+        assert "flatten_0" in result.data[2]["lineage"]
+
+        # All lineage chains are distinct.
+        chains = [tuple(item["lineage"]) for item in result.data]
+        assert len(set(chains)) == 3
+
+    def test_mixed_guid_dedup_falls_to_broadcast(self):
+        """When inputs have mixed source_guids and content is transformed,
+        inference falls to broadcast (last resort). Verify it doesn't crash
+        and produces valid (if imprecise) lineage.
+        """
+        pipeline, context = self._make_dedup_pipeline_and_context()
+
+        original_data = [
+            {
+                "source_guid": f"sg-{i}",
+                "node_id": f"flatten_{i}",
+                "lineage": [f"flatten_{i}"],
+                "target_id": f"tid-{i}",
+                "content": {"q": f"Q{i}"},
+            }
+            for i in range(4)
+        ]
+        observe_filtered = [{"q": f"Q{i}"} for i in range(4)]
+
+        # Tool transforms AND reduces — no node_id, no content match.
+        dedup_output = [{"summary": "merged_A"}, {"summary": "merged_B"}]
+
+        context.source_data = original_data
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(dedup_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(observe_filtered, original_data, context)
+
+        result = results[0]
+        assert result.status == ProcessingStatus.SUCCESS
+        assert len(result.data) == 2
+
+        # Both outputs should have valid lineage (non-empty).
+        for item in result.data:
+            assert "lineage" in item
+            assert len(item["lineage"]) > 0

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -11,19 +11,20 @@ from agent_actions.utils.udf_management.registry import FileUDFResult
 from agent_actions.workflow.pipeline import PipelineConfig, ProcessingPipeline
 
 
-def _make_pipeline_and_context():
+def _make_pipeline_and_context(action_name="my_file_tool", *, idx=0, is_first_stage=True):
     """Create a minimal pipeline and context for FILE-mode tool tests."""
     pipeline = ProcessingPipeline(
         config=PipelineConfig(
             action_config={"kind": "tool", "granularity": "file"},
-            action_name="my_file_tool",
-            idx=0,
+            action_name=action_name,
+            idx=idx,
         ),
         processor_factory=object(),
     )
     context = ProcessingContext(
         agent_config={"kind": "tool", "granularity": "file"},
-        agent_name="my_file_tool",
+        agent_name=action_name,
+        is_first_stage=is_first_stage,
     )
     return pipeline, context
 
@@ -809,38 +810,11 @@ def test_file_tool_large_cardinality_expansion():
 
 
 class TestInferSourceMapping:
-    """Direct unit tests for _infer_source_mapping logic."""
+    """Edge-case unit tests for _infer_source_mapping.
 
-    def test_identity_when_counts_match(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
-
-        result = _infer_source_mapping(
-            output_count=3,
-            input_data=[{"source_guid": "a"}, {"source_guid": "b"}, {"source_guid": "c"}],
-            action_name="test",
-        )
-        assert result == {0: 0, 1: 1, 2: 2}
-
-    def test_broadcast_when_shared_source_guid(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
-
-        result = _infer_source_mapping(
-            output_count=5,
-            input_data=[{"source_guid": "sg-shared"}, {"source_guid": "sg-shared"}],
-            action_name="test",
-        )
-        assert result == {0: 0, 1: 0, 2: 0, 3: 0, 4: 0}
-
-    def test_fallback_when_ambiguous(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
-
-        result = _infer_source_mapping(
-            output_count=3,
-            input_data=[{"source_guid": "sg-1"}, {"source_guid": "sg-2"}],
-            action_name="test",
-        )
-        # Fallback: all map to first input
-        assert result == {0: 0, 1: 0, 2: 0}
+    Core tier coverage (identity, node-id, content, heuristic) lives in
+    tests/unit/workflow/test_file_mode_source_mapping.py.
+    """
 
     def test_zero_output_returns_empty_mapping(self):
         from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
@@ -961,23 +935,6 @@ class TestDedupSharedGuidLineage:
     all outputs inherited input[0]'s lineage.
     """
 
-    @staticmethod
-    def _make_dedup_pipeline_and_context(action_name="dedup_tool"):
-        pipeline = ProcessingPipeline(
-            config=PipelineConfig(
-                action_config={"kind": "tool", "granularity": "file"},
-                action_name=action_name,
-                idx=1,
-            ),
-            processor_factory=object(),
-        )
-        context = ProcessingContext(
-            agent_config={"kind": "tool", "granularity": "file"},
-            agent_name=action_name,
-            is_first_stage=False,
-        )
-        return pipeline, context
-
     def test_dedup_shared_guid_distinct_lineage_via_content_match(self):
         """7 inputs (shared guid) → 6 outputs via dedup → each output gets
         its own parent's lineage, not all from input[0].
@@ -985,7 +942,7 @@ class TestDedupSharedGuidLineage:
         This reproduces the exact bug from the report: observe-filtered data
         (no node_id), content fingerprint matching resolves the correct parent.
         """
-        pipeline, context = self._make_dedup_pipeline_and_context()
+        pipeline, context = _make_pipeline_and_context("dedup_tool", idx=1, is_first_stage=False)
 
         # 7 input records from the same source page — all share source_guid.
         # Each has a distinct lineage from a prior flatten step.
@@ -1041,7 +998,7 @@ class TestDedupSharedGuidLineage:
         """Same scenario but tool receives full records (no observe filter)
         and passes them through with node_id intact → node_id matching fires.
         """
-        pipeline, context = self._make_dedup_pipeline_and_context()
+        pipeline, context = _make_pipeline_and_context("dedup_tool", idx=1, is_first_stage=False)
 
         # Full records with framework metadata.
         original_data = [
@@ -1093,7 +1050,7 @@ class TestDedupSharedGuidLineage:
 
     def test_dedup_reorder_shared_guid_content_match(self):
         """Dedup reorders output — content matching correctly maps non-sequential."""
-        pipeline, context = self._make_dedup_pipeline_and_context()
+        pipeline, context = _make_pipeline_and_context("dedup_tool", idx=1, is_first_stage=False)
 
         original_data = [
             {
@@ -1142,7 +1099,7 @@ class TestDedupSharedGuidLineage:
         inference falls to broadcast (last resort). Verify it doesn't crash
         and produces valid (if imprecise) lineage.
         """
-        pipeline, context = self._make_dedup_pipeline_and_context()
+        pipeline, context = _make_pipeline_and_context("dedup_tool", idx=1, is_first_stage=False)
 
         original_data = [
             {


### PR DESCRIPTION
## Summary

When a FILE-granularity tool changes record count (e.g. dedup 7→6) and all inputs share the same `source_guid`, the framework was assigning the first input's lineage to ALL outputs. Every downstream `context_scope.observe` lookup returned the same ancestor data — N unique records rendered as 1 repeated.

**Root cause:** `_infer_source_mapping()` in `pipeline_file_mode.py` broadcast all outputs to `input[0]` when `source_guid` was shared and counts differed.

**Fix:** Replace broadcast-to-first with a 4-tier inference cascade:

| Tier | Strategy | When it fires |
|------|----------|---------------|
| 1 | Identity `{i:i}` | output_count == input_count (unchanged) |
| 2 | Node-ID matching | Outputs carry `node_id` from inputs (no observe filter) |
| 3 | Content fingerprint | Output content matches observe-filtered input |
| 4 | Positional/broadcast | Fallback (improved: positional for reduction) |

**Scope:** Single file modified (`pipeline_file_mode.py`). Zero changes to `FileUDFResult`, `LineageEnricher`, `LineageBuilder`, or any consumer. The enricher already handles arbitrary mappings — only the inference was broken.

## Verification

- 30 unit tests for the 4-tier cascade (new file: `test_file_mode_source_mapping.py`)
- 4 deterministic integration tests through the full pipeline: `process_file_mode_tool` → inference → enrichment → verify distinct lineage per record (added to `test_pipeline_file_mode_tool.py`)
- 48 existing FILE-mode tests pass with zero regressions
- Full suite: 5301 passed, 0 failed
- `ruff format --check` and `ruff check` clean on all changed files