### PR TITLE
docs: correct 5 broken retry+reprompt claims

### DIFF
--- a/agent_actions/skills/agent-actions-workflow/references/reprompt-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/reprompt-patterns.md
@@ -141,7 +141,15 @@ When both reprompt and guard are configured on the same action:
 2. If guard skips/filters → reprompt is bypassed entirely (nothing to validate)
 3. If guard passes → LLM executes → reprompt validation runs on output
 
-Guards and reprompt operate on different data: guards check input, reprompt checks output.
+Guards and reprompt operate on different data: guards check input, reprompt checks output. Note that `on_exhausted` only applies when reprompt actually runs — guard-skipped records bypass it entirely.
+
+## Reprompt + Retry Interaction
+
+When both retry and reprompt are configured, retry runs inside each reprompt attempt. If retry exhausts during a reprompt cycle:
+
+- The attempt is marked `exhausted=True, passed=False`
+- `on_exhausted` is respected: `"raise"` fails the action, `"return_last"` accepts the last valid response from a prior attempt (if one exists)
+- Recovery metadata captures both retry and reprompt state
 
 ## Reprompt in Batch Mode
 

--- a/docs.agent-actions/docs/reference/execution/batch-recovery.md
+++ b/docs.agent-actions/docs/reference/execution/batch-recovery.md
@@ -95,7 +95,7 @@ After Phase 1 ensures all recoverable records are present, Phase 2 checks whethe
 
 1. Load the validation UDF specified in `reprompt.validation`
 2. For each attempt (up to `max_attempts`):
-   - Validate all successful results that haven't already passed
+   - Validate all results that haven't already passed (API-failed records fail validation and are included)
    - Identify failures
    - If all pass, stop
    - For each failed result:
@@ -147,9 +147,9 @@ When a record goes through both phases, retry metadata from Phase 1 is preserved
 
 ### Skip Logic
 
-Phase 2 skips records that:
-- Were not successful (no valid response to validate)
-- Already have reprompt metadata marked as passed (from a previous cycle)
+Phase 2 skips records that already have reprompt metadata marked as passed (from a previous cycle).
+
+API-failed records (`success=False`) are **not** skipped — they fail validation and are reprompted with guidance to retry. This prevents API failures from silently graduating as valid output.
 
 ## Recovery Metadata
 

--- a/docs.agent-actions/docs/reference/validation/reprompting.md
+++ b/docs.agent-actions/docs/reference/validation/reprompting.md
@@ -18,8 +18,10 @@ The reprompting system provides:
 - **Configurable exhaustion** - Control what happens when all attempts fail
 
 :::info Retry vs Reprompt
-**Retry** handles transient errors (rate limits, network issues) - same request, wait, retry.
-**Reprompt** handles validation errors (bad JSON, schema violations) - modify prompt with feedback, retry.
+**Retry** handles transient errors (rate limits, network issues) — same request, wait, retry.
+**Reprompt** handles validation errors (bad JSON, schema violations) — modify prompt with feedback, retry.
+
+When both are configured, retry runs inside each reprompt attempt. If retry exhausts during a reprompt cycle, the `on_exhausted` policy is respected. API-failed records that reach validation are rejected and reprompted, not silently graduated.
 
 See [Retry & Error Handling](../execution/retry.md) for transient error handling.
 :::
@@ -227,6 +229,10 @@ flowchart LR
 ```
 
 A single record might be retried twice (transport failures), then reprompted once (schema failure) — that's 4 LLM calls total. The recovery metadata captures the full history.
+
+#### Retry Exhaustion Inside Reprompt
+
+If retry exhausts during a reprompt attempt, the record is marked `exhausted=True, passed=False`. The `on_exhausted` policy applies: `"raise"` stops the workflow, `"return_last"` accepts the last response from a prior successful attempt if one exists.
 
 ### Batch Mode
 


### PR DESCRIPTION
## Summary
- Bugs #01 (retry exhaustion misreported) and #02 (API failures bypass validation) are fixed — docs still claimed the old broken behavior
- Updated 3 doc files to match current code: retry+reprompt interaction documented, batch Phase 2 skip logic corrected, on_exhausted guard-skip clarified

## Verification
- Confirmed both fixes landed via git log (commits c2a6e2e, 51b6f67)
- Cross-referenced each of the 5 broken claims from bug spec #18 against current code behavior