### PR TITLE
fix: cross-workflow record handoff delivers content and source_guid

### DIFF
--- a/.changes/unreleased/Bug Fix-20260418-132517.yaml
+++ b/.changes/unreleased/Bug Fix-20260418-132517.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: Cross-workflow records now deliver content and propagate source_guid through downstream pipelines
+time: 2026-04-18T13:25:17.450389+01:00

--- a/agent_actions/input/context/historical.py
+++ b/agent_actions/input/context/historical.py
@@ -4,6 +4,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
+from agent_actions.prompt.context.scope_namespace import _extract_content_data
+
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
 
@@ -101,7 +103,7 @@ class HistoricalNodeDataLoader:
         )
 
         if record:
-            content: dict[str, Any] = record.get("content", {})
+            content: dict[str, Any] = _extract_content_data(record)
             content_keys = list(content.keys()) if isinstance(content, dict) else []
             logger.debug(
                 "[HISTORICAL] Found record for action '%s': node_id=%s, content_keys=%s",

--- a/agent_actions/workflow/managers/loop.py
+++ b/agent_actions/workflow/managers/loop.py
@@ -385,9 +385,11 @@ class VersionOutputCorrelator:
 
     def _merge_with_pattern(self, agent_records: dict[str, dict[str, Any]]) -> dict[str, Any]:
         """Merge content into nested namespaces keyed by version agent name."""
+        from agent_actions.prompt.context.scope_namespace import _extract_content_data
+
         merged_content = {}
         for agent_name, record in agent_records.items():
-            content = record.get("content", {})
+            content = _extract_content_data(record)
             merged_content[agent_name] = content
         return merged_content
 

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -108,14 +108,20 @@ def _reattach_source_guid(
     Mutates structured_data in place.  Only sets source_guid when the output
     item does not already carry a truthy value (explicit tool values win).
     """
-    if not source_mapping or not original_data:
+    if source_mapping is None or not original_data:
         return
 
     for i, item in enumerate(structured_data):
         if item.get("source_guid"):
             continue  # Tool explicitly set it — respect that
 
-        source_idx = source_mapping.get(i, 0)
+        source_idx = source_mapping.get(i)
+        if source_idx is None:
+            # No node_id match — positional fallback only when cardinalities match
+            if len(structured_data) == len(original_data):
+                source_idx = i
+            else:
+                continue  # Cardinality mismatch — no safe positional fallback
         if isinstance(source_idx, list):
             source_idx = source_idx[0]  # Many-to-one: use first parent
 

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -126,7 +126,7 @@ def _reattach_source_guid(
             # and cardinalities match (1:1 passthrough by tools that don't preserve node_id).
             # When mapping has entries, unmapped outputs are genuinely new records.
             if not source_mapping and len(structured_data) == len(original_data):
-                source_idx = i
+                source_idx: int | list[int] = i
             else:
                 continue  # Unmapped output — new record, no parent to inherit from
         else:

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -318,6 +318,7 @@ class ActionRunner:
 
         upstream_target = Path(upstream_folder) / "target" / dep_name
         if upstream_target.exists() and any(upstream_target.iterdir()):
+            self._sync_virtual_action_to_local_backend(dep_name, upstream_target)
             return upstream_target
 
         # SQLite-backed workflows don't write target directories to disk.
@@ -344,6 +345,7 @@ class ActionRunner:
                     dep_name,
                     upstream_target,
                 )
+                self._sync_virtual_action_to_local_backend(dep_name, upstream_target)
                 return upstream_target
         except Exception as e:
             logger.debug("Upstream storage backend export failed for '%s': %s", dep_name, e)
@@ -355,6 +357,43 @@ class ActionRunner:
             upstream_target,
         )
         return None
+
+    def _sync_virtual_action_to_local_backend(self, dep_name: str, upstream_target: Path) -> None:
+        """Copy virtual action data into the downstream's storage backend.
+
+        The historical loader queries ``self.storage_backend`` (the downstream's
+        database).  Without this sync, virtual action records only exist in
+        the upstream's storage, so observe resolution finds nothing.
+        """
+        if getattr(self, "storage_backend", None) is None:
+            return
+
+        import json
+
+        for file_path in sorted(upstream_target.iterdir()):
+            if not file_path.is_file() or file_path.suffix != ".json":
+                continue
+            try:
+                data = json.loads(file_path.read_text())
+                if isinstance(data, list):
+                    self.storage_backend.write_target(
+                        action_name=dep_name,
+                        relative_path=file_path.name,
+                        data=data,
+                    )
+                    logger.debug(
+                        "Synced virtual action '%s/%s' to local storage backend (%d records)",
+                        dep_name,
+                        file_path.name,
+                        len(data),
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to sync virtual action '%s/%s' to local backend: %s",
+                    dep_name,
+                    file_path.name,
+                    e,
+                )
 
     def _get_upstream_backend(self, upstream_folder: str, upstream_workflow: str) -> Any:
         """Get or create a cached storage backend for an upstream workflow."""

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -365,7 +365,7 @@ class ActionRunner:
         database).  Without this sync, virtual action records only exist in
         the upstream's storage, so observe resolution finds nothing.
         """
-        if getattr(self, "storage_backend", None) is None:
+        if self.storage_backend is None:
             return
 
         import json

--- a/tests/preprocessing/context/test_ancestry_chain_matching.py
+++ b/tests/preprocessing/context/test_ancestry_chain_matching.py
@@ -509,3 +509,72 @@ class TestConditionalMerge:
         )
         result = HistoricalNodeDataLoader.load_historical_node_data(request)
         assert result is None
+
+
+class TestHistoricalContentExtraction:
+    """Content extraction from flat vs wrapped record formats."""
+
+    def test_flat_record_returns_business_fields(self):
+        """Historical loader extracts content from flat records (no 'content' wrapper)."""
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        backend.read_target.return_value = [
+            {
+                "source_guid": "sg-001",
+                "node_id": "extract_abc123",
+                "lineage": ["extract_abc123"],
+                "target_id": "tid-001",
+                "metadata": {"model": "gpt-4"},
+                "question_text": "What is X?",
+                "answer_text": "X is Y.",
+            }
+        ]
+
+        request = HistoricalDataRequest(
+            action_name="extract",
+            lineage=["extract_abc123", "enrich_def456"],
+            source_guid="sg-001",
+            file_path="/tmp/test.json",
+            agent_indices={"extract": 0, "enrich": 1},
+            storage_backend=backend,
+        )
+        result = HistoricalNodeDataLoader.load_historical_node_data(request)
+
+        assert result is not None
+        assert result.get("question_text") == "What is X?"
+        assert result.get("answer_text") == "X is Y."
+        # Metadata keys excluded
+        assert "source_guid" not in result
+        assert "node_id" not in result
+        assert "lineage" not in result
+        assert "target_id" not in result
+        assert "metadata" not in result
+
+    def test_wrapped_record_returns_content_dict(self):
+        """Historical loader extracts content from wrapped records."""
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        backend.read_target.return_value = [
+            {
+                "source_guid": "sg-001",
+                "node_id": "extract_abc123",
+                "lineage": ["extract_abc123"],
+                "content": {"question_text": "What is X?", "answer_text": "X is Y."},
+            }
+        ]
+
+        request = HistoricalDataRequest(
+            action_name="extract",
+            lineage=["extract_abc123", "enrich_def456"],
+            source_guid="sg-001",
+            file_path="/tmp/test.json",
+            agent_indices={"extract": 0, "enrich": 1},
+            storage_backend=backend,
+        )
+        result = HistoricalNodeDataLoader.load_historical_node_data(request)
+
+        assert result is not None
+        assert result.get("question_text") == "What is X?"
+        assert result.get("answer_text") == "X is Y."

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -763,8 +763,8 @@ def test_file_tool_non_dict_output_items():
 
     # Non-dict wrapped as {"content": {"value": ...}} — no node_id, so no mapping
     assert results[0].data[0]["content"]["value"] == "just a string"
-    # New record — enrichment pipeline sets source_guid="" (no parent to inherit from)
-    assert results[0].data[0].get("source_guid") == ""
+    # Same cardinality (1:1) — positional fallback propagates source_guid from input
+    assert results[0].data[0].get("source_guid") == "sg-1"
 
 
 def test_file_tool_merge_reduces_to_fewer_outputs():
@@ -949,3 +949,34 @@ class TestReattachSourceGuid:
 
         # Out of bounds → not set (no crash)
         assert "source_guid" not in structured[0]
+
+    def test_empty_mapping_positional_fallback_same_cardinality(self):
+        """Empty source_mapping with same cardinality uses positional fallback."""
+        from agent_actions.workflow.pipeline_file_mode import _reattach_source_guid
+
+        structured = [{"content": {"val": 1}}, {"content": {"val": 2}}]
+        mapping: dict = {}  # Empty — no node_id matches
+        original = [{"source_guid": "sg-a"}, {"source_guid": "sg-b"}]
+
+        _reattach_source_guid(structured, mapping, original)
+
+        assert structured[0]["source_guid"] == "sg-a"
+        assert structured[1]["source_guid"] == "sg-b"
+
+    def test_empty_mapping_no_fallback_different_cardinality(self):
+        """Empty source_mapping with different cardinality does NOT reattach."""
+        from agent_actions.workflow.pipeline_file_mode import _reattach_source_guid
+
+        structured = [
+            {"content": {"val": 1}},
+            {"content": {"val": 2}},
+            {"content": {"val": 3}},
+        ]
+        mapping: dict = {}  # Empty — no node_id matches
+        original = [{"source_guid": "sg-a"}, {"source_guid": "sg-b"}]
+
+        _reattach_source_guid(structured, mapping, original)
+
+        # Cardinality mismatch (3 vs 2): no safe positional fallback
+        for item in structured:
+            assert "source_guid" not in item

--- a/tests/unit/workflow/test_virtual_actions.py
+++ b/tests/unit/workflow/test_virtual_actions.py
@@ -136,6 +136,7 @@ class TestRunnerVirtualActionResolution:
         runner = ActionRunner.__new__(ActionRunner)
         runner.project_root = tmp_path
         runner.workflow_name = "enrich"
+        runner.storage_backend = None
         runner.virtual_actions = {
             "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
         }
@@ -155,6 +156,7 @@ class TestRunnerVirtualActionResolution:
         runner = ActionRunner.__new__(ActionRunner)
         runner.project_root = tmp_path
         runner.workflow_name = "enrich"
+        runner.storage_backend = None
         runner.virtual_actions = {
             "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
         }
@@ -169,6 +171,7 @@ class TestRunnerVirtualActionResolution:
         runner = ActionRunner.__new__(ActionRunner)
         runner.project_root = tmp_path
         runner.workflow_name = "enrich"
+        runner.storage_backend = None
         runner.virtual_actions = {
             "extract": VirtualAction(source_workflow="nonexistent", action_name="extract"),
         }

--- a/tests/unit/workflow/test_virtual_actions.py
+++ b/tests/unit/workflow/test_virtual_actions.py
@@ -209,3 +209,61 @@ class TestRunnerVirtualActionResolution:
 
         assert len(result) == 1
         assert result[0] == upstream_io / "target" / "extract"
+
+
+class TestVirtualActionStorageSync:
+    """Virtual action data synced to downstream storage backend."""
+
+    def test_virtual_action_syncs_to_local_backend(self, tmp_path):
+        """After resolving virtual action dir, data is written to downstream's backend."""
+        import json
+        from unittest.mock import MagicMock
+
+        from agent_actions.workflow.runner import ActionRunner
+
+        # Create upstream directory with data
+        upstream_io = tmp_path / "ingest" / "agent_io"
+        extract_dir = upstream_io / "target" / "extract"
+        extract_dir.mkdir(parents=True)
+        records = [{"source_guid": "sg-1", "node_id": "extract_abc", "question": "Q1"}]
+        (extract_dir / "data.json").write_text(json.dumps(records))
+
+        # Set up runner with mock storage backend
+        mock_backend = MagicMock()
+        runner = ActionRunner.__new__(ActionRunner)
+        runner.project_root = tmp_path
+        runner.workflow_name = "enrich"
+        runner.storage_backend = mock_backend
+        runner.virtual_actions = {
+            "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
+        }
+
+        result = runner._resolve_virtual_action_directory("extract")
+        assert result is not None
+
+        # Verify write_target was called on the downstream's backend
+        mock_backend.write_target.assert_called_once_with(
+            action_name="extract",
+            relative_path="data.json",
+            data=records,
+        )
+
+    def test_virtual_action_no_sync_without_backend(self, tmp_path):
+        """No crash when storage_backend is None."""
+        from agent_actions.workflow.runner import ActionRunner
+
+        upstream_io = tmp_path / "ingest" / "agent_io"
+        extract_dir = upstream_io / "target" / "extract"
+        extract_dir.mkdir(parents=True)
+        (extract_dir / "data.json").write_text('[{"id": 1}]')
+
+        runner = ActionRunner.__new__(ActionRunner)
+        runner.project_root = tmp_path
+        runner.workflow_name = "enrich"
+        runner.storage_backend = None
+        runner.virtual_actions = {
+            "extract": VirtualAction(source_workflow="ingest", action_name="extract"),
+        }
+
+        result = runner._resolve_virtual_action_directory("extract")
+        assert result is not None  # Works without backend sync


### PR DESCRIPTION
## Summary
- Historical loader now extracts content from flat records (no "content" wrapper) using `_extract_content_data()` instead of `record.get("content", {})`
- Virtual action data synced to downstream's storage backend via `_sync_virtual_action_to_local_backend()` so observe resolution can find it
- `_reattach_source_guid()` fixed: empty source_mapping (`{}`) no longer causes early return; positional fallback propagates source_guid for same-cardinality (1:1) tool outputs

## Verification
- 5335 tests pass, 2 skipped
- `ruff format --check` and `ruff check` clean (pre-existing issues excluded)
- New regression tests for all three fixes: flat record content extraction, positional source_guid fallback, virtual action backend sync