### PR TITLE
fix: rewrite sync reprompt with graduated pool (evaluation loop)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260420-063000.yaml
+++ b/.changes/unreleased/Bug Fix-20260420-063000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix sync reprompt to use graduated pool — only re-validate failing records, not all"
+time: 2026-04-20T06:30:00.000000Z

--- a/.changes/unreleased/Enhancement or New Feature-20260420-062000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260420-062000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add generic EvaluationLoop with graduated pool pattern for batch result evaluation"
+time: 2026-04-20T06:20:00.000000Z

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -140,12 +140,9 @@ def validate_and_reprompt(
     all_graduated: list[BatchResult] = []
     active_results = results
     reprompted_ids: dict[str, int] = {}
-    validation_passed: set[str] = set()
 
     for attempt in range(max_attempts):
         graduated, still_failing = loop.split(active_results)
-        for r in graduated:
-            validation_passed.add(r.custom_id)
         all_graduated.extend(graduated)
 
         if not still_failing:
@@ -319,7 +316,7 @@ def validate_and_reprompt(
             r.recovery_metadata = RecoveryMetadata()
         r.recovery_metadata.reprompt = RepromptMetadata(
             attempts=reprompted_ids[r.custom_id],
-            passed=r.custom_id in validation_passed,
+            passed=True,
             validation=validation_name,
         )
 

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -88,12 +88,18 @@ def validate_and_reprompt(
     file_name: str | None,
     agent_config: dict[str, Any] | None,
 ) -> list[BatchResult]:
-    """Validate results and reprompt failures with feedback."""
+    """Validate results and reprompt failures using graduated pool pattern.
+
+    Records that pass validation are graduated and never re-validated.
+    Only failing records are resubmitted for reprompt.
+    Each cycle, the failure set can only shrink — never grow.
+    """
+    from agent_actions.processing.evaluation import EvaluationLoop
+    from agent_actions.processing.evaluation.strategies import ValidationStrategy
     from agent_actions.processing.recovery.reprompt import parse_reprompt_config
     from agent_actions.processing.recovery.response_validator import (
         build_validation_feedback,
         resolve_feedback_strategies,
-        safe_validate,
     )
     from agent_actions.processing.recovery.validation import get_validation_function
     from agent_actions.processing.types import RepromptMetadata
@@ -122,65 +128,60 @@ def validate_and_reprompt(
         logger.error("Failed to get validation function: %s", e)
         return results
 
-    reprompt_attempts: dict[str, int] = {}
-    validation_status: dict[str, bool] = {}
-    result_map = {r.custom_id: r for r in results}
+    strategy = ValidationStrategy(
+        validation_func=validation_func,
+        feedback_message=feedback_message,
+        strategies=strategies,
+        max_attempts=max_attempts,
+        on_exhausted=on_exhausted,
+    )
+    loop = EvaluationLoop(strategy)
 
-    attempt = 0
-    while attempt < max_attempts:
-        attempt += 1
+    all_graduated: list[BatchResult] = []
+    active_results = results
+    reprompted_ids: dict[str, int] = {}
+    validation_passed: set[str] = set()
 
-        failed_results = []
-        for result in result_map.values():
-            if not result.success:
-                continue
+    for attempt in range(max_attempts):
+        graduated, still_failing = loop.split(active_results)
+        for r in graduated:
+            validation_passed.add(r.custom_id)
+        all_graduated.extend(graduated)
 
-            if (
-                result.recovery_metadata
-                and result.recovery_metadata.reprompt
-                and result.recovery_metadata.reprompt.passed
-            ):
-                continue
-
-            is_valid = safe_validate(
-                validation_func,
-                result.content,
-                context=result.custom_id,
-                catch=(Exception,),
-            )
-
-            validation_status[result.custom_id] = is_valid
-
-            if not is_valid:
-                failed_results.append(result)
-
-        if not failed_results:
-            logger.info("All %d records passed validation", len(result_map))
+        if not still_failing:
+            logger.info("All records passed validation after %d attempts", attempt + 1)
             break
 
         logger.warning(
             "Reprompt attempt %d/%d: %d records failed validation",
-            attempt,
+            attempt + 1,
             max_attempts,
-            len(failed_results),
+            len(still_failing),
         )
 
-        for failed_result in failed_results:
-            reprompt_attempts[failed_result.custom_id] = (
-                reprompt_attempts.get(failed_result.custom_id, 0) + 1
-            )
+        for r in still_failing:
+            reprompted_ids[r.custom_id] = reprompted_ids.get(r.custom_id, 0) + 1
 
-        if attempt >= max_attempts:
-            if on_exhausted == "raise" and failed_results:
+        if attempt == max_attempts - 1:
+            if on_exhausted == "raise" and still_failing:
                 raise RuntimeError(
-                    f"Reprompt validation exhausted for {failed_results[0].custom_id} "
-                    f"after {attempt} attempts (validation: {validation_name})"
+                    f"Reprompt validation exhausted for {still_failing[0].custom_id} "
+                    f"after {attempt + 1} attempts (validation: {validation_name})"
                 )
+            for r in still_failing:
+                if not r.recovery_metadata:
+                    r.recovery_metadata = RecoveryMetadata()
+                r.recovery_metadata.reprompt = RepromptMetadata(
+                    attempts=reprompted_ids[r.custom_id],
+                    passed=False,
+                    validation=validation_name,
+                )
+            all_graduated.extend(still_failing)
             break
 
         use_critique = (raw_reprompt_config or {}).get("use_llm_critique", False)
         critique_after = (raw_reprompt_config or {}).get("critique_after_attempt", 2)
-        apply_critique = use_critique and attempt >= critique_after and attempt < max_attempts
+        apply_critique = use_critique and attempt + 1 >= critique_after
 
         if apply_critique:
             from agent_actions.processing.recovery.critique import (
@@ -188,15 +189,15 @@ def validate_and_reprompt(
                 invoke_critique,
             )
 
-            if len(failed_results) > 10:
+            if len(still_failing) > 10:
                 logger.warning(
                     "Critique enabled for %d failed records — each requires a "
                     "synchronous LLM call, expect increased latency",
-                    len(failed_results),
+                    len(still_failing),
                 )
 
         reprompt_records = []
-        for failed_result in failed_results:
+        for failed_result in still_failing:
             custom_id = failed_result.custom_id
 
             if custom_id not in context_map:
@@ -223,7 +224,7 @@ def validate_and_reprompt(
                     logger.info(
                         "LLM critique appended for %s (attempt %d)",
                         custom_id,
-                        attempt,
+                        attempt + 1,
                     )
                 except Exception:
                     logger.warning(
@@ -242,12 +243,13 @@ def validate_and_reprompt(
 
         if not reprompt_records:
             logger.warning("No records to reprompt")
+            all_graduated.extend(still_failing)
             break
 
         try:
             from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
 
-            reprompt_batch_name = f"{file_name or 'batch'}_reprompt_{attempt}"
+            reprompt_batch_name = f"{file_name or 'batch'}_reprompt_{attempt + 1}"
             preparator = BatchTaskPreparator(
                 action_indices=action_indices,
                 dependency_configs=dependency_configs,
@@ -285,13 +287,15 @@ def validate_and_reprompt(
                     batch_id,
                     final_status,
                 )
+                all_graduated.extend(still_failing)
                 break
 
             reprompt_results = provider.retrieve_results(batch_id, output_directory)
 
+            failing_map = {r.custom_id: r for r in still_failing}
             for reprompt_result in reprompt_results:
-                if reprompt_result.custom_id in result_map:
-                    existing_recovery = result_map[reprompt_result.custom_id].recovery_metadata
+                if reprompt_result.custom_id in failing_map:
+                    existing_recovery = failing_map[reprompt_result.custom_id].recovery_metadata
 
                     if not reprompt_result.recovery_metadata:
                         reprompt_result.recovery_metadata = RecoveryMetadata()
@@ -299,27 +303,27 @@ def validate_and_reprompt(
                     if existing_recovery and existing_recovery.retry:
                         reprompt_result.recovery_metadata.retry = existing_recovery.retry
 
-                result_map[reprompt_result.custom_id] = reprompt_result
+            active_results = reprompt_results
 
         except Exception as e:
             logger.exception("Error during reprompt batch submission: %s", e)
+            all_graduated.extend(still_failing)
             break
 
-    for custom_id, attempts in reprompt_attempts.items():
-        if custom_id in result_map:
-            result = result_map[custom_id]
-            passed = validation_status.get(custom_id, False)
+    for r in all_graduated:
+        if r.custom_id not in reprompted_ids:
+            continue
+        if r.recovery_metadata and r.recovery_metadata.reprompt:
+            continue
+        if not r.recovery_metadata:
+            r.recovery_metadata = RecoveryMetadata()
+        r.recovery_metadata.reprompt = RepromptMetadata(
+            attempts=reprompted_ids[r.custom_id],
+            passed=r.custom_id in validation_passed,
+            validation=validation_name,
+        )
 
-            if not result.recovery_metadata:
-                result.recovery_metadata = RecoveryMetadata()
-
-            result.recovery_metadata.reprompt = RepromptMetadata(
-                attempts=attempts,
-                passed=passed,
-                validation=validation_name,
-            )
-
-    return list(result_map.values())
+    return all_graduated
 
 
 def validate_results(

--- a/agent_actions/processing/evaluation/__init__.py
+++ b/agent_actions/processing/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Generic evaluation loop with graduated pool pattern."""
+
+from agent_actions.processing.evaluation.loop import EvaluationLoop, EvaluationStrategy
+
+__all__ = ["EvaluationLoop", "EvaluationStrategy"]

--- a/agent_actions/processing/evaluation/loop.py
+++ b/agent_actions/processing/evaluation/loop.py
@@ -1,0 +1,109 @@
+"""
+EvaluationLoop — graduated pool pattern for batch result evaluation.
+
+Strategy-agnostic: concrete strategies (validation, critique, etc.)
+implement the EvaluationStrategy protocol and are plugged in by callers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+
+if TYPE_CHECKING:
+    from agent_actions.llm.providers.batch_base import BatchResult
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class EvaluationStrategy(Protocol):
+    """What changes between reprompt, critique, etc."""
+
+    def evaluate(self, result: BatchResult) -> bool: ...
+
+    def build_feedback(self, result: BatchResult) -> str: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def max_attempts(self) -> int: ...
+
+    @property
+    def on_exhausted(self) -> str: ...
+
+
+class EvaluationLoop:
+    """The mechanism. Same for all strategies."""
+
+    def __init__(self, strategy: EvaluationStrategy) -> None:
+        self.strategy = strategy
+
+    def _is_already_graduated(self, result: BatchResult) -> bool:
+        """Check if a result was already graduated in a prior cycle."""
+        meta = getattr(result, "recovery_metadata", None)
+        if not isinstance(meta, dict):
+            return False
+        eval_meta = meta.get("evaluation", {})
+        return eval_meta.get("passed") is True
+
+    def split(self, results: list[BatchResult]) -> tuple[list[BatchResult], list[BatchResult]]:
+        """→ (graduated, still_failing). Skips already-graduated."""
+        graduated: list[BatchResult] = []
+        still_failing: list[BatchResult] = []
+
+        for result in results:
+            if self._is_already_graduated(result):
+                graduated.append(result)
+                continue
+
+            if self.strategy.evaluate(result):
+                graduated.append(result)
+            else:
+                still_failing.append(result)
+
+        logger.info(
+            "EvaluationLoop[%s].split: %d graduated, %d still failing (of %d total)",
+            self.strategy.name,
+            len(graduated),
+            len(still_failing),
+            len(results),
+        )
+        return graduated, still_failing
+
+    def tag_graduated(self, results: list[BatchResult]) -> None:
+        """Mark as done. Never evaluated again."""
+        for result in results:
+            meta = getattr(result, "recovery_metadata", None)
+            if not isinstance(meta, dict):
+                meta = {}
+            meta["evaluation"] = {
+                "passed": True,
+                "strategy_name": self.strategy.name,
+            }
+            cast(Any, result).recovery_metadata = meta
+
+    def build_resubmission(self, failed: list[BatchResult], context_map: dict) -> list[dict]:
+        """Append strategy.build_feedback() to each, return submission records."""
+        submissions: list[dict] = []
+
+        for result in failed:
+            custom_id = result.custom_id
+            context = context_map.get(custom_id, {})
+            feedback = self.strategy.build_feedback(result)
+
+            submission = {
+                "custom_id": custom_id,
+                "context": context,
+                "feedback": feedback,
+                "user_content": context.get("user_content", "") + "\n\n" + feedback,
+            }
+            submissions.append(submission)
+
+        logger.info(
+            "EvaluationLoop[%s].build_resubmission: %d records",
+            self.strategy.name,
+            len(submissions),
+        )
+        return submissions

--- a/agent_actions/processing/evaluation/strategies/__init__.py
+++ b/agent_actions/processing/evaluation/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""Concrete evaluation strategies."""
+
+from agent_actions.processing.evaluation.strategies.validation import ValidationStrategy
+
+__all__ = ["ValidationStrategy"]

--- a/agent_actions/processing/evaluation/strategies/validation.py
+++ b/agent_actions/processing/evaluation/strategies/validation.py
@@ -28,7 +28,7 @@ class ValidationStrategy:
         feedback_message: str,
         strategies: list[FeedbackStrategy] | None = None,
         max_attempts: int = 3,
-        on_exhausted: str = "keep_last",
+        on_exhausted: str = "return_last",
     ) -> None:
         self._validation_func = validation_func
         self._feedback_message = feedback_message

--- a/agent_actions/processing/evaluation/strategies/validation.py
+++ b/agent_actions/processing/evaluation/strategies/validation.py
@@ -1,0 +1,76 @@
+"""ValidationStrategy — wraps reprompt validation as an EvaluationStrategy."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from agent_actions.processing.recovery.response_validator import (
+    build_validation_feedback,
+    safe_validate,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from agent_actions.llm.providers.batch_base import BatchResult
+    from agent_actions.processing.recovery.response_validator import FeedbackStrategy
+
+logger = logging.getLogger(__name__)
+
+
+class ValidationStrategy:
+    """Reprompt validation as an EvaluationStrategy."""
+
+    def __init__(
+        self,
+        validation_func: Callable[[Any], bool],
+        feedback_message: str,
+        strategies: list[FeedbackStrategy] | None = None,
+        max_attempts: int = 3,
+        on_exhausted: str = "keep_last",
+    ) -> None:
+        self._validation_func = validation_func
+        self._feedback_message = feedback_message
+        self._strategies = strategies
+        self._max_attempts = max_attempts
+        self._on_exhausted = on_exhausted
+
+    @property
+    def name(self) -> str:
+        return "validation"
+
+    @property
+    def max_attempts(self) -> int:
+        return self._max_attempts
+
+    @property
+    def on_exhausted(self) -> str:
+        return self._on_exhausted
+
+    def evaluate(self, result: BatchResult) -> bool:
+        """Return True if the result passes validation."""
+        if not result.success:
+            return True
+
+        if (
+            result.recovery_metadata
+            and result.recovery_metadata.reprompt
+            and result.recovery_metadata.reprompt.passed
+        ):
+            return True
+
+        return safe_validate(
+            self._validation_func,
+            result.content,
+            context=result.custom_id,
+            catch=(Exception,),
+        )
+
+    def build_feedback(self, result: BatchResult) -> str:
+        """Build validation feedback for a failing result."""
+        return build_validation_feedback(
+            failed_response=result.content,
+            feedback_message=self._feedback_message,
+            strategies=self._strategies,
+        )

--- a/tests/unit/test_evaluation_loop.py
+++ b/tests/unit/test_evaluation_loop.py
@@ -1,0 +1,330 @@
+"""Tests for the EvaluationLoop graduated pool mechanism."""
+
+from unittest.mock import MagicMock
+
+from agent_actions.processing.evaluation.loop import EvaluationLoop
+
+
+def _make_result(custom_id: str, recovery_metadata: dict | None = None) -> MagicMock:
+    """Create a mock BatchResult."""
+    result = MagicMock()
+    result.custom_id = custom_id
+    result.recovery_metadata = recovery_metadata if recovery_metadata is not None else {}
+    return result
+
+
+def _make_strategy(evaluate_fn=None, name="test", max_attempts=3, on_exhausted="keep"):
+    """Create a mock EvaluationStrategy."""
+    strategy = MagicMock()
+    strategy.name = name
+    strategy.max_attempts = max_attempts
+    strategy.on_exhausted = on_exhausted
+    strategy.evaluate = evaluate_fn or (lambda r: True)
+    strategy.build_feedback.return_value = "Please fix this."
+    return strategy
+
+
+class TestSplit:
+    def test_all_pass(self):
+        strategy = _make_strategy(evaluate_fn=lambda r: True)
+        loop = EvaluationLoop(strategy)
+        results = [_make_result("r1"), _make_result("r2")]
+
+        graduated, failing = loop.split(results)
+
+        assert len(graduated) == 2
+        assert len(failing) == 0
+        assert graduated[0].custom_id == "r1"
+        assert graduated[1].custom_id == "r2"
+
+    def test_all_fail(self):
+        strategy = _make_strategy(evaluate_fn=lambda r: False)
+        loop = EvaluationLoop(strategy)
+        results = [_make_result("r1"), _make_result("r2")]
+
+        graduated, failing = loop.split(results)
+
+        assert len(graduated) == 0
+        assert len(failing) == 2
+        assert failing[0].custom_id == "r1"
+        assert failing[1].custom_id == "r2"
+
+    def test_mixed(self):
+        def evaluate(r):
+            return r.custom_id == "r1"
+
+        strategy = _make_strategy(evaluate_fn=evaluate)
+        loop = EvaluationLoop(strategy)
+        results = [_make_result("r1"), _make_result("r2"), _make_result("r3")]
+
+        graduated, failing = loop.split(results)
+
+        assert [r.custom_id for r in graduated] == ["r1"]
+        assert [r.custom_id for r in failing] == ["r2", "r3"]
+
+    def test_already_graduated_skipped(self):
+        strategy = _make_strategy()
+        loop = EvaluationLoop(strategy)
+        already_done = _make_result("r1", recovery_metadata={"evaluation": {"passed": True}})
+        fresh = _make_result("r2")
+
+        graduated, failing = loop.split([already_done, fresh])
+
+        assert len(graduated) == 2
+        assert graduated[0].custom_id == "r1"
+        assert graduated[1].custom_id == "r2"
+
+    def test_empty_input(self):
+        strategy = _make_strategy()
+        loop = EvaluationLoop(strategy)
+
+        graduated, failing = loop.split([])
+
+        assert graduated == []
+        assert failing == []
+
+    def test_missing_recovery_metadata(self):
+        """Result with no recovery_metadata attribute is treated as not graduated."""
+        strategy = _make_strategy(evaluate_fn=lambda r: False)
+        loop = EvaluationLoop(strategy)
+        result = MagicMock(spec=[])
+        result.custom_id = "r1"
+
+        _, failing = loop.split([result])
+
+        assert len(failing) == 1
+        assert failing[0].custom_id == "r1"
+
+    def test_graduated_not_re_evaluated(self):
+        call_log = []
+
+        def tracking_evaluate(r):
+            call_log.append(r.custom_id)
+            return True
+
+        strategy = _make_strategy(evaluate_fn=tracking_evaluate)
+        loop = EvaluationLoop(strategy)
+        already_done = _make_result("r1", recovery_metadata={"evaluation": {"passed": True}})
+        fresh = _make_result("r2")
+
+        loop.split([already_done, fresh])
+
+        assert "r1" not in call_log
+        assert "r2" in call_log
+
+    def test_none_recovery_metadata(self):
+        strategy = _make_strategy(evaluate_fn=lambda r: True)
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1", recovery_metadata=None)
+        result.recovery_metadata = None
+
+        graduated, _ = loop.split([result])
+
+        assert len(graduated) == 1
+
+    def test_evaluation_false_not_graduated(self):
+        """evaluation.passed=False means not graduated — must be re-evaluated."""
+        call_log = []
+
+        def tracking_evaluate(r):
+            call_log.append(r.custom_id)
+            return False
+
+        strategy = _make_strategy(evaluate_fn=tracking_evaluate)
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1", recovery_metadata={"evaluation": {"passed": False}})
+
+        _, failing = loop.split([result])
+
+        assert "r1" in call_log
+        assert len(failing) == 1
+
+
+class TestTagGraduated:
+    def test_sets_passed_true(self):
+        strategy = _make_strategy(name="validation")
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1")
+
+        loop.tag_graduated([result])
+
+        assert result.recovery_metadata["evaluation"]["passed"] is True
+
+    def test_sets_strategy_name(self):
+        strategy = _make_strategy(name="my_strategy")
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1")
+
+        loop.tag_graduated([result])
+
+        assert result.recovery_metadata["evaluation"]["strategy_name"] == "my_strategy"
+
+    def test_creates_metadata_if_missing(self):
+        strategy = _make_strategy()
+        loop = EvaluationLoop(strategy)
+        result = MagicMock(spec=[])
+        result.custom_id = "r1"
+        result.recovery_metadata = None
+
+        loop.tag_graduated([result])
+
+        assert result.recovery_metadata["evaluation"]["passed"] is True
+
+    def test_preserves_existing_metadata_keys(self):
+        strategy = _make_strategy()
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1", recovery_metadata={"retry": {"attempts": 2}})
+
+        loop.tag_graduated([result])
+
+        assert result.recovery_metadata["retry"] == {"attempts": 2}
+        assert result.recovery_metadata["evaluation"]["passed"] is True
+
+    def test_multiple_results(self):
+        strategy = _make_strategy(name="test")
+        loop = EvaluationLoop(strategy)
+        results = [_make_result("r1"), _make_result("r2"), _make_result("r3")]
+
+        loop.tag_graduated(results)
+
+        for r in results:
+            assert r.recovery_metadata["evaluation"]["passed"] is True
+            assert r.recovery_metadata["evaluation"]["strategy_name"] == "test"
+
+
+class TestBuildResubmission:
+    def test_appends_feedback(self):
+        strategy = _make_strategy()
+        strategy.build_feedback.return_value = "Fix the format."
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1")
+        context_map = {"r1": {"user_content": "original prompt"}}
+
+        submissions = loop.build_resubmission([result], context_map)
+
+        assert len(submissions) == 1
+        assert submissions[0]["custom_id"] == "r1"
+        assert submissions[0]["feedback"] == "Fix the format."
+        assert "original prompt" in submissions[0]["user_content"]
+        assert "Fix the format." in submissions[0]["user_content"]
+
+    def test_uses_context_map(self):
+        strategy = _make_strategy()
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1")
+        context_map = {
+            "r1": {"user_content": "hello", "extra_field": "value"},
+        }
+
+        submissions = loop.build_resubmission([result], context_map)
+
+        assert submissions[0]["context"] == context_map["r1"]
+
+    def test_empty_failed_list(self):
+        strategy = _make_strategy()
+        loop = EvaluationLoop(strategy)
+
+        submissions = loop.build_resubmission([], {"r1": {}})
+
+        assert submissions == []
+
+    def test_missing_context_key(self):
+        """Result not in context_map gets empty context dict."""
+        strategy = _make_strategy()
+        strategy.build_feedback.return_value = "feedback"
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r_missing")
+
+        submissions = loop.build_resubmission([result], {})
+
+        assert len(submissions) == 1
+        assert submissions[0]["context"] == {}
+        assert submissions[0]["custom_id"] == "r_missing"
+
+    def test_does_not_mutate_original_result(self):
+        strategy = _make_strategy()
+        strategy.build_feedback.return_value = "feedback"
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1", recovery_metadata={"existing": "data"})
+        original_meta = dict(result.recovery_metadata)
+
+        loop.build_resubmission([result], {"r1": {"user_content": "prompt"}})
+
+        assert result.recovery_metadata == original_meta
+
+    def test_does_not_mutate_context_map(self):
+        strategy = _make_strategy()
+        strategy.build_feedback.return_value = "feedback"
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1")
+        context_map = {"r1": {"user_content": "original"}}
+        original_context = dict(context_map["r1"])
+
+        loop.build_resubmission([result], context_map)
+
+        assert context_map["r1"] == original_context
+
+    def test_feedback_appended_after_user_content(self):
+        """Feedback is separated from original content by double newline."""
+        strategy = _make_strategy()
+        strategy.build_feedback.return_value = "FEEDBACK"
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1")
+        context_map = {"r1": {"user_content": "ORIGINAL"}}
+
+        submissions = loop.build_resubmission([result], context_map)
+
+        assert submissions[0]["user_content"] == "ORIGINAL\n\nFEEDBACK"
+
+    def test_multiple_results_preserves_order(self):
+        strategy = _make_strategy()
+        strategy.build_feedback.return_value = "fix"
+        loop = EvaluationLoop(strategy)
+        results = [_make_result("r3"), _make_result("r1"), _make_result("r2")]
+        context_map = {
+            "r3": {"user_content": "c3"},
+            "r1": {"user_content": "c1"},
+            "r2": {"user_content": "c2"},
+        }
+
+        submissions = loop.build_resubmission(results, context_map)
+
+        assert [s["custom_id"] for s in submissions] == ["r3", "r1", "r2"]
+
+
+class TestSplitThenTagRoundtrip:
+    """Test the full split → tag → re-split cycle."""
+
+    def test_graduated_survive_second_split(self):
+        """Records tagged as graduated in cycle 1 are skipped in cycle 2."""
+        strategy = _make_strategy(evaluate_fn=lambda r: True)
+        loop = EvaluationLoop(strategy)
+        results = [_make_result("r1"), _make_result("r2")]
+
+        graduated, _ = loop.split(results)
+        loop.tag_graduated(graduated)
+
+        # Second cycle: make strategy reject everything — graduated should still pass
+        loop.strategy.evaluate = lambda r: False
+        graduated2, failing2 = loop.split(results)
+
+        assert [r.custom_id for r in graduated2] == ["r1", "r2"]
+        assert failing2 == []
+
+    def test_failing_then_passing(self):
+        """Records that fail in cycle 1 can graduate in cycle 2."""
+        attempt = [0]
+
+        def evaluate_second_time(r):
+            attempt[0] += 1
+            return attempt[0] > 1
+
+        strategy = _make_strategy(evaluate_fn=evaluate_second_time)
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1")
+
+        _, failing = loop.split([result])
+        assert len(failing) == 1
+
+        graduated, _ = loop.split([result])
+        assert len(graduated) == 1

--- a/tests/unit/test_validation_strategy.py
+++ b/tests/unit/test_validation_strategy.py
@@ -62,7 +62,7 @@ class TestValidationStrategyProtocol:
 
     def test_on_exhausted_default(self):
         strategy = ValidationStrategy(validation_func=_always_pass, feedback_message="fix")
-        assert strategy.on_exhausted == "keep_last"
+        assert strategy.on_exhausted == "return_last"
 
     def test_on_exhausted_custom(self):
         strategy = ValidationStrategy(

--- a/tests/unit/test_validation_strategy.py
+++ b/tests/unit/test_validation_strategy.py
@@ -1,0 +1,290 @@
+"""Tests for ValidationStrategy and graduated pool integration."""
+
+from unittest.mock import MagicMock
+
+from agent_actions.processing.evaluation.loop import EvaluationLoop, EvaluationStrategy
+from agent_actions.processing.evaluation.strategies.validation import ValidationStrategy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    custom_id: str,
+    content: dict | None = None,
+    success: bool = True,
+    recovery_metadata=None,
+) -> MagicMock:
+    """Create a mock BatchResult."""
+    result = MagicMock()
+    result.custom_id = custom_id
+    result.content = content or {"text": "hello"}
+    result.success = success
+    result.recovery_metadata = recovery_metadata
+    return result
+
+
+def _always_pass(response):
+    return True
+
+
+def _always_fail(response):
+    return False
+
+
+# ---------------------------------------------------------------------------
+# ValidationStrategy unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidationStrategyProtocol:
+    def test_satisfies_evaluation_strategy_protocol(self):
+        strategy = ValidationStrategy(
+            validation_func=_always_pass,
+            feedback_message="fix it",
+        )
+        assert isinstance(strategy, EvaluationStrategy)
+
+    def test_name_is_validation(self):
+        strategy = ValidationStrategy(validation_func=_always_pass, feedback_message="fix")
+        assert strategy.name == "validation"
+
+    def test_max_attempts_default(self):
+        strategy = ValidationStrategy(validation_func=_always_pass, feedback_message="fix")
+        assert strategy.max_attempts == 3
+
+    def test_max_attempts_custom(self):
+        strategy = ValidationStrategy(
+            validation_func=_always_pass, feedback_message="fix", max_attempts=5
+        )
+        assert strategy.max_attempts == 5
+
+    def test_on_exhausted_default(self):
+        strategy = ValidationStrategy(validation_func=_always_pass, feedback_message="fix")
+        assert strategy.on_exhausted == "keep_last"
+
+    def test_on_exhausted_custom(self):
+        strategy = ValidationStrategy(
+            validation_func=_always_pass, feedback_message="fix", on_exhausted="raise"
+        )
+        assert strategy.on_exhausted == "raise"
+
+
+class TestValidationStrategyEvaluate:
+    def test_passing_result(self):
+        strategy = ValidationStrategy(validation_func=_always_pass, feedback_message="fix")
+        result = _make_result("r1", content={"valid": True})
+        assert strategy.evaluate(result) is True
+
+    def test_failing_result(self):
+        strategy = ValidationStrategy(validation_func=_always_fail, feedback_message="fix")
+        result = _make_result("r1", content={"valid": False})
+        assert strategy.evaluate(result) is False
+
+    def test_success_false_skips_validation(self):
+        """API-failed results pass through without validation."""
+        call_log = []
+
+        def tracking_validate(response):
+            call_log.append(response)
+            return False
+
+        strategy = ValidationStrategy(validation_func=tracking_validate, feedback_message="fix")
+        result = _make_result("r1", success=False)
+        assert strategy.evaluate(result) is True
+        assert call_log == []
+
+    def test_already_passed_skips_validation(self):
+        """Results with reprompt.passed=True skip validation."""
+        call_log = []
+
+        def tracking_validate(response):
+            call_log.append(response)
+            return False
+
+        reprompt_meta = MagicMock()
+        reprompt_meta.passed = True
+        recovery = MagicMock()
+        recovery.reprompt = reprompt_meta
+
+        strategy = ValidationStrategy(validation_func=tracking_validate, feedback_message="fix")
+        result = _make_result("r1", recovery_metadata=recovery)
+        assert strategy.evaluate(result) is True
+        assert call_log == []
+
+    def test_exception_in_validation_returns_false(self):
+        """Exceptions in validation UDF are caught as failures."""
+
+        def raising_validate(response):
+            raise ValueError("bad data")
+
+        strategy = ValidationStrategy(validation_func=raising_validate, feedback_message="fix")
+        result = _make_result("r1")
+        assert strategy.evaluate(result) is False
+
+    def test_uses_result_content(self):
+        """Validation function receives result.content."""
+        received = []
+
+        def capture_validate(response):
+            received.append(response)
+            return True
+
+        strategy = ValidationStrategy(validation_func=capture_validate, feedback_message="fix")
+        content = {"key": "value"}
+        result = _make_result("r1", content=content)
+        strategy.evaluate(result)
+        assert received == [content]
+
+
+class TestValidationStrategyBuildFeedback:
+    def test_returns_feedback_string(self):
+        strategy = ValidationStrategy(
+            validation_func=_always_fail, feedback_message="Field 'name' is required"
+        )
+        result = _make_result("r1", content={"incomplete": True})
+        feedback = strategy.build_feedback(result)
+        assert isinstance(feedback, str)
+        assert "Field 'name' is required" in feedback
+
+    def test_includes_failed_response(self):
+        strategy = ValidationStrategy(validation_func=_always_fail, feedback_message="invalid")
+        result = _make_result("r1", content={"bad": "data"})
+        feedback = strategy.build_feedback(result)
+        assert "bad" in feedback
+
+
+# ---------------------------------------------------------------------------
+# Graduated pool integration: ValidationStrategy + EvaluationLoop
+# ---------------------------------------------------------------------------
+
+
+class TestGraduatedPoolIntegration:
+    """Test ValidationStrategy with EvaluationLoop — the graduated pool pattern."""
+
+    def test_all_pass_first_attempt(self):
+        strategy = ValidationStrategy(validation_func=_always_pass, feedback_message="fix")
+        loop = EvaluationLoop(strategy)
+        results = [_make_result("r1"), _make_result("r2")]
+
+        graduated, failing = loop.split(results)
+
+        assert len(graduated) == 2
+        assert len(failing) == 0
+
+    def test_partial_pass_splits_correctly(self):
+        def validate(response):
+            return response.get("valid", False)
+
+        strategy = ValidationStrategy(validation_func=validate, feedback_message="fix")
+        loop = EvaluationLoop(strategy)
+        results = [
+            _make_result("r1", content={"valid": True}),
+            _make_result("r2", content={"valid": False}),
+            _make_result("r3", content={"valid": True}),
+        ]
+
+        graduated, failing = loop.split(results)
+
+        assert [r.custom_id for r in graduated] == ["r1", "r3"]
+        assert [r.custom_id for r in failing] == ["r2"]
+
+    def test_failure_set_shrinks_each_cycle(self):
+        """With deterministic validation, failure set can only shrink."""
+        attempt_counter = [0]
+
+        def improving_validate(response):
+            # Pass more records each cycle
+            threshold = response.get("threshold", 0)
+            return attempt_counter[0] >= threshold
+
+        strategy = ValidationStrategy(validation_func=improving_validate, feedback_message="fix")
+        loop = EvaluationLoop(strategy)
+
+        results = [
+            _make_result("r1", content={"threshold": 0}),  # passes cycle 0
+            _make_result("r2", content={"threshold": 1}),  # passes cycle 1
+            _make_result("r3", content={"threshold": 2}),  # passes cycle 2
+        ]
+
+        # Cycle 0
+        attempt_counter[0] = 0
+        graduated_0, failing_0 = loop.split(results)
+        assert len(graduated_0) == 1
+        assert len(failing_0) == 2
+
+        # Cycle 1 — only failing records re-evaluated
+        attempt_counter[0] = 1
+        graduated_1, failing_1 = loop.split(failing_0)
+        assert len(graduated_1) == 1
+        assert len(failing_1) == 1
+
+        # Cycle 2
+        attempt_counter[0] = 2
+        graduated_2, failing_2 = loop.split(failing_1)
+        assert len(graduated_2) == 1
+        assert len(failing_2) == 0
+
+        total_graduated = graduated_0 + graduated_1 + graduated_2
+        assert [r.custom_id for r in total_graduated] == ["r1", "r2", "r3"]
+
+    def test_graduated_never_re_evaluated(self):
+        """Once graduated, a record is never passed to evaluate() again."""
+        evaluated_ids = []
+
+        def tracking_validate(response):
+            return True
+
+        strategy = ValidationStrategy(validation_func=tracking_validate, feedback_message="fix")
+        # Patch to track calls
+        original_evaluate = strategy.evaluate
+
+        def tracking_evaluate(result):
+            evaluated_ids.append(result.custom_id)
+            return original_evaluate(result)
+
+        strategy.evaluate = tracking_evaluate
+        loop = EvaluationLoop(strategy)
+
+        results = [_make_result("r1"), _make_result("r2")]
+
+        # Cycle 0 — both evaluated, both graduate
+        graduated_0, _ = loop.split(results)
+        assert set(evaluated_ids) == {"r1", "r2"}
+
+        # Cycle 1 — pass same results, but since we're using the graduated pool
+        # pattern correctly, only new active_results go into split.
+        # Simulating: active_results would be reprompt results (empty in this case)
+        evaluated_ids.clear()
+        graduated_1, _ = loop.split([])
+        assert evaluated_ids == []
+
+    def test_api_failures_pass_through(self):
+        """Results with success=False are graduated without validation."""
+        strategy = ValidationStrategy(validation_func=_always_fail, feedback_message="fix")
+        loop = EvaluationLoop(strategy)
+
+        results = [
+            _make_result("r1", success=True),
+            _make_result("r2", success=False),  # API failure
+        ]
+
+        graduated, failing = loop.split(results)
+
+        assert [r.custom_id for r in graduated] == ["r2"]
+        assert [r.custom_id for r in failing] == ["r1"]
+
+    def test_build_feedback_for_failing(self):
+        strategy = ValidationStrategy(
+            validation_func=_always_fail, feedback_message="Missing required field"
+        )
+        loop = EvaluationLoop(strategy)
+        result = _make_result("r1", content={"incomplete": True})
+        context_map = {"r1": {"user_content": "original prompt"}}
+
+        submissions = loop.build_resubmission([result], context_map)
+
+        assert len(submissions) == 1
+        assert "Missing required field" in submissions[0]["feedback"]
+        assert "original prompt" in submissions[0]["user_content"]


### PR DESCRIPTION
## Summary
- Extract reprompt validation into `ValidationStrategy` implementing `EvaluationStrategy` protocol
- Rewrite `validate_and_reprompt()` to use graduated pool pattern via `EvaluationLoop`
- Records that pass validation are graduated and never re-validated
- Fixes the bug where non-deterministic validation causes the failure set to shift but never shrink

## What changed
- **New**: `agent_actions/processing/evaluation/strategies/validation.py` — `ValidationStrategy` class wrapping existing `safe_validate()` and `build_validation_feedback()` into the `EvaluationStrategy` protocol
- **Modified**: `agent_actions/llm/batch/services/reprompt_ops.py` — `validate_and_reprompt()` now uses `EvaluationLoop.split()` to separate graduated/failing records each cycle, only resubmitting the failure set
- **New tests**: 20 tests covering strategy protocol compliance, evaluate/build_feedback behavior, and graduated pool integration

## Verification
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- `pytest` — 5568 passed, 2 skipped
- Existing `test_validate_and_reprompt_passes_source_data` still passes
- `ValidationStrategy` satisfies `isinstance(strategy, EvaluationStrategy)` check
- `validate_results()` and `submit_reprompt_batch()` unchanged (used by async path)