### PR TITLE
feat: virtual action injection for cross-workflow dependencies

### DIFF
--- a/agent_actions/config/manager.py
+++ b/agent_actions/config/manager.py
@@ -39,6 +39,7 @@ class ConfigManager:
         self.agent_configs: dict[str, AgentConfig] = {}
         self.execution_order: list[str] = []
         self.tool_path: list[str] | None = None
+        self.virtual_action_names: set[str] = set()
         self.template_dir = str(resolve_project_root(project_root) / "templates")
         self.environment_config: EnvironmentConfig | None = None
         self.workflow_config: Any = None
@@ -294,13 +295,16 @@ class ConfigManager:
             self.agent_configs[agent_type] = AgentConfig.model_validate(config_dict)
 
         workflow_actions = list(self.agent_configs.keys())
+        # Include virtual actions (from upstream workflows) as valid
+        # reference targets for dependency inference and validation.
+        all_known_actions = workflow_actions + list(self.virtual_action_names)
 
         dependency_graph = {}
         for agent_type, config in self.agent_configs.items():
             if config.is_operational:
                 try:
                     input_sources, context_sources = infer_dependencies(
-                        config.model_dump(), workflow_actions, agent_type
+                        config.model_dump(), all_known_actions, agent_type
                     )
                     all_deps: list[Any] = input_sources + context_sources
                 except Exception as e:
@@ -312,6 +316,9 @@ class ConfigManager:
                     )
                     all_deps = list(config.dependencies)
 
+                # Filter to local operational actions only — virtual actions
+                # (from upstream workflows) are valid references but are NOT
+                # added to the dependency graph since they're pre-completed.
                 dependencies = [
                     dep
                     for dep in all_deps

--- a/agent_actions/config/manager.py
+++ b/agent_actions/config/manager.py
@@ -295,8 +295,6 @@ class ConfigManager:
             self.agent_configs[agent_type] = AgentConfig.model_validate(config_dict)
 
         workflow_actions = list(self.agent_configs.keys())
-        # Include virtual actions (from upstream workflows) as valid
-        # reference targets for dependency inference and validation.
         all_known_actions = workflow_actions + list(self.virtual_action_names)
 
         dependency_graph = {}
@@ -316,9 +314,6 @@ class ConfigManager:
                     )
                     all_deps = list(config.dependencies)
 
