### PR TITLE
refactor: simplify evaluation loop — extract factory, fix efficiency

### DIFF
--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +54,30 @@ class RecoveryState:
     # Which evaluation strategy is active (e.g., "validation", "critique")
     evaluation_strategy_name: str | None = None
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict without deep-copying already-serialized lists.
+
+        ``dataclasses.asdict()`` recursively copies every nested dict/list,
+        which is wasteful for ``accumulated_results`` and ``graduated_results``
+        — they are already plain ``list[dict]`` ready for JSON serialization.
+        """
+        return {
+            "phase": self.phase,
+            "retry_attempt": self.retry_attempt,
+            "retry_max_attempts": self.retry_max_attempts,
+            "missing_ids": self.missing_ids,
+            "record_failure_counts": self.record_failure_counts,
+            "reprompt_attempt": self.reprompt_attempt,
+            "reprompt_max_attempts": self.reprompt_max_attempts,
+            "validation_name": self.validation_name,
+            "reprompt_attempts_per_record": self.reprompt_attempts_per_record,
+            "validation_status": self.validation_status,
+            "on_exhausted": self.on_exhausted,
+            "accumulated_results": self.accumulated_results,
+            "graduated_results": self.graduated_results,
+            "evaluation_strategy_name": self.evaluation_strategy_name,
+        }
+
 
 class RecoveryStateManager:
     """Persists RecoveryState to JSON files in the batch/ subdirectory."""
@@ -65,7 +89,7 @@ class RecoveryStateManager:
         ensure_directory_exists(state_path, is_file=True)
 
         with open(state_path, "w", encoding="utf-8") as f:
-            json.dump(asdict(state), f, indent=2, ensure_ascii=False)
+            json.dump(state.to_dict(), f, ensure_ascii=False)
 
         logger.debug(
             "Saved recovery state to %s (phase=%s, retry=%d, reprompt=%d)",

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -254,19 +254,14 @@ def handle_reprompt_recovery(
     (never the full accumulated set).  Results that pass are graduated and
     persisted to ``state.graduated_results`` so they are never re-evaluated.
     """
-    from agent_actions.llm.batch.services.reprompt_ops import _load_validation_udf
-    from agent_actions.processing.evaluation import EvaluationLoop
-    from agent_actions.processing.evaluation.strategies import ValidationStrategy
-    from agent_actions.processing.recovery.reprompt import parse_reprompt_config
-    from agent_actions.processing.recovery.response_validator import (
-        resolve_feedback_strategies,
-    )
-    from agent_actions.processing.recovery.validation import get_validation_function
+    from agent_actions.llm.batch.services.reprompt_ops import build_evaluation_loop
 
