### PR TITLE
fix: lineage_sources includes all branch nodes, not just leaves

### DIFF
--- a/.changes/unreleased/Bug Fix-20260423-081000.yaml
+++ b/.changes/unreleased/Bug Fix-20260423-081000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Diamond/fan-in patterns with asymmetric branch depths now resolve context dependencies correctly"
+time: 2026-04-23T08:10:00.000000Z

--- a/agent_actions/utils/lineage/builder.py
+++ b/agent_actions/utils/lineage/builder.py
@@ -69,8 +69,10 @@ class LineageBuilder:
     ) -> dict:
         """Add lineage from multiple source items (many-to-one).
 
-        For multiple sources, adds a ``lineage_sources`` field with all parent
-        node_ids. Ancestry chain is propagated from the first source item.
+        For multiple sources, adds a ``lineage_sources`` field with every
+        node_id from every source's lineage chain, so downstream lookups
+        can resolve any ancestor on any branch. Ancestry chain is propagated
+        from the first source item.
         """
         obj = obj.copy()
         obj["node_id"] = node_id
@@ -89,7 +91,7 @@ class LineageBuilder:
                 lineage = item.get("lineage", [])
                 filtered = LineageBuilder.filter_node_lineage(lineage)
                 if filtered:
-                    parent_node_ids.append(filtered[-1])
+                    parent_node_ids.extend(filtered)
 
             base_lineage = LineageBuilder.filter_node_lineage(first_source.get("lineage", []))
             obj["lineage"] = base_lineage + [node_id]

--- a/tests/preprocessing/context/test_ancestry_chain_matching.py
+++ b/tests/preprocessing/context/test_ancestry_chain_matching.py
@@ -5,7 +5,8 @@ The matcher uses exact node_id key-join with two explicit modes:
 - Mode 1 (Ancestor): node_id in lineage chain
 - Mode 2 (Merge parent): node_id in lineage_sources
 
