### PR TITLE
fix: dispatch_task() resolves functions in tool subdirectories

### DIFF
--- a/.changes/unreleased/Bug Fix-20260419-060000.yaml
+++ b/.changes/unreleased/Bug Fix-20260419-060000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "dispatch_task() resolves functions in tool subdirectories using recursive search fallback"
+time: 2026-04-19T06:00:00.000000Z

--- a/agent_actions/utils/module_loader.py
+++ b/agent_actions/utils/module_loader.py
@@ -174,7 +174,7 @@ def _resolve_module_file(module_name: str, search_dir: str | Path) -> Path | Non
             return matches[0]
         if len(matches) > 1:
             logger.error(
-                "Ambiguous dispatch_task resolution: '%s' found in multiple locations: %s",
+                "Ambiguous module resolution: '%s' found in multiple locations: %s",
                 module_name,
                 [str(m.relative_to(search_dir)) for m in matches],
             )

--- a/agent_actions/utils/module_loader.py
+++ b/agent_actions/utils/module_loader.py
@@ -167,6 +167,19 @@ def _resolve_module_file(module_name: str, search_dir: str | Path) -> Path | Non
     if candidate.is_file():
         return candidate
 
+    if "." not in module_name:
+        target_filename = f"{module_name}.py"
+        matches = [p for p in search_dir.rglob(target_filename) if p.is_file()]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            logger.error(
+                "Ambiguous dispatch_task resolution: '%s' found in multiple locations: %s",
+                module_name,
+                [str(m.relative_to(search_dir)) for m in matches],
+            )
+            return None
+
     return None
 
 

--- a/tests/integration/test_dispatch_task_e2e.py
+++ b/tests/integration/test_dispatch_task_e2e.py
@@ -152,7 +152,6 @@ class TestDispatchTaskEndToEnd:
 
     def test_dispatch_resolves_function_in_subdirectory(self, tools_dir):
         """dispatch_task() finds a UDF located in a subdirectory of tools_path."""
