### PR TITLE
refactor: parameterize determine_execution_order, document virtual action contracts

### DIFF
--- a/agent_actions/config/manager.py
+++ b/agent_actions/config/manager.py
@@ -39,7 +39,6 @@ class ConfigManager:
         self.agent_configs: dict[str, AgentConfig] = {}
         self.execution_order: list[str] = []
         self.tool_path: list[str] | None = None
-        self.virtual_action_names: set[str] = set()
         self.template_dir = str(resolve_project_root(project_root) / "templates")
         self.environment_config: EnvironmentConfig | None = None
         self.workflow_config: Any = None
@@ -273,11 +272,15 @@ class ConfigManager:
             merged_agent_config = AgentConfig.model_validate(merged_dict)
             self.agent_configs[agent_type] = merged_agent_config
 
-    def determine_execution_order(self) -> None:
+    def determine_execution_order(self, virtual_action_names: set[str] | None = None) -> None:
         """Determine execution order of agents based on their dependencies.
 
         Uses auto-inferred dependencies from context_scope to build the execution graph.
         Only considers is_operational agents.
+
+        Args:
+            virtual_action_names: Action names from upstream workflows that are valid
+                dependency targets but should not appear in the execution order.
         """
         from agent_actions.input.context.normalizer import normalize_all_agent_configs
         from agent_actions.output.response.config_schema import AgentConfig
@@ -295,7 +298,7 @@ class ConfigManager:
             self.agent_configs[agent_type] = AgentConfig.model_validate(config_dict)
 
         workflow_actions = list(self.agent_configs.keys())
