### PR TITLE
fix: guard-skip no longer cascade-blocks downstream

### DIFF
--- a/.changes/unreleased/Bug Fix-20260420-061000.yaml
+++ b/.changes/unreleased/Bug Fix-20260420-061000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Guard-skipped actions no longer cascade-block downstream when all records are skipped"
+time: 2026-04-20T06:10:00.000000Z

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -671,15 +671,17 @@ def _process_online_mode_with_record_processor(
         storage_backend=ctx.storage_backend,
     )
 
-    # If input had records but no actual work was done (all guard-skipped/
-    # filtered/unprocessed), signal this to the executor via a node-level
-    # disposition so the tally shows SKIP instead of OK.
+    # Signal node-level SKIP only when output is truly empty (all-filtered).
+    # Guard-skipped records ARE in `processed_items` (result_collector extends
+    # output for SKIPPED status), so downstream can consume them — do not
+    # cascade-block when passthrough data exists.
     if (
         data_chunk
         and stats.success == 0
         and stats.failed == 0
         and stats.exhausted == 0
         and stats.deferred == 0
+        and not processed_items
     ):
         if ctx.storage_backend is not None:
             try:
@@ -687,7 +689,7 @@ def _process_online_mode_with_record_processor(
                     ctx.agent_name,
                     NODE_LEVEL_RECORD_ID,
                     DISPOSITION_SKIPPED,
-                    reason="All records guard-skipped or filtered",
+                    reason="All records filtered — no output produced",
                 )
             except Exception as e:
                 logger.warning(

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -602,7 +602,7 @@ class ProcessingPipeline:
                         self.config.action_name,
                         NODE_LEVEL_RECORD_ID,
                         DISPOSITION_SKIPPED,
-                        reason="All records guard-skipped or filtered",
+                        reason="All records filtered — no output produced",
                     )
                 except Exception as e:
                     logger.warning(

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -583,17 +583,17 @@ class ProcessingPipeline:
             storage_backend=self.config.storage_backend,
         )
 
-        # If input had records but no actual work was done (all guard-skipped/
-        # filtered/unprocessed), signal this to the executor via a node-level
-        # disposition so the tally shows SKIP instead of OK.
-        # Exhausted/deferred records represent real processing attempts, so they
-        # must NOT trigger the skip signal.
+        # Signal node-level SKIP only when output is truly empty (all-filtered).
+        # Guard-skipped records ARE in `output` (result_collector extends output
+        # for SKIPPED status), so downstream can consume them — do not cascade-
+        # block when passthrough data exists.
         if (
             data
             and stats.success == 0
             and stats.failed == 0
             and stats.exhausted == 0
             and stats.deferred == 0
+            and not output
         ):
             storage_backend = self.config.storage_backend
             if storage_backend is not None:

--- a/tests/unit/input/test_initial_pipeline_return.py
+++ b/tests/unit/input/test_initial_pipeline_return.py
@@ -246,7 +246,7 @@ class TestInitialPipelineGuardSkipAndToolAction:
             "test_agent",
             "__node__",
             "skipped",
-            reason="All records guard-skipped or filtered",
+            reason="All records filtered — no output produced",
         )
 
     def test_empty_input_does_not_raise(self, online_ctx):

--- a/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
+++ b/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
@@ -89,7 +89,7 @@ class TestGuardSkipDisposition:
             "test_action",
             NODE_LEVEL_RECORD_ID,
             DISPOSITION_SKIPPED,
-            reason="All records guard-skipped or filtered",
+            reason="All records filtered — no output produced",
         )
 
     def test_no_disposition_when_all_unprocessed_with_output(self, pipeline_and_mocks):

--- a/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
+++ b/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
@@ -46,25 +46,44 @@ def pipeline_and_mocks(tmp_path):
 class TestGuardSkipDisposition:
     """Tests for DISPOSITION_SKIPPED write after collect_results."""
 
-    def _run_with_stats(self, pipeline, config, stats, file_path, base_dir, output_dir, data=None):
-        """Call process() with mocked collect_results stats."""
+    def _run_with_stats(
+        self, pipeline, config, stats, file_path, base_dir, output_dir, data=None, output=None
+    ):
+        """Call process() with mocked collect_results stats.
+
+        Args:
+            output: The output list returned by collect_results. Defaults to
+                ``data`` (simulating passthrough). Pass ``[]`` to simulate
+                filtered records that produce no output.
+        """
         if data is None:
             data = [{"id": "1"}, {"id": "2"}]
+        if output is None:
+            output = data
 
         pipeline.record_processor.process_batch.return_value = []
 
         with patch(
             "agent_actions.workflow.pipeline.ResultCollector.collect_results",
-            return_value=(data, stats),
+            return_value=(output, stats),
         ):
             pipeline.process(file_path, base_dir, output_dir, data=data)
 