-        # Create a function inside a subdirectory
         subdir = tools_dir / "qanalabs-quiz-gen"
         subdir.mkdir()
         (subdir / "sub_opener.py").write_text(

--- a/tests/integration/test_dispatch_task_e2e.py
+++ b/tests/integration/test_dispatch_task_e2e.py
@@ -43,7 +43,7 @@ def tools_dir(tmp_path):
     # Clean up loaded modules from sys.modules
     clear_module_cache()
     for name in list(sys.modules):
-        if name in ("get_opener", "summarize", "bad_udf"):
+        if name in ("get_opener", "summarize", "bad_udf", "sub_opener"):
             del sys.modules[name]
 
 
@@ -149,6 +149,34 @@ class TestDispatchTaskEndToEnd:
 
         assert "dispatch_task" not in result.formatted_prompt
         assert "During monitoring, you notice an anomaly" in result.formatted_prompt
+
+    def test_dispatch_resolves_function_in_subdirectory(self, tools_dir):
+        """dispatch_task() finds a UDF located in a subdirectory of tools_path."""
+        # Create a function inside a subdirectory
+        subdir = tools_dir / "qanalabs-quiz-gen"
+        subdir.mkdir()
+        (subdir / "sub_opener.py").write_text(
+            'def sub_opener(context_data, *args):\n    return "Found in subdirectory"\n'
+        )
+
+        config = {
+            "agent_type": "test",
+            "prompt": "inline",
+            "context_scope": {"observe": ["source.*"]},
+            "tool_path": [str(tools_dir)],
+        }
+        field_context = {"source": {"text": "hello"}}
+
+        with _stub_raw_prompt("Result: dispatch_task('sub_opener')"):
+            result = PromptPreparationService.prepare_prompt_with_field_context(
+                agent_config=config,
+                agent_name="test",
+                contents={},
+                field_context=field_context,
+            )
+
+        assert "dispatch_task" not in result.formatted_prompt
+        assert "Found in subdirectory" in result.formatted_prompt
 
     def test_no_tools_config_leaves_literal(self):
         """Without any tools config, dispatch_task passes through as literal text."""

--- a/tests/utilities/test_module_loader.py
+++ b/tests/utilities/test_module_loader.py
@@ -134,6 +134,51 @@ def test_resolve_module_file_empty_name(tmp_path):
     assert result is None
 
 
+def test_resolve_module_file_subdirectory(tmp_path):
+    """Recursive fallback finds module in a subdirectory."""
+    subdir = tmp_path / "qanalabs-quiz-gen"
+    subdir.mkdir()
+    target = subdir / "my_function.py"
+    target.write_text("X = 1")
+    result = _resolve_module_file("my_function", tmp_path)
+    assert result == target
+
+
+def test_resolve_module_file_flat_takes_precedence(tmp_path):
+    """Flat path is preferred over recursive match when both exist."""
+    flat = tmp_path / "my_function.py"
+    flat.write_text("X = 1")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "my_function.py").write_text("X = 2")
+    result = _resolve_module_file("my_function", tmp_path)
+    assert result == flat
+
+
+def test_resolve_module_file_ambiguous_returns_none(tmp_path, capsys):
+    """Ambiguous match (same name in multiple subdirs) returns None and logs error."""
+    for name in ("sub_a", "sub_b"):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "my_function.py").write_text("X = 1")
+    result = _resolve_module_file("my_function", tmp_path)
+    assert result is None
+    assert "Ambiguous dispatch_task resolution" in capsys.readouterr().err
+
+
+def test_resolve_module_file_dotted_name_no_recursive(tmp_path):
+    """Dotted module names use direct path only, no recursive fallback."""
+    subdir = tmp_path / "deep"
+    subdir.mkdir()
+    pkg = subdir / "pkg"
+    pkg.mkdir()
+    (pkg / "mod.py").write_text("X = 1")
+    # Direct path: tmp_path/pkg/mod.py does not exist
+    # Recursive would find deep/pkg/mod.py but dotted names skip recursive
+    result = _resolve_module_file("pkg.mod", tmp_path)
+    assert result is None
+
+
 def test_load_module_from_directory_basic(tmp_path):
     """Load a simple module without mutating sys.path."""
     (tmp_path / "dir_mod.py").write_text("VALUE = 99")

--- a/tests/utilities/test_module_loader.py
+++ b/tests/utilities/test_module_loader.py
@@ -163,7 +163,7 @@ def test_resolve_module_file_ambiguous_returns_none(tmp_path, capsys):
         (d / "my_function.py").write_text("X = 1")
     result = _resolve_module_file("my_function", tmp_path)
     assert result is None
-    assert "Ambiguous dispatch_task resolution" in capsys.readouterr().err
+    assert "Ambiguous module resolution" in capsys.readouterr().err
 
 
 def test_resolve_module_file_dotted_name_no_recursive(tmp_path):
@@ -173,8 +173,6 @@ def test_resolve_module_file_dotted_name_no_recursive(tmp_path):
     pkg = subdir / "pkg"
     pkg.mkdir()
     (pkg / "mod.py").write_text("X = 1")
-    # Direct path: tmp_path/pkg/mod.py does not exist
-    # Recursive would find deep/pkg/mod.py but dotted names skip recursive
     result = _resolve_module_file("pkg.mod", tmp_path)
     assert result is None
 


### PR DESCRIPTION
## Summary
- _resolve_module_file() now searches subdirectories via rglob when flat lookup fails
- Ambiguous matches (same filename in multiple subdirectories) log an error, not silent wrong pick
- Matches UDF discovery behavior which already uses rglob()

Fixes: specs/bugs/pending/bug_dispatch_task_subdirectory_resolution.md

## Verification
- Unit tests: subdirectory found, flat precedence, ambiguous error, dotted names unaffected
- E2E test: real UDF in subdirectory resolved through full dispatch pipeline
- All 5511 tests pass, lint/format clean