### PR TITLE
fix: dispatch_task() now resolves UDF functions in prompts

### DIFF
--- a/.changes/unreleased/Bug Fix-20260419-120000.yaml
+++ b/.changes/unreleased/Bug Fix-20260419-120000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "dispatch_task() in prompt templates now resolves UDF functions instead of passing the literal string to the LLM"
+time: 2026-04-19T12:00:00.000000Z

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -158,6 +158,11 @@ class PromptPreparationService:
             mode=mode,
         )
 
+        if not tools_path:
+            from agent_actions.utils.tools_resolver import resolve_tools_path
+
+            tools_path = resolve_tools_path(agent_config)
+
         if tools_path:
             formatted_prompt, _ = PromptUtils.inject_function_outputs_into_prompt(
                 formatted_prompt,
@@ -266,10 +271,16 @@ class PromptPreparationService:
             field_context_metadata=field_context_metadata,
         )
 
-        if request.tools_path:
+        tools_path = request.tools_path
+        if not tools_path:
+            from agent_actions.utils.tools_resolver import resolve_tools_path
+
+            tools_path = resolve_tools_path(request.agent_config)
+
+        if tools_path:
             formatted_prompt, _ = PromptUtils.inject_function_outputs_into_prompt(
                 formatted_prompt,
-                request.tools_path,
+                tools_path,
                 json.dumps(llm_context, ensure_ascii=False),
                 agent_config=request.agent_config,
             )

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -158,18 +158,9 @@ class PromptPreparationService:
             mode=mode,
         )
 
-        if not tools_path:
-            from agent_actions.utils.tools_resolver import resolve_tools_path
-
-            tools_path = resolve_tools_path(agent_config)
-
-        if tools_path:
-            formatted_prompt, _ = PromptUtils.inject_function_outputs_into_prompt(
-                formatted_prompt,
-                tools_path,
-                json.dumps(llm_context, ensure_ascii=False),
-                agent_config=agent_config,
-            )
+        formatted_prompt = PromptPreparationService._resolve_and_inject_dispatch(
+            formatted_prompt, llm_context, agent_config, tools_path
+        )
 
         metadata = {
             "mode": mode,
@@ -271,20 +262,9 @@ class PromptPreparationService:
             field_context_metadata=field_context_metadata,
         )
 
-        tools_path = request.tools_path
-        if not tools_path:
-            from agent_actions.utils.tools_resolver import resolve_tools_path
-
-            tools_path = resolve_tools_path(request.agent_config)
-
-        if tools_path:
-            formatted_prompt, _ = PromptUtils.inject_function_outputs_into_prompt(
-                formatted_prompt,
-                tools_path,
-                json.dumps(llm_context, ensure_ascii=False),
-                agent_config=request.agent_config,
-            )
-            logger.debug("Injected function outputs for dispatch_task()")
+        formatted_prompt = PromptPreparationService._resolve_and_inject_dispatch(
+            formatted_prompt, llm_context, request.agent_config, request.tools_path
+        )
 
         metadata: dict[str, Any] = {
             "mode": request.mode,
@@ -494,6 +474,30 @@ class PromptPreparationService:
                 },
                 cause=e,
             ) from e
