### PR TITLE
update: rewrite agent-actions-workflow skill

### DIFF
--- a/agent_actions/skills/agent-actions-workflow/SKILL.md
+++ b/agent_actions/skills/agent-actions-workflow/SKILL.md
@@ -1,236 +1,165 @@
 ---
 name: agent-actions-workflow
-description: Build, configure, and debug agent-actions agentic workflows. Use this skill whenever the user works with workflow YAML configs, writes UDF tool functions, configures context_scope (observe/passthrough/drop), sets up guards, versions, schemas, seed data, prompt templates, reprompt validation, batch mode, HITL actions, reduce_key aggregation, or cross-workflow chaining (upstream declarations, --downstream/--upstream flags). Also trigger when debugging pipeline output — empty records, guard filtering issues, schema mismatches, unexpected action results, caching problems, or stale re-runs. Trigger on CLI questions about agac run, agac render, agac validate-udfs, or agac batch. Even if the user just says "add an action", "why is my output empty", "my UDF returns None", "records are being filtered", "chain workflows", or "run downstream", this skill applies.
+description: Build, configure, and debug agent-actions agentic workflows. Use this skill whenever the user works with workflow YAML configs, writes UDF tool functions, configures context_scope (observe/passthrough/drop), sets up guards, versions, schemas, seed data, prompt templates, reprompt validation, batch mode, HITL actions, reduce_key aggregation, or cross-workflow chaining. Also trigger when debugging pipeline output — empty records, guard filtering, schema mismatches, unexpected action results, caching problems, or stale re-runs. Trigger on CLI questions about agac run, agac render, agac validate-udfs, or agac batch. Even if the user just says "add an action", "why is my output empty", "my UDF returns None", "records are being filtered", "chain workflows", or "run downstream", this skill applies.
 ---
 
 # Agent Actions Workflow Builder
 
-## Understanding the Pipeline First
+agent-actions is declarative. You describe WHAT each action does and WHAT data it needs. The framework handles execution order, data routing, and record provenance — like Terraform handles state.
 
-agent-actions handles data plumbing implicitly, like Terraform handles state:
-- You don't manage data flow between actions — `context_scope` declares it
-- You don't track record provenance — `lineage` handles it
-- You don't orchestrate execution order — `dependencies` handles it
-- You don't write vendor-specific LLM code — `model_vendor` abstracts it
-
-Your job: define WHAT each action does and WHAT data it needs. The framework handles HOW.
-
-Before changing anything, read the workflow YAML and check what the upstream action actually produces (`cat agent_io/target/<parent>/sample.json`). Most bugs come from mismatched expectations between actions.
+Before changing anything, read the workflow YAML and check what upstream actually produces. Most issues come from mismatched expectations between actions.
 
 ```bash
 agac run -a my_workflow              # Run workflow
 agac render -a my_workflow           # Compiled YAML (schemas inlined, versions expanded)
 ```
 
-## How Data Flows
+## Data Flow
 
 ```
-Source record
-  → Framework adds source_guid, node_id, lineage
-    → observe resolves fields via lineage (historical lookup)
-      → LLM/tool receives observed fields (namespaced for tools, Jinja-accessible for prompts)
-        → Tool processes and returns result
-          → passthrough fields merge into output
-            → Output stored with extended lineage
-              → Next action's observe resolves via this lineage
-```
-
-Once you understand this chain, most issues become obvious:
-- UDF gets None for a field? Fields are namespaced — use `content["action_name"]["field"]`
-- Downstream can't see a field? It wasn't in `passthrough` — only `observe` fields reach the LLM, `passthrough` fields reach the output
-- Historical lookup fails? Lineage is broken — check the upstream action's output for correct `lineage` arrays
-
-## Project Layout
-
-```
-project/
- agent_actions.yml                  # Project config
- agent_workflow/my_workflow/        # Dir name = YAML name = name: field
-   agent_config/my_workflow.yml
-   agent_io/staging/                # Input data
-   agent_io/target/                 # Output per action
-   seed_data/                       # Static reference data
- prompt_store/                      # Prompt templates
- schema/                            # Output schemas (flat — no subdirs)
- tools/my_workflow/                 # UDF tool scripts
+Source record → framework adds source_guid, node_id, lineage
+  → observe resolves fields via lineage
+    → LLM/tool receives observed fields
+      → passthrough merges into output (tool never saw them)
+        → output stored with extended lineage → next action resolves via this lineage
 ```
 
 ## Context Scope
 
-Every action declares `context_scope` — this is the core abstraction. It controls exactly what data flows in and out, replacing implicit data passing with explicit declarations.
+The core abstraction. Every action declares what data flows in and out.
+
+| Directive | What it does | LLM/tool sees it? | In output? |
+|-----------|-------------|:---:|:---:|
+| `observe` | **Loads** data from upstream via lineage | Yes | No |
+| `passthrough` | **Forwards** data to output, bypassing the action | No | Yes |
+| `drop` | **Excludes** data from context | No | No |
+
+Actions referenced in `observe`/`passthrough` but not in `dependencies` are **auto-inferred** as context dependencies — no need to list them in `dependencies`.
+
+The reason this matters: `observe` controls what gets loaded into the action's resolved context. Downstream actions consuming this action's output through version merge or lineage can only access fields that were loaded here. If a downstream aggregator needs `upstream.field`, the intermediate action must observe it.
+
+## Schema: What Gets Generated
+
+`schema` declares fields the action **creates from scratch**. Every field in schema is generated new — the LLM fills it in, the tool returns it.
+
+**A field must never appear in both schema and observe/passthrough.** Schema means "generate this." If you put an upstream field in schema, the LLM regenerates it non-deterministically, causing silent data drift. This is the most common source of data corruption in multi-action pipelines.
 
 ```yaml
-- name: generate_explanation
-  dependencies: [extract_facts]
-  context_scope:
-    observe:                         # What the LLM/tool sees
-      - extract_facts.*              # All fields from parent
-      - source.page_content          # Original input via lineage
-    passthrough:                     # Forwarded to output, LLM never sees it
-      - source.url
-    drop:                            # Excluded from context entirely
-      - extract_facts.debug_info
+# Judge action: schema = judgment only, reviewed data = passthrough
+schema:
+  decision_reasoning: string         # the only field this action creates
+context_scope:
+  passthrough:                       # data survives unchanged
+    - write_question.question
+    - write_question.answer
+  observe:                           # judge reads these to decide
+    - write_question.answer_explanation
 ```
 
