### PR TITLE
docs: update docs site for additive content model

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260424-094001.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260424-094001.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Update docs site to reflect additive content model: namespaced tool data access, dotted guard conditions, observe as namespace selection"
+time: 2026-04-24T09:40:01.000000Z

--- a/docs.agent-actions/docs/guides/custom-tools.md
+++ b/docs.agent-actions/docs/guides/custom-tools.md
@@ -22,7 +22,7 @@ from agent_actions import udf_tool
 @udf_tool()
 def validate_product_price(data: dict[str, Any]) -> dict[str, Any]:
     """Ensure product price is positive and reasonable."""
-    price = data.get('price', 0)
+    price = data["source"]["price"]
     if price <= 0:
         raise ValueError(f"Price must be positive, got {price}")
     return data
@@ -34,6 +34,9 @@ actions:
   - name: price_validator
     kind: tool
     impl: validate_product_price
+    context_scope:
+      observe:
+        - source.*
 ```
 
 Agent Actions discovers tools automatically—no module paths needed.
@@ -48,11 +51,10 @@ from agent_actions import udf_tool
 def my_tool(data: dict[str, Any]) -> dict[str, Any]:
     """
     Args:
-        data: Flat dict of observed fields from upstream actions.
-              Fields are delivered without namespace wrappers — access
-              them directly with data.get("field").
-              When two upstream actions share a field name, the
-              framework qualifies them: data.get("action.field").
+        data: Dict of namespaced fields from upstream actions.
+              Each upstream action's output is nested under its
+              action name: data["action_name"]["field"].
+              Source data is under data["source"]["field"].
 
     Returns:
         Modified data dict
@@ -71,7 +73,7 @@ def my_tool(data: dict[str, Any]) -> dict[str, Any]:
 @udf_tool()
 def validate_email(data: dict[str, Any]) -> dict[str, Any]:
     import re
-    email = data.get('email', '')
+    email = data["source"]["email"]
     if not re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', email):
         raise ValueError(f"Invalid email: {email}")
     return data
@@ -82,7 +84,8 @@ def validate_email(data: dict[str, Any]) -> dict[str, Any]:
 ```python
 @udf_tool()
 def enrich_customer_data(data: dict[str, Any]) -> dict[str, Any]:
-    ltv = data.get('lifetime_value', 0)
+    customer = data["classify_customer"]
+    ltv = customer["lifetime_value"]
     if ltv > 10000:
         data['tier'] = 'platinum'
     elif ltv > 5000:
@@ -98,7 +101,7 @@ def enrich_customer_data(data: dict[str, Any]) -> dict[str, Any]:
 @udf_tool()
 def fetch_product_details(data: dict[str, Any]) -> dict[str, Any]:
     import requests
-    product_id = data.get('product_id')
+    product_id = data["extract_data"]["product_id"]
     response = requests.get(f"https://api.example.com/products/{product_id}")
     if response.ok:
         data['external_details'] = response.json()
