### PR TITLE
feat: additive content model — write side (Step 1a)

### DIFF
--- a/agent_actions/input/preprocessing/transformation/transformer.py
+++ b/agent_actions/input/preprocessing/transformation/transformer.py
@@ -57,8 +57,14 @@ class DataTransformer:
         return result
 
     @staticmethod
-    def transform_structure(data: list[dict]) -> list[dict]:
-        """Flatten nested {source_guid: contents} structure to list of dicts."""
+    def transform_structure(data: list[dict], action_name: str | None = None) -> list[dict]:
+        """Flatten nested {source_guid: contents} structure to list of dicts.
+
+        When *action_name* is provided, content is wrapped under the action
+        namespace (additive model).
+        """
+        from agent_actions.utils.content import wrap_content
+
         result = []
 
         for data_item in data:
@@ -66,9 +72,15 @@ class DataTransformer:
                 for source_guid, contents in data_item.items():
                     if isinstance(contents, list):
                         for content in contents:
-                            result.append({"source_guid": source_guid, "content": content})
+                            wrapped = wrap_content(action_name, content) if action_name else content
+                            result.append({"source_guid": source_guid, "content": wrapped})
                     else:
-                        result.append({"source_guid": source_guid, "content": contents})
+                        wrapped = (
+                            wrap_content(action_name, contents)
+                            if action_name and isinstance(contents, dict)
+                            else contents
+                        )
+                        result.append({"source_guid": source_guid, "content": wrapped})
 
         return result
 

--- a/agent_actions/input/preprocessing/transformation/transformer.py
+++ b/agent_actions/input/preprocessing/transformation/transformer.py
@@ -57,12 +57,17 @@ class DataTransformer:
         return result
 
     @staticmethod
-    def transform_structure(data: list[dict], action_name: str | None = None) -> list[dict]:
+    def transform_structure(data: list[dict], action_name: str = "") -> list[dict]:
         """Flatten nested {source_guid: contents} structure to list of dicts.
 
-        When *action_name* is provided, content is wrapped under the action
-        namespace (additive model).
+        Content is wrapped under *action_name* namespace (additive model).
+
+        Raises:
+            ValueError: If *action_name* is empty.
         """
+        if not action_name:
+            raise ValueError("action_name is required for namespaced content wrapping")
+
         from agent_actions.utils.content import wrap_content
 
         result = []
@@ -72,12 +77,16 @@ class DataTransformer:
                 for source_guid, contents in data_item.items():
                     if isinstance(contents, list):
                         for content in contents:
-                            wrapped = wrap_content(action_name, content) if action_name else content
-                            result.append({"source_guid": source_guid, "content": wrapped})
+                            result.append(
+                                {
+                                    "source_guid": source_guid,
+                                    "content": wrap_content(action_name, content),
+                                }
+                            )
                     else:
                         wrapped = (
                             wrap_content(action_name, contents)
-                            if action_name and isinstance(contents, dict)
+                            if isinstance(contents, dict)
                             else contents
                         )
                         result.append({"source_guid": source_guid, "content": wrapped})

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -423,11 +423,19 @@ class BatchResultProcessor:
                             "RecoveryMetadata.retry is None for exhausted record "
                             f"custom_id={custom_id}; expected retry metadata with attempt count"
                         )
+                    from agent_actions.utils.content import get_existing_content, wrap_content
+
                     empty_content = ExhaustedRecordBuilder.build_empty_content(
                         ctx.agent_config or {}
                     )