-| Directive | LLM sees it? | In output? | Use for |
-|-----------|:---:|:---:|---|
-| `observe` | Yes | No | Data the action processes |
-| `passthrough` | No | Yes | Metadata, IDs, fields downstream needs |
-| `drop` | No | No | Noise reduction, bias prevention |
-
-Actions referenced in `observe`/`passthrough` but not in `dependencies` are auto-inferred as context dependencies — no need to list them twice.
-
-## Actions
-
-**LLM action** — sends a prompt to a model, gets structured output:
-```yaml
-- name: classify_issue
-  dependencies: [source]
-  model_vendor: openai
-  model_name: gpt-4o-mini
-  schema: { issue_type: string, severity: string }
-  prompt: $support_resolution.Classify_Issue
-  context_scope:
-    observe: [source.*]
-```
-
-**Tool action** — runs a Python function for deterministic logic:
-```yaml
-- name: aggregate_votes
-  dependencies: [score_quality]
-  kind: tool
-  impl: aggregate_quality_scores
-  context_scope:
-    observe: [score_quality.*]
-```
+**Field placement decision:**
+- Action creates this field → `schema`
+- Action reads this field → `observe`
+- Field must reach downstream unchanged → `passthrough`
 
 ## Writing UDFs
 
-Observed fields arrive **namespaced by the action that produced them**. This matters because multiple upstream actions can share field names without collision.
+Observed fields arrive **namespaced**: `content["action_name"]["field"]`. Flatten them, then build output with **only schema-declared fields**:
 
 ```python
-from typing import Any
-from agent_actions import udf_tool
-
 @udf_tool()
-def enrich_listing(data: dict[str, Any]) -> list[dict[str, Any]]:
+def my_tool(data: dict[str, Any]) -> list[dict[str, Any]]:
     content = data.get("content", data)
 
-    # Upstream fields are under the action name
-    copy = content.get("write_marketing_copy", {})
-    title = copy.get("listing_title", "")
+    # Flatten namespaced fields
+    flat = {}
+    for key, value in content.items():
+        if isinstance(value, dict):
+            flat.update(value)
+        else:
+            flat[key] = value
 
-    # Seed data lives under "seed"
-    rules = content.get("seed", {}).get("marketplace_rules", {})
+    # Return ONLY schema fields — never flat.copy() or data.copy()
+    result = {
+        "computed_field": process(flat.get("input_field", "")),
+        "question": flat.get("question", ""),
+    }
+    for field in ("source_quote", "answer_explanation"):
+        if field in flat:
+            result[field] = flat[field]
 
-    return [{"enriched_title": f"{title} — {rules.get('brand', '')}"}]
+    return [result]
 ```
 
-A few things to remember:
-- Access fields as `content["action_name"]["field"]` — not `content["field"]` (flat access returns None)
-- Seed data: `content["seed"]["key"]`
-- Version merge: `content["score_quality_1"]`, `content["score_quality_2"]`, etc.
-- Return `list[dict]` — or `dict` when the YAML uses `passthrough`
-- The `data.get("content", data)` wrapper is a safety net that should always be there
+Copying all input into output (`flat.copy()`) leaks upstream fields — including arbitrary text that happens to be a dict key — past schema validation. The framework validates output against the schema and rejects unexpected fields.
 
-## Guards
+**FILE mode:** Each record carries a `node_id` the framework uses to track lineage. Return the original record dict to preserve it. Return a new dict without `node_id` for aggregation (creates fresh lineage). Read business data from `record["content"]["field"]`.
 
-Guards filter records based on upstream output. The key insight: guards check **input** to the action, not its own output. So you place the guard on the action that *consumes* the data, not the one that *produces* it.
-
-Guard conditions evaluate against **flattened** field names from the action's observed data. If you observe `extract_claims.*`, the guard sees `claims` and `confidence` directly — not `extract_claims.claims`.
-
-```yaml
-- name: extract_claims              # Produces claims — no guard here
-
-- name: validate_claims
-  dependencies: [extract_claims]
-  guard:
-    condition: 'len(claims) >= 1 and confidence >= 0.7'
-    on_false: "filter"              # filter = remove record | skip = pass through
-  context_scope:
-    observe: [extract_claims.*]
+```python
+# Passthrough: return record → lineage preserved
+outputs.append(record)
+# Transform: mutate content, return record → lineage preserved
+record["content"]["score"] = normalized
+outputs.append(record)
+# Aggregation: new dict → fresh lineage
+outputs.append({"summary": "merged", "count": len(data)})
 ```
 
-Quote string literals: `status == "approved"` — unquoted strings are treated as field names and produce a preflight error.
+## Versions and Aggregation
 
-## Versions
+Run an action N times in parallel, then merge. The aggregator receives each version namespaced: `content["score_quality_1"]["score"]`, etc.
 
-When you need consensus (multiple independent judgments on the same data), use versions to run an action N times in parallel, then merge:
+The aggregator can only access fields from indirect upstreams if the **version source loaded them** via observe. If the aggregator needs `upstream.answer`, add it to the version source's observe — otherwise the merge can't resolve it.
 
 ```yaml
-- name: score_quality
+- name: validator
   versions: { range: [1, 3], mode: parallel }
-  schema: { score: number, reasoning: string }
-
-- name: aggregate_scores
-  dependencies: [score_quality]
-  kind: tool
-  impl: aggregate_quality_scores
-  version_consumption: { source: score_quality, pattern: merge }
   context_scope:
-    observe: [score_quality.*]
-```
+    observe:
+      - content_action.*
+      - upstream.answer              # aggregator needs this — load it here
 
-The merge tool receives each version namespaced: `content["score_quality_1"]["score"]`, `content["score_quality_2"]["score"]`, etc.
-
-## Seed Data and Prompts
-
-**Seed data** — static JSON loaded into context:
-```yaml
-defaults:
+- name: aggregate
+  version_consumption: { source: validator, pattern: merge }
   context_scope:
