### PR TITLE
fix: reprompt batch reconciles missing records instead of silently dropping

### DIFF
--- a/.changes/unreleased/Bug Fix-20260422-076000.yaml
+++ b/.changes/unreleased/Bug Fix-20260422-076000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Reprompt batch reconciles submitted vs received records — missing records are exhausted, not silently dropped"
+time: 2026-04-22T07:60:00.000000Z

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.batch.services.retry_polling import (
     import_validation_module,
     wait_for_batch_completion,
@@ -314,6 +315,29 @@ def validate_and_reprompt(
                 break
 
             reprompt_results = provider.retrieve_results(batch_id, output_directory)
+
+            submitted_ids = {r.custom_id for r in still_failing}
+            received_ids = BatchResultReconciler.collect_result_custom_ids(reprompt_results)
+            dropped_ids = submitted_ids - received_ids
+
+            if dropped_ids:
+                logger.warning(
+                    "Reprompt batch %s: provider dropped %d of %d records: %s",
+                    batch_id,
+                    len(dropped_ids),
+                    len(submitted_ids),
+                    sorted(dropped_ids),
+                )
+                for r in still_failing:
+                    if r.custom_id in dropped_ids:
+                        if not r.recovery_metadata:
+                            r.recovery_metadata = RecoveryMetadata()
+                        r.recovery_metadata.reprompt = RepromptMetadata(
+                            attempts=reprompted_ids.get(r.custom_id, 1),
+                            passed=False,
+                            validation=validation_name,
+                        )
+                        all_graduated.append(r)
 
             failing_map = {r.custom_id: r for r in still_failing}
             for reprompt_result in reprompt_results:

--- a/tests/manual/repro_bug_05_reprompt_drops_records.py
+++ b/tests/manual/repro_bug_05_reprompt_drops_records.py
@@ -1,0 +1,173 @@
+"""Reproduce: reprompt batch silently drops records when provider returns fewer.
+
+Simulates validate_and_reprompt() with 10 records where 5 fail validation.
+The mock provider returns only 3 of the 5 resubmitted records (dropped 2).
+Before the fix, the 2 dropped records vanish from the final output entirely.
+After the fix, they appear with recovery metadata (passed=False).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent_actions.llm.providers.batch_base import BatchResult
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+NUM_RECORDS = 10
+FAIL_IDS = {"rec_003", "rec_005", "rec_006", "rec_008", "rec_009"}
+DROPPED_IDS = {"rec_006", "rec_009"}  # Provider will not return these
+RETURNED_IDS = FAIL_IDS - DROPPED_IDS  # rec_003, rec_005, rec_008
+
+
+def make_results():
+    return [
+        BatchResult(
+            custom_id=f"rec_{i:03d}",
+            content='{"answer": "bad"}'
+            if f"rec_{i:03d}" in FAIL_IDS
+            else f'{{"answer": "ok_{i}"}}',
+            success=True,
+        )
+        for i in range(NUM_RECORDS)
+    ]
+
+
+def make_context_map():
+    return {
+        f"rec_{i:03d}": {
+            "content": {"question": f"q_{i}"},
+            "user_content": f"original prompt {i}",
+            "target_id": f"rec_{i:03d}",
+        }
+        for i in range(NUM_RECORDS)
+    }
+
+
+def validation_func(content):
+    """Reject records whose content contains 'bad'."""
+    return "bad" not in str(content)
+
+
+# ---------------------------------------------------------------------------
+# Reproduce
+# ---------------------------------------------------------------------------
+
+
+def run():
+    from agent_actions.llm.batch.services.reprompt_ops import validate_and_reprompt
+
+    results = make_results()
+    context_map = make_context_map()
+    all_input_ids = {r.custom_id for r in results}
+
+    # Provider returns only RETURNED_IDS (drops DROPPED_IDS)
+    provider = MagicMock()
+    provider.submit_batch.return_value = ("batch_rp_1", "submitted")
+    provider.retrieve_results.return_value = [
+        BatchResult(custom_id=cid, content='{"answer": "fixed"}', success=True)
+        for cid in RETURNED_IDS
+    ]
+
+    mock_parse = MagicMock()
+    mock_parse.return_value = MagicMock(
+        validation_name="check_it",
+        max_attempts=2,
+        on_exhausted="return_last",
+    )
+
+    with (
+        patch(
+            "agent_actions.processing.recovery.reprompt.parse_reprompt_config",
+            mock_parse,
+        ),
+        patch(
+            "agent_actions.processing.recovery.validation.get_validation_function",
+            return_value=(validation_func, "fix it"),
+        ),
+        patch(
+            "agent_actions.processing.recovery.response_validator.build_validation_feedback",
+            return_value="Please fix",
+        ),
+        patch(
+            "agent_actions.processing.recovery.response_validator.resolve_feedback_strategies",
+            return_value=[],
+        ),
+        patch(
+            "agent_actions.llm.batch.services.reprompt_ops._load_source_data_for_reprompt",
+            return_value=None,
+        ),
+        patch(
+            "agent_actions.llm.batch.services.reprompt_ops.wait_for_batch_completion",
+            return_value="completed",
+        ),
+        patch(
+            "agent_actions.llm.batch.services.reprompt_ops.BatchStatus",
+        ) as MockBatchStatus,
+        patch("agent_actions.llm.batch.processing.preparator.BatchTaskPreparator") as MockPrep,
+    ):
+        MockBatchStatus.COMPLETED = "completed"
+        mock_prep = MockPrep.return_value
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [MagicMock() for _ in range(len(FAIL_IDS))]
+        mock_prep.prepare_tasks.return_value = mock_prepared
+
+        final = validate_and_reprompt(
+            action_indices={},
+            dependency_configs={},
+            storage_backend=None,
+            results=results,
+            provider=provider,
+            context_map=context_map,
+            output_directory="/tmp/out",
+            file_name="batch_1",
+            agent_config={"reprompt": {"validation": "check_it", "max_attempts": 2}},
+        )
+
+    final_ids = {r.custom_id for r in final}
+    missing = all_input_ids - final_ids
+
+    print(f"Input records:    {len(all_input_ids)} — {sorted(all_input_ids)}")
+    print(f"Output records:   {len(final_ids)} — {sorted(final_ids)}")
+    print(f"Missing records:  {len(missing)} — {sorted(missing)}")
+    print()
+
+    if missing:
+        print("BUG CONFIRMED: records silently dropped by reprompt batch")
+        print(f"  Dropped IDs: {sorted(missing)}")
+        print(f"  Expected dropped: {sorted(DROPPED_IDS)}")
+
+        # Compare with retry path (which does reconcile)
+        print()
+        print("The retry path uses BatchResultReconciler to detect missing records")
+        print("and builds exhausted recovery metadata. The reprompt path has none of this.")
+        return False
+    else:
+        # Check that dropped records have recovery metadata
+        dropped_with_metadata = []
+        for r in final:
+            if r.custom_id in DROPPED_IDS:
+                has_meta = (
+                    r.recovery_metadata
+                    and r.recovery_metadata.reprompt
+                    and not r.recovery_metadata.reprompt.passed
+                )
+                dropped_with_metadata.append((r.custom_id, has_meta))
+
+        print("FIX VERIFIED: all records present in output")
+        for cid, has_meta in dropped_with_metadata:
+            status = "has recovery metadata (passed=False)" if has_meta else "MISSING metadata"
+            print(f"  {cid}: {status}")
+
+        all_have_meta = all(m for _, m in dropped_with_metadata)
+        if all_have_meta:
+            print("\nAll dropped records correctly marked with recovery metadata.")
+            return True
+        else:
+            print("\nWARNING: some dropped records lack recovery metadata.")
+            return False
+
+
+if __name__ == "__main__":
+    ok = run()
+    raise SystemExit(0 if ok else 1)

--- a/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
+++ b/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
@@ -385,6 +385,277 @@ class TestSelectiveRepromptResubmission:
         assert accessed_ids == FAIL_IDS
 
 
+class TestRepromptDroppedRecordReconciliation:
+    """Prove that records dropped by the provider are detected, not silently lost."""
+
+    @patch("agent_actions.llm.batch.processing.preparator.BatchTaskPreparator")
+    def test_dropped_records_appear_in_output_with_metadata(self, MockPreparator):
+        """Provider returns 1 of 3 failed records — 2 dropped records appear
+        in output with reprompt recovery metadata (passed=False)."""
+        from agent_actions.llm.batch.services.reprompt_ops import validate_and_reprompt
+
+        results = _make_results(10, fail_ids=FAIL_IDS)
+        context_map = _make_context_map(10)
+
+        mock_prep = MockPreparator.return_value
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [MagicMock() for _ in range(3)]
+        mock_prep.prepare_tasks.return_value = mock_prepared
+
+        # Provider drops rec_007 and rec_009 — only returns rec_003
+        provider = MagicMock()
+        provider.submit_batch.return_value = ("batch_rp_1", "submitted")
+        provider.retrieve_results.return_value = [
+            BatchResult(custom_id="rec_003", content='{"answer": "fixed"}', success=True),
+        ]
+
+        with (
+            _reprompt_patches(),
+            patch(
+                "agent_actions.processing.recovery.validation.get_validation_function",
+                return_value=(_validation_func_for_bad_content, "fix it"),
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.wait_for_batch_completion",
+                return_value="completed",
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.BatchStatus",
+            ) as MockBatchStatus,
+        ):
+            MockBatchStatus.COMPLETED = "completed"
+            final = validate_and_reprompt(
+                action_indices={},
+                dependency_configs={},
+                storage_backend=None,
+                results=results,
+                provider=provider,
+                context_map=context_map,
+                output_directory="/tmp/out",
+                file_name="batch_1",
+                agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
+            )
+
+        final_ids = {r.custom_id for r in final}
+        input_ids = {r.custom_id for r in results}
+
+        # Every input record must appear in the output — none lost
+        assert final_ids == input_ids, f"Missing: {input_ids - final_ids}"
+
+        # Dropped records must have reprompt metadata with passed=False
+        dropped_ids = {"rec_007", "rec_009"}
+        for r in final:
+            if r.custom_id in dropped_ids:
+                assert r.recovery_metadata is not None, f"{r.custom_id} missing recovery_metadata"
+                assert r.recovery_metadata.reprompt is not None, (
+                    f"{r.custom_id} missing reprompt metadata"
+                )
+                assert r.recovery_metadata.reprompt.passed is False, (
+                    f"{r.custom_id} should be marked passed=False"
+                )
+                assert r.recovery_metadata.reprompt.validation == "check_it"
+
+    @patch("agent_actions.llm.batch.processing.preparator.BatchTaskPreparator")
+    def test_no_records_dropped_is_zero_diff(self, MockPreparator):
+        """When provider returns all records, behavior is identical to before the fix."""
+        from agent_actions.llm.batch.services.reprompt_ops import validate_and_reprompt
+
+        results = _make_results(10, fail_ids=FAIL_IDS)
+        context_map = _make_context_map(10)
+
+        mock_prep = MockPreparator.return_value
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [MagicMock() for _ in range(3)]
+        mock_prep.prepare_tasks.return_value = mock_prepared
+
+        # Provider returns ALL 3 failing records — none dropped
+        provider = MagicMock()
+        provider.submit_batch.return_value = ("batch_rp_1", "submitted")
+        provider.retrieve_results.return_value = [
+            BatchResult(custom_id=cid, content='{"answer": "fixed"}', success=True)
+            for cid in FAIL_IDS
+        ]
+
+        with (
+            _reprompt_patches(),
+            patch(
+                "agent_actions.processing.recovery.validation.get_validation_function",
+                return_value=(_validation_func_for_bad_content, "fix it"),
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.wait_for_batch_completion",
+                return_value="completed",
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.BatchStatus",
+            ) as MockBatchStatus,
+        ):
+            MockBatchStatus.COMPLETED = "completed"
+            final = validate_and_reprompt(
+                action_indices={},
+                dependency_configs={},
+                storage_backend=None,
+                results=results,
+                provider=provider,
+                context_map=context_map,
+                output_directory="/tmp/out",
+                file_name="batch_1",
+                agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
+            )
+
+        final_ids = {r.custom_id for r in final}
+        input_ids = {r.custom_id for r in results}
+        assert final_ids == input_ids
+
+        # Every reprompted record must have passed=True metadata
+        for r in final:
+            if r.custom_id in FAIL_IDS:
+                assert r.recovery_metadata is not None, f"{r.custom_id} missing recovery_metadata"
+                assert r.recovery_metadata.reprompt is not None, (
+                    f"{r.custom_id} missing reprompt metadata"
+                )
+                assert r.recovery_metadata.reprompt.passed is True, (
+                    f"{r.custom_id} should be marked passed=True"
+                )
+
+    @patch("agent_actions.llm.batch.processing.preparator.BatchTaskPreparator")
+    def test_all_records_dropped_all_exhausted(self, MockPreparator):
+        """Provider drops every record — all end up in output with passed=False."""
+        from agent_actions.llm.batch.services.reprompt_ops import validate_and_reprompt
+
+        fail_ids = {"rec_001", "rec_002"}
+        results = _make_results(5, fail_ids=fail_ids)
+        context_map = _make_context_map(5)
+
+        mock_prep = MockPreparator.return_value
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [MagicMock() for _ in range(2)]
+        mock_prep.prepare_tasks.return_value = mock_prepared
+
+        # Provider returns NOTHING
+        provider = MagicMock()
+        provider.submit_batch.return_value = ("batch_rp_1", "submitted")
+        provider.retrieve_results.return_value = []
+
+        with (
+            _reprompt_patches(),
+            patch(
+                "agent_actions.processing.recovery.validation.get_validation_function",
+                return_value=(_validation_func_for_bad_content, "fix it"),
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.wait_for_batch_completion",
+                return_value="completed",
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.BatchStatus",
+            ) as MockBatchStatus,
+        ):
+            MockBatchStatus.COMPLETED = "completed"
+            final = validate_and_reprompt(
+                action_indices={},
+                dependency_configs={},
+                storage_backend=None,
+                results=results,
+                provider=provider,
+                context_map=context_map,
+                output_directory="/tmp/out",
+                file_name="batch_1",
+                agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
+            )
+
+        final_ids = {r.custom_id for r in final}
+        input_ids = {r.custom_id for r in results}
+        assert final_ids == input_ids, f"Missing: {input_ids - final_ids}"
+
+        # Both dropped records marked as failed
+        for r in final:
+            if r.custom_id in fail_ids:
+                assert r.recovery_metadata is not None
+                assert r.recovery_metadata.reprompt is not None
+                assert r.recovery_metadata.reprompt.passed is False
+
+    @patch("agent_actions.llm.batch.processing.preparator.BatchTaskPreparator")
+    def test_dropped_records_not_counted_twice(self, MockPreparator):
+        """Dropped records go to all_graduated only — not also to active_results.
+
+        If a dropped record leaked into active_results it would be re-validated
+        and could be counted in both graduated and active pools.
+        """
+        from agent_actions.llm.batch.services.reprompt_ops import validate_and_reprompt
+
+        fail_ids = {"rec_001", "rec_002", "rec_003"}
+        dropped_id = "rec_002"
+        results = _make_results(5, fail_ids=fail_ids)
+        context_map = _make_context_map(5)
+
+        mock_prep = MockPreparator.return_value
+        mock_prepared = MagicMock()
+        mock_prepared.tasks = [MagicMock() for _ in range(3)]
+        mock_prep.prepare_tasks.return_value = mock_prepared
+
+        # Attempt 1: provider drops rec_002, returns rec_001 and rec_003 (still bad)
+        # Attempt 2: provider returns rec_001 and rec_003 fixed
+        provider_retrieve_side_effects = [
+            # Attempt 1: drop rec_002
+            [
+                BatchResult(custom_id="rec_001", content='{"answer": "bad"}', success=True),
+                BatchResult(custom_id="rec_003", content='{"answer": "bad"}', success=True),
+            ],
+            # Attempt 2: both pass
+            [
+                BatchResult(custom_id="rec_001", content='{"answer": "fixed"}', success=True),
+                BatchResult(custom_id="rec_003", content='{"answer": "fixed"}', success=True),
+            ],
+        ]
+
+        provider = MagicMock()
+        provider.submit_batch.return_value = ("batch_rp", "submitted")
+        provider.retrieve_results.side_effect = provider_retrieve_side_effects
+
+        with (
+            _reprompt_patches(),
+            patch(
+                "agent_actions.processing.recovery.validation.get_validation_function",
+                return_value=(_validation_func_for_bad_content, "fix it"),
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.wait_for_batch_completion",
+                return_value="completed",
+            ),
+            patch(
+                "agent_actions.llm.batch.services.reprompt_ops.BatchStatus",
+            ) as MockBatchStatus,
+        ):
+            MockBatchStatus.COMPLETED = "completed"
+            final = validate_and_reprompt(
+                action_indices={},
+                dependency_configs={},
+                storage_backend=None,
+                results=results,
+                provider=provider,
+                context_map=context_map,
+                output_directory="/tmp/out",
+                file_name="batch_1",
+                agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
+            )
+
+        final_ids = [r.custom_id for r in final]
+        input_ids = {r.custom_id for r in results}
+
+        # All records present
+        assert set(final_ids) == input_ids
+
+        # No duplicate IDs in output
+        assert len(final_ids) == len(set(final_ids)), f"Duplicate IDs in output: {final_ids}"
+
+        # rec_002 is marked as dropped (passed=False)
+        rec_002 = [r for r in final if r.custom_id == dropped_id][0]
+        assert rec_002.recovery_metadata is not None
+        assert rec_002.recovery_metadata.reprompt is not None
+        assert rec_002.recovery_metadata.reprompt.passed is False
+
+
 class TestCheckAndSubmitRepromptSelectivity:
     """check_and_submit_reprompt only submits failed records."""
 


### PR DESCRIPTION
## Summary
- After reprompt batch results are retrieved, reconcile submitted vs received custom_ids — records the provider dropped are added to the graduated pool with `RepromptMetadata(passed=False)` and a warning is logged
- Reuses `BatchResultReconciler.collect_result_custom_ids()` from the retry path for consistency
- Previously `active_results = reprompt_results` replaced the failing set wholesale — missing records vanished from both `all_graduated` and `active_results`

## Verification
- `python tests/manual/repro_bug_05_reprompt_drops_records.py` confirms bug (exit 1 before fix, exit 0 after)
- 4 new regression tests in `TestRepromptDroppedRecordReconciliation`:
  - `test_dropped_records_appear_in_output_with_metadata` — 2 of 3 dropped, both in output with `passed=False`
  - `test_no_records_dropped_is_zero_diff` — zero-diff when provider returns all
  - `test_all_records_dropped_all_exhausted` — provider returns nothing, all exhausted
  - `test_dropped_records_not_counted_twice` — multi-attempt, dropped record not duplicated
- `ruff format --check` clean
- `ruff check` clean
- `pytest` — 5695 passed, 2 skipped