+                    existing = get_existing_content(original_row)
+                    if not ctx.agent_config or "action_name" not in ctx.agent_config:
+                        raise ValueError(
+                            "agent_config must contain 'action_name' for content namespacing"
+                        )
+                    stage6_action_name = ctx.agent_config["action_name"]
                     exhausted_item = {
-                        "content": empty_content,
+                        "content": wrap_content(stage6_action_name, empty_content, existing),
                         "source_guid": source_guid,
                         "metadata": {"retry_exhausted": True, "agent_type": "tombstone"},
                         "_unprocessed": True,
@@ -464,8 +472,10 @@ class BatchResultProcessor:
                     else:
                         reason = "batch_not_returned"
 
+                    from agent_actions.utils.content import get_existing_content
+
                     passthrough_item = {
-                        "content": original_row.get("content", original_row),
+                        "content": get_existing_content(original_row),
                         "source_guid": source_guid,
                         "metadata": {
                             "reason": reason,

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -231,9 +231,9 @@ class BatchResultProcessor:
                     custom_id,
                 )
 
-        action_name = (
-            ctx.agent_config.get("action_name", "unknown") if ctx.agent_config else "unknown"
-        )
+        if not ctx.agent_config or "action_name" not in ctx.agent_config:
+            raise ValueError("agent_config must contain 'action_name' for content namespacing")
+        action_name = ctx.agent_config["action_name"]
         structured_items = DataTransformer.transform_structure(
             [{original_source_guid: generated_list}], action_name
         )

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -231,8 +231,11 @@ class BatchResultProcessor:
                     custom_id,
                 )
 
+        action_name = (
+            ctx.agent_config.get("action_name", "unknown") if ctx.agent_config else "unknown"
+        )
         structured_items = DataTransformer.transform_structure(
-            [{original_source_guid: generated_list}]
+            [{original_source_guid: generated_list}], action_name
         )
 
         # Batch items inherit target_id from the original input row.

--- a/agent_actions/processing/exhausted_builder.py
+++ b/agent_actions/processing/exhausted_builder.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from agent_actions.processing.types import RecoveryMetadata
+from agent_actions.utils.content import get_existing_content, wrap_content
 from agent_actions.utils.id_generation import IDGenerator
 
 
@@ -46,11 +47,12 @@ class ExhaustedRecordBuilder:
             resolved_source_guid = "unknown"
 
         empty_content = ExhaustedRecordBuilder.build_empty_content(agent_config)
+        existing = get_existing_content(original_row) if isinstance(original_row, dict) else {}
 
         node_id = IDGenerator.generate_node_id(action_name)
         exhausted_item: dict[str, Any] = {
             "source_guid": resolved_source_guid,
-            "content": empty_content,
+            "content": wrap_content(action_name, empty_content, existing),
             "node_id": node_id,
             "metadata": {"retry_exhausted": True, "agent_type": "tombstone"},
             "_recovery": recovery_metadata.to_dict(),

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -58,7 +58,8 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
                         context_for_passthrough, content_dict, fields_to_merge
                     )
                 )
-        return DataTransformer.transform_structure([{source_guid: updated}])
+        action_name = agent_config.get("agent_type", "unknown")
+        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
 
     @staticmethod
     def has_passthrough_config(agent_config: dict) -> bool:
@@ -132,7 +133,8 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
                         context_for_passthrough, item_dict, fields_to_merge
                     )
                 )
-        return DataTransformer.transform_structure([{source_guid: updated}])
+        action_name = agent_config.get("agent_type", "unknown")
+        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
 
 
 class NoOpStrategy(IPassthroughTransformStrategy):
@@ -187,4 +189,5 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
         passthrough_fields: dict | None = None,
     ) -> list:
         """Structure data without passthrough."""
-        return DataTransformer.transform_structure([{source_guid: data}])
+        action_name = agent_config.get("agent_type", "unknown")
+        return DataTransformer.transform_structure([{source_guid: data}], action_name)

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -58,7 +58,7 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
                         context_for_passthrough, content_dict, fields_to_merge
                     )
                 )
-        action_name = agent_config.get("agent_type", "unknown")
+        action_name = agent_config["agent_type"]
         return DataTransformer.transform_structure([{source_guid: updated}], action_name)
 
     @staticmethod
@@ -133,7 +133,7 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
                         context_for_passthrough, item_dict, fields_to_merge
                     )
                 )
-        action_name = agent_config.get("agent_type", "unknown")
+        action_name = agent_config["agent_type"]
         return DataTransformer.transform_structure([{source_guid: updated}], action_name)
 
 
@@ -189,5 +189,5 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
         passthrough_fields: dict | None = None,
     ) -> list:
         """Structure data without passthrough."""
-        action_name = agent_config.get("agent_type", "unknown")
+        action_name = agent_config["agent_type"]
         return DataTransformer.transform_structure([{source_guid: data}], action_name)

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -76,5 +76,5 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
                 merged.append(merged_item)
             else:
                 merged.append(item)
