### PR TITLE
feat: --downstream and --upstream CLI flags for workflow chaining

### DIFF
--- a/agent_actions/cli/run.py
+++ b/agent_actions/cli/run.py
@@ -51,6 +51,46 @@ class RunCommand:
             workflow.run()
 
     def execute(self, project_root: Path | None = None) -> None:
+        if self.args.downstream or self.args.upstream:
+            self._execute_chain(project_root)
+            return
+
+        self._execute_single(project_root)
+
+    def _execute_chain(self, project_root: Path | None = None) -> None:
+        """Execute a chain of workflows based on --downstream/--upstream flags."""
+        from agent_actions.workflow.orchestrator import WorkflowOrchestrator
+
+        effective_root = project_root or Path.cwd()
+        orchestrator = WorkflowOrchestrator(effective_root)
+
+        if self.args.upstream and self.args.downstream:
+            direction = "full"
+        elif self.args.downstream:
+            direction = "downstream"
+        else:
+            direction = "upstream"
+
+        plan = orchestrator.resolve_execution_plan(self.agent_name, direction)
+        click.echo(f"Execution plan ({direction}): {' -> '.join(plan)}")
+
+        for workflow_name in plan:
+            click.echo(f"\n--- Running workflow: {workflow_name} ---")
+            chain_args = RunCommandArgs(
+                agent=workflow_name,
+                user_code=self.args.user_code,
+                use_tools=self.args.use_tools,
+                execution_mode=self.args.execution_mode,
+                concurrency_limit=self.args.concurrency_limit,
+                fresh=self.args.fresh,
+                verify_keys=self.args.verify_keys,
+                downstream=False,
+                upstream=False,
+            )
+            RunCommand(chain_args)._execute_single(project_root=project_root)
+
+    def _execute_single(self, project_root: Path | None = None) -> None:
+        """Execute a single workflow."""
         click.echo(f"Starting agent run for: {self.args.agent}")
 
         if project_root is not None:
@@ -239,6 +279,18 @@ class RunCommand:
     default=False,
     help="Verify API keys are valid by probing vendor endpoints before execution",
 )