+
+    @staticmethod
+    def _resolve_and_inject_dispatch(
+        formatted_prompt: str,
+        llm_context: dict[str, Any],
+        agent_config: dict[str, Any],
+        tools_path: str | None = None,
+    ) -> str:
+        """Resolve tools_path from agent_config if needed and inject dispatch_task() results."""
+        if not tools_path:
+            from agent_actions.utils.tools_resolver import resolve_tools_path
+
+            tools_path = resolve_tools_path(agent_config)
+
+        if tools_path:
+            formatted_prompt, _ = PromptUtils.inject_function_outputs_into_prompt(
+                formatted_prompt,
+                tools_path,
+                json.dumps(llm_context, ensure_ascii=False),
+                agent_config=agent_config,
+            )
+            logger.debug("Injected function outputs for dispatch_task()")
+
+        return formatted_prompt
 
     @staticmethod
     def _build_llm_context(

--- a/tests/integration/test_dispatch_task_e2e.py
+++ b/tests/integration/test_dispatch_task_e2e.py
@@ -1,0 +1,192 @@
+"""End-to-end simulation of dispatch_task() resolution.
+
+Creates a real UDF on disk, configures agent_config to point at it,
+and verifies the full pipeline: prompt rendering → tools_path resolution
+→ UDF loading → dispatch_task replacement. No mocks on the dispatch path.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.prompt.service import PromptPreparationService
+from agent_actions.utils.module_loader import clear_module_cache
+
+
+@pytest.fixture()
+def tools_dir(tmp_path):
+    """Create a tools directory with a real UDF module."""
+    tools = tmp_path / "tools"
+    tools.mkdir()
+
+    # A simple UDF that returns a computed string
+    (tools / "get_opener.py").write_text(
+        'def get_opener(context_data, *args):\n'
+        '    return "During monitoring, you notice an anomaly"\n'
+    )
+
+    # A UDF that uses context data
+    (tools / "summarize.py").write_text(
+        'import json\n'
+        'def summarize(context_data, *args):\n'
+        '    data = json.loads(context_data) if isinstance(context_data, str) else context_data\n'
+        '    keys = list(data.keys()) if isinstance(data, dict) else []\n'
+        '    return f"Summary of {len(keys)} fields"\n'
+    )
+
+    # A UDF that returns None (should error)
+    (tools / "bad_udf.py").write_text(
+        'def bad_udf(context_data, *args):\n'
+        '    return None\n'
+    )
+
+    yield tools
+
+    # Clean up loaded modules from sys.modules
+    clear_module_cache()
+    for name in list(sys.modules):
+        if name in ("get_opener", "summarize", "bad_udf"):
+            del sys.modules[name]
+
+
+def _stub_raw_prompt(text):
+    return patch(
+        "agent_actions.prompt.service.PromptFormatter.get_raw_prompt",
+        return_value=text,
+    )
+
+
+class TestDispatchTaskEndToEnd:
+    """Full pipeline: real UDF on disk, no mocks on the dispatch path."""
+
+    def test_dispatch_resolves_real_udf(self, tools_dir):
+        """dispatch_task('get_opener') loads the module and injects its return value."""
+        config = {
+            "agent_type": "test",
+            "prompt": "inline",
+            "context_scope": {"observe": ["source.*"]},
+            "tool_path": [str(tools_dir)],
+        }
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Start with: dispatch_task('get_opener')"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "During monitoring, you notice an anomaly" in result.formatted_prompt
+
+    def test_dispatch_passes_context_to_udf(self, tools_dir):
+        """The UDF receives the LLM context as its first argument."""
+        config = {
+            "agent_type": "test",
+            "prompt": "inline",
+            "context_scope": {"observe": ["source.*"]},
+            "tool_path": [str(tools_dir)],
+        }
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Result: dispatch_task('summarize')"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "Summary of" in result.formatted_prompt
+
+    def test_dispatch_none_return_raises(self, tools_dir):
+        """UDF returning None raises AgentActionsError, not silent passthrough."""
+        from agent_actions.errors import AgentActionsError
+
+        config = {
+            "agent_type": "test",
+            "prompt": "inline",
+            "context_scope": {"observe": ["source.*"]},
+            "tool_path": [str(tools_dir)],
+        }
+        field_context = {"source": {"text": "hello"}}
+
+        with (
+            _stub_raw_prompt("Value: dispatch_task('bad_udf')"),
+            pytest.raises(AgentActionsError, match="returned None"),
+        ):
+            PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+    def test_dispatch_missing_function_raises(self, tools_dir):
+        """Referencing a non-existent UDF raises, not literal passthrough."""
+        from agent_actions.errors import ConfigurationError
+
+        config = {
+            "agent_type": "test",
+            "prompt": "inline",
+            "context_scope": {"observe": ["source.*"]},
+            "tool_path": [str(tools_dir)],
+        }
+        field_context = {"source": {"text": "hello"}}
+
+        with (
+            _stub_raw_prompt("Value: dispatch_task('nonexistent_func')"),
+            pytest.raises(ConfigurationError, match="nonexistent_func"),
+        ):
+            PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+    def test_dispatch_auto_resolves_without_explicit_tools_path(self, tools_dir):
+        """The fix: tools_path auto-resolved from config, not passed by caller."""
+        config = {
+            "agent_type": "test",
+            "prompt": "inline",
+            "context_scope": {"observe": ["source.*"]},
+            "tool_path": [str(tools_dir)],
+        }
+        field_context = {"source": {"text": "hello"}}
+
+        # Call prepare_prompt_with_field_context WITHOUT tools_path arg.
+        # Before the fix, this would pass "dispatch_task('get_opener')" as literal.
+        with _stub_raw_prompt("Opener: dispatch_task('get_opener')"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+                # tools_path intentionally omitted — auto-resolution under test
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "During monitoring, you notice an anomaly" in result.formatted_prompt
+
+    def test_no_tools_config_leaves_literal(self):
+        """Without any tools config, dispatch_task passes through as literal text."""
+        config = {
+            "agent_type": "test",
+            "prompt": "inline",
+            "context_scope": {"observe": ["source.*"]},
+        }
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Value: dispatch_task('anything')"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert "dispatch_task('anything')" in result.formatted_prompt

--- a/tests/integration/test_dispatch_task_e2e.py
+++ b/tests/integration/test_dispatch_task_e2e.py
@@ -22,24 +22,21 @@ def tools_dir(tmp_path):
 
     # A simple UDF that returns a computed string
     (tools / "get_opener.py").write_text(
-        'def get_opener(context_data, *args):\n'
+        "def get_opener(context_data, *args):\n"
         '    return "During monitoring, you notice an anomaly"\n'
     )
 
     # A UDF that uses context data
     (tools / "summarize.py").write_text(
-        'import json\n'
-        'def summarize(context_data, *args):\n'
-        '    data = json.loads(context_data) if isinstance(context_data, str) else context_data\n'
-        '    keys = list(data.keys()) if isinstance(data, dict) else []\n'
+        "import json\n"
+        "def summarize(context_data, *args):\n"
+        "    data = json.loads(context_data) if isinstance(context_data, str) else context_data\n"
+        "    keys = list(data.keys()) if isinstance(data, dict) else []\n"
         '    return f"Summary of {len(keys)} fields"\n'
     )
 
     # A UDF that returns None (should error)
-    (tools / "bad_udf.py").write_text(
-        'def bad_udf(context_data, *args):\n'
-        '    return None\n'
-    )
+    (tools / "bad_udf.py").write_text("def bad_udf(context_data, *args):\n    return None\n")
 
     yield tools
 

--- a/tests/integration/test_dispatch_task_e2e.py
+++ b/tests/integration/test_dispatch_task_e2e.py
@@ -60,36 +60,15 @@ def _stub_raw_prompt(text):
 class TestDispatchTaskEndToEnd:
     """Full pipeline: real UDF on disk, no mocks on the dispatch path."""
 
-    def test_dispatch_resolves_real_udf(self, tools_dir):
-        """dispatch_task('get_opener') loads the module and injects its return value."""
-        config = {
-            "agent_type": "test",
-            "prompt": "inline",
-            "context_scope": {"observe": ["source.*"]},
-            "tool_path": [str(tools_dir)],
-        }
-        field_context = {"source": {"text": "hello"}}
-
-        with _stub_raw_prompt("Start with: dispatch_task('get_opener')"):
-            result = PromptPreparationService.prepare_prompt_with_field_context(
-                agent_config=config,
-                agent_name="test",
-                contents={},
-                field_context=field_context,
-            )
-
-        assert "dispatch_task" not in result.formatted_prompt
-        assert "During monitoring, you notice an anomaly" in result.formatted_prompt
-
     def test_dispatch_passes_context_to_udf(self, tools_dir):
-        """The UDF receives the LLM context as its first argument."""
+        """The UDF receives the LLM context (with observed fields) as its first argument."""
         config = {
             "agent_type": "test",
             "prompt": "inline",
             "context_scope": {"observe": ["source.*"]},
             "tool_path": [str(tools_dir)],
         }
-        field_context = {"source": {"text": "hello"}}
+        field_context = {"source": {"text": "hello", "category": "test"}}
 
         with _stub_raw_prompt("Result: dispatch_task('summarize')"):
             result = PromptPreparationService.prepare_prompt_with_field_context(
@@ -100,7 +79,9 @@ class TestDispatchTaskEndToEnd:
             )
 
         assert "dispatch_task" not in result.formatted_prompt
-        assert "Summary of" in result.formatted_prompt
+        # source.* observe produces {"source": {...}} in llm_context — 1 top-level key.
+        # "0 fields" would mean empty context wasn't passed; "1 fields" proves it was.
+        assert "Summary of 1 fields" in result.formatted_prompt
 
     def test_dispatch_none_return_raises(self, tools_dir):
         """UDF returning None raises AgentActionsError, not silent passthrough."""

--- a/tests/unit/prompt/test_dispatch_tools_path_resolution.py
+++ b/tests/unit/prompt/test_dispatch_tools_path_resolution.py
@@ -1,0 +1,257 @@
+"""Tests for dispatch_task() tools_path auto-resolution in PromptPreparationService.
+
+Verifies that dispatch_task() calls in prompts are resolved even when the caller
+does not explicitly pass tools_path, as long as agent_config contains a resolvable
+tool path (via tool_path, tools.path, or OpenAI format).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.config.types import RunMode
+from agent_actions.errors import AgentActionsError
+from agent_actions.prompt.service import PromptPreparationService
+
+
+def _make_agent_config(*, tool_path=None, tools=None, extra=None):
+    """Build a minimal agent_config dict for prompt preparation tests."""
+    config = {
+        "agent_type": "test_action",
+        "prompt": "inline",
+        "context_scope": {"observe": ["source.*"]},
+    }
+    if tool_path is not None:
+        config["tool_path"] = tool_path
+    if tools is not None:
+        config["tools"] = tools
+    if extra:
+        config.update(extra)
+    return config
+
+
+def _stub_raw_prompt(text):
+    """Patch PromptFormatter.get_raw_prompt to return static text."""
+    return patch(
+        "agent_actions.prompt.service.PromptFormatter.get_raw_prompt",
+        return_value=text,
+    )
+
+
+def _stub_udf(return_value="computed_result"):
+    """Patch StringProcessor.call_user_function to return a static value."""
+    return patch(
+        "agent_actions.prompt.prompt_utils.StringProcessor.call_user_function",
+        return_value=return_value,
+    )
+
+
+def _stub_udf_error(error_msg="Could not find function"):
+    """Patch StringProcessor.call_user_function to raise an error."""
+    return patch(
+        "agent_actions.prompt.prompt_utils.StringProcessor.call_user_function",
+        side_effect=AgentActionsError(error_msg),
+    )
+
+
+class TestDispatchToolsPathResolution:
+    """dispatch_task() resolves when tools_path is auto-resolved from agent_config."""
+
+    def test_dispatch_resolved_with_explicit_tools_path(self):
+        """dispatch_task() works when tools_path is explicitly provided."""
+        config = _make_agent_config()
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("dynamic_value"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+                tools_path="/explicit/tools",
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "dynamic_value" in result.formatted_prompt
+
+    def test_dispatch_resolved_via_tool_path_list(self):
+        """dispatch_task() resolves when tools_path comes from tool_path list in config."""
+        config = _make_agent_config(tool_path=["tools/my_workflow"])
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("resolved_output"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+                # tools_path intentionally NOT provided
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "resolved_output" in result.formatted_prompt
+
+    def test_dispatch_resolved_via_tool_path_string(self):
+        """dispatch_task() resolves when tool_path is a plain string."""
+        config = _make_agent_config(tool_path="tools/my_workflow")
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("string_path_result"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "string_path_result" in result.formatted_prompt
+
+    def test_dispatch_resolved_via_tools_dict_path(self):
+        """dispatch_task() resolves when tools is a dict with path key."""
+        config = _make_agent_config(tools={"path": "tools/my_workflow"})
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("dict_path_result"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "dict_path_result" in result.formatted_prompt
+
+    def test_no_dispatch_without_tools_config(self):
+        """When no tools config exists and no dispatch calls, prompt is unchanged."""
+        config = _make_agent_config()
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Plain prompt without dispatch calls"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert result.formatted_prompt == "Plain prompt without dispatch calls"
+
+    def test_dispatch_literal_without_tools_config(self):
+        """dispatch_task() passes through as literal when no tools config exists."""
+        config = _make_agent_config()
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        # No tools config -> resolve_tools_path returns None -> dispatch skipped
+        assert "dispatch_task('my_func')" in result.formatted_prompt
+
+    def test_dispatch_error_surfaces(self):
+        """dispatch_task() with missing function raises, not silently passes through."""
+        config = _make_agent_config(tool_path=["tools"])
+        field_context = {"source": {"text": "hello"}}
+
+        with (
+            _stub_raw_prompt("Use: dispatch_task('nonexistent')"),
+            _stub_udf_error("Could not find function 'nonexistent'"),
+            pytest.raises(AgentActionsError, match="Could not find function"),
+        ):
+            PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+    def test_multiple_dispatch_calls_all_resolved(self):
+        """Multiple dispatch_task() calls in one prompt are all resolved."""
+        config = _make_agent_config(tool_path=["tools"])
+        field_context = {"source": {"text": "hello"}}
+        call_count = 0
+
+        def mock_call(name, path, ctx):
+            nonlocal call_count
+            call_count += 1
+            return f"result_{call_count}"
+
+        with (
+            _stub_raw_prompt("A: dispatch_task('a') B: dispatch_task('b')"),
+            patch(
+                "agent_actions.prompt.prompt_utils.StringProcessor.call_user_function",
+                side_effect=mock_call,
+            ),
+        ):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "result_" in result.formatted_prompt
+
+
+class TestDispatchInternalPathResolution:
+    """dispatch_task() resolves via _prepare_prompt_internal when tools_path not in request."""
+
+    def test_internal_resolves_from_agent_config(self):
+        """_prepare_prompt_internal auto-resolves tools_path from agent_config."""
+        config = _make_agent_config(tool_path=["tools/my_workflow"])
+
+        with (
+            _stub_raw_prompt("Content: dispatch_task('gen')"),
+            _stub_udf("generated_content"),
+            patch(
+                "agent_actions.prompt.service.build_field_context_with_history",
+                return_value={"source": {"text": "data"}},
+            ),
+        ):
+            result = PromptPreparationService.prepare_prompt_with_context(
+                agent_config=config,
+                agent_name="test",
+                contents={"text": "data"},
+                mode=RunMode.ONLINE,
+                # tools_path intentionally NOT provided
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "generated_content" in result.formatted_prompt
+
+    def test_explicit_tools_path_takes_precedence(self):
+        """Explicit tools_path overrides auto-resolution from agent_config."""
+        config = _make_agent_config(tool_path=["config/path"])
+
+        calls = []
+
+        def capture_call(name, path, ctx):
+            calls.append(path)
+            return "result"
+
+        with (
+            _stub_raw_prompt("dispatch_task('func')"),
+            patch(
+                "agent_actions.prompt.prompt_utils.StringProcessor.call_user_function",
+                side_effect=capture_call,
+            ),
+            patch(
+                "agent_actions.prompt.service.build_field_context_with_history",
+                return_value={"source": {"text": "data"}},
+            ),
+        ):
+            PromptPreparationService.prepare_prompt_with_context(
+                agent_config=config,
+                agent_name="test",
+                contents={"text": "data"},
+                tools_path="/explicit/override",
+            )
+
+        assert calls[0] == "/explicit/override"

--- a/tests/unit/prompt/test_dispatch_tools_path_resolution.py
+++ b/tests/unit/prompt/test_dispatch_tools_path_resolution.py
@@ -14,7 +14,7 @@ from agent_actions.errors import AgentActionsError
 from agent_actions.prompt.service import PromptPreparationService
 
 
-def _make_agent_config(*, tool_path=None, tools=None, extra=None):
+def _make_agent_config(*, tool_path=None, tools=None):
     """Build a minimal agent_config dict for prompt preparation tests."""
     config = {
         "agent_type": "test_action",
@@ -25,8 +25,6 @@ def _make_agent_config(*, tool_path=None, tools=None, extra=None):
         config["tool_path"] = tool_path
     if tools is not None:
         config["tools"] = tools
-    if extra:
-        config.update(extra)
     return config
 
 
@@ -46,14 +44,6 @@ def _stub_udf(return_value="computed_result"):
     )
 
 
-def _stub_udf_error(error_msg="Could not find function"):
-    """Patch StringProcessor.call_user_function to raise an error."""
-    return patch(
-        "agent_actions.prompt.prompt_utils.StringProcessor.call_user_function",
-        side_effect=AgentActionsError(error_msg),
-    )
-
-
 class TestDispatchToolsPathResolution:
     """dispatch_task() resolves when tools_path is auto-resolved from agent_config."""
 
@@ -62,7 +52,7 @@ class TestDispatchToolsPathResolution:
         config = _make_agent_config()
         field_context = {"source": {"text": "hello"}}
 
-        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("dynamic_value"):
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf():
             result = PromptPreparationService.prepare_prompt_with_field_context(
                 agent_config=config,
                 agent_name="test",
@@ -72,31 +62,23 @@ class TestDispatchToolsPathResolution:
             )
 
         assert "dispatch_task" not in result.formatted_prompt
-        assert "dynamic_value" in result.formatted_prompt
+        assert "computed_result" in result.formatted_prompt
 
-    def test_dispatch_resolved_via_tool_path_list(self):
-        """dispatch_task() resolves when tools_path comes from tool_path list in config."""
-        config = _make_agent_config(tool_path=["tools/my_workflow"])
+    @pytest.mark.parametrize(
+        "config_kwargs, test_id",
+        [
+            ({"tool_path": ["tools/my_workflow"]}, "tool_path_list"),
+            ({"tool_path": "tools/my_workflow"}, "tool_path_string"),
+            ({"tools": {"path": "tools/my_workflow"}}, "tools_dict_path"),
+        ],
+        ids=["tool_path_list", "tool_path_string", "tools_dict_path"],
+    )
+    def test_dispatch_resolved_via_config(self, config_kwargs, test_id):
+        """dispatch_task() resolves via auto-resolution from different config formats."""
+        config = _make_agent_config(**config_kwargs)
         field_context = {"source": {"text": "hello"}}
 
-        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("resolved_output"):
-            result = PromptPreparationService.prepare_prompt_with_field_context(
-                agent_config=config,
-                agent_name="test",
-                contents={},
-                field_context=field_context,
-                # tools_path intentionally NOT provided
-            )
-
-        assert "dispatch_task" not in result.formatted_prompt
-        assert "resolved_output" in result.formatted_prompt
-
-    def test_dispatch_resolved_via_tool_path_string(self):
-        """dispatch_task() resolves when tool_path is a plain string."""
-        config = _make_agent_config(tool_path="tools/my_workflow")
-        field_context = {"source": {"text": "hello"}}
-
-        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("string_path_result"):
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf():
             result = PromptPreparationService.prepare_prompt_with_field_context(
                 agent_config=config,
                 agent_name="test",
@@ -105,38 +87,7 @@ class TestDispatchToolsPathResolution:
             )
 
         assert "dispatch_task" not in result.formatted_prompt
-        assert "string_path_result" in result.formatted_prompt
-
-    def test_dispatch_resolved_via_tools_dict_path(self):
-        """dispatch_task() resolves when tools is a dict with path key."""
-        config = _make_agent_config(tools={"path": "tools/my_workflow"})
-        field_context = {"source": {"text": "hello"}}
-
-        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf("dict_path_result"):
-            result = PromptPreparationService.prepare_prompt_with_field_context(
-                agent_config=config,
-                agent_name="test",
-                contents={},
-                field_context=field_context,
-            )
-
-        assert "dispatch_task" not in result.formatted_prompt
-        assert "dict_path_result" in result.formatted_prompt
-
-    def test_no_dispatch_without_tools_config(self):
-        """When no tools config exists and no dispatch calls, prompt is unchanged."""
-        config = _make_agent_config()
-        field_context = {"source": {"text": "hello"}}
-
-        with _stub_raw_prompt("Plain prompt without dispatch calls"):
-            result = PromptPreparationService.prepare_prompt_with_field_context(
-                agent_config=config,
-                agent_name="test",
-                contents={},
-                field_context=field_context,
-            )
-
-        assert result.formatted_prompt == "Plain prompt without dispatch calls"
+        assert "computed_result" in result.formatted_prompt
 
     def test_dispatch_literal_without_tools_config(self):
         """dispatch_task() passes through as literal when no tools config exists."""
@@ -151,7 +102,6 @@ class TestDispatchToolsPathResolution:
                 field_context=field_context,
             )
 
-        # No tools config -> resolve_tools_path returns None -> dispatch skipped
         assert "dispatch_task('my_func')" in result.formatted_prompt
 
     def test_dispatch_error_surfaces(self):
@@ -161,7 +111,10 @@ class TestDispatchToolsPathResolution:
 
         with (
             _stub_raw_prompt("Use: dispatch_task('nonexistent')"),
-            _stub_udf_error("Could not find function 'nonexistent'"),
+            patch(
+                "agent_actions.prompt.prompt_utils.StringProcessor.call_user_function",
+                side_effect=AgentActionsError("Could not find function 'nonexistent'"),
+            ),
             pytest.raises(AgentActionsError, match="Could not find function"),
         ):
             PromptPreparationService.prepare_prompt_with_field_context(
@@ -220,7 +173,6 @@ class TestDispatchInternalPathResolution:
                 agent_name="test",
                 contents={"text": "data"},
                 mode=RunMode.ONLINE,
-                # tools_path intentionally NOT provided
             )
 
         assert "dispatch_task" not in result.formatted_prompt

--- a/tests/unit/prompt/test_dispatch_tools_path_resolution.py
+++ b/tests/unit/prompt/test_dispatch_tools_path_resolution.py
@@ -104,6 +104,45 @@ class TestDispatchToolsPathResolution:
 
         assert "dispatch_task('my_func')" in result.formatted_prompt
 
+    def test_empty_string_tools_path_triggers_resolution(self):
+        """Empty string tools_path is falsy — triggers auto-resolution from config."""
+        config = _make_agent_config(tool_path=["tools/my_workflow"])
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Use: dispatch_task('my_func')"), _stub_udf():
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+                tools_path="",
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "computed_result" in result.formatted_prompt
+
+    def test_config_validation_error_propagates(self):
+        """ConfigValidationError from resolve_tools_path propagates, not swallowed."""
+        from agent_actions.errors import ConfigValidationError
+
+        config = _make_agent_config()
+        field_context = {"source": {"text": "hello"}}
+
+        with (
+            _stub_raw_prompt("Use: dispatch_task('my_func')"),
+            patch(
+                "agent_actions.utils.tools_resolver.resolve_tools_path",
+                side_effect=ConfigValidationError("path traversal detected"),
+            ),
+            pytest.raises(ConfigValidationError, match="path traversal"),
+        ):
+            PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
     def test_dispatch_error_surfaces(self):
         """dispatch_task() with missing function raises, not silently passes through."""
         config = _make_agent_config(tool_path=["tools"])


### PR DESCRIPTION
## Summary
- Fixed tools_path propagation so dispatch_task() calls in prompts are resolved before sending to LLM
- PromptPreparationService now auto-resolves tools_path from agent_config (via resolve_tools_path) when not explicitly provided
- dispatch_task('function_name') now calls the UDF and injects the result into the prompt instead of passing the literal string

## Root cause
Both `prepare_prompt_with_field_context()` and `_prepare_prompt_internal()` gated dispatch injection behind `if tools_path:` but did not attempt to resolve tools_path from agent_config when not provided. Several code paths (initial pipeline validation, file mode pipeline) pass tools_path=None, causing dispatch_task() to flow as a literal string to the LLM.

## Verification
- Test: dispatch_task in prompt resolves to UDF output (explicit tools_path, tool_path list, tool_path string, tools.path dict)
- Test: dispatch_task with missing function produces actionable error
- Test: actions without tools/ directory don't break
- Test: explicit tools_path takes precedence over auto-resolution
- Test: multiple dispatch calls all resolved
- Full suite passes (5339 passed)
- ruff format + ruff check clean (no new warnings)