-        action_name = agent_config.get("agent_type", "unknown")
+        action_name = agent_config["agent_type"]
         return DataTransformer.transform_structure([{source_guid: merged}], action_name)

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -76,4 +76,5 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
                 merged.append(merged_item)
             else:
                 merged.append(item)
-        return DataTransformer.transform_structure([{source_guid: merged}])
+        action_name = agent_config.get("agent_type", "unknown")
+        return DataTransformer.transform_structure([{source_guid: merged}], action_name)

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -209,24 +209,38 @@ def process_file_mode_tool(
             )
 
         # Separate business data from framework fields in tool output.
-        # Tools may return full records (with content wrapper) or flat dicts.
+        # Additive model: wrap tool output under action namespace, preserve
+        # existing namespaces from the input record.
+        from agent_actions.utils.content import get_existing_content, wrap_content
+
         structured_data = []
-        for item in raw_response:
+        for idx, item in enumerate(raw_response):
             if isinstance(item, dict):
                 if isinstance(item.get("content"), dict):
-                    # Tool returned a full record — use content directly.
                     data_fields = item["content"]
                 else:
-                    # Tool returned a flat dict — strip reserved fields.
                     data_fields = {k: v for k, v in item.items() if k not in _TOOL_RESERVED_FIELDS}
-                structured_item = {"content": data_fields}
+
+                # Carry forward existing namespaces from the input record.
+                input_idx = source_mapping.get(idx) if source_mapping else None
+                if isinstance(input_idx, list):
+                    input_idx = input_idx[0]
+                existing = {}
+                if isinstance(input_idx, int) and input_idx < len(original_data):
+                    existing = get_existing_content(original_data[input_idx])
+
+                structured_item: dict[str, Any] = {
+                    "content": wrap_content(context.agent_name, data_fields, existing),
+                }
 
                 if "source_guid" in item:
                     structured_item["source_guid"] = item["source_guid"]
 
                 structured_data.append(structured_item)
             else:
-                structured_data.append({"content": {"value": item}})
+                structured_data.append(
+                    {"content": wrap_content(context.agent_name, {"value": item})}
+                )
 
         # Reattach source_guid from input records — authoritative for FILE mode.
         # LineageBuilder._propagate_ancestry_chain and RequiredFieldsEnricher

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -415,6 +415,7 @@ def test_record_tool_list_return_produces_multiple_output_items():
     agent_config = {
         "kind": "tool",
         "granularity": "record",
+        "agent_type": "flatten_tool",
         "context_scope": {"observe": ["source.*"]},
     }
     agent_name = "flatten_tool"
@@ -446,8 +447,7 @@ def test_record_tool_list_return_produces_multiple_output_items():
     # Verify the result contains all 3 expanded items
     assert result.status == ProcessingStatus.SUCCESS
     assert len(result.data) == 3
-    # RECORD mode — content is still flat until record_processor is updated
-    contents = [r["content"] for r in result.data]
+    contents = [r["content"]["flatten_tool"] for r in result.data]
     assert contents[0] == {"question": "Q1", "answer": "A1"}
     assert contents[1] == {"question": "Q2", "answer": "A2"}
     assert contents[2] == {"question": "Q3", "answer": "A3"}
@@ -461,8 +461,8 @@ def test_record_tool_list_return_produces_multiple_output_items():
         [result], agent_config, agent_name, is_first_stage=False
     )
     assert len(output) == 3
-    assert output[0]["content"]["question"] == "Q1"
-    assert output[2]["content"]["question"] == "Q3"
+    assert output[0]["content"]["flatten_tool"]["question"] == "Q1"
+    assert output[2]["content"]["flatten_tool"]["question"] == "Q3"
 
 
 # --- SchemaValidationError re-raise in process_batch ---

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -54,8 +54,8 @@ def test_file_udf_result_unwrapped():
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
     assert len(result.data) == 2
-    assert result.data[0]["content"]["name"] == "alice"
-    assert result.data[1]["content"]["name"] == "bob"
+    assert result.data[0]["content"]["my_file_tool"]["name"] == "alice"
+    assert result.data[1]["content"]["my_file_tool"]["name"] == "bob"
 
 
 def test_file_udf_result_source_mapping_auto_inferred():
