### PR TITLE
fix: retry transient OpenAI 400 errors and guard schema=None

### DIFF
--- a/.changes/unreleased/Bug Fix-20260416-183000.yaml
+++ b/.changes/unreleased/Bug Fix-20260416-183000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Retry transient OpenAI 400 JSON parsing errors instead of failing immediately; guard response_format when schema is None"
+time: 2026-04-16T18:30:00.000000Z

--- a/agent_actions/llm/providers/openai/client.py
+++ b/agent_actions/llm/providers/openai/client.py
@@ -92,7 +92,11 @@ class OpenAIClient(BaseClient):
         completion_kwargs: dict[str, Any] = {
             "model": model_name,
             "messages": messages,
-            "response_format": {"type": "json_schema", "json_schema": schema},
+            "response_format": (
+                {"type": "json_schema", "json_schema": schema}
+                if schema
+                else {"type": "json_object"}
+            ),
             **extract_generation_params(
                 agent_config,
                 extra_params=("frequency_penalty", "presence_penalty"),

--- a/agent_actions/processing/recovery/retry.py
+++ b/agent_actions/processing/recovery/retry.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 
 RETRIABLE_ERRORS = (NetworkError, RateLimitError)
 
+_TRANSIENT_API_ERROR_PATTERNS = (
+    "could not parse the json body",
+    "we are currently processing your json schema",
+)
+
 
 @dataclass
 class RetryResult:
@@ -50,8 +55,18 @@ def classify_error(error: Exception) -> str:
 
 
 def is_retriable_error(error: Exception) -> bool:
-    """Return True if the error is retriable (NetworkError or RateLimitError)."""
-    return isinstance(error, RETRIABLE_ERRORS)
+    """Return True if the error is retriable.
+
+    Retriable errors include NetworkError, RateLimitError, and VendorAPIError
+    instances whose message matches a known transient pattern (e.g. OpenAI
+    intermittently returning 400 "could not parse the JSON body").
+    """
+    if isinstance(error, RETRIABLE_ERRORS):
+        return True
+    if isinstance(error, VendorAPIError):
+        msg = str(error).lower()
+        return any(pattern in msg for pattern in _TRANSIENT_API_ERROR_PATTERNS)
+    return False
 
 
 class RetryService:

--- a/tests/core/test_retry_service.py
+++ b/tests/core/test_retry_service.py
@@ -60,6 +60,18 @@ class TestIsRetriableError:
         """VendorAPIError is not retriable by default."""
         assert not is_retriable_error(VendorAPIError("api error"))
 
+    def test_vendor_api_error_transient_json_parse_is_retriable(self):
+        """VendorAPIError with transient JSON parse message is retriable."""
+        error = VendorAPIError(
+            "openai API error: We could not parse the JSON body of your request."
+        )
+        assert is_retriable_error(error)
+
+    def test_vendor_api_error_schema_processing_is_retriable(self):
+        """VendorAPIError with schema processing message is retriable."""
+        error = VendorAPIError("We are currently processing your JSON schema. Please try again.")
+        assert is_retriable_error(error)
+
     def test_value_error_not_retriable(self):
         """ValueError is not retriable."""
         assert not is_retriable_error(ValueError("bad value"))
@@ -187,6 +199,20 @@ class TestRetryServiceNonRetriableErrors:
 
         assert exc_info.value is error
         operation.assert_called_once()
+
+    def test_transient_json_parse_error_retried(self):
+        """VendorAPIError with transient JSON parse message is retried."""
+        service = RetryService(max_attempts=3)
+        transient = VendorAPIError(
+            "openai API error: We could not parse the JSON body of your request."
+        )
+        operation = Mock(side_effect=[transient, "success"])
+
+        result = service.execute(operation)
+
+        assert result.response == "success"
+        assert result.attempts == 2
+        assert operation.call_count == 2
 
 
 class TestCreateRetryServiceFromConfig:


### PR DESCRIPTION
## Summary

- **Transient 400 retry**: `is_retriable_error` now recognizes `VendorAPIError` with known transient messages ("could not parse the JSON body", "currently processing your JSON schema") as retriable. The existing `RetryService` handles backoff — no new retry logic needed. This is at the unified level so all vendors benefit.
- **OpenAI schema=None guard**: `response_format` now falls back to `{type: "json_object"}` when schema is None, instead of sending `json_schema: null` (guaranteed 400). Matches the pattern already applied to Groq/Mistral/Cohere in PR #272.

### Root cause

gpt-5-mini intermittently returns 400 "could not parse the JSON body" on structured output requests. This is a [known OpenAI issue](https://community.openai.com/t/openai-gpt-5-mini-with-structured-output-returns-malformed-json-filled-with-whitespace-instead-of-valid-response/1377686) — retries succeed. Previously these errors were classified as non-retriable `VendorAPIError` and failed immediately.

### Files changed
| File | Change |
|------|--------|
| `processing/recovery/retry.py` | `is_retriable_error` checks VendorAPIError messages against transient patterns |
| `llm/providers/openai/client.py` | Guard response_format when schema is None |
| `tests/core/test_retry_service.py` | 3 new tests for transient error detection and retry behavior |

## Test plan

- [x] 5329 tests pass (3 new)
- [x] Ruff lint + format clean
- [x] Existing `VendorAPIError("api error")` still NOT retriable (test preserved)
- [x] Transient JSON parse error IS retriable and succeeds on retry (new test)

Closes: `specs/bugs/pending/bug_openai_error.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)