### PR TITLE
feat: step-by-step progress in sequential execution

### DIFF
--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -442,12 +442,47 @@ class AgentWorkflow:
                     levels, self.action_indices
                 )
                 self.console.print(f"Found {total_actions} actions to run.")
+                state_mgr = self.services.core.state_manager
+                executor = self.services.core.action_executor
 
-                for idx, action_name in enumerate(self.execution_order):
-                    manager.set_context(action_name=action_name, action_index=idx)
+                for level_idx, level_actions in enumerate(levels):
+                    # Verify completed actions still have outputs (matches
+                    # parallel executor — resets stale completions to pending)
+                    for action_name in level_actions:
+                        if state_mgr.is_completed(action_name):
+                            executor.verify_completion_status(action_name)
 
-                    should_stop = self._run_single_action(idx, action_name, total_actions)
-                    if should_stop:
+                    pending = [a for a in level_actions if not state_mgr.is_completed(a)]
+                    if not pending:
+                        self.console.print(
+                            f"[yellow]Step {level_idx}: All actions complete (skipped)[/yellow]"
+                        )
+                        continue
+
+                    action_count = len(pending)
+                    self.console.print(
+                        f"[cyan]Step {level_idx}: Starting "
+                        f"{action_count} {'action' if action_count == 1 else 'actions'}...[/cyan]"
+                    )
+
+                    level_start = datetime.now()
+                    stop = False
+                    for action_name in pending:
+                        idx = self.action_indices[action_name]
+                        manager.set_context(action_name=action_name, action_index=idx)
+                        should_stop = self._run_single_action(idx, action_name, total_actions)
+                        if should_stop:
+                            stop = True
+                            break
+
+                    level_duration = (datetime.now() - level_start).total_seconds()
+                    has_failed = any(state_mgr.is_failed(a) for a in level_actions)
+                    color = "red" if has_failed else "green"
+                    self.console.print(
+                        f"[{color}]Step {level_idx} complete ({level_duration:.2f}s)[/{color}]"
+                    )
+
+                    if stop:
                         break
 
                 state_mgr = self.services.core.state_manager


### PR DESCRIPTION
## Summary
Sequential `run()` now shows the same step progress as parallel `run()`:
- `Step N: Starting M actions...` (cyan)
- `Step N: All actions complete (skipped)` (yellow)  
- `Step N complete (Xs)` (green/red based on result)

Previously sequential mode only printed `"Found N actions to run."` and ran silently. Now it uses the same execution levels from `ActionLevelOrchestrator` to drive the loop, matching the parallel executor's output.

This was most visible in cross-workflow chaining where the downstream workflow ran sequentially and showed no progress, while the upstream (parallel) showed full step-by-step output.

## Verification
- All 5290 tests pass, 0 regressions
- Sequential output now matches parallel format