### PR TITLE
fix: NiFi-inspired record identity for FILE-mode lineage

### DIFF
--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -325,33 +325,29 @@ def apply_observe_for_file_mode(
         else:
             cross_ns_data = {}
 
-        ordered: dict[str, Any] = {}
+        # NiFi-inspired: enrich the record in-place rather than stripping
+        # to a flat dict.  The tool receives the full record (framework
+        # fields + content) with cross-namespace data injected into content.
+        # Identity (node_id) naturally survives because nothing strips it.
+        enriched = dict(item)  # shallow copy — don't mutate caller's data
+        enriched_content = dict(content)  # shallow copy of content
+
         for ns, field, output_key in resolved:
             if field == "*":
-                ns_data = None
+                # Wildcard: inject all fields from cross-namespace source.
                 if ns in cross_ns_data:
-                    ns_data = cross_ns_data[ns]
-                elif not has_reliable_ns or ns in input_source_names:
-                    ns_data = content
-                if ns_data:
-                    for f, v in ns_data.items():
+                    for f, v in cross_ns_data[ns].items():
                         key = f"{ns}.{f}" if qualify_wildcards else f
-                        ordered[key] = v
+                        enriched_content[key] = v
+                # Input-source wildcard: content already has all fields.
                 continue
 
-            # Cross-namespace data takes priority for non-input namespaces.
+            # Cross-namespace data: inject into content.
             if ns in cross_ns_data and field in cross_ns_data[ns]:
-                ordered[output_key] = cross_ns_data[ns][field]
-            # Input source (per-record content) -- only when ns is actually
-            # an input source.  Without this guard, an unresolved non-input
-            # namespace (e.g. dep_b) would silently grab a same-named field
-            # from the primary record, producing incorrect context.
-            # When has_reliable_ns is False (content-key heuristic), we
-            # allow the fallback for all refs since we can't distinguish
-            # input namespaces from others.
+                enriched_content[output_key] = cross_ns_data[ns][field]
+            # Input source: field is already in content — no injection needed.
             elif (not has_reliable_ns or ns in input_source_names) and field in content:
-                ordered[output_key] = content[field]
-            # Field not found anywhere -- skip silently (logged at debug).
+                pass  # already present in enriched_content
             else:
                 logger.debug(
                     "[FILE OBSERVE] Field '%s' (ns='%s') not found for action '%s'. "
@@ -363,6 +359,7 @@ def apply_observe_for_file_mode(
                     list(cross_ns_data.get(ns, {}).keys()),
                 )
 
-        filtered.append(ordered)
+        enriched["content"] = enriched_content
+        filtered.append(enriched)
 
     return filtered

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -292,6 +292,11 @@ def apply_observe_for_file_mode(
     # Historical lookups depend on source_guid + lineage + parent/root target IDs,
     # so the cache key must include all discriminators to avoid returning stale
     # data when records share a source_guid but diverge in ancestry.
+    # Fast path: no cross-namespace refs to resolve — return data unmodified.
+    # Copies and per-record loops are only needed when injecting cross-ns data.
+    if not needed_ns:
+        return data
+
     cross_ns_cache: dict[tuple, dict[str, dict]] = {}
     filtered: list[dict] = []
     for item in data:
@@ -302,50 +307,42 @@ def apply_observe_for_file_mode(
         content = item.get("content", item) if isinstance(item.get("content"), dict) else item
 
         # Resolve cross-namespace data (cached by ancestry key).
-        if needed_ns:
-            sguid = item.get("source_guid")
-            cache_key = (
-                sguid,
-                tuple(item.get("lineage", [])),
-                item.get("parent_target_id"),
-                item.get("root_target_id"),
+        sguid = item.get("source_guid")
+        cache_key = (
+            sguid,
+            tuple(item.get("lineage", [])),
+            item.get("parent_target_id"),
+            item.get("root_target_id"),
+        )
+        if cache_key not in cross_ns_cache:
+            matched_source = source_index.get(sguid, source_data[0] if source_data else None)
+            cross_ns_cache[cache_key] = _load_file_mode_cross_namespace_data(
+                needed_ns=needed_ns,
+                record=item,
+                agent_name=agent_name,
+                agent_indices=agent_indices,
+                file_path=file_path,
+                source_record=matched_source,
+                storage_backend=storage_backend,
             )
-            if cache_key not in cross_ns_cache:
-                matched_source = source_index.get(sguid, source_data[0] if source_data else None)
-                cross_ns_cache[cache_key] = _load_file_mode_cross_namespace_data(
-                    needed_ns=needed_ns,
-                    record=item,
-                    agent_name=agent_name,
-                    agent_indices=agent_indices,
-                    file_path=file_path,
-                    source_record=matched_source,
-                    storage_backend=storage_backend,
-                )
-            cross_ns_data = cross_ns_cache[cache_key]
-        else:
-            cross_ns_data = {}
+        cross_ns_data = cross_ns_cache[cache_key]
 
-        # NiFi-inspired: enrich the record in-place rather than stripping
-        # to a flat dict.  The tool receives the full record (framework
-        # fields + content) with cross-namespace data injected into content.
-        # Identity (node_id) naturally survives because nothing strips it.
-        enriched = dict(item)  # shallow copy — don't mutate caller's data
-        enriched_content = dict(content)  # shallow copy of content
+        # NiFi-inspired: enrich the record rather than stripping to a flat
+        # dict.  Shallow-copy record + content to avoid mutating caller's
+        # data when injecting cross-namespace fields.
+        enriched = dict(item)
+        enriched_content = dict(content)
 
         for ns, field, output_key in resolved:
             if field == "*":
-                # Wildcard: inject all fields from cross-namespace source.
                 if ns in cross_ns_data:
                     for f, v in cross_ns_data[ns].items():
                         key = f"{ns}.{f}" if qualify_wildcards else f
                         enriched_content[key] = v
-                # Input-source wildcard: content already has all fields.
                 continue
 
-            # Cross-namespace data: inject into content.
             if ns in cross_ns_data and field in cross_ns_data[ns]:
                 enriched_content[output_key] = cross_ns_data[ns][field]
-            # Input source: field is already in content — no injection needed.
             elif (not has_reliable_ns or ns in input_source_names) and field in content:
                 pass  # already present in enriched_content
             else:

--- a/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
+++ b/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
@@ -97,7 +97,7 @@ def my_function(data: dict[str, Any]) -> list[dict[str, Any]]:
 
 ## File Mode
 
-UDF receives ALL records at once as a list. Unlike Record mode, the `content` wrapper is preserved — you must unwrap each item.
+UDF receives ALL records at once as a list. Each record is a full framework record with `content`, `node_id`, `source_guid`, and `lineage`. Read business data from `record["content"]`. Return records to preserve lineage.
 
 ```python
 from agent_actions import udf_tool
@@ -105,38 +105,57 @@ from agent_actions.config.schema import Granularity
 
 @udf_tool(granularity=Granularity.FILE)
 def run_dedup(data: list[dict]) -> list[dict]:
-    """FILE mode: each item has {"content": {...}, "source_guid": "..."}."""
+    """FILE mode: filter/dedup — pass through full records to preserve lineage."""
     seen = {}
     outputs = []
 
     for record in data:
-        content = record.get("content", record)  # Required — wrapper preserved
+        content = record.get("content", record)
         fact = content.get("fact", "")
         if fact not in seen:
             seen[fact] = True
-            outputs.append(content)
+            outputs.append(record)  # return the full record, not just content
 
     return outputs
 ```
 
-**What each item looks like:**
+**What each record looks like:**
 
 ```json
 {
-  "content": {
-    "extract_claims": {"claims": ["claim 1"], "confidence": 0.9}
-  },
+  "node_id": "flatten_claims_abc123_0",
   "source_guid": "abc-123",
-  "node_id": "node_2_xxx_0",
-  "lineage": ["node_0_yyy", "node_1_zzz", "node_2_xxx_0"]
+  "lineage": ["extract_abc", "flatten_claims_abc123_0"],
+  "content": {
+    "fact": "The sky is blue",
+    "confidence": 0.9,
+    "source_quote": "..."
+  }
 }
 ```
 
 | Input | Output |
 |-------|--------|
-| `list[dict]` — each item retains `content` wrapper | `list[dict]` — business data only |
+| `list[dict]` — full records with `content`, `node_id`, `lineage` | `list[dict]` — return full records for passthrough; new dicts for aggregation |
 
-**Metadata is automatic.** FILE-mode tools return business data only — never handle `source_guid`, lineage, or `node_id`. The framework propagates metadata automatically based on input/output cardinality.
+**Two rules for FILE tools:**
+
+1. **Read business data from `record["content"]["field"]`** — not `record["field"]`.
+2. **Return the original record dict for passthrough operations** (filter, dedup, sort, transform). This preserves `node_id` and lineage automatically. For aggregation/synthesis (creating new data not from a single input), return a new dict without `node_id` — the framework treats it as a new record.
+
+```python
+# Passthrough (dedup, filter, sort) — return the record:
+outputs.append(record)  # node_id survives, lineage tracked
+
+# Transform (modify fields) — mutate content, return the record:
+record["content"]["score"] = normalized_score
+outputs.append(record)  # node_id survives, lineage tracked
+
+# Aggregation (create new data) — return a new dict:
+outputs.append({"summary": "merged result", "count": len(data)})  # no node_id = new record
+```
+
+**Lineage is automatic.** The framework matches each output to its input by `node_id`. You never set, copy, or manage `node_id` — just return the record and the framework handles the rest. Inspired by Apache NiFi's FlowFile model: tools handle business logic, the framework handles identity.
 
 **Use FILE for:** Aggregation, deduplication, clustering, cross-record analysis.
 

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -190,7 +190,7 @@ def process_file_mode_tool(
             ]
 
         # Framework-managed: resolve which input produced each output by node_id.
-        source_mapping: dict[int, int] | None = None
+        source_mapping: dict[int, int | list[int]] | None = None
         if original_data:
             source_mapping = _resolve_source_mapping(
                 raw_outputs=raw_response,

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -198,11 +198,17 @@ def process_file_mode_tool(
                 action_name=context.agent_name,
             )
 
-        # Separate business data from framework fields in tool output
+        # Separate business data from framework fields in tool output.
+        # Tools may return full records (with content wrapper) or flat dicts.
         structured_data = []
         for item in raw_response:
             if isinstance(item, dict):
-                data_fields = {k: v for k, v in item.items() if k not in _TOOL_RESERVED_FIELDS}
+                if isinstance(item.get("content"), dict):
+                    # Tool returned a full record — use content directly.
+                    data_fields = item["content"]
+                else:
+                    # Tool returned a flat dict — strip reserved fields.
+                    data_fields = {k: v for k, v in item.items() if k not in _TOOL_RESERVED_FIELDS}
                 structured_item = {"content": data_fields}
 
                 if "source_guid" in item:

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -58,7 +58,7 @@ def _resolve_source_mapping(
     raw_outputs: list[dict],
     input_data: list[dict],
     action_name: str,
-) -> dict[int, int]:
+) -> dict[int, int | list[int]]:
     """Resolve which input produced each output by ``node_id``.
 
     NiFi-inspired: every record carries identity (``node_id``) through the
@@ -79,14 +79,9 @@ def _resolve_source_mapping(
             if isinstance(nid, str):
                 nid_to_idx[nid] = i
 
-    if not nid_to_idx:
-        return {}
-
-    mapping: dict[int, int] = {}
+    mapping: dict[int, int | list[int]] = {}
     for i, item in enumerate(raw_outputs):
-        if not isinstance(item, dict):
-            continue
-        nid = item.get("node_id")
+        nid = item.get("node_id") if isinstance(item, dict) else None
         if not isinstance(nid, str):
             continue  # New record — no parent.  Gets fresh lineage.
         if nid not in nid_to_idx:

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -54,40 +54,50 @@ _TOOL_RESERVED_FIELDS = frozenset(
 # ---------------------------------------------------------------------------
 
 
-def _infer_source_mapping(
-    output_count: int,
+def _resolve_source_mapping(
+    raw_outputs: list[dict],
     input_data: list[dict],
     action_name: str,
-) -> dict[int, int | list[int]] | None:
-    """Infer source_mapping when the tool does not provide one.
+) -> dict[int, int]:
+    """Resolve which input produced each output by ``node_id``.
 
-    Priority:
-    1. Identity mapping when output count matches input count (most common).
-    2. Broadcast when all inputs share the same source_guid.
-    3. Fallback broadcast to first input (with warning).
+    NiFi-inspired: every record carries identity (``node_id``) through the
+    pipeline.  The framework preserves it through the observe filter; tools
+    receive full records and pass them through.  The framework matches each
+    output to its input by ``node_id`` — no heuristics, no guessing.
+
+    Returns a mapping of ``output_index -> input_index`` for outputs that
+    carry a ``node_id`` matching an input.  Outputs without a matching
+    ``node_id`` are omitted — they are new records (e.g. aggregation
+    results) and will receive fresh lineage with no parent.
     """
-    input_count = len(input_data)
+    # Build lookup: node_id -> input index
+    nid_to_idx: dict[str, int] = {}
+    for i, item in enumerate(input_data):
+        if isinstance(item, dict):
+            nid = item.get("node_id")
+            if isinstance(nid, str):
+                nid_to_idx[nid] = i
 
-    if output_count == input_count:
-        return {i: i for i in range(output_count)}
+    mapping: dict[int, int] = {}
+    for i, item in enumerate(raw_outputs):
+        if not isinstance(item, dict):
+            continue
+        nid = item.get("node_id")
+        if not isinstance(nid, str):
+            continue  # New record — no parent.  Gets fresh lineage.
+        if nid not in nid_to_idx:
+            logger.warning(
+                "FILE tool '%s': output[%d] has node_id '%s' not found in inputs. "
+                "Treating as new record.",
+                action_name,
+                i,
+                nid,
+            )
+            continue
+        mapping[i] = nid_to_idx[nid]
 
-    # Check if all inputs share the same source_guid
-    source_guids = {
-        item.get("source_guid")
-        for item in input_data
-        if isinstance(item, dict) and item.get("source_guid")
-    }
-    if len(source_guids) == 1:
-        return {i: 0 for i in range(output_count)}
-
-    logger.warning(
-        "FILE tool '%s' changed cardinality (%d → %d) with mixed source_guids. "
-        "All outputs will inherit source_guid from first input.",
-        action_name,
-        input_count,
-        output_count,
-    )
-    return {i: 0 for i in range(output_count)}
+    return mapping
 
 
 def _reattach_source_guid(
@@ -176,11 +186,11 @@ def process_file_mode_tool(
                 )
             ]
 
-        # Framework-managed: infer which inputs produced which outputs.
-        source_mapping = None
+        # Framework-managed: resolve which input produced each output by node_id.
+        source_mapping: dict[int, int | list[int]] | None = None
         if original_data:
-            source_mapping = _infer_source_mapping(
-                output_count=len(raw_response),
+            source_mapping = _resolve_source_mapping(
+                raw_outputs=raw_response,
                 input_data=original_data,
                 action_name=context.agent_name,
             )

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -79,6 +79,9 @@ def _resolve_source_mapping(
             if isinstance(nid, str):
                 nid_to_idx[nid] = i
 
+    if not nid_to_idx:
+        return {}
+
     mapping: dict[int, int] = {}
     for i, item in enumerate(raw_outputs):
         if not isinstance(item, dict):
@@ -187,7 +190,7 @@ def process_file_mode_tool(
             ]
 
         # Framework-managed: resolve which input produced each output by node_id.
-        source_mapping: dict[int, int | list[int]] | None = None
+        source_mapping: dict[int, int] | None = None
         if original_data:
             source_mapping = _resolve_source_mapping(
                 raw_outputs=raw_response,

--- a/docs.agent-actions/docs/guides/custom-tools.md
+++ b/docs.agent-actions/docs/guides/custom-tools.md
@@ -114,6 +114,41 @@ def calculate_order_totals(data: dict[str, Any]) -> dict[str, Any]:
     return data
 ```
 
+## File-Level Tools
+
+For operations that need access to all records at once (deduplication, aggregation, cross-record analysis), use `Granularity.FILE`. FILE tools receive **full records** with framework metadata.
+
+```python
+from agent_actions import udf_tool
+from agent_actions.config.schema import Granularity
+
+@udf_tool(granularity=Granularity.FILE)
+def deduplicate_questions(data: list[dict]) -> list[dict]:
+    """Dedup by question text — return full records to preserve lineage."""
+    seen = set()
+    result = []
+    for record in data:
+        content = record.get("content", record)
+        question = content.get("question_text", "")
+        if question not in seen:
+            seen.add(question)
+            result.append(record)  # pass through the full record
+    return result
+```
+
+**Key differences from record-level tools:**
+
+| | Record-level | File-level |
+|---|---|---|
+| Input | Single `dict` with unwrapped business fields | `list[dict]` — each record has `content`, `node_id`, `lineage` |
+| Read fields | `data["field"]` | `record["content"]["field"]` |
+| Passthrough | Return modified dict | Return the original record dict |
+| New records | N/A | Return a new dict without `node_id` |
+
+:::tip Lineage tracking
+Each record carries a `node_id` that the framework uses to track lineage. When you return the original record, lineage extends automatically. When you return a new dict (aggregation), the framework creates fresh lineage. You never manage `node_id` directly.
+:::
+
 ## CLI Commands
 
 ```bash

--- a/docs.agent-actions/docs/reference/data-io/data-lineage.md
+++ b/docs.agent-actions/docs/reference/data-io/data-lineage.md
@@ -179,6 +179,37 @@ actions:
     {% if slow_path %}Slow result: {{ slow_path.result }}{% endif %}
 ```
 
+## FILE-Mode Lineage
+
+FILE-mode tools receive all records at once. The framework tracks each record's identity through the tool using `node_id` — inspired by [Apache NiFi's FlowFile model](https://nifi.apache.org/docs/nifi-docs/html/nifi-in-depth.html) where every record carries an immutable UUID through every processor.
+
+**How it works:**
+
+1. Each input record carries a `node_id` from the previous action
+2. The tool receives full records and returns them
+3. The framework matches each output to its input by `node_id`
+4. Matched outputs extend the parent's lineage chain
+5. Outputs without `node_id` (aggregation results) get fresh lineage
+
+```
+Input records:                        Tool output:                     After enrichment:
+┌──────────────────────┐              ┌──────────────────────┐         ┌──────────────────────┐
+│ node_id: flatten_q0  │──── kept ───▶│ node_id: flatten_q0  │────────▶│ lineage: [...,       │
+│ content: {q: "Q0"}   │              │ content: {q: "Q0"}   │         │   flatten_q0,        │
+└──────────────────────┘              └──────────────────────┘         │   dedup_tool_0]      │
+┌──────────────────────┐                                               └──────────────────────┘
+│ node_id: flatten_q1  │──── dropped (not in output)
+│ content: {q: "Q1"}   │
+└──────────────────────┘
+┌──────────────────────┐              ┌──────────────────────┐         ┌──────────────────────┐
+│ node_id: flatten_q2  │──── kept ───▶│ node_id: flatten_q2  │────────▶│ lineage: [...,       │
+│ content: {q: "Q2"}   │              │ content: {q: "Q2"}   │         │   flatten_q2,        │
+└──────────────────────┘              └──────────────────────┘         │   dedup_tool_1]      │
+                                                                       └──────────────────────┘
+```
+
+Downstream actions can use `context_scope.observe` to load data from any ancestor in the lineage chain — because each record traces back to the correct parent, not a shared fallback.
+
 ## Matching Priority
 
 When loading historical data, Agent Actions uses this priority:

--- a/docs.agent-actions/docs/reference/execution/granularity.md
+++ b/docs.agent-actions/docs/reference/execution/granularity.md
@@ -83,22 +83,29 @@ def validate_email(data, **kwargs):
 
 ### File-Level Tool
 
+FILE tools receive full records with `content`, `node_id`, `source_guid`, and `lineage`. Read business data from `record["content"]`. Return the original record to preserve lineage.
+
 ```python
 from agent_actions import udf_tool
 from agent_actions.config.schema import Granularity
 
 @udf_tool(granularity=Granularity.FILE)
 def deduplicate_facts(records, **kwargs):
-    """Process entire array of records."""
+    """Dedup — return full records to preserve lineage tracking."""
     seen = set()
     unique = []
     for record in records:
-        key = record.get('fact_text')
+        content = record.get("content", record)
+        key = content.get("fact_text")
         if key not in seen:
             seen.add(key)
-            unique.append(record)
+            unique.append(record)  # pass through full record
     return unique
 ```
+
+:::tip Record Identity
+FILE tools receive records with a `node_id` that tracks each record's identity through the pipeline. When you return the original record dict, the framework automatically matches it to the correct input and extends the lineage chain. For aggregation (creating new data), return a new dict without `node_id` — the framework treats it as a new record.
+:::
 
 ## Mixing Granularities
 
@@ -123,17 +130,21 @@ actions:
 - **Record → File**: Records collected into array for file-level action
 - **File → Record**: Array elements distributed to record-level processing
 
-## Output Wrapping
+## Output Processing
 
-File mode tools have output automatically wrapped with metadata:
+After a FILE tool returns, the framework:
+
+1. **Matches outputs to inputs by `node_id`** — if an output carries a `node_id` from an input, the framework extends that input's lineage.
+2. **Treats outputs without `node_id` as new records** — they get fresh lineage (e.g., aggregation results).
+3. **Wraps and enriches** — assigns new `target_id`, `node_id`, and extends the `lineage` chain.
 
 ```json
 {
   "source_guid": "abc-123",
   "content": {"question": "What is MCP?"},
   "target_id": "new-uuid-1",
-  "node_id": "flatten_questions_xyz_0",
-  "lineage": ["extract_qa_previous", "flatten_questions_xyz_0"]
+  "node_id": "deduplicate_facts_xyz_0",
+  "lineage": ["extract_qa_abc", "flatten_questions_def_0", "deduplicate_facts_xyz_0"]
 }
 ```
 

--- a/docs.agent-actions/docs/reference/tools/index.md
+++ b/docs.agent-actions/docs/reference/tools/index.md
@@ -73,21 +73,23 @@ def filter_questions_by_score(data: dict, **kwargs) -> dict:
 
 ### File Granularity
 
-Use when your logic needs cross-record context:
+Use when your logic needs cross-record context. FILE tools receive **full records** with framework metadata (`node_id`, `source_guid`, `lineage`) and a `content` dict containing business data.
 
 ```python
 from agent_actions import udf_tool
 from agent_actions.config.schema import Granularity
 
 @udf_tool(granularity=Granularity.FILE)
-def run_dedup(data: list, **kwargs) -> list:
+def run_dedup(data: list[dict], **kwargs) -> list[dict]:
+    """Dedup — return full records to preserve lineage."""
     seen = set()
     unique = []
     for record in data:
-        fact = record.get('fact', '')
+        content = record.get("content", record)
+        fact = content.get("fact", "")
         if fact not in seen:
             seen.add(fact)
-            unique.append(record)
+            unique.append(record)  # return the full record
     return unique
 ```
 
@@ -97,22 +99,24 @@ File granularity is exclusively supported for tool actions. LLM actions must use
 
 ### File Granularity Constraints
 
-- **Guards are not supported** - Implement filtering logic within your tool instead
-- **Input is an array** - Your function receives the entire array of records
-- **Output flexibility** - Return an array of any size (N→M transformation)
+- **Input is an array of full records** — each record has `content`, `node_id`, `source_guid`, `lineage`
+- **Read business data from `record["content"]["field"]`** — not `record["field"]`
+- **Return the original record for passthrough** (filter, dedup, sort, transform) — preserves `node_id` and lineage
+- **Return a new dict for aggregation** (no `node_id`) — framework creates fresh lineage
+- **Output flexibility** — return an array of any size (N→M transformation)
 
 See [Granularity](../execution/granularity.md) for detailed documentation.
 
-### Metadata is Automatic
+### Record Identity and Lineage
 
-The framework handles all metadata propagation (`source_guid`, lineage, `node_id`) automatically. Tools just return business data:
+The framework tracks each record through the pipeline using `node_id` — inspired by [Apache NiFi's FlowFile model](https://nifi.apache.org/docs/nifi-docs/html/nifi-in-depth.html). You never manage `node_id` directly. The framework handles it automatically based on what you return:
 
 ```python
 from agent_actions import udf_tool
 from agent_actions.config.schema import Granularity
 
 @udf_tool(granularity=Granularity.FILE)
-def dedup_tool(data: list, **kwargs) -> list:
+def dedup_tool(data: list[dict], **kwargs) -> list[dict]:
     seen = {}
     outputs = []
 
@@ -121,12 +125,21 @@ def dedup_tool(data: list, **kwargs) -> list:
         fact = content.get("fact", "")
         if fact not in seen:
             seen[fact] = True
-            outputs.append(content)
+            outputs.append(record)  # full record → lineage extended
 
     return outputs
+
+
+@udf_tool(granularity=Granularity.FILE)
+def aggregate_tool(data: list[dict], **kwargs) -> list[dict]:
+    total = sum(r.get("content", r).get("score", 0) for r in data)
+    return [{"summary": f"Total: {total}", "count": len(data)}]  # new dict → fresh lineage
 ```
 
-The framework infers which inputs produced which outputs and propagates `source_guid` and lineage accordingly. Tools never need to handle framework metadata.
+| What you return | Framework behavior |
+|---|---|
+| Original record dict (has `node_id`) | Extends parent lineage — downstream `observe` can load ancestor data |
+| New dict (no `node_id`) | Creates new root — fresh lineage, no parent |
 
 ## Tool Discovery
 

--- a/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
+++ b/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
@@ -1,8 +1,13 @@
 """
 Aggregate all clause-level risk analyses into a unified contract risk report.
 
-FILE granularity — receives ALL clause records at once and emits a single
-aggregated summary. This is the REDUCE step of the Map-Reduce pattern.
+FILE granularity — receives ALL clause records at once (full records with
+content, node_id, lineage) and emits a single aggregated summary. This is
+the REDUCE step of the Map-Reduce pattern.
+
+Since this tool creates a NEW record (not derived from a single input),
+the output dict has no node_id — the framework treats it as a new root
+with fresh lineage.
 """
 
 from typing import Any

--- a/tests/integration/test_context_scope_audit.py
+++ b/tests/integration/test_context_scope_audit.py
@@ -300,8 +300,13 @@ class TestFileModeObserve:
         """Build a list of file-mode records from content dicts."""
         return [{"content": c, "source_guid": f"sg_{i}"} for i, c in enumerate(contents)]
 
-    def test_file_mode_filters_per_record(self):
-        """observe specific field -> each record filtered to that field only."""
+    def test_file_mode_enriches_per_record(self):
+        """observe specific field -> full record returned with content intact.
+
+        NiFi-inspired: observe enriches records (injects cross-namespace data)
+        rather than stripping to flat dicts. Framework fields and all original
+        content fields are preserved. The tool receives full records.
+        """
         data = self._make_records(
             {"question": "What?", "answer": "42", "noise": "junk"},
             {"question": "Why?", "answer": "because", "noise": "more junk"},
@@ -317,11 +322,16 @@ class TestFileModeObserve:
             agent_indices={"dep": 0, "act": 1},
         )
         assert len(result) == 2
-        assert result[0] == {"question": "What?", "answer": "42"}
-        assert result[1] == {"question": "Why?", "answer": "because"}
+        # Full records preserved — content has all original fields
+        assert result[0]["content"]["question"] == "What?"
+        assert result[0]["content"]["answer"] == "42"
+        assert result[0]["content"]["noise"] == "junk"  # not stripped
+        assert result[0]["source_guid"] == "sg_0"  # framework field preserved
+        assert result[1]["content"]["question"] == "Why?"
+        assert result[1]["content"]["answer"] == "because"
 
     def test_file_mode_wildcard_single_ns_includes_all(self):
-        """observe: ['dep.*'] on input source -> all content fields per record."""
+        """observe: ['dep.*'] on input source -> full record, all content fields."""
         data = self._make_records(
             {"q": "What?", "a": "42"},
             {"q": "Why?", "a": "because"},
@@ -337,8 +347,11 @@ class TestFileModeObserve:
             agent_indices={"dep": 0, "act": 1},
         )
         assert len(result) == 2
-        assert result[0] == {"q": "What?", "a": "42"}
-        assert result[1] == {"q": "Why?", "a": "because"}
+        assert result[0]["content"]["q"] == "What?"
+        assert result[0]["content"]["a"] == "42"
+        assert result[0]["source_guid"] == "sg_0"
+        assert result[1]["content"]["q"] == "Why?"
+        assert result[1]["content"]["a"] == "because"
 
     def test_file_mode_wildcard_does_not_skip_specific_refs(self):
         """observe: ['dep_a.*', 'dep_b.field'] must still resolve dep_b.field.
@@ -364,9 +377,9 @@ class TestFileModeObserve:
             agent_indices={"dep_a": 0, "dep_b": 1, "act": 2},
         )
         assert len(result) == 1
-        # dep_a wildcard should include all content fields
-        assert "text" in result[0]
-        assert "score" in result[0]
+        # dep_a wildcard should include all content fields (in content dict)
+        assert "text" in result[0]["content"]
+        assert "score" in result[0]["content"]
 
     def test_file_mode_no_observe_returns_data_unchanged(self):
         """No observe refs -> data returned as-is."""

--- a/tests/integration/test_context_scope_integrity.py
+++ b/tests/integration/test_context_scope_integrity.py
@@ -848,7 +848,7 @@ class TestFileModeObserve:
     """FILE-mode specific observe behavior."""
 
     def test_file_mode_observe_filters_fields_per_record(self):
-        """FILE-mode observe returns only declared fields for each record in array."""
+        """FILE-mode observe returns full records with all content preserved (NiFi enrichment)."""
         data = [
             {
                 "content": {"title": "Record 1", "body": "Text 1", "secret": "hidden1"},
@@ -879,9 +879,11 @@ class TestFileModeObserve:
 
         assert len(result) == 3
         for i, record in enumerate(result, 1):
-            assert record["title"] == f"Record {i}"
-            assert record["body"] == f"Text {i}"
-            assert "secret" not in record
+            assert record["content"]["title"] == f"Record {i}"
+            assert record["content"]["body"] == f"Text {i}"
+            # NiFi enrichment preserves all original content fields
+            assert record["content"]["secret"] == f"hidden{i}"
+            assert record["source_guid"] == f"sg{i}"
 
     def test_file_mode_observe_preserves_record_order(self):
         """Output array order matches input array order."""
@@ -914,9 +916,9 @@ class TestFileModeObserve:
         )
 
         assert len(result) == 3
-        assert result[0]["name"] == "Charlie"
-        assert result[1]["name"] == "Alice"
-        assert result[2]["name"] == "Bob"
+        assert result[0]["content"]["name"] == "Charlie"
+        assert result[1]["content"]["name"] == "Alice"
+        assert result[2]["content"]["name"] == "Bob"
 
     def test_file_mode_cross_namespace_loading(self):
         """FILE-mode loads ancestor data per-record using ancestry cache."""
@@ -961,15 +963,17 @@ class TestFileModeObserve:
 
         assert len(result) == 1
         # Input source field from record content
-        assert result[0]["text"] == "Biology paper"
-        # Cross-namespace field from historical lookup
-        assert result[0]["category"] == "science"
-        # Excluded fields absent
-        assert "length" not in result[0]
-        assert "score" not in result[0]
+        assert result[0]["content"]["text"] == "Biology paper"
+        # Cross-namespace field injected into content from historical lookup
+        assert result[0]["content"]["category"] == "science"
+        # NiFi enrichment: all original content fields preserved
+        assert result[0]["content"]["length"] == 500
+        # Framework fields preserved at top level
+        assert result[0]["source_guid"] == "sg1"
 
     def test_file_mode_missing_field_warns(self):
-        """FILE-mode: observe references field not in record -> field absent from output."""
+        """FILE-mode: observe references field not in record -> field absent from output,
+        but all original content fields are preserved (NiFi enrichment)."""
         data = [
             {
                 "content": {"title": "Exists", "body": "Also exists", "extra": "here too"},
@@ -989,12 +993,12 @@ class TestFileModeObserve:
         )
 
         assert len(result) == 1
-        assert result[0]["title"] == "Exists"
-        # nonexistent_field is simply absent (not an error in file mode)
-        assert "nonexistent_field" not in result[0]
-        # Other undeclared fields are excluded
-        assert "body" not in result[0]
-        assert "extra" not in result[0]
+        assert result[0]["content"]["title"] == "Exists"
+        # nonexistent_field is simply absent (not injected)
+        assert "nonexistent_field" not in result[0]["content"]
+        # NiFi enrichment: all original content fields are preserved
+        assert result[0]["content"]["body"] == "Also exists"
+        assert result[0]["content"]["extra"] == "here too"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -418,7 +418,9 @@ class TestApplyObserveForFileMode:
         assert result == ["just a string", "another string"]
 
     def test_hitl_merge_back_unaffected(self):
-        """Filtered output is a shallow copy; original_data is unmodified."""
+        """No cross-namespace refs → fast path returns data as-is.
+        Original is unmodified because nothing was injected.
+        """
         original = [
             {"source_guid": "sg-1", "content": {"question": "Q?", "secret": "hidden"}},
         ]
@@ -426,12 +428,10 @@ class TestApplyObserveForFileMode:
         filtered = apply_observe_for_file_mode(
             data=original, agent_config=config, agent_name="test"
         )
-        # NiFi enrichment: content is preserved (no stripping)
         assert filtered[0]["content"]["question"] == "Q?"
         assert filtered[0]["content"]["secret"] == "hidden"
-        # Filtered is a shallow copy, not the same object
-        assert filtered[0] is not original[0]
-        # Original should be unmodified
+        # No cross-namespace refs → fast path returns data directly
+        assert filtered is original
         assert original[0]["content"]["secret"] == "hidden"
 
     def test_source_data_flat_format(self):

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -153,7 +153,7 @@ class TestApplyObserveForFileMode:
     """Integration tests for the main file-mode observe filter."""
 
     def test_cross_namespace_resolution(self):
-        """observe: [upstream.question, source.url] resolves per-record source."""
+        """observe: [upstream.question, source.url] enriches records with cross-ns data."""
         data = [
             {"source_guid": "sg-1", "content": {"question": "What is X?", "answer": "Y"}},
             {"source_guid": "sg-2", "content": {"question": "What is Z?", "answer": "W"}},
@@ -173,8 +173,13 @@ class TestApplyObserveForFileMode:
             source_data=source_data,
         )
         assert len(result) == 2
-        assert result[0] == {"question": "What is X?", "url": "https://one.com"}
-        assert result[1] == {"question": "What is Z?", "url": "https://two.com"}
+        # Full records returned; cross-namespace url injected into content
+        assert result[0]["content"]["question"] == "What is X?"
+        assert result[0]["content"]["url"] == "https://one.com"
+        assert result[0]["source_guid"] == "sg-1"
+        assert result[1]["content"]["question"] == "What is Z?"
+        assert result[1]["content"]["url"] == "https://two.com"
+        assert result[1]["source_guid"] == "sg-2"
 
     def test_multi_dep_collision_distinct_values(self):
         """dep_a.title and dep_b.title from different namespaces get distinct values."""
@@ -203,10 +208,11 @@ class TestApplyObserveForFileMode:
             )
 
         assert len(result) == 1
-        # "title" collides → qualified keys with DIFFERENT values
-        assert result[0]["dep_a.title"] == "Title from A"
-        assert result[0]["dep_b.title"] == "Title from B"
-        assert result[0]["body"] == "Body A"
+        # "title" collides: dep_a.title stays as original "title" in content (input source),
+        # dep_b.title injected with qualified key from historical lookup
+        assert result[0]["content"]["title"] == "Title from A"
+        assert result[0]["content"]["dep_b.title"] == "Title from B"
+        assert result[0]["content"]["body"] == "Body A"
 
     def test_context_source_loading(self):
         """Observe ref targeting an action NOT in dependencies loads via historical."""
@@ -236,22 +242,27 @@ class TestApplyObserveForFileMode:
                 file_path="/tmp/test.json",
             )
 
-        assert result[0] == {"question": "Q?", "category": "science"}
+        assert result[0]["content"]["question"] == "Q?"
+        assert result[0]["content"]["category"] == "science"
+        assert result[0]["source_guid"] == "sg-1"
 
-    def test_backward_compat_single_upstream(self):
-        """Simple single-upstream observe produces identical output to old method."""
+    def test_single_upstream_preserves_full_records(self):
+        """Single-upstream observe returns full records with all content preserved."""
         data = [
-            {"content": {"question": "Q1", "answer": "A1", "extra": "drop"}},
-            {"content": {"question": "Q2", "answer": "A2", "extra": "drop"}},
+            {"content": {"question": "Q1", "answer": "A1", "extra": "kept"}},
+            {"content": {"question": "Q2", "answer": "A2", "extra": "kept"}},
         ]
         config = {
             "context_scope": {"observe": ["upstream.question", "upstream.answer"]},
         }
         result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
         assert len(result) == 2
-        assert list(result[0].keys()) == ["question", "answer"]
-        assert result[0] == {"question": "Q1", "answer": "A1"}
-        assert result[1] == {"question": "Q2", "answer": "A2"}
+        # NiFi enrichment: full records returned, all content fields preserved
+        assert result[0]["content"]["question"] == "Q1"
+        assert result[0]["content"]["answer"] == "A1"
+        assert result[0]["content"]["extra"] == "kept"
+        assert result[1]["content"]["question"] == "Q2"
+        assert result[1]["content"]["answer"] == "A2"
 
     def test_graceful_degradation_unresolvable_namespace(self):
         """Unresolvable namespace warns and skips — doesn't crash."""
@@ -275,8 +286,9 @@ class TestApplyObserveForFileMode:
             agent_indices={"upstream": 0, "review": 1},
             file_path="/tmp/test.json",
         )
-        # Only upstream.question should be present
-        assert result[0] == {"question": "Q?"}
+        # Full record returned; upstream.question present in content
+        assert result[0]["content"]["question"] == "Q?"
+        assert result[0]["source_guid"] == "sg-1"
 
     def test_unresolved_non_input_ns_does_not_leak_record_field(self):
         """Non-input namespace field must NOT fall back to a same-named record field.
@@ -299,7 +311,8 @@ class TestApplyObserveForFileMode:
             },
         }
         # dep_b has no historical data (load returns None) — its field should
-        # be omitted, NOT filled from the primary record's 'score'.
+        # not be injected from cross-namespace. The record's own "score" field
+        # is still in content (NiFi enrichment preserves all original fields).
         with patch(
             "agent_actions.prompt.context.scope_file_mode._load_historical_node",
             return_value=None,
@@ -311,10 +324,12 @@ class TestApplyObserveForFileMode:
                 agent_indices={"dep_a": 0, "dep_b": 1, "merge": 2},
                 file_path="/tmp/test.json",
             )
-        # dep_a.question resolved from record; dep_b.score must be absent.
-        assert result[0] == {"question": "Q?"}
-        assert "score" not in result[0]
-        assert "dep_b.score" not in result[0]
+        # dep_a.question resolved from record content
+        assert result[0]["content"]["question"] == "Q?"
+        # dep_b.score was not injected (no historical data)
+        assert "dep_b.score" not in result[0]["content"]
+        # The record's own "score" field is preserved (NiFi: no stripping)
+        assert result[0]["content"]["score"] == 99
 
     def test_no_deps_with_agent_indices_skips_historical_load(self):
         """Without explicit deps, historical load must NOT shadow live record content.
@@ -350,8 +365,10 @@ class TestApplyObserveForFileMode:
             )
         # Historical load should NOT have been attempted.
         mock_load.assert_not_called()
-        # Live record values must be used.
-        assert result[0] == {"question": "LIVE Q", "answer": "LIVE A"}
+        # Live record values must be used (full record returned).
+        assert result[0]["content"]["question"] == "LIVE Q"
+        assert result[0]["content"]["answer"] == "LIVE A"
+        assert result[0]["source_guid"] == "sg-1"
 
     def test_source_ref_resolves_without_explicit_deps(self):
         """source.url must load from source_data even when no dependencies are declared.
@@ -372,18 +389,20 @@ class TestApplyObserveForFileMode:
             agent_name="review",
             source_data=source_data,
         )
-        assert result[0] == {"question": "Q?", "url": "https://example.com"}
+        assert result[0]["content"]["question"] == "Q?"
+        assert result[0]["content"]["url"] == "https://example.com"
 
     def test_no_observe_returns_data_as_is(self):
         data = [{"content": {"a": 1}}]
         result = apply_observe_for_file_mode(data=data, agent_config={}, agent_name="test")
         assert result is data
 
-    def test_wildcard_returns_all_content_fields(self):
+    def test_wildcard_returns_full_record_with_content(self):
+        """Wildcard observe returns full records with all content preserved."""
         data = [{"content": {"a": 1, "b": 2}}]
         config = {"context_scope": {"observe": ["upstream.*"]}}
         result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-        assert result == [{"a": 1, "b": 2}]
+        assert result[0]["content"] == {"a": 1, "b": 2}
 
     def test_non_dict_records_do_not_crash_heuristic(self):
         """Primitive entries (strings, ints) must not crash the content-key heuristic.
@@ -399,7 +418,7 @@ class TestApplyObserveForFileMode:
         assert result == ["just a string", "another string"]
 
     def test_hitl_merge_back_unaffected(self):
-        """Filtered output is display-only; original_data is separate for merge."""
+        """Filtered output is a shallow copy; original_data is unmodified."""
         original = [
             {"source_guid": "sg-1", "content": {"question": "Q?", "secret": "hidden"}},
         ]
@@ -407,8 +426,11 @@ class TestApplyObserveForFileMode:
         filtered = apply_observe_for_file_mode(
             data=original, agent_config=config, agent_name="test"
         )
-        # Filtered should not contain secret
-        assert "secret" not in filtered[0]
+        # NiFi enrichment: content is preserved (no stripping)
+        assert filtered[0]["content"]["question"] == "Q?"
+        assert filtered[0]["content"]["secret"] == "hidden"
+        # Filtered is a shallow copy, not the same object
+        assert filtered[0] is not original[0]
         # Original should be unmodified
         assert original[0]["content"]["secret"] == "hidden"
 
@@ -426,7 +448,8 @@ class TestApplyObserveForFileMode:
             agent_name="test",
             source_data=source_data,
         )
-        assert result[0] == {"question": "Q?", "url": "https://example.com"}
+        assert result[0]["content"]["question"] == "Q?"
+        assert result[0]["content"]["url"] == "https://example.com"
 
     def test_multi_source_guid_source_namespace(self):
         """Two records with different source_guid get different source.url values."""
@@ -448,8 +471,10 @@ class TestApplyObserveForFileMode:
             agent_name="review",
             source_data=source_data,
         )
-        assert result[0] == {"question": "Q1", "url": "https://a.com"}
-        assert result[1] == {"question": "Q2", "url": "https://b.com"}
+        assert result[0]["content"]["question"] == "Q1"
+        assert result[0]["content"]["url"] == "https://a.com"
+        assert result[1]["content"]["question"] == "Q2"
+        assert result[1]["content"]["url"] == "https://b.com"
 
     def test_multi_source_guid_context_dep(self):
         """Two records with different source_guid trigger separate historical loads."""
@@ -476,8 +501,10 @@ class TestApplyObserveForFileMode:
                 agent_indices={"upstream": 0, "classify": 1, "review": 2},
                 file_path="/tmp/test.json",
             )
-        assert result[0] == {"q": "Q1", "category": "cat-sg-A"}
-        assert result[1] == {"q": "Q2", "category": "cat-sg-B"}
+        assert result[0]["content"]["q"] == "Q1"
+        assert result[0]["content"]["category"] == "cat-sg-A"
+        assert result[1]["content"]["q"] == "Q2"
+        assert result[1]["content"]["category"] == "cat-sg-B"
         assert mock_load.call_count == 2
 
     def test_ancestry_cache_avoids_redundant_loads(self):
@@ -511,8 +538,8 @@ class TestApplyObserveForFileMode:
                 agent_indices={"upstream": 0, "classify": 1, "review": 2},
                 file_path="/tmp/test.json",
             )
-        assert result[0]["category"] == "science"
-        assert result[1]["category"] == "science"
+        assert result[0]["content"]["category"] == "science"
+        assert result[1]["content"]["category"] == "science"
         # Only one load — cache hit for the second record.
         mock_load.assert_called_once()
 
@@ -534,7 +561,9 @@ class TestApplyObserveForFileMode:
             agent_name="review",
             source_data=source_data,
         )
-        assert result[0] == {"q": "Q1", "url": "https://fallback.com"}
+        assert result[0]["content"]["q"] == "Q1"
+        assert result[0]["content"]["url"] == "https://fallback.com"
+        assert result[0]["source_guid"] == "sg-unknown"
 
     def test_fan_in_non_primary_dep_loaded_historically(self):
         """In a fan-in flow, non-primary deps must be loaded via historical lookup."""
@@ -563,8 +592,10 @@ class TestApplyObserveForFileMode:
                 agent_indices={"dep_a": 0, "dep_b": 1, "merge": 2},
                 file_path="/tmp/test.json",
             )
-        # dep_a.question comes from record content; dep_b.score from historical.
-        assert result[0] == {"question": "Q?", "score": 42}
+        # dep_a.question from record content; dep_b.score injected from historical.
+        assert result[0]["content"]["question"] == "Q?"
+        assert result[0]["content"]["score"] == 42
+        assert result[0]["source_guid"] == "sg-1"
         mock_load.assert_called_once()
 
     def test_ancestry_divergent_records_get_separate_lookups(self):
@@ -606,7 +637,9 @@ class TestApplyObserveForFileMode:
                 agent_indices={"upstream": 0, "classify": 1, "review": 2},
                 file_path="/tmp/test.json",
             )
-        assert result[0] == {"q": "Q1", "label": "label-A"}
-        assert result[1] == {"q": "Q2", "label": "label-B"}
+        assert result[0]["content"]["q"] == "Q1"
+        assert result[0]["content"]["label"] == "label-A"
+        assert result[1]["content"]["q"] == "Q2"
+        assert result[1]["content"]["label"] == "label-B"
         # Two separate loads — different ancestry despite same source_guid.
         assert call_count[0] == 2

--- a/tests/unit/workflow/test_file_mode_source_mapping.py
+++ b/tests/unit/workflow/test_file_mode_source_mapping.py
@@ -1,0 +1,194 @@
+"""Tests for FILE-mode source mapping via node_id (NiFi-inspired).
+
+The framework preserves node_id through the observe filter. Tools receive
+full records with identity. The framework matches outputs to inputs by
+node_id — one approach, no heuristics.
+"""
+
+from __future__ import annotations
+
+from agent_actions.workflow.pipeline_file_mode import _resolve_source_mapping
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _input(idx: int, *, node_id: str | None = None) -> dict:
+    """Build a minimal input record with framework metadata."""
+    item: dict = {
+        "source_guid": "sg-A",
+        "content": {"question": f"Q{idx}", "idx": idx},
+        "lineage": [f"upstream_{idx}"],
+    }
+    if node_id is not None:
+        item["node_id"] = node_id
+    return item
+
+
+# ===================================================================
+# Core: node_id matching
+# ===================================================================
+
+
+class TestNodeIdMatching:
+    """The one approach: match outputs to inputs by node_id."""
+
+    def test_passthrough_dedup_drops_middle_record(self):
+        """7 inputs, tool drops record [3], 6 outputs with node_id intact."""
+        inputs = [_input(i, node_id=f"flatten_q{i}") for i in range(7)]
+        outputs = [{"node_id": f"flatten_q{i}", "question": f"Q{i}"} for i in range(7) if i != 3]
+        mapping = _resolve_source_mapping(outputs, inputs, "dedup")
+        assert mapping == {0: 0, 1: 1, 2: 2, 3: 4, 4: 5, 5: 6}
+
+    def test_passthrough_filter_reorders(self):
+        """Tool returns records [4, 1, 0] — reordered subset."""
+        inputs = [_input(i, node_id=f"n{i}") for i in range(5)]
+        outputs = [{"node_id": "n4"}, {"node_id": "n1"}, {"node_id": "n0"}]
+        mapping = _resolve_source_mapping(outputs, inputs, "filter")
+        assert mapping == {0: 4, 1: 1, 2: 0}
+
+    def test_transform_preserves_identity(self):
+        """Tool modifies content but keeps node_id — same count, matched."""
+        inputs = [_input(i, node_id=f"n{i}") for i in range(3)]
+        outputs = [
+            {"node_id": "n0", "question": "Q0_UPPER"},
+            {"node_id": "n1", "question": "Q1_UPPER"},
+            {"node_id": "n2", "question": "Q2_UPPER"},
+        ]
+        mapping = _resolve_source_mapping(outputs, inputs, "transform")
+        assert mapping == {0: 0, 1: 1, 2: 2}
+
+    def test_single_record_passthrough(self):
+        """1 input, 1 output with matching node_id."""
+        inputs = [_input(0, node_id="n0")]
+        outputs = [{"node_id": "n0", "result": "done"}]
+        mapping = _resolve_source_mapping(outputs, inputs, "tool")
+        assert mapping == {0: 0}
+
+
+# ===================================================================
+# New records: no node_id = no parent
+# ===================================================================
+
+
+class TestNewRecords:
+    """Outputs without node_id are new records — fresh lineage, no parent."""
+
+    def test_aggregation_creates_new_record(self):
+        """Tool merges 5 inputs into 1 new record. No node_id on output."""
+        inputs = [_input(i, node_id=f"n{i}") for i in range(5)]
+        outputs = [{"summary": "aggregated result"}]
+        mapping = _resolve_source_mapping(outputs, inputs, "aggregate")
+        assert mapping == {}
+
+    def test_expansion_creates_new_records(self):
+        """Tool generates 5 new records from 1 input. No node_id on outputs."""
+        inputs = [_input(0, node_id="n0")]
+        outputs = [{"generated": f"item_{i}"} for i in range(5)]
+        mapping = _resolve_source_mapping(outputs, inputs, "expand")
+        assert mapping == {}
+
+    def test_mixed_passthrough_and_new(self):
+        """Some outputs have node_id (passthrough), some don't (new)."""
+        inputs = [_input(i, node_id=f"n{i}") for i in range(3)]
+        outputs = [
+            {"node_id": "n0", "original": True},  # passthrough
+            {"summary": "new record"},  # new
+            {"node_id": "n2", "original": True},  # passthrough
+        ]
+        mapping = _resolve_source_mapping(outputs, inputs, "mixed")
+        # Only indices 0 and 2 are in the mapping. Index 1 is a new record.
+        assert mapping == {0: 0, 2: 2}
+
+    def test_empty_outputs(self):
+        """Tool returns empty list."""
+        inputs = [_input(0, node_id="n0")]
+        mapping = _resolve_source_mapping([], inputs, "tool")
+        assert mapping == {}
+
+    def test_empty_inputs(self):
+        """No inputs (shouldn't happen in practice but handle gracefully)."""
+        outputs = [{"result": "something"}]
+        mapping = _resolve_source_mapping(outputs, [], "tool")
+        assert mapping == {}
+
+
+# ===================================================================
+# Edge cases
+# ===================================================================
+
+
+class TestEdgeCases:
+    """Boundary conditions and defensive behavior."""
+
+    def test_unknown_node_id_warns_and_treats_as_new(self):
+        """Output has node_id not matching any input — treated as new record."""
+        inputs = [_input(0, node_id="n0")]
+        outputs = [{"node_id": "n_unknown", "data": "x"}]
+        mapping = _resolve_source_mapping(outputs, inputs, "tool")
+        assert mapping == {}
+
+    def test_non_dict_output_skipped(self):
+        """Non-dict items in output are skipped (no crash)."""
+        inputs = [_input(0, node_id="n0")]
+        outputs = ["not a dict", {"node_id": "n0", "data": "x"}]
+        mapping = _resolve_source_mapping(outputs, inputs, "tool")
+        # Only index 1 matched. Index 0 was a non-dict.
+        assert mapping == {1: 0}
+
+    def test_inputs_without_node_id(self):
+        """Inputs have no node_id (first-stage data) — nothing to match."""
+        inputs = [_input(i) for i in range(3)]  # no node_id
+        outputs = [{"data": "x"}]
+        mapping = _resolve_source_mapping(outputs, inputs, "tool")
+        assert mapping == {}
+
+    def test_non_string_node_id_skipped(self):
+        """Output with non-string node_id is treated as new record."""
+        inputs = [_input(0, node_id="n0")]
+        outputs = [{"node_id": 42, "data": "x"}]
+        mapping = _resolve_source_mapping(outputs, inputs, "tool")
+        assert mapping == {}
+
+
+# ===================================================================
+# The reported bug scenario
+# ===================================================================
+
+
+class TestReportedBug:
+    """Reproduce the exact scenario from the bug report."""
+
+    def test_dedup_shared_guid_7_to_6(self):
+        """7 records from same page (shared source_guid), dedup to 6.
+
+        Before fix: all outputs mapped to input[0] (broadcast-to-first).
+        After fix: each output matched to its specific input by node_id.
+        """
+        questions = [
+            "security isolation violations",
+            "capability negotiation extensibility",
+            "multiple MCP servers",
+            "unique ID in requests",
+            "HTTP vs STDIO",
+            "structure spec compliance",
+            "security isolation violations v2",  # duplicate of [0]
+        ]
+        inputs = [
+            {
+                "source_guid": "sg-page1",
+                "node_id": f"flatten_q{i}",
+                "lineage": [f"flatten_q{i}"],
+                "content": {"question": q, "idx": i},
+            }
+            for i, q in enumerate(questions)
+        ]
+        # Dedup drops record [6] (duplicate). Returns 6 with node_ids.
+        outputs = [
+            {"node_id": f"flatten_q{i}", "question": q, "idx": i}
+            for i, q in enumerate(questions[:6])
+        ]
+        mapping = _resolve_source_mapping(outputs, inputs, "dedup")
+        # Each output maps to its correct input — NOT all to input[0].
+        assert mapping == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -59,16 +59,16 @@ def test_file_udf_result_unwrapped():
 
 
 def test_file_udf_result_source_mapping_auto_inferred():
-    """Framework always infers source_mapping — tools never provide it."""
+    """Framework resolves source_mapping by node_id — tools never provide it."""
     pipeline, context = _make_pipeline_and_context()
 
     udf_result = FileUDFResult(
-        outputs=[{"name": "alice"}, {"name": "bob"}],
+        outputs=[{"name": "alice", "node_id": "n1"}, {"name": "bob", "node_id": "n2"}],
     )
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "content": {"id": 2}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
     ]
 
     with patch(
@@ -77,33 +77,33 @@ def test_file_udf_result_source_mapping_auto_inferred():
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Framework inferred identity mapping (2 in, 2 out)
+    # Framework resolved mapping via node_id
     assert results[0].source_mapping == {0: 0, 1: 1}
 
 
 def test_file_tool_plain_list_auto_infers_identity_mapping():
-    """Plain list return with same count auto-infers identity source_mapping."""
+    """Plain list return with node_id resolves source_mapping via node_id match."""
     pipeline, context = _make_pipeline_and_context()
 
-    input_data = [{"source_guid": "sg-1", "content": {"id": 1}}]
+    input_data = [{"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}}]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"score": 0.9}], True),
+        return_value=([{"score": 0.9, "node_id": "n1"}], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Auto-inferred identity mapping (same input/output count)
+    # Resolved mapping via node_id
     assert results[0].source_mapping == {0: 0}
 
 
 def test_file_udf_result_mapping_always_inferred():
-    """FileUDFResult triggers framework-inferred mapping like plain lists."""
+    """FileUDFResult resolves mapping via node_id like plain lists."""
     pipeline, context = _make_pipeline_and_context()
 
-    udf_result = FileUDFResult(outputs=[{"name": "alice"}])
+    udf_result = FileUDFResult(outputs=[{"name": "alice", "node_id": "n1"}])
 
-    input_data = [{"source_guid": "sg-1", "content": {"id": 1}}]
+    input_data = [{"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}}]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
@@ -111,7 +111,7 @@ def test_file_udf_result_mapping_always_inferred():
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Framework inferred identity mapping (1 in, 1 out)
+    # Framework resolved mapping via node_id
     assert results[0].source_mapping == {0: 0}
 
 
@@ -548,18 +548,18 @@ def test_result_collector_does_not_raise_when_all_filtered():
 
 
 def test_file_tool_plain_list_preserves_source_guid():
-    """Plain list tool output gets source_guid from input via identity mapping."""
+    """Plain list tool output gets source_guid from input via node_id mapping."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "content": {"id": 2}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
     ]
 
-    # Tool returns plain list — no source_guid, no FileUDFResult
+    # Tool returns plain list with node_id — no source_guid, no FileUDFResult
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"score": 0.9}, {"score": 0.8}], True),
+        return_value=([{"score": 0.9, "node_id": "n1"}, {"score": 0.8, "node_id": "n2"}], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -568,73 +568,73 @@ def test_file_tool_plain_list_preserves_source_guid():
     assert result.data[1]["source_guid"] == "sg-2"
 
 
-def test_file_tool_filter_fewer_outputs_uses_first_source_guid():
-    """When tool filters N→fewer with mixed source_guids, all outputs get first input's source_guid."""
+def test_file_tool_filter_fewer_outputs_with_node_id():
+    """When tool filters N→fewer, outputs with node_id get correct source_guid."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "content": {"id": 2}},
-        {"source_guid": "sg-3", "content": {"id": 3}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
+        {"source_guid": "sg-3", "node_id": "n3", "content": {"id": 3}},
     ]
 
-    # Tool filters 3→2 (no mapping — framework can't know which were kept)
+    # Tool filters 3→2, passes through node_id for matched records
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"name": "alice"}, {"name": "charlie"}], True),
+        return_value=(
+            [{"name": "alice", "node_id": "n1"}, {"name": "charlie", "node_id": "n3"}],
+            True,
+        ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
     result = results[0]
-    # All outputs get first input's source_guid (framework fallback)
+    # node_id-based mapping resolves correct source_guids
     assert result.data[0]["source_guid"] == "sg-1"
-    assert result.data[1]["source_guid"] == "sg-1"
+    assert result.data[1]["source_guid"] == "sg-3"
 
 
-def test_file_tool_shared_source_guid_broadcast():
-    """When all inputs share source_guid, all outputs inherit it regardless of cardinality."""
+def test_file_tool_new_records_without_node_id_get_no_source_guid():
+    """Tool outputs without node_id are new records — no source_guid reattached."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-shared", "content": {"q": "A"}},
-        {"source_guid": "sg-shared", "content": {"q": "B"}},
+        {"source_guid": "sg-shared", "node_id": "n1", "content": {"q": "A"}},
+        {"source_guid": "sg-shared", "node_id": "n2", "content": {"q": "B"}},
     ]
 
-    # Tool returns different count — no explicit mapping
+    # Tool returns new records (no node_id) — these are new, not passthrough
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=([{"q": "A1"}, {"q": "A2"}, {"q": "B1"}], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # All outputs inherit the shared source_guid
+    # No node_id in outputs → empty mapping (new records, no parent)
+    assert results[0].source_mapping == {}
+    # Enrichment pipeline sets source_guid="" on new records (no parent to inherit from)
     for item in results[0].data:
-        assert item["source_guid"] == "sg-shared"
+        assert item.get("source_guid") == ""
 
 
-def test_file_tool_cardinality_change_without_mapping_still_sets_source_guid(capsys):
-    """N→M without mapping still sets source_guid on all outputs."""
+def test_file_tool_cardinality_change_new_records_get_empty_mapping():
+    """N→M with new records (no node_id) produces empty source_mapping."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"q": "A"}},
-        {"source_guid": "sg-2", "content": {"q": "B"}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"q": "A"}},
+        {"source_guid": "sg-2", "node_id": "n2", "content": {"q": "B"}},
     ]
 
-    # Tool returns different count, mixed source_guids, no mapping
+    # Tool returns different count, no node_id → all new records
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=([{"q": "X"}, {"q": "Y"}, {"q": "Z"}], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Warning emitted about cardinality change (to stderr via logger)
-    captured = capsys.readouterr()
-    assert "changed cardinality" in captured.err
-
-    # All outputs still have source_guid (not empty, not None)
-    for item in results[0].data:
-        assert item.get("source_guid"), f"source_guid missing or empty: {item}"
+    # No node_id → empty mapping (new records, no parent)
+    assert results[0].source_mapping == {}
 
 
 def test_file_tool_source_guid_never_empty_string():
@@ -642,12 +642,12 @@ def test_file_tool_source_guid_never_empty_string():
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
     ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"result": "ok"}], True),
+        return_value=([{"result": "ok", "node_id": "n1"}], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -679,31 +679,35 @@ def test_file_tool_tool_explicit_source_guid_respected():
 
 
 def test_file_tool_mixed_source_guid_some_set_some_not():
-    """Tool returns mix of items with and without source_guid — framework fills gaps."""
+    """Tool returns mix of items with and without source_guid — framework fills gaps via node_id."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "content": {"id": 2}},
-        {"source_guid": "sg-3", "content": {"id": 3}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
+        {"source_guid": "sg-3", "node_id": "n3", "content": {"id": 3}},
     ]
 
-    # Tool sets source_guid on item[1] but not on [0] or [2]
+    # Tool sets source_guid on item[1] but not on [0] or [2]; node_id on [0] and [2]
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=(
-            [{"val": "a"}, {"val": "b", "source_guid": "sg-tool-explicit"}, {"val": "c"}],
+            [
+                {"val": "a", "node_id": "n1"},
+                {"val": "b", "source_guid": "sg-tool-explicit"},
+                {"val": "c", "node_id": "n3"},
+            ],
             True,
         ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
     result = results[0]
-    # Item 0: no explicit source_guid → framework reattaches from input[0]
+    # Item 0: no explicit source_guid, node_id matched → framework reattaches from input[0]
     assert result.data[0]["source_guid"] == "sg-1"
-    # Item 1: tool explicitly set it → respected
+    # Item 1: tool explicitly set it → respected (no node_id, so not in mapping)
     assert result.data[1]["source_guid"] == "sg-tool-explicit"
-    # Item 2: no explicit source_guid → framework reattaches from input[2]
+    # Item 2: no explicit source_guid, node_id matched → framework reattaches from input[2]
     assert result.data[2]["source_guid"] == "sg-3"
 
 
@@ -747,32 +751,33 @@ def test_file_tool_non_dict_output_items():
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
     ]
 
-    # Tool returns a non-dict item (string)
+    # Tool returns a non-dict item (string) — no node_id possible, treated as new record
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=(["just a string"], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Non-dict wrapped as {"content": {"value": ...}} — source_guid reattached
-    assert results[0].data[0]["source_guid"] == "sg-1"
+    # Non-dict wrapped as {"content": {"value": ...}} — no node_id, so no mapping
     assert results[0].data[0]["content"]["value"] == "just a string"
+    # New record — enrichment pipeline sets source_guid="" (no parent to inherit from)
+    assert results[0].data[0].get("source_guid") == ""
 
 
 def test_file_tool_merge_reduces_to_fewer_outputs():
-    """N→fewer merge: framework broadcasts first input's source_guid."""
+    """N→fewer merge: new records (no node_id) get empty mapping."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"q": "A"}},
-        {"source_guid": "sg-2", "content": {"q": "B"}},
-        {"source_guid": "sg-3", "content": {"q": "C"}},
+        {"source_guid": "sg-1", "node_id": "n1", "content": {"q": "A"}},
+        {"source_guid": "sg-2", "node_id": "n2", "content": {"q": "B"}},
+        {"source_guid": "sg-3", "node_id": "n3", "content": {"q": "C"}},
     ]
 
-    # Tool merges 3→2 (framework can't know which merged)
+    # Tool merges 3→2 — new records with no node_id (aggregation results)
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=([{"merged": "AB"}, {"single": "C"}], True),
@@ -780,98 +785,97 @@ def test_file_tool_merge_reduces_to_fewer_outputs():
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
     result = results[0]
-    # All outputs get first input's source_guid (fallback for mixed guids)
-    for item in result.data:
-        assert item["source_guid"] == "sg-1"
+    # New records — no node_id → empty mapping, no source_guid reattached
+    assert result.source_mapping == {}
 
 
 def test_file_tool_large_cardinality_expansion():
-    """1→N expansion: all outputs inherit the single input's source_guid."""
+    """1→N expansion: outputs with node_id inherit source_guid, others are new."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-only", "content": {"nested": [1, 2, 3, 4, 5]}},
+        {"source_guid": "sg-only", "node_id": "n1", "content": {"nested": [1, 2, 3, 4, 5]}},
     ]
 
-    # Tool explodes 1 input into 5 outputs
+    # Tool explodes 1 input into 5 new outputs (no node_id — aggregation/expansion)
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=([{"val": i} for i in range(5)], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # All 5 outputs inherit the single input's source_guid (shared-source shortcut)
-    for item in results[0].data:
-        assert item["source_guid"] == "sg-only"
+    # No node_id on outputs → empty mapping (new records)
+    assert results[0].source_mapping == {}
+    assert len(results[0].data) == 5
 
 
-# --- Hardening: _infer_source_mapping unit tests ---
+# --- Hardening: _resolve_source_mapping unit tests ---
 
 
-class TestInferSourceMapping:
-    """Direct unit tests for _infer_source_mapping logic."""
+class TestResolveSourceMapping:
+    """Direct unit tests for _resolve_source_mapping logic."""
 
-    def test_identity_when_counts_match(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
+    def test_matches_by_node_id(self):
+        from agent_actions.workflow.pipeline_file_mode import _resolve_source_mapping
 
-        result = _infer_source_mapping(
-            output_count=3,
-            input_data=[{"source_guid": "a"}, {"source_guid": "b"}, {"source_guid": "c"}],
+        result = _resolve_source_mapping(
+            raw_outputs=[{"node_id": "a"}, {"node_id": "b"}, {"node_id": "c"}],
+            input_data=[{"node_id": "a"}, {"node_id": "b"}, {"node_id": "c"}],
             action_name="test",
         )
         assert result == {0: 0, 1: 1, 2: 2}
 
-    def test_broadcast_when_shared_source_guid(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
+    def test_reordered_outputs_match_correctly(self):
+        from agent_actions.workflow.pipeline_file_mode import _resolve_source_mapping
 
-        result = _infer_source_mapping(
-            output_count=5,
-            input_data=[{"source_guid": "sg-shared"}, {"source_guid": "sg-shared"}],
+        result = _resolve_source_mapping(
+            raw_outputs=[{"node_id": "c"}, {"node_id": "a"}],
+            input_data=[{"node_id": "a"}, {"node_id": "b"}, {"node_id": "c"}],
             action_name="test",
         )
-        assert result == {0: 0, 1: 0, 2: 0, 3: 0, 4: 0}
+        assert result == {0: 2, 1: 0}
 
-    def test_fallback_when_ambiguous(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
+    def test_no_node_id_in_outputs_returns_empty(self):
+        from agent_actions.workflow.pipeline_file_mode import _resolve_source_mapping
 
-        result = _infer_source_mapping(
-            output_count=3,
-            input_data=[{"source_guid": "sg-1"}, {"source_guid": "sg-2"}],
+        result = _resolve_source_mapping(
+            raw_outputs=[{"val": "x"}, {"val": "y"}, {"val": "z"}],
+            input_data=[{"node_id": "a"}, {"node_id": "b"}],
             action_name="test",
         )
-        # Fallback: all map to first input
-        assert result == {0: 0, 1: 0, 2: 0}
+        # No node_id on outputs → all new records → empty mapping
+        assert result == {}
 
-    def test_zero_output_returns_empty_mapping(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
+    def test_zero_outputs_returns_empty_mapping(self):
+        from agent_actions.workflow.pipeline_file_mode import _resolve_source_mapping
 
-        result = _infer_source_mapping(
-            output_count=0,
-            input_data=[{"source_guid": "sg-1"}],
+        result = _resolve_source_mapping(
+            raw_outputs=[],
+            input_data=[{"node_id": "a"}],
             action_name="test",
         )
         assert result == {}
 
-    def test_zero_input_returns_identity_if_zero_output(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
+    def test_zero_inputs_returns_empty_mapping(self):
+        from agent_actions.workflow.pipeline_file_mode import _resolve_source_mapping
 
-        result = _infer_source_mapping(
-            output_count=0,
+        result = _resolve_source_mapping(
+            raw_outputs=[],
             input_data=[],
             action_name="test",
         )
         assert result == {}
 
-    def test_input_without_source_guid_falls_to_broadcast(self):
-        from agent_actions.workflow.pipeline_file_mode import _infer_source_mapping
+    def test_input_without_node_id_not_matchable(self):
+        from agent_actions.workflow.pipeline_file_mode import _resolve_source_mapping
 
-        result = _infer_source_mapping(
-            output_count=3,
-            input_data=[{"content": "no guid"}, {"content": "also none"}],
+        result = _resolve_source_mapping(
+            raw_outputs=[{"node_id": "a"}, {"node_id": "b"}],
+            input_data=[{"content": "no nid"}, {"content": "also none"}],
             action_name="test",
         )
-        # No source_guids → empty set → len != 1 → falls to broadcast warning
-        assert result == {0: 0, 1: 0, 2: 0}
+        # No node_id on inputs → nothing to match → empty mapping
+        assert result == {}
 
 
 # --- Hardening: _reattach_source_guid unit tests ---

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -523,14 +523,14 @@ def test_new_observe_no_observe_returns_data_as_is():
 
 
 def test_new_observe_handles_flat_records():
-    """Records without content wrapper: NiFi enrichment preserves all fields."""
+    """Records without content wrapper: no cross-ns refs → fast path returns as-is."""
     data = [{"question": "Q1", "answer": "A1", "extra": "keep"}]
     config = {"context_scope": {"observe": ["upstream.answer", "upstream.question"]}}
     result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-    # Flat records get content added; all original fields preserved
-    assert result[0]["content"]["answer"] == "A1"
-    assert result[0]["content"]["question"] == "Q1"
-    assert result[0]["content"]["extra"] == "keep"
+    # No cross-namespace refs → fast path returns data unmodified
+    assert result[0]["answer"] == "A1"
+    assert result[0]["question"] == "Q1"
+    assert result[0]["extra"] == "keep"
 
 
 def test_new_observe_wildcard_returns_all_content_fields():

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -351,11 +351,13 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
         agent_name="review_data",
     )
 
-    # Filtered records should only contain observe fields in defined order
-    assert list(filtered[0].keys()) == ["question", "answer"]
-    assert list(filtered[1].keys()) == ["question", "answer"]
-    assert filtered[0]["question"] == "What is X?"
-    assert filtered[1]["answer"] == "Z is W"
+    # NiFi enrichment: filtered records are full records with all content preserved
+    assert filtered[0]["content"]["question"] == "What is X?"
+    assert filtered[0]["content"]["answer"] == "X is Y"
+    # All original content fields preserved (no stripping)
+    assert filtered[0]["content"]["selectedAnswerer"] == "Alice"
+    assert filtered[0]["source_guid"] == "sg-1"
+    assert filtered[1]["content"]["answer"] == "Z is W"
 
     # Verify HITL receives filtered data but merge uses original_data
     captured_context = {}
@@ -373,9 +375,8 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
     ):
         results = pipeline._process_file_mode_hitl(filtered, original_data, context)
 
-    # HITL UI should have received only filtered fields
-    assert list(captured_context["context"][0].keys()) == ["question", "answer"]
-    assert "selectedAnswerer" not in captured_context["context"][0]
+    # HITL UI receives full enriched records
+    assert captured_context["context"][0]["content"]["question"] == "What is X?"
 
     # Output merge should preserve ALL original content fields
     assert len(results) == 1
@@ -522,37 +523,36 @@ def test_new_observe_no_observe_returns_data_as_is():
 
 
 def test_new_observe_handles_flat_records():
-    """Records without content wrapper should be filtered directly."""
-    data = [{"question": "Q1", "answer": "A1", "extra": "drop"}]
+    """Records without content wrapper: NiFi enrichment preserves all fields."""
+    data = [{"question": "Q1", "answer": "A1", "extra": "keep"}]
     config = {"context_scope": {"observe": ["upstream.answer", "upstream.question"]}}
     result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-    assert list(result[0].keys()) == ["answer", "question"]
-    assert result[0]["answer"] == "A1"
+    # Flat records get content added; all original fields preserved
+    assert result[0]["content"]["answer"] == "A1"
+    assert result[0]["content"]["question"] == "Q1"
+    assert result[0]["content"]["extra"] == "keep"
 
 
 def test_new_observe_wildcard_returns_all_content_fields():
-    """observe: ['upstream.*'] should return all content fields from each record."""
+    """observe: ['upstream.*'] should return full records with all content preserved."""
     data = [
         {"content": {"question": "Q1", "answer": "A1", "extra": "keep"}},
         {"content": {"question": "Q2", "answer": "A2", "extra": "also keep"}},
     ]
     config = {"context_scope": {"observe": ["upstream.*"]}}
     result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-    assert result == [
-        {"question": "Q1", "answer": "A1", "extra": "keep"},
-        {"question": "Q2", "answer": "A2", "extra": "also keep"},
-    ]
+    assert result[0]["content"] == {"question": "Q1", "answer": "A1", "extra": "keep"}
+    assert result[1]["content"] == {"question": "Q2", "answer": "A2", "extra": "also keep"}
 
 
 def test_new_observe_collision_uses_qualified_keys():
-    """When two refs share the same bare key, both appear with qualified keys.
+    """When two refs share the same bare key with NiFi enrichment.
 
     NOTE: No agent_indices/file_path provided, so dep_b cannot load
-    historically and falls through to content lookup — both qualified keys
-    get the same value.  This test exercises key-naming (qualified vs bare),
-    not cross-namespace value accuracy; see
-    TestApplyObserveForFileMode.test_multi_dep_collision_distinct_values
-    in test_file_mode_observe.py for the distinct-value assertion.
+    historically and falls through to content lookup. With NiFi enrichment,
+    the original content fields are preserved as-is (no qualified key
+    renaming for input-source fields). The original 'title' and 'body'
+    remain in content.
     """
     data = [{"content": {"title": "My Title", "body": "My Body"}}]
     config = {
@@ -561,18 +561,19 @@ def test_new_observe_collision_uses_qualified_keys():
         },
     }
     result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-    assert list(result[0].keys()) == ["dep_a.title", "dep_b.title", "body"]
-    assert result[0]["dep_a.title"] == "My Title"
-    assert result[0]["dep_b.title"] == "My Title"  # same value — see docstring
-    assert result[0]["body"] == "My Body"
+    # NiFi enrichment: full record with original content preserved
+    assert result[0]["content"]["title"] == "My Title"
+    assert result[0]["content"]["body"] == "My Body"
 
 
 def test_new_observe_no_collision_stays_bare():
-    """When all refs have unique bare keys, output keys remain bare."""
+    """When all refs have unique bare keys, content fields are preserved."""
     data = [{"content": {"question": "Q1", "answer": "A1"}}]
     config = {"context_scope": {"observe": ["upstream.question", "upstream.answer"]}}
     result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-    assert list(result[0].keys()) == ["question", "answer"]
+    # NiFi enrichment: full record returned with content preserved
+    assert result[0]["content"]["question"] == "Q1"
+    assert result[0]["content"]["answer"] == "A1"
 
 
 def test_new_observe_invalid_ref_does_not_misalign_pairs():
@@ -584,7 +585,6 @@ def test_new_observe_invalid_ref_does_not_misalign_pairs():
         },
     }
     result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-    assert list(result[0].keys()) == ["dep_a.title", "dep_b.title", "body"]
-    assert result[0]["dep_a.title"] == "T"
-    assert result[0]["dep_b.title"] == "T"
-    assert result[0]["body"] == "B"
+    # NiFi enrichment: full record with original content preserved
+    assert result[0]["content"]["title"] == "T"
+    assert result[0]["content"]["body"] == "B"


### PR DESCRIPTION
## Summary

Adopt Apache NiFi's FlowFile principle for FILE-mode record tracking:
the framework preserves record identity (`node_id`) through every stage.
Tools receive full records, pass them through, and the framework matches
outputs to inputs by `node_id`. No heuristics, no guessing.

**Two production changes:**

1. **Observe filter enriches instead of strips** — `apply_observe_for_file_mode`
   now injects cross-namespace data into `record["content"]` while preserving
   all framework fields (`node_id`, `source_guid`, `lineage`). Tools receive
   full records instead of flat dicts.

2. **Single matching approach** — `_infer_source_mapping` (count-based heuristics,
   source_guid broadcasting) replaced with `_resolve_source_mapping` (node_id
   lookup). Outputs with `node_id` → extend parent lineage. Outputs without
   → new records, fresh lineage. One approach.

**Breaking change:** FILE-mode tools receive full records. Tool authors access
business data via `record["content"]["field"]` instead of `record["field"]`.
Dev-phase only, no external users affected.

**Design:** See `specs/034-file-mode-record-identity.md` for the full spec
with NiFi references and design rationale.

## Verification

- 5304 tests passed, 0 failed
- 15 new tests for `_resolve_source_mapping` (node_id matching, new records, edge cases)
- 44 existing tests updated for full-record observe output
- ruff format/check clean on all changed files
- Cross-namespace observe resolution verified working (enriches into content)