### PR TITLE
fix: YAML run_mode overrides stale batch target files

### DIFF
--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 
 from rich.console import Console
 
-from agent_actions.config.types import ActionConfigDict
+from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.errors import get_error_detail
 from agent_actions.llm.providers.usage_tracker import get_last_usage
 from agent_actions.logging.core.manager import fire_event
@@ -950,7 +950,11 @@ class ActionExecutor:
                 params.action_idx,
             )
             duration = (datetime.now() - params.start_time).total_seconds()
-            batch_status = self._check_batch_submission(params.action_name, params.action_idx)
+            batch_status = self._check_batch_submission(
+                params.action_name,
+                params.action_idx,
+                configured_run_mode=params.action_config.get("run_mode"),
+            )
             return self._handle_run_success(params, output_folder, duration, batch_status)
 
         except Exception as e:
@@ -974,7 +978,11 @@ class ActionExecutor:
                 params.action_idx,
             )
             duration = (datetime.now() - params.start_time).total_seconds()
-            batch_status = self._check_batch_submission(params.action_name, params.action_idx)
+            batch_status = self._check_batch_submission(
+                params.action_name,
+                params.action_idx,
+                configured_run_mode=params.action_config.get("run_mode"),
+            )
             return self._handle_run_success(params, output_folder, duration, batch_status)
 
         except Exception as e:
@@ -997,11 +1005,18 @@ class ActionExecutor:
 
         return None
 
-    def _check_batch_submission(self, action_name: str, action_idx: int) -> str | None:
+    def _check_batch_submission(
+        self,
+        action_name: str,
+        action_idx: int,
+        configured_run_mode: RunMode | None = None,
+    ) -> str | None:
         """Check if batch jobs were submitted."""
         workflow_name = self.deps.action_runner.workflow_name
         agent_io_path = Path(self.deps.action_runner.get_action_folder(workflow_name))
         return cast(
             str | None,
-            self.deps.batch_manager.check_batch_submission(action_name, action_idx, agent_io_path),
+            self.deps.batch_manager.check_batch_submission(
+                action_name, action_idx, agent_io_path, configured_run_mode=configured_run_mode
+            ),
         )

--- a/agent_actions/workflow/managers/batch.py
+++ b/agent_actions/workflow/managers/batch.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from rich.console import Console
 
+from agent_actions.config.types import RunMode
 from agent_actions.errors import ConfigurationError, ProcessingError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import (
@@ -174,9 +175,17 @@ class BatchLifecycleManager:
             )
 
     def check_batch_submission(
-        self, agent_name: str, agent_idx: int, agent_io_path: Path
+        self,
+        agent_name: str,
+        agent_idx: int,
+        agent_io_path: Path,
+        configured_run_mode: RunMode | None = None,
     ) -> str | None:
         """Return 'batch_submitted', 'passthrough', 'no_batches', or None."""
+        # YAML config is authoritative — stale batch files do not override
+        if configured_run_mode == RunMode.ONLINE:
+            return None
+
         node_output_dir = agent_io_path / "target" / agent_name
         registry_file = node_output_dir / "batch" / ".batch_registry.json"
 

--- a/tests/unit/workflow/managers/test_batch_lifecycle_disposition.py
+++ b/tests/unit/workflow/managers/test_batch_lifecycle_disposition.py
@@ -124,7 +124,6 @@ class TestCheckBatchSubmissionRunMode:
         )
         agent_io = Path("/tmp/fake_agent_io")
 
