### PR TITLE
fix: schema validation handles guard-filtered upstream fields

### DIFF
--- a/.changes/unreleased/Bug Fix-20260419-100000.yaml
+++ b/.changes/unreleased/Bug Fix-20260419-100000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Downstream tool actions no longer crash on absent fields from guard-filtered upstream records; schema validation auto-fixes guard-nullable fields to accept null"
+time: 2026-04-19T10:00:00.000000Z

--- a/agent_actions/validation/static_analyzer/__init__.py
+++ b/agent_actions/validation/static_analyzer/__init__.py
@@ -43,12 +43,14 @@ from .type_checker import StaticTypeChecker
 from .workflow_static_analyzer import (
     WorkflowStaticAnalyzer,
     analyze_workflow,
+    apply_guard_nullable_schema_fixes,
 )
 
 __all__ = [
     # Main entry points
     "WorkflowStaticAnalyzer",
     "analyze_workflow",
+    "apply_guard_nullable_schema_fixes",
     # Graph components
     "DataFlowGraph",
     "DataFlowNode",

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -1710,3 +1710,149 @@ def analyze_workflow(
         result.set_strict_mode(True)
 
     return result
+
+
+# ── Guard-nullable schema auto-fix ──────────────────────────────────
+
+
+def _make_schema_field_nullable(schema: dict[str, Any], field_name: str) -> bool:
+    """Add ``"null"`` to a field's type in a JSON Schema dict.
+
+    Handles standard ``properties`` format, ``items.properties`` (array schema),
+    and nested ``schema`` wrapper.  Returns ``True`` if the field was modified.
+    """
+    # Standard properties format
+    properties = schema.get("properties")
+    if isinstance(properties, dict) and field_name in properties:
+        field_def = properties[field_name]
+        if isinstance(field_def, dict) and "type" in field_def:
+            field_type = field_def["type"]
+            if isinstance(field_type, str) and field_type != "null":
+                field_def["type"] = [field_type, "null"]
+                return True
+            if isinstance(field_type, list) and "null" not in field_type:
+                field_type.append("null")
+                return True
+
+    # Array items.properties format
+    items = schema.get("items")
+    if isinstance(items, dict):
+        if _make_schema_field_nullable(items, field_name):
+            return True
+
+    # Nested schema wrapper (e.g. OpenAI compiled)
+    nested = schema.get("schema")
+    if isinstance(nested, dict):
+        if _make_schema_field_nullable(nested, field_name):
+            return True
+
+    return False
+
+
+def apply_guard_nullable_schema_fixes(
+    action_configs: dict[str, dict[str, Any]],
+) -> list[str]:
+    """Make guard-nullable fields accept ``null`` in downstream ``json_output_schema``.
+
+    When upstream actions have ``guard.on_false`` set to ``"filter"`` or
+    ``"skip"``, downstream tool actions that observe those fields may receive
+    ``None`` at runtime.  This function modifies ``json_output_schema`` **in
+    place** so that ``jsonschema.validate()`` accepts ``null`` for those fields.
+
+    Call this after schema compilation and static validation but before
+    workflow execution.
+
+    Returns:
+        List of fixed field paths (e.g. ``["consumer.field"]``).
+    """
+    fixes: list[str] = []
+
+    # Step 1: Identify guarded actions with filter/skip behavior.
+    guarded_actions: set[str] = set()
+    for name, config in action_configs.items():
+        guard = config.get("guard")
+        if not guard:
+            continue
+        if isinstance(guard, dict):
+            behavior = guard.get("on_false", "filter")
+        elif isinstance(guard, str):
+            behavior = "filter"  # string guards default to filter
+        else:
+            continue
+        if behavior in ("filter", "skip"):
+            guarded_actions.add(name)
+
+    if not guarded_actions:
+        return fixes
+
+    # Step 1b: Build passthrough map for transitive resolution.
+    # {action_name: {source_action: set_of_fields_or_wildcard}}
+    passthrough_map: dict[str, dict[str, set[str] | str]] = {}
+    for name, config in action_configs.items():
+        cs = config.get("context_scope")
+        if not isinstance(cs, dict):
+            continue
+        pt_refs = cs.get("passthrough", [])
+        if not isinstance(pt_refs, list):
+            continue
+        for ref in pt_refs:
+            if not isinstance(ref, str) or "." not in ref:
+                continue
+            pt_source, pt_field = ref.split(".", 1)
+            if pt_field == "*":
+                passthrough_map.setdefault(name, {})[pt_source] = "*"
+            else:
+                existing = passthrough_map.setdefault(name, {}).get(pt_source, set())
+                if existing != "*":  # wildcard supersedes specifics
+                    if isinstance(existing, set):
+                        existing.add(pt_field)
+                    passthrough_map[name][pt_source] = existing
+
+    # Step 2: For each tool action, find observed fields from guarded upstreams.
+    for consumer_name, consumer_config in action_configs.items():
+        if consumer_config.get("model_vendor") != "tool":
+            continue
+
+        json_schema = consumer_config.get("json_output_schema")
+        if not json_schema or not isinstance(json_schema, dict):
+            continue
+
+        context_scope = consumer_config.get("context_scope")
+        if not isinstance(context_scope, dict):
+            continue
+
+        observe_refs = context_scope.get("observe", [])
+        if not isinstance(observe_refs, list):
+            continue
+
+        guard_nullable_fields: set[str] = set()
+        for ref in observe_refs:
+            if not isinstance(ref, str) or "." not in ref:
+                continue
+            source, field = ref.split(".", 1)
+            if field == "*":
+                continue
+
+            # Case 1: Direct observation of a guarded action.
+            if source in guarded_actions:
+                guard_nullable_fields.add(field)
+                continue
+
+            # Case 2: Transitive — source passthroughs from a guarded action.
+            source_pts = passthrough_map.get(source, {})
+            for g_name in guarded_actions:
+                pt_fields = source_pts.get(g_name)
+                if pt_fields is None:
+                    continue
+                if pt_fields == "*" or (isinstance(pt_fields, set) and field in pt_fields):
+                    guard_nullable_fields.add(field)
+
+        if not guard_nullable_fields:
+            continue
+
+        # Step 3: Make those fields nullable in json_output_schema.
+        for field_name in sorted(guard_nullable_fields):
+            if _make_schema_field_nullable(json_schema, field_name):
+                fixes.append(f"{consumer_name}.{field_name}")
+
+    return fixes

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -1786,6 +1786,16 @@ def apply_guard_nullable_schema_fixes(
     if not guarded_actions:
         return fixes
 
+    # Step 1a: Extract schema field names for each guarded action.
+    # Used to verify wildcard passthrough fields actually belong to the guarded action.
+    guarded_fields: dict[str, set[str]] = {}
+    for g_name in guarded_actions:
+        g_config = action_configs[g_name]
+        schema = g_config.get("json_output_schema") or g_config.get("schema")
+        if schema:
+            field_types = WorkflowStaticAnalyzer._extract_field_types_from_schema(schema)
+            guarded_fields[g_name] = set(field_types.keys())
+
     # Step 1b: Build passthrough map for transitive resolution.
     # {action_name: {source_action: set_of_fields_or_wildcard}}
     passthrough_map: dict[str, dict[str, set[str] | str]] = {}
@@ -1845,7 +1855,11 @@ def apply_guard_nullable_schema_fixes(
                 pt_fields = source_pts.get(g_name)
                 if pt_fields is None:
                     continue
-                if pt_fields == "*" or (isinstance(pt_fields, set) and field in pt_fields):
+                if pt_fields == "*":
+                    # Wildcard: only if the field is actually produced by the guarded action
+                    if field in guarded_fields.get(g_name, set()):
+                        guard_nullable_fields.add(field)
+                elif isinstance(pt_fields, set) and field in pt_fields:
                     guard_nullable_fields.add(field)
 
         if not guard_nullable_fields:

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -1774,7 +1774,8 @@ def apply_guard_nullable_schema_fixes(
         if not guard:
             continue
         if isinstance(guard, dict):
-            behavior = guard.get("on_false", "filter")
+            # Post-expansion configs use "behavior"; raw configs use "on_false".
+            behavior = guard.get("behavior", guard.get("on_false", "filter"))
         elif isinstance(guard, str):
             behavior = "filter"  # string guards default to filter
         else:

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -173,6 +173,19 @@ class AgentWorkflow:
                 hint="Fix the static type errors above before running the workflow.",
             )
 
+        # Auto-fix schemas for fields that may be None due to guard filtering.
+        from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+            apply_guard_nullable_schema_fixes,
+        )
+
+        guard_fixes = apply_guard_nullable_schema_fixes(self.action_configs)
+        if guard_fixes:
+            logger.info(
+                "Auto-fixed %d guard-nullable schema field(s): %s",
+                len(guard_fixes),
+                ", ".join(guard_fixes),
+            )
+
         guard_errors = self._validate_guard_conditions()
         if guard_errors:
             raise PreFlightValidationError(

--- a/tests/manual/doc_audit/test_guard_filtered_schema.py
+++ b/tests/manual/doc_audit/test_guard_filtered_schema.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Manual end-to-end test: guard-filtered schema validation.
+
+Simulates the full lifecycle of a guard-filtered record flowing through
+a downstream tool action.  Proves that:
+
+  1. WITHOUT the fix, jsonschema.validate crashes on None fields
+  2. The auto-fix modifies only the right fields in the schema
+  3. AFTER the fix, filtered records pass validation
+  4. Non-filtered records are still validated strictly
+  5. The fix works with post-expansion guard format (behavior key)
+  6. Transitive passthrough chains are also fixed
+
+Run:
+    python tests/manual/doc_audit/test_guard_filtered_schema.py
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# --- path fixup for standalone execution ---
+if __name__ == "__main__":
+    _root = Path(__file__).resolve().parents[3]
+    if str(_root) not in sys.path:
+        sys.path.insert(0, str(_root))
+
+import jsonschema
+
+from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+    apply_guard_nullable_schema_fixes,
+)
+
+# ── Colors ──────────────────────────────────────────────────────────
+
+CYAN = "\033[36m"
+GREEN = "\033[32m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def _header(title: str) -> None:
+    print(f"\n{CYAN}{'═' * 72}")
+    print(f"  {title}")
+    print(f"{'═' * 72}{RESET}")
+
+
+def _pass(msg: str) -> None:
+    print(f"  {GREEN}PASS{RESET}  {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  {RED}FAIL{RESET}  {msg}")
+
+
+def _info(msg: str) -> None:
+    print(f"  {DIM}INFO{RESET}  {msg}")
+
+
+def _show_schema(label: str, schema: dict) -> None:
+    print(f"  {YELLOW}{label}:{RESET}")
+    for line in json.dumps(schema, indent=2).splitlines():
+        print(f"    {DIM}{line}{RESET}")
+
+
+# ── Workflow simulation ─────────────────────────────────────────────
+
+
+def build_action_configs() -> dict[str, dict[str, Any]]:
+    """Simulate what the config pipeline produces for a real workflow.
+
+    Workflow:
+        fix_failed_validation (guarded, on_false: filter)
+          -> produces: options (object), answer (string)
+
+        select_validated_questions (tool, observes fix_failed_validation.options)
+          -> schema: options (object), summary (string)
+    """
+    return {
+        "fix_failed_validation": {
+            "model_vendor": "openai",
+            # Post-expansion guard format (what coordinator actually sees)
+            "guard": {
+                "clause": 'validation_status == "FAIL"',
+                "scope": "item",
+                "behavior": "filter",
+            },
+        },
+        "select_validated_questions": {
+            "model_vendor": "tool",
+            "json_output_schema": {
+                "type": "object",
+                "properties": {
+                    "options": {"type": "object"},
+                    "summary": {"type": "string"},
+                },
+                "required": ["options", "summary"],
+                "additionalProperties": False,
+            },
+            "context_scope": {
+                "observe": [
+                    "fix_failed_validation.options",
+                ],
+            },
+        },
+    }
+
+
+def build_transitive_action_configs() -> dict[str, dict[str, Any]]:
+    """Simulate a transitive passthrough chain: guarded -> intermediate -> tool.
+
+    Workflow:
+        extract_qa (guarded, on_false: filter)
+          -> produces: qa_content (object)
+
+        enrich_qa (passthrough extract_qa.*)
+          -> adds: enrichment (string)
+
+        format_output (tool, observes enrich_qa.qa_content)
+          -> schema: qa_content (object), enrichment (string)
+    """
+    return {
+        "extract_qa": {
+            "model_vendor": "openai",
+            "guard": {
+                "clause": "has_qa_content == true",
+                "scope": "item",
+                "behavior": "filter",
+            },
+            "schema": [{"id": "qa_content", "type": "object"}],
+        },
+        "enrich_qa": {
+            "model_vendor": "openai",
+            "context_scope": {
+                "observe": ["extract_qa.qa_content"],
+                "passthrough": ["extract_qa.*"],
+            },
+        },
+        "format_output": {
+            "model_vendor": "tool",
+            "json_output_schema": {
+                "type": "object",
+                "properties": {
+                    "qa_content": {"type": "object"},
+                    "enrichment": {"type": "string"},
+                },
+                "required": ["qa_content", "enrichment"],
+                "additionalProperties": False,
+            },
+            "context_scope": {
+                "observe": [
+                    "enrich_qa.qa_content",
+                    "enrich_qa.enrichment",
+                ],
+            },
+        },
+    }
+
+
+# ── Test scenarios ──────────────────────────────────────────────────
+
+passed = 0
+failed = 0
+
+
+def check(condition: bool, msg: str) -> None:
+    global passed, failed
+    if condition:
+        _pass(msg)
+        passed += 1
+    else:
+        _fail(msg)
+        failed += 1
+
+
+def scenario_1_crash_without_fix() -> None:
+    """Prove that WITHOUT the fix, a filtered record crashes."""
+    _header("SCENARIO 1: Without fix — filtered record CRASHES")
+
+    configs = build_action_configs()
+    schema = configs["select_validated_questions"]["json_output_schema"]
+    _show_schema("Schema before fix", schema)
+
+    # Simulate what the tool returns when upstream was filtered
+    filtered_record_output = {"options": None, "summary": "Record passed validation"}
+
+    _info("Tool output for filtered record: options=None, summary='...'")
+
+    try:
+        jsonschema.validate(instance=filtered_record_output, schema=schema)
+        _fail("Expected ValidationError but validation passed!")
+        check(False, "Unfixed schema rejects None for 'options'")
+    except jsonschema.ValidationError as e:
+        _info(f"Error: {e.message}")
+        check(
+            "None is not of type" in e.message,
+            "Unfixed schema rejects None for 'options'",
+        )
+
+
+def scenario_2_fix_applied() -> None:
+    """Show what the fix does to the schema."""
+    _header("SCENARIO 2: Auto-fix modifies schema")
+
+    configs = build_action_configs()
+    schema_before = copy.deepcopy(configs["select_validated_questions"]["json_output_schema"])
+
+    fixes = apply_guard_nullable_schema_fixes(configs)
+    schema_after = configs["select_validated_questions"]["json_output_schema"]
+
+    _info(f"Fixes applied: {fixes}")
+    _show_schema("Schema BEFORE", schema_before)
+    _show_schema("Schema AFTER", schema_after)
+
+    check(
+        fixes == ["select_validated_questions.options"],
+        "Fix targets exactly 'select_validated_questions.options'",
+    )
+    check(
+        schema_after["properties"]["options"]["type"] == ["object", "null"],
+        "'options' type changed to ['object', 'null']",
+    )
+    check(
+        schema_after["properties"]["summary"]["type"] == "string",
+        "'summary' type unchanged (not from guarded upstream)",
+    )
+    check(
+        "options" in schema_after.get("required", []),
+        "'options' still required (field must be present, just nullable)",
+    )
+
+
+def scenario_3_filtered_record_passes() -> None:
+    """After fix, a filtered record's None values pass validation."""
+    _header("SCENARIO 3: After fix — filtered record PASSES")
+
+    configs = build_action_configs()
+    apply_guard_nullable_schema_fixes(configs)
+    schema = configs["select_validated_questions"]["json_output_schema"]
+
+    filtered_output = {"options": None, "summary": "Record passed validation"}
+    _info(f"Tool output: {json.dumps(filtered_output)}")
+
+    try:
+        jsonschema.validate(instance=filtered_output, schema=schema)
+        check(True, "Filtered record (options=None) passes validation")
+    except jsonschema.ValidationError as e:
+        _fail(f"Unexpected error: {e.message}")
+        check(False, "Filtered record (options=None) passes validation")
+
+
+def scenario_4_non_filtered_still_strict() -> None:
+    """Non-filtered records are still validated strictly."""
+    _header("SCENARIO 4: Non-filtered records — still strict")
+
+    configs = build_action_configs()
+    apply_guard_nullable_schema_fixes(configs)
+    schema = configs["select_validated_questions"]["json_output_schema"]
+
+    # Valid object passes
+    valid_output = {"options": {"a": 1, "b": 2}, "summary": "Looks good"}
+    try:
+        jsonschema.validate(instance=valid_output, schema=schema)
+        check(True, "Valid object for 'options' still passes")
+    except jsonschema.ValidationError:
+        check(False, "Valid object for 'options' still passes")
+
+    # Wrong type still fails
+    wrong_type_output = {"options": "not an object", "summary": "Looks good"}
+    try:
+        jsonschema.validate(instance=wrong_type_output, schema=schema)
+        check(False, "String for 'options' still fails")
+    except jsonschema.ValidationError:
+        check(True, "String for 'options' still fails")
+
+    # Missing required field still fails
+    missing_field_output = {"summary": "No options at all"}
+    try:
+        jsonschema.validate(instance=missing_field_output, schema=schema)
+        check(False, "Missing 'options' still fails")
+    except jsonschema.ValidationError:
+        check(True, "Missing 'options' still fails")
+
+    # None for NON-guarded field still fails
+    none_summary_output = {"options": {"a": 1}, "summary": None}
+    try:
+        jsonschema.validate(instance=none_summary_output, schema=schema)
+        check(False, "None for non-guarded 'summary' still fails")
+    except jsonschema.ValidationError:
+        check(True, "None for non-guarded 'summary' still fails")
+
+
+def scenario_5_warn_guard_not_fixed() -> None:
+    """Guards with on_false: 'warn' should NOT be treated as filterable."""
+    _header("SCENARIO 5: Warn guard — no fix applied")
+
+    configs = build_action_configs()
+    # Change guard to warn (post-expansion format)
+    configs["fix_failed_validation"]["guard"]["behavior"] = "warn"
+
+    fixes = apply_guard_nullable_schema_fixes(configs)
+    schema = configs["select_validated_questions"]["json_output_schema"]
+
+    _info(f"Fixes applied: {fixes}")
+
+    check(fixes == [], "No fixes applied for warn guard")
+    check(
+        schema["properties"]["options"]["type"] == "object",
+        "'options' type remains 'object' (not made nullable)",
+    )
+
+
+def scenario_6_transitive_passthrough() -> None:
+    """Fix works through transitive passthrough chains."""
+    _header("SCENARIO 6: Transitive passthrough chain")
+
+    configs = build_transitive_action_configs()
+    schema_before = copy.deepcopy(configs["format_output"]["json_output_schema"])
+
+    fixes = apply_guard_nullable_schema_fixes(configs)
+    schema_after = configs["format_output"]["json_output_schema"]
+
+    _info("Chain: extract_qa (guarded) -> enrich_qa (passthrough) -> format_output (tool)")
+    _info(f"Fixes applied: {fixes}")
+    _show_schema("Schema BEFORE", schema_before)
+    _show_schema("Schema AFTER", schema_after)
+
+    check(
+        "format_output.qa_content" in fixes,
+        "Transitive field 'qa_content' fixed through passthrough",
+    )
+    check(
+        "format_output.enrichment" not in fixes,
+        "'enrichment' NOT fixed (not from guarded upstream)",
+    )
+    check(
+        schema_after["properties"]["qa_content"]["type"] == ["object", "null"],
+        "'qa_content' type changed to ['object', 'null']",
+    )
+    check(
+        schema_after["properties"]["enrichment"]["type"] == "string",
+        "'enrichment' type unchanged",
+    )
+
+    # Verify filtered record passes after fix
+    filtered_output = {"qa_content": None, "enrichment": "n/a"}
+    try:
+        jsonschema.validate(instance=filtered_output, schema=schema_after)
+        check(True, "Filtered transitive record passes validation")
+    except jsonschema.ValidationError as e:
+        _fail(f"Unexpected error: {e.message}")
+        check(False, "Filtered transitive record passes validation")
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    print(f"\n{BOLD}{CYAN}Guard-Filtered Schema Validation — End-to-End Test{RESET}")
+    print(f"{DIM}Simulates the full lifecycle: config expansion -> auto-fix -> validation")
+    print("Proves the fix works for direct observation, transitive passthrough,")
+    print(f"and preserves strict validation for non-filtered records.{RESET}")
+
+    scenario_1_crash_without_fix()
+    scenario_2_fix_applied()
+    scenario_3_filtered_record_passes()
+    scenario_4_non_filtered_still_strict()
+    scenario_5_warn_guard_not_fixed()
+    scenario_6_transitive_passthrough()
+
+    # Summary
+    total = passed + failed
+    print(f"\n{CYAN}{'═' * 72}{RESET}")
+    color = GREEN if failed == 0 else RED
+    print(f"  {color}{passed}/{total} passed, {failed} failed{RESET}")
+    print(f"{CYAN}{'═' * 72}{RESET}\n")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/validation/test_guard_nullable_fields.py
+++ b/tests/unit/validation/test_guard_nullable_fields.py
@@ -1,12 +1,18 @@
-"""Tests for _check_guard_nullable_fields() pre-flight check.
+"""Tests for guard-nullable field detection and auto-fix.
 
-Detects fields that may be None due to upstream guard filtering
-and warns when a downstream tool action's schema declares those
-fields as non-nullable types.
+Part 1: _check_guard_nullable_fields() pre-flight warnings.
+Part 2: apply_guard_nullable_schema_fixes() auto-fix of json_output_schema.
+Part 3: Runtime validation with guard-nullable fields.
 """
+
+import copy
+
+import pytest
 
 from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
     WorkflowStaticAnalyzer,
+    _make_schema_field_nullable,
+    apply_guard_nullable_schema_fixes,
 )
 
 
@@ -308,3 +314,595 @@ class TestGuardNullableFields:
         assert len(guard_warnings) == 1
         assert guard_warnings[0].hint is not None
         assert "remove" in guard_warnings[0].hint or "handle None" in guard_warnings[0].hint
+
+
+# ── Part 2: Auto-fix tests ──────────────────────────────────────────
+
+
+def _tool_config(name, *, json_output_schema, observe, guard=None):
+    """Build a tool action config dict as it appears in action_configs at runtime."""
+    config = {
+        "model_vendor": "tool",
+        "json_output_schema": json_output_schema,
+        "context_scope": {"observe": observe},
+    }
+    if guard:
+        config["guard"] = guard
+    return name, config
+
+
+def _guarded_llm_config(name, *, guard):
+    """Build a guarded LLM action config dict."""
+    return name, {"guard": guard, "model_vendor": "openai"}
+
+
+class TestMakeSchemaFieldNullable:
+    """Tests for _make_schema_field_nullable helper."""
+
+    def test_string_type_becomes_list(self):
+        schema = {"properties": {"field": {"type": "object"}}}
+        assert _make_schema_field_nullable(schema, "field") is True
+        assert schema["properties"]["field"]["type"] == ["object", "null"]
+
+    def test_already_nullable_not_modified(self):
+        schema = {"properties": {"field": {"type": ["object", "null"]}}}
+        assert _make_schema_field_nullable(schema, "field") is False
+
+    def test_list_type_without_null_gets_null_appended(self):
+        schema = {"properties": {"field": {"type": ["string", "integer"]}}}
+        assert _make_schema_field_nullable(schema, "field") is True
+        assert schema["properties"]["field"]["type"] == ["string", "integer", "null"]
+
+    def test_field_not_in_schema_returns_false(self):
+        schema = {"properties": {"other": {"type": "object"}}}
+        assert _make_schema_field_nullable(schema, "missing") is False
+
+    def test_handles_array_items_format(self):
+        schema = {
+            "type": "array",
+            "items": {"properties": {"field": {"type": "object"}}},
+        }
+        assert _make_schema_field_nullable(schema, "field") is True
+        assert schema["items"]["properties"]["field"]["type"] == ["object", "null"]
+
+    def test_handles_nested_schema_wrapper(self):
+        schema = {"schema": {"properties": {"field": {"type": "string"}}}}
+        assert _make_schema_field_nullable(schema, "field") is True
+        assert schema["schema"]["properties"]["field"]["type"] == ["string", "null"]
+
+    def test_null_type_not_modified(self):
+        schema = {"properties": {"field": {"type": "null"}}}
+        assert _make_schema_field_nullable(schema, "field") is False
+
+    def test_no_type_key_returns_false(self):
+        schema = {"properties": {"field": {"description": "no type"}}}
+        assert _make_schema_field_nullable(schema, "field") is False
+
+    def test_empty_schema_returns_false(self):
+        assert _make_schema_field_nullable({}, "field") is False
+
+
+class TestApplyGuardNullableSchemaFixes:
+    """Tests for apply_guard_nullable_schema_fixes auto-fix function."""
+
+    def test_basic_fix_makes_field_nullable(self):
+        """Guarded upstream + tool observing -> field made nullable."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"insights": {"type": "object"}},
+                        "required": ["insights"],
+                    },
+                    observe=["extract.insights"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+
+        assert fixes == ["consumer.insights"]
+        assert action_configs["consumer"]["json_output_schema"]["properties"]["insights"][
+            "type"
+        ] == ["object", "null"]
+
+    def test_no_guard_no_fix(self):
+        """No guarded upstream -> no fixes applied."""
+        action_configs = dict(
+            [
+                ("extract", {"model_vendor": "openai"}),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"insights": {"type": "object"}},
+                    },
+                    observe=["extract.insights"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_non_tool_consumer_not_fixed(self):
+        """LLM consumer is not fixed (no strict schema validation)."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                (
+                    "consumer",
+                    {
+                        "model_vendor": "openai",
+                        "json_output_schema": {
+                            "type": "object",
+                            "properties": {"insights": {"type": "object"}},
+                        },
+                        "context_scope": {"observe": ["extract.insights"]},
+                    },
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_already_nullable_skipped(self):
+        """Field already nullable -> not modified, not in fix list."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"insights": {"type": ["object", "null"]}},
+                    },
+                    observe=["extract.insights"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_wildcard_observe_not_fixed(self):
+        """Wildcard observe (action.*) -> not fixed (can't enumerate fields)."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"insights": {"type": "object"}},
+                    },
+                    observe=["extract.*"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_multiple_guarded_sources_fixed(self):
+        """Two guarded upstreams -> both fields fixed."""
+        action_configs = dict(
+            [
+                _guarded_llm_config("action_a", guard={"condition": "x > 0", "on_false": "filter"}),
+                _guarded_llm_config("action_b", guard={"condition": "y > 0", "on_false": "skip"}),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {
+                            "field_a": {"type": "object"},
+                            "field_b": {"type": "array"},
+                        },
+                    },
+                    observe=["action_a.field_a", "action_b.field_b"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert sorted(fixes) == ["consumer.field_a", "consumer.field_b"]
+
+    def test_string_guard_defaults_to_filter(self):
+        """String-style guard -> defaults to filter -> fix applied."""
+        action_configs = dict(
+            [
+                ("extract", {"model_vendor": "openai", "guard": "score >= 6"}),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"data": {"type": "object"}},
+                    },
+                    observe=["extract.data"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == ["consumer.data"]
+
+    def test_guard_warn_behavior_not_fixed(self):
+        """on_false: 'warn' does not produce None -> no fix."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "warn"},
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"data": {"type": "object"}},
+                    },
+                    observe=["extract.data"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_field_not_in_json_output_schema_not_fixed(self):
+        """Observed field not in consumer's json_output_schema -> no fix."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"other_field": {"type": "object"}},
+                    },
+                    observe=["extract.missing_field"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_no_json_output_schema_skipped(self):
+        """Tool without json_output_schema -> skipped."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                (
+                    "consumer",
+                    {
+                        "model_vendor": "tool",
+                        "context_scope": {"observe": ["extract.data"]},
+                    },
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_modifies_schema_in_place(self):
+        """Verify the schema dict is modified in place (shared reference)."""
+        schema = {
+            "type": "object",
+            "properties": {"insights": {"type": "object"}},
+        }
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config("consumer", json_output_schema=schema, observe=["extract.insights"]),
+            ]
+        )
+
+        apply_guard_nullable_schema_fixes(action_configs)
+
+        # The original schema object should be modified
+        assert schema["properties"]["insights"]["type"] == ["object", "null"]
+
+    def test_transitive_wildcard_passthrough_fixed(self):
+        """A -> B (passthrough A.*) -> C (tool observes B.field) -> field made nullable."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "guarded_action",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                (
+                    "intermediate",
+                    {
+                        "model_vendor": "openai",
+                        "context_scope": {
+                            "observe": ["guarded_action.insights"],
+                            "passthrough": ["guarded_action.*"],
+                        },
+                    },
+                ),
+                _tool_config(
+                    "final_tool",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"insights": {"type": "object"}},
+                    },
+                    observe=["intermediate.insights"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+
+        assert fixes == ["final_tool.insights"]
+        assert action_configs["final_tool"]["json_output_schema"]["properties"]["insights"][
+            "type"
+        ] == ["object", "null"]
+
+    def test_transitive_specific_passthrough_fixed(self):
+        """Specific passthrough (not wildcard) also fixed transitively."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "guarded",
+                    guard={"condition": "ok == true", "on_false": "skip"},
+                ),
+                (
+                    "middle",
+                    {
+                        "model_vendor": "openai",
+                        "context_scope": {
+                            "observe": ["guarded.data"],
+                            "passthrough": ["guarded.data"],
+                        },
+                    },
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"data": {"type": "object"}},
+                    },
+                    observe=["middle.data"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+
+        assert fixes == ["consumer.data"]
+
+    def test_transitive_non_matching_passthrough_not_fixed(self):
+        """Passthrough from guarded action but different field -> not fixed."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "guarded",
+                    guard={"condition": "ok == true", "on_false": "filter"},
+                ),
+                (
+                    "middle",
+                    {
+                        "model_vendor": "openai",
+                        "context_scope": {
+                            "observe": ["guarded.other"],
+                            "passthrough": ["guarded.other"],
+                        },
+                    },
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"data": {"type": "object"}},
+                    },
+                    observe=["middle.data"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_idempotent_second_call_returns_empty(self):
+        """Calling fix twice returns empty on second call."""
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"insights": {"type": "object"}},
+                    },
+                    observe=["extract.insights"],
+                ),
+            ]
+        )
+
+        first = apply_guard_nullable_schema_fixes(action_configs)
+        second = apply_guard_nullable_schema_fixes(action_configs)
+
+        assert first == ["consumer.insights"]
+        assert second == []
+
+
+# ── Part 3: Runtime validation integration ──────────────────────────
+
+
+class TestGuardNullableRuntimeValidation:
+    """Verify that auto-fixed schemas pass jsonschema validation correctly."""
+
+    def test_null_value_passes_after_fix(self):
+        """After fix, jsonschema.validate accepts None for guard-nullable field."""
+        import jsonschema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "insights": {"type": "object"},
+                "summary": {"type": "string"},
+            },
+            "required": ["insights", "summary"],
+            "additionalProperties": False,
+        }
+
+        # Before fix: None fails
+        data = {"insights": None, "summary": "test"}
+        with pytest.raises(jsonschema.ValidationError, match="None is not of type 'object'"):
+            jsonschema.validate(instance=data, schema=schema)
+
+        # Apply fix
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config("consumer", json_output_schema=schema, observe=["extract.insights"]),
+            ]
+        )
+        apply_guard_nullable_schema_fixes(action_configs)
+
+        # After fix: None passes
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_valid_object_still_passes_after_fix(self):
+        """Non-null object values still pass validation after fix."""
+        import jsonschema
+
+        schema = {
+            "type": "object",
+            "properties": {"insights": {"type": "object"}},
+            "required": ["insights"],
+        }
+
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config("consumer", json_output_schema=schema, observe=["extract.insights"]),
+            ]
+        )
+        apply_guard_nullable_schema_fixes(action_configs)
+
+        data = {"insights": {"key": "value"}}
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_wrong_type_still_fails_after_fix(self):
+        """Non-null wrong type (e.g. string instead of object) still fails."""
+        import jsonschema
+
+        schema = {
+            "type": "object",
+            "properties": {"insights": {"type": "object"}},
+            "required": ["insights"],
+        }
+
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config("consumer", json_output_schema=schema, observe=["extract.insights"]),
+            ]
+        )
+        apply_guard_nullable_schema_fixes(action_configs)
+
+        data = {"insights": "not an object"}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=data, schema=schema)
+
+    def test_missing_required_field_still_fails(self):
+        """Required field completely absent still fails (not too permissive)."""
+        import jsonschema
+
+        schema = {
+            "type": "object",
+            "properties": {"insights": {"type": "object"}, "summary": {"type": "string"}},
+            "required": ["insights", "summary"],
+        }
+
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config("consumer", json_output_schema=schema, observe=["extract.insights"]),
+            ]
+        )
+        apply_guard_nullable_schema_fixes(action_configs)
+
+        # "insights" is required — absent should still fail
+        data = {"summary": "test"}
+        with pytest.raises(jsonschema.ValidationError, match="'insights' is a required property"):
+            jsonschema.validate(instance=data, schema=schema)
+
+    def test_non_guarded_field_type_unchanged(self):
+        """Fields NOT from guarded upstreams keep original strict type."""
+        import jsonschema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "insights": {"type": "object"},
+                "summary": {"type": "string"},
+            },
+            "required": ["insights", "summary"],
+        }
+        original_schema = copy.deepcopy(schema)
+
+        action_configs = dict(
+            [
+                _guarded_llm_config(
+                    "extract",
+                    guard={"condition": "score >= 6", "on_false": "filter"},
+                ),
+                _tool_config("consumer", json_output_schema=schema, observe=["extract.insights"]),
+            ]
+        )
+        apply_guard_nullable_schema_fixes(action_configs)
+
+        # "insights" was fixed, "summary" was NOT
+        assert schema["properties"]["insights"]["type"] == ["object", "null"]
+        assert (
+            schema["properties"]["summary"]["type"]
+            == original_schema["properties"]["summary"]["type"]
+        )
+
+        # None for "summary" should still fail
+        data = {"insights": {"key": "val"}, "summary": None}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=data, schema=schema)

--- a/tests/unit/validation/test_guard_nullable_fields.py
+++ b/tests/unit/validation/test_guard_nullable_fields.py
@@ -682,9 +682,13 @@ class TestApplyGuardNullableSchemaFixes:
         """A -> B (passthrough A.*) -> C (tool observes B.field) -> field made nullable."""
         action_configs = dict(
             [
-                _guarded_llm_config(
+                (
                     "guarded_action",
-                    guard={"condition": "score >= 6", "on_false": "filter"},
+                    {
+                        "model_vendor": "openai",
+                        "guard": {"condition": "score >= 6", "on_false": "filter"},
+                        "schema": [{"id": "insights", "type": "object"}],
+                    },
                 ),
                 (
                     "intermediate",
@@ -746,6 +750,55 @@ class TestApplyGuardNullableSchemaFixes:
         fixes = apply_guard_nullable_schema_fixes(action_configs)
 
         assert fixes == ["consumer.data"]
+
+    def test_transitive_wildcard_only_fixes_guarded_fields(self):
+        """Wildcard passthrough only fixes fields produced by the guarded action, not the intermediate's own fields."""
+        action_configs = dict(
+            [
+                (
+                    "guarded",
+                    {
+                        "model_vendor": "openai",
+                        "guard": {"condition": "ok == true", "on_false": "filter"},
+                        "schema": [{"id": "qa_content", "type": "object"}],
+                    },
+                ),
+                (
+                    "intermediate",
+                    {
+                        "model_vendor": "openai",
+                        "context_scope": {
+                            "observe": ["guarded.qa_content"],
+                            "passthrough": ["guarded.*"],
+                        },
+                    },
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {
+                            "qa_content": {"type": "object"},
+                            "enrichment": {"type": "string"},
+                        },
+                    },
+                    observe=["intermediate.qa_content", "intermediate.enrichment"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+
+        assert fixes == ["consumer.qa_content"]
+        # qa_content is from guarded action -> nullable
+        assert action_configs["consumer"]["json_output_schema"]["properties"]["qa_content"][
+            "type"
+        ] == ["object", "null"]
+        # enrichment is the intermediate's own field -> NOT nullable
+        assert (
+            action_configs["consumer"]["json_output_schema"]["properties"]["enrichment"]["type"]
+            == "string"
+        )
 
     def test_transitive_non_matching_passthrough_not_fixed(self):
         """Passthrough from guarded action but different field -> not fixed."""

--- a/tests/unit/validation/test_guard_nullable_fields.py
+++ b/tests/unit/validation/test_guard_nullable_fields.py
@@ -564,6 +564,56 @@ class TestApplyGuardNullableSchemaFixes:
         fixes = apply_guard_nullable_schema_fixes(action_configs)
         assert fixes == []
 
+    def test_post_expansion_guard_format_warn_not_fixed(self):
+        """Post-expansion guard uses 'behavior' key, not 'on_false'. Warn must not fix."""
+        action_configs = dict(
+            [
+                (
+                    "extract",
+                    {
+                        "model_vendor": "openai",
+                        "guard": {"clause": "score >= 6", "scope": "item", "behavior": "warn"},
+                    },
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"data": {"type": "object"}},
+                    },
+                    observe=["extract.data"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == []
+
+    def test_post_expansion_guard_format_filter_fixed(self):
+        """Post-expansion guard with behavior: filter -> field made nullable."""
+        action_configs = dict(
+            [
+                (
+                    "extract",
+                    {
+                        "model_vendor": "openai",
+                        "guard": {"clause": "score >= 6", "scope": "item", "behavior": "filter"},
+                    },
+                ),
+                _tool_config(
+                    "consumer",
+                    json_output_schema={
+                        "type": "object",
+                        "properties": {"data": {"type": "object"}},
+                    },
+                    observe=["extract.data"],
+                ),
+            ]
+        )
+
+        fixes = apply_guard_nullable_schema_fixes(action_configs)
+        assert fixes == ["consumer.data"]
+
     def test_field_not_in_json_output_schema_not_fixed(self):
         """Observed field not in consumer's json_output_schema -> no fix."""
         action_configs = dict(


### PR DESCRIPTION
## Summary
- Downstream actions no longer crash on absent fields from guard-filtered upstream records
- Schema validation treats fields from filterable upstream as nullable for filtered records
- Non-filtered records still validated strictly

## Root Cause
When upstream actions have `guard.on_false: "filter"` or `"skip"`, filtered records pass through without output fields. Downstream tool actions observing those fields receive `None` values, and `jsonschema.validate()` rejects `None` for non-nullable types (`"None is not of type 'object'"`).

## Fix
Added `apply_guard_nullable_schema_fixes()` to the static analyzer module. During pre-flight validation (before workflow execution), it:
1. Identifies guarded upstream actions with filter/skip behavior
2. Finds downstream tool actions that observe fields from those upstreams (direct and transitive passthrough)
3. Modifies `json_output_schema` in place to accept `null` for those fields

The fix runs after static validation but before execution, so both batch and online modes benefit.

## Verification
- 40 tests covering: field detection, schema modification, transitive passthrough, idempotency, runtime jsonschema validation
- Existing 11 static analyzer warning tests unchanged and passing
- Full suite: 5416 passed, 2 skipped
- `ruff format --check` and `ruff check` clean on all changed files