-        all_known_actions = workflow_actions + list(self.virtual_action_names)
+        all_known_actions = workflow_actions + list(virtual_action_names or set())
 
         dependency_graph = {}
         for agent_type, config in self.agent_configs.items():

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -150,7 +150,9 @@ def build_field_context_with_history(
 
         # BATCH MODE - Use auto-inferred context dependencies
         workflow_actions = list(agent_indices.keys())
-        # Include virtual actions (from upstream workflows) as valid references
+        # Virtual action names from upstream workflows are injected into
+        # action_config by config_pipeline.load_workflow_configs(). Include
+        # them so infer_dependencies() accepts cross-workflow references.
         virtual_names = agent_config.get("_virtual_action_names", [])
         if virtual_names:
             workflow_actions = workflow_actions + virtual_names

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -150,16 +150,11 @@ def build_field_context_with_history(
 
         # BATCH MODE - Use auto-inferred context dependencies
         workflow_actions = list(agent_indices.keys())
-        # Virtual action names from upstream workflows are injected into
-        # action_config by config_pipeline.load_workflow_configs(). Include
-        # them so infer_dependencies() accepts cross-workflow references.
-        virtual_names = agent_config.get("_virtual_action_names", [])
-        if virtual_names:
-            workflow_actions = workflow_actions + virtual_names
 
-        # Infer input sources vs context sources
+        # Infer input sources vs context sources. Validation is skipped
+        # because the static validator already caught invalid references.
         input_sources, context_sources = infer_dependencies(
-            agent_config, workflow_actions, agent_name
+            agent_config, workflow_actions, agent_name, validate=False
         )
 
         logger.debug(

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -228,7 +228,7 @@ def apply_observe_for_file_mode(
     if agent_indices:
         try:
             input_sources, _ = infer_dependencies(
-                agent_config, list(agent_indices.keys()), agent_name
+                agent_config, list(agent_indices.keys()), agent_name, validate=False
             )
             input_source_names = set(input_sources)
             has_reliable_ns = bool(input_source_names)

--- a/agent_actions/prompt/context/scope_inference.py
+++ b/agent_actions/prompt/context/scope_inference.py
@@ -148,7 +148,11 @@ def _resolve_input_sources_for_fan_in(
 
 
 def infer_dependencies(
-    action_config: dict, workflow_actions: list[str], action_name: str = "unknown"
+    action_config: dict,
+    workflow_actions: list[str],
+    action_name: str = "unknown",
+    *,
+    validate: bool = True,
 ) -> tuple[list[str], list[str]]:
     """
     Infer input sources and context sources from action configuration.
@@ -335,24 +339,27 @@ def infer_dependencies(
         ]
 
     # 5. Validate all referenced actions exist in workflow
-    all_referenced = set(input_sources_expanded) | set(context_sources_expanded)
-    for dep_action in all_referenced:
-        if dep_action in SPECIAL_NAMESPACES:
-            continue
+    # Skipped at runtime (validate=False) because the static validator
+    # already caught invalid references during preflight.
+    if validate:
+        all_referenced = set(input_sources_expanded) | set(context_sources_expanded)
+        for dep_action in all_referenced:
+            if dep_action in SPECIAL_NAMESPACES:
+                continue
 
-        if dep_action not in workflow_actions:
-            raise ConfigurationError(
-                f"Action '{action_name}': References '{dep_action}' in dependencies/context_scope "
-                f"but '{dep_action}' not found in workflow.\n\n"
-                f"Available actions: {workflow_actions}",
-                context={
-                    "action": action_name,
-                    "missing_action": dep_action,
-                    "workflow_actions": workflow_actions,
-                    "input_sources": input_sources_expanded,
-                    "context_sources": context_sources_expanded,
-                },
-            )
+            if dep_action not in workflow_actions:
+                raise ConfigurationError(
+                    f"Action '{action_name}': References '{dep_action}' in dependencies/context_scope "
+                    f"but '{dep_action}' not found in workflow.\n\n"
+                    f"Available actions: {workflow_actions}",
+                    context={
+                        "action": action_name,
+                        "missing_action": dep_action,
+                        "workflow_actions": workflow_actions,
+                        "input_sources": input_sources_expanded,
+                        "context_sources": context_sources_expanded,
+                    },
+                )
 
     logger.debug(
         f"[INFER_DEPS] Action '{action_name}': "

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -1428,7 +1428,7 @@ class WorkflowStaticAnalyzer:
 
         workflow_actions = [
             a.get("name") for a in self.workflow_config.get("actions", []) if a.get("name")
-        ]
+        ] + list(self.external_action_names)
 
         try:
             input_sources, context_sources = infer_dependencies(

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -74,7 +74,13 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
         _inject_upstream_virtual_actions, "inject_upstream_virtual_actions", manager, manager
     )
 
-    _run_config_stage(manager.determine_execution_order, "determine_execution_order", manager)
+    virtual_action_names = set(virtual_actions.keys()) if virtual_actions else set()
+    _run_config_stage(
+        manager.determine_execution_order,
+        "determine_execution_order",
+        manager,
+        virtual_action_names,
+    )
 
     execution_order = manager.execution_order
     action_configs = manager.get_all_agent_configs_as_dicts()
@@ -91,6 +97,9 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
         action_config["workflow_config_path"] = config.paths.constructor_path
         if config.project_root:
             action_config["_project_root"] = str(config.project_root)
+        # Injected so scope_builder.build_field_context_with_history() can
+        # include upstream workflow actions in infer_dependencies() validation.
+        # Read by: agent_actions/prompt/context/scope_builder.py
         if virtual_actions:
             action_config["_virtual_action_names"] = list(virtual_actions.keys())
 
@@ -142,7 +151,6 @@ def _inject_upstream_virtual_actions(
                 action_name=action_name,
             )
 
-    manager.virtual_action_names = set(virtual_actions.keys())
     return virtual_actions
 
 

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -97,11 +97,6 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
         action_config["workflow_config_path"] = config.paths.constructor_path
         if config.project_root:
             action_config["_project_root"] = str(config.project_root)
-        # Injected so scope_builder.build_field_context_with_history() can
-        # include upstream workflow actions in infer_dependencies() validation.
-        # Read by: agent_actions/prompt/context/scope_builder.py
-        if virtual_actions:
-            action_config["_virtual_action_names"] = list(virtual_actions.keys())
 
     return WorkflowMetadata(
         agent_name=manager.agent_name,

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -117,11 +117,6 @@ def _inject_upstream_virtual_actions(
 ) -> dict[str, VirtualAction]:
     """Parse ``upstream`` declarations and build virtual action map.
 
-    The returned dict is passed to ``determine_execution_order()`` (as
-    ``virtual_action_names``) and injected into action configs (as
-    ``_virtual_action_names``) so that dependency inference accepts
-    cross-workflow references without adding them to the execution DAG.
-
     Returns:
         Dict mapping action name to ``VirtualAction``.
     """

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -115,11 +115,12 @@ def load_workflow_configs(config: WorkflowRuntimeConfig, console: Console) -> Wo
 def _inject_upstream_virtual_actions(
     manager: ConfigManager,
 ) -> dict[str, VirtualAction]:
-    """Parse ``upstream`` declarations and register virtual actions.
+    """Parse ``upstream`` declarations and build virtual action map.
 
-    Virtual actions are added to ``manager.virtual_action_names`` so that
-    ``determine_execution_order()`` and ``infer_dependencies()`` accept
-    them as valid dependency targets without adding them to the DAG.
+    The returned dict is passed to ``determine_execution_order()`` (as
+    ``virtual_action_names``) and injected into action configs (as
+    ``_virtual_action_names``) so that dependency inference accepts
+    cross-workflow references without adding them to the execution DAG.
 
     Returns:
         Dict mapping action name to ``VirtualAction``.

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -361,10 +361,12 @@ class ActionRunner:
         if upstream_workflow not in self._upstream_backends:
             from agent_actions.storage import get_storage_backend
 
+            # Use the same backend type as the current workflow
+            current_type = self.storage_backend.backend_type if self.storage_backend else "sqlite"
             backend = get_storage_backend(
                 workflow_path=str(Path(upstream_folder).parent),
                 workflow_name=upstream_workflow,
-                backend_type="sqlite",
+                backend_type=current_type,
             )
             backend.initialize()
             self._upstream_backends[upstream_workflow] = backend

--- a/tests/unit/workflow/test_virtual_actions.py
+++ b/tests/unit/workflow/test_virtual_actions.py
@@ -81,11 +81,8 @@ class TestConfigManagerVirtualActions:
         user_agents = mgr.get_user_agents()
         mgr.merge_agent_configs(user_agents)
 
-        # Register "extract" as a virtual action
-        mgr.virtual_action_names = {"extract"}
-
         # This should NOT raise — "extract" is a valid virtual action target
-        mgr.determine_execution_order()
+        mgr.determine_execution_order(virtual_action_names={"extract"})
 
         # "enrich" should be in execution order, "extract" should not
         assert "enrich" in mgr.execution_order


### PR DESCRIPTION
## Summary
Architectural cleanup of cross-workflow virtual action propagation.

- **Parameterize `determine_execution_order`**: Accepts `virtual_action_names` as explicit parameter instead of reading from side-effect attribute on ConfigManager
- **Separate inference from validation in `infer_dependencies`**: Add `validate=False` for runtime callers (scope_builder, scope_file_mode) since the static validator already caught invalid references during preflight. This eliminates the `_virtual_action_names` injection into action config dicts entirely
- **Backend-agnostic upstream resolution**: Derive upstream storage backend type from current workflow instead of hardcoding `"sqlite"`
- **Fix static analyzer graph builder**: Include `external_action_names` in workflow actions for dependency inference (eliminates fallback warning)

### What was eliminated
- `ConfigManager.virtual_action_names` instance variable (side effect)
- `action_config["_virtual_action_names"]` injection into every action config dict
- Redundant runtime validation that only existed to re-check what preflight already validated

### What was kept (with rationale)
- `WorkflowMetadata.virtual_actions` — canonical source of truth
- `ActionRunner.virtual_actions` — runtime resolution needs full VirtualAction objects
- `external_action_names` threading through validation chain — clean parameter passing

## Verification
- All 5290 tests pass, 0 regressions
- `ruff check` and `ruff format --check` clean
- `mypy` passes on changed files
- Tested end-to-end on qanalabs-quiz-maker with `--downstream` chaining