### PR TITLE
feat: observe as namespace selection from record content

### DIFF
--- a/.changes/unreleased/Breaking Change-20260423-086000.yaml
+++ b/.changes/unreleased/Breaking Change-20260423-086000.yaml
@@ -1,0 +1,3 @@
+kind: Breaking Change
+body: "Observe reads from record namespaces instead of storage backend lookups"
+time: 2026-04-23T08:60:00.000000Z

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -23,7 +23,6 @@ __all__ = [
 ]
 
 
-# Complex field context building with historical data requires all these parameters
 def build_field_context_with_history(
     agent_name: str,
     agent_config: dict | None,

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -1,4 +1,4 @@
-"""Field context builder with historical data loading."""
+"""Field context builder — reads from record's namespaced content."""
 
 import logging
 from typing import TYPE_CHECKING, Any, Optional
@@ -11,12 +11,9 @@ from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextNamespaceLoadedEvent
 from agent_actions.prompt.context.scope_inference import infer_dependencies
 from agent_actions.prompt.context.scope_namespace import (
-    _detect_version_namespaces,
-    _enrich_source_namespace,
     _extract_allowed_fields_per_dependency,
     _extract_content_data,
     _filter_and_store_fields,
-    _load_historical_node,
 )
 
 logger = logging.getLogger(__name__)
@@ -44,9 +41,8 @@ def build_field_context_with_history(
     """
     Build field context with explicit namespace structure.
 
-    AUTO-INFERRED CONTEXT DEPENDENCIES:
-    - Input sources (from dependencies field): Data already in current_item
-    - Context sources (auto-inferred from context_scope): Loaded via historical loader
+    Additive content model: all dependency data lives on the record's
+    namespaced content.  No storage backend lookup required.
 
     IMPORTANT: agent_indices is REQUIRED when action has dependencies.
     No fallbacks - this ensures consistent behavior across all execution modes.
@@ -88,12 +84,16 @@ def build_field_context_with_history(
 
     field_context = {}
 
-    # 1. SOURCE namespace - original input data
-    source_namespace = {}
-    if source_content:
-        source_namespace = _extract_content_data(source_content)
-
-    source_namespace = _enrich_source_namespace(source_namespace, current_item)
+    # 1. SOURCE namespace - original input data.
+    # source_content is raw input (not a record), so we must not filter
+    # _RECORD_METADATA_KEYS from it.  _extract_content_data is designed
+    # for records; use it only to unwrap the {"content": {...}} wrapper.
+    source_namespace: dict = {}
+    if source_content and isinstance(source_content, dict):
+        if "content" in source_content and isinstance(source_content["content"], dict):
+            source_namespace = source_content["content"]
+        else:
+            source_namespace = dict(source_content)
 
     if source_namespace:
         field_context["source"] = source_namespace
@@ -107,24 +107,15 @@ def build_field_context_with_history(
             )
         )
 
-    # 2. DEPENDENCY namespaces - separate input sources from context sources
-    logger.debug(
-        "[CONTEXT BUILD] Action '%s': agent_config=%s, agent_indices=%s, current_item=%s, file_path=%s",
-        agent_name,
-        bool(agent_config),
-        len(agent_indices) if agent_indices else 0,
-        bool(current_item),
-        bool(file_path),
-    )
+    # 2. DEPENDENCY namespaces — read from record's namespaced content.
+    # With the additive content model, every previous action's output is
+    # stored under its namespace on the record: content = {"action_a": {...}, ...}.
+    # No storage backend lookup required.
     batch_mode_enabled = bool(agent_config and agent_indices and current_item and file_path)
     logger.debug(
-        "[CONTEXT BUILD] Action '%s': batch_mode_enabled=%s (config=%s, indices=%s, item=%s, path=%s)",
+        "[CONTEXT BUILD] Action '%s': batch_mode_enabled=%s",
         agent_name,
         batch_mode_enabled,
-        bool(agent_config),
-        bool(agent_indices),
-        bool(current_item),
-        bool(file_path),
     )
     if batch_mode_enabled:
         # Narrowed by batch_mode_enabled — all are truthy
@@ -145,11 +136,7 @@ def build_field_context_with_history(
                 f"file_path must not be None when batch_mode is enabled (action: '{agent_name}')"
             )
 
-        # BATCH MODE - Use auto-inferred context dependencies
         workflow_actions = list(agent_indices.keys())
-
-        # Infer input sources vs context sources. Validation is skipped
-        # because the static validator already caught invalid references.
         input_sources, context_sources = infer_dependencies(
             agent_config, workflow_actions, agent_name, validate=False
         )
@@ -161,252 +148,54 @@ def build_field_context_with_history(
             context_sources,
         )
 
-        lineage = current_item.get("lineage", [])
-        source_guid = current_item.get("source_guid")
-        current_idx = agent_indices.get(agent_name, 999)
-        allowed_fields_map = None
+        # Additive model: all dependency data lives on the record.
+        namespaced_content = _extract_content_data(current_item)
+        all_deps = input_sources + context_sources
 
-        # 2a. INPUT SOURCES - Data is already in current_item (the file being processed)
-        # Put it under the action name so prompts can reference {{ action_name.field }}
-        if input_sources and current_item:
-            input_data = _extract_content_data(current_item)
-
-            # Get allowed fields for input sources
-            all_deps_for_fields = input_sources + context_sources
+        if all_deps:
             allowed_fields_map = _extract_allowed_fields_per_dependency(
-                all_deps_for_fields, context_scope, agent_name
+                all_deps, context_scope, agent_name
             )
 
-            # Check if input_data contains nested version namespaces from version_consumption
-            # This happens when upstream action used version_consumption with merge pattern
-            # Structure: {version_1: {fields}, version_2: {fields}, ...}
-            version_namespaces_detected = _detect_version_namespaces(input_data, input_sources)
-
-            if version_namespaces_detected:
-                # Split nested version namespaces into separate top-level namespaces
-                logger.debug(
-                    "[VERSION NAMESPACES] Detected nested version namespaces in input_data: %s",
-                    version_namespaces_detected,
-                )
-
-                for version_name, version_data in input_data.items():
-                    if not isinstance(version_data, dict):
-                        # Not a version namespace, skip
-                        continue
-
-                    if version_name not in version_namespaces_detected:
-                        # Not a detected version namespace, skip
-                        continue
-
-                    # Add as separate namespace in field_context
-                    allowed_fields = allowed_fields_map.get(version_name)
-                    _filter_and_store_fields(
-                        field_context,
-                        version_name,
-                        version_data,
-                        allowed_fields,
-                        source_type="VERSION NAMESPACE",
-                        metadata_collector=metadata_collector,
-                    )
-
-                # Load parallel version sources via historical lookup
-                # When input_sources has multiple versioned branches (e.g., action_1, action_2),
-                # current_item only contains data from one. Load others from historical data.
-                parallel_version_sources = [
-                    src
-                    for src in input_sources
-                    if src not in field_context and src in agent_indices
-                ]
-                if parallel_version_sources and source_guid:
-                    logger.debug(
-                        "[PARALLEL VERSIONS] Loading %d parallel version sources "
-                        "via historical lookup: %s",
-                        len(parallel_version_sources),
-                        parallel_version_sources,
-                    )
-                    for version_source in parallel_version_sources:
-                        version_idx = agent_indices.get(version_source)
-                        if version_idx is None or version_idx >= current_idx:
-                            continue
-
-                        try:
-                            historical_data = _load_historical_node(
-                                action_name=version_source,
-                                lineage=lineage,
-                                source_guid=source_guid or "",
-                                file_path=file_path,
-                                agent_indices=agent_indices,
-                                parent_target_id=current_item.get("parent_target_id"),
-                                root_target_id=current_item.get("root_target_id"),
-                                output_directory=output_directory,
-                                storage_backend=storage_backend,
-                                lineage_sources=current_item.get("lineage_sources"),
-                            )
-                        except (ValueError, TypeError, KeyError):
-                            logger.warning(
-                                "Failed to load historical data for version source '%s'",
-                                version_source,
-                                exc_info=True,
-                            )
-                            historical_data = None
-
-                        if historical_data:
-                            allowed_fields = allowed_fields_map.get(version_source)
-                            _filter_and_store_fields(
-                                field_context,
-                                version_source,
-                                historical_data,
-                                allowed_fields,
-                                source_type="PARALLEL VERSION",
-                                metadata_collector=metadata_collector,
-                            )
-                        else:
-                            logger.warning(
-                                "[PARALLEL VERSION] Could not load '%s' "
-                                "via historical lookup. source_guid=%s",
-                                version_source,
-                                source_guid,
-                            )
-            else:
-                # No version namespaces detected - use original behavior
-                logger.debug(
-                    "[INPUT SOURCE] input_data keys: %s",
-                    list(input_data.keys()) if input_data else "EMPTY",
-                )
-                for input_source_name in input_sources:
-                    allowed_fields = allowed_fields_map.get(input_source_name)
-                    logger.debug(
-                        "[INPUT SOURCE] '%s': allowed_fields=%s",
-                        input_source_name,
-                        allowed_fields,
-                    )
-                    _filter_and_store_fields(
-                        field_context,
-                        input_source_name,
-                        input_data,
-                        allowed_fields,
-                        source_type="INPUT SOURCE",
-                        fail_on_missing=True,
-                        metadata_collector=metadata_collector,
-                    )
-
-        # 2b. CONTEXT SOURCES - Load via historical loader (lineage matching)
-        logger.debug(
-            "[CONTEXT SOURCES CHECK] Action '%s': context_sources=%s, will load=%s",
-            agent_name,
-            context_sources,
-            bool(context_sources),
-        )
-        if context_sources:
-            # Get allowed fields for context sources
-            if allowed_fields_map is None:
-                all_deps_for_fields = input_sources + context_sources
-                allowed_fields_map = _extract_allowed_fields_per_dependency(
-                    all_deps_for_fields, context_scope, agent_name
-                )
-
-            logger.debug(
-                "[CONTEXT SOURCES] Loading %d context dependencies: %s (storage_backend=%s)",
-                len(context_sources),
-                context_sources,
-                "available" if storage_backend else "NOT available",
-            )
-
-            for dep_name in context_sources:
-                # Skip special reserved namespaces - they're populated differently
+            for dep_name in all_deps:
                 if dep_name in SPECIAL_NAMESPACES:
                     logger.debug("Skipping special namespace '%s' (handled separately)", dep_name)
                     continue
 
-                # Check if dependency should be loaded
-                dep_idx = agent_indices.get(dep_name)
-                if dep_idx is None:
-                    logger.warning(
-                        "Context dependency '%s' not found in agent_indices. Available: %s",
-                        dep_name,
-                        list(agent_indices.keys()),
-                    )
-                    continue
-
-                if dep_idx >= current_idx:
+                dep_data = namespaced_content.get(dep_name)
+                if dep_data is None:
+                    # Missing namespace: skipped action or not yet produced — not an error.
                     logger.debug(
-                        "Skipping context dependency '%s' (comes after current action)",
+                        "[RECORD NAMESPACE] '%s' not found on record for action '%s'",
                         dep_name,
+                        agent_name,
                     )
                     continue
 
-                # Load historical data
-                logger.debug(
-                    "[HISTORICAL LOAD] Loading context dep '%s' from file_path=%s",
-                    dep_name,
-                    file_path,
-                )
-                try:
-                    historical_data = _load_historical_node(
-                        action_name=dep_name,
-                        lineage=lineage,
-                        source_guid=source_guid or "",
-                        file_path=file_path,
-                        agent_indices=agent_indices,
-                        parent_target_id=current_item.get("parent_target_id"),
-                        root_target_id=current_item.get("root_target_id"),
-                        output_directory=output_directory,
-                        storage_backend=storage_backend,
-                        lineage_sources=current_item.get("lineage_sources"),
-                    )
-                except (ValueError, TypeError, KeyError):
+                if not isinstance(dep_data, dict):
                     logger.warning(
-                        "Failed to load historical data for context dep '%s'",
+                        "[RECORD NAMESPACE] '%s' for action '%s' is %s, not dict — skipping",
                         dep_name,
-                        exc_info=True,
-                    )
-                    historical_data = None
-
-                logger.debug(
-                    "[HISTORICAL] Action '%s': dep='%s' -> %s",
-                    agent_name,
-                    dep_name,
-                    "FOUND" if historical_data else "NOT FOUND",
-                )
-                if historical_data is None:
-                    logger.warning(
-                        "[CONTEXT SOURCE] Context dependency '%s' historical data not found. "
-                        "Lineage: %s, source_guid: %s. "
-                        "Dependency will not be available in field_context.",
-                        dep_name,
-                        lineage,
-                        source_guid,
+                        agent_name,
+                        type(dep_data).__name__,
                     )
                     continue
 
-                logger.debug(
-                    "[HISTORICAL LOAD] Loaded context dep '%s': fields=%s",
-                    dep_name,
-                    list(historical_data.keys()),
-                )
-
-                # PROGRESSIVE DATA EXPOSURE: Filter to only allowed fields
                 allowed_fields = allowed_fields_map.get(dep_name)
                 _filter_and_store_fields(
                     field_context,
                     dep_name,
-                    historical_data,
+                    dep_data,
                     allowed_fields,
-                    source_type="CONTEXT SOURCE",
+                    source_type="RECORD NAMESPACE",
                     fail_on_missing=True,
                     metadata_collector=metadata_collector,
                 )
 
     else:
-        # Log why batch mode condition wasn't met
         logger.debug(
-            "[CONTEXT BUILD SKIP] Action '%s': Batch mode condition not met. "
-            "agent_config=%s, agent_indices=%s, current_item=%s, file_path=%s",
+            "[CONTEXT BUILD SKIP] Action '%s': Batch mode condition not met.",
             agent_name,
-            bool(agent_config),
-            len(agent_indices) if agent_indices else 0,
-            bool(current_item),
-            bool(file_path),
         )
 
     if agent_config and agent_config.get("dependencies") and not agent_indices:

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -66,8 +66,8 @@ def build_field_context_with_history(
         current_item: Current record being processed (has lineage, content)
         file_path: Path to current file
         context_scope: Controls which fields to load (progressive data exposure)
-        output_directory: Optional output directory (legacy, unused)
-        storage_backend: Optional storage backend for loading historical data from SQLite/TinyDB
+        output_directory: Unused (legacy parameter retained for caller compatibility)
+        storage_backend: Unused (legacy parameter retained for caller compatibility)
 
     Returns:
         Dict with namespaces: source, {dep_names}, version, workflow

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -1,4 +1,4 @@
-"""File-mode observe filtering for namespace-aware context resolution."""
+"""File-mode observe filtering — reads from record's namespaced content."""
 
 import logging
 from collections import Counter
@@ -9,12 +9,8 @@ if TYPE_CHECKING:
 
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
-from agent_actions.prompt.context.scope_inference import infer_dependencies
 from agent_actions.prompt.context.scope_namespace import (
-    _RECORD_METADATA_KEYS,
-    _detect_version_namespaces,
     _extract_content_data,
-    _load_historical_node,
 )
 from agent_actions.prompt.context.scope_parsing import parse_field_reference
 
@@ -67,123 +63,6 @@ def _resolve_observe_refs(
     return parsed
 
 
-def _load_file_mode_cross_namespace_data(
-    needed_ns: set,
-    record: dict,
-    agent_name: str,
-    agent_indices: dict[str, int] | None = None,
-    file_path: str | None = None,
-    source_record: dict | None = None,
-    storage_backend: Optional["StorageBackend"] = None,
-) -> dict[str, dict]:
-    """Load data for namespaces NOT present in the per-record content.
-
-    Returns ``{namespace: {field: value}}`` for source and context-dep
-    namespaces.  Input-source namespaces (whose data lives in each record's
-    ``content``) are *not* loaded here.
-
-    *needed_ns* is the set of namespace identifiers that require
-    cross-namespace loading, pre-computed by the caller (which applies
-    the ``has_reliable_ns`` gate).  This method must not recompute it.
-
-    Called once per unique ancestry key in a file; the caller caches the
-    result so that records sharing the same key skip redundant I/O.
-    """
-    cross_ns: dict[str, dict] = {}
-
-    # Defensive copy -- we mutate via discard below.
-    needed_ns = set(needed_ns)
-
-    if not needed_ns:
-        return cross_ns
-
-    # --- "source" namespace: use the matched source record ----
-    if "source" in needed_ns:
-        needed_ns.discard("source")
-        if source_record:
-            cross_ns["source"] = _extract_content_data(source_record)
-        else:
-            logger.warning(
-                "[FILE OBSERVE] 'source' namespace referenced but no source_record available "
-                "for action '%s'.",
-                agent_name,
-            )
-
-    # --- context dependency namespaces: load via historical lookup -----
-    if needed_ns and record and agent_indices and file_path:
-        lineage = record.get("lineage", [])
-        source_guid = record.get("source_guid")
-        current_idx = agent_indices.get(agent_name, 999)
-
-        for ns in needed_ns:
-            dep_idx = agent_indices.get(ns)
-            if dep_idx is None:
-                logger.warning(
-                    "[FILE OBSERVE] Namespace '%s' not found in agent_indices for action '%s'. "
-                    "Available: %s. Skipping.",
-                    ns,
-                    agent_name,
-                    list(agent_indices.keys()),
-                )
-                continue
-            if dep_idx >= current_idx:
-                logger.debug(
-                    "[FILE OBSERVE] Skipping namespace '%s' (comes after current action '%s').",
-                    ns,
-                    agent_name,
-                )
-                continue
-
-            if not source_guid:
-                logger.warning(
-                    "[FILE OBSERVE] Cannot load namespace '%s': record has no "
-                    "source_guid. action='%s'.",
-                    ns,
-                    agent_name,
-                )
-                continue
-
-            try:
-                hist = _load_historical_node(
-                    action_name=ns,
-                    lineage=lineage,
-                    source_guid=source_guid,
-                    file_path=file_path,
-                    agent_indices=agent_indices,
-                    parent_target_id=record.get("parent_target_id"),
-                    root_target_id=record.get("root_target_id"),
-                    storage_backend=storage_backend,
-                )
-                if hist:
-                    cross_ns[ns] = hist
-                else:
-                    logger.warning(
-                        "[FILE OBSERVE] Historical data not found for namespace '%s'. "
-                        "action='%s', source_guid=%s.",
-                        ns,
-                        agent_name,
-                        source_guid,
-                    )
-            except (OSError, KeyError, TypeError, ValueError, AttributeError):
-                logger.warning(
-                    "[FILE OBSERVE] Failed to load historical data for namespace '%s'. "
-                    "action='%s'. Skipping.",
-                    ns,
-                    agent_name,
-                    exc_info=True,
-                )
-    elif needed_ns:
-        for ns in needed_ns:
-            logger.warning(
-                "[FILE OBSERVE] Cannot load namespace '%s': missing agent_indices/file_path/record "
-                "for action '%s'. Skipping.",
-                ns,
-                agent_name,
-            )
-
-    return cross_ns
-
-
 def apply_observe_for_file_mode(
     data: list[dict],
     agent_config: dict,
@@ -195,14 +74,15 @@ def apply_observe_for_file_mode(
 ) -> list[dict]:
     """Namespace-aware observe filter for file-mode (array-level) data.
 
-    Replaces the simplified ``_apply_observe_filter`` which stripped
-    namespaces and looked up bare keys in the record content.  This method
-    resolves cross-namespace references (``source.url``, context deps)
-    correctly.
+    With the additive content model, every previous action's output is
+    stored under its namespace on each record.  Observe refs select
+    fields from these namespaces — no storage backend lookup required.
 
-    Returns a filtered ``List[Dict]`` with the same shape as the old method
-    so downstream callers (``_process_file_mode_tool``,
-    ``_process_file_mode_hitl``) are unaffected.
+    The ``source`` namespace is the only cross-record reference: it is
+    resolved from *source_data* (the original input file records).
+
+    Returns a new list of enriched records with observed fields injected
+    into each record's content.
     """
     context_scope = agent_config.get("context_scope") or {}
     observe_refs = context_scope.get("observe")
@@ -219,194 +99,61 @@ def apply_observe_for_file_mode(
     # wildcards exist (prevents bare-key collisions across namespaces).
     qualify_wildcards = len(wildcard_ns) > 1
 
-    # Determine which namespaces are "input sources" (data in each record).
-    # Use fan-in-aware inference so non-primary deps are loaded historically.
-    # `has_reliable_ns` tracks whether input_source_names contains real
-    # namespace identifiers (from deps/infer_dependencies) vs content-key
-    # guesses.  When True, we can safely gate content fallback to only
-    # input-source namespaces; when False we must allow it for all refs.
-    input_source_names: set = set()
-    has_reliable_ns = False
-    if agent_indices:
-        try:
-            input_sources, _ = infer_dependencies(
-                agent_config, list(agent_indices.keys()), agent_name, validate=False
-            )
-            input_source_names = set(input_sources)
-            has_reliable_ns = bool(input_source_names)
-        except Exception:
-            logger.warning(
-                "[FILE OBSERVE] infer_dependencies failed for '%s'; "
-                "falling back to raw dependencies.",
-                agent_name,
-                exc_info=True,
-            )
-
-    if not input_source_names:
-        # Fallback: raw dependencies or content-key heuristic.
-        deps = (
-            agent_config["dependencies"]
-            if "dependencies" in agent_config
-            else agent_config.get("depends_on")
-        )
-        if deps:
-            if isinstance(deps, str):
-                input_source_names = {deps}
-            else:
-                input_source_names = {d for d in deps if isinstance(d, str)}
-            has_reliable_ns = True
-        elif data and isinstance(data[0], dict):
-            # Best-effort heuristic: treat all top-level keys in record
-            # content as input-source namespaces.  This can misclassify a
-            # key that coincidentally matches a namespace name, but without
-            # explicit dependencies there is no reliable way to distinguish
-            # input-source keys from metadata.  has_reliable_ns stays False.
-            sample = data[0]
-            sample_content_val = sample.get("content")
-            sample_content = (
-                sample_content_val
-                if isinstance(sample_content_val, dict) and sample_content_val
-                else {k: v for k, v in sample.items() if k not in _RECORD_METADATA_KEYS}
-            )
-            input_source_names = set(sample_content.keys())
-
-    # Detect version-correlated namespaces in record content.
-    # When upstream used version_consumption with merge pattern, records
-    # contain nested dicts keyed by version action names (e.g.,
-    # {"gen_code_1": {"code": "..."}, "gen_code_2": {"code": "..."}}).
-    # These must be resolved from content directly — historical lookup
-    # fails because version keys aren't ancestor nodes in the lineage.
-    version_ns_in_content: set[str] = set()
-    if data and isinstance(data[0], dict):
-        sample = data[0]
-        sample_cv = sample.get("content")
-        sample_content = (
-            sample_cv
-            if isinstance(sample_cv, dict) and sample_cv
-            else {k: v for k, v in sample.items() if k not in _RECORD_METADATA_KEYS}
-        )
-        if sample_content:
-            ref_namespaces = [ns for ns, _, _ in resolved]
-            detected = _detect_version_namespaces(sample_content, ref_namespaces)
-            version_ns_in_content = set(detected)
-            if version_ns_in_content:
-                logger.debug(
-                    "[FILE OBSERVE] Detected version namespaces in content: %s",
-                    version_ns_in_content,
-                )
-
-    # Determine which namespaces need cross-namespace loading.
-    # "source" is always a known cross-namespace ref (loaded from
-    # source_data, not historical lookups) so it is always eligible.
-    # Version namespaces detected in content are resolved directly from
-    # the record (not via historical lookup), so they skip needed_ns.
-    # Other namespaces require has_reliable_ns because when
-    # input_source_names contains content keys (heuristic), the
-    # `ns not in input_source_names` check would misclassify every
-    # namespace as cross-namespace and trigger spurious historical
-    # loads whose stale results would shadow live record data.
-    needed_ns: set = set()
-    for ns, _field, _ in resolved:
-        if ns == "source":
-            needed_ns.add(ns)
-        elif ns in version_ns_in_content:
-            pass  # Resolved from content directly, not historical lookup
-        elif has_reliable_ns and ns not in input_source_names:
-            needed_ns.add(ns)
-
-    # Build source index for matching source records by source_guid.
+    # Build source index for "source" namespace (the only cross-record ref).
+    has_source_refs = any(ns == "source" for ns, _, _ in resolved)
     source_index: dict[str | None, dict] = {}
-    if "source" in needed_ns and source_data:
+    if has_source_refs and source_data:
         for src in source_data:
             sguid = src.get("source_guid") if isinstance(src, dict) else None
             if sguid:
                 source_index[sguid] = src
 
-    # Per-record loop with ancestry-aware cache.
-    # Historical lookups depend on source_guid + lineage + parent/root target IDs,
-    # so the cache key must include all discriminators to avoid returning stale
-    # data when records share a source_guid but diverge in ancestry.
-    # Fast path: no cross-namespace refs AND no version namespaces to resolve.
-    if not needed_ns and not version_ns_in_content:
-        return data
-
-    cross_ns_cache: dict[tuple, dict[str, dict]] = {}
+    # Per-record loop: extract observed fields from namespaced content.
     filtered: list[dict] = []
     for item in data:
         if not isinstance(item, dict):
             filtered.append(item)  # type: ignore[unreachable]
             continue
 
-        # Extract content, guarding against the empty-content trap:
-        # item.get("content", item) returns {} when content exists but is
-        # empty, instead of falling back to item.  Filter metadata keys
-        # from the fallback to prevent infrastructure fields from leaking
-        # into enriched_content (source_guid, lineage, node_id, etc.).
+        # Extract namespaced content from record.
         content_val = item.get("content")
-        content = (
-            content_val
-            if isinstance(content_val, dict) and content_val
-            else {k: v for k, v in item.items() if k not in _RECORD_METADATA_KEYS}
-        )
+        content = content_val if isinstance(content_val, dict) else {}
 
-        # Resolve cross-namespace data (cached by ancestry key).
-        sguid = item.get("source_guid")
-        cache_key = (
-            sguid,
-            tuple(item.get("lineage", [])),
-            item.get("parent_target_id"),
-            item.get("root_target_id"),
-        )
-        if cache_key not in cross_ns_cache:
-            matched_source = source_index.get(sguid, source_data[0] if source_data else None)
-            cross_ns_cache[cache_key] = _load_file_mode_cross_namespace_data(
-                needed_ns=needed_ns,
-                record=item,
-                agent_name=agent_name,
-                agent_indices=agent_indices,
-                file_path=file_path,
-                source_record=matched_source,
-                storage_backend=storage_backend,
-            )
-        cross_ns_data = cross_ns_cache[cache_key]
-
-        # Inject version namespace data directly from record content.
-        # Version-correlated records have nested dicts that must be
-        # resolved here — not via historical lookup (which fails for
-        # version keys).  Work on a copy to avoid mutating the cache.
-        if version_ns_in_content:
-            cross_ns_data = dict(cross_ns_data)
-            for vns in version_ns_in_content:
-                if vns in content and isinstance(content[vns], dict):
-                    cross_ns_data[vns] = content[vns]
-
-        # NiFi-inspired: enrich the record rather than stripping to a flat
-        # dict.  Shallow-copy record + content to avoid mutating caller's
-        # data when injecting cross-namespace fields.
+        # Shallow-copy to avoid mutating caller's data.
         enriched = dict(item)
         enriched_content = dict(content)
 
-        for ns, field, output_key in resolved:
-            if field == "*":
-                if ns in cross_ns_data:
-                    for f, v in cross_ns_data[ns].items():
-                        key = f"{ns}.{f}" if qualify_wildcards else f
-                        enriched_content[key] = v
-                continue
+        # Resolve source record once per item (not per ref).
+        source_content: dict = {}
+        if has_source_refs:
+            sguid = item.get("source_guid")
+            matched_source = source_index.get(sguid, source_data[0] if source_data else None)
+            source_content = _extract_content_data(matched_source) if matched_source else {}
 
-            if ns in cross_ns_data and field in cross_ns_data[ns]:
-                enriched_content[output_key] = cross_ns_data[ns][field]
-            elif (not has_reliable_ns or ns in input_source_names) and field in content:
-                pass  # already present in enriched_content
+        for ns, field, output_key in resolved:
+            # Resolve namespace data.
+            if ns == "source":
+                ns_data = source_content
+            else:
+                # Action namespace: directly on the record's namespaced content.
+                ns_data = content.get(ns, {})
+                if not isinstance(ns_data, dict):
+                    ns_data = {}
+
+            if field == "*":
+                for f, v in ns_data.items():
+                    key = f"{ns}.{f}" if qualify_wildcards else f
+                    enriched_content[key] = v
+            elif field in ns_data:
+                enriched_content[output_key] = ns_data[field]
             else:
                 logger.debug(
                     "[FILE OBSERVE] Field '%s' (ns='%s') not found for action '%s'. "
-                    "content keys=%s, cross_ns keys=%s.",
+                    "ns_data keys=%s.",
                     field,
                     ns,
                     agent_name,
-                    list(content.keys()),
-                    list(cross_ns_data.get(ns, {}).keys()),
+                    list(ns_data.keys()),
                 )
 
         enriched["content"] = enriched_content

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -9,10 +9,9 @@ if TYPE_CHECKING:
 
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
-from agent_actions.prompt.context.scope_namespace import (
-    _extract_content_data,
-)
+from agent_actions.prompt.context.scope_namespace import _extract_content_data
 from agent_actions.prompt.context.scope_parsing import parse_field_reference
+from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
 
@@ -93,15 +92,21 @@ def apply_observe_for_file_mode(
     if not resolved:
         return data
 
-    # Track which namespaces use wildcards (expanded per-record below).
-    wildcard_ns: set[str] = {ns for ns, field, _ in resolved if field == "*"}
+    # Single pass over resolved refs: collect wildcards and detect source refs.
+    wildcard_ns: set[str] = set()
+    has_source_refs = False
+    for ns, field, _ in resolved:
+        if field == "*":
+            wildcard_ns.add(ns)
+        if ns == "source":
+            has_source_refs = True
     # Qualify wildcard-expanded keys with namespace when multiple
     # wildcards exist (prevents bare-key collisions across namespaces).
     qualify_wildcards = len(wildcard_ns) > 1
 
     # Build source index for "source" namespace (the only cross-record ref).
-    has_source_refs = any(ns == "source" for ns, _, _ in resolved)
     source_index: dict[str | None, dict] = {}
+    fallback_source = source_data[0] if source_data else None
     if has_source_refs and source_data:
         for src in source_data:
             sguid = src.get("source_guid") if isinstance(src, dict) else None
@@ -109,33 +114,32 @@ def apply_observe_for_file_mode(
                 source_index[sguid] = src
 
     # Per-record loop: extract observed fields from namespaced content.
+    source_content_cache: dict[str | None, dict] = {}
     filtered: list[dict] = []
     for item in data:
         if not isinstance(item, dict):
             filtered.append(item)  # type: ignore[unreachable]
             continue
 
-        # Extract namespaced content from record.
-        content_val = item.get("content")
-        content = content_val if isinstance(content_val, dict) else {}
+        content = get_existing_content(item)
 
         # Shallow-copy to avoid mutating caller's data.
         enriched = dict(item)
         enriched_content = dict(content)
 
-        # Resolve source record once per item (not per ref).
-        source_content: dict = {}
+        # Resolve source content once per item, cached by source_guid.
+        source_ns_data: dict = {}
         if has_source_refs:
             sguid = item.get("source_guid")
-            matched_source = source_index.get(sguid, source_data[0] if source_data else None)
-            source_content = _extract_content_data(matched_source) if matched_source else {}
+            if sguid not in source_content_cache:
+                matched = source_index.get(sguid, fallback_source)
+                source_content_cache[sguid] = _extract_content_data(matched) if matched else {}
+            source_ns_data = source_content_cache[sguid]
 
         for ns, field, output_key in resolved:
-            # Resolve namespace data.
             if ns == "source":
-                ns_data = source_content
+                ns_data = source_ns_data
             else:
-                # Action namespace: directly on the record's namespaced content.
                 ns_data = content.get(ns, {})
                 if not isinstance(ns_data, dict):
                     ns_data = {}

--- a/tests/integration/test_batch_realtime_parity.py
+++ b/tests/integration/test_batch_realtime_parity.py
@@ -333,11 +333,17 @@ class TestEdgeCases:
     def test_empty_contents_parity(
         self,
         parity_agent_config_no_context_scope,
+        parity_contents,
         parity_current_item,
         parity_agent_indices,
         parity_dependency_configs,
     ):
-        """Both modes should handle empty contents identically."""
+        """Both modes should handle empty contents identically.
+
+        source_content is required so the observed source.text field exists
+        at runtime.  With the additive model, the source namespace is
+        populated exclusively from source_content — not from current_item.
+        """
         common_args = {
             "agent_config": parity_agent_config_no_context_scope,
             "agent_name": "parity_test_agent_simple",
@@ -345,6 +351,7 @@ class TestEdgeCases:
             "agent_indices": parity_agent_indices,
             "dependency_configs": parity_dependency_configs,
             "current_item": parity_current_item,
+            "source_content": parity_contents,
         }
 
         batch_result = PromptPreparationService.prepare_prompt_with_context(

--- a/tests/integration/test_context_scope_audit.py
+++ b/tests/integration/test_context_scope_audit.py
@@ -294,20 +294,16 @@ class TestFrameworkNamespaces:
 
 
 class TestFileModeObserve:
-    """FILE mode observe must filter per-record, not bypass filtering."""
+    """FILE mode observe must extract fields from namespaced content."""
 
-    def _make_records(self, *contents):
-        """Build a list of file-mode records from content dicts."""
-        return [{"content": c, "source_guid": f"sg_{i}"} for i, c in enumerate(contents)]
+    def _make_records(self, ns_name, *contents):
+        """Build file-mode records with namespaced content."""
+        return [{"content": {ns_name: c}, "source_guid": f"sg_{i}"} for i, c in enumerate(contents)]
 
     def test_file_mode_enriches_per_record(self):
-        """observe specific field -> full record returned with content intact.
-
-        NiFi-inspired: observe enriches records (injects cross-namespace data)
-        rather than stripping to flat dicts. Framework fields and all original
-        content fields are preserved. The tool receives full records.
-        """
+        """observe specific field -> extracts from namespace, preserves original."""
         data = self._make_records(
+            "dep",
             {"question": "What?", "answer": "42", "noise": "junk"},
             {"question": "Why?", "answer": "because", "noise": "more junk"},
         )
@@ -322,17 +318,19 @@ class TestFileModeObserve:
             agent_indices={"dep": 0, "act": 1},
         )
         assert len(result) == 2
-        # Full records preserved — content has all original fields
+        # Observed fields extracted from namespace
         assert result[0]["content"]["question"] == "What?"
         assert result[0]["content"]["answer"] == "42"
-        assert result[0]["content"]["noise"] == "junk"  # not stripped
-        assert result[0]["source_guid"] == "sg_0"  # framework field preserved
+        # Original namespace preserved
+        assert result[0]["content"]["dep"]["noise"] == "junk"
+        assert result[0]["source_guid"] == "sg_0"
         assert result[1]["content"]["question"] == "Why?"
         assert result[1]["content"]["answer"] == "because"
 
     def test_file_mode_wildcard_single_ns_includes_all(self):
-        """observe: ['dep.*'] on input source -> full record, all content fields."""
+        """observe: ['dep.*'] extracts all fields from namespace."""
         data = self._make_records(
+            "dep",
             {"q": "What?", "a": "42"},
             {"q": "Why?", "a": "because"},
         )
@@ -354,22 +352,20 @@ class TestFileModeObserve:
         assert result[1]["content"]["a"] == "because"
 
     def test_file_mode_wildcard_does_not_skip_specific_refs(self):
-        """observe: ['dep_a.*', 'dep_b.field'] must still resolve dep_b.field.
-
-        Previously, any wildcard caused a global short-circuit (return data),
-        skipping cross-namespace resolution for specific-field refs.
-        """
-        data = self._make_records(
-            {"text": "hello", "score": 0.9},
-        )
+        """observe: ['dep_a.*', 'dep_b.field'] resolves both namespaces."""
+        data = [
+            {
+                "content": {
+                    "dep_a": {"text": "hello", "score": 0.9},
+                    "dep_b": {"extra": "bonus"},
+                },
+                "source_guid": "sg_0",
+            }
+        ]
         agent_config = {
             "dependencies": "dep_a",
             "context_scope": {"observe": ["dep_a.*", "dep_b.extra"]},
         }
-        # dep_b is a context source not in the record — without the fix,
-        # the wildcard on dep_a would return raw data skipping dep_b loading.
-        # With the fix, dep_b.extra should be attempted (may be absent if no
-        # historical data, but the wildcard should not prevent the attempt).
         result = apply_observe_for_file_mode(
             data,
             agent_config,
@@ -377,13 +373,15 @@ class TestFileModeObserve:
             agent_indices={"dep_a": 0, "dep_b": 1, "act": 2},
         )
         assert len(result) == 1
-        # dep_a wildcard should include all content fields (in content dict)
-        assert "text" in result[0]["content"]
-        assert "score" in result[0]["content"]
+        # dep_a wildcard extracts all fields (qualified because 2 wildcards? no, only 1)
+        assert result[0]["content"]["text"] == "hello"
+        assert result[0]["content"]["score"] == 0.9
+        # dep_b specific field also extracted
+        assert result[0]["content"]["extra"] == "bonus"
 
     def test_file_mode_no_observe_returns_data_unchanged(self):
         """No observe refs -> data returned as-is."""
-        data = [{"content": {"a": 1}, "source_guid": "sg_0"}]
+        data = [{"content": {"dep": {"a": 1}}, "source_guid": "sg_0"}]
         agent_config = {"dependencies": "dep", "context_scope": {}}
         result = apply_observe_for_file_mode(data, agent_config, agent_name="act")
         assert result == data

--- a/tests/integration/test_context_scope_integrity.py
+++ b/tests/integration/test_context_scope_integrity.py
@@ -848,22 +848,19 @@ class TestFileModeObserve:
     """FILE-mode specific observe behavior."""
 
     def test_file_mode_observe_filters_fields_per_record(self):
-        """FILE-mode observe returns full records with all content preserved (NiFi enrichment)."""
+        """FILE-mode observe extracts fields from namespaced content."""
         data = [
             {
-                "content": {"title": "Record 1", "body": "Text 1", "secret": "hidden1"},
+                "content": {"dep": {"title": "Record 1", "body": "Text 1", "secret": "hidden1"}},
                 "source_guid": "sg1",
-                "lineage": [],
             },
             {
-                "content": {"title": "Record 2", "body": "Text 2", "secret": "hidden2"},
+                "content": {"dep": {"title": "Record 2", "body": "Text 2", "secret": "hidden2"}},
                 "source_guid": "sg2",
-                "lineage": [],
             },
             {
-                "content": {"title": "Record 3", "body": "Text 3", "secret": "hidden3"},
+                "content": {"dep": {"title": "Record 3", "body": "Text 3", "secret": "hidden3"}},
                 "source_guid": "sg3",
-                "lineage": [],
             },
         ]
         agent_config = {
@@ -881,27 +878,24 @@ class TestFileModeObserve:
         for i, record in enumerate(result, 1):
             assert record["content"]["title"] == f"Record {i}"
             assert record["content"]["body"] == f"Text {i}"
-            # NiFi enrichment preserves all original content fields
-            assert record["content"]["secret"] == f"hidden{i}"
+            # Original namespace preserved
+            assert record["content"]["dep"]["secret"] == f"hidden{i}"
             assert record["source_guid"] == f"sg{i}"
 
     def test_file_mode_observe_preserves_record_order(self):
         """Output array order matches input array order."""
         data = [
             {
-                "content": {"name": "Charlie", "age": 30, "city": "NYC"},
+                "content": {"dep": {"name": "Charlie", "age": 30, "city": "NYC"}},
                 "source_guid": "sg3",
-                "lineage": [],
             },
             {
-                "content": {"name": "Alice", "age": 25, "city": "LA"},
+                "content": {"dep": {"name": "Alice", "age": 25, "city": "LA"}},
                 "source_guid": "sg1",
-                "lineage": [],
             },
             {
-                "content": {"name": "Bob", "age": 35, "city": "Chicago"},
+                "content": {"dep": {"name": "Bob", "age": 35, "city": "Chicago"}},
                 "source_guid": "sg2",
-                "lineage": [],
             },
         ]
         agent_config = {
@@ -920,29 +914,19 @@ class TestFileModeObserve:
         assert result[1]["content"]["name"] == "Alice"
         assert result[2]["content"]["name"] == "Bob"
 
-    def test_file_mode_cross_namespace_loading(self):
-        """FILE-mode loads ancestor data per-record using ancestry cache."""
-        storage = MockStorageBackend(
-            {
-                "classify": [
-                    {
-                        "node_id": "classify_r1",
-                        "source_guid": "sg1",
-                        "content": {
-                            "category": "science",
-                            "score": 0.95,
-                            "method": "auto",
-                        },
-                    },
-                ],
-            }
-        )
+    def test_file_mode_cross_namespace_from_record(self):
+        """FILE-mode reads cross-namespace data from record's namespaced content.
 
+        With the additive model, all previous action outputs are on the record.
+        No storage backend lookup needed.
+        """
         data = [
             {
-                "content": {"text": "Biology paper", "length": 500, "format": "pdf"},
+                "content": {
+                    "extract": {"text": "Biology paper", "length": 500, "format": "pdf"},
+                    "classify": {"category": "science", "score": 0.95, "method": "auto"},
+                },
                 "source_guid": "sg1",
-                "lineage": ["classify_r1", "extract_r1"],
                 "node_id": "enrich_r1",
             },
         ]
@@ -950,35 +934,30 @@ class TestFileModeObserve:
             "context_scope": {"observe": ["extract.text", "classify.category"]},
             "dependencies": "extract",
         }
-        agent_indices = {"extract": 0, "classify": 1, "enrich": 2}
 
         result = apply_observe_for_file_mode(
             data=data,
             agent_config=agent_config,
             agent_name="enrich",
-            agent_indices=agent_indices,
-            file_path="/mock/path/file.json",
-            storage_backend=storage,
         )
 
         assert len(result) == 1
-        # Input source field from record content
+        # Fields extracted from namespaces
         assert result[0]["content"]["text"] == "Biology paper"
-        # Cross-namespace field injected into content from historical lookup
         assert result[0]["content"]["category"] == "science"
-        # NiFi enrichment: all original content fields preserved
-        assert result[0]["content"]["length"] == 500
-        # Framework fields preserved at top level
+        # Original namespaces preserved
+        assert result[0]["content"]["extract"]["length"] == 500
         assert result[0]["source_guid"] == "sg1"
 
     def test_file_mode_missing_field_warns(self):
-        """FILE-mode: observe references field not in record -> field absent from output,
-        but all original content fields are preserved (NiFi enrichment)."""
+        """FILE-mode: observe references missing field -> field absent from output,
+        but all original content preserved."""
         data = [
             {
-                "content": {"title": "Exists", "body": "Also exists", "extra": "here too"},
+                "content": {
+                    "dep": {"title": "Exists", "body": "Also exists", "extra": "here too"},
+                },
                 "source_guid": "sg1",
-                "lineage": [],
             },
         ]
         agent_config = {
@@ -996,9 +975,9 @@ class TestFileModeObserve:
         assert result[0]["content"]["title"] == "Exists"
         # nonexistent_field is simply absent (not injected)
         assert "nonexistent_field" not in result[0]["content"]
-        # NiFi enrichment: all original content fields are preserved
-        assert result[0]["content"]["body"] == "Also exists"
-        assert result[0]["content"]["extra"] == "here too"
+        # Original namespace preserved
+        assert result[0]["content"]["dep"]["body"] == "Also exists"
+        assert result[0]["content"]["dep"]["extra"] == "here too"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_deterministic_matcher_agentic_patterns.py
+++ b/tests/integration/test_deterministic_matcher_agentic_patterns.py
@@ -126,11 +126,13 @@ class TestContractReviewerPattern:
             "generate_summary": 4,
         }
 
-    def test_summary_observes_aggregate_via_ancestor_mode(self, contract_storage, contract_indices):
-        """generate_summary resolves aggregate_risk via lineage (ancestor mode).
+    def test_summary_observes_aggregate_via_record_namespace(
+        self, contract_storage, contract_indices
+    ):
+        """generate_summary reads aggregate_risk from record's namespaced content.
 
-        The summary action's lineage includes aggregate_risk_uuid_agg.
-        This tests the linear chain AFTER the fan-in.
+        With the additive model, aggregate_risk output is stored under its
+        namespace on the record — no storage backend lookup needed.
         """
         current_item = {
             "source_guid": "contract-001",
@@ -140,7 +142,13 @@ class TestContractReviewerPattern:
                 "aggregate_risk_uuid_agg",
                 "generate_summary_uuid_gs",
             ],
-            "content": {},
+            "content": {
+                "aggregate_risk": {
+                    "overall_risk": "high",
+                    "clause_count": 3,
+                    "high_risk_clauses": [1],
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -164,7 +172,6 @@ class TestContractReviewerPattern:
                     "aggregate_risk.high_risk_clauses",
                 ]
             },
-            storage_backend=contract_storage,
         )
 
         assert "aggregate_risk" in field_context
@@ -314,7 +321,10 @@ class TestProductListingPattern:
     def test_format_listing_sees_correct_product_description(
         self, product_storage, product_indices
     ):
-        """format_listing for prod-001 sees 'Premium organic coffee', not 'Budget instant'."""
+        """format_listing for prod-001 reads from record's namespaced content.
+
+        With the additive model, all upstream outputs are on the record.
+        """
         current_item = {
             "source_guid": "prod-001",
             "node_id": "format_listing_uuid_fl",
@@ -327,7 +337,16 @@ class TestProductListingPattern:
                 "optimize_seo_uuid_os",
                 "format_listing_uuid_fl",
             ],
-            "content": {},
+            "content": {
+                "generate_description": {
+                    "product_description": "Premium organic coffee beans",
+                    "search_keywords": ["organic", "coffee", "fair-trade"],
+                },
+                "validate_compliance": {
+                    "compliance_passed": True,
+                    "violations": [],
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -351,7 +370,6 @@ class TestProductListingPattern:
                     "validate_compliance.compliance_passed",
                 ]
             },
-            storage_backend=product_storage,
         )
 
         assert "generate_description" in field_context
@@ -476,7 +494,7 @@ class TestVersionedClassifierPattern:
     def test_final_decision_observes_aggregate_consensus(
         self, versioned_storage, versioned_indices
     ):
-        """final_decision sees the aggregated consensus, not individual classifiers."""
+        """final_decision reads aggregate consensus from record's namespaced content."""
         current_item = {
             "source_guid": "doc-001",
             "node_id": "final_decision_uuid_fd",
@@ -485,7 +503,13 @@ class TestVersionedClassifierPattern:
                 "aggregate_classifications_uuid_ac",
                 "final_decision_uuid_fd",
             ],
-            "content": {},
+            "content": {
+                "aggregate_classifications": {
+                    "consensus_label": "spam",
+                    "vote_count": {"spam": 2, "ham": 1},
+                    "avg_confidence": 0.823,
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -509,7 +533,6 @@ class TestVersionedClassifierPattern:
                     "aggregate_classifications.avg_confidence",
                 ]
             },
-            storage_backend=versioned_storage,
         )
 
         assert "aggregate_classifications" in field_context
@@ -638,7 +661,7 @@ class TestHITLCrossGatePattern:
         }
 
     def test_approved_record_2_sees_its_own_consolidation(self, hitl_storage, hitl_indices):
-        """generate_question for record 2 sees page 12, not page 47."""
+        """generate_question for record 2 reads consolidation from record namespace."""
         current_item = {
             "source_guid": "mcp-src-002",
             "node_id": "generate_question_uuid_gq2",
@@ -649,7 +672,13 @@ class TestHITLCrossGatePattern:
                 "review_uuid_r2",
                 "generate_question_uuid_gq2",
             ],
-            "content": {},
+            "content": {
+                "consolidate": {
+                    "final_source_quote": "The MCP protocol enables tool use",
+                    "answer": "MCP provides a standard interface for AI tool invocation",
+                    "source_page": 12,
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -663,7 +692,6 @@ class TestHITLCrossGatePattern:
             current_item=current_item,
             file_path="/mock/batch_001.json",
             context_scope={"observe": ["consolidate.answer", "consolidate.source_page"]},
-            storage_backend=hitl_storage,
         )
 
         assert "consolidate" in field_context
@@ -674,7 +702,7 @@ class TestHITLCrossGatePattern:
         )
 
     def test_approved_record_5_sees_its_own_consolidation(self, hitl_storage, hitl_indices):
-        """generate_question for record 5 sees page 47, not page 12."""
+        """generate_question for record 5 reads its own consolidation from record namespace."""
         current_item = {
             "source_guid": "mcp-src-005",
             "node_id": "generate_question_uuid_gq5",
@@ -685,7 +713,13 @@ class TestHITLCrossGatePattern:
                 "review_uuid_r5",
                 "generate_question_uuid_gq5",
             ],
-            "content": {},
+            "content": {
+                "consolidate": {
+                    "final_source_quote": "The MCP protocol enables tool use",
+                    "answer": "MCP allows LLMs to call external tools safely",
+                    "source_page": 47,
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -699,7 +733,6 @@ class TestHITLCrossGatePattern:
             current_item=current_item,
             file_path="/mock/batch_001.json",
             context_scope={"observe": ["consolidate.answer", "consolidate.source_page"]},
-            storage_backend=hitl_storage,
         )
 
         assert "consolidate" in field_context
@@ -784,7 +817,7 @@ class TestDiamondMergePattern:
         }
 
     def test_merge_observes_both_branches(self, diamond_storage, diamond_indices):
-        """merge_report sees SEO data AND recommendation data from both branches."""
+        """merge_report reads both branches from record's namespaced content."""
         merged_item = {
             "source_guid": "book-001",
             "node_id": "merge_report_uuid_mr",
@@ -793,11 +826,16 @@ class TestDiamondMergePattern:
                 "branch_seo_uuid_bs",
                 "merge_report_uuid_mr",
             ],
-            "lineage_sources": [
-                "branch_seo_uuid_bs",
-                "branch_recommendations_uuid_br",
-            ],
-            "content": {},
+            "content": {
+                "branch_seo": {
+                    "seo_title": "Top 10 Python Libraries for Data Science",
+                    "keywords": ["python", "data-science", "pandas"],
+                },
+                "branch_recommendations": {
+                    "recommended_audience": "intermediate developers",
+                    "similar_books": ["Fluent Python", "Python Data Science Handbook"],
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -821,24 +859,21 @@ class TestDiamondMergePattern:
                     "branch_recommendations.recommended_audience",
                 ]
             },
-            storage_backend=diamond_storage,
         )
 
-        # branch_seo is in lineage (ancestor mode)
         assert "branch_seo" in field_context
         assert (
             field_context["branch_seo"]["seo_title"] == "Top 10 Python Libraries for Data Science"
         )
 
-        # branch_recommendations is in lineage_sources (merge-parent mode)
         assert "branch_recommendations" in field_context
         assert (
             field_context["branch_recommendations"]["recommended_audience"]
             == "intermediate developers"
         )
 
-    def test_both_branches_in_lineage_mode_1_only(self, diamond_storage, diamond_indices):
-        """Both parallel branch node_ids in lineage — resolved via Mode 1 without lineage_sources."""
+    def test_both_branches_in_content(self, diamond_storage, diamond_indices):
+        """Both parallel branches on the record — resolved from namespaced content."""
         merged_item = {
             "source_guid": "book-001",
             "node_id": "merge_report_uuid_mr",
@@ -848,8 +883,16 @@ class TestDiamondMergePattern:
                 "branch_recommendations_uuid_br",
                 "merge_report_uuid_mr",
             ],
-            # lineage_sources is None — Mode 1 alone must resolve both
-            "content": {},
+            "content": {
+                "branch_seo": {
+                    "seo_title": "Top 10 Python Libraries for Data Science",
+                    "keywords": ["python", "data-science", "pandas"],
+                },
+                "branch_recommendations": {
+                    "recommended_audience": "intermediate developers",
+                    "similar_books": ["Fluent Python", "Python Data Science Handbook"],
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -873,7 +916,6 @@ class TestDiamondMergePattern:
                     "branch_recommendations.recommended_audience",
                 ]
             },
-            storage_backend=diamond_storage,
         )
 
         assert "branch_seo" in field_context
@@ -887,20 +929,21 @@ class TestDiamondMergePattern:
         )
 
     def test_diamond_wildcard_observe(self, diamond_storage, diamond_indices):
-        """Wildcard observe loads all fields from both parallel branches."""
+        """Wildcard observe loads all fields from both branches on the record."""
         merged_item = {
             "source_guid": "book-001",
             "node_id": "merge_report_uuid_mr",
-            "lineage": [
-                "source_uuid_b",
-                "branch_seo_uuid_bs",
-                "merge_report_uuid_mr",
-            ],
-            "lineage_sources": [
-                "branch_seo_uuid_bs",
-                "branch_recommendations_uuid_br",
-            ],
-            "content": {},
+            "lineage": ["source_uuid_b", "branch_seo_uuid_bs", "merge_report_uuid_mr"],
+            "content": {
+                "branch_seo": {
+                    "seo_title": "Top 10 Python Libraries for Data Science",
+                    "keywords": ["python", "data-science", "pandas"],
+                },
+                "branch_recommendations": {
+                    "recommended_audience": "intermediate developers",
+                    "similar_books": ["Fluent Python", "Python Data Science Handbook"],
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -909,25 +952,17 @@ class TestDiamondMergePattern:
                 "idx": 3,
                 "dependencies": [],
                 "context_scope": {
-                    "observe": [
-                        "branch_seo.*",
-                        "branch_recommendations.*",
-                    ]
+                    "observe": ["branch_seo.*", "branch_recommendations.*"],
                 },
             },
             agent_indices=diamond_indices,
             current_item=merged_item,
             file_path="/mock/batch_001.json",
             context_scope={
-                "observe": [
-                    "branch_seo.*",
-                    "branch_recommendations.*",
-                ]
+                "observe": ["branch_seo.*", "branch_recommendations.*"],
             },
-            storage_backend=diamond_storage,
         )
 
-        # Wildcard: all fields from both branches
         assert (
             field_context["branch_seo"]["seo_title"] == "Top 10 Python Libraries for Data Science"
         )
@@ -942,16 +977,17 @@ class TestDiamondMergePattern:
         ]
 
     def test_single_upstream_observe_unchanged(self, diamond_storage, diamond_indices):
-        """Single-branch observe still works — regression guard for parallel branch fix."""
+        """Single-branch observe still works — regression guard."""
         single_dep_item = {
             "source_guid": "book-001",
             "node_id": "merge_report_uuid_mr",
-            "lineage": [
-                "source_uuid_b",
-                "branch_seo_uuid_bs",
-                "merge_report_uuid_mr",
-            ],
-            "content": {},
+            "lineage": ["source_uuid_b", "branch_seo_uuid_bs", "merge_report_uuid_mr"],
+            "content": {
+                "branch_seo": {
+                    "seo_title": "Top 10 Python Libraries for Data Science",
+                    "keywords": ["python", "data-science", "pandas"],
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -959,15 +995,12 @@ class TestDiamondMergePattern:
             agent_config={
                 "idx": 3,
                 "dependencies": [],
-                "context_scope": {
-                    "observe": ["branch_seo.seo_title"],
-                },
+                "context_scope": {"observe": ["branch_seo.seo_title"]},
             },
             agent_indices=diamond_indices,
             current_item=single_dep_item,
             file_path="/mock/batch_001.json",
             context_scope={"observe": ["branch_seo.seo_title"]},
-            storage_backend=diamond_storage,
         )
 
         assert "branch_seo" in field_context

--- a/tests/integration/test_deterministic_record_matcher.py
+++ b/tests/integration/test_deterministic_record_matcher.py
@@ -139,7 +139,7 @@ class TestAncestorMode:
         assert content["answer_text"] == "Paris is the capital of France"
 
     def test_e2e_context_build_loads_observed_field(self, linear_pipeline_storage):
-        """build_field_context_with_history resolves extract.answer_text correctly."""
+        """build_field_context_with_history reads extract namespace from record."""
         current_item = {
             "source_guid": "src-001",
             "node_id": "classify_uuid_ccc",
@@ -149,7 +149,12 @@ class TestAncestorMode:
                 "transform_uuid_xxx",
                 "classify_uuid_ccc",
             ],
-            "content": {},
+            "content": {
+                "extract": {
+                    "answer_text": "Paris is the capital of France",
+                    "confidence": 0.98,
+                },
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -163,7 +168,6 @@ class TestAncestorMode:
             current_item=current_item,
             file_path="/mock/test.json",
             context_scope={"observe": ["extract.answer_text"]},
-            storage_backend=linear_pipeline_storage,
         )
 
         assert "extract" in field_context
@@ -267,13 +271,16 @@ class TestMergeParentMode:
         assert content["label"] == "neutral"
 
     def test_e2e_context_build_with_lineage_sources(self, merge_storage):
-        """build_field_context_with_history passes lineage_sources through the full chain."""
+        """build_field_context_with_history reads merge branches from record namespace."""
         merged_item = {
             "source_guid": "src-merge",
             "node_id": "merge_action_uuid_mmm",
             "lineage": ["source_uuid_m", "branch_a_uuid_aaa", "merge_action_uuid_mmm"],
             "lineage_sources": ["branch_a_uuid_aaa", "branch_b_uuid_bbb"],
-            "content": {},
+            "content": {
+                "branch_a": {"score": 0.85, "label": "positive"},
+                "branch_b": {"score": 0.42, "label": "neutral"},
+            },
         }
 
         field_context = build_field_context_with_history(
@@ -287,7 +294,6 @@ class TestMergeParentMode:
             current_item=merged_item,
             file_path="/mock/test.json",
             context_scope={"observe": ["branch_b.score", "branch_b.label"]},
-            storage_backend=merge_storage,
         )
 
         assert "branch_b" in field_context, (

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -1,13 +1,12 @@
-"""Tests for file-mode observe filtering helpers.
+"""Tests for file-mode observe filtering with namespaced content.
 
-Covers cross-namespace resolution, collision handling, graceful degradation,
-and backward compatibility with the old _apply_observe_filter behaviour.
+With the additive content model, each record's ``content`` is namespaced:
+``{"action_a": {"field": "val"}, "action_b": {"field": "val"}}``.
+Observe refs select fields from these namespaces — no storage lookup needed.
+The only cross-record reference is ``source.*`` (resolved from source_data).
 """
 
-from unittest.mock import patch
-
 from agent_actions.prompt.context.scope_file_mode import (
-    _load_file_mode_cross_namespace_data,
     _resolve_observe_refs,
     apply_observe_for_file_mode,
 )
@@ -63,644 +62,273 @@ class TestResolveObserveRefs:
 
 
 # -----------------------------------------------------------------------
-# _load_file_mode_cross_namespace_data
-# -----------------------------------------------------------------------
-
-
-class TestLoadFileModeCrossNamespaceData:
-    """Unit tests for cross-namespace data loading."""
-
-    def test_source_namespace_from_source_record(self):
-        """source.* refs should be loaded from source_record."""
-        source_record = {"content": {"url": "https://example.com", "title": "Example"}}
-        result = _load_file_mode_cross_namespace_data(
-            needed_ns={"source"},
-            record={"source_guid": "sg-1", "content": {"question": "Q?"}},
-            agent_name="test",
-            source_record=source_record,
-        )
-        assert "source" in result
-        assert result["source"]["url"] == "https://example.com"
-
-    def test_source_namespace_missing_source_record(self):
-        """source refs with no source_record should warn but not crash."""
-        result = _load_file_mode_cross_namespace_data(
-            needed_ns={"source"},
-            record={"content": {"q": 1}},
-            agent_name="test",
-            source_record=None,
-        )
-        # Empty — graceful degradation
-        assert "source" not in result
-
-    def test_input_source_refs_not_loaded(self):
-        """Caller excludes input sources from needed_ns; helper gets empty set."""
-        result = _load_file_mode_cross_namespace_data(
-            needed_ns=set(),
-            record={"content": {"question": "Q?"}},
-            agent_name="test",
-        )
-        assert result == {}
-
-    def test_context_dep_loaded_via_historical(self):
-        """Context dep namespace should be loaded via _load_historical_node."""
-        record = {
-            "source_guid": "sg-1",
-            "lineage": ["classify_node"],
-            "content": {"question": "Q?"},
-        }
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value={"category": "science", "confidence": 0.9},
-        ) as mock_load:
-            result = _load_file_mode_cross_namespace_data(
-                needed_ns={"classify"},
-                record=record,
-                agent_name="test",
-                agent_indices={"classify": 0, "test": 1},
-                file_path="/tmp/test.json",
-            )
-        assert result["classify"]["category"] == "science"
-        mock_load.assert_called_once()
-
-    def test_context_dep_not_in_agent_indices_warns(self):
-        """Namespace not in agent_indices should be skipped with warning."""
-        result = _load_file_mode_cross_namespace_data(
-            needed_ns={"unknown_action"},
-            record={"source_guid": "sg-1", "content": {}},
-            agent_name="test",
-            agent_indices={"test": 0},
-            file_path="/tmp/test.json",
-        )
-        assert result == {}
-
-    def test_empty_needed_ns(self):
-        """Empty needed_ns should return empty dict immediately."""
-        result = _load_file_mode_cross_namespace_data(
-            needed_ns=set(),
-            record={"content": {"q": 1}},
-            agent_name="test",
-        )
-        assert result == {}
-
-
-# -----------------------------------------------------------------------
-# apply_observe_for_file_mode (integration)
+# apply_observe_for_file_mode — namespaced content
 # -----------------------------------------------------------------------
 
 
 class TestApplyObserveForFileMode:
-    """Integration tests for the main file-mode observe filter."""
+    """Integration tests for file-mode observe with namespaced content."""
 
-    def test_cross_namespace_resolution(self):
-        """observe: [upstream.question, source.url] enriches records with cross-ns data."""
+    def test_single_namespace_specific_fields(self):
+        """observe: [extract.text] reads from content["extract"]["text"]."""
         data = [
-            {"source_guid": "sg-1", "content": {"question": "What is X?", "answer": "Y"}},
-            {"source_guid": "sg-2", "content": {"question": "What is Z?", "answer": "W"}},
+            {
+                "content": {
+                    "extract": {"text": "article about physics", "source_url": "wiki.com"},
+                }
+            },
+        ]
+        config = {"context_scope": {"observe": ["extract.text"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="classify")
+        assert result[0]["content"]["text"] == "article about physics"
+        # Original namespace preserved
+        assert result[0]["content"]["extract"]["text"] == "article about physics"
+
+    def test_multi_namespace_observe(self):
+        """observe: [extract.text, classify.topic] reads from two namespaces."""
+        data = [
+            {
+                "content": {
+                    "extract": {"text": "physics article", "source_url": "wiki.com"},
+                    "classify": {"topic": "science", "confidence": 0.95},
+                }
+            },
+        ]
+        config = {"context_scope": {"observe": ["extract.text", "classify.topic"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="summarize")
+        assert result[0]["content"]["text"] == "physics article"
+        assert result[0]["content"]["topic"] == "science"
+
+    def test_wildcard_observe_single_namespace(self):
+        """observe: [extract.*] returns all fields from extract namespace."""
+        data = [
+            {
+                "content": {
+                    "extract": {"text": "hello", "source_url": "example.com"},
+                    "classify": {"topic": "test"},
+                }
+            },
+        ]
+        config = {"context_scope": {"observe": ["extract.*"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="summarize")
+        assert result[0]["content"]["text"] == "hello"
+        assert result[0]["content"]["source_url"] == "example.com"
+
+    def test_wildcard_multiple_namespaces_qualify_keys(self):
+        """Multiple wildcard namespaces produce qualified keys to avoid collisions."""
+        data = [
+            {
+                "content": {
+                    "extract": {"text": "hello", "source_url": "ex.com"},
+                    "classify": {"topic": "science", "confidence": 0.9},
+                }
+            },
+        ]
+        config = {"context_scope": {"observe": ["extract.*", "classify.*"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="summarize")
+        # Qualified keys because multiple wildcards
+        assert result[0]["content"]["extract.text"] == "hello"
+        assert result[0]["content"]["classify.topic"] == "science"
+
+    def test_source_namespace_from_source_data(self):
+        """source.url resolves from source_data, not from record content."""
+        data = [
+            {
+                "source_guid": "sg-1",
+                "content": {
+                    "extract": {"text": "article"},
+                },
+            },
         ]
         source_data = [
-            {"source_guid": "sg-1", "content": {"url": "https://one.com", "title": "One"}},
-            {"source_guid": "sg-2", "content": {"url": "https://two.com", "title": "Two"}},
+            {"source_guid": "sg-1", "content": {"url": "https://example.com", "title": "Ex"}},
         ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.question", "source.url"]},
-        }
+        config = {"context_scope": {"observe": ["extract.text", "source.url"]}}
         result = apply_observe_for_file_mode(
             data=data,
             agent_config=config,
-            agent_name="review",
+            agent_name="classify",
             source_data=source_data,
         )
-        assert len(result) == 2
-        # Full records returned; cross-namespace url injected into content
-        assert result[0]["content"]["question"] == "What is X?"
-        assert result[0]["content"]["url"] == "https://one.com"
-        assert result[0]["source_guid"] == "sg-1"
-        assert result[1]["content"]["question"] == "What is Z?"
-        assert result[1]["content"]["url"] == "https://two.com"
-        assert result[1]["source_guid"] == "sg-2"
-
-    def test_multi_dep_collision_distinct_values(self):
-        """dep_a.title and dep_b.title from different namespaces get distinct values."""
-        data = [
-            {
-                "source_guid": "sg-1",
-                "lineage": ["dep_a_node"],
-                "content": {"title": "Title from A", "body": "Body A"},
-            }
-        ]
-        config = {
-            "dependencies": "dep_a",
-            "context_scope": {"observe": ["dep_a.title", "dep_b.title", "dep_a.body"]},
-        }
-
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value={"title": "Title from B", "score": 42},
-        ):
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="merge_action",
-                agent_indices={"dep_a": 0, "dep_b": 1, "merge_action": 2},
-                file_path="/tmp/test.json",
-            )
-
-        assert len(result) == 1
-        # "title" collides: dep_a.title stays as original "title" in content (input source),
-        # dep_b.title injected with qualified key from historical lookup
-        assert result[0]["content"]["title"] == "Title from A"
-        assert result[0]["content"]["dep_b.title"] == "Title from B"
-        assert result[0]["content"]["body"] == "Body A"
-
-    def test_context_source_loading(self):
-        """Observe ref targeting an action NOT in dependencies loads via historical."""
-        data = [
-            {
-                "source_guid": "sg-1",
-                "lineage": ["classify_node"],
-                "content": {"question": "Q?"},
-            }
-        ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {
-                "observe": ["upstream.question", "classify.category"],
-            },
-        }
-
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value={"category": "science"},
-        ):
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="review",
-                agent_indices={"upstream": 0, "classify": 1, "review": 2},
-                file_path="/tmp/test.json",
-            )
-
-        assert result[0]["content"]["question"] == "Q?"
-        assert result[0]["content"]["category"] == "science"
-        assert result[0]["source_guid"] == "sg-1"
-
-    def test_single_upstream_preserves_full_records(self):
-        """Single-upstream observe returns full records with all content preserved."""
-        data = [
-            {"content": {"question": "Q1", "answer": "A1", "extra": "kept"}},
-            {"content": {"question": "Q2", "answer": "A2", "extra": "kept"}},
-        ]
-        config = {
-            "context_scope": {"observe": ["upstream.question", "upstream.answer"]},
-        }
-        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-        assert len(result) == 2
-        # NiFi enrichment: full records returned, all content fields preserved
-        assert result[0]["content"]["question"] == "Q1"
-        assert result[0]["content"]["answer"] == "A1"
-        assert result[0]["content"]["extra"] == "kept"
-        assert result[1]["content"]["question"] == "Q2"
-        assert result[1]["content"]["answer"] == "A2"
-
-    def test_graceful_degradation_unresolvable_namespace(self):
-        """Unresolvable namespace warns and skips — doesn't crash."""
-        data = [
-            {
-                "source_guid": "sg-1",
-                "content": {"question": "Q?"},
-            }
-        ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {
-                "observe": ["upstream.question", "nonexistent.field"],
-            },
-        }
-        # No agent_indices for nonexistent → graceful skip
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="review",
-            agent_indices={"upstream": 0, "review": 1},
-            file_path="/tmp/test.json",
-        )
-        # Full record returned; upstream.question present in content
-        assert result[0]["content"]["question"] == "Q?"
-        assert result[0]["source_guid"] == "sg-1"
-
-    def test_unresolved_non_input_ns_does_not_leak_record_field(self):
-        """Non-input namespace field must NOT fall back to a same-named record field.
-
-        Regression: without the ns-in-input_source_names guard, dep_b.score
-        would silently copy the primary record's 'score' field and label it as
-        dep_b's data — producing incorrect context.
-        """
-        data = [
-            {
-                "source_guid": "sg-1",
-                "lineage": ["dep_a_node"],
-                "content": {"question": "Q?", "score": 99},
-            }
-        ]
-        config = {
-            "dependencies": "dep_a",
-            "context_scope": {
-                "observe": ["dep_a.question", "dep_b.score"],
-            },
-        }
-        # dep_b has no historical data (load returns None) — its field should
-        # not be injected from cross-namespace. The record's own "score" field
-        # is still in content (NiFi enrichment preserves all original fields).
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value=None,
-        ):
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="merge",
-                agent_indices={"dep_a": 0, "dep_b": 1, "merge": 2},
-                file_path="/tmp/test.json",
-            )
-        # dep_a.question resolved from record content
-        assert result[0]["content"]["question"] == "Q?"
-        # dep_b.score was not injected (no historical data)
-        assert "dep_b.score" not in result[0]["content"]
-        # The record's own "score" field is preserved (NiFi: no stripping)
-        assert result[0]["content"]["score"] == 99
-
-    def test_no_deps_with_agent_indices_skips_historical_load(self):
-        """Without explicit deps, historical load must NOT shadow live record content.
-
-        Regression: when input_source_names is built from content keys (heuristic),
-        the namespace "upstream" is not in that set, so needed_ns incorrectly
-        includes it and triggers a historical lookup.  If that lookup succeeds,
-        the stale historical value takes priority over the current record,
-        producing silently inconsistent output.
-        """
-        data = [
-            {
-                "source_guid": "sg-1",
-                "lineage": ["upstream_node"],
-                "content": {"question": "LIVE Q", "answer": "LIVE A"},
-            }
-        ]
-        # No dependencies / depends_on — forces content-key heuristic.
-        config = {
-            "context_scope": {"observe": ["upstream.question", "upstream.answer"]},
-        }
-
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value={"question": "STALE Q", "answer": "STALE A"},
-        ) as mock_load:
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="review",
-                agent_indices={"upstream": 0, "review": 1},
-                file_path="/tmp/test.json",
-            )
-        # Historical load should NOT have been attempted.
-        mock_load.assert_not_called()
-        # Live record values must be used (full record returned).
-        assert result[0]["content"]["question"] == "LIVE Q"
-        assert result[0]["content"]["answer"] == "LIVE A"
-        assert result[0]["source_guid"] == "sg-1"
-
-    def test_source_ref_resolves_without_explicit_deps(self):
-        """source.url must load from source_data even when no dependencies are declared.
-
-        Regression: the has_reliable_ns gate blocked all cross-namespace loading
-        when deps were absent, causing source.url to silently return an empty
-        object despite source_data being available.
-        """
-        data = [{"content": {"question": "Q?"}}]
-        source_data = [{"content": {"url": "https://example.com", "title": "Ex"}}]
-        # No dependencies / depends_on — forces content-key heuristic.
-        config = {
-            "context_scope": {"observe": ["upstream.question", "source.url"]},
-        }
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="review",
-            source_data=source_data,
-        )
-        assert result[0]["content"]["question"] == "Q?"
+        assert result[0]["content"]["text"] == "article"
         assert result[0]["content"]["url"] == "https://example.com"
 