+@click.option(
+    "--downstream",
+    is_flag=True,
+    default=False,
+    help="Also run all workflows that depend on this one",
+)
+@click.option(
+    "--upstream",
+    is_flag=True,
+    default=False,
+    help="Run all upstream workflow dependencies before this one",
+)
 @handles_user_errors("run")
 @requires_project
 def run(
@@ -249,6 +301,8 @@ def run(
     concurrency_limit: int = 5,
     fresh: bool = False,
     verify_keys: bool = False,
+    downstream: bool = False,
+    upstream: bool = False,
     project_root: Path | None = None,
 ) -> None:
     """
@@ -262,6 +316,8 @@ def run(
         agac run -a my_agent
         agac run -a my_agent --execution-mode parallel
         agac run -a my_agent --fresh
+        agac run -a my_agent --downstream
+        agac run -a my_agent --upstream
     """
     args = RunCommandArgs(
         agent=agent,
@@ -271,6 +327,8 @@ def run(
         concurrency_limit=concurrency_limit,
         fresh=fresh,
         verify_keys=verify_keys,
+        downstream=downstream,
+        upstream=upstream,
     )
     command = RunCommand(args)
     command.execute(project_root=project_root)

--- a/agent_actions/cli/run.py
+++ b/agent_actions/cli/run.py
@@ -64,6 +64,7 @@ class RunCommand:
         effective_root = project_root or Path.cwd()
         orchestrator = WorkflowOrchestrator(effective_root)
 
+        direction: Literal["downstream", "upstream", "full"]
         if self.args.upstream and self.args.downstream:
             direction = "full"
         elif self.args.downstream:

--- a/agent_actions/cli/run.py
+++ b/agent_actions/cli/run.py
@@ -76,21 +76,12 @@ class RunCommand:
 
         for workflow_name in plan:
             click.echo(f"\n--- Running workflow: {workflow_name} ---")
-            chain_args = RunCommandArgs(
-                agent=workflow_name,
-                user_code=self.args.user_code,
-                use_tools=self.args.use_tools,
-                execution_mode=self.args.execution_mode,
-                concurrency_limit=self.args.concurrency_limit,
-                fresh=self.args.fresh,
-                verify_keys=self.args.verify_keys,
-                downstream=False,
-                upstream=False,
+            chain_args = self.args.model_copy(
+                update={"agent": workflow_name, "downstream": False, "upstream": False}
             )
             RunCommand(chain_args)._execute_single(project_root=project_root)
 
     def _execute_single(self, project_root: Path | None = None) -> None:
-        """Execute a single workflow."""
         click.echo(f"Starting agent run for: {self.args.agent}")
 
         if project_root is not None:

--- a/agent_actions/validation/run_validator.py
+++ b/agent_actions/validation/run_validator.py
@@ -26,9 +26,5 @@ class RunCommandArgs(BaseModel):
     verify_keys: bool = Field(
         False, description="Verify API keys are valid by probing vendor endpoints before execution"
     )
-    downstream: bool = Field(
-        False, description="Run downstream dependent workflows after this one"
-    )
-    upstream: bool = Field(
-        False, description="Run upstream workflow dependencies before this one"
-    )
+    downstream: bool = Field(False, description="Run downstream dependent workflows after this one")
+    upstream: bool = Field(False, description="Run upstream workflow dependencies before this one")

--- a/agent_actions/validation/run_validator.py
+++ b/agent_actions/validation/run_validator.py
@@ -26,3 +26,9 @@ class RunCommandArgs(BaseModel):
     verify_keys: bool = Field(
         False, description="Verify API keys are valid by probing vendor endpoints before execution"
     )
+    downstream: bool = Field(
+        False, description="Run downstream dependent workflows after this one"
+    )
+    upstream: bool = Field(
+        False, description="Run upstream workflow dependencies before this one"
+    )

--- a/agent_actions/workflow/orchestrator.py
+++ b/agent_actions/workflow/orchestrator.py
@@ -8,6 +8,7 @@ or ``--upstream`` CLI flags.
 import logging
 from collections import deque
 from pathlib import Path
+from typing import Literal
 
 import yaml
 
@@ -126,7 +127,9 @@ class WorkflowOrchestrator:
 
         return workflow_name, upstream_workflows
 
-    def resolve_execution_plan(self, target: str, direction: str) -> list[str]:
+    def resolve_execution_plan(
+        self, target: str, direction: Literal["downstream", "upstream", "full"]
+    ) -> list[str]:
         """Resolve the ordered list of workflows to execute.
 
         Args:

--- a/tests/unit/cli/test_run_chaining.py
+++ b/tests/unit/cli/test_run_chaining.py
@@ -1,0 +1,207 @@
+"""Tests for --downstream and --upstream CLI flags.
+
+Covers:
+- RunCommandArgs accepts downstream/upstream flags
+- RunCommand.execute delegates to _execute_chain when flags are set
+- RunCommand._execute_chain resolves plan and calls _execute_single per workflow
+- Without flags, execute delegates to _execute_single (existing behavior)
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from agent_actions.validation.run_validator import RunCommandArgs
+
+
+class TestRunCommandArgsFlags:
+    """RunCommandArgs accepts downstream/upstream fields."""
+
+    def test_defaults_false(self):
+        args = RunCommandArgs(agent="test")
+        assert args.downstream is False
+        assert args.upstream is False
+
+    def test_downstream_true(self):
+        args = RunCommandArgs(agent="test", downstream=True)
+        assert args.downstream is True
+        assert args.upstream is False
+
+    def test_upstream_true(self):
+        args = RunCommandArgs(agent="test", upstream=True)
+        assert args.upstream is True
+        assert args.downstream is False
+
+    def test_both_true(self):
+        args = RunCommandArgs(agent="test", downstream=True, upstream=True)
+        assert args.downstream is True
+        assert args.upstream is True
+
+
+class TestRunCommandChaining:
+    """RunCommand routes to chain or single execution based on flags."""
+
+    def test_no_flags_calls_execute_single(self):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="test")
+        cmd = RunCommand(args)
+
+        with patch.object(cmd, "_execute_single") as mock_single:
+            cmd.execute(project_root=Path("/tmp"))
+
+        mock_single.assert_called_once_with(Path("/tmp"))
+
+    def test_downstream_calls_execute_chain(self):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="test", downstream=True)
+        cmd = RunCommand(args)
+
+        with patch.object(cmd, "_execute_chain") as mock_chain:
+            cmd.execute(project_root=Path("/tmp"))
+
+        mock_chain.assert_called_once_with(Path("/tmp"))
+
+    def test_upstream_calls_execute_chain(self):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="test", upstream=True)
+        cmd = RunCommand(args)
+
+        with patch.object(cmd, "_execute_chain") as mock_chain:
+            cmd.execute(project_root=Path("/tmp"))
+
+        mock_chain.assert_called_once_with(Path("/tmp"))
+
+    def test_both_flags_calls_execute_chain(self):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="test", downstream=True, upstream=True)
+        cmd = RunCommand(args)
+
+        with patch.object(cmd, "_execute_chain") as mock_chain:
+            cmd.execute(project_root=Path("/tmp"))
+
+        mock_chain.assert_called_once_with(Path("/tmp"))
+
+
+class TestExecuteChain:
+    """RunCommand._execute_chain resolves plan and executes workflows."""
+
+    def test_downstream_resolves_correct_direction(self, tmp_path):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="ingest", downstream=True)
+        cmd = RunCommand(args)
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.resolve_execution_plan.return_value = ["ingest", "enrich"]
+
+        with (
+            patch(
+                "agent_actions.workflow.orchestrator.WorkflowOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch.object(RunCommand, "_execute_single"),
+        ):
+            cmd._execute_chain(project_root=tmp_path)
+
+        mock_orchestrator.resolve_execution_plan.assert_called_once_with("ingest", "downstream")
+
+    def test_upstream_resolves_correct_direction(self, tmp_path):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="enrich", upstream=True)
+        cmd = RunCommand(args)
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.resolve_execution_plan.return_value = ["ingest", "enrich"]
+
+        with (
+            patch(
+                "agent_actions.workflow.orchestrator.WorkflowOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch.object(RunCommand, "_execute_single"),
+        ):
+            cmd._execute_chain(project_root=tmp_path)
+
+        mock_orchestrator.resolve_execution_plan.assert_called_once_with("enrich", "upstream")
+
+    def test_both_flags_resolves_full_direction(self, tmp_path):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="enrich", downstream=True, upstream=True)
+        cmd = RunCommand(args)
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.resolve_execution_plan.return_value = ["ingest", "enrich", "analyze"]
+
+        with (
+            patch(
+                "agent_actions.workflow.orchestrator.WorkflowOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch.object(RunCommand, "_execute_single"),
+        ):
+            cmd._execute_chain(project_root=tmp_path)
+
+        mock_orchestrator.resolve_execution_plan.assert_called_once_with("enrich", "full")
+
+    def test_chain_executes_each_workflow_in_order(self, tmp_path):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="ingest", downstream=True)
+        cmd = RunCommand(args)
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.resolve_execution_plan.return_value = ["ingest", "enrich", "analyze"]
+
+        executed_workflows = []
+
+        def track_execute(self_inner, project_root=None):
+            executed_workflows.append(self_inner.agent_name)
+
+        with (
+            patch(
+                "agent_actions.workflow.orchestrator.WorkflowOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch.object(RunCommand, "_execute_single", track_execute),
+        ):
+            cmd._execute_chain(project_root=tmp_path)
+
+        assert executed_workflows == ["ingest", "enrich", "analyze"]
+
+    def test_chain_does_not_pass_flags_to_child_workflows(self, tmp_path):
+        from agent_actions.cli.run import RunCommand
+
+        args = RunCommandArgs(agent="ingest", downstream=True, fresh=True)
+        cmd = RunCommand(args)
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.resolve_execution_plan.return_value = ["ingest"]
+
+        created_commands = []
+        original_init = RunCommand.__init__
+
+        def capture_init(self_inner, args_inner):
+            original_init(self_inner, args_inner)
+            created_commands.append(args_inner)
+
+        with (
+            patch(
+                "agent_actions.workflow.orchestrator.WorkflowOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch.object(RunCommand, "__init__", capture_init),
+            patch.object(RunCommand, "_execute_single"),
+        ):
+            cmd._execute_chain(project_root=tmp_path)
+
+        # The child workflow args should NOT have downstream/upstream flags
+        child_args = created_commands[-1]
+        assert child_args.downstream is False
+        assert child_args.upstream is False
+        # But should preserve other flags
+        assert child_args.fresh is True


### PR DESCRIPTION
## Summary
- Add `--downstream` and `--upstream` flags to `agac run`
- When flagged, `RunCommand.execute()` delegates to `_execute_chain()` which resolves the workflow DAG via `WorkflowOrchestrator` and executes each workflow in topological order
- `--downstream`: run target then all dependents
- `--upstream`: run all dependencies then target
- Both flags: run full lineage
- Without flags: existing single-workflow behavior unchanged (routes to `_execute_single()`)
- Child workflows get `downstream=False, upstream=False` to prevent recursion
- 13 new tests covering flag routing, direction resolution, execution order, and flag stripping

PR 3 of 3 for cross-workflow chaining. This completes the feature:
- PR 1: Schema + validation + orchestrator
- PR 2: Virtual action injection + I/O resolution
- PR 3: CLI flags (this PR)

## Verification
- All 5289 tests pass (5276 existing + 13 new), 0 regressions
- `ruff check` and `ruff format --check` clean
- `mypy` passes on all changed files