### PR TITLE
feat: self-reflection feedback strategy for reprompt retries

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260414-100000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260414-100000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add self-reflection feedback strategy for reprompt retries (use_self_reflection config option)"
+time: 2026-04-14T10:00:00.000000Z

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -104,6 +104,10 @@ class RepromptConfig(BaseModel):
         default="return_last",
         description="Behavior when max_attempts exhausted: return_last or raise",
     )
+    use_self_reflection: bool = Field(
+        default=False,
+        description="Include self-reflection instruction in retry prompts",
+    )
 
 
 class HitlConfig(BaseModel):

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -55,6 +55,7 @@ def validate_and_reprompt(
     from agent_actions.processing.recovery.reprompt import parse_reprompt_config
     from agent_actions.processing.recovery.response_validator import (
         build_validation_feedback,
+        resolve_feedback_strategies,
         safe_validate,
     )
     from agent_actions.processing.recovery.validation import get_validation_function
@@ -74,6 +75,7 @@ def validate_and_reprompt(
     validation_name = parsed.validation_name
     max_attempts = parsed.max_attempts
     on_exhausted = parsed.on_exhausted
+    strategies = resolve_feedback_strategies(raw_reprompt_config)
 
     _load_validation_udf(agent_config, raw_reprompt_config or {})
 
@@ -155,6 +157,7 @@ def validate_and_reprompt(
             feedback = build_validation_feedback(
                 failed_response=failed_result.content,
                 feedback_message=feedback_message,
+                strategies=strategies,
             )
 
             original_user_content = original_record.get("user_content", "")
@@ -340,14 +343,19 @@ def submit_reprompt_batch(
         BatchTaskPreparator,
     )
     from agent_actions.processing.recovery.reprompt import parse_reprompt_config
-    from agent_actions.processing.recovery.response_validator import build_validation_feedback
+    from agent_actions.processing.recovery.response_validator import (
+        build_validation_feedback,
+        resolve_feedback_strategies,
+    )
     from agent_actions.processing.recovery.validation import get_validation_function
 
-    parsed = parse_reprompt_config((agent_config or {}).get("reprompt", {}))
+    raw_reprompt_config = (agent_config or {}).get("reprompt", {})
+    parsed = parse_reprompt_config(raw_reprompt_config)
     if parsed is None:
         return None
 
     validation_name = parsed.validation_name
+    strategies = resolve_feedback_strategies(raw_reprompt_config)
 
     try:
         _, feedback_message = get_validation_function(validation_name)
@@ -367,6 +375,7 @@ def submit_reprompt_batch(
         feedback = build_validation_feedback(
             failed_response=failed_result.content,
             feedback_message=feedback_message,
+            strategies=strategies,
         )
 
         original_user_content = original_record.get("user_content", "")

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -11,6 +10,7 @@ from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.validation_events import RepromptValidationFailedEvent
 
 from .response_validator import (
+    FeedbackStrategy,
     UdfValidator,
     build_validation_feedback,
     resolve_feedback_strategies,
@@ -18,6 +18,8 @@ from .response_validator import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .response_validator import ResponseValidator
 
 logger = logging.getLogger(__name__)
@@ -70,7 +72,7 @@ class RepromptService:
         max_attempts: int = 2,
         on_exhausted: str = "return_last",
         validator: ResponseValidator | None = None,
-        strategies: list | None = None,
+        strategies: list[FeedbackStrategy] | None = None,
     ):
         """Initialize with either a ``validation_name`` or a pre-built ``validator``.
 

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Any
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.validation_events import RepromptValidationFailedEvent
 
-from .response_validator import UdfValidator, build_validation_feedback, safe_validate
+from .response_validator import (
+    UdfValidator,
+    build_validation_feedback,
+    resolve_feedback_strategies,
+    safe_validate,
+)
 
 if TYPE_CHECKING:
     from .response_validator import ResponseValidator
@@ -65,6 +70,7 @@ class RepromptService:
         max_attempts: int = 2,
         on_exhausted: str = "return_last",
         validator: ResponseValidator | None = None,
+        strategies: list | None = None,
     ):
         """Initialize with either a ``validation_name`` or a pre-built ``validator``.
 
@@ -95,6 +101,7 @@ class RepromptService:
             self.validation_name = validation_name
 
         self.validation_func = self._validator.validate
+        self._strategies = strategies or []
 
     @property
     def feedback_message(self) -> str:
@@ -171,7 +178,9 @@ class RepromptService:
             if attempts >= self.max_attempts:
                 break
 
-            feedback = build_validation_feedback(response, self._validator.feedback_message)
+            feedback = build_validation_feedback(
+                response, self._validator.feedback_message, strategies=self._strategies
+            )
             current_prompt = f"{original_prompt}\n\n{feedback}"
 
         logger.error(
@@ -214,6 +223,7 @@ def create_reprompt_service_from_config(
         ValueError: If required 'validation' key is missing and no validator provided.
     """
     parsed = parse_reprompt_config(reprompt_config)
+    strategies = resolve_feedback_strategies(reprompt_config)
 
     if parsed is None:
         if validator is not None:
@@ -224,6 +234,7 @@ def create_reprompt_service_from_config(
                 max_attempts=cfg.get("max_attempts", 2),
                 on_exhausted=cfg.get("on_exhausted", "return_last"),
                 validator=validator,
+                strategies=strategies,
             )
         if reprompt_config:
             raise ValueError(
@@ -237,4 +248,5 @@ def create_reprompt_service_from_config(
         max_attempts=parsed.max_attempts,
         on_exhausted=parsed.on_exhausted,
         validator=validator,
+        strategies=strategies,
     )

--- a/agent_actions/processing/recovery/response_validator.py
+++ b/agent_actions/processing/recovery/response_validator.py
@@ -9,6 +9,9 @@ from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
+# Strategy callable: (failed_response, feedback_message) -> extra prompt text
+FeedbackStrategy = Callable[[Any, str], str]
+
 
 # ---------------------------------------------------------------------------
 # Protocol
@@ -195,7 +198,7 @@ class ComposedValidator:
 def build_validation_feedback(
     failed_response: Any,
     feedback_message: str,
-    strategies: list[Callable[[Any, str], str]] | None = None,
+    strategies: list[FeedbackStrategy] | None = None,
 ) -> str:
     """Build the feedback string appended to the prompt on validation failure."""
     try:
@@ -233,9 +236,9 @@ Now produce your corrected response."""
 
 def resolve_feedback_strategies(
     reprompt_config: dict | None,
-) -> list[Callable[[Any, str], str]]:
+) -> list[FeedbackStrategy]:
     """Turn reprompt config flags into an ordered list of feedback strategies."""
-    strategies: list[Callable[[Any, str], str]] = []
+    strategies: list[FeedbackStrategy] = []
     if (reprompt_config or {}).get("use_self_reflection"):
         strategies.append(self_reflection_strategy)
     return strategies

--- a/agent_actions/processing/recovery/response_validator.py
+++ b/agent_actions/processing/recovery/response_validator.py
@@ -192,19 +192,53 @@ class ComposedValidator:
 # ---------------------------------------------------------------------------
 
 
-def build_validation_feedback(failed_response: Any, feedback_message: str) -> str:
+def build_validation_feedback(
+    failed_response: Any,
+    feedback_message: str,
+    strategies: list[Callable[[Any, str], str]] | None = None,
+) -> str:
     """Build the feedback string appended to the prompt on validation failure."""
     try:
         response_str = json.dumps(failed_response, indent=2)
     except Exception:
         response_str = str(failed_response)
 
-    return f"""---
+    base = f"""---
 Your response failed validation: {feedback_message}
 
 Your response: {response_str}
 
 Please correct and respond again."""
+
+    for strategy in strategies or []:
+        base += "\n\n" + strategy(failed_response, feedback_message)
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Feedback strategies
+# ---------------------------------------------------------------------------
+
+
+def self_reflection_strategy(failed_response: Any, feedback_message: str) -> str:
+    """Instruct the model to analyze its failure before retrying."""
+    return """Before producing your corrected response, analyze what went wrong:
+1. What specific error did you make in your previous response?
+2. Why did you make this error?
+3. What must be different in your next response to pass validation?
+
+Now produce your corrected response."""
+
+
+def resolve_feedback_strategies(
+    reprompt_config: dict | None,
+) -> list[Callable[[Any, str], str]]:
+    """Turn reprompt config flags into an ordered list of feedback strategies."""
+    strategies: list[Callable[[Any, str], str]] = []
+    if (reprompt_config or {}).get("use_self_reflection"):
+        strategies.append(self_reflection_strategy)
+    return strategies
 
 
 # ---------------------------------------------------------------------------

--- a/agent_actions/skills/agent-actions-workflow/references/reprompt-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/reprompt-patterns.md
@@ -31,6 +31,7 @@ How to configure automatic retry with feedback when LLM output fails validation.
 | `validation` | string | None | Name of `@reprompt_validation` function |
 | `max_attempts` | int | 2 | Total attempts including first try (1-10) |
 | `on_exhausted` | string | `"return_last"` | What to do when all attempts fail |
+| `use_self_reflection` | bool | `false` | Add reflection instruction to retry prompts |
 
 **`on_exhausted` options:**
 - `"return_last"` — Accept the last response even though it failed validation. Downstream actions receive potentially invalid data.
@@ -118,6 +119,32 @@ Execution order per attempt:
 3. If schema passes → custom UDF checks business logic
 4. If either fails → feedback appended to prompt, retry
 
+## Self-Reflection
+
+By default, retry prompts tell the model *what* failed but not *why*. Enable self-reflection to add an instruction asking the model to analyze its failure before retrying:
+
+```yaml
+- name: extract_codes
+  schema: bisac_codes
+  reprompt:
+    validation: "check_valid_bisac"
+    max_attempts: 3
+    use_self_reflection: true
+```
+
+This appends to the retry prompt:
+
+```
+Before producing your corrected response, analyze what went wrong:
+1. What specific error did you make in your previous response?
+2. Why did you make this error?
+3. What must be different in your next response to pass validation?
+
+Now produce your corrected response.
+```
+
+No extra API calls — it only modifies the retry prompt text. Use it for complex schemas where the model tends to repeat the same mistake.
+
 ## How the Retry Loop Works
 
 ```
@@ -131,7 +158,7 @@ on_exhausted: "return_last" → accept last response
 on_exhausted: "raise" → RuntimeError
 ```
 
-Each retry appends the validation feedback to the prompt, giving the LLM context about what went wrong. The feedback accumulates — attempt 3 sees feedback from attempts 1 and 2.
+Each retry appends the validation feedback to the prompt, giving the LLM context about what went wrong. When `use_self_reflection: true`, the feedback also includes a reflection instruction asking the model to analyze its failure before responding.
 
 ## Reprompt + Guard Interaction
 

--- a/docs.agent-actions/docs/reference/validation/reprompting.md
+++ b/docs.agent-actions/docs/reference/validation/reprompting.md
@@ -14,6 +14,7 @@ Reprompting is Agent Actions' automatic retry system for validation errors. When
 The reprompting system provides:
 
 - **Automatic retries** - Retry failed validations up to a configurable limit
+- **Self-reflection** - Optionally instruct the model to analyze its failure before retrying
 - **Configurable exhaustion** - Control what happens when all attempts fail
 
 :::info Retry vs Reprompt
@@ -45,6 +46,7 @@ defaults:
 |--------|------|---------|-------------|
 | `max_attempts` | integer | 2 | Maximum retry attempts |
 | `on_exhausted` | string | `return_last` | Behavior when attempts exhausted |
+| `use_self_reflection` | boolean | `false` | Include self-reflection instruction in retry prompts |
 
 ### Custom Validation Functions
 
@@ -79,6 +81,30 @@ When a record exhausts all reprompt attempts, `on_exhausted` determines what hap
 |-------|----------|
 | `return_last` | Return the last response (even if invalid), workflow continues (default) |
 | `raise` | Raise an exception, workflow fails |
+
+### Self-Reflection
+
+By default, retry prompts include the validation error and the failed response — the model knows *what* failed but gets no help thinking about *why*. Self-reflection adds an instruction asking the model to analyze its failure before retrying:
+
+```yaml
+defaults:
+  reprompt:
+    max_attempts: 3
+    use_self_reflection: true
+```
+
+When enabled, the retry prompt includes:
+
+```
+Before producing your corrected response, analyze what went wrong:
+1. What specific error did you make in your previous response?
+2. Why did you make this error?
+3. What must be different in your next response to pass validation?
+
+Now produce your corrected response.
+```
+
+This activates the model's reasoning about the failure rather than just re-rolling with the same prompt. It costs no extra API calls — it only modifies the retry prompt text.
 
 ## How It Works
 

--- a/tests/manual/doc_audit/test_self_reflection.py
+++ b/tests/manual/doc_audit/test_self_reflection.py
@@ -112,9 +112,7 @@ def main() -> int:
     )
 
     # --- Scenario 2: WITH reflection ---
-    prompts_with = _run_scenario(
-        "SCENARIO 2: Reprompt WITH self-reflection", use_reflection=True
-    )
+    prompts_with = _run_scenario("SCENARIO 2: Reprompt WITH self-reflection", use_reflection=True)
 
     # --- Comparison ---
     _header("COMPARISON: Retry prompt #2 (after first failure)")
@@ -128,7 +126,7 @@ def main() -> int:
 
     _label("Added text (reflection block)")
     # Show what reflection adds
-    extra = prompts_with[1][len(prompts_without[1]):]
+    extra = prompts_with[1][len(prompts_without[1]) :]
     if extra.strip():
         for line in extra.strip().splitlines():
             print(f"    {GREEN}{line}{RESET}")

--- a/tests/manual/doc_audit/test_self_reflection.py
+++ b/tests/manual/doc_audit/test_self_reflection.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Manual smoke test: self-reflection feedback strategy.
+
+Runs the reprompt loop with a fake LLM and PRINTS the retry prompts
+so a human can inspect what the model would actually see — with and
+without self-reflection enabled.
+
+Run:
+    python tests/manual/doc_audit/test_self_reflection.py
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+# --- path fixup for standalone execution ---
+if __name__ == "__main__":
+    _root = Path(__file__).resolve().parents[3]
+    if str(_root) not in sys.path:
+        sys.path.insert(0, str(_root))
+
+from agent_actions.processing.recovery.reprompt import RepromptService
+from agent_actions.processing.recovery.response_validator import self_reflection_strategy
+from agent_actions.processing.recovery.validation import (
+    _VALIDATION_REGISTRY,
+    reprompt_validation,
+)
+
+CYAN = "\033[36m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+DIM = "\033[2m"
+RESET = "\033[0m"
+RULE = "─" * 72
+
+
+def _header(title: str) -> None:
+    print(f"\n{CYAN}{'═' * 72}")
+    print(f"  {title}")
+    print(f"{'═' * 72}{RESET}\n")
+
+
+def _label(text: str) -> None:
+    print(f"{YELLOW}  ▸ {text}{RESET}")
+
+
+def _show_prompt(prompt: str) -> None:
+    """Print a prompt with indentation so structure is visible."""
+    for line in prompt.splitlines():
+        print(f"  {DIM}│{RESET} {line}")
+    print(f"  {DIM}│{RESET}")
+
+
+def _run_scenario(title: str, use_reflection: bool) -> list[str]:
+    """Run reprompt loop, return all prompts sent to the fake LLM."""
+    _VALIDATION_REGISTRY.clear()
+
+    @reprompt_validation("Response must contain a 'entities' list with at least one item")
+    def check_entities(response: dict) -> bool:
+        entities = response.get("entities")
+        return isinstance(entities, list) and len(entities) > 0
+
+    prompts: list[str] = []
+    call_count = 0
+
+    def fake_llm(prompt: str):
+        nonlocal call_count
+        prompts.append(prompt)
+        call_count += 1
+        if call_count <= 2:
+            # Fail: missing entities field, then empty list
+            if call_count == 1:
+                return {"text": "Acme Corp signed a deal"}, True
+            return {"entities": []}, True
+        # Succeed on attempt 3
+        return {"entities": [{"name": "Acme Corp", "type": "organization"}]}, True
+
+    strategies = [self_reflection_strategy] if use_reflection else []
+
+    service = RepromptService(
+        validation_name="check_entities",
+        max_attempts=4,
+        strategies=strategies,
+    )
+
+    _header(title)
+    result = service.execute(fake_llm, "Extract all entities from the following text.")
+
+    for i, prompt in enumerate(prompts):
+        attempt_num = i + 1
+        is_retry = attempt_num > 1
+        label = f"Attempt {attempt_num}" + (" (retry)" if is_retry else " (initial)")
+        _label(label)
+        _show_prompt(prompt)
+
+    status = f"{GREEN}PASSED{RESET}" if result.passed else f"\033[31mFAILED{RESET}"
+    print(f"  Result: {status} after {result.attempts} attempts")
+    return prompts
+
+
+def main() -> int:
+    print(f"\n{CYAN}Self-Reflection Smoke Test{RESET}")
+    print(f"{DIM}Inspect the retry prompts below. The reflection-enabled version")
+    print(f"should include analysis instructions that help the model reason{RESET}")
+    print(f"{DIM}about its failure before retrying.{RESET}")
+
+    # --- Scenario 1: WITHOUT reflection ---
+    prompts_without = _run_scenario(
+        "SCENARIO 1: Reprompt WITHOUT self-reflection", use_reflection=False
+    )
+
+    # --- Scenario 2: WITH reflection ---
+    prompts_with = _run_scenario(
+        "SCENARIO 2: Reprompt WITH self-reflection", use_reflection=True
+    )
+
+    # --- Comparison ---
+    _header("COMPARISON: Retry prompt #2 (after first failure)")
+
+    _label("WITHOUT reflection — prompt length")
+    print(f"    {len(prompts_without[1])} chars\n")
+
+    _label("WITH reflection — prompt length")
+    print(f"    {len(prompts_with[1])} chars")
+    print(f"    (+{len(prompts_with[1]) - len(prompts_without[1])} chars from reflection)\n")
+
+    _label("Added text (reflection block)")
+    # Show what reflection adds
+    extra = prompts_with[1][len(prompts_without[1]):]
+    if extra.strip():
+        for line in extra.strip().splitlines():
+            print(f"    {GREEN}{line}{RESET}")
+    else:
+        print(f"    \033[31mNO DIFFERENCE — reflection not appended!\033[0m")
+        return 1
+
+    print(f"\n{RULE}")
+    print(f"  {GREEN}Review the prompts above.{RESET}")
+    print(f"  Does the reflection instruction help the model reason about its failure?")
+    print(f"{RULE}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/manual/doc_audit/test_self_reflection.py
+++ b/tests/manual/doc_audit/test_self_reflection.py
@@ -12,7 +12,6 @@ Run:
 from __future__ import annotations
 
 import sys
-import textwrap
 from pathlib import Path
 
 # --- path fixup for standalone execution ---
@@ -131,12 +130,12 @@ def main() -> int:
         for line in extra.strip().splitlines():
             print(f"    {GREEN}{line}{RESET}")
     else:
-        print(f"    \033[31mNO DIFFERENCE — reflection not appended!\033[0m")
+        print("    \033[31mNO DIFFERENCE — reflection not appended!\033[0m")
         return 1
 
     print(f"\n{RULE}")
     print(f"  {GREEN}Review the prompts above.{RESET}")
-    print(f"  Does the reflection instruction help the model reason about its failure?")
+    print("  Does the reflection instruction help the model reason about its failure?")
     print(f"{RULE}\n")
     return 0
 

--- a/tests/unit/core/test_response_validator.py
+++ b/tests/unit/core/test_response_validator.py
@@ -18,7 +18,9 @@ from agent_actions.processing.recovery.response_validator import (
     SchemaValidator,
     UdfValidator,
     build_validation_feedback,
+    resolve_feedback_strategies,
     safe_validate,
+    self_reflection_strategy,
 )
 from agent_actions.processing.recovery.validation import (
     _VALIDATION_REGISTRY,
@@ -310,3 +312,69 @@ class TestSafeValidate:
         # Should not raise — context is used in logging
         result = safe_validate(bad, {}, context="my_action")
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Feedback strategies
+# ---------------------------------------------------------------------------
+
+
+class TestSelfReflectionStrategy:
+    """Tests for self_reflection_strategy and resolve_feedback_strategies."""
+
+    def test_strategy_returns_reflection_text(self):
+        result = self_reflection_strategy({"bad": "data"}, "missing field X")
+        assert "analyze what went wrong" in result.lower()
+        assert "corrected response" in result.lower()
+
+    def test_strategy_ignores_inputs(self):
+        """Reflection text is static — doesn't depend on response or error."""
+        r1 = self_reflection_strategy({"a": 1}, "error A")
+        r2 = self_reflection_strategy({"b": 2}, "error B")
+        assert r1 == r2
+
+    def test_resolve_empty_config(self):
+        assert resolve_feedback_strategies(None) == []
+        assert resolve_feedback_strategies({}) == []
+
+    def test_resolve_reflection_disabled(self):
+        assert resolve_feedback_strategies({"use_self_reflection": False}) == []
+
+    def test_resolve_reflection_enabled(self):
+        strategies = resolve_feedback_strategies({"use_self_reflection": True})
+        assert len(strategies) == 1
+        assert strategies[0] is self_reflection_strategy
+
+    def test_build_feedback_without_strategies(self):
+        """No strategies = identical to old behavior."""
+        base = build_validation_feedback({"x": 1}, "bad field")
+        with_none = build_validation_feedback({"x": 1}, "bad field", strategies=None)
+        with_empty = build_validation_feedback({"x": 1}, "bad field", strategies=[])
+        assert base == with_none == with_empty
+
+    def test_build_feedback_with_reflection(self):
+        """Reflection text is appended after base feedback."""
+        base = build_validation_feedback({"x": 1}, "bad field")
+        with_reflection = build_validation_feedback(
+            {"x": 1}, "bad field", strategies=[self_reflection_strategy]
+        )
+        assert with_reflection.startswith(base)
+        assert "analyze what went wrong" in with_reflection.lower()
+        assert len(with_reflection) > len(base)
+
+    def test_multiple_strategies_compose(self):
+        """Multiple strategies are appended in order."""
+
+        def strategy_a(resp, err):
+            return "STRATEGY_A_OUTPUT"
+
+        def strategy_b(resp, err):
+            return "STRATEGY_B_OUTPUT"
+
+        result = build_validation_feedback(
+            {"x": 1}, "err", strategies=[strategy_a, strategy_b]
+        )
+        assert "STRATEGY_A_OUTPUT" in result
+        assert "STRATEGY_B_OUTPUT" in result
+        # A appears before B
+        assert result.index("STRATEGY_A_OUTPUT") < result.index("STRATEGY_B_OUTPUT")

--- a/tests/unit/core/test_response_validator.py
+++ b/tests/unit/core/test_response_validator.py
@@ -371,9 +371,7 @@ class TestSelfReflectionStrategy:
         def strategy_b(resp, err):
             return "STRATEGY_B_OUTPUT"
 
-        result = build_validation_feedback(
-            {"x": 1}, "err", strategies=[strategy_a, strategy_b]
-        )
+        result = build_validation_feedback({"x": 1}, "err", strategies=[strategy_a, strategy_b])
         assert "STRATEGY_A_OUTPUT" in result
         assert "STRATEGY_B_OUTPUT" in result
         # A appears before B


### PR DESCRIPTION
## Summary
- Added `use_self_reflection` config field to RepromptConfig (default: false)
- When enabled, retry prompts include a reflection instruction asking the model to analyze its failure before responding
- Extensible strategy pattern on `build_validation_feedback()` — future strategies require one function + one config flag
- Both online and batch paths share the same strategy resolution via `resolve_feedback_strategies()`

## Verification
- All 5326 tests pass
- New tests for `self_reflection_strategy`, `resolve_feedback_strategies`, and `build_validation_feedback` with strategies
- `ruff check` and `ruff format --check` clean