@@ -110,7 +113,7 @@ def fetch_product_details(data: dict[str, Any]) -> dict[str, Any]:
 ```python
 @udf_tool()
 def calculate_order_totals(data: dict[str, Any]) -> dict[str, Any]:
-    items = data.get('items', [])
+    items = data["source"]["items"]
     subtotal = sum(item['price'] * item['quantity'] for item in items)
     data['subtotal'] = subtotal
     data['tax'] = subtotal * 0.08
@@ -133,7 +136,7 @@ def deduplicate_questions(data: list[dict]) -> list[dict]:
     result = []
     for record in data:
         content = record["content"]
-        question = content.get("question_text", "")
+        question = content["extract_questions"]["question_text"]
         if question not in seen:
             seen.add(question)
             result.append(record)  # pass through the full record
@@ -144,8 +147,8 @@ def deduplicate_questions(data: list[dict]) -> list[dict]:
 
 | | Record-level | File-level |
 |---|---|---|
-| Input | Single `dict` with unwrapped business fields | `list[dict]` — each record has `content`, `node_id`, `lineage` |
-| Read fields | `data["field"]` | `record["content"]["field"]` |
+| Input | Single `dict` with namespaced upstream data | `list[dict]` — each record has `content`, `node_id`, `lineage` |
+| Read fields | `data["action_name"]["field"]` | `record["content"]["action_name"]["field"]` |
 | Passthrough | Return modified dict | Return the original record dict |
 | New records | N/A | Return a new dict without `node_id` |
 

--- a/docs.agent-actions/docs/guides/design-patterns.md
+++ b/docs.agent-actions/docs/guides/design-patterns.md
@@ -366,7 +366,7 @@ actions:
   - name: fulfill_order
     dependencies: [classify_order]
     guard:
-      condition: 'order_status == "in_stock"'
+      condition: 'classify_order.order_status == "in_stock"'
       on_false: "filter"
     intent: "Generate fulfillment instructions for in-stock orders"
     prompt: $prompts.fulfill_order
@@ -384,7 +384,7 @@ actions:
   - name: create_backorder
     dependencies: [classify_order]
     guard:
-      condition: 'order_status == "out_of_stock"'
+      condition: 'classify_order.order_status == "out_of_stock"'
       on_false: "filter"
     intent: "Create backorder with estimated restock timeline"
     prompt: $prompts.create_backorder
@@ -401,7 +401,7 @@ actions:
   - name: process_refund
     dependencies: [classify_order]
     guard:
-      condition: 'order_status == "cancelled"'
+      condition: 'classify_order.order_status == "cancelled"'
       on_false: "filter"
     intent: "Process refund and generate confirmation"
     prompt: $prompts.process_refund
@@ -503,7 +503,7 @@ actions:
   - name: finalize
     dependencies: [critique_against_guidelines]
     guard:
-      condition: 'approved == true'
+      condition: 'critique_against_guidelines.approved == true'
       on_false: "filter"
     prompt: |
       Polish this approved marketing copy for publication.
@@ -521,7 +521,7 @@ actions:
   - name: revise
     dependencies: [critique_against_guidelines]
     guard:
-      condition: 'approved == false'
+      condition: 'critique_against_guidelines.approved == false'
       on_false: "filter"
     prompt: |
       Revise this marketing copy based on the critique.
@@ -727,7 +727,7 @@ actions:
   - name: extract_invoice
     dependencies: [detect_document_type]
     guard:
-      condition: 'document_type == "invoice"'
+      condition: 'detect_document_type.document_type == "invoice"'
       on_false: "filter"
     intent: "Extract structured data from invoices"
     prompt: $prompts.extract_invoice
@@ -747,7 +747,7 @@ actions:
   - name: analyze_contract
     dependencies: [detect_document_type]
     guard:
-      condition: 'document_type == "contract"'
+      condition: 'detect_document_type.document_type == "contract"'
       on_false: "filter"
     intent: "Analyze contract terms and flag key obligations"
     prompt: $prompts.analyze_contract
@@ -766,7 +766,7 @@ actions:
   - name: respond_to_letter
     dependencies: [detect_document_type]
     guard:
-      condition: 'document_type == "letter"'
+      condition: 'detect_document_type.document_type == "letter"'
       on_false: "filter"
     intent: "Draft appropriate response to correspondence"
     prompt: $prompts.respond_to_letter
@@ -963,7 +963,7 @@ def aggregate_votes(data: dict[str, Any]) -> dict[str, Any]:
     """Majority vote across 3 parallel voters."""
     keep_count = sum(
         1 for i in range(1, 4)
-        if data.get(f"vote_quality_{i}", {}).get("verdict") == "keep"
+        if data[f"vote_quality_{i}"]["verdict"] == "keep"
     )
     return {
         "filter": "keep" if keep_count >= 2 else "filter",
@@ -977,7 +977,7 @@ def aggregate_votes(data: dict[str, Any]) -> dict[str, Any]:
 - name: generate_answer
   dependencies: [aggregate_votes]
   guard:
-    condition: 'filter == "keep"'
+    condition: 'aggregate_votes.filter == "keep"'
     on_false: filter
   prompt: $my_workflow.Generate_Answer
 ```

--- a/docs.agent-actions/docs/guides/human-in-the-loop.md
+++ b/docs.agent-actions/docs/guides/human-in-the-loop.md
@@ -188,13 +188,13 @@ HITL decision fields (`hitl_status`, `user_comment`, `timestamp`) are merged dir
 
 #### Guards
 