-        # Even with registry file present, ONLINE mode should return None
         with patch.object(Path, "exists", return_value=True):
             result = manager.check_batch_submission(
                 "extract", 0, agent_io, configured_run_mode=RunMode.ONLINE

--- a/tests/unit/workflow/managers/test_batch_lifecycle_disposition.py
+++ b/tests/unit/workflow/managers/test_batch_lifecycle_disposition.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent_actions.config.types import RunMode
 from agent_actions.errors import ConfigurationError
 from agent_actions.workflow.managers.batch import BatchLifecycleManager
 
@@ -109,3 +110,74 @@ class TestCheckBatchSubmission:
             result = manager.check_batch_submission("extract", 0, agent_io)
 
         assert result is None
+
+
+class TestCheckBatchSubmissionRunMode:
+    """Test that configured_run_mode overrides stale batch file detection."""
+
+    def test_online_mode_ignores_stale_registry(
+        self, mock_job_manager, mock_processing_service, mock_storage_backend
+    ):
+        """Stale .batch_registry.json + run_mode=ONLINE → returns None."""
+        manager = BatchLifecycleManager(
+            mock_job_manager, mock_processing_service, storage_backend=mock_storage_backend
+        )
+        agent_io = Path("/tmp/fake_agent_io")
+
+        # Even with registry file present, ONLINE mode should return None
+        with patch.object(Path, "exists", return_value=True):
+            result = manager.check_batch_submission(
+                "extract", 0, agent_io, configured_run_mode=RunMode.ONLINE
+            )
+
+        assert result is None
+
+    def test_batch_mode_respects_registry(
+        self, mock_job_manager, mock_processing_service, mock_storage_backend
+    ):
+        """Stale .batch_registry.json + run_mode=BATCH → returns 'batch_submitted'."""
+        manager = BatchLifecycleManager(
+            mock_job_manager, mock_processing_service, storage_backend=mock_storage_backend
+        )
+        agent_io = Path("/tmp/fake_agent_io")
+
+        with patch.object(Path, "exists", return_value=True):
+            result = manager.check_batch_submission(
+                "extract", 0, agent_io, configured_run_mode=RunMode.BATCH
+            )
+
+        assert result == "batch_submitted"
+
+    def test_no_registry_online_mode(
+        self, mock_job_manager, mock_processing_service, mock_storage_backend
+    ):
+        """No registry file + run_mode=ONLINE → returns None (short-circuits)."""
+        mock_storage_backend.has_disposition.return_value = False
+
+        manager = BatchLifecycleManager(
+            mock_job_manager, mock_processing_service, storage_backend=mock_storage_backend
+        )
+        agent_io = Path("/tmp/fake_agent_io")
+
+        with patch.object(Path, "exists", return_value=False):
+            result = manager.check_batch_submission(
+                "extract", 0, agent_io, configured_run_mode=RunMode.ONLINE
+            )
+
+        assert result is None
+        # Should not even check filesystem or dispositions
+        mock_storage_backend.has_disposition.assert_not_called()
+
+    def test_none_run_mode_preserves_existing_behavior(
+        self, mock_job_manager, mock_processing_service, mock_storage_backend
+    ):
+        """configured_run_mode=None (default) → existing behavior unchanged."""
+        manager = BatchLifecycleManager(
+            mock_job_manager, mock_processing_service, storage_backend=mock_storage_backend
+        )
+        agent_io = Path("/tmp/fake_agent_io")
+
+        with patch.object(Path, "exists", return_value=True):
+            result = manager.check_batch_submission("extract", 0, agent_io)
+
+        assert result == "batch_submitted"


### PR DESCRIPTION
## Summary
- `check_batch_submission()` now accepts `configured_run_mode` parameter
- When run_mode is ONLINE, stale `.batch_registry.json` files are ignored
- YAML config is always authoritative for execution mode

Fixes: specs/bugs/pending/bug_target_folder_overrides_run_mode.md

## Verification
- Tests for stale batch files with online run_mode (returns None, not "batch_submitted")
- Tests for active batch with batch run_mode (still correctly returns "batch_submitted")
- Tests for no registry + online mode (short-circuits without checking filesystem)
- Tests for default None run_mode (backward compatible, existing behavior unchanged)
- Full suite: 5501 passed, 0 failures
- Lint: all checks passed