-    raw_reprompt_config = (agent_config or {}).get("reprompt")
-    parsed = parse_reprompt_config(raw_reprompt_config)
-    if parsed is None:
-        # No validation configured — treat all recovery results as graduated.
+    setup = build_evaluation_loop(
+        agent_config,
+        max_attempts=state.reprompt_max_attempts,
+        on_exhausted=state.on_exhausted,
+    )
+    if setup is None:
         return finalize_batch_output(
             service,
             batch_results=recovery_results,
@@ -281,24 +276,10 @@ def handle_reprompt_recovery(
             start_time=start_time,
         )
 
-    _load_validation_udf(agent_config, raw_reprompt_config or {})
-    validation_func, feedback_message = get_validation_function(parsed.validation_name)
-    strategies = resolve_feedback_strategies(raw_reprompt_config)
+    loop, strategy, _ = setup
 
-    strategy = ValidationStrategy(
-        validation_func=validation_func,
-        feedback_message=feedback_message,
-        strategies=strategies,
-        max_attempts=state.reprompt_max_attempts,
-        on_exhausted=state.on_exhausted,
-    )
-    loop = EvaluationLoop(strategy)
-
-    # Only evaluate what came back from the reprompt batch — NOT the full set.
     graduated, still_failing = loop.split(recovery_results)
     loop.tag_graduated(graduated)
-
-    # Persist graduated results (never re-evaluated on next cycle).
     state.graduated_results.extend(BatchRetryService.serialize_results(graduated))
     state.evaluation_strategy_name = strategy.name
 
@@ -348,8 +329,11 @@ def handle_reprompt_recovery(
             attempt=state.reprompt_attempt,
             on_exhausted=state.on_exhausted,
         )
-        state.graduated_results.extend(BatchRetryService.serialize_results(still_failing))
+    # Deserialize prior-cycle graduated results; append current cycle's objects
+    # directly to avoid a redundant serialize→deserialize round-trip.
     final_results = BatchRetryService.deserialize_results(state.graduated_results)
+    if still_failing:
+        final_results.extend(still_failing)
     # Rebuild exhausted_recovery from state if retry had exhausted records.
     # Invariant: state.missing_ids and state.record_failure_counts are frozen
     # at the end of the retry phase (set in handle_retry_recovery or
@@ -405,35 +389,15 @@ def check_and_submit_reprompt(
         True if processing should continue (no reprompt, or reprompt exhausted/failed).
         False if a reprompt batch was submitted (caller should return None).
     """
-    from agent_actions.llm.batch.services.reprompt_ops import _load_validation_udf
-    from agent_actions.processing.evaluation import EvaluationLoop
-    from agent_actions.processing.evaluation.strategies import ValidationStrategy
-    from agent_actions.processing.recovery.reprompt import parse_reprompt_config
-    from agent_actions.processing.recovery.response_validator import (
-        resolve_feedback_strategies,
-    )
-    from agent_actions.processing.recovery.validation import get_validation_function
+    from agent_actions.llm.batch.services.reprompt_ops import build_evaluation_loop
 
-    raw_reprompt_config = (agent_config or {}).get("reprompt")
-    parsed = parse_reprompt_config(raw_reprompt_config)
-    if parsed is None:
+    setup = build_evaluation_loop(agent_config)
+    if setup is None:
         return True
 
-    max_attempts = parsed.max_attempts
-    on_exhausted = parsed.on_exhausted
-
-    _load_validation_udf(agent_config, raw_reprompt_config or {})
-    validation_func, feedback_message = get_validation_function(parsed.validation_name)
-    strategies = resolve_feedback_strategies(raw_reprompt_config)
-
-    strategy = ValidationStrategy(
-        validation_func=validation_func,
-        feedback_message=feedback_message,
-        strategies=strategies,
-        max_attempts=max_attempts,
-        on_exhausted=on_exhausted,
-    )
-    loop = EvaluationLoop(strategy)
+    loop, strategy, _ = setup
+    max_attempts = strategy.max_attempts
+    on_exhausted = strategy.on_exhausted
 
     graduated, still_failing = loop.split(batch_results)
     loop.tag_graduated(graduated)
@@ -492,7 +456,6 @@ def check_and_submit_reprompt(
     state.validation_name = strategy.name
     state.on_exhausted = on_exhausted
     state.evaluation_strategy_name = strategy.name
-    # Persist graduated results immediately — never re-evaluated.
     state.graduated_results = BatchRetryService.serialize_results(graduated)
     for fr in still_failing:
         state.reprompt_attempts_per_record[fr.custom_id] = (

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -77,6 +77,54 @@ def _load_validation_udf(
         import_validation_module(validation_module, None)
 
 
+def build_evaluation_loop(
+    agent_config: dict[str, Any] | None,
+    *,
+    max_attempts: int | None = None,
+    on_exhausted: str | None = None,
+) -> tuple | None:
+    """Build an EvaluationLoop + ValidationStrategy from agent_config.
+
+    Consolidates the repeated config-parse → UDF-load → strategy-construct
+    sequence used by validate_and_reprompt, handle_reprompt_recovery, and
+    check_and_submit_reprompt.
+
+    Returns ``(loop, strategy, validation_name)`` or ``None`` if reprompt
+    is not configured or the validation function cannot be resolved.
+    """
+    from agent_actions.processing.evaluation import EvaluationLoop
+    from agent_actions.processing.evaluation.strategies import ValidationStrategy
+    from agent_actions.processing.recovery.reprompt import parse_reprompt_config
+    from agent_actions.processing.recovery.response_validator import (
+        resolve_feedback_strategies,
+    )
+    from agent_actions.processing.recovery.validation import get_validation_function
+
+    raw_reprompt_config = (agent_config or {}).get("reprompt")
+    parsed = parse_reprompt_config(raw_reprompt_config)
+    if parsed is None:
+        return None
+
+    _load_validation_udf(agent_config, raw_reprompt_config or {})
+
+    try:
+        validation_func, feedback_message = get_validation_function(parsed.validation_name)
+    except ValueError as e:
+        logger.error("Failed to get validation function: %s", e)
+        return None
+
+    strategies = resolve_feedback_strategies(raw_reprompt_config)
+
+    strategy = ValidationStrategy(
+        validation_func=validation_func,
+        feedback_message=feedback_message,
+        strategies=strategies,
+        max_attempts=max_attempts if max_attempts is not None else parsed.max_attempts,
+        on_exhausted=on_exhausted if on_exhausted is not None else parsed.on_exhausted,
+    )
+    return EvaluationLoop(strategy), strategy, parsed.validation_name
+
+
 def validate_and_reprompt(
     action_indices: dict[str, int],
     dependency_configs: dict[str, dict],
@@ -94,49 +142,28 @@ def validate_and_reprompt(
     Only failing records are resubmitted for reprompt.
     Each cycle, the failure set can only shrink — never grow.
     """
-    from agent_actions.processing.evaluation import EvaluationLoop
-    from agent_actions.processing.evaluation.strategies import ValidationStrategy
-    from agent_actions.processing.recovery.reprompt import parse_reprompt_config
     from agent_actions.processing.recovery.response_validator import (
         build_validation_feedback,
-        resolve_feedback_strategies,
     )
-    from agent_actions.processing.recovery.validation import get_validation_function
     from agent_actions.processing.types import RepromptMetadata
 
-    raw_reprompt_config = (agent_config or {}).get("reprompt")
-    parsed = parse_reprompt_config(raw_reprompt_config)
     logger.debug(
-        "Batch reprompt check: agent_config has %d keys, parsed=%s",
+        "Batch reprompt check: agent_config has %d keys",
         len(agent_config or {}),
-        parsed,
     )
-    if parsed is None:
+    setup = build_evaluation_loop(agent_config)
+    if setup is None:
         logger.debug("Reprompt not configured, skipping validation")
         return results
 
-    validation_name = parsed.validation_name
-    max_attempts = parsed.max_attempts
-    on_exhausted = parsed.on_exhausted
-    strategies = resolve_feedback_strategies(raw_reprompt_config)
+    loop, strategy, validation_name = setup
+    max_attempts = strategy.max_attempts
+    on_exhausted = strategy.on_exhausted
+    feedback_message = strategy._feedback_message
+    strategies = strategy._strategies
+    raw_reprompt_config = (agent_config or {}).get("reprompt") or {}
 
-    _load_validation_udf(agent_config, raw_reprompt_config or {})
-
-    try:
-        validation_func, feedback_message = get_validation_function(validation_name)
-    except ValueError as e:
-        logger.error("Failed to get validation function: %s", e)
-        return results
-
-    strategy = ValidationStrategy(
-        validation_func=validation_func,
-        feedback_message=feedback_message,
-        strategies=strategies,
-        max_attempts=max_attempts,
-        on_exhausted=on_exhausted,
-    )
-    loop = EvaluationLoop(strategy)
-
+    source_data = _load_source_data_for_reprompt(storage_backend)
     all_graduated: list[BatchResult] = []
     active_results = results
     reprompted_ids: dict[str, int] = {}
@@ -252,7 +279,6 @@ def validate_and_reprompt(
                 dependency_configs=dependency_configs,
                 storage_backend=storage_backend,
             )
-            source_data = _load_source_data_for_reprompt(storage_backend)
             prepared = preparator.prepare_tasks(
                 agent_config=agent_config or {},
                 data=reprompt_records,

--- a/tests/unit/llm/test_recovery_state_graduated.py
+++ b/tests/unit/llm/test_recovery_state_graduated.py
@@ -1,7 +1,6 @@
 """Tests for graduated results tracking in RecoveryState."""
 
 import json
-from pathlib import Path
 
 from agent_actions.llm.batch.infrastructure.recovery_state import (
     RecoveryState,

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -231,7 +231,9 @@ class TestHandleRepromptRecoveryGraduatedPool:
         call_kwargs = service._retry_service.apply_exhausted_reprompt_metadata.call_args.kwargs
         assert call_kwargs["validation_name"] == "validation"
         assert {r.custom_id for r in call_kwargs["results"]} == {"r2"}
-        assert len(state.graduated_results) == 2
+        # Only graduated records (r1) are in state; exhausted records (r2) are
+        # combined directly at finalization without a serialize round-trip.
+        assert len(state.graduated_results) == 1
 
     def test_all_graduated_no_submission(self, mock_loop):
         """When all recovery_results pass, no reprompt batch is submitted."""


### PR DESCRIPTION
## Summary
- **Extract `build_evaluation_loop()` factory** in `reprompt_ops.py` — collapses 3 identical 10-line setup blocks (parse config → load UDF → get validation func → construct strategy → construct loop) into a single function used by `validate_and_reprompt`, `handle_reprompt_recovery`, and `check_and_submit_reprompt`
- **Hoist `_load_source_data_for_reprompt()`** above the sync reprompt loop — was re-reading the DB on every reprompt iteration despite source data being loop-invariant
- **Add `RecoveryState.to_dict()`** — avoids `asdict()` deep-copying `graduated_results` and `accumulated_results` (already plain `list[dict]`); drops `indent=2` from recovery state JSON writes
- **Remove serialize→deserialize round-trip** at finalization in `handle_reprompt_recovery` — exhausted records are combined directly with deserialized graduated results instead of being serialized into state then immediately deserialized back

## Verification
- `ruff check` and `ruff format --check` pass
- Full test suite: **5613 passed, 2 skipped, 0 failed**
- All evaluation loop tests (75 across 4 files) pass
- All reprompt tests (217) pass
- All recovery tests (39) pass