-    seed_path:
-      rubric: $file:evaluation_rubric.json
+    observe:
+      - validator.*
+      - upstream.answer              # resolves because version source loaded it
 ```
 
-In prompts: `{{ seed.rubric.min_score }}`. In UDFs: `content.get("seed", {}).get("rubric", {})`. The config key is `seed_path:` but the reference prefix is `seed.` — using `seed_data.` is a common mistake that silently resolves to empty.
+## Modifying Actions
 
-**Prompt templates** — defined in `prompt_store/workflow_name.md`:
-```markdown
-{prompt Classify_Issue}
-Classify: {{ source.ticket_text }}
-Categories: {{ seed.routing_rules.categories }}
-{end_prompt}
-```
-Reference as `prompt: $workflow_name.Classify_Issue`.
+When changing an existing action:
+
+- **Remove a field from schema** → check every downstream observe/passthrough reference to it. They break.
+- **Move schema → passthrough** → field is no longer generated, it's forwarded. Verify upstream produces it.
+- **Move observe → passthrough** → tool/LLM can no longer read it, but it still appears in output.
+- **After any change** → clear cached data (target_data + prompt_trace + run_results.json) and rerun. The framework caches aggressively — stale data masks your changes.
+
+## Creating Actions
+
+| Type | YAML needs | Python | Prompt | Schema |
+|------|-----------|:---:|:---:|:---:|
+| LLM | `schema` + `prompt` + `context_scope` | — | Yes | Inline or file |
+| Tool (Record) | `kind: tool` + `impl` | `@udf_tool()` | — | File |
+| Tool (FILE) | `kind: tool` + `granularity: file` | `@udf_tool(granularity=FILE)` | — | File |
+| Versioned | `versions` + `version_consumption` | Aggregator UDF | Voter prompt | Both |
+| Judge | schema = decision only | — | Yes | Inline |
+| HITL | `kind: hitl` + `granularity: file` | — | — | — |
+
+Templates in `assets/templates/`. Checklist: **[Action Anatomy](references/action-anatomy.md)**.
 
 ## Debugging
 
-When output looks wrong, start with: what did the upstream action actually produce?
+Start with: what did upstream actually produce? Query the DB — see **[Debugging Guide](references/debugging-guide.md)** for the full triage checklist, inspection scripts, and cache clearing. Field consistency issues (one record missing a field breaks all downstream) are covered in **[Framework Contracts](references/framework-contracts.md)** §30.
 
-```bash
-cat agent_io/target/<action>/sample.json | python3 -c "
-import json, sys; data = json.load(sys.stdin)
-print(f'{len(data)} records')
-if data: print(list(data[0].get('content', data[0]).keys())[:10])
-"
-```
-
-Use `record_limit: 2` on any action to test with minimal API spend. Check `events.json` for guard/error events. For the full triage checklist and prompt trace inspection, read **[Debugging Guide](references/debugging-guide.md)**.
+`record_limit: 2` on any action to test with minimal API spend.
 
 ## References
 
-Read these when you need depth beyond what's covered above:
+**Configuration:** [YAML Schema](references/yaml-schema.md) · [Schema Design](references/schema-design-guide.md) · [Context Scope](references/context-scope-guide.md)
 
-### Configuration
-- **[YAML Schema](references/yaml-schema.md)** — all action fields, config hierarchy, dependency patterns, vendors
-- **[Schema Design Guide](references/schema-design-guide.md)** — inline vs file, required/optional, TypedDict mapping, field name alignment
-- **[Context Scope](references/context-scope-guide.md)** — observe/drop/passthrough, output_field, seed data details
+**Building:** [UDF Reference](references/udf-reference.md) · [Action Anatomy](references/action-anatomy.md) · [Prompt Patterns](references/prompt-patterns.md) · [Dynamic Injection](references/dynamic-content-injection.md)
 
-### Building
-- **[UDF Reference](references/udf-reference.md)** — @udf_tool decorator, record/file mode, namespaced access, passthrough, version merge
-- **[Action Anatomy](references/action-anatomy.md)** — action structure, pre-creation checklist, data lineage, record matching
-- **[Prompt Patterns](references/prompt-patterns.md)** — Jinja2 templates, variable access, max_tokens/temperature, anti-patterns
-- **[Dynamic Content Injection](references/dynamic-content-injection.md)** — tool action injection pattern for randomized/computed prompt content
+**Patterns:** [Workflow](references/workflow-patterns.md) · [Data Flow](references/data-flow-patterns.md) · [Aggregation](references/aggregation-patterns.md) · [HITL](references/hitl-patterns.md)
 
-### Patterns
-- **[Workflow Patterns](references/workflow-patterns.md)** — fan-in, diamond, ensemble, conditional merge, map-reduce
-- **[Data Flow Patterns](references/data-flow-patterns.md)** — source format, metadata, data shapes, grounded retrieval
-- **[Aggregation Patterns](references/aggregation-patterns.md)** — reduce_key, fan-in matching, merging parallel branches
-- **[HITL Patterns](references/hitl-patterns.md)** — human-in-the-loop with guards, lineage, passthrough
-
-### Quality & Debugging
-- **[Reprompt Patterns](references/reprompt-patterns.md)** — validation UDFs, retry configuration, schema-based reprompt
-- **[Framework Contracts](references/framework-contracts.md)** — 28 contracts: what works, what doesn't, workarounds
-- **[Debugging Guide](references/debugging-guide.md)** — triage checklist, caching behavior, prompt traces, error messages
-- **[CLI Reference](references/cli-reference.md)** — run, render, validate-udfs, batch mode, debug commands
+**Quality:** [Reprompt](references/reprompt-patterns.md) · [Framework Contracts](references/framework-contracts.md) (33 contracts) · [Debugging](references/debugging-guide.md) · [CLI](references/cli-reference.md)

--- a/agent_actions/skills/agent-actions-workflow/assets/templates/udf_file_tool.py.template
+++ b/agent_actions/skills/agent-actions-workflow/assets/templates/udf_file_tool.py.template
@@ -1,0 +1,37 @@
+"""{{TOOL_TITLE}} — FILE granularity tool."""
+
+from agent_actions import udf_tool
+from agent_actions.config.schema import Granularity
+
+
+@udf_tool(granularity=Granularity.FILE)
+def {{tool_function_name}}(data: list[dict]) -> list[dict]:
+    """
+    FILE mode: receives full records with node_id, source_guid, lineage.
+
+    Lineage rules:
+    - Each record carries a node_id the framework uses to track identity.
+    - Passthrough: return the original record dict → lineage extends automatically.
+    - Transform: mutate record["content"], return the record → lineage preserved.
+    - Aggregation: return a new dict without node_id → framework creates fresh lineage.
+
+    Read business data from record["content"]["field"], not record["field"].
+    """
+    results = []
+
+    for record in data:
+        content = record.get("content", record)
+
+        # Passthrough example: filter records, return originals to preserve lineage
+        if content.get("required_field"):
+            results.append(record)  # full record — node_id survives
+
+        # Transform example: modify content in-place, return the record
+        # content["normalized_score"] = normalize(content["score"])
+        # results.append(record)  # node_id survives, lineage tracked
+
+    # Aggregation example: create new data not tied to a single input
+    # results.append({"summary": "merged", "count": len(data)})  # no node_id = new record
+
+    print(f"{{tool_function_name}}: {len(data)} in, {len(results)} out")
+    return results

--- a/agent_actions/skills/agent-actions-workflow/assets/templates/udf_tool.py.template
+++ b/agent_actions/skills/agent-actions-workflow/assets/templates/udf_tool.py.template
@@ -8,9 +8,23 @@ from agent_actions import udf_tool
 def {{tool_function_name}}(data: dict[str, Any]) -> list[dict[str, Any]]:
     """{{Brief description of what this tool does.}}"""
     content = data.get("content", data)
-    result = content.copy()
 
-    # Your processing logic here
-    result["output_field"] = content.get("input_field", "")
+    # Unwrap namespaced observed fields
+    flat = {}
+    for key, value in content.items():
+        if isinstance(value, dict):
+            flat.update(value)
+        else:
+            flat[key] = value
+
+    # Build result with only schema-declared fields
+    result = {
+        "output_field": flat.get("input_field", ""),
+    }
+
+    # Carry forward fields downstream needs
+    for field in ("question", "options", "answer"):
+        if field in flat:
+            result[field] = flat[field]
 
     return [result]

--- a/agent_actions/skills/agent-actions-workflow/assets/templates/udf_version_merge.py.template
+++ b/agent_actions/skills/agent-actions-workflow/assets/templates/udf_version_merge.py.template
@@ -1,0 +1,36 @@
+"""{{TOOL_TITLE}} — Aggregates votes from parallel version sources."""
+
+from typing import Any, Dict, List
+from agent_actions import udf_tool
+
+
+@udf_tool()
+def {{tool_function_name}}(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Merge tool for version_consumption pattern.
+    Receives versioned outputs namespaced as {{source_action}}_1, _2, _3.
+    """
+    content = data.get("content", data)
+
+    # Extract versioned results
+    votes = []
+    for i in range(1, {{version_count + 1}}):
+        version_data = content.get(f"{{source_action}}_{i}", {})
+        if version_data:
+            votes.append(version_data)
+
+    # Extract non-versioned observed fields (flattened)
+    flat = {}
+    for key, value in content.items():
+        if isinstance(value, dict) and not key.startswith("{{source_action}}_"):
+            flat.update(value)
+        elif not isinstance(value, dict):
+            flat[key] = value
+
+    # Your aggregation logic here
+    result = {
+        "total_votes": len(votes),
+        "question": flat.get("question", ""),
+    }
+
+    return [result]

--- a/agent_actions/skills/agent-actions-workflow/references/common-pitfalls.md
+++ b/agent_actions/skills/agent-actions-workflow/references/common-pitfalls.md
@@ -1,0 +1,495 @@
+# Common Pitfalls Reference
+
+Frequent mistakes and how to avoid them.
+
+## 1. Guards Filtering All Records
+
+**Symptom:** Downstream actions have 0 records (sample.json contains `[]`).
+
+**Cause:** Guard condition evaluated to false for ALL records.
+
+**Example:**
+```
+validate_code_quality: 5 records (all validation_status="FAIL")
+generate_explanation:  0 records (guard filters all)
+```
+
+**Fix:**
+- Fix upstream prompts to produce passing values
+- Lower threshold: `>= 7` instead of `>= 8`
+- Allow multiple statuses: `'status == "PASS" or status == "NEEDS_REVIEW"'`
+
+## 2. Duplicate UDF Function Names
+
+**Symptom:** Error about duplicate function name.
+
+**Cause:** Same `@udf_tool()` function name in multiple directories.
+
+**Fix:**
+- Remove one duplicate
+- Rename to unique names
+- Move shared code to `tools/shared/`
+
+## 3. Forgetting Content Wrapper
+
+**Symptom:** KeyError or wrong output.
+
+**Wrong:**
+```python
+def my_udf(data):
+    return [{'result': data['my_field']}]
+```
+
+**Correct:**
+```python
+def my_udf(data):
+    content = data.get('content', data)
+    return [{'result': content['my_field']}]
+```
+
+## 4. UDF Returning Dict Instead of List
+
+**Wrong:**
+```python
+return {'result': 'value'}
+```
+
+**Correct:**
+```python
+return [{'result': 'value'}]
+```
+
+## 5. Guard on Wrong Action
+
+**Symptom:** Guard doesn't filter as expected.
+
+**Cause:** Guards check INPUT, not OUTPUT.
+
+**Wrong:**
+```yaml
+- name: validate_data
+  guard:
+    condition: 'validation_status == "PASS"'  # Checks INPUT!
+```
+
+**Correct:**
+```yaml
+- name: validate_data
+  # No guard - produces validation_status
+
+- name: next_action
+  dependencies: [validate_data]
+  guard:
+    condition: 'validation_status == "PASS"'  # Checks validate_data OUTPUT
+```
+
+## 6. Cross-Workflow: impl vs Action Name
+
+**Wrong:**
+```yaml
+dependencies:
+  - workflow: upstream
+    action: generate_vscode_mockup  # This is impl name!
+```
+
+**Correct:**
+```yaml
+dependencies:
+  - workflow: upstream
+    action: format_code_blocks  # This is action name
+```
+
+## 7. Empty Output Looks Like Success
+
+**Symptom:** Workflow shows "success" but no useful output.
+
+**Cause:** Guards filtered everything, or missing schema/prompt.
+
+**Always verify:**
+- Check record counts in each sample.json
+- Look for 2-byte files (empty arrays)
+- Check events.json for errors
+
+## 8. Dependency Not in context_scope
+
+**Error:** `Dependency 'X' declared but not referenced in context_scope`
+
+**Wrong:**
+```yaml
+dependencies: [generate_output]
+context_scope:
+  observe:
+    - source.raw_data  # Missing generate_output!
+```
+
+**Correct:**
+```yaml
+dependencies: [generate_output]
+context_scope:
+  observe:
+    - generate_output.*  # REQUIRED
+    - source.raw_data
+```
+
+## 9. Versioned Actions Context Scope
+
+**Wrong:**
+```yaml
+context_scope:
+  observe:
+    - filter_quality.vote  # Won't work with versions!
+```
+
+**Correct:**
+```yaml
+context_scope:
+  observe:
+    - filter_quality.*  # Wildcard captures ALL versions
+```
+
+## 10. Schema Files in Nested Directory / Schema References with Folder Prefix
+
+**Error:** `Schema file not found`
+
+**Cause:** Framework only looks in `schema/`, not recursively. Schema names are globally unique.
+
+**Wrong file path:** `schema/my_workflow/my_schema.yml`
+
+**Correct file path:** `schema/my_schema.yml`
+
+**Wrong reference in YAML:**
+```yaml
+schema: review_analyzer/extract_claims   # Folder prefix not allowed!
+```
+
+**Correct reference in YAML:**
+```yaml
+schema: extract_claims                   # Name only - globally unique
+```
+
+## 11. Legacy Workflow Format
+
+**Symptom:** Workflow uses `plan:` section.
+
+**Legacy:**
+```yaml
+plan:
+  - action_a
+  - action_b <- action_a
+```
+
+**Current:**
+```yaml
+actions:
+  - name: action_a
+    dependencies: []
+
+  - name: action_b
+    dependencies: [action_a]
+```
+
+## 12. Missing Return Type in UDF
+
+**Always return `list[dict[str, Any]]`:**
+
+```python
+@udf_tool()
+def my_udf(data: dict[str, Any]) -> list[dict[str, Any]]:
+    # ...
+    return [result]  # List!
+```
+
+## 13. dispatch_task() in Prompt Templates
+
+**Symptom:** LLM outputs the literal text `dispatch_task('function_name')` instead of the function result.
+
+**Cause:** `dispatch_task()` in prompt templates is unreliable - it may not be processed before the prompt is sent to the LLM.
+
+**Wrong:**
+```markdown
+{prompt Write_Question}
+Use this opener: dispatch_task('get_opener')
+...
+{end_prompt}
+```
+
+**Correct:** Use a tool action to inject dynamic content:
+
+```yaml
+# Step 1: Tool action injects content
+- name: inject_opener
+  kind: tool
+  impl: inject_random_opener
+  context_scope:
+    passthrough:
+      - upstream.*
+
+# Step 2: LLM action uses injected content
+- name: write_question
+  dependencies: [inject_opener]
+  context_scope:
+    observe:
+      - inject_opener.*
+```
+
+```markdown
+{prompt Write_Question}
+Use this opener: {{ inject_opener.suggested_opener }}
+...
+{end_prompt}
+```
+
+See: **[Dynamic Content Injection](dynamic-content-injection.md)**
+
+## 14. `seed_data.` vs `seed.` Namespace
+
+**Symptom:** Seed data in prompts/observe resolves to empty or undefined.
+
+**Cause:** The config key is `seed_data:` (or `seed_path:`) but the runtime namespace is `seed.` — not `seed_data.`.
+
+**Wrong:**
+```yaml
+observe:
+  - seed_data.rubric         # ← Wrong namespace
+```
+```
+{{ seed_data.rubric.score_range }}   ← Won't resolve
+```
+
+**Correct:**
+```yaml
+observe:
+  - seed.rubric              # ← Correct namespace
+```
+```
+{{ seed.rubric.score_range }}        ← Works
+```
+
+## 15. UDF Defaults Don't Match Schema Types
+
+**Symptom:** Schema validation errors on UDF output despite fields being present.
+
+**Cause:** Default/fallback values in the UDF don't match the schema type.
+
+**Wrong:**
+```python
+service_tier = None    # schema says type: string → None fails validation
+assigned_teams = None  # schema says type: array → None fails validation
+```
+
+**Correct:**
+```python
+service_tier = ""      # empty string satisfies type: string
+assigned_teams = []    # empty list satisfies type: array
+```
+
+## 16. Stale Cache Poisons Re-runs
+
+**Symptom:** Re-running after a failure completes in 0.03s with empty output. Actions show "completed" from cached empty results.
+
+**Cause:** Failed runs cache empty results. Next run picks up cached empties instead of re-running.
+
+**Fix:**
+```bash
+rm -rf agent_workflow/<workflow>/agent_io/target/*
+rm -rf agent_workflow/<workflow>/agent_io/source/
+agac run -a <workflow>
+```
+
+## 17. Redundant Dependencies
+
+**Symptom:** Action declares dependencies it doesn't need.
+
+**Cause:** Confusing execution ordering (`dependencies`) with data access (`context_scope`). If action B is already upstream of action C through the dependency chain, you don't need to declare B as a dependency of D — only declare C.
+
+**Wrong:**
+```yaml
+- name: assign_team
+  dependencies: [classify_issue, assess_severity]  # classify_issue is redundant
+```
+
+**Correct:**
+```yaml
+- name: assign_team
+  dependencies: [assess_severity]  # classify_issue is transitively upstream
+```
+
+`dependencies` controls execution ordering and file flow. If an action is already transitively upstream through the dependency chain, listing it again is redundant.
+
+## 18. Running Full Data During Development
+
+**Symptom:** Workflow takes 30 minutes to run while iterating on prompts.
+
+**Cause:** Processing all records and files when you only need a few to validate.
+
+**Fix:** Use `record_limit` and `file_limit` to cap processing. `record_limit` works on **any action** — not just start nodes — so you can test a single downstream action without re-running the full pipeline:
+```yaml
+actions:
+  - name: extract
+    record_limit: 10   # Process only 10 records per file
+    file_limit: 2       # Walk only 2 files
+
+  - name: expensive_llm_action
+    dependencies: [extract]
+    record_limit: 2     # Test prompt on 2 records before full API spend
+```
+
+Remove limits when ready for production. Changing limits between runs automatically invalidates the action's completion status so it re-executes.
+
+## 19. Missing passthrough When Injecting Content
+
+**Symptom:** Downstream action can't access upstream fields after injection.
+
+**Cause:** Tool action doesn't forward upstream fields.
+
+**Wrong:**
+```yaml
+- name: inject_opener
+  context_scope:
+    observe:
+      - upstream.quiz_type    # Only observes, doesn't forward
+```
+
+**Correct:**
+```yaml
+- name: inject_opener
+  context_scope:
+    observe:
+      - upstream.quiz_type
+    passthrough:
+      - upstream.*            # Forward ALL upstream fields
+```
+
+**Note:** With passthrough, UDF returns `dict` (not list) with ONLY new fields.
+
+## 20. Guard Conditions Can't Reference `output_field` Values
+
+**Symptom:** Guard condition `severity != "low"` doesn't filter as expected.
+
+**Cause:** With `output_field`, the value lives under the output field name in the data namespace, but guard conditions can't resolve it. This is a known framework limitation.
+
+**No working syntax currently.** If you need to filter on non-JSON output, use a tool action to post-process instead of a guard.
+
+## 21. `additionalProperties: false` Blocks Unlisted UDF Fields
+
+**Symptom:** Schema validation error on a field your UDF returns.
+
+**Cause:** Schema has `additionalProperties: false` but UDF returns a field not listed in the schema.
+
+**Fix:** Add every field your UDF returns to the schema, even computed/derived fields.
+
+```yaml
+# If UDF returns {"title": "...", "parties": [...], "risk_score": 0.8}
+# then schema must list ALL three:
+fields:
+  - id: title
+    type: string
+  - id: parties
+    type: array
+  - id: risk_score
+    type: number
+additionalProperties: false
+```
+
+## 22. Drop Directives on Passthrough Fields Match Nothing
+
+**Symptom:** Drop directive produces repeated runtime warnings but doesn't drop anything.
+
+**Cause:** Drop directives only apply to schema fields in observed namespaces. Passthrough fields are not in the schema namespace — they're merged after validation.
+
+```yaml
+# WRONG — passthrough fields can't be dropped
+context_scope:
+  drop:
+    - upstream_action.passthrough_field  # matches nothing, warns
+
+# If you need to exclude passthrough fields, don't passthrough them:
+context_scope:
+  passthrough:
+    - upstream_action.field_i_want      # selective, not wildcard
+```
+
+## 23. Tool UDF Accesses Fields via Flat Keys (Silent Default)
+
+**Symptom:** Tool action produces zero/default values for all records despite upstream actions completing successfully.
+
+**Cause:** UDFs access upstream fields via flat `content.get("field")` but the framework delivers fields **namespaced by action name** — `content["action_name"]["field"]`, not `content["field"]`.
+
+**Wrong:**
+```python
+score = content.get("consensus_score", 0)  # None — field is namespaced
+```
+
+**Correct:**
+```python
+aggregate = content.get("aggregate_scores", {})
+score = aggregate.get("consensus_score", 0)  # Namespaced access
+```
+
+## 24. Schema Field Name Doesn't Match LLM Output
+
+**Symptom:** Downstream action fails with "declared fields not found" even though the upstream action completed OK.
+
+**Cause:** The schema says `id: claims` but the LLM produces `factual_claims` (influenced by the prompt wording). Schema validation may not catch this if the field isn't required, and the wrong name flows into the storage backend.
+
+**Fix:**
+1. Check the storage backend output for the action
+2. Compare actual field names against schema `id:` values
+3. Rename the schema field to match what the LLM naturally produces
+4. Update all observe references and prompt templates
+
+## 25. Guard-Filtered Fields Cause Schema Validation Failures
+
+**Symptom:** `None is not of type 'object'` or `Additional properties are not allowed` on a downstream tool action.
+
+**Cause:** When an upstream action has `on_false: "filter"`, its output fields are absent for filtered records. If the downstream tool's schema declares those fields:
+- As `type: object` (not nullable) → rejects None
+- NOT in the schema at all → rejects as "additional properties" when the guard passes
+
+**Fix:** Declare the field in the schema but NOT in `required`. The tool should omit the key (not set it to None) when the upstream was filtered:
+```python
+if content.get("response_text"):
+    result["merchant_response"] = {"response_text": content["response_text"]}
+```
+
+## 26. Versions Range Off-by-One
+
+**Symptom:** `Dependency 'action_0' declared but not referenced in context_scope`
+
+**Cause:** `range: [0, 3]` creates versions 0,1,2,3 (4 versions) but the aggregate only observes `action_1.*`, `action_2.*`, `action_3.*`.
+
+**Fix:** Use `range: [1, 3]` for 3 versions (1-indexed), matching the observe references.
+
+## 27. Reprompt Validation UDF Not Discovered
+
+**Symptom:** Framework ignores the `reprompt.validation` setting — no reprompting happens.
+
+**Cause:** The UDF file exists but isn't in the tools discovery path.
+
+**Fix:** Put it in `tools/shared/reprompt_validations.py` with a `tools/shared/__init__.py`:
+```
+tools/
+├── my_workflow/
+│   └── my_tool.py
+└── shared/
+    ├── __init__.py
+    └── reprompt_validations.py
+```
+
+## 28. Guard Condition Uses != or > Operators
+
+**Symptom:** Guard skips ALL records even when field values should pass the condition.
+
+**Cause:** Known parser bug — the `WhereClauseParser` silently maps `!=` and `>` to `==`.
+
+**Test directly:**
+```python
+from agent_actions.input.preprocessing.filtering.guard_filter import GuardFilter, FilterItemRequest
+gf = GuardFilter()
+r = gf.filter_item(FilterItemRequest(data={"severity": "high"}, condition='severity != "low"'))
+print(r.matched)  # Returns False — BUG
+```
+
+**Workaround:** Avoid `!=` and `>` in guard conditions. Use positive conditions:
+- Instead of `severity != "low"` → use `severity == "medium" or severity == "high"`
+- Instead of `score > 6` → use `score >= 7`

--- a/agent_actions/skills/agent-actions-workflow/references/framework-contracts.md
+++ b/agent_actions/skills/agent-actions-workflow/references/framework-contracts.md
@@ -323,3 +323,76 @@ Use `record_limit` and `file_limit` to cap processing during development. `recor
 ```
 
 Remove limits when ready for production.
+
+### 29. UDF output must contain only schema-declared fields
+
+**Status:** Working — schema validation rejects unexpected fields.
+
+The framework validates UDF output against the action's schema. If `additionalProperties` is not set or is false, any field not in the schema causes a validation error. UDFs that copy input data (`result = data.copy()` or `result = flat.copy()`) leak upstream fields — including arbitrary text that happens to be a dict key — into the output.
+
+**Rule:** Always build the result dict with explicit fields:
+```python
+# Build with only schema fields
+result = {
+    "computed_field": value,
+    "question": flat.get("question", ""),
+}
+# Carry forward known fields explicitly
+for field in ("source_quote", "answer_explanation"):
+    if field in flat:
+        result[field] = flat[field]
+```
+
+### 30. Field consistency across records for context resolution
+
+**Status:** Working — by design.
+
+When an action observes `upstream.field`, the framework checks that `field` exists in **every** record of `upstream`'s output. If even one record is missing the field (incomplete LLM output, HITL tombstone), the entire downstream action fails with `declared fields ['field'] not found`.
+
+The error message `Available: ['field_a', 'field_b']` shows fields present in ALL records. The missing field exists in most but not all. Purge incomplete records by `source_guid` from all action outputs.
+
+### 31. Version consumption context resolution
+
+**Status:** Working — by design.
+
+When an action uses `version_consumption: { source: X, pattern: merge }`, the merged data only includes fields that the version source X **loaded** via observe. If the merge consumer needs a field from an indirect upstream, that field must appear in the version source's `observe` — otherwise the framework cannot resolve it through the merge.
+
+```yaml
+# Version source must observe any field the aggregator needs from indirect upstreams
+- name: validator
+  context_scope:
+    observe:
+      - reconstruct_options.options
+      - reconstruct_options.answer    # Aggregator needs this — must be loaded here
+
+- name: aggregator
+  version_consumption: { source: validator, pattern: merge }
+  context_scope:
+    observe:
+      - validator.*
+      - reconstruct_options.answer    # Resolves because validator loaded it
+```
+
+### 32. Judge actions must not regenerate upstream data
+
+**Status:** Working — by design (schema = "generate this").
+
+When an LLM action evaluates existing data (judge, reviewer, selector), its schema must contain **only** the judgment output. Upstream data fields in the schema cause the LLM to regenerate them — non-deterministically, introducing drift. Fields the judge reads go in `observe`. Fields that must survive to downstream go in `passthrough`.
+
+```yaml
+# Judge action: schema = decision only, data = passthrough
+schema:
+  decision_reasoning: string
+context_scope:
+  passthrough:
+    - content_action.question
+    - content_action.answer
+  observe:
+    - content_action.answer_explanation
+```
+
+### 33. Three state stores must be cleared together
+
+**Status:** Working — by design.
+
+The framework caches results in `target_data` (SQLite), `prompt_trace` (SQLite), and `run_results.json`. Clearing one without the others causes stale state — the framework may skip actions it thinks completed but whose data was deleted. Always clear all three when resetting an action.

--- a/agent_actions/skills/agent-actions-workflow/references/udf-decorator.md
+++ b/agent_actions/skills/agent-actions-workflow/references/udf-decorator.md
@@ -1,0 +1,191 @@
+# @udf_tool Decorator Reference
+
+The `@udf_tool` decorator registers Python functions as tool actions in workflows.
+
+## Syntax
+
+```python
+from agent_actions import udf_tool
+
+@udf_tool()
+def my_function(data: dict) -> dict:
+    """Process data and return result."""
+    return {"result": f"Processed: {data['text']}"}
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `granularity` | Granularity | No | `RECORD` (default) or `FILE` |
+
+Input and output schemas are defined via the YAML `schema:` field in the workflow configuration, not in the decorator.
+
+## Directory Structure
+
+```
+project/
+├── agent_actions.yml
+├── tools/
+│   ├── __init__.py
+│   ├── my_workflow/
+│   │   ├── __init__.py
+│   │   ├── transform_data.py
+│   │   └── filter_records.py
+│   └── shared/
+│       └── utils.py
+```
+
+## Workflow Reference
+
+```yaml
+- name: flatten_the_facts
+  kind: tool
+  impl: flatten_quotes  # Function name (case-insensitive)
+  granularity: record
+```
+
+## Granularity
+
+### Record (Default)
+
+Process one record at a time:
+
+```python
+@udf_tool()
+def filter_questions_by_score(data: dict) -> dict:
+    content = data.get('content', data)
+    score = content.get('syllabus_alignment_score', 0)
+    result = content.copy()
+    if score >= 85:
+        result['question_status'] = "KEEP"
+    else:
+        result['question_status'] = "FILTER"
+    return result
+```
+
+```yaml
+- name: filter_low_quality_questions
+  kind: tool
+  impl: filter_questions_by_score
+  granularity: record
+```
+
+### File
+
+Process all records at once:
+
+```python
+from agent_actions.config.schema import Granularity
+
+@udf_tool(granularity=Granularity.FILE)
+def run_dedup(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen = set()
+    unique = []
+    for record in data:
+        fact = record.get('fact', '')
+        if fact not in seen:
+            seen.add(fact)
+            unique.append(record)
+    return unique
+```
+
+```yaml
+- name: cluster_list
+  kind: tool
+  impl: run_dedup
+  granularity: file
+```
+
+Use FILE for: Aggregation, deduplication, clustering, cross-record analysis.
+
+## FileUDFResult for FILE-Mode Tools
+
+`FileUDFResult` wraps FILE-mode output with optional metadata. The runtime
+unwraps it to `.outputs` before structuring records.
+
+**Important:** Lineage is tracked via `source_guid`, not `source_mapping`.
+The pipeline's FILE-mode handler preserves `source_guid` on each output item
+and `LineageEnricher` resolves ancestry from it. `source_mapping` is validated
+at construction time but is **not yet consumed** by the runtime for lineage
+resolution. Always copy `source_guid` from inputs to outputs for correct
+lineage.
+
+```python
+from agent_actions import FileUDFResult
+
+@udf_tool(granularity=Granularity.FILE)
+def dedup_with_lineage(data: list[dict]) -> FileUDFResult:
+    seen = {}
+    outputs = []
+
+    for record in data:
+        fact = record.get("content", record).get("fact", "")
+        if fact not in seen:
+            seen[fact] = True
+            # Preserve source_guid so the framework can resolve lineage
+            outputs.append({
+                **record.get("content", record),
+                "source_guid": record.get("source_guid"),
+            })
+
+    return FileUDFResult(
+        outputs=outputs,
+        input_count=len(data),
+    )
+```
+
+## Nested TypedDicts for Complex Output
+
+When your UDF returns nested objects, use nested `TypedDict` classes instead of `dict[str, Any]`. The framework converts `dict[str, Any]` to `additionalProperties: {type: string}`, causing schema validation errors.
+
+```python
+# BAD - schema validation errors (all values forced to string)
+class MyOutput(TypedDict, total=False):
+    results: list[dict[str, Any]]
+    metadata: dict[str, Any]
+
+# GOOD - explicit nested types preserve int/float/etc.
+class SearchMetadata(TypedDict, total=False):
+    total_count: int
+    method: str
+
+class MatchingItem(TypedDict, total=False):
+    id: str
+    score: float
+
+class MyOutput(TypedDict, total=False):
+    results: list[MatchingItem]
+    metadata: SearchMetadata
+```
+
+## Best Practices
+
+- **Use `.get()` with defaults** for all field access: `data.get('score', 0)` prevents `KeyError` on missing fields.
+- **Document expected input/output** in the docstring so downstream consumers know what fields to expect.
+- **Use descriptive TypedDict names** (`QuestionQualityInput`, not `Input1`) when using typed schemas.
+- **Return complete records** -- prefer `content.copy()` + add fields over building from scratch, so downstream actions retain all upstream data.
+
+## Error Handling
+
+**Duplicate Function Names:**
+```
+DuplicateFunctionError: Function 'process_data' already registered
+```
+Function names must be unique across all tool files.
+
+**Function Not Found:**
+```
+FunctionNotFoundError: Function 'nonexistent_func' not found
+```
+Check file is in `tools/`, imported, and function name matches `impl`.
+
+## CLI Commands
+
+```bash
+# List registered UDFs
+agac list-udfs -u <tools_path>
+
+# Validate UDF schemas
+agac validate-udfs -a <workflow_name> -u <tools_path>
+```

--- a/agent_actions/skills/agent-actions-workflow/references/udf-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/udf-patterns.md
@@ -1,0 +1,216 @@
+# UDF Patterns Reference
+
+Python UDF patterns for agent-actions workflows.
+
+## Record vs File: What Your UDF Receives
+
+The framework passes different data structures depending on granularity:
+
+| | Record (default) | File |
+|---|---|---|
+| **Input** | `dict` — business fields only, already unwrapped | `list[dict]` — each item has `{"content": {...}, "source_guid": "..."}` |
+| **Content wrapper** | Stripped by framework | Preserved — you must unwrap each item |
+| **Return type** | `list[dict]` (or `dict` with passthrough) | `FileUDFResult` |
+
+## Record Template
+
+In Record mode, the framework unwraps the content before calling your function. The `.get("content", data)` is a safety net but the data is already flat:
+
+```python
+from typing import Any
+from agent_actions import udf_tool
+
+@udf_tool()
+def my_function(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Process one record at a time."""
+    content = data.get("content", data)  # Safety net — usually already unwrapped
+    result = content.copy()
+    result["computed_field"] = some_calculation(content)
+    return [result]
+```
+
+## Passthrough Pattern
+
+When using `passthrough` in the YAML config, return a **dict** (not list) with only the new fields:
+
+```python
+@udf_tool()
+def inject_random_opener(data: dict) -> dict:
+    """Inject computed content. Return dict when using passthrough."""
+    content = data.get('content', data)
+    quiz_type = content.get('quiz_type_used', 'general').lower()
+    opener = random.choice(OPENERS.get(quiz_type, OPENERS['default']))
+    return {"suggested_opener": opener, "quiz_type": quiz_type.upper()}
+```
+
+## Version Consumption Merge
+
+Process merged results from parallel versioned actions:
+
+```python
+@udf_tool()
+def process_merged(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Merge outputs from versioned actions."""
+    content = data.get('content', data)
+    results = []
+
+    for i in range(1, 6):
+        worker_key = f'process_data_{i}'
+        worker_data = content.get(worker_key, {})
+        if isinstance(worker_data, dict):
+            results.append({
+                'worker_id': i,
+                'result': worker_data.get('result'),
+                'score': worker_data.get('score', 0),
+            })
+
+    output = content.copy()
+    output['all_results'] = results
+    output['average_score'] = (
+        sum(r['score'] for r in results) / len(results) if results else 0
+    )
+    return [output]
+```
+
+## FILE Granularity
+
+Receives ALL records at once as a list. Unlike Record mode, the content wrapper is **preserved** — you must unwrap each item with `.get("content", record)`. Preserve `source_guid` for lineage:
+
+```python
+from agent_actions import udf_tool, FileUDFResult
+from agent_actions.config.schema import Granularity
+
+@udf_tool(granularity=Granularity.FILE)
+def run_dedup(data: list[dict]) -> FileUDFResult:
+    """FILE mode: each item still has {"content": {...}, "source_guid": "..."}."""
+    seen = {}
+    outputs = []
+
+    for record in data:
+        content = record.get("content", record)  # ← Required here: wrapper preserved
+        fact = content.get("fact", "")
+        if fact not in seen:
+            seen[fact] = True
+            outputs.append({
+                **content,
+                "source_guid": record.get("source_guid"),
+            })
+
+    return FileUDFResult(outputs=outputs, input_count=len(data))
+```
+
+## How Observed Fields Arrive in UDFs
+
+Observed fields arrive **namespaced by action name**. Access them as `content.get("action_name", {}).get("field")`.
+
+### 1. Standard observed fields (NAMESPACED)
+
+Observed fields are nested under the action name that produced them. This preserves data integrity when multiple upstream actions share field names.
+
+```python
+# CORRECT — namespaced access
+title = content.get("write_marketing_copy", {}).get("listing_title", "")
+
+# WRONG — flat access returns None (fields are namespaced)
+title = content.get("listing_title", "")  # None — field is under action namespace
+```
+
+When observing from a single upstream action, you can unwrap the namespace upfront:
+
+```python
+upstream = content.get("write_marketing_copy", {})
+title = upstream.get("listing_title", "")
+description = upstream.get("listing_description", "")
+```
+
+### 2. `output_field` values (under the ACTION namespace)
+
+With `json_mode: false` and `output_field`, the raw text is stored under the `output_field` name within the action namespace.
+
+```python
+# Config: output_field: severity  (on action "assess_severity")
+
+# CORRECT — action namespace, then field name
+severity = content.get("assess_severity", {}).get("severity", "")
+
+# WRONG — flat access
+severity = content.get("severity", "")  # None
+```
+
+**Note:** The default `output_field` is `raw_response`. Access via `content.get("action_name", {}).get("raw_response", "")`.
+
+### 3. Version consumption merge (NAMESPACED under expanded names)
+
+Versioned data is nested under expanded action names. Each version's data is preserved independently — no data loss from field name collisions.
+
+```python
+scorer_1 = content.get("score_quality_1", {}).get("overall_score")
+scorer_2 = content.get("score_quality_2", {}).get("overall_score")
+scorer_3 = content.get("score_quality_3", {}).get("overall_score")
+
+# Iterate all versions dynamically
+scores = []
+for key, data in content.items():
+    if key.startswith("score_quality_") and isinstance(data, dict):
+        scores.append(data.get("overall_score", 0))
+```
+
+### 4. Seed data (under `seed` namespace)
+
+Seed data observed as `seed.marketplace_rules` arrives under `content["seed"]["marketplace_rules"]`.
+
+```python
+rules = content.get("seed", {}).get("marketplace_rules", {})
+```
+
+## Common Mistakes
+
+```python
+# WRONG: Forgot content wrapper
+def bad_udf(data):
+    return [{'result': data['field']}]  # KeyError if wrapped
+
+# WRONG: Returned dict instead of list (without passthrough)
+def bad_udf(data):
+    return {'result': 'value'}  # Must be [{'result': 'value'}]
+
+# WRONG: Flat access for observed fields (fields are namespaced)
+def bad_udf(data):
+    content = data.get("content", data)
+    result = content.get("field")  # None — field is under action namespace
+    # CORRECT: result = content.get("upstream_action", {}).get("field")
+
+# WRONG: Default doesn't match schema type
+def bad_udf(data):
+    return [{"name": None}]  # schema says type: string → validation error
+    # CORRECT: return [{"name": ""}]
+```
+
+## Type Mapping
+
+| JSON | Python |
+|------|--------|
+| string | `str` |
+| integer | `int` |
+| number | `float` |
+| array | `list[str]` or `list[Any]` |
+| object | `dict` |
+| varies | `Any` |
+
+## TypedDict Note
+
+When your UDF returns nested objects, use nested `TypedDict` classes instead of `dict[str, Any]`. The framework converts `dict[str, Any]` to `additionalProperties: {type: string}`, which forces all values to strings and causes schema validation errors.
+
+```python
+# BAD
+class MyOutput(TypedDict, total=False):
+    metadata: dict[str, Any]       # All values forced to string
+
+# GOOD
+class SearchMetadata(TypedDict, total=False):
+    total_count: int
+    method: str
+
+class MyOutput(TypedDict, total=False):
+    metadata: SearchMetadata       # Types preserved
+```

--- a/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
+++ b/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
@@ -324,6 +324,21 @@ def bad_udf(data):
     for record in data:
         fact = record.get("fact")  # None — fact is inside "content"
     # CORRECT: fact = record.get("content", record).get("fact")
+
+# WRONG: Copying all input into output — leaks arbitrary fields past schema validation
+def bad_udf(data):
+    content = data.get("content", data)
+    flat = {}
+    for k, v in content.items():
+        if isinstance(v, dict): flat.update(v)
+        else: flat[k] = v
+    result = flat.copy()                    # Distractor text becomes a top-level key
+    result["computed"] = do_something()
+    return [result]
+    # CORRECT: build result with only schema-declared fields
+    # result = {"computed": do_something(), "question": flat.get("question", "")}
+    # for field in ("source_quote", "answer"):
+    #     if field in flat: result[field] = flat[field]
 ```
 
 ## Best Practices


### PR DESCRIPTION
## Summary
- **SKILL.md** (299→165 lines): Rewrote from debugging-oriented to framework-first. Every section answers "what does the framework expect" not "here's a bug we found". Pushed inspection scripts and cache clearing to references.
- **framework-contracts.md**: +5 contracts (29-33) — UDF output validation, field consistency, version consumption resolution, judge action schema rule, three-store cache clearing
- **udf-reference.md**: Added flat.copy() anti-pattern to Common Mistakes
- **udf_tool.py.template**: Fixed content.copy() → explicit field construction with namespace unwrapping
- **udf_file_tool.py.template** (NEW): FILE mode template with lineage rules (passthrough + new content)
- **udf_version_merge.py.template** (NEW): Version merge UDF template
- **common-pitfalls.md** (NEW): Consolidated common pitfalls reference
- **udf-decorator.md** (NEW): UDF decorator reference
- **udf-patterns.md** (NEW): UDF patterns reference

## Verification
- Content-only change (skills docs/templates), no runtime code affected
- All vendor references (Anthropic, OpenAI, etc.) are legitimate model/vendor names, not attribution