### PR TITLE
fix: prevent batch resubmission loop with upstream guard skip

### DIFF
--- a/.changes/unreleased/Bug Fix-20260419-073200.yaml
+++ b/.changes/unreleased/Bug Fix-20260419-073200.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch resubmission loop: prevent submit_batch_job from resubmitting completed batches when upstream guard filters records with on_false: skip"
+time: 2026-04-19T07:32:00.000000Z

--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -183,6 +183,13 @@ class BatchSubmissionService:
                     "Use --batch_continue to process completed batches."
                 )
                 return SubmissionResult(batch_id=entry.batch_id)
+            if entry and entry.status == BatchStatus.COMPLETED:
+                logger.info(
+                    "Found completed batch job for %s: %s — skipping resubmission",
+                    batch_name,
+                    entry.batch_id,
+                )
+                return SubmissionResult(batch_id=entry.batch_id)
 
         tasks, context_map = self.prepare_batch_tasks(
             agent_config, data, output_directory, batch_name, source_data, workflow_metadata

--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -183,6 +183,8 @@ class BatchSubmissionService:
                     "Use --batch_continue to process completed batches."
                 )
                 return SubmissionResult(batch_id=entry.batch_id)
+            # Only COMPLETED blocks resubmission. FAILED/CANCELLED fall through
+            # so the framework can retry automatically without --force.
             if entry and entry.status == BatchStatus.COMPLETED:
                 logger.info(
                     "Found completed batch job for %s: %s — skipping resubmission",

--- a/tests/simulation/simulate_batch_resubmission.py
+++ b/tests/simulation/simulate_batch_resubmission.py
@@ -5,7 +5,9 @@ This script simulates the multi-run batch lifecycle to confirm that:
 2. An in-flight batch is NOT resubmitted
 3. A failed/cancelled batch IS resubmitted
 4. Force flag overrides the completed guard
-5. Guard-filtered (fewer tasks) batches still settle correctly
+5. Guard-filtered batches settle correctly (fewer tasks submitted)
+6. Reconciliation merges processed + skipped into consolidated output
+7. Dispositions correctly mark guard-skipped records as SKIPPED in the DB
 
 Run:
     python tests/simulation/simulate_batch_resubmission.py
@@ -15,14 +17,120 @@ import json
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_constants import (
+    BatchStatus,
+    ContextMetaKeys,
+    FilterStatus,
+)
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.batch.services.submission import BatchSubmissionService
+from agent_actions.storage.backend import (
+    DISPOSITION_FAILED,
+    DISPOSITION_FILTERED,
+    DISPOSITION_SKIPPED,
+)
+
+# ======================================================================
+# Mock storage backend with disposition tracking
+# ======================================================================
+
+
+class MockStorageBackend:
+    """In-memory storage backend that tracks dispositions."""
+
+    def __init__(self):
+        self._dispositions: dict[tuple[str, str, str], str | None] = {}
+
+    def set_disposition(
+        self,
+        action_name: str,
+        record_id: str,
+        disposition: str,
+        reason: str | None = None,
+        **kwargs,
+    ) -> None:
+        self._dispositions[(action_name, record_id, disposition)] = reason
+
+    def clear_disposition(
+        self,
+        action_name: str,
+        disposition: str | None = None,
+        record_id: str | None = None,
+    ) -> int:
+        keys_to_delete = [
+            k
+            for k in self._dispositions
+            if k[0] == action_name
+            and (disposition is None or k[2] == disposition)
+            and (record_id is None or k[1] == record_id)
+        ]
+        for k in keys_to_delete:
+            del self._dispositions[k]
+        return len(keys_to_delete)
+
+    def has_disposition(
+        self, action_name: str, disposition: str, record_id: str | None = None
+    ) -> bool:
+        return any(
+            k[0] == action_name and k[2] == disposition and (record_id is None or k[1] == record_id)
+            for k in self._dispositions
+        )
+
+    def get_dispositions_by_type(self, action_name: str, disposition: str) -> list[str]:
+        """Return record_ids with the given disposition."""
+        return [k[1] for k in self._dispositions if k[0] == action_name and k[2] == disposition]
+
+
+# ======================================================================
+# Context map builder — simulates what BatchTaskPreparator produces
+# ======================================================================
+
+
+def build_context_map(
+    total_records: int,
+    skipped_ids: set[int],
+    filtered_ids: set[int] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Build a context map with INCLUDED, SKIPPED, and FILTERED records.
+
+    Mirrors the output of BatchTaskPreparator._process_single_item().
+    """
+    filtered_ids = filtered_ids or set()
+    context_map: dict[str, dict[str, Any]] = {}
+
+    for i in range(total_records):
+        custom_id = f"rec-{i:03d}"
+        record: dict[str, Any] = {
+            "target_id": custom_id,
+            "content": {"text": f"Record {i} content", "category": f"cat-{i % 3}"},
+            "source_guid": f"sg-{i:03d}",
+        }
+
+        if i in skipped_ids:
+            BatchContextMetadata.set_filter_status(record, FilterStatus.SKIPPED)
+            record[ContextMetaKeys.FILTER_PHASE] = "unified"
+        elif i in filtered_ids:
+            BatchContextMetadata.set_filter_status(record, FilterStatus.FILTERED)
+            record[ContextMetaKeys.FILTER_PHASE] = "unified"
+        else:
+            BatchContextMetadata.set_filter_status(record, FilterStatus.INCLUDED)
+
+        context_map[custom_id] = record
+
+    return context_map
+
+
+# ======================================================================
+# Simulation runner — submission guard tests (existing)
+# ======================================================================
 
 
 class SimulationRunner:
@@ -35,10 +143,9 @@ class SimulationRunner:
         self.batch_dir.mkdir(parents=True, exist_ok=True)
         self.registry_path = self.batch_dir / ".batch_registry.json"
         self.run_count = 0
-        self.submissions = []
+        self.submissions: list[dict[str, Any]] = []
 
     def _make_service(self, force: bool = False) -> BatchSubmissionService:
-        """Create a real-ish submission service with mocked provider."""
         svc = BatchSubmissionService(
             task_preparator=MagicMock(),
             client_resolver=MagicMock(),
@@ -48,8 +155,6 @@ class SimulationRunner:
             ),
             force_batch=force,
         )
-
-        # Mock task preparation to return tasks
         mock_prepared = MagicMock()
         mock_prepared.tasks = [
             {"target_id": f"r{i}", "content": f"data-{i}", "prompt": "p"} for i in range(10)
@@ -59,19 +164,15 @@ class SimulationRunner:
         mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
         svc._task_preparator.prepare_tasks.return_value = mock_prepared
 
-        # Mock provider to return a unique batch ID per submission
         batch_id = f"batch-{len(self.submissions) + 1:03d}"
         svc._client_resolver.get_for_config.return_value = MagicMock(
             submit_batch=MagicMock(return_value=(batch_id, "submitted"))
         )
-
         return svc
 
     def submit_run(self, force: bool = False, label: str = "") -> str:
-        """Simulate one workflow run's batch submission attempt."""
         self.run_count += 1
         svc = self._make_service(force=force)
-
         with (
             patch("agent_actions.llm.batch.services.submission.fire_event"),
             patch("agent_actions.llm.batch.services.submission.get_manager"),
@@ -82,7 +183,6 @@ class SimulationRunner:
                 data=[{"id": i} for i in range(10)],
                 output_directory=str(self.output_dir),
             )
-
         was_new = svc._task_preparator.prepare_tasks.called
         self.submissions.append(
             {
@@ -95,172 +195,333 @@ class SimulationRunner:
         return result.batch_id
 
     def set_registry_status(self, batch_name: str, status: str):
-        """Manually update the registry status (simulating provider completion)."""
         manager = BatchRegistryManager(self.registry_path)
         entry = manager.get_batch_job(batch_name)
         if entry:
             manager.update_status(entry.batch_id, status)
 
-    def get_registry(self) -> dict:
-        """Read the current registry state."""
-        if not self.registry_path.exists():
-            return {}
-        with open(self.registry_path) as f:
-            return json.load(f)
-
     def print_registry(self):
-        """Print registry state."""
-        reg = self.get_registry()
-        if not reg:
+        if not self.registry_path.exists():
             print("    Registry: (empty)")
+            return
+        with open(self.registry_path) as f:
+            reg = json.load(f)
         for key, entry in reg.items():
             print(f"    [{key}] batch_id={entry['batch_id']} status={entry['status']}")
+
+
+# ======================================================================
+# Scenarios
+# ======================================================================
+
+
+def run_submission_guard_scenarios(work_dir: Path) -> tuple[int, int]:
+    """Scenarios 1-5: submission guard logic."""
+    passed = 0
+    failed = 0
+
+    def check(condition: bool, pass_msg: str, fail_msg: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            print(f"  PASS: {pass_msg}")
+            passed += 1
+        else:
+            print(f"  FAIL: {fail_msg}")
+            failed += 1
+
+    # Scenario 1: Completed batch not resubmitted
+    print("\n--- Scenario 1: Completed batch is NOT resubmitted ---")
+    sim = SimulationRunner(work_dir / "s1")
+    bid1 = sim.submit_run(label="initial")
+    sim.set_registry_status("my_action", BatchStatus.COMPLETED)
+    bid2 = sim.submit_run(label="after completion")
+    check(
+        bid2 == bid1 and not sim.submissions[-1]["new_submission"],
+        "Completed batch was NOT resubmitted",
+        "Completed batch was resubmitted!",
+    )
+    bid3 = sim.submit_run(label="third run")
+    check(
+        bid3 == bid1 and not sim.submissions[-1]["new_submission"],
+        "Still not resubmitted on 3rd run",
+        "Resubmitted on 3rd run!",
+    )
+
+    # Scenario 2: In-flight blocks
+    print("\n--- Scenario 2: In-flight batch blocks resubmission ---")
+    sim2 = SimulationRunner(work_dir / "s2")
+    bid1 = sim2.submit_run(label="initial")
+    sim2.set_registry_status("my_action", BatchStatus.IN_PROGRESS)
+    bid2 = sim2.submit_run(label="while in-flight")
+    check(
+        bid2 == bid1 and not sim2.submissions[-1]["new_submission"],
+        "In-flight batch was NOT resubmitted",
+        "In-flight batch was resubmitted!",
+    )
+
+    # Scenario 3: Failed allows resubmission
+    print("\n--- Scenario 3: Failed batch allows resubmission ---")
+    sim3 = SimulationRunner(work_dir / "s3")
+    sim3.submit_run(label="initial")
+    sim3.set_registry_status("my_action", BatchStatus.FAILED)
+    bid2 = sim3.submit_run(label="after failure")
+    check(
+        sim3.submissions[-1]["new_submission"],
+        "Failed batch WAS resubmitted",
+        "Failed batch was not resubmitted!",
+    )
+
+    # Scenario 4: Force overrides
+    print("\n--- Scenario 4: Force flag overrides completed guard ---")
+    sim4 = SimulationRunner(work_dir / "s4")
+    sim4.submit_run(label="initial")
+    sim4.set_registry_status("my_action", BatchStatus.COMPLETED)
+    sim4.submit_run(force=True, label="forced resubmit")
+    check(
+        sim4.submissions[-1]["new_submission"],
+        "Force flag overrode completed guard",
+        "Force flag did not override completed guard!",
+    )
+
+    # Scenario 5: Cancelled allows resubmission
+    print("\n--- Scenario 5: Cancelled batch allows resubmission ---")
+    sim5 = SimulationRunner(work_dir / "s5")
+    sim5.submit_run(label="initial")
+    sim5.set_registry_status("my_action", BatchStatus.CANCELLED)
+    sim5.submit_run(label="after cancel")
+    check(
+        sim5.submissions[-1]["new_submission"],
+        "Cancelled batch WAS resubmitted",
+        "Cancelled batch was not resubmitted!",
+    )
+
+    return passed, failed
+
+
+def run_reconciliation_scenarios() -> tuple[int, int]:
+    """Scenarios 6-8: reconciliation, passthrough, and disposition logic."""
+    passed = 0
+    failed = 0
+
+    def check(condition: bool, pass_msg: str, fail_msg: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            print(f"  PASS: {pass_msg}")
+            passed += 1
+        else:
+            print(f"  FAIL: {fail_msg}")
+            failed += 1
+
+    # ------------------------------------------------------------------
+    # Scenario 6: Reconciler splits processed vs skipped correctly
+    # ------------------------------------------------------------------
+    print("\n--- Scenario 6: Reconciler identifies passthrough records ---")
+    print("  Setup: 10 records — 7 INCLUDED, 3 SKIPPED (guard)")
+
+    context_map = build_context_map(total_records=10, skipped_ids={2, 5, 8})
+
+    # Simulate batch results for the 7 INCLUDED records only
+    included_ids = [
+        cid
+        for cid, row in context_map.items()
+        if BatchContextMetadata.get_filter_status(row) == FilterStatus.INCLUDED
+    ]
+    assert len(included_ids) == 7, f"Expected 7 included, got {len(included_ids)}"
+
+    reconciler = BatchResultReconciler(context_map)
+    for cid in included_ids:
+        reconciler.mark_processed(cid)
+
+    result = reconciler.reconcile()
+
+    check(
+        len(result.processed_ids) == 7,
+        f"7 records marked processed (got {len(result.processed_ids)})",
+        f"Expected 7 processed, got {len(result.processed_ids)}",
+    )
+
+    check(
+        len(result.passthrough_records) == 3,
+        f"3 records identified as passthrough (got {len(result.passthrough_records)})",
+        f"Expected 3 passthrough, got {len(result.passthrough_records)}",
+    )
+
+    passthrough_ids = {cid for cid, _ in result.passthrough_records}
+    expected_passthrough = {"rec-002", "rec-005", "rec-008"}
+    check(
+        passthrough_ids == expected_passthrough,
+        f"Passthrough IDs match skipped records: {passthrough_ids}",
+        f"Expected {expected_passthrough}, got {passthrough_ids}",
+    )
+
+    # Verify all passthrough records have SKIPPED status
+    for cid, row in result.passthrough_records:
+        status = BatchContextMetadata.get_filter_status(row)
+        check(
+            status == FilterStatus.SKIPPED,
+            f"{cid} has SKIPPED status",
+            f"{cid} has {status} status, expected SKIPPED",
+        )
+
+    check(
+        len(result.missing_ids) == 0,
+        "No missing IDs (all included records were processed)",
+        f"Unexpected missing IDs: {result.missing_ids}",
+    )
+
+    # ------------------------------------------------------------------
+    # Scenario 7: FILTERED records excluded from passthrough
+    # ------------------------------------------------------------------
+    print("\n--- Scenario 7: FILTERED records excluded from passthrough ---")
+    print("  Setup: 10 records — 6 INCLUDED, 2 SKIPPED, 2 FILTERED")
+
+    context_map_filtered = build_context_map(
+        total_records=10, skipped_ids={3, 7}, filtered_ids={1, 9}
+    )
+
+    included_ids_f = [
+        cid
+        for cid, row in context_map_filtered.items()
+        if BatchContextMetadata.get_filter_status(row) == FilterStatus.INCLUDED
+    ]
+    assert len(included_ids_f) == 6, f"Expected 6 included, got {len(included_ids_f)}"
+
+    reconciler_f = BatchResultReconciler(context_map_filtered)
+    for cid in included_ids_f:
+        reconciler_f.mark_processed(cid)
+
+    result_f = reconciler_f.reconcile()
+
+    check(
+        len(result_f.passthrough_records) == 2,
+        f"Only 2 passthrough (SKIPPED only, not FILTERED): {[c for c, _ in result_f.passthrough_records]}",
+        f"Expected 2 passthrough, got {len(result_f.passthrough_records)}",
+    )
+
+    filtered_in_passthrough = [
+        cid
+        for cid, row in result_f.passthrough_records
+        if BatchContextMetadata.get_filter_status(row) == FilterStatus.FILTERED
+    ]
+    check(
+        len(filtered_in_passthrough) == 0,
+        "No FILTERED records in passthrough",
+        f"FILTERED records leaked into passthrough: {filtered_in_passthrough}",
+    )
+
+    # ------------------------------------------------------------------
+    # Scenario 8: Disposition writer marks skipped records correctly
+    # ------------------------------------------------------------------
+    print("\n--- Scenario 8: Disposition writer marks guard-skipped records ---")
+    print("  Setup: 10 output items — 7 processed, 3 guard-skipped with _unprocessed=True")
+
+    from agent_actions.llm.batch.services.processing_recovery import write_record_dispositions
+
+    storage = MockStorageBackend()
+    mock_service = MagicMock()
+    mock_service._storage_backend = storage
+
+    # Build output items as the result processor would produce them
+    output_items: list[dict[str, Any]] = []
+
+    # 7 successfully processed records (no _unprocessed flag)
+    for i in range(10):
+        if i in {2, 5, 8}:
+            continue
+        output_items.append(
+            {
+                "content": {"summary": f"LLM response for record {i}"},
+                "source_guid": f"sg-{i:03d}",
+                "metadata": {"agent_type": "llm"},
+            }
+        )
+
+    # 3 guard-skipped passthrough records (with _unprocessed=True)
+    for i in [2, 5, 8]:
+        output_items.append(
+            {
+                "content": {"text": f"Record {i} content", "category": f"cat-{i % 3}"},
+                "source_guid": f"sg-{i:03d}",
+                "metadata": {"reason": "guard_skipped", "agent_type": "tombstone"},
+                "_unprocessed": True,
+            }
+        )
+
+    write_record_dispositions(mock_service, output_items, "my_action")
+
+    # Verify: 3 SKIPPED dispositions
+    skipped_records = storage.get_dispositions_by_type("my_action", DISPOSITION_SKIPPED)
+    check(
+        len(skipped_records) == 3,
+        f"3 records have SKIPPED disposition: {skipped_records}",
+        f"Expected 3 SKIPPED, got {len(skipped_records)}: {skipped_records}",
+    )
+
+    expected_skipped_guids = {"sg-002", "sg-005", "sg-008"}
+    check(
+        set(skipped_records) == expected_skipped_guids,
+        "Correct source_guids are SKIPPED",
+        f"Expected {expected_skipped_guids}, got {set(skipped_records)}",
+    )
+
+    # Verify: no FAILED or FILTERED dispositions
+    failed_records = storage.get_dispositions_by_type("my_action", DISPOSITION_FAILED)
+    check(
+        len(failed_records) == 0,
+        "No FAILED dispositions (all processed records succeeded)",
+        f"Unexpected FAILED dispositions: {failed_records}",
+    )
+
+    filtered_records = storage.get_dispositions_by_type("my_action", DISPOSITION_FILTERED)
+    check(
+        len(filtered_records) == 0,
+        "No FILTERED dispositions (guard-skipped != where-clause filtered)",
+        f"Unexpected FILTERED dispositions: {filtered_records}",
+    )
+
+    # Verify: reasons are set correctly
+    for sg in expected_skipped_guids:
+        reason = storage._dispositions.get(("my_action", sg, DISPOSITION_SKIPPED))
+        check(
+            reason == "guard_skipped",
+            f"{sg} disposition reason is 'guard_skipped'",
+            f"{sg} reason is '{reason}', expected 'guard_skipped'",
+        )
+
+    # Verify: consolidated output has all 10 records
+    check(
+        len(output_items) == 10,
+        "Consolidated output has all 10 records (7 processed + 3 skipped)",
+        f"Expected 10 output items, got {len(output_items)}",
+    )
+
+    # Verify: processed records have LLM content, skipped have original
+    processed_count = sum(1 for item in output_items if not item.get("_unprocessed"))
+    skipped_count = sum(1 for item in output_items if item.get("_unprocessed"))
+    check(
+        processed_count == 7 and skipped_count == 3,
+        f"Output split: {processed_count} processed + {skipped_count} skipped = {len(output_items)} total",
+        f"Expected 7+3, got {processed_count}+{skipped_count}",
+    )
+
+    return passed, failed
 
 
 def run_simulation():
     """Run the full simulation."""
     print("=" * 70)
-    print("BATCH RESUBMISSION GUARD — SIMULATION")
+    print("BATCH RESUBMISSION GUARD — FULL PIPELINE SIMULATION")
     print("=" * 70)
 
-    passed = 0
-    failed = 0
-
     with tempfile.TemporaryDirectory() as tmpdir:
-        work_dir = Path(tmpdir)
+        p1, f1 = run_submission_guard_scenarios(Path(tmpdir))
+        p2, f2 = run_reconciliation_scenarios()
 
-        # ------------------------------------------------------------------
-        # Scenario 1: Normal lifecycle — submit, complete, no resubmit
-        # ------------------------------------------------------------------
-        print("\n--- Scenario 1: Completed batch is NOT resubmitted ---")
-        sim = SimulationRunner(work_dir / "s1")
-
-        # Run 1: First submission
-        bid1 = sim.submit_run(label="initial submission")
-        print(f"  Run 1: batch_id={bid1}, new_submission={sim.submissions[-1]['new_submission']}")
-        sim.print_registry()
-        assert sim.submissions[-1]["new_submission"], "Run 1 should submit new batch"
-
-        # Simulate provider completing the batch
-        sim.set_registry_status("my_action", BatchStatus.COMPLETED)
-        print("  (Provider completes the batch)")
-        sim.print_registry()
-
-        # Run 2: Should NOT resubmit
-        bid2 = sim.submit_run(label="after completion")
-        print(f"  Run 2: batch_id={bid2}, new_submission={sim.submissions[-1]['new_submission']}")
-        sim.print_registry()
-
-        if bid2 == bid1 and not sim.submissions[-1]["new_submission"]:
-            print("  PASS: Completed batch was NOT resubmitted")
-            passed += 1
-        else:
-            print("  FAIL: Completed batch was resubmitted!")
-            failed += 1
-
-        # Run 3: Still should NOT resubmit
-        bid3 = sim.submit_run(label="third run")
-        print(f"  Run 3: batch_id={bid3}, new_submission={sim.submissions[-1]['new_submission']}")
-
-        if bid3 == bid1 and not sim.submissions[-1]["new_submission"]:
-            print("  PASS: Still not resubmitted on 3rd run")
-            passed += 1
-        else:
-            print("  FAIL: Resubmitted on 3rd run!")
-            failed += 1
-
-        # ------------------------------------------------------------------
-        # Scenario 2: In-flight batch blocks resubmission
-        # ------------------------------------------------------------------
-        print("\n--- Scenario 2: In-flight batch blocks resubmission ---")
-        sim2 = SimulationRunner(work_dir / "s2")
-
-        bid1 = sim2.submit_run(label="initial")
-        print(f"  Run 1: batch_id={bid1}, new={sim2.submissions[-1]['new_submission']}")
-
-        # Batch is still in-flight (submitted → in_progress)
-        sim2.set_registry_status("my_action", BatchStatus.IN_PROGRESS)
-        print("  (Batch moves to in_progress)")
-
-        bid2 = sim2.submit_run(label="while in-flight")
-        print(f"  Run 2: batch_id={bid2}, new={sim2.submissions[-1]['new_submission']}")
-
-        if bid2 == bid1 and not sim2.submissions[-1]["new_submission"]:
-            print("  PASS: In-flight batch was NOT resubmitted")
-            passed += 1
-        else:
-            print("  FAIL: In-flight batch was resubmitted!")
-            failed += 1
-
-        # ------------------------------------------------------------------
-        # Scenario 3: Failed batch allows resubmission
-        # ------------------------------------------------------------------
-        print("\n--- Scenario 3: Failed batch allows resubmission ---")
-        sim3 = SimulationRunner(work_dir / "s3")
-
-        bid1 = sim3.submit_run(label="initial")
-        print(f"  Run 1: batch_id={bid1}, new={sim3.submissions[-1]['new_submission']}")
-
-        sim3.set_registry_status("my_action", BatchStatus.FAILED)
-        print("  (Batch fails)")
-
-        bid2 = sim3.submit_run(label="after failure")
-        print(f"  Run 2: batch_id={bid2}, new={sim3.submissions[-1]['new_submission']}")
-
-        if sim3.submissions[-1]["new_submission"] and bid2 != bid1:
-            print("  PASS: Failed batch WAS resubmitted (new batch)")
-            passed += 1
-        else:
-            print("  FAIL: Failed batch was not resubmitted!")
-            failed += 1
-
-        # ------------------------------------------------------------------
-        # Scenario 4: Force flag overrides completed guard
-        # ------------------------------------------------------------------
-        print("\n--- Scenario 4: Force flag overrides completed guard ---")
-        sim4 = SimulationRunner(work_dir / "s4")
-
-        bid1 = sim4.submit_run(label="initial")
-        sim4.set_registry_status("my_action", BatchStatus.COMPLETED)
-        print(f"  Run 1: batch_id={bid1} (completed)")
-
-        bid2 = sim4.submit_run(force=True, label="forced resubmit")
-        print(
-            f"  Run 2 (force=True): batch_id={bid2}, new={sim4.submissions[-1]['new_submission']}"
-        )
-
-        if sim4.submissions[-1]["new_submission"]:
-            print("  PASS: Force flag overrode completed guard")
-            passed += 1
-        else:
-            print("  FAIL: Force flag did not override completed guard!")
-            failed += 1
-
-        # ------------------------------------------------------------------
-        # Scenario 5: Cancelled batch allows resubmission
-        # ------------------------------------------------------------------
-        print("\n--- Scenario 5: Cancelled batch allows resubmission ---")
-        sim5 = SimulationRunner(work_dir / "s5")
-
-        bid1 = sim5.submit_run(label="initial")
-        sim5.set_registry_status("my_action", BatchStatus.CANCELLED)
-        print(f"  Run 1: batch_id={bid1} (cancelled)")
-
-        bid2 = sim5.submit_run(label="after cancel")
-        print(f"  Run 2: batch_id={bid2}, new={sim5.submissions[-1]['new_submission']}")
-
-        if sim5.submissions[-1]["new_submission"]:
-            print("  PASS: Cancelled batch WAS resubmitted")
-            passed += 1
-        else:
-            print("  FAIL: Cancelled batch was not resubmitted!")
-            failed += 1
-
-    # ------------------------------------------------------------------
-    # Summary
-    # ------------------------------------------------------------------
-    print("\n" + "=" * 70)
+    passed = p1 + p2
+    failed = f1 + f2
     total = passed + failed
+
+    print("\n" + "=" * 70)
     print(f"RESULTS: {passed}/{total} passed, {failed}/{total} failed")
     if failed == 0:
         print("ALL SCENARIOS PASSED")

--- a/tests/simulation/simulate_batch_resubmission.py
+++ b/tests/simulation/simulate_batch_resubmission.py
@@ -1,0 +1,277 @@
+"""Manual simulation: batch resubmission loop fix verification.
+
+This script simulates the multi-run batch lifecycle to confirm that:
+1. A completed batch is NOT resubmitted on subsequent runs
+2. An in-flight batch is NOT resubmitted
+3. A failed/cancelled batch IS resubmitted
+4. Force flag overrides the completed guard
+5. Guard-filtered (fewer tasks) batches still settle correctly
+
+Run:
+    python tests/simulation/simulate_batch_resubmission.py
+"""
+
+import json
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
+from agent_actions.llm.batch.services.submission import BatchSubmissionService
+
+
+class SimulationRunner:
+    """Simulates multiple workflow runs against a real registry on disk."""
+
+    def __init__(self, work_dir: Path):
+        self.work_dir = work_dir
+        self.output_dir = work_dir / "agent_io" / "target" / "my_action"
+        self.batch_dir = self.output_dir / "batch"
+        self.batch_dir.mkdir(parents=True, exist_ok=True)
+        self.registry_path = self.batch_dir / ".batch_registry.json"
+        self.run_count = 0
+        self.submissions = []
+
+    def _make_service(self, force: bool = False) -> BatchSubmissionService:
+        """Create a real-ish submission service with mocked provider."""
+        svc = BatchSubmissionService(
+            task_preparator=MagicMock(),
+            client_resolver=MagicMock(),
+            context_manager=MagicMock(),
+            registry_manager_factory=lambda out_dir: BatchRegistryManager(
+                Path(out_dir) / "batch" / ".batch_registry.json"
+            ),
+            force_batch=force,
+        )
+
+        # Mock task preparation to return tasks
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [
+            {"target_id": f"r{i}", "content": f"data-{i}", "prompt": "p"}
+            for i in range(10)
+        ]
+        mock_prepared.context_map = {}
+        mock_prepared.task_count = 10
+        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
+        svc._task_preparator.prepare_tasks.return_value = mock_prepared
+
+        # Mock provider to return a unique batch ID per submission
+        batch_id = f"batch-{len(self.submissions) + 1:03d}"
+        svc._client_resolver.get_for_config.return_value = MagicMock(
+            submit_batch=MagicMock(return_value=(batch_id, "submitted"))
+        )
+
+        return svc
+
+    def submit_run(self, force: bool = False, label: str = "") -> str:
+        """Simulate one workflow run's batch submission attempt."""
+        self.run_count += 1
+        svc = self._make_service(force=force)
+
+        with (
+            patch("agent_actions.llm.batch.services.submission.fire_event"),
+            patch("agent_actions.llm.batch.services.submission.get_manager"),
+        ):
+            result = svc.submit_batch_job(
+                agent_config={"model_vendor": "openai"},
+                batch_name="my_action",
+                data=[{"id": i} for i in range(10)],
+                output_directory=str(self.output_dir),
+            )
+
+        was_new = svc._task_preparator.prepare_tasks.called
+        self.submissions.append(
+            {
+                "run": self.run_count,
+                "label": label,
+                "batch_id": result.batch_id,
+                "new_submission": was_new,
+            }
+        )
+        return result.batch_id
+
+    def set_registry_status(self, batch_name: str, status: str):
+        """Manually update the registry status (simulating provider completion)."""
+        manager = BatchRegistryManager(self.registry_path)
+        entry = manager.get_batch_job(batch_name)
+        if entry:
+            manager.update_status(entry.batch_id, status)
+
+    def get_registry(self) -> dict:
+        """Read the current registry state."""
+        if not self.registry_path.exists():
+            return {}
+        with open(self.registry_path) as f:
+            return json.load(f)
+
+    def print_registry(self):
+        """Print registry state."""
+        reg = self.get_registry()
+        if not reg:
+            print("    Registry: (empty)")
+        for key, entry in reg.items():
+            print(f"    [{key}] batch_id={entry['batch_id']} status={entry['status']}")
+
+
+def run_simulation():
+    """Run the full simulation."""
+    print("=" * 70)
+    print("BATCH RESUBMISSION GUARD — SIMULATION")
+    print("=" * 70)
+
+    passed = 0
+    failed = 0
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        work_dir = Path(tmpdir)
+
+        # ------------------------------------------------------------------
+        # Scenario 1: Normal lifecycle — submit, complete, no resubmit
+        # ------------------------------------------------------------------
+        print("\n--- Scenario 1: Completed batch is NOT resubmitted ---")
+        sim = SimulationRunner(work_dir / "s1")
+
+        # Run 1: First submission
+        bid1 = sim.submit_run(label="initial submission")
+        print(f"  Run 1: batch_id={bid1}, new_submission={sim.submissions[-1]['new_submission']}")
+        sim.print_registry()
+        assert sim.submissions[-1]["new_submission"], "Run 1 should submit new batch"
+
+        # Simulate provider completing the batch
+        sim.set_registry_status("my_action", BatchStatus.COMPLETED)
+        print("  (Provider completes the batch)")
+        sim.print_registry()
+
+        # Run 2: Should NOT resubmit
+        bid2 = sim.submit_run(label="after completion")
+        print(f"  Run 2: batch_id={bid2}, new_submission={sim.submissions[-1]['new_submission']}")
+        sim.print_registry()
+
+        if bid2 == bid1 and not sim.submissions[-1]["new_submission"]:
+            print("  PASS: Completed batch was NOT resubmitted")
+            passed += 1
+        else:
+            print("  FAIL: Completed batch was resubmitted!")
+            failed += 1
+
+        # Run 3: Still should NOT resubmit
+        bid3 = sim.submit_run(label="third run")
+        print(f"  Run 3: batch_id={bid3}, new_submission={sim.submissions[-1]['new_submission']}")
+
+        if bid3 == bid1 and not sim.submissions[-1]["new_submission"]:
+            print("  PASS: Still not resubmitted on 3rd run")
+            passed += 1
+        else:
+            print("  FAIL: Resubmitted on 3rd run!")
+            failed += 1
+
+        # ------------------------------------------------------------------
+        # Scenario 2: In-flight batch blocks resubmission
+        # ------------------------------------------------------------------
+        print("\n--- Scenario 2: In-flight batch blocks resubmission ---")
+        sim2 = SimulationRunner(work_dir / "s2")
+
+        bid1 = sim2.submit_run(label="initial")
+        print(f"  Run 1: batch_id={bid1}, new={sim2.submissions[-1]['new_submission']}")
+
+        # Batch is still in-flight (submitted → in_progress)
+        sim2.set_registry_status("my_action", BatchStatus.IN_PROGRESS)
+        print("  (Batch moves to in_progress)")
+
+        bid2 = sim2.submit_run(label="while in-flight")
+        print(f"  Run 2: batch_id={bid2}, new={sim2.submissions[-1]['new_submission']}")
+
+        if bid2 == bid1 and not sim2.submissions[-1]["new_submission"]:
+            print("  PASS: In-flight batch was NOT resubmitted")
+            passed += 1
+        else:
+            print("  FAIL: In-flight batch was resubmitted!")
+            failed += 1
+
+        # ------------------------------------------------------------------
+        # Scenario 3: Failed batch allows resubmission
+        # ------------------------------------------------------------------
+        print("\n--- Scenario 3: Failed batch allows resubmission ---")
+        sim3 = SimulationRunner(work_dir / "s3")
+
+        bid1 = sim3.submit_run(label="initial")
+        print(f"  Run 1: batch_id={bid1}, new={sim3.submissions[-1]['new_submission']}")
+
+        sim3.set_registry_status("my_action", BatchStatus.FAILED)
+        print("  (Batch fails)")
+
+        bid2 = sim3.submit_run(label="after failure")
+        print(f"  Run 2: batch_id={bid2}, new={sim3.submissions[-1]['new_submission']}")
+
+        if sim3.submissions[-1]["new_submission"] and bid2 != bid1:
+            print("  PASS: Failed batch WAS resubmitted (new batch)")
+            passed += 1
+        else:
+            print("  FAIL: Failed batch was not resubmitted!")
+            failed += 1
+
+        # ------------------------------------------------------------------
+        # Scenario 4: Force flag overrides completed guard
+        # ------------------------------------------------------------------
+        print("\n--- Scenario 4: Force flag overrides completed guard ---")
+        sim4 = SimulationRunner(work_dir / "s4")
+
+        bid1 = sim4.submit_run(label="initial")
+        sim4.set_registry_status("my_action", BatchStatus.COMPLETED)
+        print(f"  Run 1: batch_id={bid1} (completed)")
+
+        bid2 = sim4.submit_run(force=True, label="forced resubmit")
+        print(f"  Run 2 (force=True): batch_id={bid2}, new={sim4.submissions[-1]['new_submission']}")
+
+        if sim4.submissions[-1]["new_submission"]:
+            print("  PASS: Force flag overrode completed guard")
+            passed += 1
+        else:
+            print("  FAIL: Force flag did not override completed guard!")
+            failed += 1
+
+        # ------------------------------------------------------------------
+        # Scenario 5: Cancelled batch allows resubmission
+        # ------------------------------------------------------------------
+        print("\n--- Scenario 5: Cancelled batch allows resubmission ---")
+        sim5 = SimulationRunner(work_dir / "s5")
+
+        bid1 = sim5.submit_run(label="initial")
+        sim5.set_registry_status("my_action", BatchStatus.CANCELLED)
+        print(f"  Run 1: batch_id={bid1} (cancelled)")
+
+        bid2 = sim5.submit_run(label="after cancel")
+        print(f"  Run 2: batch_id={bid2}, new={sim5.submissions[-1]['new_submission']}")
+
+        if sim5.submissions[-1]["new_submission"]:
+            print("  PASS: Cancelled batch WAS resubmitted")
+            passed += 1
+        else:
+            print("  FAIL: Cancelled batch was not resubmitted!")
+            failed += 1
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 70)
+    total = passed + failed
+    print(f"RESULTS: {passed}/{total} passed, {failed}/{total} failed")
+    if failed == 0:
+        print("ALL SCENARIOS PASSED")
+    else:
+        print("SOME SCENARIOS FAILED")
+    print("=" * 70)
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = run_simulation()
+    sys.exit(0 if success else 1)

--- a/tests/simulation/simulate_batch_resubmission.py
+++ b/tests/simulation/simulate_batch_resubmission.py
@@ -14,7 +14,6 @@ Run:
 import json
 import sys
 import tempfile
-from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -22,7 +21,6 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry
 from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
 from agent_actions.llm.batch.services.submission import BatchSubmissionService
 
@@ -54,8 +52,7 @@ class SimulationRunner:
         # Mock task preparation to return tasks
         mock_prepared = MagicMock()
         mock_prepared.tasks = [
-            {"target_id": f"r{i}", "content": f"data-{i}", "prompt": "p"}
-            for i in range(10)
+            {"target_id": f"r{i}", "content": f"data-{i}", "prompt": "p"} for i in range(10)
         ]
         mock_prepared.context_map = {}
         mock_prepared.task_count = 10
@@ -228,7 +225,9 @@ def run_simulation():
         print(f"  Run 1: batch_id={bid1} (completed)")
 
         bid2 = sim4.submit_run(force=True, label="forced resubmit")
-        print(f"  Run 2 (force=True): batch_id={bid2}, new={sim4.submissions[-1]['new_submission']}")
+        print(
+            f"  Run 2 (force=True): batch_id={bid2}, new={sim4.submissions[-1]['new_submission']}"
+        )
 
         if sim4.submissions[-1]["new_submission"]:
             print("  PASS: Force flag overrode completed guard")

--- a/tests/unit/test_batch_resubmission_guard.py
+++ b/tests/unit/test_batch_resubmission_guard.py
@@ -31,6 +31,20 @@ def _make_entry(status: str, batch_id: str = "batch-123") -> BatchJobEntry:
     )
 
 
+def _stub_submission_path(svc: BatchSubmissionService, batch_id: str = "batch-new") -> None:
+    """Wire up mocks so submit_batch_job can reach _submit_to_provider."""
+    mock_prepared = MagicMock()
+    mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
+    mock_prepared.context_map = {}
+    mock_prepared.task_count = 1
+    mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
+    svc._task_preparator.prepare_tasks.return_value = mock_prepared
+
+    svc._client_resolver.get_for_config.return_value = MagicMock(
+        submit_batch=MagicMock(return_value=(batch_id, "submitted"))
+    )
+
+
 class TestCompletedBatchSkipsResubmission:
     """Completed batch in registry must block new submission."""
 
@@ -49,18 +63,15 @@ class TestCompletedBatchSkipsResubmission:
 
         assert result.batch_id == "batch-done-1"
         assert result.is_submitted
-        # prepare_batch_tasks must NOT be called — no new submission
         svc._task_preparator.prepare_tasks.assert_not_called()
 
     def test_completed_batch_does_not_compare_record_counts(self, tmp_path):
         """Completed batch blocks resubmission regardless of input data size change."""
         svc = _make_service()
-        # Registry has a batch that completed with 5 records
         entry = _make_entry(BatchStatus.COMPLETED, batch_id="batch-5")
         entry.record_count = 5
         svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
 
-        # New run has 10 records — still should NOT resubmit
         result = svc.submit_batch_job(
             agent_config={"model_vendor": "openai"},
             batch_name="my_action",
@@ -102,18 +113,7 @@ class TestFailedCancelledBatchAllowsResubmission:
         svc = _make_service()
         entry = _make_entry(status, batch_id="batch-failed")
         svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
-
-        # Mock the task preparation and submission path
-        mock_prepared = MagicMock()
-        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
-        mock_prepared.context_map = {}
-        mock_prepared.task_count = 1
-        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
-        svc._task_preparator.prepare_tasks.return_value = mock_prepared
-
-        svc._client_resolver.get_for_config.return_value = MagicMock(
-            submit_batch=MagicMock(return_value=("batch-new", "submitted"))
-        )
+        _stub_submission_path(svc, batch_id="batch-new")
 
         with (
             patch("agent_actions.llm.batch.services.submission.fire_event"),
@@ -126,7 +126,6 @@ class TestFailedCancelledBatchAllowsResubmission:
                 output_directory=str(tmp_path),
             )
 
-        # Should have submitted a NEW batch
         assert result.batch_id == "batch-new"
         svc._task_preparator.prepare_tasks.assert_called_once()
 
@@ -139,17 +138,7 @@ class TestForceOverridesCompletedGuard:
         svc = _make_service()
         entry = _make_entry(BatchStatus.COMPLETED, batch_id="batch-done")
         svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
-
-        mock_prepared = MagicMock()
-        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
-        mock_prepared.context_map = {}
-        mock_prepared.task_count = 1
-        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
-        svc._task_preparator.prepare_tasks.return_value = mock_prepared
-
-        svc._client_resolver.get_for_config.return_value = MagicMock(
-            submit_batch=MagicMock(return_value=("batch-forced", "submitted"))
-        )
+        _stub_submission_path(svc, batch_id="batch-forced")
 
         with (
             patch("agent_actions.llm.batch.services.submission.fire_event"),
@@ -171,17 +160,7 @@ class TestForceOverridesCompletedGuard:
         svc = _make_service(force_batch=True)
         entry = _make_entry(BatchStatus.COMPLETED, batch_id="batch-done")
         svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
-
-        mock_prepared = MagicMock()
-        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
-        mock_prepared.context_map = {}
-        mock_prepared.task_count = 1
-        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
-        svc._task_preparator.prepare_tasks.return_value = mock_prepared
-
-        svc._client_resolver.get_for_config.return_value = MagicMock(
-            submit_batch=MagicMock(return_value=("batch-forced-2", "submitted"))
-        )
+        _stub_submission_path(svc, batch_id="batch-forced-2")
 
         with (
             patch("agent_actions.llm.batch.services.submission.fire_event"),
@@ -204,17 +183,7 @@ class TestNoBatchEntryAllowsSubmission:
         """First-time batch submission works when registry is empty."""
         svc = _make_service()
         svc._registry_manager_factory.return_value.get_batch_job.return_value = None
-
-        mock_prepared = MagicMock()
-        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
-        mock_prepared.context_map = {}
-        mock_prepared.task_count = 1
-        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
-        svc._task_preparator.prepare_tasks.return_value = mock_prepared
-
-        svc._client_resolver.get_for_config.return_value = MagicMock(
-            submit_batch=MagicMock(return_value=("batch-first", "submitted"))
-        )
+        _stub_submission_path(svc, batch_id="batch-first")
 
         with (
             patch("agent_actions.llm.batch.services.submission.fire_event"),

--- a/tests/unit/test_batch_resubmission_guard.py
+++ b/tests/unit/test_batch_resubmission_guard.py
@@ -1,0 +1,231 @@
+"""Tests for batch resubmission prevention when completed batch exists."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.services.submission import BatchSubmissionService
+
+
+def _make_service(force_batch: bool = False) -> BatchSubmissionService:
+    """Create a BatchSubmissionService with mocked dependencies."""
+    return BatchSubmissionService(
+        task_preparator=MagicMock(),
+        client_resolver=MagicMock(),
+        context_manager=MagicMock(),
+        registry_manager_factory=MagicMock(),
+        force_batch=force_batch,
+    )
+
+
+def _make_entry(status: str, batch_id: str = "batch-123") -> BatchJobEntry:
+    """Create a BatchJobEntry with given status."""
+    return BatchJobEntry(
+        batch_id=batch_id,
+        status=status,
+        timestamp="2026-04-19T00:00:00+00:00",
+        provider="openai",
+        record_count=10,
+    )
+
+
+class TestCompletedBatchSkipsResubmission:
+    """Completed batch in registry must block new submission."""
+
+    def test_completed_batch_returns_existing_batch_id(self, tmp_path):
+        """When a completed batch exists, submit_batch_job returns its ID without resubmitting."""
+        svc = _make_service()
+        entry = _make_entry(BatchStatus.COMPLETED, batch_id="batch-done-1")
+        svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
+
+        result = svc.submit_batch_job(
+            agent_config={"model_vendor": "openai"},
+            batch_name="my_action",
+            data=[{"id": 1}],
+            output_directory=str(tmp_path),
+        )
+
+        assert result.batch_id == "batch-done-1"
+        assert result.is_submitted
+        # prepare_batch_tasks must NOT be called — no new submission
+        svc._task_preparator.prepare_tasks.assert_not_called()
+
+    def test_completed_batch_does_not_compare_record_counts(self, tmp_path):
+        """Completed batch blocks resubmission regardless of input data size change."""
+        svc = _make_service()
+        # Registry has a batch that completed with 5 records
+        entry = _make_entry(BatchStatus.COMPLETED, batch_id="batch-5")
+        entry.record_count = 5
+        svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
+
+        # New run has 10 records — still should NOT resubmit
+        result = svc.submit_batch_job(
+            agent_config={"model_vendor": "openai"},
+            batch_name="my_action",
+            data=[{"id": i} for i in range(10)],
+            output_directory=str(tmp_path),
+        )
+
+        assert result.batch_id == "batch-5"
+        svc._task_preparator.prepare_tasks.assert_not_called()
+
+
+class TestInFlightBatchStillBlocks:
+    """Existing in-flight guard must continue to work."""
+
+    @pytest.mark.parametrize("status", list(BatchStatus.in_flight_states()))
+    def test_in_flight_statuses_block_resubmission(self, tmp_path, status):
+        """All in-flight statuses block new submission."""
+        svc = _make_service()
+        entry = _make_entry(status, batch_id="batch-inflight")
+        svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
+
+        result = svc.submit_batch_job(
+            agent_config={"model_vendor": "openai"},
+            batch_name="my_action",
+            data=[{"id": 1}],
+            output_directory=str(tmp_path),
+        )
+
+        assert result.batch_id == "batch-inflight"
+        svc._task_preparator.prepare_tasks.assert_not_called()
+
+
+class TestFailedCancelledBatchAllowsResubmission:
+    """Failed and cancelled batches should allow automatic resubmission."""
+
+    @pytest.mark.parametrize("status", [BatchStatus.FAILED, BatchStatus.CANCELLED])
+    def test_failed_or_cancelled_batch_allows_new_submission(self, tmp_path, status):
+        """Failed/cancelled batches do not block — framework should retry."""
+        svc = _make_service()
+        entry = _make_entry(status, batch_id="batch-failed")
+        svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
+
+        # Mock the task preparation and submission path
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
+        mock_prepared.context_map = {}
+        mock_prepared.task_count = 1
+        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
+        svc._task_preparator.prepare_tasks.return_value = mock_prepared
+
+        svc._client_resolver.get_for_config.return_value = MagicMock(
+            submit_batch=MagicMock(return_value=("batch-new", "submitted"))
+        )
+
+        with (
+            patch("agent_actions.llm.batch.services.submission.fire_event"),
+            patch("agent_actions.llm.batch.services.submission.get_manager"),
+        ):
+            result = svc.submit_batch_job(
+                agent_config={"model_vendor": "openai"},
+                batch_name="my_action",
+                data=[{"id": 1}],
+                output_directory=str(tmp_path),
+            )
+
+        # Should have submitted a NEW batch
+        assert result.batch_id == "batch-new"
+        svc._task_preparator.prepare_tasks.assert_called_once()
+
+
+class TestForceOverridesCompletedGuard:
+    """Force flag must bypass the completed batch guard."""
+
+    def test_force_flag_resubmits_over_completed_batch(self, tmp_path):
+        """submit_batch_job(force=True) submits new batch even when completed exists."""
+        svc = _make_service()
+        entry = _make_entry(BatchStatus.COMPLETED, batch_id="batch-done")
+        svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
+
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
+        mock_prepared.context_map = {}
+        mock_prepared.task_count = 1
+        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
+        svc._task_preparator.prepare_tasks.return_value = mock_prepared
+
+        svc._client_resolver.get_for_config.return_value = MagicMock(
+            submit_batch=MagicMock(return_value=("batch-forced", "submitted"))
+        )
+
+        with (
+            patch("agent_actions.llm.batch.services.submission.fire_event"),
+            patch("agent_actions.llm.batch.services.submission.get_manager"),
+        ):
+            result = svc.submit_batch_job(
+                agent_config={"model_vendor": "openai"},
+                batch_name="my_action",
+                data=[{"id": 1}],
+                output_directory=str(tmp_path),
+                force=True,
+            )
+
+        assert result.batch_id == "batch-forced"
+        svc._task_preparator.prepare_tasks.assert_called_once()
+
+    def test_force_batch_constructor_flag_resubmits_over_completed(self, tmp_path):
+        """BatchSubmissionService(force_batch=True) bypasses completed guard."""
+        svc = _make_service(force_batch=True)
+        entry = _make_entry(BatchStatus.COMPLETED, batch_id="batch-done")
+        svc._registry_manager_factory.return_value.get_batch_job.return_value = entry
+
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
+        mock_prepared.context_map = {}
+        mock_prepared.task_count = 1
+        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
+        svc._task_preparator.prepare_tasks.return_value = mock_prepared
+
+        svc._client_resolver.get_for_config.return_value = MagicMock(
+            submit_batch=MagicMock(return_value=("batch-forced-2", "submitted"))
+        )
+
+        with (
+            patch("agent_actions.llm.batch.services.submission.fire_event"),
+            patch("agent_actions.llm.batch.services.submission.get_manager"),
+        ):
+            result = svc.submit_batch_job(
+                agent_config={"model_vendor": "openai"},
+                batch_name="my_action",
+                data=[{"id": 1}],
+                output_directory=str(tmp_path),
+            )
+
+        assert result.batch_id == "batch-forced-2"
+
+
+class TestNoBatchEntryAllowsSubmission:
+    """When no batch exists in registry, normal submission proceeds."""
+
+    def test_no_existing_entry_submits_normally(self, tmp_path):
+        """First-time batch submission works when registry is empty."""
+        svc = _make_service()
+        svc._registry_manager_factory.return_value.get_batch_job.return_value = None
+
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [{"target_id": "r1", "content": "x", "prompt": "p"}]
+        mock_prepared.context_map = {}
+        mock_prepared.task_count = 1
+        mock_prepared.stats = MagicMock(total_filtered=0, total_skipped=0)
+        svc._task_preparator.prepare_tasks.return_value = mock_prepared
+
+        svc._client_resolver.get_for_config.return_value = MagicMock(
+            submit_batch=MagicMock(return_value=("batch-first", "submitted"))
+        )
+
+        with (
+            patch("agent_actions.llm.batch.services.submission.fire_event"),
+            patch("agent_actions.llm.batch.services.submission.get_manager"),
+        ):
+            result = svc.submit_batch_job(
+                agent_config={"model_vendor": "openai"},
+                batch_name="my_action",
+                data=[{"id": 1}],
+                output_directory=str(tmp_path),
+            )
+
+        assert result.batch_id == "batch-first"
+        svc._task_preparator.prepare_tasks.assert_called_once()


### PR DESCRIPTION
## Summary
- Fix batch submission loop when downstream batch action receives guard-skipped records from upstream
- `submit_batch_job` only checked for in-flight batches; completed batches fell through and resubmitted on every run
- Added `BatchStatus.COMPLETED` check alongside the in-flight guard — completed batches return existing batch_id for lifecycle processing
- Failed/cancelled batches still allow automatic resubmission; `force` flag overrides all guards

## Verification
- 11 unit tests covering: completed blocks resubmit, in-flight blocks resubmit, failed/cancelled allow resubmit, force overrides, record count mismatch ignored
- Manual simulation script (`tests/simulation/simulate_batch_resubmission.py`) — 6/6 scenarios pass
- Full suite: 5344 passed, 2 skipped
- `ruff format --check` and `ruff check` clean