-    def test_no_observe_returns_data_as_is(self):
-        data = [{"content": {"a": 1}}]
-        result = apply_observe_for_file_mode(data=data, agent_config={}, agent_name="test")
-        assert result is data
-
-    def test_wildcard_returns_full_record_with_content(self):
-        """Wildcard observe returns full records with all content preserved."""
-        data = [{"content": {"a": 1, "b": 2}}]
-        config = {"context_scope": {"observe": ["upstream.*"]}}
-        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-        assert result[0]["content"] == {"a": 1, "b": 2}
-
-    def test_non_dict_records_do_not_crash_heuristic(self):
-        """Primitive entries (strings, ints) must not crash the content-key heuristic.
-
-        Regression: without an isinstance check, data[0].get() raises
-        AttributeError when the first element is a string or number.
-        """
-        data = ["just a string", "another string"]
-        config = {"context_scope": {"observe": ["upstream.question"]}}
-        # No dependencies → triggers heuristic fallback path.
-        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
-        # Non-dict items pass through unmodified.
-        assert result == ["just a string", "another string"]
-
-    def test_hitl_merge_back_unaffected(self):
-        """No cross-namespace refs → fast path returns data as-is.
-        Original is unmodified because nothing was injected.
-        """
-        original = [
-            {"source_guid": "sg-1", "content": {"question": "Q?", "secret": "hidden"}},
-        ]
-        config = {"context_scope": {"observe": ["upstream.question"]}}
-        filtered = apply_observe_for_file_mode(
-            data=original, agent_config=config, agent_name="test"
-        )
-        assert filtered[0]["content"]["question"] == "Q?"
-        assert filtered[0]["content"]["secret"] == "hidden"
-        # No cross-namespace refs → fast path returns data directly
-        assert filtered is original
-        assert original[0]["content"]["secret"] == "hidden"
-
-    def test_source_data_flat_format(self):
-        """source_data in flat format (no content wrapper) should still work."""
-        data = [{"content": {"question": "Q?"}}]
-        source_data = [{"url": "https://example.com", "title": "Example"}]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.question", "source.url"]},
-        }
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="test",
-            source_data=source_data,
-        )
-        assert result[0]["content"]["question"] == "Q?"
-        assert result[0]["content"]["url"] == "https://example.com"
-
-    def test_multi_source_guid_source_namespace(self):
+    def test_source_namespace_multi_guid(self):
         """Two records with different source_guid get different source.url values."""
         data = [
-            {"source_guid": "sg-A", "content": {"question": "Q1"}},
-            {"source_guid": "sg-B", "content": {"question": "Q2"}},
+            {"source_guid": "sg-A", "content": {"extract": {"text": "Q1"}}},
+            {"source_guid": "sg-B", "content": {"extract": {"text": "Q2"}}},
         ]
         source_data = [
             {"source_guid": "sg-A", "content": {"url": "https://a.com"}},
             {"source_guid": "sg-B", "content": {"url": "https://b.com"}},
         ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.question", "source.url"]},
-        }
+        config = {"context_scope": {"observe": ["extract.text", "source.url"]}}
         result = apply_observe_for_file_mode(
             data=data,
             agent_config=config,
-            agent_name="review",
+            agent_name="classify",
             source_data=source_data,
         )
