### PR TITLE
fix: version consumption merge delivers data to FILE mode tools

### DIFF
--- a/.changes/unreleased/Bug Fix-20260422-075000.yaml
+++ b/.changes/unreleased/Bug Fix-20260422-075000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Version consumption merge now delivers data correctly to FILE mode tool actions"
+time: 2026-04-22T07:50:00.000000Z

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -17,5 +17,5 @@ loaders for cataloging prompts at documentation time.
 | `scope_application.py` | Module | Context scope application: observe/passthrough/drop filtering, LLM context formatting. | `preprocessing` |
 | `scope_namespace.py` | Module | Namespace enrichment, historical data loading, field filtering, and allowed-fields extraction. | `preprocessing` |
 | `scope_builder.py` | Module | `build_field_context_with_history`: assembles source/dependency/version/workflow namespaces. | `preprocessing` |
-| `scope_file_mode.py` | Module | File-mode observe filtering with cross-namespace resolution and ancestry-aware caching. | `preprocessing` |
+| `scope_file_mode.py` | Module | File-mode observe filtering with cross-namespace resolution, version namespace detection, and ancestry-aware caching. | `preprocessing` |
 | `static_loader.py` | Module | Static prompt loader used during docs generation to read prompt store files. | `tooling.docs`, `file_io` |

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -11,6 +11,7 @@ from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
 from agent_actions.prompt.context.scope_inference import infer_dependencies
 from agent_actions.prompt.context.scope_namespace import (
+    _detect_version_namespaces,
     _extract_content_data,
     _load_historical_node,
 )
