### PR TITLE
feat: enrichment pipeline with namespaced content

### DIFF
--- a/.changes/unreleased/Breaking Change-20260423-088000.yaml
+++ b/.changes/unreleased/Breaking Change-20260423-088000.yaml
@@ -1,0 +1,3 @@
+kind: Breaking Change
+body: "Enrichment pipeline works with namespaced content — passthrough merges into action namespace"
+time: 2026-04-23T08:80:00.000000Z

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -173,19 +173,25 @@ class PassthroughEnricher(Enricher):
     """Merge passthrough fields into results."""
 
     def enrich(self, result: ProcessingResult, context: ProcessingContext) -> ProcessingResult:
-        """Merge passthrough_fields into each item.
+        """Merge passthrough_fields into the current action's content namespace.
 
-        Targets the ``content`` sub-dict when present (structured output),
-        otherwise merges directly into the top-level item dict (passthrough
-        into the flat content namespace).
+        Content is namespaced: ``{"action_a": {...}, "action_b": {...}}``.
+        Passthrough fields are merged into ``content[context.action_name]``,
+        not at the top level.
         """
         if not result.passthrough_fields:
             return result
 
+        action_name = context.action_name
         for item in result.data:
-            content = item.get("content", item)
-            if isinstance(content, dict):
-                content.update(result.passthrough_fields)
+            content = item.get("content")
+            if not isinstance(content, dict):
+                continue
+            ns = content.get(action_name)
+            if isinstance(ns, dict):
+                ns.update(result.passthrough_fields)
+            else:
+                content[action_name] = dict(result.passthrough_fields)
 
         return result
 

--- a/agent_actions/utils/passthrough_builder.py
+++ b/agent_actions/utils/passthrough_builder.py
@@ -42,7 +42,7 @@ class PassthroughItemBuilder:
         node_id = IDGenerator.generate_node_id(action_name)
 
         lineage = LineageBuilder.build_lineage(row, node_id)
-        content = row.get("content", row)
+        content = row.get("content", {})
 
         processed_item = FieldManager().create_processed_item(
             source_guid=resolved_source_guid,

--- a/tests/manual/repro_088_enrichment.py
+++ b/tests/manual/repro_088_enrichment.py
@@ -1,0 +1,208 @@
+"""Manual repro for spec 088: PassthroughEnricher with namespaced content.
+
+Run: python -m tests.manual.repro_088_enrichment
+"""
+
+from agent_actions.processing.enrichment import (
+    LineageEnricher,
+    MetadataEnricher,
+    PassthroughEnricher,
+    RecoveryEnricher,
+)
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+    RecoveryMetadata,
+    RetryMetadata,
+)
+
+
+def _make_context(action_name="action_c"):
+    return ProcessingContext(
+        agent_config={"agent_type": action_name, "kind": "llm", "granularity": "record"},
+        agent_name=action_name,
+        is_first_stage=False,
+    )
+
+
+def scenario_1_passthrough_enricher_namespaced():
+    """PassthroughEnricher should merge passthrough fields INTO action namespace."""
+    print("\n=== Scenario 1: PassthroughEnricher with namespaced content ===")
+
+    result = ProcessingResult(
+        status=ProcessingStatus.SUCCESS,
+        data=[
+            {
+                "content": {
+                    "action_a": {"field_a": "val_a"},
+                    "action_b": {"field_b": "val_b"},
+                    "action_c": {"llm_field": "llm_output"},
+                },
+            }
+        ],
+        passthrough_fields={"passthrough_field": "preserved_value"},
+    )
+    context = _make_context("action_c")
+
+    enricher = PassthroughEnricher()
+    enriched = enricher.enrich(result, context)
+
+    content = enriched.data[0]["content"]
+    print(f"  Content after enrichment: {content}")
+
+    # EXPECTED: passthrough_field inside action_c namespace
+    expected_in_ns = "passthrough_field" in content.get("action_c", {})
+    # BUG: passthrough_field at top level (alongside action_a, action_b, action_c)
+    at_top_level = "passthrough_field" in content and "passthrough_field" not in content.get(
+        "action_c", {}
+    )
+
+    if at_top_level:
+        print("  RESULT: BUG — passthrough_field merged at TOP LEVEL (alongside namespaces)")
+    elif expected_in_ns:
+        print("  RESULT: FIXED — passthrough_field merged INTO action_c namespace")
+    else:
+        print(f"  RESULT: UNEXPECTED — check content: {content}")
+
+
+def scenario_2_lineage_enricher_record_level():
+    """LineageEnricher should NOT modify content internals."""
+    print("\n=== Scenario 2: LineageEnricher works at record level ===")
+
+    namespaced_content = {
+        "action_a": {"field_a": "val_a"},
+        "action_b": {"field_b": "val_b"},
+    }
+    result = ProcessingResult(
+        status=ProcessingStatus.SUCCESS,
+        data=[{"content": dict(namespaced_content), "source_guid": "sg-1"}],
+        source_guid="sg-1",
+    )
+    context = _make_context("action_c")
+    context.is_first_stage = True
+
+    enricher = LineageEnricher()
+    enriched = enricher.enrich(result, context)
+
+    item = enriched.data[0]
+    content = item["content"]
+    has_lineage = "lineage" in item
+    has_node_id = "node_id" in item
+    content_unchanged = set(content.keys()) == set(namespaced_content.keys())
+
+    print(f"  lineage at record level: {has_lineage}")
+    print(f"  node_id at record level: {has_node_id}")
+    print(f"  content unchanged: {content_unchanged} (keys: {list(content.keys())})")
+
+    if has_lineage and has_node_id and content_unchanged:
+        print("  RESULT: OK — LineageEnricher works at record level, content untouched")
+    else:
+        print("  RESULT: UNEXPECTED")
+
+
+def scenario_3_metadata_enricher_record_level():
+    """MetadataEnricher should NOT modify content internals."""
+    print("\n=== Scenario 3: MetadataEnricher works at record level ===")
+
+    namespaced_content = {"action_a": {"field_a": "val_a"}}
+    result = ProcessingResult(
+        status=ProcessingStatus.SUCCESS,
+        data=[{"content": dict(namespaced_content)}],
+        pre_extracted_metadata={"model": "gpt-4", "tokens": 100},
+    )
+    context = _make_context("action_c")
+
+    enricher = MetadataEnricher()
+    enriched = enricher.enrich(result, context)
+
+    item = enriched.data[0]
+    has_metadata = "metadata" in item
+    content_unchanged = set(item["content"].keys()) == set(namespaced_content.keys())
+
+    print(f"  metadata at record level: {has_metadata}")
+    print(f"  content unchanged: {content_unchanged}")
+
+    if has_metadata and content_unchanged:
+        print("  RESULT: OK — MetadataEnricher works at record level")
+    else:
+        print("  RESULT: UNEXPECTED")
+
+
+def scenario_4_recovery_enricher_record_level():
+    """RecoveryEnricher should NOT modify content internals."""
+    print("\n=== Scenario 4: RecoveryEnricher works at record level ===")
+
+    namespaced_content = {"action_a": {"field_a": "val_a"}}
+    result = ProcessingResult(
+        status=ProcessingStatus.SUCCESS,
+        data=[{"content": dict(namespaced_content)}],
+        recovery_metadata=RecoveryMetadata(
+            retry=RetryMetadata(attempts=2, failures=1, succeeded=True, reason="timeout")
+        ),
+    )
+    context = _make_context("action_c")
+
+    enricher = RecoveryEnricher()
+    enriched = enricher.enrich(result, context)
+
+    item = enriched.data[0]
+    has_recovery = "_recovery" in item
+    content_unchanged = set(item["content"].keys()) == set(namespaced_content.keys())
+
+    print(f"  _recovery at record level: {has_recovery}")
+    print(f"  content unchanged: {content_unchanged}")
+
+    if has_recovery and content_unchanged:
+        print("  RESULT: OK — RecoveryEnricher works at record level")
+    else:
+        print("  RESULT: UNEXPECTED")
+
+
+def scenario_5_passthrough_builder():
+    """passthrough_builder content extraction with namespaced content."""
+    print("\n=== Scenario 5: PassthroughItemBuilder content extraction ===")
+
+    from agent_actions.utils.passthrough_builder import PassthroughItemBuilder
+
+    row = {
+        "content": {"action_a": {"field_a": "val_a"}, "action_b": {"field_b": "val_b"}},
+        "target_id": "tid-1",
+        "source_guid": "sg-1",
+    }
+    item = PassthroughItemBuilder.build_item(
+        row=row, reason="where_clause_not_matched", action_name="action_c"
+    )
+
+    content = item["content"]
+    print(f"  tombstone content: {content}")
+
+    # Content should be the namespaced dict, not the entire row
+    if "action_a" in content and "action_b" in content:
+        print("  RESULT: OK — namespaced content preserved in tombstone")
+    else:
+        print("  RESULT: UNEXPECTED")
+
+    # Also test the fallback case (no content key)
+    row_no_content = {"field1": "val1", "target_id": "tid-2"}
+    item2 = PassthroughItemBuilder.build_item(
+        row=row_no_content, reason="where_clause_not_matched", action_name="action_c"
+    )
+    content2 = item2["content"]
+    print(f"  tombstone content (no content key): {content2}")
+
+    if content2 is row_no_content:
+        print("  RESULT: BUG — falls back to entire row (includes target_id etc)")
+    elif content2 == {}:
+        print("  RESULT: FIXED — empty dict when no content key")
+    else:
+        print(f"  RESULT: UNEXPECTED — {content2}")
+
+
+if __name__ == "__main__":
+    scenario_1_passthrough_enricher_namespaced()
+    scenario_2_lineage_enricher_record_level()
+    scenario_3_metadata_enricher_record_level()
+    scenario_4_recovery_enricher_record_level()
+    scenario_5_passthrough_builder()
+    print("\n=== Done ===")

--- a/tests/unit/processing/test_enrichment_namespaced.py
+++ b/tests/unit/processing/test_enrichment_namespaced.py
@@ -1,0 +1,308 @@
+"""Tests for enrichment pipeline with namespaced content.
+
+Content is namespaced: {"action_a": {...}, "action_b": {...}}.
+PassthroughEnricher must merge into content[action_name], not top-level.
+Other enrichers must NOT modify content internals — they work at record level.
+"""
+
+from agent_actions.processing.enrichment import (
+    EnrichmentPipeline,
+    LineageEnricher,
+    MetadataEnricher,
+    PassthroughEnricher,
+    RecoveryEnricher,
+    RequiredFieldsEnricher,
+    VersionIdEnricher,
+)
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+    RecoveryMetadata,
+    RetryMetadata,
+)
+
+
+def _make_context(action_name="action_c", is_first_stage=False):
+    return ProcessingContext(
+        agent_config={"agent_type": action_name, "kind": "llm", "granularity": "record"},
+        agent_name=action_name,
+        is_first_stage=is_first_stage,
+    )
+
+
+def _namespaced_content():
+    return {
+        "action_a": {"field_a": "val_a"},
+        "action_b": {"field_b": "val_b"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# PassthroughEnricher — namespaced content
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughEnricherNamespaced:
+    """PassthroughEnricher merges passthrough fields into the action namespace."""
+
+    def test_merges_into_existing_action_namespace(self):
+        """Passthrough fields merge INTO content[action_name], not top-level."""
+        content = {**_namespaced_content(), "action_c": {"llm_field": "llm_output"}}
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            passthrough_fields={"pt_field": "preserved"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        out = enriched.data[0]["content"]
+        # passthrough field is inside action_c namespace
+        assert out["action_c"]["pt_field"] == "preserved"
+        assert out["action_c"]["llm_field"] == "llm_output"
+        # NOT at top level
+        assert "pt_field" not in out
+
+    def test_creates_namespace_when_absent(self):
+        """If action namespace doesn't exist, passthrough fields create it."""
+        content = _namespaced_content()  # no action_c
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            passthrough_fields={"pt_field": "preserved"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        out = enriched.data[0]["content"]
+        assert out["action_c"] == {"pt_field": "preserved"}
+        assert "pt_field" not in out
+
+    def test_preserves_other_namespaces(self):
+        """Other action namespaces are not modified."""
+        content = {**_namespaced_content(), "action_c": {"llm_field": "val"}}
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            passthrough_fields={"pt_field": "preserved"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        out = enriched.data[0]["content"]
+        assert out["action_a"] == {"field_a": "val_a"}
+        assert out["action_b"] == {"field_b": "val_b"}
+
+    def test_no_passthrough_fields_is_noop(self):
+        """Empty passthrough_fields returns result unchanged."""
+        content = {**_namespaced_content(), "action_c": {"llm_field": "val"}}
+        data = [{"content": content}]
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=data,
+            passthrough_fields={},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        assert enriched.data[0]["content"] == content
+
+    def test_multiple_items(self):
+        """Passthrough fields merge into each item's action namespace."""
+        items = [
+            {"content": {**_namespaced_content(), "action_c": {"idx": 0}}},
+            {"content": {**_namespaced_content(), "action_c": {"idx": 1}}},
+        ]
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=items,
+            passthrough_fields={"pt": "val"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        for i in range(2):
+            assert enriched.data[i]["content"]["action_c"]["pt"] == "val"
+            assert enriched.data[i]["content"]["action_c"]["idx"] == i
+            assert "pt" not in enriched.data[i]["content"]
+
+    def test_item_without_content_key_skipped(self):
+        """Items with no content dict are skipped without error."""
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"some_field": "val"}],
+            passthrough_fields={"pt": "val"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        assert "content" not in enriched.data[0]
+        assert "pt" not in enriched.data[0]
+
+    def test_multiple_passthrough_fields(self):
+        """Multiple passthrough fields all merge into action namespace."""
+        content = {**_namespaced_content(), "action_c": {"llm_field": "val"}}
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            passthrough_fields={"pt_a": "a", "pt_b": "b", "pt_c": "c"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        ns = enriched.data[0]["content"]["action_c"]
+        assert ns["pt_a"] == "a"
+        assert ns["pt_b"] == "b"
+        assert ns["pt_c"] == "c"
+        assert ns["llm_field"] == "val"
+
+
+# ---------------------------------------------------------------------------
+# Other enrichers — verify they don't touch content internals
+# ---------------------------------------------------------------------------
+
+
+class TestLineageEnricherNamespaced:
+    """LineageEnricher works at record level — content untouched."""
+
+    def test_content_untouched(self):
+        content = _namespaced_content()
+        original_keys = set(content.keys())
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content, "source_guid": "sg-1"}],
+            source_guid="sg-1",
+        )
+        context = _make_context("action_c", is_first_stage=True)
+        enriched = LineageEnricher().enrich(result, context)
+
+        item = enriched.data[0]
+        assert "lineage" in item
+        assert "node_id" in item
+        assert set(item["content"].keys()) == original_keys
+
+
+class TestMetadataEnricherNamespaced:
+    """MetadataEnricher works at record level — content untouched."""
+
+    def test_content_untouched(self):
+        content = _namespaced_content()
+        original_keys = set(content.keys())
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            pre_extracted_metadata={"model": "gpt-4", "tokens": 100},
+        )
+        context = _make_context("action_c")
+        enriched = MetadataEnricher().enrich(result, context)
+
+        item = enriched.data[0]
+        assert "metadata" in item
+        assert set(item["content"].keys()) == original_keys
+
+
+class TestVersionIdEnricherNamespaced:
+    """VersionIdEnricher works at record level — content untouched."""
+
+    def test_content_untouched(self):
+        content = _namespaced_content()
+        original_keys = set(content.keys())
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+        )
+        context = _make_context("action_c")
+        context.agent_config["version_id"] = True
+        enriched = VersionIdEnricher().enrich(result, context)
+
+        item = enriched.data[0]
+        assert set(item["content"].keys()) == original_keys
+
+
+class TestRequiredFieldsEnricherNamespaced:
+    """RequiredFieldsEnricher works at record level — content untouched."""
+
+    def test_content_untouched(self):
+        content = _namespaced_content()
+        original_keys = set(content.keys())
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content, "source_guid": "sg-1"}],
+            source_guid="sg-1",
+        )
+        context = _make_context("action_c")
+        enriched = RequiredFieldsEnricher().enrich(result, context)
+
+        item = enriched.data[0]
+        assert "source_guid" in item
+        assert "target_id" in item
+        assert set(item["content"].keys()) == original_keys
+
+
+class TestRecoveryEnricherNamespaced:
+    """RecoveryEnricher works at record level — content untouched."""
+
+    def test_content_untouched(self):
+        content = _namespaced_content()
+        original_keys = set(content.keys())
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            recovery_metadata=RecoveryMetadata(
+                retry=RetryMetadata(attempts=2, failures=1, succeeded=True, reason="timeout")
+            ),
+        )
+        context = _make_context("action_c")
+        enriched = RecoveryEnricher().enrich(result, context)
+
+        item = enriched.data[0]
+        assert "_recovery" in item
+        assert set(item["content"].keys()) == original_keys
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline — all enrichers in sequence
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentPipelineNamespaced:
+    """Full enrichment pipeline with namespaced content."""
+
+    def test_full_pipeline_passthrough_in_correct_namespace(self):
+        """All enrichers run in sequence — passthrough in action namespace, others at record level."""
+        content = {
+            "action_a": {"field_a": "val_a"},
+            "action_b": {"field_b": "val_b"},
+            "action_c": {"llm_field": "llm_output"},
+        }
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content, "source_guid": "sg-1"}],
+            source_guid="sg-1",
+            passthrough_fields={"pt_field": "preserved_value"},
+            pre_extracted_metadata={"model": "gpt-4"},
+            recovery_metadata=RecoveryMetadata(
+                retry=RetryMetadata(attempts=2, failures=1, succeeded=True, reason="timeout")
+            ),
+        )
+        context = _make_context("action_c", is_first_stage=True)
+
+        enriched = EnrichmentPipeline().enrich(result, context)
+
+        item = enriched.data[0]
+
+        # Passthrough fields merged into action_c namespace
+        assert item["content"]["action_c"]["pt_field"] == "preserved_value"
+        assert item["content"]["action_c"]["llm_field"] == "llm_output"
+        assert "pt_field" not in item["content"]
+
+        # Other namespaces preserved
+        assert item["content"]["action_a"] == {"field_a": "val_a"}
+        assert item["content"]["action_b"] == {"field_b": "val_b"}
+
+        # Record-level enrichments present
+        assert "lineage" in item
+        assert "node_id" in item
+        assert "metadata" in item
+        assert "_recovery" in item