-    def test_writes_disposition_when_all_guard_skipped(self, pipeline_and_mocks):
-        """DISPOSITION_SKIPPED should be written when all records are skipped."""
+    def test_no_disposition_when_all_guard_skipped_with_output(self, pipeline_and_mocks):
+        """Guard-skipped records ARE in output — no node-level skip, downstream proceeds."""
         pipeline, config, fp, base, out = pipeline_and_mocks
         stats = CollectionStats(skipped=2)
 
         self._run_with_stats(pipeline, config, stats, fp, base, out)
+
+        config.storage_backend.set_disposition.assert_not_called()
+
+    def test_writes_disposition_when_all_filtered(self, pipeline_and_mocks):
+        """All-filtered produces empty output — node-level skip blocks downstream."""
+        pipeline, config, fp, base, out = pipeline_and_mocks
+        stats = CollectionStats(filtered=2)
+
+        self._run_with_stats(pipeline, config, stats, fp, base, out, output=[])
 
         config.storage_backend.set_disposition.assert_called_once_with(
             "test_action",
@@ -73,21 +92,30 @@ class TestGuardSkipDisposition:
             reason="All records guard-skipped or filtered",
         )
 
-    def test_writes_disposition_when_all_filtered(self, pipeline_and_mocks):
-        """DISPOSITION_SKIPPED should be written when all records are filtered."""
-        pipeline, config, fp, base, out = pipeline_and_mocks
-        stats = CollectionStats(filtered=2)
-
-        self._run_with_stats(pipeline, config, stats, fp, base, out)
-
-        config.storage_backend.set_disposition.assert_called_once()
-
-    def test_writes_disposition_when_all_unprocessed(self, pipeline_and_mocks):
-        """DISPOSITION_SKIPPED should be written when all records are unprocessed."""
+    def test_no_disposition_when_all_unprocessed_with_output(self, pipeline_and_mocks):
+        """Unprocessed records ARE in output — no node-level skip."""
         pipeline, config, fp, base, out = pipeline_and_mocks
         stats = CollectionStats(unprocessed=2)
 
         self._run_with_stats(pipeline, config, stats, fp, base, out)
+
+        config.storage_backend.set_disposition.assert_not_called()
+
+    def test_no_disposition_when_mixed_skip_filter_with_output(self, pipeline_and_mocks):
+        """Mixed skip+filter: skipped records produce output, so no cascade-block."""
+        pipeline, config, fp, base, out = pipeline_and_mocks
+        stats = CollectionStats(skipped=1, filtered=1)
+
+        self._run_with_stats(pipeline, config, stats, fp, base, out, output=[{"id": "1"}])
+
+        config.storage_backend.set_disposition.assert_not_called()
+
+    def test_writes_disposition_when_skipped_data_is_empty(self, pipeline_and_mocks):
+        """Guard-skipped records with empty data produce empty output — cascade-block."""
+        pipeline, config, fp, base, out = pipeline_and_mocks
+        stats = CollectionStats(skipped=2)
+
+        self._run_with_stats(pipeline, config, stats, fp, base, out, output=[])
 
         config.storage_backend.set_disposition.assert_called_once()
 
@@ -142,19 +170,19 @@ class TestGuardSkipDisposition:
         """DISPOSITION_SKIPPED must NOT crash if storage_backend is None."""
         pipeline, config, fp, base, out = pipeline_and_mocks
         config.storage_backend = None
-        stats = CollectionStats(skipped=2)
+        stats = CollectionStats(filtered=2)
 
-        # Should not raise
-        self._run_with_stats(pipeline, config, stats, fp, base, out)
+        # Should not raise — empty output enters the block, but backend is None
+        self._run_with_stats(pipeline, config, stats, fp, base, out, output=[])
 
     def test_storage_error_is_logged_not_raised(self, pipeline_and_mocks):
         """Storage errors during disposition write should be logged, not propagated."""
         pipeline, config, fp, base, out = pipeline_and_mocks
         config.storage_backend.set_disposition.side_effect = RuntimeError("DB error")
-        stats = CollectionStats(skipped=2)
+        stats = CollectionStats(filtered=2)
 
-        # Should not raise
-        self._run_with_stats(pipeline, config, stats, fp, base, out)
+        # Should not raise — empty output enters the block, storage error is caught
+        self._run_with_stats(pipeline, config, stats, fp, base, out, output=[])
 
 
 class TestToolActionEmptyOutputUsesGenericPath:


### PR DESCRIPTION
## Summary
- When all records are guard-skipped (`on_false: "skip"`), the pipeline set a node-level SKIPPED disposition that cascade-blocked every downstream action
- Guard-skipped records ARE in the output (result_collector extends output for SKIPPED status) — downstream can consume them
- Added `and not output` to the node-level skip condition so it only fires when output is truly empty (all-filtered)

## Verification
- 5526 tests pass, 0 failures
- 353 guard-related tests pass
- `ruff check` and `ruff format --check` clean
- New tests cover: all-skipped with output (fix), all-filtered with empty output (regression), mixed skip+filter, skipped-with-empty-data edge case