@@ -129,7 +129,7 @@ def test_file_tool_plain_list_still_works():
 
     assert len(results) == 1
     assert results[0].status == ProcessingStatus.SUCCESS
-    assert results[0].data[0]["content"]["score"] == 0.9
+    assert results[0].data[0]["content"]["my_file_tool"]["score"] == 0.9
 
 
 # --- Empty tool output detection ---
@@ -446,6 +446,7 @@ def test_record_tool_list_return_produces_multiple_output_items():
     # Verify the result contains all 3 expanded items
     assert result.status == ProcessingStatus.SUCCESS
     assert len(result.data) == 3
+    # RECORD mode — content is still flat until record_processor is updated
     contents = [r["content"] for r in result.data]
     assert contents[0] == {"question": "Q1", "answer": "A1"}
     assert contents[1] == {"question": "Q2", "answer": "A2"}
@@ -762,7 +763,7 @@ def test_file_tool_non_dict_output_items():
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
     # Non-dict wrapped as {"content": {"value": ...}} — no node_id, so no mapping
-    assert results[0].data[0]["content"]["value"] == "just a string"
+    assert results[0].data[0]["content"]["my_file_tool"]["value"] == "just a string"
     # Same cardinality (1:1) — positional fallback propagates source_guid from input
     assert results[0].data[0].get("source_guid") == "sg-1"
 
@@ -1058,10 +1059,10 @@ def test_file_tool_full_record_content_preserved():
     assert result.status == ProcessingStatus.SUCCESS
     assert len(result.data) == 2
 
-    assert result.data[0]["content"]["question_text"] == "What is X?"
-    assert result.data[0]["content"]["answer_text"] == "X is Y."
-    assert result.data[1]["content"]["question_text"] == "What is Z?"
-    assert result.data[1]["content"]["answer_text"] == "Z is W."
+    assert result.data[0]["content"]["my_file_tool"]["question_text"] == "What is X?"
+    assert result.data[0]["content"]["my_file_tool"]["answer_text"] == "X is Y."
+    assert result.data[1]["content"]["my_file_tool"]["question_text"] == "What is Z?"
+    assert result.data[1]["content"]["my_file_tool"]["answer_text"] == "Z is W."
 
 
 # --- Bug 2: Lineage collision with shared source_guid ---
@@ -1157,8 +1158,8 @@ def test_file_tool_copy_pattern_preserves_lineage():
 
     assert result.source_mapping == {0: 0, 1: 1}
 
-    assert result.data[0]["content"]["transformed"] == "new value from original"
-    assert result.data[1]["content"]["transformed"] == "new value from other"
+    assert result.data[0]["content"]["my_file_tool"]["transformed"] == "new value from original"
+    assert result.data[1]["content"]["my_file_tool"]["transformed"] == "new value from other"
 
     assert result.data[0]["source_guid"] == "sg-1"
     assert result.data[1]["source_guid"] == "sg-2"


### PR DESCRIPTION
## Summary
Every place that creates record content now wraps it under the action's namespace, preserving existing namespaces from input records. This is the write side of the additive content model.

### Changes
- `pipeline_file_mode.py` — FILE mode tool output wrapped under action namespace
- `transformer.py` — `transform_structure` requires `action_name` (no fallback, raises ValueError)
- `context_scope.py` — 3 transformation strategies pass `action_name` via `agent_config["agent_type"]`
- `precomputed.py` — 1 transformation strategy, same pattern
- `result_processor.py` — batch results, exhausted items, passthrough items all namespaced
- `exhausted_builder.py` — tombstone records carry existing namespaces + empty action namespace

### Contracts (strict, no fallbacks)
- `transform_structure(data, action_name)` — `action_name` required, `ValueError` if empty
- `agent_config["agent_type"]` — `KeyError` if missing (no `"unknown"` default)
- `ctx.agent_config["action_name"]` — `ValueError` with clear message if missing
- Content format: `{"content": {"action_name": {fields}, "prev_action": {fields}}}`

### What this does NOT change (yet)
- Read side (observe, guards, tool input) — Step 1b
- Downstream consumers still read flat content where they haven't been updated

## Verification
- 5791 tests pass (0 regressions)
- `ruff check` and `ruff format --check` clean
- 5 commits, each with green test suite