-No fallbacks. No guessing. If node_id isn't found, returns None.
+lineage_sources contains every node_id from every merge parent's lineage
+chain, so Mode 2 resolves both leaf and intermediate nodes on all branches.
 
 RFC Reference: docs/specs/RFC_ancestry_chain.md
 """
@@ -609,3 +610,100 @@ class TestHistoricalContentExtraction:
         assert result is not None
         assert result.get("question_text") == "What is X?"
         assert result.get("answer_text") == "X is Y."
+
+
+class TestAsymmetricDiamondFanIn:
+    """Tests for diamond/fan-in with asymmetric branch depths.
+
+    DAG:
+        root → B → C          (branch A, depth 2)
+        root → D → E → F      (branch B, depth 3)
+        merge at G
+
+    lineage_sources includes every node_id from every merge parent's
+    lineage chain, so Mode 2 resolves intermediate nodes on all branches.
+    """
+
+    @pytest.fixture
+    def diamond_dag(self):
+        """Build asymmetric diamond DAG records."""
+        from agent_actions.utils.lineage.builder import LineageBuilder
+
+        agent_indices = {"root": 0, "B": 1, "C": 2, "D": 3, "E": 4, "F": 5, "G": 6}
+
+        root = {"source_guid": "sg-001", "node_id": "root_001", "lineage": ["root_001"]}
+
+        branch_a_b = LineageBuilder.add_lineage_tracking({}, root, "B_002")
+        branch_a_c = LineageBuilder.add_lineage_tracking({}, branch_a_b, "C_003")
+
+        branch_b_d = LineageBuilder.add_lineage_tracking({}, root, "D_004")
+        branch_b_e = LineageBuilder.add_lineage_tracking({}, branch_b_d, "E_005")
+        branch_b_f = LineageBuilder.add_lineage_tracking({}, branch_b_e, "F_006")
+
+        merged_g = LineageBuilder.add_lineage_tracking_from_sources(
+            {"source_guid": "sg-001"},
+            [branch_a_c, branch_b_f],
+            "G_007",
+        )
+
+        return {"merged_g": merged_g, "agent_indices": agent_indices}
+
+    def test_lineage_sources_includes_all_branch_nodes(self, diamond_dag):
+        """lineage_sources contains every node_id from both branches."""
+        merged = diamond_dag["merged_g"]
+        ls = merged["lineage_sources"]
+        for nid in ("root_001", "B_002", "C_003", "D_004", "E_005", "F_006"):
+            assert nid in ls, f"{nid} missing from lineage_sources"
+
+    def test_intermediate_nodes_resolved_via_mode2(self, diamond_dag):
+        """_find_target_node_id finds D and E through lineage_sources (Mode 2)."""
+        merged = diamond_dag["merged_g"]
+        indices = diamond_dag["agent_indices"]
+
+        for action, expected in (("D", "D_004"), ("E", "E_005")):
+            result = HistoricalNodeDataLoader._find_target_node_id(
+                action_name=action,
+                lineage=merged["lineage"],
+                lineage_sources=merged.get("lineage_sources"),
+                agent_indices=indices,
+            )
+            assert result == expected, f"Expected {expected} for {action}, got {result}"
+
+    def test_first_branch_resolved_via_mode1(self, diamond_dag):
+        """Nodes on the first branch are in lineage — Mode 1 finds them."""
+        merged = diamond_dag["merged_g"]
+        indices = diamond_dag["agent_indices"]
+
+        result = HistoricalNodeDataLoader._find_target_node_id(
+            action_name="B",
+            lineage=merged["lineage"],
+            lineage_sources=merged.get("lineage_sources"),
+            agent_indices=indices,
+        )
+        assert result == "B_002"
+
+    def test_leaf_node_resolved_via_mode2(self, diamond_dag):
+        """Leaf node F on branch B is in lineage_sources — Mode 2 finds it."""
+        merged = diamond_dag["merged_g"]
+        indices = diamond_dag["agent_indices"]
+
+        result = HistoricalNodeDataLoader._find_target_node_id(
+            action_name="F",
+            lineage=merged["lineage"],
+            lineage_sources=merged.get("lineage_sources"),
+            agent_indices=indices,
+        )
+        assert result == "F_006"
+
+    def test_nonexistent_action_returns_none(self, diamond_dag):
+        """Action not on any branch returns None."""
+        merged = diamond_dag["merged_g"]
+        indices = diamond_dag["agent_indices"]
+
+        result = HistoricalNodeDataLoader._find_target_node_id(
+            action_name="Z",
+            lineage=merged["lineage"],
+            lineage_sources=merged.get("lineage_sources"),
+            agent_indices={**indices, "Z": 7},
+        )
+        assert result is None

--- a/tests/utilities/test_lineage_unified.py
+++ b/tests/utilities/test_lineage_unified.py
@@ -288,8 +288,9 @@ class TestLineageSourcesPropagation:
 
         result = LineageBuilder.add_lineage_tracking_from_sources(obj, source_items, "merge_node")
 
-        # Uses the computed lineage_sources from source items, not parent's
-        assert result["lineage_sources"] == ["branch_a_1", "branch_b_2"]
+        # Uses the computed lineage_sources from source items, not parent's.
+        # lineage_sources includes every node_id from every source's lineage chain.
+        assert result["lineage_sources"] == ["root_0", "branch_a_1", "root_0", "branch_b_2"]
 
 
 class TestUnifiedLineageObjectImmutability:


### PR DESCRIPTION
## Summary
- `add_lineage_tracking_from_sources` only appended the last node_id from each source's lineage into `lineage_sources`. In diamond/fan-in DAGs with asymmetric branch depths, intermediate nodes on deeper branches were absent — `_find_target_node_id` Mode 2 couldn't find them.
- Root-cause fix: `append(filtered[-1])` → `extend(filtered)` in `builder.py`. `lineage_sources` now contains every node_id from every merge parent's lineage chain. Mode 2 resolves intermediate nodes naturally.

## Verification
- `ruff format --check` clean, `ruff check` clean
- Full test suite: 5754 passed, 0 failed
- 5 new tests for asymmetric diamond pattern (intermediate node resolution, first-branch Mode 1, leaf Mode 2, nonexistent action)
- 1 existing test updated to match new `lineage_sources` content