-        assert result[0]["content"]["question"] == "Q1"
+        assert result[0]["content"]["text"] == "Q1"
         assert result[0]["content"]["url"] == "https://a.com"
-        assert result[1]["content"]["question"] == "Q2"
+        assert result[1]["content"]["text"] == "Q2"
         assert result[1]["content"]["url"] == "https://b.com"
 
-    def test_multi_source_guid_context_dep(self):
-        """Two records with different source_guid trigger separate historical loads."""
-        data = [
-            {"source_guid": "sg-A", "lineage": ["c_node"], "content": {"q": "Q1"}},
-            {"source_guid": "sg-B", "lineage": ["c_node"], "content": {"q": "Q2"}},
-        ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.q", "classify.category"]},
-        }
-
-        def fake_load(*, action_name, source_guid, **kw):
-            return {"category": f"cat-{source_guid}"}
-
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            side_effect=fake_load,
-        ) as mock_load:
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="review",
-                agent_indices={"upstream": 0, "classify": 1, "review": 2},
-                file_path="/tmp/test.json",
-            )
-        assert result[0]["content"]["q"] == "Q1"
-        assert result[0]["content"]["category"] == "cat-sg-A"
-        assert result[1]["content"]["q"] == "Q2"
-        assert result[1]["content"]["category"] == "cat-sg-B"
-        assert mock_load.call_count == 2
-
-    def test_ancestry_cache_avoids_redundant_loads(self):
-        """Two records with identical ancestry result in exactly one historical load."""
-        data = [
-            {
-                "source_guid": "sg-1",
-                "lineage": ["c_node"],
-                "parent_target_id": "p1",
-                "content": {"q": "Q1"},
-            },
-            {
-                "source_guid": "sg-1",
-                "lineage": ["c_node"],
-                "parent_target_id": "p1",
-                "content": {"q": "Q2"},
-            },
-        ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.q", "classify.category"]},
-        }
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value={"category": "science"},
-        ) as mock_load:
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="review",
-                agent_indices={"upstream": 0, "classify": 1, "review": 2},
-                file_path="/tmp/test.json",
-            )
-        assert result[0]["content"]["category"] == "science"
-        assert result[1]["content"]["category"] == "science"
-        # Only one load — cache hit for the second record.
-        mock_load.assert_called_once()
-
     def test_source_guid_fallback_to_first_source(self):
