### PR TITLE
cleanup: remove content unwrapping and flatten calls from tool path

### DIFF
--- a/.changes/unreleased/Under the Hood-20260423-090000.yaml
+++ b/.changes/unreleased/Under the Hood-20260423-090000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove dead code from replacement content model — prepare_tool_context, original_context parameter chain, content fallback pattern in task_preparer"
+time: 2026-04-23T09:00:00.000000Z

--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -27,7 +27,6 @@ def create_dynamic_agent(
     tool_args: dict[str, Any] | None = None,
     source_content: Any | None = None,
     additional_context: dict | None = None,
-    original_context: str | dict | None = None,
 ) -> list[Any]:
     """Build and execute a prompt against the selected vendor.
 
@@ -42,8 +41,6 @@ def create_dynamic_agent(
         source_content: Source content for tool handler (optional).
         additional_context: Additional context from context_scope.observe (optional).
             Formatted and appended to prompt before LLM invocation.
-        original_context: Original untransformed context for guards/debug (optional).
-            Tools and LLMs use the same transformed context_data_str.
 
     Returns:
         List of response items from the LLM.
@@ -75,7 +72,7 @@ def create_dynamic_agent(
     is_tool = model_vendor == "tool"
 
     # Prepare context data (critical: preserve context separation)
-    context_data = ContextService.prepare_context_data(context_data_str, original_context, is_tool)
+    context_data = ContextService.prepare_context_data(context_data_str, is_tool)
 
     # Note: dispatch_task() injection now happens in PromptPreparationService
     captured_results = {}

--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -71,7 +71,6 @@ def create_dynamic_agent(
     model_vendor = (agent_config.get(MODEL_VENDOR_KEY) or "").lower()
     is_tool = model_vendor == "tool"
 
-    # Prepare context data (critical: preserve context separation)
     context_data = ContextService.prepare_context_data(context_data_str, is_tool)
 
     # Note: dispatch_task() injection now happens in PromptPreparationService

--- a/agent_actions/llm/realtime/services/context.py
+++ b/agent_actions/llm/realtime/services/context.py
@@ -14,18 +14,15 @@ class ContextService:
     @staticmethod
     def prepare_context_data(
         context_data_str: str | dict,
-        original_context: str | dict | None,
         is_tool: bool,
     ) -> str | dict:
         """
         Prepare context data for LLM/tool invocation.
 
-        CRITICAL: Tools and LLMs now share the same llm_context to ensure
-        consistent behavior across vendors.
+        Tools receive namespaced data directly. LLMs receive JSON strings.
 
         Args:
-            context_data_str: Context data for LLM (may have context_scope.drop applied)
-            original_context: Original untransformed context for tools (optional)
+            context_data_str: Context data (may have context_scope.drop applied)
             is_tool: Whether this is a tool vendor invocation
 
         Returns:
@@ -39,27 +36,3 @@ class ContextService:
         if isinstance(context_data_str, str):
             return context_data_str
         return json.dumps(ensure_json_safe(context_data_str), ensure_ascii=False)
-
-    @staticmethod
-    def prepare_tool_context(
-        context_data_str: str | dict, original_context: str | dict | None
-    ) -> str:
-        """
-        Prepare tool context as JSON string for tool injection.
-
-        CRITICAL: Tools and LLMs now share the same llm_context.
-
-        Args:
-            context_data_str: Transformed context data (with context_scope.drop applied)
-            original_context: Original untransformed context for tools (optional)
-
-        Returns:
-            JSON string of tool context
-        """
-        result = ContextService.prepare_context_data(
-            context_data_str, original_context, is_tool=False
-        )
-        # Ensure string return type for backward compatibility
-        if isinstance(result, str):
-            return result
-        return json.dumps(result, ensure_ascii=False)

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -65,7 +65,6 @@ def run_dynamic_agent(
         tool_args=tool_args,
         source_content=source_content,
         additional_context=None,
-        original_context=context,
     )
 
     response = _validate_llm_output_schema(

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -11,6 +11,7 @@ from agent_actions.processing.prepared_task import (
     PreparationContext,
     PreparedTask,
 )
+from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class TaskPreparer:
             return PreparedTask(
                 target_id=target_id,
                 source_guid=source_guid,
-                original_content=item.get("content", item) if isinstance(item, dict) else item,
+                original_content=get_existing_content(item) if isinstance(item, dict) else item,
                 guard_status=GuardStatus.UPSTREAM_UNPROCESSED,
             )
 

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -82,7 +82,7 @@ class TestTaskPreparerUpstreamUnprocessed:
     def test_returns_upstream_unprocessed_status(self):
         preparer = TaskPreparer()
         item = {
-            "content": "stale data",
+            "content": {"upstream_action": {"data": "stale"}},
             "source_guid": "sg_123",
             "_unprocessed": True,
         }
@@ -92,7 +92,7 @@ class TestTaskPreparerUpstreamUnprocessed:
         assert result.is_upstream_unprocessed is True
         assert result.guard_behavior is None
         assert result.source_guid == "sg_123"
-        assert result.original_content == "stale data"
+        assert result.original_content == {"upstream_action": {"data": "stale"}}
         assert result.formatted_prompt == ""
 
     @patch.object(TaskPreparer, "_load_full_context")
@@ -100,7 +100,7 @@ class TestTaskPreparerUpstreamUnprocessed:
         """Verify _load_full_context is NOT called for unprocessed records."""
         preparer = TaskPreparer()
         item = {
-            "content": "stale",
+            "content": {"upstream_action": {"val": "stale"}},
             "_unprocessed": True,
         }
         preparer.prepare(item, self._make_context())
@@ -109,7 +109,7 @@ class TestTaskPreparerUpstreamUnprocessed:
     def test_preserves_existing_target_id(self):
         preparer = TaskPreparer()
         item = {
-            "content": "stale",
+            "content": {"upstream_action": {"val": "stale"}},
             "source_guid": "sg_456",
             "_unprocessed": True,
         }

--- a/tests/unit/processing/test_tool_input_namespaced.py
+++ b/tests/unit/processing/test_tool_input_namespaced.py
@@ -23,7 +23,7 @@ class TestContextServiceNamespaced:
     def test_tool_receives_namespaced_dict(self):
         """Tool path returns the namespaced dict unchanged — no flatten."""
         namespaced = {"extract": {"text": "hello"}, "classify": {"topic": "science"}}
-        result = ContextService.prepare_context_data(namespaced, None, is_tool=True)
+        result = ContextService.prepare_context_data(namespaced, is_tool=True)
         assert result == namespaced
         assert isinstance(result["extract"], dict)
         assert result["extract"]["text"] == "hello"
@@ -34,7 +34,7 @@ class TestContextServiceNamespaced:
             "extract": {"text": "original"},
             "rewrite": {"text": "rewritten"},
         }