@@ -260,14 +261,43 @@ def apply_observe_for_file_mode(
             # explicit dependencies there is no reliable way to distinguish
             # input-source keys from metadata.  has_reliable_ns stays False.
             sample = data[0]
+            sample_content_val = sample.get("content")
             sample_content = (
-                sample.get("content", sample) if isinstance(sample.get("content"), dict) else sample
+                sample_content_val
+                if isinstance(sample_content_val, dict) and sample_content_val
+                else sample
             )
             input_source_names = set(sample_content.keys())
+
+    # Detect version-correlated namespaces in record content.
+    # When upstream used version_consumption with merge pattern, records
+    # contain nested dicts keyed by version action names (e.g.,
+    # {"gen_code_1": {"code": "..."}, "gen_code_2": {"code": "..."}}).
+    # These must be resolved from content directly — historical lookup
+    # fails because version keys aren't ancestor nodes in the lineage.
+    version_ns_in_content: set[str] = set()
+    if data and isinstance(data[0], dict):
+        sample = data[0]
+        sample_content = (
+            sample.get("content", sample)
+            if isinstance(sample.get("content"), dict) and sample.get("content")
+            else sample
+        )
+        if sample_content:
+            ref_namespaces = [ns for ns, _, _ in resolved]
+            detected = _detect_version_namespaces(sample_content, ref_namespaces)
+            version_ns_in_content = set(detected)
+            if version_ns_in_content:
+                logger.debug(
+                    "[FILE OBSERVE] Detected version namespaces in content: %s",
+                    version_ns_in_content,
+                )
 
     # Determine which namespaces need cross-namespace loading.
     # "source" is always a known cross-namespace ref (loaded from
     # source_data, not historical lookups) so it is always eligible.
+    # Version namespaces detected in content are resolved directly from
+    # the record (not via historical lookup), so they skip needed_ns.
     # Other namespaces require has_reliable_ns because when
     # input_source_names contains content keys (heuristic), the
     # `ns not in input_source_names` check would misclassify every
@@ -277,6 +307,8 @@ def apply_observe_for_file_mode(
     for ns, _field, _ in resolved:
         if ns == "source":
             needed_ns.add(ns)
+        elif ns in version_ns_in_content:
+            pass  # Resolved from content directly, not historical lookup
         elif has_reliable_ns and ns not in input_source_names:
             needed_ns.add(ns)
 
@@ -292,9 +324,8 @@ def apply_observe_for_file_mode(
     # Historical lookups depend on source_guid + lineage + parent/root target IDs,
     # so the cache key must include all discriminators to avoid returning stale
     # data when records share a source_guid but diverge in ancestry.
-    # Fast path: no cross-namespace refs to resolve — return data unmodified.
-    # Copies and per-record loops are only needed when injecting cross-ns data.
-    if not needed_ns:
+    # Fast path: no cross-namespace refs AND no version namespaces to resolve.
+    if not needed_ns and not version_ns_in_content:
         return data
 
     cross_ns_cache: dict[tuple, dict[str, dict]] = {}
@@ -304,7 +335,11 @@ def apply_observe_for_file_mode(
             filtered.append(item)  # type: ignore[unreachable]
             continue
 
-        content = item.get("content", item) if isinstance(item.get("content"), dict) else item
+        # Extract content, guarding against the empty-content trap:
+        # item.get("content", item) returns {} when content exists but is
+        # empty, instead of falling back to item.  Check for non-empty dict.
+        content_val = item.get("content")
+        content = content_val if isinstance(content_val, dict) and content_val else item
 
         # Resolve cross-namespace data (cached by ancestry key).
         sguid = item.get("source_guid")
@@ -326,6 +361,16 @@ def apply_observe_for_file_mode(
                 storage_backend=storage_backend,
             )
         cross_ns_data = cross_ns_cache[cache_key]
+
+        # Inject version namespace data directly from record content.
+        # Version-correlated records have nested dicts that must be
+        # resolved here — not via historical lookup (which fails for
+        # version keys).  Work on a copy to avoid mutating the cache.
+        if version_ns_in_content:
+            cross_ns_data = dict(cross_ns_data)
+            for vns in version_ns_in_content:
+                if vns in content and isinstance(content[vns], dict):
+                    cross_ns_data[vns] = content[vns]
 
         # NiFi-inspired: enrich the record rather than stripping to a flat
         # dict.  Shallow-copy record + content to avoid mutating caller's

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -278,11 +278,8 @@ def apply_observe_for_file_mode(
     version_ns_in_content: set[str] = set()
     if data and isinstance(data[0], dict):
         sample = data[0]
-        sample_content = (
-            sample.get("content", sample)
-            if isinstance(sample.get("content"), dict) and sample.get("content")
-            else sample
-        )
+        sample_cv = sample.get("content")
+        sample_content = sample_cv if isinstance(sample_cv, dict) and sample_cv else sample
         if sample_content:
             ref_namespaces = [ns for ns, _, _ in resolved]
             detected = _detect_version_namespaces(sample_content, ref_namespaces)

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -11,6 +11,7 @@ from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
 from agent_actions.prompt.context.scope_inference import infer_dependencies
 from agent_actions.prompt.context.scope_namespace import (
+    _RECORD_METADATA_KEYS,
     _detect_version_namespaces,
     _extract_content_data,
     _load_historical_node,
@@ -265,7 +266,7 @@ def apply_observe_for_file_mode(
             sample_content = (
                 sample_content_val
                 if isinstance(sample_content_val, dict) and sample_content_val
-                else sample
+                else {k: v for k, v in sample.items() if k not in _RECORD_METADATA_KEYS}
             )
             input_source_names = set(sample_content.keys())
 
@@ -279,7 +280,11 @@ def apply_observe_for_file_mode(
     if data and isinstance(data[0], dict):
         sample = data[0]
         sample_cv = sample.get("content")
-        sample_content = sample_cv if isinstance(sample_cv, dict) and sample_cv else sample
+        sample_content = (
+            sample_cv
+            if isinstance(sample_cv, dict) and sample_cv
+            else {k: v for k, v in sample.items() if k not in _RECORD_METADATA_KEYS}
+        )
         if sample_content:
             ref_namespaces = [ns for ns, _, _ in resolved]
             detected = _detect_version_namespaces(sample_content, ref_namespaces)
@@ -334,9 +339,15 @@ def apply_observe_for_file_mode(
 
         # Extract content, guarding against the empty-content trap:
         # item.get("content", item) returns {} when content exists but is
-        # empty, instead of falling back to item.  Check for non-empty dict.
+        # empty, instead of falling back to item.  Filter metadata keys
+        # from the fallback to prevent infrastructure fields from leaking
+        # into enriched_content (source_guid, lineage, node_id, etc.).
         content_val = item.get("content")
-        content = content_val if isinstance(content_val, dict) and content_val else item
+        content = (
+            content_val
+            if isinstance(content_val, dict) and content_val
+            else {k: v for k, v in item.items() if k not in _RECORD_METADATA_KEYS}
+        )
 
         # Resolve cross-namespace data (cached by ancestry key).
         sguid = item.get("source_guid")

--- a/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
+++ b/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
@@ -208,6 +208,15 @@ for key, data in content.items():
         scores.append(data.get("overall_score", 0))
 ```
 
+When observe uses wildcards (`score_quality.*`), fields are also expanded as qualified flat keys alongside the nested dicts:
+
+```python
+# With observe: [score_quality_1.*, score_quality_2.*]
+# Both access patterns work:
+score = content.get("score_quality_1", {}).get("overall_score")  # nested dict
+score = content.get("score_quality_1.overall_score")              # expanded key
+```
+
 ### Seed data
 
 Seed data lives under the `seed` namespace:

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -562,7 +562,12 @@ def apply_observe_filter(data: list[dict], agent_config: ActionConfigDict) -> li
         if not isinstance(item, dict):
             filtered.append(item)  # type: ignore[unreachable]
             continue
-        content = item.get("content", item) if isinstance(item.get("content"), dict) else item
+        content_val = item.get("content")
+        content = (
+            content_val
+            if isinstance(content_val, dict) and content_val
+            else {k: v for k, v in item.items() if k not in _TOOL_RESERVED_FIELDS}
+        )
         ordered = {ok: content[bk] for ok, bk in key_pairs if bk in content}
         missing = [bk for _, bk in key_pairs if bk not in content]
         if missing:

--- a/docs.agent-actions/docs/reference/execution/versions.md
+++ b/docs.agent-actions/docs/reference/execution/versions.md
@@ -151,7 +151,7 @@ for key, data in content.items():
         results.append(data)
 ```
 
-When observe uses wildcards (`extract_raw_qa.*`), fields are also expanded as qualified flat keys (`extract_raw_qa_1.field`, `extract_raw_qa_2.field`) alongside the nested dicts. Both access patterns work.
+When observe uses wildcards (`extract_raw_qa.*`), fields are also expanded as qualified flat keys (`extract_raw_qa_1.questions`, `extract_raw_qa_2.questions`) alongside the nested dicts. Both access patterns work.
 
 ## Common Patterns
 

--- a/docs.agent-actions/docs/reference/execution/versions.md
+++ b/docs.agent-actions/docs/reference/execution/versions.md
@@ -102,30 +102,30 @@ Downstream actions consume outputs from all version iterations. The `version_con
 
 ### merge (Fan-In)
 
-The most common pattern. All version outputs are collected into a single record, keyed by version name (e.g., `extract_raw_qa_1`, `extract_raw_qa_2`). Use this for aggregation, voting, and consensus:
+The most common pattern. All version outputs are collected into a single record, keyed by version name (e.g., `score_quality_1`, `score_quality_2`). Use this for aggregation, voting, and consensus:
 
 ```yaml
-- name: extract_raw_qa
+- name: score_quality
   versions:
     range: [1, 3]
 
-- name: flatten_questions
-  dependencies: [extract_raw_qa]
+- name: aggregate_scores
+  dependencies: [score_quality]
   version_consumption:
-    source: extract_raw_qa
+    source: score_quality
     pattern: merge
   context_scope:
     observe:
-      - extract_raw_qa.*  # Wildcard reference
+      - score_quality.*  # Wildcard reference
 ```
 
 Outputs are merged as nested namespaces:
 
 ```json
 {
-  "extract_raw_qa_1": {"questions": ["Q1a", "Q1b"]},
-  "extract_raw_qa_2": {"questions": ["Q2a", "Q2b"]},
-  "extract_raw_qa_3": {"questions": ["Q3a", "Q3b"]}
+  "score_quality_1": {"overall_score": 8, "confidence": 0.9},
+  "score_quality_2": {"overall_score": 7, "confidence": 0.85},
+  "score_quality_3": {"overall_score": 9, "confidence": 0.95}
 }
 ```
 
@@ -133,25 +133,25 @@ Access in prompts (LLM actions):
 
 ```yaml
 prompt: |
-  Strategy 1: {{ extract_raw_qa_1.questions }}
-  Strategy 2: {{ extract_raw_qa_2.questions }}
+  Scorer 1: {{ score_quality_1.overall_score }}
+  Scorer 2: {{ score_quality_2.overall_score }}
 ```
 
 Access in tool UDFs (FILE mode):
 
 ```python
 # Each version is a nested dict in content
-version_1 = content.get("extract_raw_qa_1", {})
-version_2 = content.get("extract_raw_qa_2", {})
+scorer_1 = content.get("score_quality_1", {})
+scorer_2 = content.get("score_quality_2", {})
 
 # Iterate all versions dynamically
-results = []
+scores = []
 for key, data in content.items():
-    if key.startswith("extract_raw_qa_") and isinstance(data, dict):
-        results.append(data)
+    if key.startswith("score_quality_") and isinstance(data, dict):
+        scores.append(data.get("overall_score", 0))
 ```
 
-When observe uses wildcards (`extract_raw_qa.*`), fields are also expanded as qualified flat keys (`extract_raw_qa_1.questions`, `extract_raw_qa_2.questions`) alongside the nested dicts. Both access patterns work.
+When observe uses wildcards (`score_quality.*`), fields are also expanded as qualified flat keys (`score_quality_1.overall_score`, `score_quality_2.overall_score`) alongside the nested dicts. Both access patterns work.
 
 ## Common Patterns
 

--- a/docs.agent-actions/docs/reference/execution/versions.md
+++ b/docs.agent-actions/docs/reference/execution/versions.md
@@ -129,13 +129,29 @@ Outputs are merged as nested namespaces:
 }
 ```
 
-Access in prompts:
+Access in prompts (LLM actions):
 
 ```yaml
 prompt: |
   Strategy 1: {{ extract_raw_qa_1.questions }}
   Strategy 2: {{ extract_raw_qa_2.questions }}
 ```
+
+Access in tool UDFs (FILE mode):
+
+```python
+# Each version is a nested dict in content
+version_1 = content.get("extract_raw_qa_1", {})
+version_2 = content.get("extract_raw_qa_2", {})
+
+# Iterate all versions dynamically
+results = []
+for key, data in content.items():
+    if key.startswith("extract_raw_qa_") and isinstance(data, dict):
+        results.append(data)
+```
+
+When observe uses wildcards (`extract_raw_qa.*`), fields are also expanded as qualified flat keys (`extract_raw_qa_1.field`, `extract_raw_qa_2.field`) alongside the nested dicts. Both access patterns work.
 
 ## Common Patterns
 

--- a/tests/manual/repro_bug_03_version_merge_tool.py
+++ b/tests/manual/repro_bug_03_version_merge_tool.py
@@ -1,0 +1,246 @@
+"""Reproduction script for version_consumption merge bug in FILE mode tools.
+
+Bug 1: apply_observe_for_file_mode fails to expand version namespace fields
+       because it either takes the fast path (skipping wildcard expansion) or
+       tries historical lookup (which fails — version keys aren't ancestors).
+       LLM actions work because build_field_context_with_history uses
+       _detect_version_namespaces() which the FILE mode path lacks.
+
+Bug 2: data.get("content", data) returns {} when content key exists but is
+       empty, instead of falling back to the full record.
+
+Run:  python tests/manual/repro_bug_03_version_merge_tool.py
+Expected: FAIL before fix, PASS after fix.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+sys.path.insert(0, project_root)
+
+from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode
+
+
+def test_version_wildcard_expansion():
+    """Bug 1a: Wildcard observe on version namespaces not expanded."""
+    # Simulated version-correlated merged data (3 version sources).
+    # This is what VersionOutputCorrelator._merge_with_pattern produces.
+    data = [
+        {
+            "source_guid": "sg-001",
+            "node_id": "node-1",
+            "content": {
+                "gen_code_1": {"code": "def foo(): pass", "language": "python"},
+                "gen_code_2": {"code": "function bar() {}", "language": "javascript"},
+                "gen_code_3": {"code": "fn baz() {}", "language": "rust"},
+            },
+            "lineage": ["lineage-1"],
+        }
+    ]
+
+    agent_config = {
+        "name": "aggregate",
+        "dependencies": ["gen_code_1", "gen_code_2", "gen_code_3"],
+        "context_scope": {
+            "observe": ["gen_code_1.*", "gen_code_2.*", "gen_code_3.*"],
+        },
+    }
+
+    agent_indices = {
+        "source": 0,
+        "gen_code_1": 1,
+        "gen_code_2": 2,
+        "gen_code_3": 3,
+        "aggregate": 4,
+    }
+
+    # Patch historical loader to avoid filesystem access — it's irrelevant here
+    # because version data lives in the record content, not in historical files.
+    with patch(
+        "agent_actions.prompt.context.scope_file_mode._load_historical_node",
+        return_value=None,
+    ):
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=agent_config,
+            agent_name="aggregate",
+            agent_indices=agent_indices,
+            file_path="/tmp/test.json",
+        )
+
+    content = result[0].get("content", result[0])
+
+    # With multiple wildcard namespaces, observe should expand to qualified keys:
+    #   gen_code_1.code, gen_code_1.language, gen_code_2.code, etc.
+    has_expanded_keys = "gen_code_1.code" in content or "gen_code_1.language" in content
+
+    if not has_expanded_keys:
+        print("BUG 1a CONFIRMED: Wildcard expansion did not produce qualified keys")
+        print(f"  content keys: {sorted(content.keys())}")
+        print("  Expected: gen_code_1.code, gen_code_1.language, gen_code_2.code, ...")
+        return False
+
+    print("BUG 1a FIXED: Wildcards correctly expanded from version namespace content")
+    print(f"  content keys: {sorted(content.keys())}")
+    return True
+
+
+def test_version_specific_field_resolution():
+    """Bug 1b: Specific field observe on version namespaces not resolved."""
+    data = [
+        {
+            "source_guid": "sg-001",
+            "node_id": "node-1",
+            "content": {
+                "gen_code_1": {"code": "def foo(): pass", "language": "python"},
+                "gen_code_2": {"code": "function bar() {}", "language": "javascript"},
+            },
+            "lineage": ["lineage-1"],
+        }
+    ]
+
+    agent_config = {
+        "name": "aggregate",
+        "dependencies": ["gen_code_1", "gen_code_2"],
+        "context_scope": {
+            "observe": ["gen_code_1.code", "gen_code_2.code"],
+        },
+    }
+
+    agent_indices = {
+        "source": 0,
+        "gen_code_1": 1,
+        "gen_code_2": 2,
+        "aggregate": 3,
+    }
+
+    with patch(
+        "agent_actions.prompt.context.scope_file_mode._load_historical_node",
+        return_value=None,
+    ):
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=agent_config,
+            agent_name="aggregate",
+            agent_indices=agent_indices,
+            file_path="/tmp/test.json",
+        )
+
+    content = result[0].get("content", result[0])
+
+    # "code" collides across namespaces → qualified keys: gen_code_1.code, gen_code_2.code
+    has_resolved = "gen_code_1.code" in content or "gen_code_2.code" in content
+
+    if not has_resolved:
+        print("BUG 1b CONFIRMED: Specific version namespace fields not resolved")
+        print(f"  content keys: {sorted(content.keys())}")
+        print("  Expected: gen_code_1.code, gen_code_2.code")
+        return False
+
+    # Verify values are correct
+    assert content.get("gen_code_1.code") == "def foo(): pass", (
+        f"gen_code_1.code mismatch: {content.get('gen_code_1.code')}"
+    )
+    assert content.get("gen_code_2.code") == "function bar() {}", (
+        f"gen_code_2.code mismatch: {content.get('gen_code_2.code')}"
+    )
+
+    print("BUG 1b FIXED: Specific version fields correctly resolved")
+    print(f"  gen_code_1.code = {content['gen_code_1.code']!r}")
+    print(f"  gen_code_2.code = {content['gen_code_2.code']!r}")
+    return True
+
+
+def test_content_empty_fallback_trap():
+    """Bug 2: Empty content {} should fall back to item-level keys.
+
+    Previously, scope_file_mode.py used:
+        content = item.get("content", item) if isinstance(item.get("content"), dict) else item
+    which returns {} when content exists but is empty, instead of falling
+    back to item.  The fix checks for non-empty dict before accepting content.
+
+    Uses a source.* observe ref so the per-record loop runs (not fast path).
+    """
+    source_data = [{"source_guid": "sg-001", "content": {"url": "https://example.com"}}]
+
+    # Record with empty content wrapper but meaningful top-level data.
+    data = [
+        {
+            "source_guid": "sg-001",
+            "node_id": "node-1",
+            "content": {},
+            "question": "What is 2+2?",
+            "lineage": ["lineage-1"],
+        }
+    ]
+
+    agent_config = {
+        "name": "downstream",
+        "dependencies": ["upstream"],
+        "context_scope": {
+            "observe": ["source.url", "upstream.question"],
+        },
+    }
+
+    agent_indices = {"source": 0, "upstream": 1, "downstream": 2}
+
+    with patch(
+        "agent_actions.prompt.context.scope_file_mode._load_historical_node",
+        return_value=None,
+    ):
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=agent_config,
+            agent_name="downstream",
+            agent_indices=agent_indices,
+            file_path="/tmp/test.json",
+            source_data=source_data,
+        )
+
+    result_item = result[0]
+    content = result_item.get("content", {})
+
+    # The old code extracted content={} from the record and never found
+    # "question" during field resolution.  The fix falls back to the full
+    # item when content is empty, making "question" visible.
+    if isinstance(content, dict) and "question" in content:
+        print("BUG 2 FIXED: Empty content falls back to item-level keys")
+        print(f"  content has 'question': {content.get('question')!r}")
+        print(f"  content has 'url' (from source): {content.get('url')!r}")
+        return True
+
+    print("BUG 2 CONFIRMED: Empty content did not fall back to item-level keys")
+    print(f"  content keys: {sorted(content.keys()) if isinstance(content, dict) else 'NOT DICT'}")
+    return False
+
+
+def main():
+    print("=" * 70)
+    print("Reproduction: version_consumption merge bug in FILE mode tools")
+    print("=" * 70)
+
+    results = []
+
+    print("\n--- Bug 1a: Wildcard expansion on version namespaces ---")
+    results.append(test_version_wildcard_expansion())
+
+    print("\n--- Bug 1b: Specific field resolution on version namespaces ---")
+    results.append(test_version_specific_field_resolution())
+
+    print("\n--- Bug 2: Empty content fallback trap ---")
+    results.append(test_content_empty_fallback_trap())
+
+    print("\n" + "=" * 70)
+    if all(results):
+        print("ALL TESTS PASS — bugs are fixed")
+        return 0
+    else:
+        failed = sum(1 for r in results if not r)
+        print(f"{failed} bug(s) still present")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -1003,6 +1003,10 @@ class TestVersionNamespaceObserve:
         assert content["url"] == "https://ex.com"
         # upstream.question from item-level fallback (content was empty)
         assert content["question"] == "Q?"
+        # Metadata keys must NOT leak into enriched content
+        assert "source_guid" not in content
+        assert "lineage" not in content
+        assert "node_id" not in content
 
     def test_non_version_input_source_not_treated_as_version_ns(self):
         """Non-version input source keys in content are NOT treated as version namespaces.

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -643,3 +643,393 @@ class TestApplyObserveForFileMode:
         assert result[1]["content"]["label"] == "label-B"
         # Two separate loads — different ancestry despite same source_guid.
         assert call_count[0] == 2
+
+
+# -----------------------------------------------------------------------
+# Version namespace detection and injection (version_consumption merge)
+# -----------------------------------------------------------------------
+
+
+class TestVersionNamespaceObserve:
+    """Tests for version-correlated namespace resolution in FILE mode.
+
+    When upstream actions use version_consumption with merge pattern,
+    records contain nested dicts keyed by version action names. The
+    observe filter must detect these and resolve fields from content
+    directly — not via historical lookup (which fails for version keys).
+    """
+
+    def _make_merged_data(self, version_count=3):
+        """Create version-correlated merged data as VersionOutputCorrelator produces."""
+        content = {}
+        for i in range(1, version_count + 1):
+            content[f"gen_code_{i}"] = {
+                "code": f"code_{i}",
+                "language": f"lang_{i}",
+            }
+        return [
+            {
+                "source_guid": "sg-001",
+                "node_id": "node-1",
+                "content": content,
+                "lineage": ["lineage-1"],
+            }
+        ]
+
+    def test_wildcard_expansion_from_version_namespaces(self):
+        """Wildcards on version namespaces expand to qualified keys from content."""
+        data = self._make_merged_data(3)
+        config = {
+            "dependencies": ["gen_code_1", "gen_code_2", "gen_code_3"],
+            "context_scope": {
+                "observe": ["gen_code_1.*", "gen_code_2.*", "gen_code_3.*"],
+            },
+        }
+        indices = {
+            "source": 0,
+            "gen_code_1": 1,
+            "gen_code_2": 2,
+            "gen_code_3": 3,
+            "aggregate": 4,
+        }
+
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="aggregate",
+            agent_indices=indices,
+            file_path="/tmp/test.json",
+        )
+
+        content = result[0]["content"]
+        # Multiple wildcard namespaces → qualified keys (ns.field)
+        assert content["gen_code_1.code"] == "code_1"
+        assert content["gen_code_1.language"] == "lang_1"
+        assert content["gen_code_2.code"] == "code_2"
+        assert content["gen_code_3.language"] == "lang_3"
+
+    def test_specific_field_resolution_from_version_namespaces(self):
+        """Specific field refs resolve from version namespace content."""
+        data = self._make_merged_data(2)
+        config = {
+            "dependencies": ["gen_code_1", "gen_code_2"],
+            "context_scope": {
+                "observe": ["gen_code_1.code", "gen_code_2.code"],
+            },
+        }
+        indices = {
+            "source": 0,
+            "gen_code_1": 1,
+            "gen_code_2": 2,
+            "aggregate": 3,
+        }
+
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="aggregate",
+            agent_indices=indices,
+            file_path="/tmp/test.json",
+        )
+
+        content = result[0]["content"]
+        # "code" collides across namespaces → qualified keys
+        assert content["gen_code_1.code"] == "code_1"
+        assert content["gen_code_2.code"] == "code_2"
+
+    def test_version_ns_does_not_trigger_historical_lookup(self):
+        """Version namespaces in content must NOT attempt historical lookup."""
+        data = self._make_merged_data(2)
+        config = {
+            "dependencies": ["gen_code_1", "gen_code_2"],
+            "context_scope": {
+                "observe": ["gen_code_1.*", "gen_code_2.*"],
+            },
+        }
+        indices = {
+            "source": 0,
+            "gen_code_1": 1,
+            "gen_code_2": 2,
+            "aggregate": 3,
+        }
+
+        with patch(
+            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
+        ) as mock_load:
+            apply_observe_for_file_mode(
+                data=data,
+                agent_config=config,
+                agent_name="aggregate",
+                agent_indices=indices,
+                file_path="/tmp/test.json",
+            )
+
+        # No historical loads — version data resolved from content directly.
+        mock_load.assert_not_called()
+
+    def test_version_ns_with_non_version_context_dep(self):
+        """Version namespaces + non-version context dep: both resolve correctly."""
+        data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "node-1",
+                "content": {
+                    "gen_code_1": {"code": "code_1"},
+                    "gen_code_2": {"code": "code_2"},
+                },
+                "lineage": ["lineage-1"],
+            }
+        ]
+        config = {
+            "dependencies": ["gen_code_1", "gen_code_2"],
+            "context_scope": {
+                "observe": [
+                    "gen_code_1.code",
+                    "gen_code_2.code",
+                    "classify.category",
+                ],
+            },
+        }
+        indices = {
+            "source": 0,
+            "gen_code_1": 1,
+            "gen_code_2": 2,
+            "classify": 3,
+            "aggregate": 4,
+        }
+
+        with patch(
+            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
+            return_value={"category": "science"},
+        ) as mock_load:
+            result = apply_observe_for_file_mode(
+                data=data,
+                agent_config=config,
+                agent_name="aggregate",
+                agent_indices=indices,
+                file_path="/tmp/test.json",
+            )
+
+        content = result[0]["content"]
+        # Version fields from content
+        assert content["gen_code_1.code"] == "code_1"
+        assert content["gen_code_2.code"] == "code_2"
+        # Context dep from historical lookup
+        assert content["category"] == "science"
+        # Historical load only for classify, not version namespaces
+        mock_load.assert_called_once()
+
+    def test_version_ns_single_wildcard_no_qualification(self):
+        """Single version namespace wildcard uses bare keys (no ns. prefix)."""
+        data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "node-1",
+                "content": {
+                    "gen_code_1": {"code": "code_1", "language": "python"},
+                },
+                "lineage": ["lineage-1"],
+            }
+        ]
+        config = {
+            "dependencies": ["gen_code_1"],
+            "context_scope": {"observe": ["gen_code_1.*"]},
+        }
+        indices = {"source": 0, "gen_code_1": 1, "aggregate": 2}
+
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="aggregate",
+            agent_indices=indices,
+            file_path="/tmp/test.json",
+        )
+
+        content = result[0]["content"]
+        # Single wildcard → bare keys (no qualification)
+        assert content["code"] == "code_1"
+        assert content["language"] == "python"
+
+    def test_version_ns_multiple_records(self):
+        """Version namespace resolution works across multiple records."""
+        data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "node-1",
+                "content": {
+                    "gen_code_1": {"code": "code_A1"},
+                    "gen_code_2": {"code": "code_A2"},
+                },
+                "lineage": ["lineage-1"],
+            },
+            {
+                "source_guid": "sg-2",
+                "node_id": "node-2",
+                "content": {
+                    "gen_code_1": {"code": "code_B1"},
+                    "gen_code_2": {"code": "code_B2"},
+                },
+                "lineage": ["lineage-2"],
+            },
+        ]
+        config = {
+            "dependencies": ["gen_code_1", "gen_code_2"],
+            "context_scope": {
+                "observe": ["gen_code_1.code", "gen_code_2.code"],
+            },
+        }
+        indices = {
+            "source": 0,
+            "gen_code_1": 1,
+            "gen_code_2": 2,
+            "aggregate": 3,
+        }
+
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="aggregate",
+            agent_indices=indices,
+            file_path="/tmp/test.json",
+        )
+
+        # First record
+        assert result[0]["content"]["gen_code_1.code"] == "code_A1"
+        assert result[0]["content"]["gen_code_2.code"] == "code_A2"
+        # Second record — different per-record content
+        assert result[1]["content"]["gen_code_1.code"] == "code_B1"
+        assert result[1]["content"]["gen_code_2.code"] == "code_B2"
+
+    def test_version_ns_preserves_original_nested_dicts(self):
+        """Original nested version namespace dicts are preserved in content."""
+        data = self._make_merged_data(2)
+        config = {
+            "dependencies": ["gen_code_1", "gen_code_2"],
+            "context_scope": {
+                "observe": ["gen_code_1.*", "gen_code_2.*"],
+            },
+        }
+        indices = {
+            "source": 0,
+            "gen_code_1": 1,
+            "gen_code_2": 2,
+            "aggregate": 3,
+        }
+
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="aggregate",
+            agent_indices=indices,
+            file_path="/tmp/test.json",
+        )
+
+        content = result[0]["content"]
+        # Original nested dicts are preserved alongside expanded keys
+        assert isinstance(content["gen_code_1"], dict)
+        assert content["gen_code_1"]["code"] == "code_1"
+        # Expanded keys also present
+        assert content["gen_code_1.code"] == "code_1"
+
+    def test_version_ns_does_not_mutate_input_data(self):
+        """Version namespace enrichment must not mutate caller's input data."""
+        data = self._make_merged_data(2)
+        original_content = dict(data[0]["content"])
+        original_keys = set(original_content.keys())
+
+        config = {
+            "dependencies": ["gen_code_1", "gen_code_2"],
+            "context_scope": {
+                "observe": ["gen_code_1.*", "gen_code_2.*"],
+            },
+        }
+        indices = {
+            "source": 0,
+            "gen_code_1": 1,
+            "gen_code_2": 2,
+            "aggregate": 3,
+        }
+
+        apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="aggregate",
+            agent_indices=indices,
+            file_path="/tmp/test.json",
+        )
+
+        # Input data must not be mutated.
+        assert set(data[0]["content"].keys()) == original_keys
+
+    def test_empty_content_fallback(self):
+        """Record with empty content {} falls back to item-level keys.
+
+        Regression: data.get("content", data) returns {} when content
+        exists but is empty, instead of falling back to the full item.
+        """
+        source_data = [{"source_guid": "sg-1", "content": {"url": "https://ex.com"}}]
+        data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "node-1",
+                "content": {},
+                "question": "Q?",
+                "lineage": ["lineage-1"],
+            }
+        ]
+        config = {
+            "dependencies": "upstream",
+            "context_scope": {
+                "observe": ["source.url", "upstream.question"],
+            },
+        }
+        indices = {"source": 0, "upstream": 1, "downstream": 2}
+
+        with patch(
+            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
+            return_value=None,
+        ):
+            result = apply_observe_for_file_mode(
+                data=data,
+                agent_config=config,
+                agent_name="downstream",
+                agent_indices=indices,
+                file_path="/tmp/test.json",
+                source_data=source_data,
+            )
+
+        content = result[0]["content"]
+        # source.url from source_data
+        assert content["url"] == "https://ex.com"
+        # upstream.question from item-level fallback (content was empty)
+        assert content["question"] == "Q?"
+
+    def test_non_version_input_source_not_treated_as_version_ns(self):
+        """Non-version input source keys in content are NOT treated as version namespaces.
+
+        Regression: only keys matching the _N pattern should be detected as
+        version namespaces.  A regular namespace like "upstream" that happens
+        to be a dict in content should NOT trigger version namespace injection.
+        """
+        data = [
+            {
+                "source_guid": "sg-1",
+                "content": {"question": "Q?", "answer": "A!"},
+            }
+        ]
+        config = {
+            "dependencies": "upstream",
+            "context_scope": {"observe": ["upstream.question"]},
+        }
+        indices = {"source": 0, "upstream": 1, "review": 2}
+
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="review",
+            agent_indices=indices,
+            file_path="/tmp/test.json",
+        )
+
+        # Fast path should fire — no version namespaces detected.
+        assert result is data


### PR DESCRIPTION
## Summary
- `apply_observe_for_file_mode` now detects version-correlated namespaces in record content using `_detect_version_namespaces` and resolves fields from them directly, instead of attempting historical lookups that fail for version keys
- Fixes the empty-content fallback trap where `item.get("content", item)` returns `{}` instead of falling back to the item when content exists but is empty
- Adds 10 new tests covering wildcard expansion, specific field resolution, mixed version+context deps, input mutation safety, and the empty-content edge case

## Verification
- Reproduction script (`tests/manual/repro_bug_03_version_merge_tool.py`) confirms all 3 bugs before fix, passes after
- All 41 file mode observe tests pass (31 existing + 10 new)
- Full test suite: 5701 passed, 0 failed
- `ruff format --check` and `ruff check` clean