--- a/tests/unit/processing/test_enrichment_namespaced.py
+++ b/tests/unit/processing/test_enrichment_namespaced.py
@@ -199,12 +199,8 @@ _RECOVERY_META = RecoveryMetadata(
             id="metadata",
         ),
         pytest.param(VersionIdEnricher, {}, {}, id="version_id"),
-        pytest.param(
-            RequiredFieldsEnricher, {"source_guid": "sg-1"}, {}, id="required_fields"
-        ),
-        pytest.param(
-            RecoveryEnricher, {"recovery_metadata": _RECOVERY_META}, {}, id="recovery"
-        ),
+        pytest.param(RequiredFieldsEnricher, {"source_guid": "sg-1"}, {}, id="required_fields"),
+        pytest.param(RecoveryEnricher, {"recovery_metadata": _RECOVERY_META}, {}, id="recovery"),
     ],
 )
 def test_enricher_does_not_touch_content(enricher_cls, extra_result_kwargs, extra_context_kwargs):

--- a/tests/unit/processing/test_enrichment_namespaced.py
+++ b/tests/unit/processing/test_enrichment_namespaced.py
@@ -5,6 +5,8 @@ PassthroughEnricher must merge into content[action_name], not top-level.
 Other enrichers must NOT modify content internals — they work at record level.
 """
 
+import pytest
+
 from agent_actions.processing.enrichment import (
     EnrichmentPipeline,
     LineageEnricher,
@@ -157,108 +159,73 @@ class TestPassthroughEnricherNamespaced:
         assert ns["pt_c"] == "c"
         assert ns["llm_field"] == "val"
 
+    def test_passthrough_field_overwrites_llm_field_with_same_key(self):
+        """Passthrough field with same key as LLM output overwrites it."""
+        content = {**_namespaced_content(), "action_c": {"shared_key": "llm_value"}}
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            passthrough_fields={"shared_key": "passthrough_value"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        assert enriched.data[0]["content"]["action_c"]["shared_key"] == "passthrough_value"
+
 
 # ---------------------------------------------------------------------------
 # Other enrichers — verify they don't touch content internals
 # ---------------------------------------------------------------------------
 
 
-class TestLineageEnricherNamespaced:
-    """LineageEnricher works at record level — content untouched."""
-
-    def test_content_untouched(self):
-        content = _namespaced_content()
-        original_keys = set(content.keys())
-        result = ProcessingResult(
-            status=ProcessingStatus.SUCCESS,
-            data=[{"content": content, "source_guid": "sg-1"}],
-            source_guid="sg-1",
-        )
-        context = _make_context("action_c", is_first_stage=True)
-        enriched = LineageEnricher().enrich(result, context)
-
-        item = enriched.data[0]
-        assert "lineage" in item
-        assert "node_id" in item
-        assert set(item["content"].keys()) == original_keys
+_RECOVERY_META = RecoveryMetadata(
+    retry=RetryMetadata(attempts=2, failures=1, succeeded=True, reason="timeout")
+)
 
 
-class TestMetadataEnricherNamespaced:
-    """MetadataEnricher works at record level — content untouched."""
+@pytest.mark.parametrize(
+    "enricher_cls,extra_result_kwargs,extra_context_kwargs",
+    [
+        pytest.param(
+            LineageEnricher,
+            {"source_guid": "sg-1"},
+            {"is_first_stage": True},
+            id="lineage",
+        ),
+        pytest.param(
+            MetadataEnricher,
+            {"pre_extracted_metadata": {"model": "gpt-4", "tokens": 100}},
+            {},
+            id="metadata",
+        ),
+        pytest.param(VersionIdEnricher, {}, {}, id="version_id"),
+        pytest.param(
+            RequiredFieldsEnricher, {"source_guid": "sg-1"}, {}, id="required_fields"
+        ),
+        pytest.param(
+            RecoveryEnricher, {"recovery_metadata": _RECOVERY_META}, {}, id="recovery"
+        ),
+    ],
+)
+def test_enricher_does_not_touch_content(enricher_cls, extra_result_kwargs, extra_context_kwargs):
+    """Each non-passthrough enricher works at record level — content keys unchanged."""
+    content = _namespaced_content()
+    original_keys = set(content.keys())
 
-    def test_content_untouched(self):
-        content = _namespaced_content()
-        original_keys = set(content.keys())
-        result = ProcessingResult(
-            status=ProcessingStatus.SUCCESS,
-            data=[{"content": content}],
-            pre_extracted_metadata={"model": "gpt-4", "tokens": 100},
-        )
-        context = _make_context("action_c")
-        enriched = MetadataEnricher().enrich(result, context)
+    data_item = {"content": content}
+    if "source_guid" in extra_result_kwargs:
+        data_item["source_guid"] = extra_result_kwargs["source_guid"]
 
-        item = enriched.data[0]
-        assert "metadata" in item
-        assert set(item["content"].keys()) == original_keys
+    result = ProcessingResult(
+        status=ProcessingStatus.SUCCESS,
+        data=[data_item],
+        **extra_result_kwargs,
+    )
+    context = _make_context("action_c", **extra_context_kwargs)
 
+    enriched = enricher_cls().enrich(result, context)
 
-class TestVersionIdEnricherNamespaced:
-    """VersionIdEnricher works at record level — content untouched."""
-
-    def test_content_untouched(self):
-        content = _namespaced_content()
-        original_keys = set(content.keys())
-        result = ProcessingResult(
-            status=ProcessingStatus.SUCCESS,
-            data=[{"content": content}],
-        )
-        context = _make_context("action_c")
-        context.agent_config["version_id"] = True
-        enriched = VersionIdEnricher().enrich(result, context)
-
-        item = enriched.data[0]
-        assert set(item["content"].keys()) == original_keys
-
-
-class TestRequiredFieldsEnricherNamespaced:
-    """RequiredFieldsEnricher works at record level — content untouched."""
-
-    def test_content_untouched(self):
-        content = _namespaced_content()
-        original_keys = set(content.keys())
-        result = ProcessingResult(
-            status=ProcessingStatus.SUCCESS,
-            data=[{"content": content, "source_guid": "sg-1"}],
-            source_guid="sg-1",
-        )
-        context = _make_context("action_c")
-        enriched = RequiredFieldsEnricher().enrich(result, context)
-
-        item = enriched.data[0]
-        assert "source_guid" in item
-        assert "target_id" in item
-        assert set(item["content"].keys()) == original_keys
-
-
-class TestRecoveryEnricherNamespaced:
-    """RecoveryEnricher works at record level — content untouched."""
-
-    def test_content_untouched(self):
-        content = _namespaced_content()
-        original_keys = set(content.keys())
-        result = ProcessingResult(
-            status=ProcessingStatus.SUCCESS,
-            data=[{"content": content}],
-            recovery_metadata=RecoveryMetadata(
-                retry=RetryMetadata(attempts=2, failures=1, succeeded=True, reason="timeout")
-            ),
-        )
-        context = _make_context("action_c")
-        enriched = RecoveryEnricher().enrich(result, context)
-
-        item = enriched.data[0]
-        assert "_recovery" in item
-        assert set(item["content"].keys()) == original_keys
+    assert set(enriched.data[0]["content"].keys()) == original_keys
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_passthrough_builder.py
+++ b/tests/unit/utils/test_passthrough_builder.py
@@ -140,14 +140,24 @@ class TestBuildItemBatchMode:
             )
         assert item["content"] == inner
 
-    def test_content_falls_back_to_entire_row(self):
-        """When row has no 'content' key, the whole row becomes content."""
+    def test_namespaced_content_preserved(self):
+        """Namespaced content is preserved in the tombstone item."""
+        namespaced = {"action_a": {"field_a": "val_a"}, "action_b": {"field_b": "val_b"}}
+        row = {"content": namespaced, "target_id": "tid-1", "source_guid": "sg-1"}
+        with _patch_id_gen():
+            item = PassthroughItemBuilder.build_item(
+                row=row, reason="where_clause_not_matched", action_name="action_c"
+            )
+        assert item["content"] == namespaced
+
+    def test_content_defaults_to_empty_dict_when_missing(self):
+        """When row has no 'content' key, content defaults to empty dict."""
         row = {"field1": "val1", "field2": "val2"}
         with _patch_id_gen():
             item = PassthroughItemBuilder.build_item(
                 row=row, reason="where_clause_not_matched", action_name="a"
             )
-        assert item["content"] == row
+        assert item["content"] == {}
 
     def test_conditional_clause_flag_in_batch(self):
         """Batch mode with conditional_clause_failed sets the right flag."""
@@ -255,7 +265,7 @@ class TestBuildItemEdgeCases:
     """Edge cases: empty rows, falsy target_ids, etc."""
 
     def test_empty_row(self):
-        """An empty row still produces a valid passthrough item."""
+        """An empty row still produces a valid passthrough item with empty content."""
         with _patch_id_gen():
             item = PassthroughItemBuilder.build_item(
                 row={}, reason="where_clause_not_matched", action_name="a"
@@ -263,7 +273,6 @@ class TestBuildItemEdgeCases:
         assert item["_unprocessed"] is True
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item["target_id"] == FIXED_TARGET_ID
-        # content falls back to entire row (empty dict)
         assert item["content"] == {}
 
     def test_falsy_target_id_in_row(self):


### PR DESCRIPTION
## Summary
- PassthroughEnricher now merges passthrough fields into `content[context.action_name]` instead of at the top level of the content dict
- PassthroughItemBuilder.build_item no longer falls back to the entire row dict when content key is missing — uses empty dict
- All other enrichers (Lineage, Metadata, VersionId, RequiredFields, Recovery) verified to work at record level only — they don't touch content internals

## Sibling patterns deferred (not owned by this clone)
The `item.get("content", item)` flat-fallback pattern also exists in:
- `processing/task_preparer.py:48,151` (clone 4 owns)
- `prompt/context/scope_file_mode.py:341` (clone 3 owns)
- `workflow/pipeline_file_mode.py:484`, `cli/preview.py:180`, `llm/providers/batch_base.py:100` (unassigned)

Documented in coordination/status.md cross-clone issue #5.

## Verification
- Manual repro script confirms bug before fix and correct behavior after
- 13 new tests for namespaced enrichment (PassthroughEnricher + all other enrichers + full pipeline)
- Updated 2 existing passthrough_builder tests for new content fallback
- Full test suite: 5805 passed, 2 skipped
- ruff check + ruff format: clean