### PR TITLE
fix: resolve 4 pending bugs (inline schema warning, AgacClient, docs gaps)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260414-113000.yaml
+++ b/.changes/unreleased/Bug Fix-20260414-113000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Warn when inline schema shadows schema_name; add missing json_mode warning to AgacClient"
+time: 2026-04-14T11:30:00.000000Z

--- a/agent_actions/llm/providers/agac/client.py
+++ b/agent_actions/llm/providers/agac/client.py
@@ -250,4 +250,11 @@ class AgacClient(BaseClient):
 
         if json_mode:
             return cls.call_json(None, agent_config, prompt_config, context_data, schema)
+        if schema is not None:
+            logger.warning(
+                "json_mode=false but schema was compiled for action '%s'. "
+                "The schema will not be sent to the LLM. "
+                "Set json_mode=true to enable schema enforcement.",
+                agent_config.get("agent_type", "unknown"),
+            )
         return cls.call_non_json(None, agent_config, prompt_config, context_data)

--- a/agent_actions/output/response/schema.py
+++ b/agent_actions/output/response/schema.py
@@ -80,6 +80,11 @@ class ResponseSchemaCompiler:
 
         # Load schema (inline or named)
         inline_schema = agent_config.get(SCHEMA_KEY)
+        if inline_schema and agent_config.get("schema_name"):
+            logger.warning(
+                "Action has both 'schema' (inline) and 'schema_name'. "
+                "Inline schema takes precedence; 'schema_name' is ignored."
+            )
         if inline_schema:
             base_schema, schema_name = _load_inline_schema(
                 inline_schema,

--- a/docs.agent-actions/docs/reference/configuration/defaults.md
+++ b/docs.agent-actions/docs/reference/configuration/defaults.md
@@ -54,6 +54,7 @@ actions:
 | `stop` | string/list | Stop sequence(s) to end generation |
 | `record_limit` | integer | Max records per file (default: unlimited) |
 | `file_limit` | integer | Max files to walk per action (default: unlimited) |
+| `enable_prompt_caching` | boolean | Enable Anthropic prompt caching to reduce costs on repeated prompts (default: `false`) |
 
 :::note Schema vs Runtime
 The `DefaultsConfig` schema defines only the core defaultable fields above. Additional fields like `api_key`, `context_scope`, `is_operational`, and `prompt_debug` are resolved at runtime through configuration merging and may not be explicitly defined in the defaults schema.

--- a/docs.agent-actions/docs/reference/validation/output-validation.md
+++ b/docs.agent-actions/docs/reference/validation/output-validation.md
@@ -153,6 +153,26 @@ The retry prompt includes:
 - Specific validation errors
 - Field/constraint that failed
 
+### Schema Mismatch Behavior
+
+Control what happens when an LLM response doesn't match the expected schema using `on_schema_mismatch`:
+
+```yaml
+- name: extract_entities
+  schema: entity_schema
+  on_schema_mismatch: reprompt   # "warn" | "reprompt" | "reject"
+  reprompt:
+    max_attempts: 3
+```
+
+| Value | Behavior |
+|-------|----------|
+| `warn` | Log a warning, accept the response anyway (default) |
+| `reprompt` | Trigger reprompt with schema errors as feedback |
+| `reject` | Reject the response, action fails |
+
+When set to `reprompt`, no custom validation UDF is needed — the schema errors are used directly as feedback to the LLM.
+
 ## Layer 3: Guard Validation
 
 Here's where it gets interesting: schema validation catches structural problems, but what about semantic ones? A score of 25 is a valid integer, but maybe you only want to process high-quality content with scores above 85.


### PR DESCRIPTION
## Summary

Resolves 5 pending bugs from `specs/bugs/pending/`:

**Code fixes:**
- `bug_inline_schema_shadows_schema_name` — warns when both `schema` and `schema_name` are set (inline wins silently)
- `bug_agac_invoke_missing_schema_warning` — adds json_mode=false schema warning to AgacClient, matching BaseClient

**Docs fixes:**
- `bug_on_schema_mismatch_undocumented` — documents `on_schema_mismatch` (warn/reprompt/reject) in output-validation.md
- `bug_prompt_caching_undocumented` — documents `enable_prompt_caching` in defaults.md

**Already fixed (closed):**
- `bug_dispatch_task_unreliable` — dispatch_task() works correctly since prompt service refactor

## Verification
- All 5326 tests pass
- ruff check/format clean