-Guards evaluate against the item's content fields directly — **do not prefix with the action name**:
+Guards evaluate against namespaced fields — use the HITL action name as the namespace prefix:
 
 ```yaml
 - name: process_approved_data
   dependencies: [review_data]
   guard:
-    condition: "hitl_status == 'approved'"
+    condition: "review_data.hitl_status == 'approved'"
     on_false: skip  # Skip processing if HITL rejected
   prompt: |
     Process the approved data:
@@ -203,36 +203,22 @@ Guards evaluate against the item's content fields directly — **do not prefix w
     Reviewer comment: {{ review_data.user_comment }}
 ```
 
-:::warning Guard field resolution
-Guards evaluate against the **flattened item content**. The HITL fields (`hitl_status`, `user_comment`) are top-level keys in each record, not nested under the action name.
-
-```yaml
-# Correct - field is at the top level of each item
-condition: "hitl_status == 'approved'"
-
-# Wrong - tries to look up data["review_data"]["hitl_status"], which doesn't exist
-condition: "review_data.hitl_status == 'approved'"
-```
-
-Note: Prompt templates (`{{ review_data.user_comment }}`) use a different resolution mechanism (context scope) and **do** use the action name prefix. Guards do not.
-:::
-
 **Common guard patterns:**
 
 ```yaml
 # Only process approved items (filter out rejected/timeout)
 guard:
-  condition: "hitl_status == 'approved'"
+  condition: "review_action.hitl_status == 'approved'"
   on_false: filter
 
 # Skip downstream if rejected (passthrough original content)
 guard:
-  condition: "hitl_status == 'approved'"
+  condition: "review_action.hitl_status == 'approved'"
   on_false: skip
 
 # Handle timeout
 guard:
-  condition: "hitl_status != 'timeout'"
+  condition: "review_action.hitl_status != 'timeout'"
   on_false: skip
 ```
 
@@ -262,7 +248,7 @@ actions:
     dependencies: [review_summary]
     intent: "Publish approved summary"
     guard:
-      condition: "hitl_status == 'approved'"
+      condition: "review_summary.hitl_status == 'approved'"
       on_false: skip
     prompt: "Publish the summary..."
 ```
@@ -290,7 +276,7 @@ actions:
     dependencies: [review_candidates]
     intent: "Process only approved candidates"
     guard:
-      condition: "hitl_status == 'approved'"
+      condition: "review_candidates.hitl_status == 'approved'"
       on_false: filter
 ```
 
@@ -316,7 +302,7 @@ actions:
   - name: stage_2_enrichment
     dependencies: [checkpoint_review]
     guard:
-      condition: "hitl_status == 'approved'"
+      condition: "checkpoint_review.hitl_status == 'approved'"
       on_false: filter  # Exclude items if stage 1 was rejected
 ```
 
@@ -334,7 +320,7 @@ actions:
     kind: hitl
     dependencies: [auto_review_quality]
     guard:
-      condition: 'decision == "review"'
+      condition: 'auto_review_quality.decision == "review"'
       on_false: skip  # Auto-approved records skip HITL, preserve original content
     hitl:
       instructions: "Review items flagged by auto-review"
@@ -351,17 +337,17 @@ The guard runs per-record before the HITL UI launches. Only records where `decis
 
 If your downstream guard filters/skips **every** item (even approved ones), the most common causes are:
 
-**1. Using action name prefix in the guard condition**
+**1. Missing action name prefix in the guard condition**
 
 ```yaml
-# Wrong - guard evaluates against flattened item content, not namespaced context
-condition: "review_data.hitl_status == 'approved'"
-
-# Correct - hitl_status is a top-level field in each item
+# Wrong - hitl_status must be namespaced under the HITL action
 condition: "hitl_status == 'approved'"
+
+# Correct - use the HITL action name as namespace prefix
+condition: "review_data.hitl_status == 'approved'"
 ```
 
-The guard evaluator flattens the item's `content` dict into a top-level namespace. Fields like `hitl_status` are accessed directly, not under the action name. See the [guard field resolution warning](#guards) above.
+Guard conditions use dotted namespace paths. Fields like `hitl_status` are accessed under the HITL action name, just like any other upstream field.
 
 **2. Wrong field name**
 
@@ -450,7 +436,7 @@ After timeout:
 
 ```yaml
 guard:
-  condition: "hitl_status != 'timeout'"
+  condition: "review_action.hitl_status != 'timeout'"
   on_false: filter
 ```
 

