### PR TITLE
fix: cascade failure reporting and batch mode timing display

### DIFF
--- a/.changes/unreleased/Bug Fix-20260418-120000.yaml
+++ b/.changes/unreleased/Bug Fix-20260418-120000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Cascade failures now report as blocked instead of independent errors; batch-mode actions show wall-clock duration from submission to completion"
+time: 2026-04-18T12:00:00.000000Z

--- a/agent_actions/cli/renderers/execution_renderer.py
+++ b/agent_actions/cli/renderers/execution_renderer.py
@@ -16,6 +16,8 @@ from rich.console import Console
 from rich.rule import Rule
 from rich.text import Text
 
+from agent_actions.workflow.executor import UPSTREAM_SKIP_PREFIX
+
 logger = logging.getLogger(__name__)
 
 _KNOWN_KINDS = frozenset({"tool", "hitl", "source", "seed"})
@@ -265,7 +267,7 @@ class ExecutionRenderer:
             for r in snap.action_results.values()
             if r.status == "skipped"
             and r.skip_reason
-            and "upstream dependency" in r.skip_reason.lower()
+            and r.skip_reason.startswith(UPSTREAM_SKIP_PREFIX)
         )
         other_skipped = status_counts["skipped"] - blocked
 

--- a/agent_actions/cli/renderers/execution_renderer.py
+++ b/agent_actions/cli/renderers/execution_renderer.py
@@ -35,6 +35,7 @@ class ActionResult:
     model_name: str = ""
     error_message: str = ""
     skip_reason: str = ""
+    execution_mode: str = ""  # "batch" for batch-mode actions
 
 
 @dataclass
@@ -92,6 +93,7 @@ def build_execution_snapshot(
             model_name=config.get("model_name", ""),
             error_message=details.get("error_message", ""),
             skip_reason=details.get("skip_reason", ""),
+            execution_mode=details.get("execution_mode", ""),
         )
 
     return WorkflowExecutionSnapshot(
@@ -235,7 +237,14 @@ class ExecutionRenderer:
             )
 
         if result.execution_time > 0:
-            line.append(f" {result.execution_time:.1f}s", style="dim yellow")
+            t = result.execution_time
+            if t >= 60:
+                time_str = f"{int(t // 60)}m{int(t % 60):02d}s"
+            else:
+                time_str = f"{t:.1f}s"
+            if result.execution_mode == "batch":
+                time_str += " (batch)"
+            line.append(f" {time_str}", style="dim yellow")
 
         return line
 
@@ -249,6 +258,16 @@ class ExecutionRenderer:
 
     def _render_footer(self, snap: WorkflowExecutionSnapshot) -> None:
         status_counts = Counter(r.status for r in snap.action_results.values())
+
+        # Distinguish blocked (upstream failed) from other skips (guard, etc.)
+        blocked = sum(
+            1
+            for r in snap.action_results.values()
+            if r.status == "skipped"
+            and r.skip_reason
+            and "upstream dependency" in r.skip_reason.lower()
+        )
+        other_skipped = status_counts["skipped"] - blocked
 
         self.console.print(Rule(style="dim"))
 
@@ -266,8 +285,10 @@ class ExecutionRenderer:
             parts.append(f"{status_counts['completed']} completed")
         if status_counts["completed_with_failures"]:
             parts.append(f"{status_counts['completed_with_failures']} partial")
-        if status_counts["skipped"]:
-            parts.append(f"{status_counts['skipped']} skipped")
+        if blocked:
+            parts.append(f"{blocked} blocked")
+        if other_skipped:
+            parts.append(f"{other_skipped} skipped")
 
         if parts:
             footer.append(f"  ({', '.join(parts)})", style="dim")

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -30,6 +30,10 @@ from agent_actions.workflow.managers.state import COMPLETED_STATUSES, ActionStat
 
 logger = logging.getLogger(__name__)
 
+# Prefix used in skip_reason for cascade failures.  The renderer checks
+# this prefix to distinguish "blocked by upstream" from "guard-filtered".
+UPSTREAM_SKIP_PREFIX = "Upstream dependency"
+
 
 @dataclass
 class ExecutorDependencies:
@@ -544,9 +548,15 @@ class ActionExecutor:
         if vc_config and isinstance(vc_config, dict):
             source_base = vc_config.get("source")
             if source_base:
