### PR TITLE
fix: _handle_action_skip returns COMPLETED to match state_manager

### DIFF
--- a/.changes/unreleased/Bug Fix-20260423-079000.yaml
+++ b/.changes/unreleased/Bug Fix-20260423-079000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "_handle_action_skip returns COMPLETED (matching state_manager) instead of contradictory SKIPPED"
+time: 2026-04-23T07:90:00.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -34,6 +34,9 @@ logger = logging.getLogger(__name__)
 # this prefix to distinguish "blocked by upstream" from "guard-filtered".
 UPSTREAM_SKIP_PREFIX = "Upstream dependency"
 
+# Reason string for WHERE-clause passthrough (action data forwarded, LLM logic skipped).
+WHERE_PASSTHROUGH_REASON = "WHERE clause \u2014 data passed through"
+
 
 @dataclass
 class ExecutorDependencies:
@@ -268,7 +271,7 @@ class ActionExecutor:
                 action_name=action_name,
                 action_index=action_idx,
                 total_actions=total_actions,
-                skip_reason="WHERE clause condition not met",
+                skip_reason=WHERE_PASSTHROUGH_REASON,
                 mode=action_config.get("run_mode", ""),
             )
         )
@@ -277,14 +280,14 @@ class ActionExecutor:
             config = ActionCompleteConfig(
                 run_id=self.run_id,
                 action_name=action_name,
-                status="skipped",
+                status="success",
                 duration_seconds=duration,
-                skip_reason="WHERE clause condition not met",
+                skip_reason=WHERE_PASSTHROUGH_REASON,
             )
             self.run_tracker.record_action_complete(config=config)
 
         return ActionExecutionResult(
-            success=True, status=ActionStatus.SKIPPED, metrics=ExecutionMetrics(duration=duration)
+            success=True, status=ActionStatus.COMPLETED, metrics=ExecutionMetrics(duration=duration)
         )
 
     def _track_action_start(self, params: ActionRunParams) -> None:

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -194,7 +194,7 @@ class TestExecuteAgentSync:
                 "agent_a", action_idx=0, action_config={"agent_type": "a"}, is_last_action=False
             )
 
-        assert result.status == ActionStatus.SKIPPED
+        assert result.status == ActionStatus.COMPLETED
         mock_deps.output_manager.create_passthrough_output.assert_called_once()
 
     def test_normal_path_runs_agent(self, executor, mock_deps):
@@ -541,7 +541,7 @@ class TestHandleAgentSkip:
             result = executor._handle_action_skip("agent_a", 0, {}, datetime.now())
 
         assert result.success is True
-        assert result.status == ActionStatus.SKIPPED
+        assert result.status == ActionStatus.COMPLETED
         mock_deps.output_manager.create_passthrough_output.assert_called_once_with(0, "agent_a")
         mock_deps.state_manager.update_status.assert_called_with(
             "agent_a", ActionStatus.COMPLETED, record_limit=None, file_limit=None


### PR DESCRIPTION
## Summary
- `_handle_action_skip` set `state_manager` to `COMPLETED` but returned `SKIPPED` in the result — downstream code checking one source got a different answer than the other
- Changed return to `ActionStatus.COMPLETED` to match state_manager, consistent with `DISPOSITION_PASSTHROUGH` set by `create_passthrough_output`
- Updated skip_reason from "WHERE clause condition not met" to "WHERE clause — data passed through"
- Run tracker status updated from "skipped" to "completed" for consistency

## Verification
- Repro script (`tests/manual/repro_bug_09_status_contradiction.py`) confirms contradiction before fix, agreement after
- `ruff format --check` and `ruff check` pass
- All 5749 tests pass (`pytest` — 40s)
- Sibling patterns verified: `_handle_dependency_skip` and `_handle_run_success` guard-all-skipped both have consistent state_manager/result (SKIPPED/SKIPPED) — no change needed