--- a/docs.agent-actions/docs/guides/non-json-mode.md
+++ b/docs.agent-actions/docs/guides/non-json-mode.md
@@ -97,7 +97,7 @@ Guards evaluate upstream field values the same way regardless of JSON mode:
   - name: draft_response
     output_field: suggested_response
     guard:
-      condition: 'severity != "low"'  # Skip for low-severity → save tokens
+      condition: 'classify_issue.severity != "low"'  # Skip for low-severity → save tokens
       on_false: "skip"
 ```
 

--- a/docs.agent-actions/docs/guides/troubleshooting.md
+++ b/docs.agent-actions/docs/guides/troubleshooting.md
@@ -185,7 +185,7 @@ field: Union[int, str]
 
 **Fix:** Normalize in your tool:
 ```python
-answer_text = data.get('answer_text')
+answer_text = data["upstream_action"]["answer_text"]
 if isinstance(answer_text, str):
     answer_text = [answer_text]
 ```
@@ -246,7 +246,7 @@ target_word_counts: dict
 @udf_tool()
 def my_function(data: dict) -> dict:
     return {
-        'question': data.get('question', ''),  # Always include
+        'question': data["upstream_action"]["question"],
         'processed': True
     }
 ```
@@ -425,13 +425,13 @@ metadata: dict  # Not Dict[str, int]
 answer_text: Union[str, List[str]]
 ```
 
-### Always Use `.get()` with Defaults
+### Access Namespaced Fields
 
 ```python
 @udf_tool()
 def safe_function(data: dict) -> dict:
-    value = data.get('field', '')  # Never KeyError
-    items = data.get('items', [])
+    value = data["upstream_action"]["field"]
+    items = data["upstream_action"]["items"]
     return {'result': value}
 ```
 

--- a/docs.agent-actions/docs/reference/context/context-scope.md
+++ b/docs.agent-actions/docs/reference/context/context-scope.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 # Context Scope
 
-Context Scope controls data visibility and flow between actions—what the LLM sees, what passes through to output, and what gets excluded.
+Context Scope controls data visibility and flow between actions—selecting which upstream namespaces an action can read from the record, what passes through to output, and what gets excluded.
 
 :::warning Required
 `context_scope` is **required** on every action. Omitting it raises a `ConfigurationError`. Every action must declare its data dependencies explicitly via `observe`, `passthrough`, or `drop`.
@@ -36,7 +36,7 @@ context_scope:
 
 ## Observe Directive
 
-The `observe` directive explicitly includes fields in the LLM context. When specified, only listed fields are visible to the LLM.
+The `observe` directive selects which upstream namespaces and fields are visible to the action. When specified, only listed namespaces are included in the LLM context.
 
 ```yaml
 - name: Cluster_Validation_Agent

--- a/docs.agent-actions/docs/reference/context/field-references.md
+++ b/docs.agent-actions/docs/reference/context/field-references.md
@@ -117,7 +117,7 @@ actions:
 - name: canonicalize_facts
   dependencies: fact_extractor
   guard:
-    condition: "candidate_facts_list != []"
+    condition: "fact_extractor.candidate_facts_list != []"
     on_false: filter
 ```
 

--- a/docs.agent-actions/docs/reference/data-io/output-format.md
+++ b/docs.agent-actions/docs/reference/data-io/output-format.md
@@ -78,7 +78,7 @@ The following fields are metadata and are automatically excluded when extracting
 - `_recovery`
 - `_unprocessed`
 
-This means when an action references upstream data, it sees the `content` fields without these wrappers or system fields.
+This means when an action references upstream data, it sees the `content` fields organized by upstream action namespace, without these wrappers or system fields.
 
 ### Record Types
 

--- a/docs.agent-actions/docs/reference/execution/granularity.md
+++ b/docs.agent-actions/docs/reference/execution/granularity.md
@@ -77,7 +77,7 @@ from agent_actions import udf_tool
 @udf_tool
 def validate_email(data, **kwargs):
     """Process single record."""
-    email = data.get('email', '')
+    email = data["source"]["email"]
     return {"valid": is_valid_email(email)}
 ```
 
@@ -96,7 +96,7 @@ def deduplicate_facts(records, **kwargs):
     unique = []
     for record in records:
         content = record["content"]
