### PR TITLE
fix: parallel branch merge preserves complete lineage

### DIFF
--- a/agent_actions/utils/lineage/builder.py
+++ b/agent_actions/utils/lineage/builder.py
@@ -32,10 +32,9 @@ class LineageBuilder:
         # it is a framework concept that must survive FILE-mode tool transformations.
         if ("source_guid" not in obj or not obj["source_guid"]) and parent_item.get("source_guid"):
             obj["source_guid"] = parent_item["source_guid"]
-        # Propagate lineage_sources from merged parent records so downstream
-        # actions can resolve all parallel branches via Mode 2 historical lookup.
+        # Propagate lineage_sources so Mode 2 historical lookup resolves all parallel branches.
         if "lineage_sources" in parent_item and "lineage_sources" not in obj:
-            obj["lineage_sources"] = parent_item["lineage_sources"]
+            obj["lineage_sources"] = parent_item["lineage_sources"].copy()
 
     @staticmethod
     def filter_node_lineage(lineage: list[Any]) -> list[str]:

--- a/agent_actions/utils/lineage/builder.py
+++ b/agent_actions/utils/lineage/builder.py
@@ -32,6 +32,10 @@ class LineageBuilder:
         # it is a framework concept that must survive FILE-mode tool transformations.
         if ("source_guid" not in obj or not obj["source_guid"]) and parent_item.get("source_guid"):
             obj["source_guid"] = parent_item["source_guid"]
+        # Propagate lineage_sources from merged parent records so downstream
+        # actions can resolve all parallel branches via Mode 2 historical lookup.
+        if "lineage_sources" in parent_item and "lineage_sources" not in obj:
+            obj["lineage_sources"] = parent_item["lineage_sources"]
 
     @staticmethod
     def filter_node_lineage(lineage: list[Any]) -> list[str]:

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -60,13 +60,7 @@ def _merge_lineage(existing: dict[str, Any], new_lineage: list[Any]) -> None:
 
 
 def _populate_lineage_sources(existing: dict[str, Any], new_record: dict[str, Any]) -> None:
-    """Track branch leaf node_ids in lineage_sources when merging parallel branches.
-
-    Called after field merging in deep_merge_record. When two records from
-    different branches (different node_ids) are merged, lineage_sources
-    accumulates the leaf node_id from each branch so the historical context
-    loader can resolve all upstream branches via Mode 2.
-    """
+    """Track branch leaf node_ids in lineage_sources when merging parallel branches."""
     existing_node_id = existing.get("node_id")
     new_node_id = new_record.get("node_id")
 

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -25,6 +25,8 @@ def deep_merge_record(existing: dict[str, Any], new_record: dict[str, Any]) -> N
         elif key not in existing:
             existing[key] = value
 
+    _populate_lineage_sources(existing, new_record)
+
 
 def _merge_lineage(existing: dict[str, Any], new_lineage: list[Any]) -> None:
     """Merge lineage arrays with deduplication by node_id."""
@@ -53,6 +55,30 @@ def _merge_lineage(existing: dict[str, Any], new_lineage: list[Any]) -> None:
                     existing_ids.add(node_id)
             else:
                 existing["lineage"].append(entry)
+
+
+def _populate_lineage_sources(existing: dict[str, Any], new_record: dict[str, Any]) -> None:
+    """Track branch leaf node_ids in lineage_sources when merging parallel branches.
+
+    Called after field merging in deep_merge_record. When two records from
+    different branches (different node_ids) are merged, lineage_sources
+    accumulates the leaf node_id from each branch so the historical context
+    loader can resolve all upstream branches via Mode 2.
+    """
+    existing_node_id = existing.get("node_id")
+    new_node_id = new_record.get("node_id")
+
+    if not existing_node_id or not new_node_id:
+        return
+
+    if existing_node_id == new_node_id:
+        return
+
+    if "lineage_sources" in existing:
+        if new_node_id not in existing["lineage_sources"]:
+            existing["lineage_sources"].append(new_node_id)
+    else:
+        existing["lineage_sources"] = [existing_node_id, new_node_id]
 
 
 def get_correlation_value(record: dict[str, Any], key_candidates: list[str]) -> str | None:

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -22,6 +22,8 @@ def deep_merge_record(existing: dict[str, Any], new_record: dict[str, Any]) -> N
                 existing["content"] = value
         elif key == "lineage" and isinstance(value, list):
             _merge_lineage(existing, value)
