### PR TITLE
docs: document reprompt UDF preflight validation

### DIFF
--- a/agent_actions/skills/agent-actions-workflow/references/reprompt-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/reprompt-patterns.md
@@ -71,6 +71,8 @@ def check_valid_bisac(response: dict) -> bool:
     )
 ```
 
+**Preflight validation:** The static analyzer checks that the `validation` name matches a `@reprompt_validation`-decorated function in your tools directory. Typos are caught at `agac validate` time, before any LLM calls, with a list of available validators in the error message.
+
 **Decorator contract:**
 - The string argument is the **feedback message** sent to the LLM on failure — make it specific
 - Function receives the parsed dict response from the LLM

--- a/docs.agent-actions/docs/reference/validation/reprompting.md
+++ b/docs.agent-actions/docs/reference/validation/reprompting.md
@@ -73,6 +73,10 @@ def check_valid_bisac(response) -> bool:
 
 When the validation function returns `False`, Agent Actions reprompts with the error message from the `@reprompt_validation` decorator, giving the LLM specific guidance on what to fix.
 
+:::tip Typos are caught early
+The static analyzer validates that the function name in `reprompt.validation` matches a `@reprompt_validation`-decorated function in your tools directory. If the name doesn't match, you'll get an error at validation time — before any LLM calls — listing the available validators.
+:::
+
 ### Exhaustion Behavior
 
 When a record exhausts all reprompt attempts, `on_exhausted` determines what happens:


### PR DESCRIPTION
## Summary
- Documents that the static analyzer validates `reprompt.validation` UDF names at preflight
- Typos are caught at `agac validate` time, before LLM calls, with available validators listed
- Updated both `docs/reference/validation/reprompting.md` and skill `reprompt-patterns.md`

Closes the docs gap from `specs/bugs/pending/bug_reprompt_udf_preflight_undocumented.md`.

## Verification
- Docs-only change, no code modified