-        key = content.get("fact_text")
+        key = content["extract_facts"]["fact_text"]
         if key not in seen:
             seen.add(key)
             unique.append(record)  # pass through full record

--- a/docs.agent-actions/docs/reference/execution/guards.md
+++ b/docs.agent-actions/docs/reference/execution/guards.md
@@ -35,9 +35,9 @@ Guards evaluate conditions and decide whether an action should run for each reco
 
 ```yaml
 guard:
-  condition: "score > 85"
-  condition: "status == 'approved'"
-  condition: "facts != []"
+  condition: "upstream_action.score > 85"
+  condition: "upstream_action.status == 'approved'"
+  condition: "upstream_action.facts != []"
 ```
 
 | Operator | Description |
@@ -63,27 +63,27 @@ Boolean keywords are case-insensitive, matching SQL convention:
 
 ```yaml
 guard:
-  condition: 'passes_filter == true'   # valid
-  condition: 'passes_filter == True'   # valid
-  condition: 'passes_filter == TRUE'   # valid
+  condition: 'upstream_action.passes_filter == true'   # valid
+  condition: 'upstream_action.passes_filter == True'   # valid
+  condition: 'upstream_action.passes_filter == TRUE'   # valid
 ```
 
 Prefer explicit comparison over a bare field reference for boolean fields. A bare reference evaluates using Python truthiness — this fails silently when the upstream action stores `"false"` as a string (which is truthy) rather than a Python `bool`:
 
 ```yaml
 # Fragile — string "false" is truthy, so the guard never filters
-condition: 'passes_filter'
+condition: 'upstream_action.passes_filter'
 
 # Explicit — correct regardless of whether the value is a bool or a string
-condition: 'passes_filter == true'
+condition: 'upstream_action.passes_filter == true'
 ```
 
 ### Built-in Functions
 
 ```yaml
 guard:
-  condition: 'len(items) > 0'
-  condition: 'max(scores) >= 85'
+  condition: 'len(upstream_action.items) > 0'
+  condition: 'max(upstream_action.scores) >= 85'
 ```
 
 Supported: `len()`, `str()`, `int()`, `float()`, `abs()`, `min()`, `max()`
@@ -96,7 +96,7 @@ Supported: `len()`, `str()`, `int()`, `float()`, `abs()`, `min()`, `max()`
 - name: canonicalize_facts
   dependencies: fact_extractor
   guard:
-    condition: 'candidate_facts_list != []'
+    condition: 'fact_extractor.candidate_facts_list != []'
     on_false: "filter"
 ```
 
@@ -105,7 +105,7 @@ Supported: `len()`, `str()`, `int()`, `float()`, `abs()`, `min()`, `max()`
 ```yaml
 - name: enhance_summary
   guard:
-    condition: 'needs_enhancement == true'
+    condition: 'analyze_content.needs_enhancement == true'
     on_false: "skip"
 ```
 
@@ -114,7 +114,7 @@ Supported: `len()`, `str()`, `int()`, `float()`, `abs()`, `min()`, `max()`
 ```yaml
 - name: generate_final_output
   guard:
-    condition: 'quality_score >= 85'
+    condition: 'evaluate_quality.quality_score >= 85'
     on_false: "filter"
 ```
 
@@ -124,9 +124,8 @@ Guards can access:
 
 | Source | Syntax |
 |--------|--------|
-| Direct field | `candidate_facts_list` |
-| Specific action | `extract_facts.count` |
-| Context scope observed | `num_similar_facts` |
+| Upstream action field | `extract_facts.count` |
+| Context scope observed | `group_by_similarity.num_similar_facts` |
 
 ```yaml
 - name: validate
@@ -134,7 +133,7 @@ Guards can access:
     observe:
       - group_by_similarity.num_similar_facts
   guard:
-    condition: 'num_similar_facts != 1'
+    condition: 'group_by_similarity.num_similar_facts != 1'
     on_false: "skip"
 ```
 
@@ -155,7 +154,7 @@ When Action A skips a record (`on_false: skip`), Action B still receives it and 
 actions:
   - name: extract_facts
     guard:
-      condition: 'status == "active"'
+      condition: 'classify.status == "active"'
       on_false: "skip"       # Inactive records pass through with original content
 
   - name: generate_summary
@@ -184,7 +183,7 @@ Guard evaluation errors are classified into three categories, each with differen
 
 ```yaml
 guard:
