### PR TITLE
fix: stale dispositions no longer falsely mark completed actions as guard-skipped

### DIFF
--- a/.changes/unreleased/Bug Fix-20260422-007000.yaml
+++ b/.changes/unreleased/Bug Fix-20260422-007000.yaml
@@ -1,3 +1,3 @@
 kind: Bug Fix
 body: "Fix false guard-skip on completed actions: clear stale dispositions on limit change, cross-check output before trusting SKIPPED, use PASSTHROUGH for WHERE-clause skip with data"
-time: 2026-04-22T00:70:00.000000Z
+time: 2026-04-22T07:00:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260422-007000.yaml
+++ b/.changes/unreleased/Bug Fix-20260422-007000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix false guard-skip on completed actions: clear stale dispositions on limit change, cross-check output before trusting SKIPPED, use PASSTHROUGH for WHERE-clause skip with data"
+time: 2026-04-22T00:70:00.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -464,39 +464,39 @@ class ActionExecutor:
     def _resolve_completion_status(self, action_name: str) -> ActionStatus:
         """Return SKIPPED if all records guard-skipped, COMPLETED_WITH_FAILURES if item-level failures exist, else COMPLETED."""
         storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
-        if storage_backend is not None:
-            try:
-                if storage_backend.has_disposition(
-                    action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
-                ):
-                    target_files = storage_backend.list_target_files(action_name)
-                    if target_files:
-                        storage_backend.clear_disposition(
-                            action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
-                        )
-                        logger.warning(
-                            "Stale guard-skip disposition on '%s' — action has %d target file(s). "
-                            "A write path set SKIPPED despite output existing. "
-                            "Clearing disposition and proceeding as COMPLETED.",
-                            action_name,
-                            len(target_files),
-                        )
-                    else:
-                        logger.info(
-                            "Action '%s' had all records guard-skipped — marking as skipped",
-                            action_name,
-                        )
-                        return ActionStatus.SKIPPED
-                item_failures = storage_backend.get_failed_items(action_name)
-                if item_failures:
-                    logger.warning(
-                        "Action '%s' completed with %d item-level failure(s)",
+        if storage_backend is None:
+            return ActionStatus.COMPLETED
+        try:
+            if storage_backend.has_disposition(
+                action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+            ):
+                target_files = storage_backend.list_target_files(action_name)
+                if not target_files:
+                    logger.info(
+                        "Action '%s' had all records guard-skipped — marking as skipped",
                         action_name,
-                        len(item_failures),
                     )
-                    return ActionStatus.COMPLETED_WITH_FAILURES
-            except Exception as e:
-                logger.warning("Could not check partial failures for %s: %s", action_name, e)
+                    return ActionStatus.SKIPPED
+                storage_backend.clear_disposition(
+                    action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+                )
+                logger.warning(
+                    "Stale guard-skip disposition on '%s' — action has %d target file(s). "
+                    "A write path set SKIPPED despite output existing. "
+                    "Clearing disposition and proceeding as COMPLETED.",
+                    action_name,
+                    len(target_files),
+                )
+            item_failures = storage_backend.get_failed_items(action_name)
+            if item_failures:
+                logger.warning(
+                    "Action '%s' completed with %d item-level failure(s)",
+                    action_name,
+                    len(item_failures),
+                )
+                return ActionStatus.COMPLETED_WITH_FAILURES
+        except Exception as e:
+            logger.warning("Could not check partial failures for %s: %s", action_name, e)
         return ActionStatus.COMPLETED
 
     def _handle_run_failure(
@@ -580,36 +580,35 @@ class ActionExecutor:
 
         if not deps_to_check:
             return None
+        storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
         for dep in deps_to_check:
             if self.deps.state_manager.is_failed(dep) or self.deps.state_manager.is_skipped(dep):
                 return dep
-            storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
-            if storage_backend is not None:
-                has_failed = storage_backend.has_disposition(
-                    dep, DISPOSITION_FAILED, record_id=NODE_LEVEL_RECORD_ID
-                )
-                if has_failed:
-                    return dep
-                has_skipped = storage_backend.has_disposition(
-                    dep, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
-                )
-                if has_skipped:
-                    target_files = storage_backend.list_target_files(dep)
-                    if target_files:
-                        storage_backend.clear_disposition(
-                            dep, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
-                        )
-                        logger.warning(
-                            "Stale upstream SKIPPED disposition on '%s' — "
-                            "upstream has %d target file(s). "
-                            "A write path set SKIPPED despite output existing. "
-                            "Clearing disposition; downstream '%s' will proceed.",
-                            dep,
-                            len(target_files),
-                            action_name,
-                        )
-                    else:
-                        return dep
+            if storage_backend is None:
+                continue
+            if storage_backend.has_disposition(
+                dep, DISPOSITION_FAILED, record_id=NODE_LEVEL_RECORD_ID
+            ):
+                return dep
+            if not storage_backend.has_disposition(
+                dep, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+            ):
+                continue
+            target_files = storage_backend.list_target_files(dep)
+            if not target_files:
+                return dep
+            storage_backend.clear_disposition(
+                dep, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+            )
+            logger.warning(
+                "Stale upstream SKIPPED disposition on '%s' — "
+                "upstream has %d target file(s). "
+                "A write path set SKIPPED despite output existing. "
+                "Clearing disposition; downstream '%s' will proceed.",
+                dep,
+                len(target_files),
+                action_name,
+            )
         return None
 
     def _handle_dependency_skip(

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -159,6 +159,12 @@ class ActionExecutor:
         ) != action_config.get("file_limit"):
             logger.info("Limit config changed for %s, resetting to pending", action_name)
             self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
+            storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
+            if storage_backend is not None:
+                try:
+                    storage_backend.clear_disposition(action_name)
+                except Exception as e:
+                    logger.warning("Failed to clear dispositions for %s: %s", action_name, e)
             return ActionStatus.PENDING
         return current_status
 
@@ -463,11 +469,28 @@ class ActionExecutor:
                 if storage_backend.has_disposition(
                     action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
                 ):
-                    logger.info(
-                        "Action '%s' had all records guard-skipped — marking as skipped",
-                        action_name,
-                    )
-                    return ActionStatus.SKIPPED
+                    # Cross-check: the pipeline only sets this disposition when
+                    # output is empty.  If target data exists, the disposition
+                    # is stale (left over from a prior run) — clear it and
+                    # warn so the write-path bug that caused it can be found.
+                    target_files = storage_backend.list_target_files(action_name)
+                    if target_files:
+                        storage_backend.clear_disposition(
+                            action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+                        )
+                        logger.warning(
+                            "Stale guard-skip disposition on '%s' — action has %d target file(s). "
+                            "A write path set SKIPPED despite output existing. "
+                            "Clearing disposition and proceeding as COMPLETED.",
+                            action_name,
+                            len(target_files),
+                        )
+                    else:
+                        logger.info(
+                            "Action '%s' had all records guard-skipped — marking as skipped",
+                            action_name,
+                        )
+                        return ActionStatus.SKIPPED
                 item_failures = storage_backend.get_failed_items(action_name)
                 if item_failures:
                     logger.warning(
@@ -566,15 +589,35 @@ class ActionExecutor:
                 return dep
             # Also check disposition — covers cascaded failures/skips from prior levels
             storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
-            if storage_backend is not None and (
-                storage_backend.has_disposition(
+            if storage_backend is not None:
+                has_failed = storage_backend.has_disposition(
                     dep, DISPOSITION_FAILED, record_id=NODE_LEVEL_RECORD_ID
                 )
-                or storage_backend.has_disposition(
+                if has_failed:
+                    return dep
+                has_skipped = storage_backend.has_disposition(
                     dep, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
                 )
-            ):
-                return dep
+                if has_skipped:
+                    # Cross-check: if the upstream produced output, the
+                    # SKIPPED disposition is stale — clear it, warn so
+                    # the write-path bug can be found, and proceed.
+                    target_files = storage_backend.list_target_files(dep)
+                    if target_files:
+                        storage_backend.clear_disposition(
+                            dep, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+                        )
+                        logger.warning(
+                            "Stale upstream SKIPPED disposition on '%s' — "
+                            "upstream has %d target file(s). "
+                            "A write path set SKIPPED despite output existing. "
+                            "Clearing disposition; downstream '%s' will proceed.",
+                            dep,
+                            len(target_files),
+                            action_name,
+                        )
+                    else:
+                        return dep
         return None
 
     def _handle_dependency_skip(

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -469,10 +469,6 @@ class ActionExecutor:
                 if storage_backend.has_disposition(
                     action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
                 ):
-                    # Cross-check: the pipeline only sets this disposition when
-                    # output is empty.  If target data exists, the disposition
-                    # is stale (left over from a prior run) — clear it and
-                    # warn so the write-path bug that caused it can be found.
                     target_files = storage_backend.list_target_files(action_name)
                     if target_files:
                         storage_backend.clear_disposition(
@@ -587,7 +583,6 @@ class ActionExecutor:
         for dep in deps_to_check:
             if self.deps.state_manager.is_failed(dep) or self.deps.state_manager.is_skipped(dep):
                 return dep
-            # Also check disposition — covers cascaded failures/skips from prior levels
             storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
             if storage_backend is not None:
                 has_failed = storage_backend.has_disposition(
@@ -599,9 +594,6 @@ class ActionExecutor:
                     dep, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
                 )
                 if has_skipped:
-                    # Cross-check: if the upstream produced output, the
-                    # SKIPPED disposition is stale — clear it, warn so
-                    # the write-path bug can be found, and proceed.
                     target_files = storage_backend.list_target_files(dep)
                     if target_files:
                         storage_backend.clear_disposition(

--- a/agent_actions/workflow/managers/output.py
+++ b/agent_actions/workflow/managers/output.py
@@ -196,9 +196,6 @@ class ActionOutputManager:
             self.storage_backend.write_target(agent_type, relative_path, data)
 
         if data_by_path:
-            # Passthrough succeeded — upstream data was written to this
-            # action's target.  Use PASSTHROUGH (not SKIPPED) so downstream
-            # actions are NOT cascade-blocked.
             self.storage_backend.set_disposition(
                 agent_type,
                 NODE_LEVEL_RECORD_ID,
@@ -206,7 +203,6 @@ class ActionOutputManager:
                 reason=f"Action {agent_type} skipped — upstream data passed through",
             )
         else:
-            # No upstream data to pass through — truly skipped.
             self.storage_backend.set_disposition(
                 agent_type,
                 NODE_LEVEL_RECORD_ID,

--- a/agent_actions/workflow/managers/output.py
+++ b/agent_actions/workflow/managers/output.py
@@ -195,10 +195,24 @@ class ActionOutputManager:
                 data = merge_records_by_key(all_records, reduce_key)
             self.storage_backend.write_target(agent_type, relative_path, data)
 
-        reason = f"Action {agent_type} skipped due to WHERE clause condition"
-        self.storage_backend.set_disposition(
-            agent_type, NODE_LEVEL_RECORD_ID, DISPOSITION_SKIPPED, reason=reason
-        )
+        if data_by_path:
+            # Passthrough succeeded — upstream data was written to this
+            # action's target.  Use PASSTHROUGH (not SKIPPED) so downstream
+            # actions are NOT cascade-blocked.
+            self.storage_backend.set_disposition(
+                agent_type,
+                NODE_LEVEL_RECORD_ID,
+                DISPOSITION_PASSTHROUGH,
+                reason=f"Action {agent_type} skipped — upstream data passed through",
+            )
+        else:
+            # No upstream data to pass through — truly skipped.
+            self.storage_backend.set_disposition(
+                agent_type,
+                NODE_LEVEL_RECORD_ID,
+                DISPOSITION_SKIPPED,
+                reason=f"Action {agent_type} skipped due to WHERE clause condition",
+            )
 
     def _read_upstream_from_backend(self, action_name: str) -> dict[str, list[dict]]:
         """Read all target files for a node from storage backend."""

--- a/tests/unit/workflow/managers/test_passthrough_output.py
+++ b/tests/unit/workflow/managers/test_passthrough_output.py
@@ -76,11 +76,11 @@ class TestPassthroughFromBackend:
             "transform", "batch_0.json", upstream_data
         )
 
-        # Disposition recorded
+        # Disposition recorded as passthrough (data was written)
         mock_storage_backend.set_disposition.assert_called_once()
         call_args = mock_storage_backend.set_disposition.call_args
         assert call_args[0][0] == "transform"
-        assert call_args[0][2] == "skipped"
+        assert call_args[0][2] == "passthrough"
 
     def test_multiple_backend_files(self, make_manager, mock_storage_backend):
         """All files from upstream node are forwarded."""
@@ -181,8 +181,8 @@ class TestPassthroughFromFilesystem:
         mock_storage_backend.write_target.assert_called_once()
         assert mock_storage_backend.write_target.call_args[0][1] == "batch_0.json"
 
-    def test_empty_upstream_writes_nothing(self, make_manager, mock_storage_backend):
-        """No upstream data → no writes, but disposition is still recorded."""
+    def test_empty_upstream_writes_skipped_disposition(self, make_manager, mock_storage_backend):
+        """No upstream data → no writes, disposition is SKIPPED (not PASSTHROUGH)."""
         mock_storage_backend.list_target_files.return_value = []
 
         mgr = make_manager(
@@ -193,6 +193,9 @@ class TestPassthroughFromFilesystem:
 
         mock_storage_backend.write_target.assert_not_called()
         mock_storage_backend.set_disposition.assert_called_once()
+        call_args = mock_storage_backend.set_disposition.call_args
+        assert call_args[0][0] == "transform"
+        assert call_args[0][2] == "skipped"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -713,8 +713,7 @@ class TestStaleDispositionFullChain:
         # Upstream "write_scenario_question" has stale SKIPPED disposition from prior run
         # but also has output from the current run.
         storage.has_disposition.side_effect = (
-            lambda dep, disp, **kw: dep == "write_scenario_question"
-            and disp == DISPOSITION_SKIPPED
+            lambda dep, disp, **kw: dep == "write_scenario_question" and disp == DISPOSITION_SKIPPED
         )
         storage.list_target_files.return_value = ["combined_scraped.json"]
         mock_deps.action_runner.storage_backend = storage
@@ -763,7 +762,8 @@ class TestStaleDispositionFullChain:
 
         # Step 1: limits changed → status reset + dispositions cleared
         mock_deps.state_manager.get_status_details.return_value = {
-            "record_limit": 9, "file_limit": None,
+            "record_limit": 9,
+            "file_limit": None,
         }
         new_status = executor._maybe_invalidate_completed_status(
             "add_answer_text", {"record_limit": 2, "file_limit": None}, ActionStatus.COMPLETED

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -96,16 +96,31 @@ class TestCheckUpstreamHealth:
         assert result == "agent_a"
 
     def test_dep_skipped_via_disposition(self, executor, mock_deps):
-        """One dep has DISPOSITION_SKIPPED in storage returns dep name."""
+        """One dep has DISPOSITION_SKIPPED in storage and no output returns dep name."""
         mock_deps.state_manager.is_failed.return_value = False
         mock_deps.state_manager.is_skipped.return_value = False
         storage = MagicMock()
         storage.has_disposition.side_effect = lambda dep, disp, **kw: disp == DISPOSITION_SKIPPED
+        storage.list_target_files.return_value = []
         mock_deps.action_runner.storage_backend = storage
 
         config = {"dependencies": ["agent_a"]}
         result = executor._check_upstream_health("agent_b", config)
         assert result == "agent_a"
+
+    def test_dep_skipped_disposition_cleared_when_upstream_has_output(self, executor, mock_deps):
+        """Stale SKIPPED disposition on upstream with output is cleared — downstream proceeds."""
+        mock_deps.state_manager.is_failed.return_value = False
+        mock_deps.state_manager.is_skipped.return_value = False
+        storage = MagicMock()
+        storage.has_disposition.side_effect = lambda dep, disp, **kw: disp == DISPOSITION_SKIPPED
+        storage.list_target_files.return_value = ["batch_0.json"]
+        mock_deps.action_runner.storage_backend = storage
+
+        config = {"dependencies": ["agent_a"]}
+        result = executor._check_upstream_health("agent_b", config)
+        assert result is None
+        storage.clear_disposition.assert_called_once()
 
     def test_no_storage_backend_only_checks_state_manager(self, executor, mock_deps):
         """No storage backend — only checks state_manager."""
@@ -572,8 +587,9 @@ class TestResolveCompletionStatus:
 
     @patch("agent_actions.workflow.executor.fire_event")
     def test_returns_skipped_when_all_records_guard_skipped(self, mock_fire, executor, mock_deps):
-        """When pipeline sets DISPOSITION_SKIPPED at node level, status should be 'skipped'."""
+        """When pipeline sets DISPOSITION_SKIPPED at node level and no output exists, status should be 'skipped'."""
         mock_deps.action_runner.storage_backend.has_disposition.return_value = True
+        mock_deps.action_runner.storage_backend.list_target_files.return_value = []
         assert executor._resolve_completion_status("agent_a") == ActionStatus.SKIPPED
         mock_deps.action_runner.storage_backend.has_disposition.assert_called_once_with(
             "agent_a", DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
@@ -583,11 +599,27 @@ class TestResolveCompletionStatus:
     def test_guard_skipped_checked_before_failed_items(self, mock_fire, executor, mock_deps):
         """Guard-skipped disposition is checked before item-level failures."""
         mock_deps.action_runner.storage_backend.has_disposition.return_value = True
+        mock_deps.action_runner.storage_backend.list_target_files.return_value = []
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "timeout"}
         ]
         assert executor._resolve_completion_status("agent_a") == ActionStatus.SKIPPED
         mock_deps.action_runner.storage_backend.get_failed_items.assert_not_called()
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_stale_skipped_disposition_cleared_when_output_exists(
+        self, mock_fire, executor, mock_deps
+    ):
+        """A SKIPPED disposition is stale if the action produced output — clear it and return COMPLETED."""
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = True
+        mock_deps.action_runner.storage_backend.list_target_files.return_value = [
+            "combined_scraped.json"
+        ]
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = []
+        assert executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED
+        mock_deps.action_runner.storage_backend.clear_disposition.assert_called_once_with(
+            "agent_a", DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+        )
 
 
 class TestCircuitBreakerIgnoresPartial:
@@ -663,3 +695,82 @@ class TestGetFailedItems:
         items = backend.get_failed_items("action_a")
         assert len(items) == 2
         assert all(i["record_id"] != NODE_LEVEL_RECORD_ID for i in items)
+
+
+class TestStaleDispositionFullChain:
+    """Integration: stale SKIPPED disposition must not block downstream when output exists.
+
+    Reproduces the exact bug: action with no guard, upstream has record_limit,
+    action produces output but gets falsely marked as guard-skipped.
+    """
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_stale_skipped_on_upstream_does_not_block_downstream(
+        self, mock_fire, executor, mock_deps
+    ):
+        """Upstream has stale SKIPPED disposition + output → downstream proceeds."""
+        storage = MagicMock()
+        # Upstream "write_scenario_question" has stale SKIPPED disposition from prior run
+        # but also has output from the current run.
+        storage.has_disposition.side_effect = (
+            lambda dep, disp, **kw: dep == "write_scenario_question"
+            and disp == DISPOSITION_SKIPPED
+        )
+        storage.list_target_files.return_value = ["combined_scraped.json"]
+        mock_deps.action_runner.storage_backend = storage
+        mock_deps.state_manager.is_failed.return_value = False
+        mock_deps.state_manager.is_skipped.return_value = False
+
+        config = {"dependencies": ["write_scenario_question"]}
+        result = executor._check_upstream_health("add_answer_text", config)
+
+        # Downstream should NOT be blocked
+        assert result is None
+        # Stale disposition should have been cleared
+        storage.clear_disposition.assert_called_once_with(
+            "write_scenario_question", DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+        )
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_action_produces_output_but_has_stale_skipped_resolves_completed(
+        self, mock_fire, executor, mock_deps
+    ):
+        """Action runs, writes output, but stale SKIPPED disposition exists → COMPLETED."""
+        storage = MagicMock()
+        storage.has_disposition.return_value = True
+        storage.list_target_files.return_value = ["combined_scraped.json"]
+        storage.get_failed_items.return_value = []
+        mock_deps.action_runner.storage_backend = storage
+
+        status = executor._resolve_completion_status("add_answer_text")
+
+        assert status == ActionStatus.COMPLETED
+        storage.clear_disposition.assert_called_once_with(
+            "add_answer_text", DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+        )
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_limit_change_clears_dispositions_then_action_resolves_completed(
+        self, mock_fire, executor, mock_deps
+    ):
+        """Full chain: limit changes → status reset + dispositions cleared → action re-runs → COMPLETED."""
+        storage = MagicMock()
+        # Stale SKIPPED disposition from prior run
+        storage.has_disposition.return_value = False  # cleared by invalidation
+        storage.list_target_files.return_value = ["combined_scraped.json"]
+        storage.get_failed_items.return_value = []
+        mock_deps.action_runner.storage_backend = storage
+
+        # Step 1: limits changed → status reset + dispositions cleared
+        mock_deps.state_manager.get_status_details.return_value = {
+            "record_limit": 9, "file_limit": None,
+        }
+        new_status = executor._maybe_invalidate_completed_status(
+            "add_answer_text", {"record_limit": 2, "file_limit": None}, ActionStatus.COMPLETED
+        )
+        assert new_status == ActionStatus.PENDING
+        storage.clear_disposition.assert_called_once_with("add_answer_text")
+
+        # Step 2: action re-runs, produces output, resolves COMPLETED
+        status = executor._resolve_completion_status("add_answer_text")
+        assert status == ActionStatus.COMPLETED

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -316,6 +316,7 @@ class TestHandleRunSuccess:
     def test_guard_all_skipped_returns_skipped(self, executor, mock_deps):
         """When all records are guard-skipped, status should be 'skipped' and ActionSkipEvent fired."""
         mock_deps.action_runner.storage_backend.has_disposition.return_value = True
+        mock_deps.action_runner.storage_backend.list_target_files.return_value = []
         params = self._make_params()
 
         with patch("agent_actions.workflow.executor.fire_event") as mock_fire:
@@ -341,6 +342,7 @@ class TestHandleRunSuccess:
     def test_guard_all_skipped_records_in_run_tracker(self, executor, mock_deps):
         """Guard-all-skipped should record in run_tracker with skip_reason."""
         mock_deps.action_runner.storage_backend.has_disposition.return_value = True
+        mock_deps.action_runner.storage_backend.list_target_files.return_value = []
         executor.run_tracker = MagicMock()
         executor.run_id = "run-123"
         params = self._make_params()

--- a/tests/unit/workflow/test_limits.py
+++ b/tests/unit/workflow/test_limits.py
@@ -343,6 +343,58 @@ class TestLimitStatusInvalidation:
         assert result.status == ActionStatus.COMPLETED
         mock_deps.action_runner.run_action.assert_not_called()
 
+    def test_limits_changed_clears_dispositions(self, executor, mock_deps):
+        """When limits change, stale dispositions must be cleared alongside status reset."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.COMPLETED
+        mock_deps.state_manager.get_status_details.return_value = {
+            "status": ActionStatus.COMPLETED,
+            "record_limit": 10,
+            "file_limit": None,
+        }
+        storage = MagicMock()
+        mock_deps.action_runner.storage_backend = storage
+
+        result = executor._maybe_invalidate_completed_status(
+            "act_a", {"record_limit": 2, "file_limit": None}, ActionStatus.COMPLETED
+        )
+
+        assert result == ActionStatus.PENDING
+        storage.clear_disposition.assert_called_once_with("act_a")
+
+    def test_limits_unchanged_does_not_clear_dispositions(self, executor, mock_deps):
+        """When limits are unchanged, dispositions are untouched."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.COMPLETED
+        mock_deps.state_manager.get_status_details.return_value = {
+            "status": ActionStatus.COMPLETED,
+            "record_limit": 10,
+            "file_limit": None,
+        }
+        storage = MagicMock()
+        mock_deps.action_runner.storage_backend = storage
+
+        result = executor._maybe_invalidate_completed_status(
+            "act_a", {"record_limit": 10, "file_limit": None}, ActionStatus.COMPLETED
+        )
+
+        assert result == ActionStatus.COMPLETED
+        storage.clear_disposition.assert_not_called()
+
+    def test_limits_changed_no_storage_backend(self, executor, mock_deps):
+        """When limits change but no storage backend, status resets without error."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.COMPLETED
+        mock_deps.state_manager.get_status_details.return_value = {
+            "status": ActionStatus.COMPLETED,
+            "record_limit": 10,
+            "file_limit": None,
+        }
+        mock_deps.action_runner.storage_backend = None
+
+        result = executor._maybe_invalidate_completed_status(
+            "act_a", {"record_limit": 2, "file_limit": None}, ActionStatus.COMPLETED
+        )
+
+        assert result == ActionStatus.PENDING
+
     def test_no_limits_old_status_no_invalidation(self, executor, mock_deps):
         """Old status file without limit keys + config with no limits = no invalidation."""
         mock_deps.state_manager.get_status.return_value = ActionStatus.COMPLETED


### PR DESCRIPTION
## Summary
- Actions that produce output were incorrectly marked as "all records guard-skipped", blocking the entire downstream pipeline
- Root cause: stale `DISPOSITION_SKIPPED` entries in the SQLite database survived across runs and fooled `_resolve_completion_status`
- Four fixes close every path that creates or trusts stale dispositions:
  1. `_maybe_invalidate_completed_status` clears dispositions when resetting status due to limit config change
  2. `_resolve_completion_status` cross-checks output before trusting SKIPPED (warns if stale)
  3. `_check_upstream_health` cross-checks upstream output before cascade-blocking (warns if stale)
  4. `create_passthrough_output` uses `DISPOSITION_PASSTHROUGH` (not SKIPPED) when WHERE-clause skip wrote data

## Root cause
`DISPOSITION_SKIPPED` was overloaded to mean two things:
- "No data exists, block downstream" (guard filtered everything)
- "Processing was skipped but data passed through" (WHERE clause with passthrough)

`DISPOSITION_PASSTHROUGH` existed the whole time for the second meaning but was never used in the WHERE-clause path. Fix #4 uses the right disposition for the right case.

Fixes #2 and #3 are warning-level safety nets (not silent fixes) — they self-heal in production but log warnings so write-path bugs can be found.

## Verification
- 5697 tests pass, 6 new tests added
- `ruff check` and `ruff format --check` clean
- Tested: guard pre-filter 0 passed / 12 skipped does NOT cascade-block downstream
- Tested: stale SKIPPED from prior run is cleared when action has output
- Tested: limit config change clears dispositions before re-run