-                # Filter to local operational actions only — virtual actions
-                # (from upstream workflows) are valid references but are NOT
-                # added to the dependency graph since they're pre-completed.
                 dependencies = [
                     dep
                     for dep in all_deps

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -456,7 +456,13 @@ class WorkflowConfig(BaseModel):
             all_deps.update(action.dependencies)
             if action.version_context and "base_name" in action.version_context:
                 base_names.add(action.version_context["base_name"])
-        dangling = all_deps - seen - base_names
+        # Upstream action names are valid dependency targets (resolved at runtime)
+        upstream_action_names: set[str] = set()
+        if self.upstream:
+            for ref in self.upstream:
+                upstream_action_names.update(ref.actions)
+
+        dangling = all_deps - seen - base_names - upstream_action_names
         if dangling:
             raise ValueError(
                 f"Dangling dependency references (not defined as actions): {sorted(dangling)}"

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -119,21 +119,19 @@ def _inject_upstream_virtual_actions(
     if not upstream_refs or not isinstance(upstream_refs, list):
         return {}
 
-    from agent_actions.workflow.orchestrator import WorkflowOrchestrator
+    # Filter to well-formed refs once, reuse for validation and building
+    parsed_refs = [ref for ref in upstream_refs if isinstance(ref, dict) and "workflow" in ref]
+    if not parsed_refs:
+        return {}
 
-    project_root = manager.project_root
-    if project_root:
-        orchestrator = WorkflowOrchestrator(project_root)
-        raw_refs = [
-            ref for ref in upstream_refs if isinstance(ref, dict) and "workflow" in ref
-        ]
-        if raw_refs:
-            orchestrator.validate_upstream_refs(manager.agent_name or "unknown", raw_refs)
+    if manager.project_root:
+        from agent_actions.workflow.orchestrator import WorkflowOrchestrator
+
+        orchestrator = WorkflowOrchestrator(manager.project_root)
+        orchestrator.validate_upstream_refs(manager.agent_name or "unknown", parsed_refs)
 
     virtual_actions: dict[str, VirtualAction] = {}
-    for ref in upstream_refs:
-        if not isinstance(ref, dict) or "workflow" not in ref:
-            continue
+    for ref in parsed_refs:
         workflow_name = ref["workflow"]
         for action_name in ref.get("actions", []):
             virtual_actions[action_name] = VirtualAction(
@@ -141,9 +139,7 @@ def _inject_upstream_virtual_actions(
                 action_name=action_name,
             )
 
-    # Register with ConfigManager so dependency resolution accepts these names
     manager.virtual_action_names = set(virtual_actions.keys())
-
     return virtual_actions
 
 

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -70,8 +70,9 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
     user_agents = _run_config_stage(manager.get_user_agents, "get_user_agents", manager)
     _run_config_stage(manager.merge_agent_configs, "merge_agent_configs", manager, user_agents)
 
-    # Inject virtual actions from upstream workflow declarations
-    virtual_actions = _inject_upstream_virtual_actions(manager)
+    virtual_actions = _run_config_stage(
+        _inject_upstream_virtual_actions, "inject_upstream_virtual_actions", manager, manager
+    )
 
     _run_config_stage(manager.determine_execution_order, "determine_execution_order", manager)
 

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -14,7 +14,7 @@ from agent_actions.logging.events import (
     UDFDiscoveryStartEvent,
     WorkflowInitializationStartEvent,
 )
-from agent_actions.workflow.models import WorkflowMetadata, WorkflowRuntimeConfig
+from agent_actions.workflow.models import VirtualAction, WorkflowMetadata, WorkflowRuntimeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,10 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
 
     user_agents = _run_config_stage(manager.get_user_agents, "get_user_agents", manager)
     _run_config_stage(manager.merge_agent_configs, "merge_agent_configs", manager, user_agents)
+
+    # Inject virtual actions from upstream workflow declarations
+    virtual_actions = _inject_upstream_virtual_actions(manager)
+
     _run_config_stage(manager.determine_execution_order, "determine_execution_order", manager)
 
     execution_order = manager.execution_order
@@ -92,7 +96,55 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
         execution_order=execution_order,
         action_indices=action_indices,
         action_configs=action_configs,
+        virtual_actions=virtual_actions,
     )
+
+
+def _inject_upstream_virtual_actions(
+    manager: ConfigManager,
+) -> dict[str, VirtualAction]:
+    """Parse ``upstream`` declarations and register virtual actions.
+
+    Virtual actions are added to ``manager.virtual_action_names`` so that
+    ``determine_execution_order()`` and ``infer_dependencies()`` accept
+    them as valid dependency targets without adding them to the DAG.
+
+    Returns:
+        Dict mapping action name to ``VirtualAction``.
+    """
+    if manager.user_config is None:
+        return {}
+
+    upstream_refs = manager.user_config.get("upstream")
+    if not upstream_refs or not isinstance(upstream_refs, list):
+        return {}
+
+    from agent_actions.workflow.orchestrator import WorkflowOrchestrator
+
+    project_root = manager.project_root
+    if project_root:
+        orchestrator = WorkflowOrchestrator(project_root)
+        raw_refs = [
+            ref for ref in upstream_refs if isinstance(ref, dict) and "workflow" in ref
+        ]
+        if raw_refs:
+            orchestrator.validate_upstream_refs(manager.agent_name or "unknown", raw_refs)
+
+    virtual_actions: dict[str, VirtualAction] = {}
+    for ref in upstream_refs:
+        if not isinstance(ref, dict) or "workflow" not in ref:
+            continue
+        workflow_name = ref["workflow"]
+        for action_name in ref.get("actions", []):
+            virtual_actions[action_name] = VirtualAction(
+                source_workflow=workflow_name,
+                action_name=action_name,
+            )
+
+    # Register with ConfigManager so dependency resolution accepts these names
+    manager.virtual_action_names = set(virtual_actions.keys())
+
+    return virtual_actions
 
 
 def discover_workflow_udfs(config: WorkflowRuntimeConfig, console: Console) -> None:

--- a/agent_actions/workflow/models.py
+++ b/agent_actions/workflow/models.py
@@ -1,6 +1,6 @@
 """Dataclass models for action workflow orchestration."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -57,6 +57,19 @@ class RuntimeContext:
 
 
 @dataclass
+class VirtualAction:
+    """An action from an upstream workflow, injected as pre-completed.
+
+    Virtual actions appear in the downstream workflow's namespace so that
+    ``context_scope`` and ``dependencies`` can reference them, but they
+    are NOT added to the execution order (they already ran).
+    """
+
+    source_workflow: str
+    action_name: str
+
+
+@dataclass
 class WorkflowMetadata:
     """Workflow configuration metadata."""
 
@@ -64,6 +77,7 @@ class WorkflowMetadata:
     execution_order: list[str]
     action_indices: dict[str, int]
     action_configs: dict[str, dict[str, Any]]
+    virtual_actions: dict[str, VirtualAction] = field(default_factory=dict)
 
 
 @dataclass

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -113,7 +113,7 @@ class ActionRunner:
         self.action_configs: dict[str, dict] | None = None
         self.execution_order: list[str] = []  # Set by service_init.initialize_services
         self.action_indices: dict[str, int] = {}  # Set by service_init.initialize_services
-        self.virtual_actions: dict = {}  # Set by service_init from WorkflowMetadata
+        self.virtual_actions: dict[str, Any] = {}  # Set by service_init from WorkflowMetadata
         self.workflow_name: str | None = None  # Set by AgentWorkflow for agent_io folder lookups
         self.manifest_manager: ManifestManager | None = None  # Set by AgentWorkflow
         self.data_source_config: str | dict[str, Any] | None = None  # Set by coordinator
@@ -295,33 +295,26 @@ class ActionRunner:
         return None
 
     def _resolve_virtual_action_directory(self, dep_name: str) -> Path | None:
-        """Resolve the output directory for a virtual action from an upstream workflow."""
+        """Resolve the output directory for a virtual action from an upstream workflow.
+
+        Uses ``FileHandler.find_specific_folder`` directly (not ``get_action_folder``)
+        because ``get_action_folder`` always resolves to ``self.workflow_name``, which
+        is the *current* workflow — not the upstream.
+        """
         virtual = self.virtual_actions[dep_name]
         upstream_workflow = virtual.source_workflow
 
-        # Find the upstream workflow's agent_io directory
-        try:
-            upstream_folder = self.get_action_folder(
-                upstream_workflow, project_root=self.project_root
-            )
-        except Exception:
-            logger.warning(
-                "Could not find agent_io for upstream workflow '%s'", upstream_workflow
-            )
+        search_dir = resolve_project_root(self.project_root)
+        upstream_folder = FileHandler.find_specific_folder(
+            str(search_dir), upstream_workflow, "agent_io"
+        )
+        if upstream_folder is None:
+            logger.warning("Could not find agent_io for upstream workflow '%s'", upstream_workflow)
             return None
 
         upstream_target = Path(upstream_folder) / "target" / dep_name
         if upstream_target.exists():
             return upstream_target
-
-        # Also check storage backend for upstream data
-        if self.storage_backend is not None:
-            try:
-                target_files = self.storage_backend.list_target_files(dep_name)
-                if target_files:
-                    return upstream_target
-            except Exception:
-                pass
 
         logger.warning(
             "Upstream action '%s' from workflow '%s' has no outputs at %s",

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -113,6 +113,7 @@ class ActionRunner:
         self.action_configs: dict[str, dict] | None = None
         self.execution_order: list[str] = []  # Set by service_init.initialize_services
         self.action_indices: dict[str, int] = {}  # Set by service_init.initialize_services
+        self.virtual_actions: dict = {}  # Set by service_init from WorkflowMetadata
         self.workflow_name: str | None = None  # Set by AgentWorkflow for agent_io folder lookups
         self.manifest_manager: ManifestManager | None = None  # Set by AgentWorkflow
         self.data_source_config: str | dict[str, Any] | None = None  # Set by coordinator
@@ -213,6 +214,15 @@ class ActionRunner:
         missing_dirs = []
 
         for dep_name in dependencies:
+            # Check if this is a virtual action from an upstream workflow
+            if dep_name in self.virtual_actions:
+                virtual_dir = self._resolve_virtual_action_directory(dep_name)
+                if virtual_dir:
+                    resolved_dirs.append(virtual_dir)
+                else:
+                    missing_dirs.append((dep_name, f"upstream:{dep_name}"))
+                continue
+
             dep_path = self._resolve_single_dependency(target_dir, dep_name)
             if dep_path:
                 resolved_dirs.append(dep_path)
@@ -282,6 +292,43 @@ class ActionRunner:
             return simple_path
 
         logger.warning("Dependency directory not found for %s", dep_name)
+        return None
+
+    def _resolve_virtual_action_directory(self, dep_name: str) -> Path | None:
+        """Resolve the output directory for a virtual action from an upstream workflow."""
+        virtual = self.virtual_actions[dep_name]
+        upstream_workflow = virtual.source_workflow
+
+        # Find the upstream workflow's agent_io directory
+        try:
+            upstream_folder = self.get_action_folder(
+                upstream_workflow, project_root=self.project_root
+            )
+        except Exception:
+            logger.warning(
+                "Could not find agent_io for upstream workflow '%s'", upstream_workflow
+            )
+            return None
+
+        upstream_target = Path(upstream_folder) / "target" / dep_name
+        if upstream_target.exists():
+            return upstream_target
+
+        # Also check storage backend for upstream data
+        if self.storage_backend is not None:
+            try:
+                target_files = self.storage_backend.list_target_files(dep_name)
+                if target_files:
+                    return upstream_target
+            except Exception:
+                pass
+
+        logger.warning(
+            "Upstream action '%s' from workflow '%s' has no outputs at %s",
+            dep_name,
+            upstream_workflow,
+            upstream_target,
+        )
         return None
 
     def _resolve_linear_directory(self, agent_folder: Path, previous_action_type: str) -> Path:

--- a/agent_actions/workflow/service_init.py
+++ b/agent_actions/workflow/service_init.py
@@ -91,6 +91,7 @@ def initialize_services(
     action_runner.execution_order = metadata.execution_order
     action_runner.action_indices = metadata.action_indices
     action_runner.action_configs = metadata.action_configs
+    action_runner.virtual_actions = metadata.virtual_actions
     action_runner.workflow_name = metadata.agent_name
     action_runner.project_root = config.project_root
 

--- a/tests/orchestration/test_agent_runner_dependency_resolution.py
+++ b/tests/orchestration/test_agent_runner_dependency_resolution.py
@@ -115,6 +115,7 @@ class TestDependencyPatterns:
         runner.action_indices = {}
         runner.manifest_manager = None
         runner.storage_backend = None
+        runner.virtual_actions = {}
         return runner
 
     @pytest.fixture
@@ -397,6 +398,7 @@ class TestResolveDependencyDirectories:
         runner.action_indices = {"action_A": 0, "action_B": 1, "action_C": 2}
         runner.manifest_manager = None  # No manifest manager for simple tests
         runner.storage_backend = None
+        runner.virtual_actions = {}
         return runner
 
     @pytest.fixture
@@ -564,6 +566,7 @@ class TestResolveDependencyDirectoriesIntegration:
         """Create ActionRunner with workflow indices."""
         runner = ActionRunner.__new__(ActionRunner)
         runner.storage_backend = None
+        runner.virtual_actions = {}
         runner.action_indices = {
             "extract_raw_qa": 0,
             "flatten_raw_questions": 1,
@@ -614,6 +617,7 @@ class TestResolveDependencyDirectoriesIntegration:
         runner.action_indices = {"validate_1": 0, "validate_2": 1, "validate_3": 2, "aggregate": 3}
         runner.manifest_manager = None
         runner.storage_backend = None
+        runner.virtual_actions = {}
 
         dependencies = ["validate_1", "validate_2", "validate_3"]
         agent_config = {"dependencies": dependencies, "reduce_key": "parent_id"}

--- a/tests/unit/workflow/test_virtual_actions.py
+++ b/tests/unit/workflow/test_virtual_actions.py
@@ -7,8 +7,6 @@ Covers:
 - Missing upstream outputs error handling
 """
 
-from unittest.mock import patch
-
 from agent_actions.workflow.models import VirtualAction, WorkflowMetadata
 
 
@@ -132,8 +130,8 @@ class TestRunnerVirtualActionResolution:
         """Virtual action resolves to the upstream workflow's target directory."""
         from agent_actions.workflow.runner import ActionRunner
 
-        # Set up upstream workflow's output directory
-        upstream_io = tmp_path / "agent_io"
+        # Create upstream workflow directory structure that FileHandler can find
+        upstream_io = tmp_path / "ingest" / "agent_io"
         (upstream_io / "target" / "extract").mkdir(parents=True)
 
         runner = ActionRunner.__new__(ActionRunner)
@@ -142,11 +140,8 @@ class TestRunnerVirtualActionResolution:
         runner.virtual_actions = {
             "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
         }
-        runner.storage_backend = None
 
-        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
-            result = runner._resolve_virtual_action_directory("extract")
-
+        result = runner._resolve_virtual_action_directory("extract")
         assert result is not None
         assert result == upstream_io / "target" / "extract"
 
@@ -155,7 +150,7 @@ class TestRunnerVirtualActionResolution:
         from agent_actions.workflow.runner import ActionRunner
 
         # Upstream workflow exists but has no outputs for "extract"
-        upstream_io = tmp_path / "agent_io"
+        upstream_io = tmp_path / "ingest" / "agent_io"
         (upstream_io / "target").mkdir(parents=True)
 
         runner = ActionRunner.__new__(ActionRunner)
@@ -164,11 +159,22 @@ class TestRunnerVirtualActionResolution:
         runner.virtual_actions = {
             "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
         }
-        runner.storage_backend = None
 
-        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
-            result = runner._resolve_virtual_action_directory("extract")
+        result = runner._resolve_virtual_action_directory("extract")
+        assert result is None
 
+    def test_virtual_action_upstream_not_found_returns_none(self, tmp_path):
+        """When upstream workflow has no agent_io directory, returns None."""
+        from agent_actions.workflow.runner import ActionRunner
+
+        runner = ActionRunner.__new__(ActionRunner)
+        runner.project_root = tmp_path
+        runner.workflow_name = "enrich"
+        runner.virtual_actions = {
+            "extract": VirtualAction(source_workflow="nonexistent", action_name="extract"),
+        }
+
+        result = runner._resolve_virtual_action_directory("extract")
         assert result is None
 
     def test_virtual_action_in_dependency_resolution(self, tmp_path):
@@ -176,11 +182,11 @@ class TestRunnerVirtualActionResolution:
         from agent_actions.workflow.runner import ActionRunner
 
         # Set up local workflow agent_io
-        local_io = tmp_path / "enrich_io"
+        local_io = tmp_path / "enrich" / "agent_io"
         (local_io / "target").mkdir(parents=True)
 
-        # Set up upstream workflow output
-        upstream_io = tmp_path / "ingest_io"
+        # Set up upstream workflow directory structure
+        upstream_io = tmp_path / "ingest" / "agent_io"
         (upstream_io / "target" / "extract").mkdir(parents=True)
 
         runner = ActionRunner.__new__(ActionRunner)
@@ -193,44 +199,12 @@ class TestRunnerVirtualActionResolution:
             "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
         }
 
-        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
-            result = runner._resolve_dependency_directories(
-                local_io,
-                ["extract"],
-                {"dependencies": ["extract"]},
-                "enrich_text",
-            )
+        result = runner._resolve_dependency_directories(
+            local_io,
+            ["extract"],
+            {"dependencies": ["extract"]},
+            "enrich_text",
+        )
 
         assert len(result) == 1
         assert result[0] == upstream_io / "target" / "extract"
-
-    def test_virtual_action_as_single_dependency(self, tmp_path):
-        """A single virtual action dependency resolves correctly."""
-        from agent_actions.workflow.runner import ActionRunner
-
-        local_io = tmp_path / "enrich_io"
-        (local_io / "target").mkdir(parents=True)
-
-        upstream_io = tmp_path / "ingest_io"
-        (upstream_io / "target" / "classify").mkdir(parents=True)
-
-        runner = ActionRunner.__new__(ActionRunner)
-        runner.project_root = tmp_path
-        runner.workflow_name = "enrich"
-        runner.action_indices = {"final_action": 0}
-        runner.manifest_manager = None
-        runner.storage_backend = None
-        runner.virtual_actions = {
-            "classify": VirtualAction(source_workflow="ingest", action_name="classify"),
-        }
-
-        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
-            result = runner._resolve_dependency_directories(
-                local_io,
-                ["classify"],
-                {"dependencies": ["classify"]},
-                "final_action",
-            )
-
-        assert len(result) == 1
-        assert result[0] == upstream_io / "target" / "classify"

--- a/tests/unit/workflow/test_virtual_actions.py
+++ b/tests/unit/workflow/test_virtual_actions.py
@@ -1,0 +1,236 @@
+"""Tests for virtual action injection and cross-workflow I/O resolution.
+
+Covers:
+- Virtual action injection from upstream declarations
+- ConfigManager accepting virtual actions as valid dependencies
+- ActionRunner resolving virtual action output directories
+- Missing upstream outputs error handling
+"""
+
+from unittest.mock import patch
+
+from agent_actions.workflow.models import VirtualAction, WorkflowMetadata
+
+
+class TestVirtualActionModel:
+    """VirtualAction dataclass."""
+
+    def test_create(self):
+        va = VirtualAction(source_workflow="ingest", action_name="extract")
+        assert va.source_workflow == "ingest"
+        assert va.action_name == "extract"
+
+
+class TestWorkflowMetadataVirtualActions:
+    """WorkflowMetadata with virtual_actions field."""
+
+    def test_default_empty(self):
+        meta = WorkflowMetadata(
+            agent_name="test",
+            execution_order=["a"],
+            action_indices={"a": 0},
+            action_configs={"a": {}},
+        )
+        assert meta.virtual_actions == {}
+
+    def test_with_virtual_actions(self):
+        va = VirtualAction(source_workflow="ingest", action_name="extract")
+        meta = WorkflowMetadata(
+            agent_name="test",
+            execution_order=["a"],
+            action_indices={"a": 0},
+            action_configs={"a": {}},
+            virtual_actions={"extract": va},
+        )
+        assert "extract" in meta.virtual_actions
+        assert meta.virtual_actions["extract"].source_workflow == "ingest"
+
+
+class TestConfigManagerVirtualActions:
+    """ConfigManager.determine_execution_order with virtual actions."""
+
+    def test_virtual_action_accepted_as_dependency(self, tmp_path):
+        """An action can depend on a virtual action without raising."""
+        from agent_actions.config.manager import ConfigManager
+
+        # Create required project structure
+        (tmp_path / "templates").mkdir()
+
+        # Create a minimal workflow config with one action that depends on "extract"
+        cfg = tmp_path / "test.yml"
+        cfg.write_text(
+            "name: test\n"
+            "description: test\n"
+            "upstream:\n"
+            "  - workflow: ingest\n"
+            "    actions: [extract]\n"
+            "defaults:\n"
+            "  model_vendor: openai\n"
+            "  model_name: gpt-4o\n"
+            "  api_key: test-key\n"
+            "actions:\n"
+            "  - name: enrich\n"
+            "    intent: do stuff\n"
+            "    dependencies: [extract]\n"
+        )
+        default = tmp_path / "default.yml"
+        default.write_text("default_agent_config: {}")
+
+        mgr = ConfigManager(str(cfg), str(default), project_root=tmp_path)
+        mgr.load_configs()
+        mgr.validate_agent_name()
+
+        user_agents = mgr.get_user_agents()
+        mgr.merge_agent_configs(user_agents)
+
+        # Register "extract" as a virtual action
+        mgr.virtual_action_names = {"extract"}
+
+        # This should NOT raise — "extract" is a valid virtual action target
+        mgr.determine_execution_order()
+
+        # "enrich" should be in execution order, "extract" should not
+        assert "enrich" in mgr.execution_order
+        assert "extract" not in mgr.execution_order
+
+    def test_unknown_dependency_excluded_without_virtual(self, tmp_path):
+        """Without virtual action registration, unknown deps are silently filtered."""
+        from agent_actions.config.manager import ConfigManager
+
+        (tmp_path / "templates").mkdir()
+
+        cfg = tmp_path / "test.yml"
+        cfg.write_text(
+            "name: test\n"
+            "description: test\n"
+            "defaults:\n"
+            "  model_vendor: openai\n"
+            "  model_name: gpt-4o\n"
+            "  api_key: test-key\n"
+            "actions:\n"
+            "  - name: enrich\n"
+            "    intent: do stuff\n"
+        )
+        default = tmp_path / "default.yml"
+        default.write_text("default_agent_config: {}")
+
+        mgr = ConfigManager(str(cfg), str(default), project_root=tmp_path)
+        mgr.load_configs()
+        mgr.validate_agent_name()
+
+        user_agents = mgr.get_user_agents()
+        mgr.merge_agent_configs(user_agents)
+        mgr.determine_execution_order()
+
+        assert "enrich" in mgr.execution_order
+
+
+class TestRunnerVirtualActionResolution:
+    """ActionRunner._resolve_virtual_action_directory."""
+
+    def test_virtual_action_resolves_to_upstream_target(self, tmp_path):
+        """Virtual action resolves to the upstream workflow's target directory."""
+        from agent_actions.workflow.runner import ActionRunner
+
+        # Set up upstream workflow's output directory
+        upstream_io = tmp_path / "agent_io"
+        (upstream_io / "target" / "extract").mkdir(parents=True)
+
+        runner = ActionRunner.__new__(ActionRunner)
+        runner.project_root = tmp_path
+        runner.workflow_name = "enrich"
+        runner.virtual_actions = {
+            "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
+        }
+        runner.storage_backend = None
+
+        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
+            result = runner._resolve_virtual_action_directory("extract")
+
+        assert result is not None
+        assert result == upstream_io / "target" / "extract"
+
+    def test_virtual_action_missing_outputs_returns_none(self, tmp_path):
+        """Virtual action with no upstream outputs returns None."""
+        from agent_actions.workflow.runner import ActionRunner
+
+        # Upstream workflow exists but has no outputs for "extract"
+        upstream_io = tmp_path / "agent_io"
+        (upstream_io / "target").mkdir(parents=True)
+
+        runner = ActionRunner.__new__(ActionRunner)
+        runner.project_root = tmp_path
+        runner.workflow_name = "enrich"
+        runner.virtual_actions = {
+            "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
+        }
+        runner.storage_backend = None
+
+        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
+            result = runner._resolve_virtual_action_directory("extract")
+
+        assert result is None
+
+    def test_virtual_action_in_dependency_resolution(self, tmp_path):
+        """Virtual actions are resolved through _resolve_dependency_directories."""
+        from agent_actions.workflow.runner import ActionRunner
+
+        # Set up local workflow agent_io
+        local_io = tmp_path / "enrich_io"
+        (local_io / "target").mkdir(parents=True)
+
+        # Set up upstream workflow output
+        upstream_io = tmp_path / "ingest_io"
+        (upstream_io / "target" / "extract").mkdir(parents=True)
+
+        runner = ActionRunner.__new__(ActionRunner)
+        runner.project_root = tmp_path
+        runner.workflow_name = "enrich"
+        runner.action_indices = {"enrich_text": 0}
+        runner.manifest_manager = None
+        runner.storage_backend = None
+        runner.virtual_actions = {
+            "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
+        }
+
+        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
+            result = runner._resolve_dependency_directories(
+                local_io,
+                ["extract"],
+                {"dependencies": ["extract"]},
+                "enrich_text",
+            )
+
+        assert len(result) == 1
+        assert result[0] == upstream_io / "target" / "extract"
+
+    def test_virtual_action_as_single_dependency(self, tmp_path):
+        """A single virtual action dependency resolves correctly."""
+        from agent_actions.workflow.runner import ActionRunner
+
+        local_io = tmp_path / "enrich_io"
+        (local_io / "target").mkdir(parents=True)
+
+        upstream_io = tmp_path / "ingest_io"
+        (upstream_io / "target" / "classify").mkdir(parents=True)
+
+        runner = ActionRunner.__new__(ActionRunner)
+        runner.project_root = tmp_path
+        runner.workflow_name = "enrich"
+        runner.action_indices = {"final_action": 0}
+        runner.manifest_manager = None
+        runner.storage_backend = None
+        runner.virtual_actions = {
+            "classify": VirtualAction(source_workflow="ingest", action_name="classify"),
+        }
+
+        with patch.object(runner, "get_action_folder", return_value=str(upstream_io)):
+            result = runner._resolve_dependency_directories(
+                local_io,
+                ["classify"],
+                {"dependencies": ["classify"]},
+                "final_action",
+            )
+
+        assert len(result) == 1
+        assert result[0] == upstream_io / "target" / "classify"


### PR DESCRIPTION
## Summary
- Add `VirtualAction` dataclass and `virtual_actions` field on `WorkflowMetadata`
- Config pipeline parses `upstream` declarations, validates refs via `WorkflowOrchestrator`, and injects virtual actions
- `ConfigManager.determine_execution_order()` passes virtual action names to `infer_dependencies()` so they're accepted as valid references without entering the execution DAG
- `WorkflowConfig.validate_workflow_invariants()` accounts for upstream action names in dangling dependency check
- `ActionRunner` resolves virtual action output directories from upstream workflow's `agent_io/target/` directory
- 9 new tests covering virtual action model, ConfigManager integration, and runner I/O resolution

PR 2 of 3 for cross-workflow chaining. After this PR, `agac run -a enrich` works if the upstream workflow already ran — upstream actions appear in the namespace and their outputs are resolved. PR 3 adds `--downstream`/`--upstream` CLI flags.

## Verification
- All 5276 tests pass (5267 existing + 9 new), 0 regressions
- `ruff check` and `ruff format --check` clean
- `mypy` passes on all changed files