### PR TITLE
fix: show execution levels in sequential mode

### DIFF
--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -437,6 +437,10 @@ class AgentWorkflow:
         with manager.context():
             try:
                 total_actions = len(self.execution_order)
+                levels = self.services.core.action_level_orchestrator.compute_execution_levels()
+                self.services.core.action_level_orchestrator.log_execution_levels(
+                    levels, self.action_indices
+                )
                 self.console.print(f"Found {total_actions} actions to run.")
 
                 for idx, action_name in enumerate(self.execution_order):

--- a/tests/unit/workflow/test_coordinator_error_enrichment.py
+++ b/tests/unit/workflow/test_coordinator_error_enrichment.py
@@ -45,6 +45,8 @@ def _build_workflow(execution_order=None):
     core = MagicMock(spec=CoreServices)
     core.state_manager = MagicMock()
     core.action_executor = MagicMock()
+    core.action_level_orchestrator = MagicMock()
+    core.action_level_orchestrator.compute_execution_levels.return_value = [["agent_a"]]
     support = MagicMock(spec=SupportServices)
     support.manifest_manager = MagicMock()
     wf.services = WorkflowServices(core=core, support=support)

--- a/tests/unit/workflow/test_coordinator_sequential.py
+++ b/tests/unit/workflow/test_coordinator_sequential.py
@@ -53,6 +53,8 @@ def _build_workflow(execution_order=None, agent_configs=None, state=None):
     core = MagicMock(spec=CoreServices)
     core.state_manager = MagicMock()
     core.action_executor = MagicMock()
+    core.action_level_orchestrator = MagicMock()
+    core.action_level_orchestrator.compute_execution_levels.return_value = [["agent_a"]]
     support = MagicMock(spec=SupportServices)
     support.manifest_manager = MagicMock()
     wf.services = WorkflowServices(core=core, support=support)


### PR DESCRIPTION
## Summary
Sequential `run()` only printed `"Found N actions to run."` while async `run()` showed the full `📊 Execution: N action(s) in M step(s)` listing with parallel levels. Now both modes call `log_execution_levels()` for consistent output.

This was most visible in cross-workflow chaining where downstream workflows ran sequentially and showed minimal output compared to the upstream workflow.


## Verification
- All 5290 tests pass, 0 regressions
- Updated 2 test fixtures to include `action_level_orchestrator` mock