-                # Find expanded version agents in the execution order
+                # Find expanded version agents in the execution order.
+                # Version agents are named {base}_{N} where N is a digit.
+                prefix = f"{source_base}_"
                 for action in self.deps.state_manager.execution_order:
-                    if action.startswith(f"{source_base}_") and action != action_name:
+                    if (
+                        action.startswith(prefix)
+                        and action[len(prefix) :].isdigit()
+                        and action != action_name
+                    ):
                         deps_to_check.append(action)
 
         if not deps_to_check:
@@ -583,7 +593,7 @@ class ActionExecutor:
         dep_status = (
             "skipped" if self.deps.state_manager.is_skipped(failed_dependency) else "failed"
         )
-        reason = f"Upstream dependency '{failed_dependency}' {dep_status}"
+        reason = f"{UPSTREAM_SKIP_PREFIX} '{failed_dependency}' {dep_status}"
         duration = (datetime.now() - start_time).total_seconds()
         self.deps.state_manager.update_status(
             action_name, ActionStatus.SKIPPED, skip_reason=reason, execution_time=duration

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -306,7 +306,11 @@ class ActionExecutor:
     ) -> ActionExecutionResult:
         """Handle successful action run result."""
         if batch_status == "batch_submitted":
-            self.deps.state_manager.update_status(params.action_name, ActionStatus.BATCH_SUBMITTED)
+            self.deps.state_manager.update_status(
+                params.action_name,
+                ActionStatus.BATCH_SUBMITTED,
+                batch_submitted_at=datetime.now().isoformat(),
+            )
             fire_event(BatchSubmittedEvent(action_name=params.action_name))
             return ActionExecutionResult(
                 success=True,
@@ -522,11 +526,32 @@ class ActionExecutor:
     def _check_upstream_health(
         self, action_name: str, action_config: ActionConfigDict
     ) -> str | None:
-        """Return the name of a failed or skipped upstream dependency, or None if all healthy."""
-        dependencies = action_config.get("dependencies", [])
-        if not dependencies:
+        """Return the name of a failed or skipped upstream dependency, or None if all healthy.
+
+        Checks both explicit dependencies and version sources.  For
+        version-correlation actions (e.g. ``aggregate_votes`` consuming
+        ``filter_learning_quality_1/2/3``), the version sources are
+        checked so that cascade failures propagate as SKIPPED instead of
+        raising "Version correlation failed" errors.
+        """
+        deps_to_check: list[str] = list(action_config.get("dependencies", []))
+
+        # Also check version sources for merge/reduce actions.  If the
+        # version agents (e.g. extract_raw_qa_1, _2, _3) are failed or
+        # skipped, this action cannot correlate — it should be skipped,
+        # not error with "Version correlation failed".
+        vc_config = action_config.get("version_consumption_config")
+        if vc_config and isinstance(vc_config, dict):
+            source_base = vc_config.get("source")
+            if source_base:
+                # Find expanded version agents in the execution order
+                for action in self.deps.state_manager.execution_order:
+                    if action.startswith(f"{source_base}_") and action != action_name:
+                        deps_to_check.append(action)
+
+        if not deps_to_check:
             return None
-        for dep in dependencies:
+        for dep in deps_to_check:
             if self.deps.state_manager.is_failed(dep) or self.deps.state_manager.is_skipped(dep):
                 return dep
             # Also check disposition — covers cascaded failures/skips from prior levels
@@ -718,6 +743,22 @@ class ActionExecutor:
             )
         )
 