+        elif key == "lineage_sources":
+            pass  # Owned by _populate_lineage_sources below
         elif key not in existing:
             existing[key] = value
 

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -195,6 +195,26 @@ class TestParallelBranchLineageSources:
 
         assert "lineage_sources" not in existing
 
+    def test_pre_existing_lineage_sources_not_inherited(self):
+        """When new_record carries lineage_sources from a prior fan-in, it is ignored — only current-level branches tracked."""
+        existing = {
+            "source_guid": "book-001",
+            "node_id": "action_g_456",
+            "lineage": ["root_0", "action_g_456"],
+            "content": {"g_field": "G"},
+        }
+        new_record = {
+            "source_guid": "book-001",
+            "node_id": "action_e_123",
+            "lineage": ["root_0", "action_b_1", "action_e_123"],
+            "lineage_sources": ["action_b_1", "action_c_2"],
+            "content": {"e_field": "E"},
+        }
+
+        deep_merge_record(existing, new_record)
+
+        assert existing["lineage_sources"] == ["action_g_456", "action_e_123"]
+
     def test_merge_records_by_key_populates_lineage_sources(self):
         """End-to-end: merge_records_by_key sets lineage_sources for parallel branch records."""
         records = [

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -130,15 +130,12 @@ class TestParallelBranchLineageSources:
 
         deep_merge_record(existing, new_record)
 
-        assert "lineage_sources" in existing
         assert existing["lineage_sources"] == [
             "generate_concept_explanation_def",
             "generate_feynman_explanation_abc",
         ]
-        # Lineage also contains both branch node_ids
         assert "generate_concept_explanation_def" in existing["lineage"]
         assert "generate_feynman_explanation_abc" in existing["lineage"]
-        # Content merged from both branches
         assert existing["content"]["concept_explanation"] == "..."
         assert existing["content"]["feynman_explanation"] == "..."
 

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -110,6 +110,159 @@ class TestMergeLineage:
         assert existing["lineage"] == "invalid"
 
 
+class TestParallelBranchLineageSources:
+    """Tests for lineage_sources population during parallel branch merges."""
+
+    def test_two_branch_merge_populates_lineage_sources(self):
+        """Merging records from two parallel branches sets lineage_sources with both leaf node_ids."""
+        existing = {
+            "source_guid": "book-001",
+            "node_id": "generate_concept_explanation_def",
+            "lineage": ["reconstruct_options_xyz", "generate_concept_explanation_def"],
+            "content": {"concept_explanation": "..."},
+        }
+        new_record = {
+            "source_guid": "book-001",
+            "node_id": "generate_feynman_explanation_abc",
+            "lineage": ["reconstruct_options_xyz", "generate_feynman_explanation_abc"],
+            "content": {"feynman_explanation": "..."},
+        }
+
+        deep_merge_record(existing, new_record)
+
+        assert "lineage_sources" in existing
+        assert existing["lineage_sources"] == [
+            "generate_concept_explanation_def",
+            "generate_feynman_explanation_abc",
+        ]
+        # Lineage also contains both branch node_ids
+        assert "generate_concept_explanation_def" in existing["lineage"]
+        assert "generate_feynman_explanation_abc" in existing["lineage"]
+        # Content merged from both branches
+        assert existing["content"]["concept_explanation"] == "..."
+        assert existing["content"]["feynman_explanation"] == "..."
+
+    def test_three_branch_merge_populates_lineage_sources(self):
+        """Merging three parallel branches accumulates all leaf node_ids in lineage_sources."""
+        branch_a = {
+            "source_guid": "book-001",
+            "node_id": "node_4_seo",
+            "lineage": ["node_0_extract", "node_4_seo"],
+            "content": {"seo_score": 85},
+        }
+        branch_b = {
+            "source_guid": "book-001",
+            "node_id": "node_5_recs",
+            "lineage": ["node_0_extract", "node_5_recs"],
+            "content": {"similar_books": ["Refactoring"]},
+        }
+        branch_c = {
+            "source_guid": "book-001",
+            "node_id": "node_6_level",
+            "lineage": ["node_0_extract", "node_6_level"],
+            "content": {"reading_level": "advanced"},
+        }
+
+        deep_merge_record(branch_a, branch_b)
+        deep_merge_record(branch_a, branch_c)
+
+        assert len(branch_a["lineage_sources"]) == 3
+        assert "node_4_seo" in branch_a["lineage_sources"]
+        assert "node_5_recs" in branch_a["lineage_sources"]
+        assert "node_6_level" in branch_a["lineage_sources"]
+
+    def test_single_branch_no_lineage_sources(self):
+        """Merging records with same node_id (same branch) does not set lineage_sources."""
+        existing = {
+            "source_guid": "abc",
+            "node_id": "action_1",
+            "lineage": ["root_0", "action_1"],
+        }
+        new_record = {
+            "source_guid": "abc",
+            "node_id": "action_1",
+            "lineage": ["root_0", "action_1"],
+            "content": {"extra": "data"},
+        }
+
+        deep_merge_record(existing, new_record)
+
+        assert "lineage_sources" not in existing
+
+    def test_no_lineage_sources_when_no_node_id(self):
+        """Records without node_id do not get lineage_sources."""
+        existing = {"source_guid": "abc", "field_1": "A"}
+        new_record = {"source_guid": "abc", "field_2": "B"}
+
+        deep_merge_record(existing, new_record)
+
+        assert "lineage_sources" not in existing
+
+    def test_merge_records_by_key_populates_lineage_sources(self):
+        """End-to-end: merge_records_by_key sets lineage_sources for parallel branch records."""
+        records = [
+            {
+                "source_guid": "book-001",
+                "node_id": "branch_a_001",
+                "lineage": ["root_0", "branch_a_001"],
+                "content": {"field_a": "A"},
+            },
+            {
+                "source_guid": "book-001",
+                "node_id": "branch_b_002",
+                "lineage": ["root_0", "branch_b_002"],
+                "content": {"field_b": "B"},
+            },
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        merged = result[0]
+        assert merged["lineage_sources"] == ["branch_a_001", "branch_b_002"]
+        assert "branch_a_001" in merged["lineage"]
+        assert "branch_b_002" in merged["lineage"]
+
+    def test_merge_json_files_populates_lineage_sources(self):
+        """End-to-end: merge_json_files from parallel branches sets lineage_sources."""
+        with TemporaryDirectory() as tmpdir:
+            file1 = Path(tmpdir) / "branch_a.json"
+            file2 = Path(tmpdir) / "branch_b.json"
+
+            file1.write_text(
+                json.dumps(
+                    [
+                        {
+                            "source_guid": "book-001",
+                            "node_id": "gen_concept_def",
+                            "lineage": ["root_xyz", "gen_concept_def"],
+                            "content": {"concept": "explanation"},
+                        }
+                    ]
+                )
+            )
+            file2.write_text(
+                json.dumps(
+                    [
+                        {
+                            "source_guid": "book-001",
+                            "node_id": "gen_feynman_abc",
+                            "lineage": ["root_xyz", "gen_feynman_abc"],
+                            "content": {"feynman": "explanation"},
+                        }
+                    ]
+                )
+            )
+
+            result = merge_json_files([file1, file2])
+
+            assert len(result) == 1
+            merged = result[0]
+            assert merged["lineage_sources"] == ["gen_concept_def", "gen_feynman_abc"]
+            assert merged["content"]["concept"] == "explanation"
+            assert merged["content"]["feynman"] == "explanation"
+
+
 class TestGetCorrelationValue:
     """Tests for get_correlation_value function."""
 

--- a/tests/utilities/test_lineage_unified.py
+++ b/tests/utilities/test_lineage_unified.py
@@ -199,6 +199,99 @@ class TestUnifiedLineageSourceGuidPropagation:
         assert result["source_guid"] == "sg-first"
 
 
+class TestLineageSourcesPropagation:
+    """Test lineage_sources propagation through ancestry chain."""
+
+    def test_lineage_sources_propagated_from_parent(self):
+        """lineage_sources on parent is propagated to child via add_unified_lineage."""
+        obj = {"content": {"merged": True}}
+        node_id = "options_combiner_ghi"
+        parent_item = {
+            "node_id": "gen_concept_def",
+            "lineage": ["root_xyz", "gen_concept_def", "gen_feynman_abc"],
+            "lineage_sources": ["gen_concept_def", "gen_feynman_abc"],
+            "target_id": "target-parent",
+        }
+
+        result = LineageBuilder.add_unified_lineage(obj, node_id, parent_item)
+
+        assert result["lineage_sources"] == ["gen_concept_def", "gen_feynman_abc"]
+        assert result["lineage"] == [
+            "root_xyz",
+            "gen_concept_def",
+            "gen_feynman_abc",
+            "options_combiner_ghi",
+        ]
+
+    def test_lineage_sources_not_set_without_parent(self):
+        """No parent → no lineage_sources on result."""
+        obj = {"content": {"text": "data"}}
+        result = LineageBuilder.add_unified_lineage(obj, "node_123")
+        assert "lineage_sources" not in result
+
+    def test_lineage_sources_not_set_when_parent_lacks_it(self):
+        """Parent without lineage_sources → no lineage_sources on result."""
+        obj = {"content": {"text": "output"}}
+        parent_item = {
+            "node_id": "single_branch_abc",
+            "lineage": ["root_0", "single_branch_abc"],
+            "target_id": "target-1",
+        }
+
+        result = LineageBuilder.add_unified_lineage(obj, "downstream_xyz", parent_item)
+
+        assert "lineage_sources" not in result
+
+    def test_existing_lineage_sources_not_overwritten(self):
+        """If obj already has lineage_sources, parent's version does not overwrite."""
+        obj = {"content": {"text": "output"}, "lineage_sources": ["own_a", "own_b"]}
+        parent_item = {
+            "lineage": ["root_0", "parent_node"],
+            "lineage_sources": ["parent_x", "parent_y"],
+            "target_id": "target-1",
+        }
+
+        result = LineageBuilder.add_unified_lineage(obj, "node_new", parent_item)
+
+        assert result["lineage_sources"] == ["own_a", "own_b"]
+
+    def test_lineage_sources_propagated_via_add_lineage_tracking(self):
+        """lineage_sources propagated through add_lineage_tracking path."""
+        obj = {"content": {"text": "output"}}
+        item = {
+            "node_id": "merged_parent_abc",
+            "lineage": ["root_0", "branch_a_1", "branch_b_2"],
+            "lineage_sources": ["branch_a_1", "branch_b_2"],
+            "target_id": "target-merged",
+        }
+
+        result = LineageBuilder.add_lineage_tracking(obj, item, "downstream_node")
+
+        assert result["lineage_sources"] == ["branch_a_1", "branch_b_2"]
+
+    def test_add_lineage_tracking_from_sources_keeps_own_lineage_sources(self):
+        """add_lineage_tracking_from_sources sets its own lineage_sources, ignoring parent's."""
+        obj = {"content": {"text": "output"}}
+        source_items = [
+            {
+                "source_guid": "sg-1",
+                "target_id": "t-1",
+                "lineage": ["root_0", "branch_a_1"],
+                "lineage_sources": ["old_x", "old_y"],
+            },
+            {
+                "source_guid": "sg-2",
+                "target_id": "t-2",
+                "lineage": ["root_0", "branch_b_2"],
+            },
+        ]
+
+        result = LineageBuilder.add_lineage_tracking_from_sources(obj, source_items, "merge_node")
+
+        # Uses the computed lineage_sources from source items, not parent's
+        assert result["lineage_sources"] == ["branch_a_1", "branch_b_2"]
+
+
 class TestUnifiedLineageObjectImmutability:
     """Test object immutability."""
 


### PR DESCRIPTION
## Summary
- Records from parallel branches now include all branch node_ids in lineage
- lineage_sources populated during merge so historical lookup Mode 2 can resolve all branches
- Single-dependency behavior unchanged

Fixes: specs/bugs/pending/bug_parallel_branch_lineage_missing.md (producer side)

## Verification
- Tests for 2-branch merge (diamond pattern)
- Tests for 3+ branch merge
- Tests for single-branch (no regression)
- lineage_sources propagation through enrichment tested
- Full suite passes (5509 tests, 0 failures)
- ruff format + ruff check clean