-  condition: 'passes_filter == true'
+  condition: 'upstream_action.passes_filter == true'
   on_false: filter
   passthrough_on_error: false   # filter the record if evaluation fails
 ```
@@ -202,11 +201,11 @@ String values on the right-hand side of comparisons **must be quoted**. Unquoted
 ```yaml
 # WRONG — "approved" is interpreted as a field name
 guard:
-  condition: 'hitl_status == approved'
+  condition: 'review_report.hitl_status == approved'
 
 # CORRECT — quote string literals
 guard:
-  condition: 'hitl_status == "approved"'
+  condition: 'review_report.hitl_status == "approved"'
 ```
 
 ## Limitations
@@ -226,7 +225,7 @@ When a guard is configured on a File-granularity action (tool or HITL), the guar
   granularity: file
   impl: deduplicate
   guard:
-    condition: 'status == "active"'
+    condition: 'upstream_action.status == "active"'
     on_false: filter  # Only active records sent to dedup tool
 ```
 

--- a/docs.agent-actions/docs/reference/execution/versions.md
+++ b/docs.agent-actions/docs/reference/execution/versions.md
@@ -140,15 +140,15 @@ prompt: |
 Access in tool UDFs (FILE mode):
 
 ```python
-# Each version is a nested dict in content
-scorer_1 = content.get("score_quality_1", {})
-scorer_2 = content.get("score_quality_2", {})
+# Each version is a nested namespace in content
+scorer_1 = content["score_quality_1"]
+scorer_2 = content["score_quality_2"]
 
 # Iterate all versions dynamically
 scores = []
 for key, data in content.items():
     if key.startswith("score_quality_") and isinstance(data, dict):
-        scores.append(data.get("overall_score", 0))
+        scores.append(data["overall_score"])
 ```
 
 When observe uses wildcards (`score_quality.*`), fields are also expanded as qualified flat keys (`score_quality_1.overall_score`, `score_quality_2.overall_score`) alongside the nested dicts. Both access patterns work.

--- a/docs.agent-actions/docs/reference/prompts/dispatch.md
+++ b/docs.agent-actions/docs/reference/prompts/dispatch.md
@@ -33,7 +33,7 @@ from agent_actions import udf_tool
 @udf_tool
 def handle_quiz_type(input_data: dict) -> dict:
     """Return appropriate authoring prompt based on quiz type."""