+    def _compute_batch_wall_clock(self, action_name: str, fallback: float) -> float:
+        """Compute wall-clock time from batch submission to now.
+
+        Falls back to *fallback* when no ``batch_submitted_at`` timestamp
+        was persisted (e.g. jobs submitted before this feature was added).
+        """
+        details = self.deps.state_manager.get_status_details(action_name)
+        submitted_at = details.get("batch_submitted_at")
+        if submitted_at:
+            try:
+                submitted_dt = datetime.fromisoformat(submitted_at)
+                return (datetime.now() - submitted_dt).total_seconds()
+            except (ValueError, TypeError):
+                pass
+        return fallback
+
     def _handle_batch_check(
         self,
         action_name: str,
@@ -738,9 +779,14 @@ class ActionExecutor:
         duration = (datetime.now() - start_time).total_seconds()
 
         if batch_status == "completed":
+            wall_clock = self._compute_batch_wall_clock(action_name, duration)
             final_status = self._resolve_completion_status(action_name)
             self.deps.state_manager.update_status(
-                action_name, final_status, **self._limit_metadata(action_config)
+                action_name,
+                final_status,
+                execution_time=wall_clock,
+                execution_mode="batch",
+                **self._limit_metadata(action_config),
             )
             fire_event(
                 BatchCompleteEvent(
@@ -749,14 +795,14 @@ class ActionExecutor:
                     total=1,
                     completed=1,
                     failed=0,
-                    elapsed_time=duration,
+                    elapsed_time=wall_clock,
                 )
             )
             return ActionExecutionResult(
                 success=True,
                 output_folder=output_folder,
                 status=final_status,
-                metrics=ExecutionMetrics(duration=duration),
+                metrics=ExecutionMetrics(duration=wall_clock),
             )
 
         if batch_status == "in_progress":
@@ -818,9 +864,14 @@ class ActionExecutor:
         duration = (datetime.now() - start_time).total_seconds()
 
         if batch_status == "completed":
+            wall_clock = self._compute_batch_wall_clock(action_name, duration)
             final_status = self._resolve_completion_status(action_name)
             self.deps.state_manager.update_status(
-                action_name, final_status, **self._limit_metadata(action_config)
+                action_name,
+                final_status,
+                execution_time=wall_clock,
+                execution_mode="batch",
+                **self._limit_metadata(action_config),
             )
             fire_event(
                 BatchCompleteEvent(
@@ -829,14 +880,14 @@ class ActionExecutor:
                     total=1,
                     completed=1,
                     failed=0,
-                    elapsed_time=duration,
+                    elapsed_time=wall_clock,
                 )
             )
             return ActionExecutionResult(
                 success=True,
                 output_folder=output_folder,
                 status=final_status,
-                metrics=ExecutionMetrics(duration=duration),
+                metrics=ExecutionMetrics(duration=wall_clock),
             )
 
         if batch_status == "in_progress":

--- a/tests/unit/cli/test_execution_renderer.py
+++ b/tests/unit/cli/test_execution_renderer.py
@@ -125,6 +125,72 @@ class TestExecutionRenderer:
         assert "┌" in output
         assert "└" in output
 
+    def test_renders_batch_time_with_indicator(self):
+        snap = _basic_snapshot(
+            action_results={
+                "batch_action": ActionResult(
+                    name="batch_action",
+                    kind="llm",
+                    status="completed",
+                    execution_time=974.0,
+                    execution_mode="batch",
+                    model_vendor="openai",
+                    model_name="gpt-4o",
+                ),
+            },
+            execution_levels=[["batch_action"]],
+        )
+        output = _capture_render(snap)
+        assert "16m14s" in output
+        assert "(batch)" in output
+
+    def test_renders_short_time_as_seconds(self):
+        snap = _basic_snapshot(
+            action_results={
+                "fast": ActionResult(
+                    name="fast", kind="tool", status="completed", execution_time=3.7
+                ),
+            },
+            execution_levels=[["fast"]],
+        )
+        output = _capture_render(snap)
+        assert "3.7s" in output
+        assert "(batch)" not in output
+
+    def test_footer_blocked_vs_skipped(self):
+        from agent_actions.workflow.executor import UPSTREAM_SKIP_PREFIX
+
+        snap = _basic_snapshot(
+            action_results={
+                "root_fail": ActionResult(
+                    name="root_fail", kind="llm", status="failed", error_message="billing"
+                ),
+                "blocked_1": ActionResult(
+                    name="blocked_1",
+                    kind="llm",
+                    status="skipped",
+                    skip_reason=f"{UPSTREAM_SKIP_PREFIX} 'root_fail' failed",
+                ),
+                "blocked_2": ActionResult(
+                    name="blocked_2",
+                    kind="tool",
+                    status="skipped",
+                    skip_reason=f"{UPSTREAM_SKIP_PREFIX} 'root_fail' failed",
+                ),
+                "guard_skip": ActionResult(
+                    name="guard_skip",
+                    kind="tool",
+                    status="skipped",
+                    skip_reason="guard condition not met",
+                ),
+            },
+            execution_levels=[["root_fail"], ["blocked_1", "blocked_2"], ["guard_skip"]],
+        )
+        output = _capture_render(snap)
+        assert "1 failed" in output
+        assert "2 blocked" in output
+        assert "1 skipped" in output
+
     def test_renders_done_footer(self):
         output = _capture_render(_basic_snapshot())
         assert "Done in" in output

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -118,6 +118,136 @@ class TestCheckUpstreamHealth:
         assert result is None
 
 
+class TestVersionSourceCascade:
+    """Tests for version-source cascade detection in _check_upstream_health."""
+
+    def test_skipped_version_source_detected(self, executor, mock_deps):
+        """Version source skipped → merge action detected as blocked."""
+        mock_deps.state_manager.execution_order = [
+            "extract_raw_qa_1",
+            "extract_raw_qa_2",
+            "extract_raw_qa_3",
+            "canonicalize_qa",
+        ]
+        mock_deps.state_manager.is_failed.return_value = False
+        mock_deps.state_manager.is_skipped.side_effect = lambda n: n.startswith("extract_raw_qa_")
+        mock_deps.action_runner.storage_backend = None
+
+        config = {
+            "dependencies": [],
+            "version_consumption_config": {"source": "extract_raw_qa", "pattern": "merge"},
+        }
+        result = executor._check_upstream_health("canonicalize_qa", config)
+        assert result == "extract_raw_qa_1"
+
+    def test_failed_version_source_detected(self, executor, mock_deps):
+        """Version source failed → merge action detected as blocked."""
+        mock_deps.state_manager.execution_order = [
+            "extract_raw_qa_1",
+            "extract_raw_qa_2",
+            "canonicalize_qa",
+        ]
+        mock_deps.state_manager.is_failed.side_effect = lambda n: n == "extract_raw_qa_2"
+        mock_deps.state_manager.is_skipped.return_value = False
+        mock_deps.action_runner.storage_backend = None
+
+        config = {
+            "dependencies": [],
+            "version_consumption_config": {"source": "extract_raw_qa", "pattern": "merge"},
+        }
+        result = executor._check_upstream_health("canonicalize_qa", config)
+        assert result == "extract_raw_qa_2"
+
+    def test_healthy_version_sources_pass(self, executor, mock_deps):
+        """All version sources healthy → returns None."""
+        mock_deps.state_manager.execution_order = [
+            "extract_raw_qa_1",
+            "extract_raw_qa_2",
+            "canonicalize_qa",
+        ]
+        mock_deps.state_manager.is_failed.return_value = False
+        mock_deps.state_manager.is_skipped.return_value = False
+        mock_deps.action_runner.storage_backend = None
+
+        config = {
+            "dependencies": [],
+            "version_consumption_config": {"source": "extract_raw_qa", "pattern": "merge"},
+        }
+        result = executor._check_upstream_health("canonicalize_qa", config)
+        assert result is None
+
+    def test_non_version_agent_not_matched(self, executor, mock_deps):
+        """Actions with same prefix but non-digit suffix are not matched."""
+        mock_deps.state_manager.execution_order = [
+            "extract_raw_qa_1",
+            "extract_raw_qa_validator",  # not a version agent
+            "canonicalize_qa",
+        ]
+        mock_deps.state_manager.is_failed.return_value = False
+        mock_deps.state_manager.is_skipped.return_value = False
+        mock_deps.action_runner.storage_backend = None
+
+        config = {
+            "dependencies": [],
+            "version_consumption_config": {"source": "extract_raw_qa", "pattern": "merge"},
+        }
+        result = executor._check_upstream_health("canonicalize_qa", config)
+        assert result is None  # only _1 is a version agent, and it's healthy
+
+    def test_no_version_config_skips_check(self, executor, mock_deps):
+        """No version_consumption_config → only checks dependencies."""
+        mock_deps.state_manager.is_failed.return_value = False
+        mock_deps.state_manager.is_skipped.return_value = False
+        mock_deps.action_runner.storage_backend = None
+
+        config = {"dependencies": []}
+        result = executor._check_upstream_health("agent_b", config)
+        assert result is None
+
+    def test_empty_version_config_skips_check(self, executor, mock_deps):
+        """Empty version_consumption_config dict → skips version source check."""
+        mock_deps.state_manager.execution_order = ["extract_1", "merge"]
+        mock_deps.state_manager.is_failed.return_value = False
+        mock_deps.state_manager.is_skipped.return_value = False
+        mock_deps.action_runner.storage_backend = None
+
+        config = {"dependencies": [], "version_consumption_config": {}}
+        result = executor._check_upstream_health("merge", config)
+        assert result is None
+
+
+class TestComputeBatchWallClock:
+    """Tests for _compute_batch_wall_clock."""
+
+    def test_computes_from_persisted_timestamp(self, executor, mock_deps):
+        """Wall-clock computed from batch_submitted_at to now."""
+        # Submitted 60 seconds ago
+        submitted = datetime.now().replace(microsecond=0)
+        from datetime import timedelta
+
+        submitted = datetime.now() - timedelta(seconds=60)
+        mock_deps.state_manager.get_status_details.return_value = {
+            "batch_submitted_at": submitted.isoformat(),
+        }
+        result = executor._compute_batch_wall_clock("agent_a", fallback=5.0)
+        assert result >= 59.0  # at least 59 seconds (clock tolerance)
+        assert result < 65.0  # not wildly off
+
+    def test_missing_timestamp_returns_fallback(self, executor, mock_deps):
+        """No batch_submitted_at → returns fallback."""
+        mock_deps.state_manager.get_status_details.return_value = {}
+        result = executor._compute_batch_wall_clock("agent_a", fallback=5.0)
+        assert result == 5.0
+
+    def test_malformed_timestamp_returns_fallback(self, executor, mock_deps):
+        """Unparseable timestamp → returns fallback."""
+        mock_deps.state_manager.get_status_details.return_value = {
+            "batch_submitted_at": "not-a-date",
+        }
+        result = executor._compute_batch_wall_clock("agent_a", fallback=3.0)
+        assert result == 3.0
+
+
 class TestHandleDependencySkip:
     """Tests for _handle_dependency_skip()."""
 

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -267,15 +267,15 @@ class TestHandleRunSuccess:
         return ActionRunParams(**defaults)
 
     def test_batch_submitted_status(self, executor, mock_deps):
-        """batch_submitted batch_status should return batch_submitted result."""
+        """batch_submitted batch_status should return batch_submitted result with timestamp."""
         params = self._make_params()
         with patch("agent_actions.workflow.executor.fire_event"):
             result = executor._handle_run_success(params, "/out", 1.0, "batch_submitted")
 
         assert result.status == ActionStatus.BATCH_SUBMITTED
-        mock_deps.state_manager.update_status.assert_called_with(
-            "agent_a", ActionStatus.BATCH_SUBMITTED
-        )
+        call_args = mock_deps.state_manager.update_status.call_args
+        assert call_args[0] == ("agent_a", ActionStatus.BATCH_SUBMITTED)
+        assert "batch_submitted_at" in call_args[1]  # timestamp persisted
 
     def test_passthrough_status(self, executor, mock_deps):
         """passthrough batch_status should mark completed."""


### PR DESCRIPTION
## Summary

**Bug 1 — Cascade failure reporting:**
- Circuit breaker now checks version source health (e.g. `filter_learning_quality_1/2/3`) before execution
- Version-correlation actions blocked by upstream failures are marked SKIPPED (not ERROR)
- Eliminates "Version correlation failed" errors that are actually cascade effects
- Footer distinguishes root failures from blocked: `✗ 1 failed (4 blocked, 33 skipped)`

**Bug 2 — Batch mode timing:**
- `batch_submitted_at` timestamp persisted when batch is submitted
- Wall-clock time computed from submission to completion on batch retrieval
- Display shows `16m14s (batch)` for batch-mode actions
- Times >= 60s formatted as `Xm XXs`

Fixes: specs/bugs/pending/bug_cascade_failure_reporting.md, bug_batch_mode_timing_misleading.md

## Verification

- 5329 tests passed, 0 failed
- Existing executor lifecycle test updated for batch_submitted_at
- ruff format/check clean