-        """Record whose source_guid doesn't match any source record falls back to source_data[0]."""
+        """Record whose source_guid doesn't match falls back to source_data[0]."""
         data = [
-            {"source_guid": "sg-unknown", "content": {"q": "Q1"}},
+            {"source_guid": "sg-unknown", "content": {"extract": {"text": "Q"}}},
         ]
         source_data = [
             {"source_guid": "sg-other", "content": {"url": "https://fallback.com"}},
         ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.q", "source.url"]},
-        }
+        config = {"context_scope": {"observe": ["extract.text", "source.url"]}}
         result = apply_observe_for_file_mode(
             data=data,
             agent_config=config,
-            agent_name="review",
+            agent_name="classify",
             source_data=source_data,
         )
-        assert result[0]["content"]["q"] == "Q1"
+        assert result[0]["content"]["text"] == "Q"
         assert result[0]["content"]["url"] == "https://fallback.com"
-        assert result[0]["source_guid"] == "sg-unknown"
 
-    def test_fan_in_non_primary_dep_loaded_historically(self):
-        """In a fan-in flow, non-primary deps must be loaded via historical lookup."""
+    def test_source_data_flat_format(self):
+        """source_data in flat format (no content wrapper) still works."""
+        data = [{"content": {"extract": {"text": "Q"}}}]
+        source_data = [{"url": "https://example.com", "title": "Example"}]
+        config = {"context_scope": {"observe": ["extract.text", "source.url"]}}
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="classify",
+            source_data=source_data,
+        )
+        assert result[0]["content"]["text"] == "Q"
+        assert result[0]["content"]["url"] == "https://example.com"
+
+    def test_missing_namespace_skipped_gracefully(self):
+        """Observing a field from a skipped action's namespace is graceful — no crash."""
         data = [
             {
-                "source_guid": "sg-1",
-                "lineage": ["dep_a_node", "dep_b_node"],
-                "content": {"question": "Q?"},
-            }
-        ]
-        config = {
-            # Fan-in: two different deps → first is primary input, second is context.
-            "dependencies": ["dep_a", "dep_b"],
-            "context_scope": {
-                "observe": ["dep_a.question", "dep_b.score"],
+                "content": {
+                    "generate": {"question": "Q?"},
+                    "validate": {"pass": True},
+                    # rewrite NOT present (guard-skipped)
+                }
             },
-        }
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value={"score": 42, "extra": "ignored"},
-        ) as mock_load:
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="merge",
-                agent_indices={"dep_a": 0, "dep_b": 1, "merge": 2},
-                file_path="/tmp/test.json",
-            )
-        # dep_a.question from record content; dep_b.score injected from historical.
+        ]
+        config = {"context_scope": {"observe": ["rewrite.output", "generate.question"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="review")
         assert result[0]["content"]["question"] == "Q?"
-        assert result[0]["content"]["score"] == 42
-        assert result[0]["source_guid"] == "sg-1"
-        mock_load.assert_called_once()
+        # rewrite namespace absent — field not injected
+        assert "output" not in result[0]["content"]
 
-    def test_ancestry_divergent_records_get_separate_lookups(self):
-        """Records with same source_guid but different lineage get separate cache entries."""
+    def test_no_observe_returns_data_as_is(self):
+        data = [{"content": {"extract": {"a": 1}}}]
+        result = apply_observe_for_file_mode(data=data, agent_config={}, agent_name="test")
+        assert result is data
+
+    def test_non_dict_records_pass_through(self):
+        """Primitive entries (strings, ints) pass through unmodified."""
+        data = ["just a string", "another string"]
+        config = {"context_scope": {"observe": ["upstream.question"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
+        assert result == ["just a string", "another string"]
+
+    def test_no_mutation_of_input_data(self):
+        """Observe enrichment must not mutate the caller's input data."""
         data = [
             {
-                "source_guid": "sg-1",
-                "lineage": ["branch_a"],
-                "parent_target_id": "parent-a",
-                "content": {"q": "Q1"},
-            },
-            {
-                "source_guid": "sg-1",
-                "lineage": ["branch_b"],
-                "parent_target_id": "parent-b",
-                "content": {"q": "Q2"},
+                "content": {
+                    "extract": {"text": "hello", "url": "ex.com"},
+                }
             },
         ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.q", "classify.label"]},
-        }
+        original_content = dict(data[0]["content"])
+        original_keys = set(original_content.keys())
 
-        call_count = [0]
+        config = {"context_scope": {"observe": ["extract.*"]}}
+        apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
 
-        def fake_load(*, action_name, lineage, parent_target_id, **kw):
-            call_count[0] += 1
-            label = "label-A" if parent_target_id == "parent-a" else "label-B"
-            return {"label": label}
+        # Input data must not be mutated
+        assert set(data[0]["content"].keys()) == original_keys
 
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            side_effect=fake_load,
-        ):
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="review",
-                agent_indices={"upstream": 0, "classify": 1, "review": 2},
-                file_path="/tmp/test.json",
-            )
-        assert result[0]["content"]["q"] == "Q1"
-        assert result[0]["content"]["label"] == "label-A"
-        assert result[1]["content"]["q"] == "Q2"
-        assert result[1]["content"]["label"] == "label-B"
-        # Two separate loads — different ancestry despite same source_guid.
-        assert call_count[0] == 2
+    def test_collision_across_namespaces(self):
+        """dep_a.title and dep_b.title get qualified keys to avoid collision."""
+        data = [
+            {
+                "content": {
+                    "dep_a": {"title": "Title from A", "body": "Body A"},
+                    "dep_b": {"title": "Title from B", "score": 42},
+                }
+            },
+        ]
+        config = {"context_scope": {"observe": ["dep_a.title", "dep_b.title", "dep_a.body"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="merge")
+        # "title" collides → qualified keys
+        assert result[0]["content"]["dep_a.title"] == "Title from A"
+        assert result[0]["content"]["dep_b.title"] == "Title from B"
+        assert result[0]["content"]["body"] == "Body A"
+
+    def test_no_storage_lookup(self):
+        """With namespaced content, no historical storage lookup is needed.
+
+        All dependency data is on the record. This test verifies the function
+        works without agent_indices, file_path, or storage_backend.
+        """
+        data = [
+            {
+                "content": {
+                    "extract": {"text": "hello"},
+                    "classify": {"topic": "science"},
+                }
+            },
+        ]
+        config = {"context_scope": {"observe": ["extract.text", "classify.topic"]}}
+        result = apply_observe_for_file_mode(
+            data=data,
+            agent_config=config,
+            agent_name="summarize",
+            agent_indices=None,
+            file_path=None,
+            storage_backend=None,
+        )
+        assert result[0]["content"]["text"] == "hello"
+        assert result[0]["content"]["topic"] == "science"
 
 
 # -----------------------------------------------------------------------
-# Version namespace detection and injection (version_consumption merge)
+# Version namespace resolution (version_consumption merge)
 # -----------------------------------------------------------------------
 
 
 class TestVersionNamespaceObserve:
-    """Tests for version-correlated namespace resolution in FILE mode.
+    """Tests for version namespaces in FILE mode with namespaced content.
 
-    When upstream actions use version_consumption with merge pattern,
-    records contain nested dicts keyed by version action names. The
-    observe filter must detect these and resolve fields from content
-    directly — not via historical lookup (which fails for version keys).
+    Version action outputs (e.g., gen_code_1, gen_code_2) are regular
+    namespaces in the additive model — no special detection needed.
     """
 
     def _make_merged_data(self, version_count=3):
-        """Create version-correlated merged data as VersionOutputCorrelator produces."""
+        """Create version-correlated merged data with namespaced content."""
         content = {}
         for i in range(1, version_count + 1):
             content[f"gen_code_{i}"] = {
                 "code": f"code_{i}",
                 "language": f"lang_{i}",
             }
-        return [
-            {
-                "source_guid": "sg-001",
-                "node_id": "node-1",
-                "content": content,
-                "lineage": ["lineage-1"],
-            }
-        ]
+        return [{"source_guid": "sg-001", "node_id": "node-1", "content": content}]
 
     def test_wildcard_expansion_from_version_namespaces(self):
         """Wildcards on version namespaces expand to qualified keys from content."""
         data = self._make_merged_data(3)
         config = {
-            "dependencies": ["gen_code_1", "gen_code_2", "gen_code_3"],
             "context_scope": {
                 "observe": ["gen_code_1.*", "gen_code_2.*", "gen_code_3.*"],
             },
         }
-        indices = {
-            "source": 0,
-            "gen_code_1": 1,
-            "gen_code_2": 2,
-            "gen_code_3": 3,
-            "aggregate": 4,
-        }
-
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="aggregate",
-            agent_indices=indices,
-            file_path="/tmp/test.json",
-        )
-
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="aggregate")
         content = result[0]["content"]
         # Multiple wildcard namespaces → qualified keys (ns.field)
         assert content["gen_code_1.code"] == "code_1"
@@ -712,141 +340,28 @@ class TestVersionNamespaceObserve:
         """Specific field refs resolve from version namespace content."""
         data = self._make_merged_data(2)
         config = {
-            "dependencies": ["gen_code_1", "gen_code_2"],
             "context_scope": {
                 "observe": ["gen_code_1.code", "gen_code_2.code"],
             },
         }
-        indices = {
-            "source": 0,
-            "gen_code_1": 1,
-            "gen_code_2": 2,
-            "aggregate": 3,
-        }
-
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="aggregate",
-            agent_indices=indices,
-            file_path="/tmp/test.json",
-        )
-
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="aggregate")
         content = result[0]["content"]
         # "code" collides across namespaces → qualified keys
         assert content["gen_code_1.code"] == "code_1"
         assert content["gen_code_2.code"] == "code_2"
 
-    def test_version_ns_does_not_trigger_historical_lookup(self):
-        """Version namespaces in content must NOT attempt historical lookup."""
-        data = self._make_merged_data(2)
-        config = {
-            "dependencies": ["gen_code_1", "gen_code_2"],
-            "context_scope": {
-                "observe": ["gen_code_1.*", "gen_code_2.*"],
-            },
-        }
-        indices = {
-            "source": 0,
-            "gen_code_1": 1,
-            "gen_code_2": 2,
-            "aggregate": 3,
-        }
-
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-        ) as mock_load:
-            apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="aggregate",
-                agent_indices=indices,
-                file_path="/tmp/test.json",
-            )
-
-        # No historical loads — version data resolved from content directly.
-        mock_load.assert_not_called()
-
-    def test_version_ns_with_non_version_context_dep(self):
-        """Version namespaces + non-version context dep: both resolve correctly."""
-        data = [
-            {
-                "source_guid": "sg-1",
-                "node_id": "node-1",
-                "content": {
-                    "gen_code_1": {"code": "code_1"},
-                    "gen_code_2": {"code": "code_2"},
-                },
-                "lineage": ["lineage-1"],
-            }
-        ]
-        config = {
-            "dependencies": ["gen_code_1", "gen_code_2"],
-            "context_scope": {
-                "observe": [
-                    "gen_code_1.code",
-                    "gen_code_2.code",
-                    "classify.category",
-                ],
-            },
-        }
-        indices = {
-            "source": 0,
-            "gen_code_1": 1,
-            "gen_code_2": 2,
-            "classify": 3,
-            "aggregate": 4,
-        }
-
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value={"category": "science"},
-        ) as mock_load:
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="aggregate",
-                agent_indices=indices,
-                file_path="/tmp/test.json",
-            )
-
-        content = result[0]["content"]
-        # Version fields from content
-        assert content["gen_code_1.code"] == "code_1"
-        assert content["gen_code_2.code"] == "code_2"
-        # Context dep from historical lookup
-        assert content["category"] == "science"
-        # Historical load only for classify, not version namespaces
-        mock_load.assert_called_once()
-
-    def test_version_ns_single_wildcard_no_qualification(self):
+    def test_single_wildcard_bare_keys(self):
         """Single version namespace wildcard uses bare keys (no ns. prefix)."""
         data = [
             {
-                "source_guid": "sg-1",
-                "node_id": "node-1",
                 "content": {
                     "gen_code_1": {"code": "code_1", "language": "python"},
-                },
-                "lineage": ["lineage-1"],
-            }
+                }
+            },
         ]
-        config = {
-            "dependencies": ["gen_code_1"],
-            "context_scope": {"observe": ["gen_code_1.*"]},
-        }
-        indices = {"source": 0, "gen_code_1": 1, "aggregate": 2}
-
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="aggregate",
-            agent_indices=indices,
-            file_path="/tmp/test.json",
-        )
-
+        config = {"context_scope": {"observe": ["gen_code_1.*"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="aggregate")
         content = result[0]["content"]
-        # Single wildcard → bare keys (no qualification)
         assert content["code"] == "code_1"
         assert content["language"] == "python"
 
@@ -854,186 +369,83 @@ class TestVersionNamespaceObserve:
         """Version namespace resolution works across multiple records."""
         data = [
             {
-                "source_guid": "sg-1",
-                "node_id": "node-1",
                 "content": {
                     "gen_code_1": {"code": "code_A1"},
                     "gen_code_2": {"code": "code_A2"},
-                },
-                "lineage": ["lineage-1"],
+                }
             },
             {
-                "source_guid": "sg-2",
-                "node_id": "node-2",
                 "content": {
                     "gen_code_1": {"code": "code_B1"},
                     "gen_code_2": {"code": "code_B2"},
-                },
-                "lineage": ["lineage-2"],
+                }
             },
         ]
         config = {
-            "dependencies": ["gen_code_1", "gen_code_2"],
             "context_scope": {
                 "observe": ["gen_code_1.code", "gen_code_2.code"],
             },
         }
-        indices = {
-            "source": 0,
-            "gen_code_1": 1,
-            "gen_code_2": 2,
-            "aggregate": 3,
-        }
-
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="aggregate",
-            agent_indices=indices,
-            file_path="/tmp/test.json",
-        )
-
-        # First record
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="aggregate")
         assert result[0]["content"]["gen_code_1.code"] == "code_A1"
         assert result[0]["content"]["gen_code_2.code"] == "code_A2"
-        # Second record — different per-record content
         assert result[1]["content"]["gen_code_1.code"] == "code_B1"
         assert result[1]["content"]["gen_code_2.code"] == "code_B2"
 
-    def test_version_ns_preserves_original_nested_dicts(self):
+    def test_preserves_original_nested_dicts(self):
         """Original nested version namespace dicts are preserved in content."""
         data = self._make_merged_data(2)
         config = {
-            "dependencies": ["gen_code_1", "gen_code_2"],
             "context_scope": {
                 "observe": ["gen_code_1.*", "gen_code_2.*"],
             },
         }
-        indices = {
-            "source": 0,
-            "gen_code_1": 1,
-            "gen_code_2": 2,
-            "aggregate": 3,
-        }
-
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="aggregate",
-            agent_indices=indices,
-            file_path="/tmp/test.json",
-        )
-
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="aggregate")
         content = result[0]["content"]
-        # Original nested dicts are preserved alongside expanded keys
+        # Original nested dicts preserved alongside expanded keys
         assert isinstance(content["gen_code_1"], dict)
         assert content["gen_code_1"]["code"] == "code_1"
-        # Expanded keys also present
         assert content["gen_code_1.code"] == "code_1"
 
-    def test_version_ns_does_not_mutate_input_data(self):
+    def test_does_not_mutate_input(self):
         """Version namespace enrichment must not mutate caller's input data."""
         data = self._make_merged_data(2)
-        original_content = dict(data[0]["content"])
-        original_keys = set(original_content.keys())
+        original_keys = set(data[0]["content"].keys())
 
         config = {
-            "dependencies": ["gen_code_1", "gen_code_2"],
             "context_scope": {
                 "observe": ["gen_code_1.*", "gen_code_2.*"],
             },
         }
-        indices = {
-            "source": 0,
-            "gen_code_1": 1,
-            "gen_code_2": 2,
-            "aggregate": 3,
-        }
-
-        apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="aggregate",
-            agent_indices=indices,
-            file_path="/tmp/test.json",
-        )
-
-        # Input data must not be mutated.
+        apply_observe_for_file_mode(data=data, agent_config=config, agent_name="aggregate")
         assert set(data[0]["content"].keys()) == original_keys
 
-    def test_empty_content_fallback(self):
-        """Record with empty content {} falls back to item-level keys.
 
-        Regression: data.get("content", data) returns {} when content
-        exists but is empty, instead of falling back to the full item.
-        """
-        source_data = [{"source_guid": "sg-1", "content": {"url": "https://ex.com"}}]
-        data = [
-            {
-                "source_guid": "sg-1",
-                "node_id": "node-1",
-                "content": {},
-                "question": "Q?",
-                "lineage": ["lineage-1"],
-            }
-        ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {
-                "observe": ["source.url", "upstream.question"],
-            },
-        }
-        indices = {"source": 0, "upstream": 1, "downstream": 2}
+# -----------------------------------------------------------------------
+# Edge cases and regressions
+# -----------------------------------------------------------------------
 
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode._load_historical_node",
-            return_value=None,
-        ):
-            result = apply_observe_for_file_mode(
-                data=data,
-                agent_config=config,
-                agent_name="downstream",
-                agent_indices=indices,
-                file_path="/tmp/test.json",
-                source_data=source_data,
-            )
 
-        content = result[0]["content"]
-        # source.url from source_data
-        assert content["url"] == "https://ex.com"
-        # upstream.question from item-level fallback (content was empty)
-        assert content["question"] == "Q?"
-        # Metadata keys must NOT leak into enriched content
-        assert "source_guid" not in content
-        assert "lineage" not in content
-        assert "node_id" not in content
+class TestEdgeCases:
+    """Edge case tests for file-mode observe."""
 
-    def test_non_version_input_source_not_treated_as_version_ns(self):
-        """Non-version input source keys in content are NOT treated as version namespaces.
+    def test_empty_content_record(self):
+        """Record with empty content {} — no crash, no fields extracted."""
+        data = [{"content": {}}]
+        config = {"context_scope": {"observe": ["extract.text"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
+        assert "text" not in result[0]["content"]
 
-        Regression: only keys matching the _N pattern should be detected as
-        version namespaces.  A regular namespace like "upstream" that happens
-        to be a dict in content should NOT trigger version namespace injection.
-        """
-        data = [
-            {
-                "source_guid": "sg-1",
-                "content": {"question": "Q?", "answer": "A!"},
-            }
-        ]
-        config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.question"]},
-        }
-        indices = {"source": 0, "upstream": 1, "review": 2}
+    def test_no_content_key(self):
+        """Record without content key — no crash."""
+        data = [{"source_guid": "sg-1"}]
+        config = {"context_scope": {"observe": ["extract.text"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
+        assert result[0]["content"] == {}
 
-        result = apply_observe_for_file_mode(
-            data=data,
-            agent_config=config,
-            agent_name="review",
-            agent_indices=indices,
-            file_path="/tmp/test.json",
-        )
-
-        # Fast path should fire — no version namespaces detected.
-        assert result is data
+    def test_namespace_is_not_dict(self):
+        """Namespace value is a string, not dict — treated as empty."""
+        data = [{"content": {"extract": "not_a_dict"}}]
+        config = {"context_scope": {"observe": ["extract.text"]}}
+        result = apply_observe_for_file_mode(data=data, agent_config=config, agent_name="test")
+        assert "text" not in result[0]["content"]

--- a/tests/unit/prompt/test_scope_builder_warning.py
+++ b/tests/unit/prompt/test_scope_builder_warning.py
@@ -1,28 +1,22 @@
-"""Regression test: infer_dependencies fallback logs at WARNING level.
+"""Regression test: build_field_context_with_history logs at DEBUG when namespace missing.
 
-When ``infer_dependencies`` raises inside ``apply_observe_for_file_mode``,
-the handler must emit a WARNING (not DEBUG) so operators can see that
-dependency inference failed and the code fell back to raw dependencies.
+With the additive content model, dependency data lives on the record's
+namespaced content.  When a namespace is absent (skipped action), the
+builder logs at DEBUG and continues — not an error.
 """
 
 import logging
-from unittest.mock import patch
 
 import pytest
 
-from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode
+from agent_actions.prompt.context.scope_builder import build_field_context_with_history
 
-_LOGGER_NAME = "agent_actions.prompt.context.scope_file_mode"
+_LOGGER_NAME = "agent_actions.prompt.context.scope_builder"
 
 
 @pytest.fixture()
 def _enable_log_propagation():
-    """Ensure the agent_actions logger propagates to root so caplog captures records.
-
-    ``LoggerFactory.reset()`` (autouse conftest fixture) clears handlers but
-    may leave ``propagate=False`` on the ``agent_actions`` logger, which
-    prevents caplog from seeing any records.
-    """
+    """Ensure the agent_actions logger propagates to root so caplog captures records."""
     aa_logger = logging.getLogger("agent_actions")
     original = aa_logger.propagate
     aa_logger.propagate = True
@@ -31,70 +25,77 @@ def _enable_log_propagation():
 
 
 @pytest.mark.usefixtures("_enable_log_propagation")
-class TestInferDependenciesFallbackWarning:
-    """Verify the except-handler around infer_dependencies logs a warning."""
+class TestMissingNamespaceLogging:
+    """Verify the builder logs gracefully when a namespace is missing."""
 
-    def test_warning_logged_when_infer_dependencies_raises(self, caplog):
-        """When infer_dependencies raises, a WARNING must be emitted."""
-        agent_config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.question"]},
+    def test_missing_namespace_logs_debug_not_error(self, caplog):
+        """When a dependency namespace is absent on the record, DEBUG is logged."""
+        current_item = {
+            "content": {
+                "extract": {"text": "hello"},
+                # "classify" is NOT present (skipped)
+            },
+            "lineage": ["node-1"],
+            "source_guid": "sg-1",
         }
-        data = [{"question": "What?"}]
-        agent_indices = {"upstream": 0, "current": 1}
-
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode.infer_dependencies",
-            side_effect=RuntimeError("boom"),
-        ):
-            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
-                result = apply_observe_for_file_mode(
-                    data=data,
-                    agent_config=agent_config,
-                    agent_name="current",
-                    agent_indices=agent_indices,
-                )
-
-        # The fallback should still produce a result (raw dependencies path)
-        assert isinstance(result, list)
-
-        # Verify the warning was emitted
-        warning_messages = [
-            record.message for record in caplog.records if record.levelno == logging.WARNING
-        ]
-        assert any(
-            "infer_dependencies failed" in msg and "current" in msg for msg in warning_messages
-        ), (
-            f"Expected a WARNING containing 'infer_dependencies failed' and "
-            f"'current', got: {warning_messages}"
-        )
-
-    def test_no_warning_when_infer_dependencies_succeeds(self, caplog):
-        """When infer_dependencies succeeds, no fallback warning is emitted."""
         agent_config = {
-            "dependencies": "upstream",
-            "context_scope": {"observe": ["upstream.question"]},
+            "dependencies": ["extract"],
+            "context_scope": {
+                "observe": ["extract.text", "classify.topic"],
+            },
         }
-        data = [{"question": "What?"}]
-        agent_indices = {"upstream": 0, "current": 1}
 
-        with patch(
-            "agent_actions.prompt.context.scope_file_mode.infer_dependencies",
-            return_value=(["upstream"], []),
-        ):
-            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
-                apply_observe_for_file_mode(
-                    data=data,
-                    agent_config=agent_config,
-                    agent_name="current",
-                    agent_indices=agent_indices,
-                )
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+            result = build_field_context_with_history(
+                agent_name="summarize",
+                agent_config=agent_config,
+                agent_indices={"extract": 0, "classify": 1, "summarize": 2},
+                current_item=current_item,
+                file_path="/tmp/test.json",
+                context_scope=agent_config["context_scope"],
+            )
 
-        warning_messages = [
-            record.message
-            for record in caplog.records
-            if record.levelno == logging.WARNING and "infer_dependencies failed" in record.message
-        ]
-        assert warning_messages == [], (
-            f"No fallback warning expected on success, got: {warning_messages}"
-        )
+        # extract namespace loaded
+        assert "extract" in result
+        assert result["extract"]["text"] == "hello"
+
+        # classify namespace absent — not in result, no error
+        assert "classify" not in result
+
+        # Should log at DEBUG, not WARNING or ERROR
+        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("classify" in msg and "not found" in msg for msg in debug_messages)
+
+    def test_all_namespaces_present(self, caplog):
+        """When all namespaces are present, no missing-namespace log is emitted."""
+        current_item = {
+            "content": {
+                "extract": {"text": "hello"},
+                "classify": {"topic": "science"},
+            },
+            "lineage": ["node-1"],
+            "source_guid": "sg-1",
+        }
+        agent_config = {
+            "dependencies": ["extract"],
+            "context_scope": {
+                "observe": ["extract.text", "classify.topic"],
+            },
+        }
+
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+            result = build_field_context_with_history(
+                agent_name="summarize",
+                agent_config=agent_config,
+                agent_indices={"extract": 0, "classify": 1, "summarize": 2},
+                current_item=current_item,
+                file_path="/tmp/test.json",
+                context_scope=agent_config["context_scope"],
+            )
+
+        assert result["extract"]["text"] == "hello"
+        assert result["classify"]["topic"] == "science"
+
+        # No "not found" messages
+        debug_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not any("not found" in msg for msg in debug_messages)


### PR DESCRIPTION
## Summary
- Observe reads from record's namespaced content instead of storage backend lookups
- Eliminates historical storage queries, version namespace detection, and FILE/RECORD mode divergence for observe
- Source namespace populated directly from source_content (no enrichment from current_item)
- Net -1025 lines: simpler code, same behavior

## What changed
- `scope_builder.py`: Unified input/context source loading — both read from `current_item["content"][dep_name]`
- `scope_file_mode.py`: Simplified to read namespaces from record content; only "source" still uses source_data
- Tests updated to use namespaced content format (additive model)

## Verification
- `ruff format --check` — clean
- `ruff check` — clean  
- `pytest` — 5779 passed, 0 failed