-    quiz_type = input_data.get("quiz_type", "APPLICATION").upper()
+    quiz_type = input_data["source"]["quiz_type"].upper()
 
     prompts = {
         "UNDERSTANDING": "Generate a conceptual question...",

--- a/docs.agent-actions/docs/reference/schemas/index.md
+++ b/docs.agent-actions/docs/reference/schemas/index.md
@@ -191,7 +191,7 @@ from agent_actions import udf_tool
 
 @udf_tool
 def select_question_schema(input_data: dict) -> str:
-    question_type = input_data.get("question_type", "").upper()
+    question_type = input_data["source"]["question_type"].upper()
 
     if question_type == "MULTIPLE_CHOICE":
         return "mc_question_schema"  # References schema/mc_question_schema.yml (or .yaml/.json)
@@ -208,7 +208,7 @@ For more dynamic cases, return a complete schema definition:
 ```python
 @udf_tool
 def select_output_schema(input_data: dict) -> dict:
-    complexity = input_data.get("complexity", "simple")
+    complexity = input_data["source"]["complexity"]
 
     if complexity == "detailed":
         return {
@@ -247,13 +247,13 @@ The dispatch tool receives all available context:
 @udf_tool
 def select_schema(input_data: dict) -> str:
     # Source fields from current record
-    content_type = input_data.get("content_type")
+    content_type = input_data["source"]["content_type"]
 
     # Seed data
-    exam_type = input_data.get("exam_syllabus", {}).get("type")
+    exam_type = input_data["seed"]["exam_syllabus"]["type"]
 
     # Upstream action outputs
-    classification = input_data.get("classify_content", {}).get("category")
+    classification = input_data["classify_content"]["category"]
 
     # Make decision based on any combination
     if classification == "code":

--- a/docs.agent-actions/docs/reference/tools/index.md
+++ b/docs.agent-actions/docs/reference/tools/index.md
@@ -16,7 +16,7 @@ from agent_actions import udf_tool
 
 @udf_tool()
 def process_text(data: dict, **kwargs) -> dict:
-    return {"result": data["text"].upper()}
+    return {"result": data["source"]["text"].upper()}
 ```
 
 ```yaml
@@ -63,7 +63,7 @@ def simple_transform(data: dict, **kwargs) -> dict:
 ```python
 @udf_tool()
 def filter_questions_by_score(data: dict, **kwargs) -> dict:
-    score = data.get('syllabus_alignment_score', 0)
+    score = data["upstream_action"]["syllabus_alignment_score"]
     if score >= 85:
         data['question_status'] = "KEEP"
     else:
@@ -86,7 +86,7 @@ def run_dedup(data: list[dict], **kwargs) -> list[dict]:
     unique = []
     for record in data:
         content = record["content"]
-        fact = content.get("fact", "")
+        fact = content["extract_facts"]["fact"]
         if fact not in seen:
             seen.add(fact)
             unique.append(record)  # return the full record
@@ -100,7 +100,7 @@ File granularity is exclusively supported for tool actions. LLM actions must use
 ### File Granularity Constraints
 
 - **Input is an array of full records** — each record has `content`, `node_id`, `source_guid`, `lineage`
-- **Read business data from `record["content"]["field"]`** — not `record["field"]`
+- **Read business data from `record["content"]["action_name"]["field"]`** — not `record["field"]`
 - **Return the original record for passthrough** (filter, dedup, sort, transform) — preserves `node_id` and lineage
 - **Return a new dict for aggregation** (no `node_id`) — framework creates fresh lineage
 - **Output flexibility** — return an array of any size (N→M transformation)
@@ -122,7 +122,7 @@ def dedup_tool(data: list[dict], **kwargs) -> list[dict]:
 
     for record in data:
         content = record["content"]
-        fact = content.get("fact", "")
+        fact = content["extract_facts"]["fact"]
         if fact not in seen:
             seen[fact] = True
             outputs.append(record)  # full record → lineage extended
@@ -132,7 +132,7 @@ def dedup_tool(data: list[dict], **kwargs) -> list[dict]:
 
 @udf_tool(granularity=Granularity.FILE)
 def aggregate_tool(data: list[dict], **kwargs) -> list[dict]:
-    total = sum(r.get("content", r).get("score", 0) for r in data)
+    total = sum(r["content"]["score_action"]["score"] for r in data)
     return [{"summary": f"Total: {total}", "count": len(data)}]  # new dict → fresh lineage
 ```
 
@@ -224,7 +224,7 @@ If you need shared logic across multiple tool files, extract it into an installa
 ```python
 @udf_tool()
 def safe_function(data: dict, **kwargs) -> dict:
-    score = data.get('score', 0)  # Use .get() with defaults
+    score = data["upstream_action"]["score"]
     return {'result': score}
 ```
 

--- a/docs.agent-actions/docs/reference/validation/output-validation.md
+++ b/docs.agent-actions/docs/reference/validation/output-validation.md
@@ -189,7 +189,7 @@ Guards validate semantic and business logic after schema passes:
 - name: generate_final
   dependencies: score_quality  # Input source
   guard:
-    condition: 'score >= 85'  # Semantic: only high quality
+    condition: 'score_quality.score >= 85'  # Semantic: only high quality
     on_false: filter
 ```
 
@@ -199,13 +199,13 @@ Guards validate semantic and business logic after schema passes:
 # Filter out responses with unwanted status
 - name: next_action
   guard:
-    condition: 'status != "invalid"'
+    condition: 'upstream_action.status != "invalid"'
     on_false: filter
 
 # Filter based on category
 - name: process_technical
   guard:
-    condition: 'category IN ["technical", "implementation"]'
+    condition: 'classify.category IN ["technical", "implementation"]'
     on_false: filter
 ```
 
@@ -221,12 +221,12 @@ Consider what happens when a guard fails. You have two choices, and they have ve
 ```yaml
 # Filter: Record stops here
 guard:
-  condition: 'quality >= 50'
+  condition: 'score_quality.quality >= 50'
   on_false: filter
 
 # Skip: Record continues without this action
 guard:
-  condition: 'needs_enhancement == true'
+  condition: 'analyze_content.needs_enhancement == true'
   on_false: skip
 ```
 
@@ -250,7 +250,7 @@ actions:
   - name: validate_facts
     dependencies: extract_facts  # Input source
     guard:
-      condition: 'candidate_facts_list != []'
+      condition: 'extract_facts.candidate_facts_list != []'
       on_false: filter
 
   # Step 3: Score quality with schema
@@ -265,7 +265,7 @@ actions:
   - name: generate_output
     dependencies: score_quality  # Input source
     guard:
-      condition: 'score >= 85'
+      condition: 'score_quality.score >= 85'
       on_false: filter
 ```
 
@@ -299,7 +299,7 @@ actions:
   - name: publish_content
     dependencies: validate_content  # Input source
     guard:
-      condition: 'is_valid == true'
+      condition: 'validate_content.is_valid == true'
       on_false: filter
 ```
 
@@ -328,7 +328,7 @@ properties:
 - name: process_valid
   dependencies: classify_content  # Input source
   guard:
-    condition: 'category != "invalid"'  # Filter "invalid" category
+    condition: 'classify_content.category != "invalid"'  # Filter "invalid" category
     on_false: filter
 ```
 
@@ -362,7 +362,7 @@ properties:
 - name: proceed_if_confident
   dependencies: assess_confidence  # Input source
   guard:
-    condition: 'confidence_score >= 70'
+    condition: 'assess_confidence.confidence_score >= 70'
     on_false: filter
 ```
 
@@ -388,26 +388,27 @@ actions:
   - name: next_step
     dependencies: custom_validate  # Input source
     guard:
-      condition: 'validation_passed == true'
+      condition: 'custom_validate.validation_passed == true'
       on_false: filter
 ```
 
 ```python
 # tools/validate_content.py
 @udf_tool()
-def validate_content(content: dict) -> dict:
+def validate_content(data: dict) -> dict:
     """Custom validation logic."""
     issues = []
+    content = data["generate_content"]
 
     # Check for prohibited words
     prohibited = ["todo", "placeholder", "tbd"]
-    text = content.get("text", "").lower()
+    text = content["text"].lower()
     for word in prohibited:
         if word in text:
             issues.append(f"Contains prohibited word: {word}")
 
     # Check minimum quality
-    if len(content.get("summary", "")) < 50:
+    if len(content["summary"]) < 50:
         issues.append("Summary too short")
 
     return {
@@ -470,7 +471,7 @@ The limitation here: reprompting costs API tokens. Guards are free. If you're fi
 # Layer 3: Guard for quality
 - name: process
   guard:
-    condition: 'quality >= threshold'
+    condition: 'upstream_action.quality >= threshold'
     on_false: filter
 ```
 
@@ -520,7 +521,7 @@ This is important: guards prevent downstream work. Place guards as early as poss
 - name: extract  # Cheap
 - name: validate  # Cheap
   guard:
-    condition: 'facts != []'
+    condition: 'extract.facts != []'
     on_false: filter
 - name: expensive_llm_call  # Only runs on valid data
   dependencies: validate  # Input source

--- a/docs.agent-actions/docs/tutorials/concepts.md
+++ b/docs.agent-actions/docs/tutorials/concepts.md
@@ -127,7 +127,7 @@ actions:
     impl: publish_to_portal
     dependencies: [review_report]
     guard:
-      condition: "hitl_status == 'approved'"
+      condition: "review_report.hitl_status == 'approved'"
       on_false: skip
 ```
 


### PR DESCRIPTION
## Summary
- Update all docs site pages (16 files) to reflect the additive content model: namespaced tool data access (`data["action_name"]["field"]`), dotted guard condition paths (`classify_order.order_status`), and observe-as-namespace-selection semantics
- Reverse HITL guard guidance — namespaced access is now the correct pattern, flat access is wrong
- Remove all `data.get("content", data)` dead fallback patterns from code examples

## Verification
- `ruff format --check` — clean
- `ruff check` — clean  
- `pytest` — 5844 passed, 2 skipped
- `grep -rn 'condition:.*'"'"'[a-z_]+ [=!<>]' docs.agent-actions/docs/` — zero flat guard conditions remaining
- `grep -rn 'data\.get("content", data)' docs.agent-actions/docs/` — zero dead patterns remaining