-        result = ContextService.prepare_context_data(namespaced, None, is_tool=True)
+        result = ContextService.prepare_context_data(namespaced, is_tool=True)
         assert result["extract"]["text"] == "original"
         assert result["rewrite"]["text"] == "rewritten"
 
@@ -45,7 +45,7 @@ class TestContextServiceNamespaced:
             "score_2": {"score": 6},
             "score_3": {"score": 9},
         }
-        result = ContextService.prepare_context_data(namespaced, None, is_tool=True)
+        result = ContextService.prepare_context_data(namespaced, is_tool=True)
         assert len(result) == 3
         assert result["score_1"]["score"] == 8
         assert result["score_2"]["score"] == 6
@@ -53,18 +53,18 @@ class TestContextServiceNamespaced:
 
     def test_tool_string_context_passthrough(self):
         """String context passes through unchanged for tools."""
-        result = ContextService.prepare_context_data("raw string", None, is_tool=True)
+        result = ContextService.prepare_context_data("raw string", is_tool=True)
         assert result == "raw string"
 
     def test_tool_empty_dict(self):
         """Empty dict passes through unchanged."""
-        result = ContextService.prepare_context_data({}, None, is_tool=True)
+        result = ContextService.prepare_context_data({}, is_tool=True)
         assert result == {}
 
     def test_llm_still_json_serializes(self):
         """LLM path still JSON-serializes dicts (unchanged behavior)."""
         namespaced = {"extract": {"text": "hello"}}
-        result = ContextService.prepare_context_data(namespaced, None, is_tool=False)
+        result = ContextService.prepare_context_data(namespaced, is_tool=False)
         assert isinstance(result, str)
         assert '"extract"' in result
 
@@ -96,8 +96,6 @@ class TestRunDynamicAgentNamespaced:
         call_args = mock_builder.call_args
         # context_data_str (positional arg 2) should be the namespaced dict
         assert call_args[0][2] == namespaced
-        # original_context should also be the same namespaced dict
-        assert call_args[1]["original_context"] == namespaced
 
     @patch("agent_actions.llm.realtime.builder.create_dynamic_agent")
     def test_content_key_not_unwrapped(self, mock_builder):


### PR DESCRIPTION
## Summary
- Remove `ContextService.prepare_tool_context` — zero callers after additive model migration
- Remove vestigial `original_context` parameter from `prepare_context_data` and `create_dynamic_agent` — declared but never read in function bodies
- Replace `item.get("content", item)` fallback in `TaskPreparer` with `get_existing_content()` from `utils/content.py`
- Update tests to use namespaced content dicts (additive model format)

## Verification
- `ruff check agent_actions tests` — clean
- `ruff format --check agent_actions tests` — clean
- `pytest` — 5824 passed, 2 skipped
- `grep -rn "flatten_observe_context" agent_actions/llm/` — zero hits
- `grep -rn 'get("content", data)' agent_actions/processing/` — zero hits
- `grep -rn "prepare_tool_context" agent_actions/` — zero hits
- `grep -rn "original_context" agent_actions/llm/realtime/` — zero hits