### PR TITLE
fix: drop directives work on passthrough wildcard fields

### DIFF
--- a/.changes/unreleased/Bug Fix-20260419-120000.yaml
+++ b/.changes/unreleased/Bug Fix-20260419-120000.yaml
@@ -1,0 +1,2 @@
+kind: Bug Fix
+body: Drop directives now correctly exclude fields from passthrough wildcards by extracting passthrough before drop and applying drop to both observe and output contexts.

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -76,7 +76,48 @@ def apply_context_scope(
         prompt_context["seed"] = static_data
         logger.debug("[SEED_DATA] Added to prompt_context under 'seed' namespace")
 
-    # Process DROP: Remove from prompt_context (security)
+    # Process PASSTHROUGH first: extract from pre-drop prompt_context.
+    # Drop is then applied to passthrough_fields explicitly below,
+    # so the drop directive removes fields from both observe and output.
+    passthrough_refs = context_scope.get("passthrough", [])
+    for field_ref in passthrough_refs:
+        try:
+            ns_name, field_name = parse_field_reference(field_ref)
+
+            if field_name == "*":
+                action_fields = extract_action_fields(prompt_context, ns_name)
+                if action_fields:
+                    passthrough_fields.setdefault(ns_name, {}).update(action_fields)
+            else:
+                value = extract_field_value(prompt_context, ns_name, field_name, default=_MISSING)
+
+                if value is _MISSING:
+                    raise ConfigurationError(
+                        f"context_scope.passthrough field '{field_ref}' not found at runtime",
+                        context={
+                            "action": action_name,
+                            "field_ref": field_ref,
+                            "directive": "passthrough",
+                            "operation": "apply_context_scope",
+                            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
+                            f"Check the output schema of '{ns_name}'.",
+                        },
+                    )
+
+                passthrough_fields.setdefault(ns_name, {})[field_name] = value
+
+        except ValueError as e:
+            fire_event(
+                ContextFieldSkippedEvent(
+                    action_name=action_name,
+                    field_ref=field_ref,
+                    reason=str(e),
+                    directive="passthrough",
+                )
+            )
+            continue
+
+    # Process DROP: Remove from prompt_context (observe) and passthrough_fields (output)
     drop_refs = context_scope.get("drop", [])
     for field_ref in drop_refs:
         try:
@@ -111,6 +152,8 @@ def apply_context_scope(
                         ns_name,
                     )
                 prompt_context[ns_name].clear()
+                if ns_name in passthrough_fields:
+                    del passthrough_fields[ns_name]
             else:
                 # Exact field: warn if absent
                 if field_name not in prompt_context[ns_name]:
@@ -123,6 +166,10 @@ def apply_context_scope(
                         ns_name,
                     )
                 prompt_context[ns_name].pop(field_name, None)
+                if ns_name in passthrough_fields:
+                    passthrough_fields[ns_name].pop(field_name, None)
+                    if not passthrough_fields[ns_name]:
+                        del passthrough_fields[ns_name]
 
         except ValueError as e:
             logger.warning(
@@ -181,47 +228,6 @@ def apply_context_scope(
                     field_ref=field_ref,
                     reason=str(e),
                     directive="observe",
-                )
-            )
-            continue
-
-    # Process PASSTHROUGH: Extract to passthrough_fields (namespaced like llm_context).
-    # Read from prompt_context (post-drop), NOT field_context, so that dropped
-    # fields cannot leak into the output via passthrough.
-    passthrough_refs = context_scope.get("passthrough", [])
-    for field_ref in passthrough_refs:
-        try:
-            ns_name, field_name = parse_field_reference(field_ref)
-
-            if field_name == "*":
-                action_fields = extract_action_fields(prompt_context, ns_name)
-                if action_fields:
-                    passthrough_fields.setdefault(ns_name, {}).update(action_fields)
-            else:
-                value = extract_field_value(prompt_context, ns_name, field_name, default=_MISSING)
-
-                if value is _MISSING:
-                    raise ConfigurationError(
-                        f"context_scope.passthrough field '{field_ref}' not found at runtime",
-                        context={
-                            "action": action_name,
-                            "field_ref": field_ref,
-                            "directive": "passthrough",
-                            "operation": "apply_context_scope",
-                            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
-                            f"Check the output schema of '{ns_name}'.",
-                        },
-                    )
-
-                passthrough_fields.setdefault(ns_name, {})[field_name] = value
-
-        except ValueError as e:
-            fire_event(
-                ContextFieldSkippedEvent(
-                    action_name=action_name,
-                    field_ref=field_ref,
-                    reason=str(e),
-                    directive="passthrough",
                 )
             )
             continue

--- a/tests/unit/prompt/context/test_scope_application.py
+++ b/tests/unit/prompt/context/test_scope_application.py
@@ -469,6 +469,162 @@ class TestDropVersioned:
         assert lc["v_2"]["name"] == "n"
 
 
+class TestDropPassthroughInteraction:
+    """Bug fix: drop directives must exclude fields from passthrough wildcards.
+
+    Previously, drop ran before passthrough extraction. Passthrough read from
+    post-drop context, so dropped fields were silently absent — same end result,
+    but drop couldn't explicitly target passthrough fields.
+
+    Now passthrough extracts from pre-drop context, then drop removes from both
+    prompt_context and passthrough_fields.
+    """
+
+    def test_drop_field_excluded_from_passthrough_wildcard(self):
+        """Core fix: drop: [upstream.debug_info] + passthrough: [upstream.*]
+        excludes debug_info from passthrough output."""
+        fc = {
+            "upstream": {"field1": "val1", "debug_info": "secret", "field2": "val2"},
+        }
+        _, _, pt = apply_context_scope(
+            fc,
+            {
+                "drop": ["upstream.debug_info"],
+                "passthrough": ["upstream.*"],
+            },
+            action_name="test",
+        )
+        assert "debug_info" not in pt.get("upstream", {})
+        assert pt["upstream"]["field1"] == "val1"
+        assert pt["upstream"]["field2"] == "val2"
+
+    def test_drop_multiple_fields_from_passthrough_wildcard(self):
+        """Multiple drop directives each exclude their field from passthrough."""
+        fc = {
+            "upstream": {
+                "field1": "val1",
+                "debug_info": "secret",
+                "internal_notes": "private",
+                "field2": "val2",
+            },
+        }
+        _, _, pt = apply_context_scope(
+            fc,
+            {
+                "drop": ["upstream.debug_info", "upstream.internal_notes"],
+                "passthrough": ["upstream.*"],
+            },
+            action_name="test",
+        )
+        assert "debug_info" not in pt.get("upstream", {})
+        assert "internal_notes" not in pt.get("upstream", {})
+        assert pt["upstream"]["field1"] == "val1"
+        assert pt["upstream"]["field2"] == "val2"
+
+    def test_drop_wildcard_clears_passthrough_namespace(self):
+        """drop: [ns.*] + passthrough: [ns.*] → passthrough namespace removed entirely."""
+        fc = {"upstream": {"a": 1, "b": 2}}
+        _, _, pt = apply_context_scope(
+            fc,
+            {
+                "drop": ["upstream.*"],
+                "passthrough": ["upstream.*"],
+            },
+            action_name="test",
+        )
+        assert "upstream" not in pt
+
+    def test_drop_all_fields_individually_removes_namespace(self):
+        """Dropping every field individually removes the namespace from passthrough."""
+        fc = {"upstream": {"a": 1, "b": 2}}
+        _, _, pt = apply_context_scope(
+            fc,
+            {
+                "drop": ["upstream.a", "upstream.b"],
+                "passthrough": ["upstream.*"],
+            },
+            action_name="test",
+        )
+        assert "upstream" not in pt
+
+    def test_drop_with_specific_passthrough_unaffected(self):
+        """Drop on a field NOT in passthrough has no effect on passthrough output."""
+        fc = {"upstream": {"wanted": "yes", "unwanted": "no"}}
+        _, _, pt = apply_context_scope(
+            fc,
+            {
+                "drop": ["upstream.unwanted"],
+                "passthrough": ["upstream.wanted"],
+            },
+            action_name="test",
+        )
+        assert pt == {"upstream": {"wanted": "yes"}}
+
+    def test_no_warning_on_drop_targeting_existing_field(self):
+        """Drop directive on a field that exists produces no 'matched zero fields' warning."""
+        fc = {"upstream": {"debug_info": "secret", "data": "ok"}}
+        with patch("agent_actions.prompt.context.scope_application.logger") as mock_logger:
+            apply_context_scope(
+                fc,
+                {
+                    "drop": ["upstream.debug_info"],
+                    "passthrough": ["upstream.*"],
+                },
+                action_name="test",
+            )
+        # No warning calls about "matched zero fields"
+        for call in mock_logger.warning.call_args_list:
+            assert "matched zero fields" not in call[0][0]
+
+    def test_drop_observe_passthrough_full_interaction(self):
+        """All three directives: drop excludes from both observe and passthrough."""
+        fc = {"upstream": {"public": "ok", "debug": "secret", "meta": "info"}}
+        pc, lc, pt = apply_context_scope(
+            fc,
+            {
+                "observe": ["upstream.*"],
+                "passthrough": ["upstream.*"],
+                "drop": ["upstream.debug"],
+            },
+            action_name="test",
+        )
+        # debug excluded from all three outputs
+        assert "debug" not in lc.get("upstream", {})
+        assert "debug" not in pt.get("upstream", {})
+        assert "debug" not in pc.get("upstream", {})
+        # Other fields present in all
+        assert lc["upstream"]["public"] == "ok"
+        assert pt["upstream"]["public"] == "ok"
+        assert pc["upstream"]["public"] == "ok"
+
+    def test_drop_and_passthrough_same_specific_field(self):
+        """Drop on the same specific field as passthrough removes it from output."""
+        fc = {"upstream": {"secret": "s", "public": "p"}}
+        _, _, pt = apply_context_scope(
+            fc,
+            {
+                "drop": ["upstream.secret"],
+                "passthrough": ["upstream.secret", "upstream.public"],
+            },
+            action_name="test",
+        )
+        assert "secret" not in pt.get("upstream", {})
+        assert pt["upstream"]["public"] == "p"
+
+    def test_drop_on_different_namespace_than_passthrough(self):
+        """Drop on namespace A, passthrough on namespace B — no cross-effect."""
+        fc = {"ns_a": {"secret": "s"}, "ns_b": {"data": "d"}}
+        _, _, pt = apply_context_scope(
+            fc,
+            {
+                "drop": ["ns_a.secret"],
+                "passthrough": ["ns_b.*"],
+            },
+            action_name="test",
+        )
+        assert pt == {"ns_b": {"data": "d"}}
+
+
 class TestAllDirectivesCombined:
     """End-to-end with all three directives."""
 


### PR DESCRIPTION
## Summary
- Drop directives now correctly exclude fields from passthrough wildcards
- `drop: [upstream.debug_info]` with `passthrough: [upstream.*]` excludes debug_info from output
- Reorders apply_context_scope() so passthrough extracts from pre-drop context, then drop applies to both observe and passthrough
- No more silent ordering dependency between drop and passthrough

## Verification
- 8 new tests for drop + passthrough interaction (wildcard, multi-field, full interaction matrix)
- All 58 scope_application tests pass
- Full suite: 5395 passed, 2 skipped
- Lint clean on changed files