### PR TITLE
docs: update skills docs for additive content model

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260424-094000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260424-094000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Update all skills documentation for additive content model: namespaced field access in UDFs, dotted namespace paths in guard conditions, observe as namespace selection"
+time: 2026-04-24T09:40:00.000000Z

--- a/agent_actions/skills/agent-actions-workflow/SKILL.md
+++ b/agent_actions/skills/agent-actions-workflow/SKILL.md
@@ -27,18 +27,18 @@ agac render -a my_workflow           # Compiled YAML (schemas inlined, versions 
 ```
 Source record
   → Framework adds source_guid, node_id, lineage
-    → observe resolves fields via lineage (historical lookup)
-      → LLM/tool receives observed fields (namespaced for tools, Jinja-accessible for prompts)
+    → observe selects which namespaces the action can read from the record
+      → LLM/tool receives observed fields (namespaced by action name)
         → Tool processes and returns result
           → passthrough fields merge into output
-            → Output stored with extended lineage
-              → Next action's observe resolves via this lineage
+            → Output stored under this action's namespace
+              → Next action's observe selects from the record's namespaces
 ```
 
 Once you understand this chain, most issues become obvious:
-- UDF gets None for a field? In RECORD mode, check for field name collisions — use `data.get("action.field")` when two upstreams share a field name. In FILE mode, read from `record["content"]["field"]`
-- Downstream can't see a field? It wasn't in `passthrough` — only `observe` fields reach the LLM, `passthrough` fields reach the output
-- Historical lookup fails? Lineage is broken — check the upstream action's output for correct `lineage` arrays
+- UDF gets None for a field? Fields are namespaced — access with `data["action_name"]["field"]`, not `data.get("field")`. In FILE mode, read from `record["content"]["action_name"]["field"]`
+- Downstream can't see a field? It wasn't in `observe` or `passthrough` — only `observe` namespaces reach the LLM, `passthrough` namespaces reach the output
+- Missing namespace? Check that the upstream action is listed in `observe` — the action name is the namespace key
 
 ## Project Layout
 
@@ -140,7 +140,7 @@ Every action falls into one of three roles. Mixing them causes bugs:
 
 ## Writing UDFs
 
-Observed fields arrive **flat** in RECORD mode tools. The framework resolves namespaces and delivers fields directly. When multiple upstream actions share a field name, the framework qualifies them as `"action.field"` to prevent collisions.
+Observed fields arrive **namespaced by action name** in RECORD mode tools. Each upstream action's fields are nested under its name as a key.
 
 ```python
 from typing import Any
@@ -148,27 +148,27 @@ from agent_actions import udf_tool
 
 @udf_tool()
 def enrich_listing(data: dict[str, Any]) -> list[dict[str, Any]]:
-    # RECORD mode: fields are flat — access directly
-    title = data.get("listing_title", "")
+    # RECORD mode: fields are namespaced by upstream action
+    title = data["extract_listing"]["listing_title"]
 
-    # Seed data is flattened like any other namespace
-    rules = data.get("marketplace_rules", {})
+    # Seed data is under the "seed" namespace
+    rules = data["seed"]["marketplace_rules"]
 
     return [{"enriched_title": f"{title} — {rules.get('brand', '')}"}]
 ```
 
 A few things to remember:
-- **RECORD mode**: Fields are flat — access with `data.get("field")` directly
-- **Collision handling**: When two upstream actions share a field name, access with `data.get("action_name.field")` (dot-qualified)
-- **FILE mode**: Access fields via `record["content"]["field"]`
-- Seed data: `data.get("key", {})` (seed namespace is flattened like any other; requires `observe: [seed.*]`)
+- **RECORD mode**: Fields are namespaced — access with `data["action_name"]["field"]`
+- **No collisions**: Each action's fields are isolated under its namespace, so field name conflicts cannot occur
+- **FILE mode**: Access fields via `record["content"]["action_name"]["field"]`
+- Seed data: `data["seed"]["key"]` (requires `observe: [seed.*]`)
 - Return `list[dict]` — or `dict` when the YAML uses `passthrough`
 
 ## Guards
 
 Guards filter records based on upstream output. The key insight: guards check **input** to the action, not its own output. So you place the guard on the action that *consumes* the data, not the one that *produces* it.
 
-Guard conditions evaluate against **flattened** field names from the action's observed data. If you observe `extract_claims.*`, the guard sees `claims` and `confidence` directly — not `extract_claims.claims`.
+Guard conditions evaluate against **dotted namespace paths** from the action's observed data. If you observe `extract_claims.*`, the guard references fields as `extract_claims.claims`, `extract_claims.confidence`, etc.
 
 ```yaml
 - name: extract_claims              # Produces claims — no guard here
@@ -176,7 +176,7 @@ Guard conditions evaluate against **flattened** field names from the action's ob
 - name: validate_claims
   dependencies: [extract_claims]
   guard:
-    condition: 'len(claims) >= 1 and confidence >= 0.7'
+    condition: 'len(extract_claims.claims) >= 1 and extract_claims.confidence >= 0.7'
     on_false: "filter"              # filter = remove record | skip = pass through
   context_scope:
     observe: [extract_claims.*]
@@ -202,20 +202,20 @@ When you need consensus (multiple independent judgments on the same data), use v
     observe: [score_quality.*]
 ```
 
-**RECORD mode** — the merge tool receives dot-qualified flat keys (because version fields like `score` collide across namespaces):
+**RECORD mode** — each version is a separate namespace:
 ```python
-score_1 = data.get("score_quality_1.score")  # 8
-score_2 = data.get("score_quality_2.score")  # 7
+score_1 = data["score_quality_1"]["score"]  # 8
+score_2 = data["score_quality_2"]["score"]  # 7
 
 # Iterate all versions:
-scores = [v for k, v in data.items() if k.endswith(".score")]
+scores = [ns["score"] for name, ns in data.items() if name.startswith("score_quality_")]
 ```
 
-**FILE mode** — each record's `content` has both nested dicts and qualified flat keys:
+**FILE mode** — version namespaces are nested dicts inside `content`:
 ```python
 # Nested dict access:
-scorer_1 = record["content"].get("score_quality_1", {})
-score = scorer_1.get("score")
+scorer_1 = record["content"]["score_quality_1"]
+score = scorer_1["score"]
 
 # Or iterate dynamically:
 for key, val in record["content"].items():
@@ -236,7 +236,7 @@ defaults:
       rubric: $file:evaluation_rubric.json
 ```
 
-In prompts: `{{ seed.rubric.min_score }}`. In UDFs (RECORD mode): `data.get("rubric", {})` — the seed namespace is flattened like any other. Requires `observe: [seed.*]` or `observe: [seed.rubric]` in the action config. The config key is `seed_path:` but the prompt prefix is `seed.` — using `seed_data.` is a common mistake that silently resolves to empty.
+In prompts: `{{ seed.rubric.min_score }}`. In UDFs (RECORD mode): `data["seed"]["rubric"]` — seed data is under the `seed` namespace. Requires `observe: [seed.*]` or `observe: [seed.rubric]` in the action config. The config key is `seed_path:` but the prompt prefix is `seed.` — using `seed_data.` is a common mistake that silently resolves to empty.
 
 **Prompt templates** — defined in `prompt_store/workflow_name.md`:
 ```markdown
@@ -266,8 +266,11 @@ import json, sys; data = json.load(sys.stdin)
 print(f'{len(data)} records')
 if data:
     rec = data[0]
-    content = rec.get('content', rec)
-    print('content keys:', list(content.keys())[:10])
+    content = rec['content']
+    print('namespaces:', list(content.keys())[:10])
+    for ns, fields in content.items():
+        if isinstance(fields, dict):
+            print(f'  {ns}: {list(fields.keys())[:5]}')
     print('record keys:', [k for k in rec if k != 'content'][:10])
 "
 ```
@@ -284,7 +287,7 @@ Read these when you need depth beyond what's covered above:
 - **[Context Scope](references/context-scope-guide.md)** — observe/drop/passthrough, output_field, seed data details
 
 ### Building
-- **[UDF Reference](references/udf-reference.md)** — @udf_tool decorator, record/file mode, flat field access, passthrough, version merge
+- **[UDF Reference](references/udf-reference.md)** — @udf_tool decorator, record/file mode, namespaced field access, passthrough, version merge
 - **[Action Anatomy](references/action-anatomy.md)** — action structure, pre-creation checklist, data lineage, record matching
 - **[Prompt Patterns](references/prompt-patterns.md)** — Jinja2 templates, variable access, max_tokens/temperature, anti-patterns
 - **[Dynamic Content Injection](references/dynamic-content-injection.md)** — tool action injection pattern for randomized/computed prompt content

--- a/agent_actions/skills/agent-actions-workflow/assets/templates/udf_tool.py.template
+++ b/agent_actions/skills/agent-actions-workflow/assets/templates/udf_tool.py.template
@@ -7,8 +7,8 @@ from agent_actions import udf_tool
 @udf_tool()
 def {{tool_function_name}}(data: dict[str, Any]) -> list[dict[str, Any]]:
     """{{Brief description of what this tool does.}}"""
-    # RECORD mode: fields arrive flat — access directly
-    input_value = data.get("input_field", "")
+    # RECORD mode: fields are namespaced by upstream action
+    input_value = data["upstream_action"]["input_field"]
 
     # Your processing logic here
     return [{"output_field": input_value}]

--- a/agent_actions/skills/agent-actions-workflow/references/action-anatomy.md
+++ b/agent_actions/skills/agent-actions-workflow/references/action-anatomy.md
@@ -71,7 +71,7 @@ flowchart LR
   
   # CONDITIONAL EXECUTION
   guard:                                  # When to run/skip
-    condition: 'validation_status == "PASS"'
+    condition: 'validate_data.validation_status == "PASS"'
     on_false: "filter"
   
   # INSTRUCTIONS
@@ -98,7 +98,7 @@ flowchart LR
   
   # CONDITIONAL EXECUTION  
   guard:
-    condition: 'status == "valid"'
+    condition: 'extract_content.status == "valid"'
     on_false: "filter"
 ```
 
@@ -182,7 +182,7 @@ def my_processing_function(data):
 
 ```yaml
 guard:
-  condition: 'status == "PASS" and score >= 8'
+  condition: 'upstream_action.status == "PASS" and upstream_action.score >= 8'
   on_false: "filter"
 ```
 
@@ -222,11 +222,11 @@ cat agent_io/target/<parent>/sample.json | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 if data:
-    content = data[0].get('content', data[0])
-    print('Fields:', list(content.keys()))
-    print('Sample values:')
-    for k, v in list(content.items())[:5]:
-        print(f'  {k}: {str(v)[:50]}...')
+    content = data[0]['content']
+    print('Namespaces:', list(content.keys()))
+    for ns, fields in content.items():
+        if isinstance(fields, dict):
+            print(f'  {ns}:', list(fields.keys())[:5])
 "
 ```
 
@@ -255,7 +255,7 @@ grep "observe:" -A20 agent_config/*.yml | grep "my_field"
 - name: use_validated
   dependencies: [validate_data]
   guard:
-    condition: 'validation_status == "PASS"'
+    condition: 'validate_data.validation_status == "PASS"'
 ```
 
 ### Merge Pattern

--- a/agent_actions/skills/agent-actions-workflow/references/aggregation-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/aggregation-patterns.md
@@ -109,15 +109,15 @@ The aggregating action receives one merged record per unique key value, with all
 
 ## UDF for Aggregated Data
 
-The merge tool receives flat fields. Unique field names are bare; collisions get dot-qualified:
+The merge tool receives fields namespaced by action name:
 
 ```python
 @udf_tool()
 def aggregate_reviews(data: dict[str, Any]) -> list[dict[str, Any]]:
-    # These field names are unique across upstreams → bare access
-    text_score = data.get("text_score", 0)
-    image_score = data.get("image_score", 0)
-    audio_score = data.get("audio_score", 0)
+    # Each upstream action's fields are under its namespace
+    text_score = data["validate_text"]["text_score"]
+    image_score = data["validate_image"]["image_score"]
+    audio_score = data["validate_audio"]["audio_score"]
 
     scores = [text_score, image_score, audio_score]
     avg = sum(scores) / len(scores) if scores else 0

--- a/agent_actions/skills/agent-actions-workflow/references/context-scope-guide.md
+++ b/agent_actions/skills/agent-actions-workflow/references/context-scope-guide.md
@@ -27,7 +27,7 @@ context_scope:
 
 ## Observe Directive
 
-Include fields in LLM context. When specified, **only listed fields** are visible.
+Select which namespaces the action can read from the record. When specified, **only listed namespaces/fields** are visible.
 
 ```yaml
 - name: Cluster_Validation_Agent
@@ -154,17 +154,17 @@ Downstream actions access `output_field` values through the normal namespace:
 ```
 
 In prompts: `{{ assess_severity.severity }}`
-In UDFs (RECORD mode): `data.get("severity", "")` — fields are flat after observe resolution
+In UDFs (RECORD mode): `data["assess_severity"]["severity"]` — fields are namespaced by action name
 
 ### Guards with output_field
 
-Guard conditions see flattened field names — the `output_field` value is promoted to top-level:
+Guard conditions use dotted namespace paths:
 
 ```yaml
 - name: escalate
   dependencies: [assess_severity]
   guard:
-    condition: 'severity != "low"'     # Direct field name, not assess_severity.severity
+    condition: 'assess_severity.severity != "low"'
   context_scope:
     observe: [assess_severity.*]
 ```
@@ -173,13 +173,13 @@ Guard conditions see flattened field names — the `output_field` value is promo
 
 - `json_mode: false` and `schema` together trigger a warning — the schema is ignored at runtime since there's no JSON to validate
 - `output_field` only works with `json_mode: false`
-- Default `output_field` is `"raw_response"` — in RECORD mode UDFs: `data.get("raw_response", "")`
+- Default `output_field` is `"raw_response"` — in RECORD mode UDFs: `data["action_name"]["raw_response"]`
 
 ## Guard Field Visibility
 
-Guard conditions evaluate against flattened field names from observed data (see Guards section in SKILL.md for examples).
+Guard conditions evaluate against dotted namespace paths from observed data (see Guards section in SKILL.md for examples). Use `action_name.field` syntax in guard conditions.
 
-**Collision risk:** When observing from multiple upstream actions with overlapping field names, the last-loaded namespace wins. Avoid this by observing specific fields instead of wildcards when field names might collide.
+**No collision risk:** Each action's fields are isolated under its namespace, so overlapping field names across upstream actions do not conflict.
 
 ## Resolution Order
 

--- a/agent_actions/skills/agent-actions-workflow/references/data-flow-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/data-flow-patterns.md
@@ -174,27 +174,31 @@ What your UDF receives after the framework processes the input.
 
 ### Record mode (default)
 
-UDF receives one record at a time. Fields are **flat** — no namespace wrappers. When two upstream actions share a field name, the framework qualifies them as `"action.field"`.
+UDF receives one record at a time. Fields are **namespaced by action name** — each upstream action's output is a nested dict.
 
 ```json
 {
-  "claims": ["claim 1", "claim 2"],
-  "confidence": 0.85
+  "extract_claims": {
+    "claims": ["claim 1", "claim 2"],
+    "confidence": 0.85
+  }
 }
 ```
 
-Access: `data.get("claims")`. With collisions: `data.get("extract_claims.claims")`.
+Access: `data["extract_claims"]["claims"]`. No collision handling needed — each action's fields are isolated under its namespace.
 
 ### FILE mode
 
-UDF receives ALL records as a list. Business fields are inside `record["content"]`, also flat.
+UDF receives ALL records as a list. Business fields are inside `record["content"]`, namespaced by action name.
 
 ```json
 [
   {
     "content": {
-      "claims": ["claim 1"],
-      "confidence": 0.9
+      "extract_claims": {
+        "claims": ["claim 1"],
+        "confidence": 0.9
+      }
     },
     "source_guid": "abc-123",
     "node_id": "node_2_xxx_0",
@@ -202,8 +206,10 @@ UDF receives ALL records as a list. Business fields are inside `record["content"
   },
   {
     "content": {
-      "claims": ["claim 2"],
-      "confidence": 0.7
+      "extract_claims": {
+        "claims": ["claim 2"],
+        "confidence": 0.7
+      }
     },
     "source_guid": "abc-123",
     "node_id": "node_2_xxx_1",
@@ -212,51 +218,53 @@ UDF receives ALL records as a list. Business fields are inside `record["content"
 ]
 ```
 
-Access: `record["content"]["claims"]` for each record.
+Access: `record["content"]["extract_claims"]["claims"]` for each record.
 
 ### Version merge
 
-After `version_consumption: {pattern: merge}`, the access pattern depends on the mode.
+After `version_consumption: {pattern: merge}`, each version is a separate namespace.
 
-**RECORD mode** — version fields collide (all versions share `score`, `reasoning`), so they arrive as dot-qualified flat keys:
+**RECORD mode** — each version's output is nested under its expanded action name:
 
 ```json
 {
-  "score_quality_1.score": 8, "score_quality_1.reasoning": "Clear structure",
-  "score_quality_2.score": 6, "score_quality_2.reasoning": "Needs more detail",
-  "score_quality_3.score": 9, "score_quality_3.reasoning": "Excellent coverage"
+  "score_quality_1": {"score": 8, "reasoning": "Clear structure"},
+  "score_quality_2": {"score": 6, "reasoning": "Needs more detail"},
+  "score_quality_3": {"score": 9, "reasoning": "Excellent coverage"}
 }
 ```
 
-Access: `data.get("score_quality_1.score")` or iterate with `[v for k, v in data.items() if k.endswith(".score")]`.
+Access: `data["score_quality_1"]["score"]` or iterate with `[ns["score"] for name, ns in data.items() if name.startswith("score_quality_")]`.
 
-**FILE mode** — version namespaces are preserved as nested dicts in `content`, alongside qualified flat keys:
+**FILE mode** — version namespaces are nested dicts inside `content`:
 
 ```json
 {
   "content": {
     "score_quality_1": {"score": 8, "reasoning": "Clear structure"},
     "score_quality_2": {"score": 6, "reasoning": "Needs more detail"},
-    "score_quality_1.score": 8, "score_quality_2.score": 6
+    "score_quality_3": {"score": 9, "reasoning": "Excellent coverage"}
   }
 }
 ```
 
-Access: `content["score_quality_1"]["score"]` (nested dict) or `content["score_quality_1.score"]` (flat key).
+Access: `content["score_quality_1"]["score"]`.
 
 ### Seed data
 
-Seed data is flattened like any other namespace. Requires `observe: [seed.*]` in the action config.
+Seed data is under the `seed` namespace. Requires `observe: [seed.*]` in the action config.
 
-**RECORD mode** — seed fields are flat:
+**RECORD mode** — seed fields are under the `seed` namespace:
 ```json
 {
-  "rubric": {"min_score": 7, "categories": ["accuracy", "clarity"]},
-  "exam_syllabus": {"exam_name": "AWS Solutions Architect", "topics": ["compute", "storage"]}
+  "seed": {
+    "rubric": {"min_score": 7, "categories": ["accuracy", "clarity"]},
+    "exam_syllabus": {"exam_name": "AWS Solutions Architect", "topics": ["compute", "storage"]}
+  }
 }
 ```
 
-Access: `data.get("rubric", {})["min_score"]`
+Access: `data["seed"]["rubric"]["min_score"]`
 
 ## Data Transformation Patterns
 

--- a/agent_actions/skills/agent-actions-workflow/references/debugging-guide.md
+++ b/agent_actions/skills/agent-actions-workflow/references/debugging-guide.md
@@ -36,7 +36,8 @@ import json, sys
 data = json.load(sys.stdin)
 print(f'  Records: {len(data)}')
 if data:
-    print(f'  Fields: {list(data[0].get(\"content\", data[0]).keys())[:8]}')
+    content = data[0]['content']
+    print(f'  Namespaces: {list(content.keys())[:8]}')
 " 2>/dev/null || echo "  No data"
 done
 ```
@@ -54,8 +55,10 @@ cat agent_workflow/<workflow>/agent_io/target/<upstream>/*.json | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 for r in data:
-    content = r.get('content', r)
-    print({k: v for k, v in content.items() if not k.startswith('_')})" 2>/dev/null
+    content = r['content']
+    for ns, fields in content.items():
+        if isinstance(fields, dict):
+            print(f'{ns}: {fields}')" 2>/dev/null
 ```
 
 All comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`) are supported. If guard results seem wrong, test the condition directly:
@@ -79,9 +82,9 @@ If the first action's API call fails (401, network error), check whether the fai
 ### 5. Tool UDF Data Access
 
 If a tool action produces zero/default values:
-- Fields arrive **namespaced by action name**: `content["aggregate_scores"]["consensus_score"]`
-- NOT flat: `content["consensus_score"]` → returns `None`
-- Check the tool code for flat `content.get("field")` patterns — these should be `content.get("action_name", {}).get("field")`
+- **RECORD mode**: Fields are namespaced — access with `data["action_name"]["field"]`, not `data.get("field")`
+- **FILE mode**: Fields are namespaced inside content — access with `record["content"]["action_name"]["field"]`
+- Check the tool code for flat `data.get("field")` patterns — these should be `data["action_name"]["field"]`
 - For a full debugging walkthrough, see [Tool Produces Empty Output](#tool-produces-empty-output)
 
 ### 5a. Prompt Trace Inspection
@@ -279,11 +282,11 @@ import json, sys
 data = json.load(sys.stdin)
 print(f'Total: {len(data)} records')
 for i, record in enumerate(data, 1):
-    content = record.get('content', {})
-    status = content.get('validation_status', 'unknown')
+    fields = record['content']['validate_code_quality']
+    status = fields.get('validation_status', 'unknown')
     print(f'  Record {i}: {status}')
     if status != 'PASS':
-        reasoning = content.get('validation_reasoning', '')[:150]
+        reasoning = fields.get('validation_reasoning', '')[:150]
         print(f'    Reason: {reasoning}...')
 "
 ```
@@ -343,14 +346,14 @@ Run with `AGENT_ACTIONS_LOG_LEVEL=DEBUG agac run -a <workflow>` and check the ou
 
 ### 2. Check field namespacing
 
-Upstream data arrives **namespaced by action name**, not flat. This is the most common cause of empty tool output:
+Upstream data arrives **namespaced by action name**. This is the most common cause of empty tool output:
 
 ```python
-# WRONG — field is not at top level
+# WRONG — flat access, field is not at top level
 value = data.get("consensus_score")  # Returns None
 
-# CORRECT — field is nested under the producing action's name
-value = data.get("aggregate_scores", {}).get("consensus_score")
+# CORRECT — field is under the producing action's namespace
+value = data["aggregate_scores"]["consensus_score"]
 ```
 
 ### 3. Check observe/context_scope configuration

--- a/agent_actions/skills/agent-actions-workflow/references/dynamic-content-injection.md
+++ b/agent_actions/skills/agent-actions-workflow/references/dynamic-content-injection.md
@@ -62,8 +62,8 @@ OPENERS = {
 @udf_tool()
 def inject_random_opener(data: dict) -> dict:
     """Inject a randomized scenario opener based on question type."""
-    # RECORD mode: fields arrive flat
-    quiz_type = data.get('quiz_type_used', 'general').lower()
+    # RECORD mode: fields are namespaced by upstream action
+    quiz_type = data["get_authoring_prompt"]["quiz_type_used"].lower()
 
     # Map quiz type to opener category
     type_to_category = {

--- a/agent_actions/skills/agent-actions-workflow/references/framework-contracts.md
+++ b/agent_actions/skills/agent-actions-workflow/references/framework-contracts.md
@@ -10,7 +10,7 @@ What each framework feature promises, its current status, and how to work with i
 
 **Status:** Working — by design.
 
-Guards evaluate the **input** to an action (upstream output), not the action's own output. Place the guard on the action that *consumes* the field, not the one that *produces* it.
+Guards evaluate the **input** to an action (upstream output), not the action's own output. Place the guard on the action that *consumes* the field, not the one that *produces* it. Guard conditions use dotted namespace paths.
 
 ```yaml
 # Guard goes on the consumer, not the producer
@@ -18,7 +18,7 @@ Guards evaluate the **input** to an action (upstream output), not the action's o
 - name: next_action
   dependencies: [validate_data]
   guard:
-    condition: 'validation_status == "PASS"'  # Checks validate_data's output
+    condition: 'validate_data.validation_status == "PASS"'  # Dotted namespace path
 ```
 
 If all records are filtered (0 records downstream), the guard condition was false for every record. Fix: adjust upstream prompts, lower thresholds, or allow multiple statuses.
@@ -82,18 +82,18 @@ With passthrough, UDF returns `dict` (not list) with only new fields.
 
 ## UDF Patterns
 
-### 6. Flat field access (RECORD mode)
+### 6. Namespaced field access (RECORD mode)
 
-**Status:** Working — framework flattens observed fields for tools.
+**Status:** Working — framework delivers fields namespaced by action name.
 
-RECORD mode tools receive flat fields. Access directly with `data.get("field")`. When two upstream actions share a field name, the framework qualifies them as `data.get("action.field")`:
+RECORD mode tools receive fields namespaced by action name. Access with `data["action_name"]["field"]`:
 
 ```python
 def my_udf(data):
-    return [{'result': data.get('my_field', '')}]
+    return [{'result': data['upstream_action']['my_field']}]
 ```
 
-For FILE mode, read from `record["content"]["field"]`.
+For FILE mode, read from `record["content"]["action_name"]["field"]`.
 
 ### 7. Return type: list vs dict
 
@@ -102,19 +102,19 @@ For FILE mode, read from `record["content"]["field"]`.
 - Without passthrough: return `list[dict]`
 - With passthrough in YAML: return `dict` with only new fields
 
-### 8. Collision-qualified field access
+### 8. Namespaced field access — no collisions
 
-**Status:** Working — unique fields are bare, collisions are dot-qualified.
+**Status:** Working — each action's fields are isolated under its namespace.
 
-When observing from multiple upstream actions, unique field names are accessed directly. Fields that appear in multiple namespaces get dot-qualified:
+When observing from multiple upstream actions, each action's fields are under its own namespace. No collision handling needed:
 
 ```python
-# Single upstream — bare access
-score = data.get("consensus_score", 0)
+# Single upstream
+score = data["aggregate_scores"]["consensus_score"]
 
-# Multiple upstreams sharing "score" — qualified access
-score_a = data.get("action_a.score", 0)
-score_b = data.get("action_b.score", 0)
+# Multiple upstreams — each isolated under its namespace
+score_a = data["action_a"]["score"]
+score_b = data["action_b"]["score"]
 ```
 
 ### 9. UDF defaults must match schema types
@@ -171,7 +171,7 @@ See: **[Dynamic Content Injection](dynamic-content-injection.md)**
 
 ## Guards
 
-### 13. Guard conditions see flattened field names
+### 13. Guard conditions use dotted namespace paths
 
 **Status:** Working — by design. See Guards section in SKILL.md for examples.
 
@@ -192,8 +192,9 @@ When `on_false: "filter"` removes records, fields produced by the filtered actio
 **Workaround:** Declare the field in the schema but NOT in `required`. In the UDF, omit the key (not set it to None) when the upstream was filtered:
 
 ```python
-if content.get("response_text"):
-    result["merchant_response"] = {"response_text": content["response_text"]}
+upstream = content.get("upstream_action", {})
+if upstream.get("response_text"):
+    result["merchant_response"] = {"response_text": upstream["response_text"]}
 ```
 
 ### 16. Guard operators
@@ -267,7 +268,7 @@ observe: [seed.rubric]              # Correct
 # NOT: seed_data.rubric             # Wrong — silently resolves to empty
 ```
 
-In prompts: `{{ seed.rubric.score_range }}`. In UDFs (RECORD mode): `data.get("rubric", {})` — seed namespace is flattened like any other.
+In prompts: `{{ seed.rubric.score_range }}`. In UDFs (RECORD mode): `data["seed"]["rubric"]` — seed data is under the `seed` namespace.
 
 ### 23. Redundant dependencies
 

--- a/agent_actions/skills/agent-actions-workflow/references/hitl-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/hitl-patterns.md
@@ -42,7 +42,7 @@ Filter records before presenting them to the human. Only records matching the gu
     timeout: 3600
   dependencies: [auto_review_quality]
   guard:
-    condition: 'decision == "review"'
+    condition: 'auto_review_quality.decision == "review"'
     on_false: "skip"             # Approved records skip human review
   context_scope:
     observe: [auto_review_quality.*]
@@ -82,7 +82,7 @@ When downstream actions depend on HITL output, use passthrough to preserve data 
       - source.id
 ```
 
-Lineage is preserved through HITL actions — downstream actions can resolve historical lookups through the HITL node back to earlier ancestors.
+Lineage is preserved through HITL actions — downstream actions can access namespaces from earlier ancestors through the HITL node.
 
 ## Auto-Review + HITL (Triage Pattern)
 
@@ -109,7 +109,7 @@ The most common production pattern: LLM pre-screens all records, routes confiden
     timeout: 3600
   dependencies: [auto_review]
   guard:
-    condition: 'decision == "review"'
+    condition: 'auto_review.decision == "review"'
     on_false: "skip"
   context_scope:
     observe: [auto_review.*]
@@ -134,10 +134,10 @@ The merge tool receives both auto-approved records (passed through by the guard 
 ```python
 @udf_tool()
 def merge_review_decisions(data: dict[str, Any]) -> list[dict[str, Any]]:
-    # Fields arrive flat — if "decision" collides across auto_review and
-    # human_review, access with qualified keys
-    auto_decision = data.get("auto_review.decision", "reject")
-    human_decision = data.get("human_review.decision")
+    # Fields are namespaced — each action's fields under its name
+    # Both use .get() since a record may arrive from only one path
+    auto_decision = data.get("auto_review", {}).get("decision", "reject")
+    human_decision = data.get("human_review", {}).get("decision")
 
     # Human review overrides auto review when present
     decision = human_decision or auto_decision

--- a/agent_actions/skills/agent-actions-workflow/references/schema-design-guide.md
+++ b/agent_actions/skills/agent-actions-workflow/references/schema-design-guide.md
@@ -253,13 +253,19 @@ agac render -a my_workflow
 # Check what an action actually produced
 cat agent_io/target/<action>/sample.json | python3 -c "
 import json, sys; data = json.load(sys.stdin)
-if data: print(json.dumps(list(data[0].get('content', data[0]).keys()), indent=2))
+if data:
+    content = data[0]['content']
+    for ns, fields in content.items():
+        if isinstance(fields, dict):
+            print(f'{ns}: {list(fields.keys())}')
 "
 
-# Compare schema field names with actual output
+# Compare schema field names with actual output (check the action's own namespace)
 diff <(grep 'id:' schema/my_schema.yml | awk '{print $3}') \
      <(cat agent_io/target/my_action/sample.json | python3 -c "
 import json, sys; data = json.load(sys.stdin)
-if data: [print(k) for k in data[0].get('content', data[0]).keys()]
+if data:
+    fields = data[0]['content'].get('my_action', {})
+    for k in fields: print(k)
 ")
 ```

--- a/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
+++ b/agent_actions/skills/agent-actions-workflow/references/udf-reference.md
@@ -29,8 +29,8 @@ from agent_actions import udf_tool
 @udf_tool()
 def my_function(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Process data and return result."""
-    # RECORD mode: fields arrive flat — access directly
-    return [{"result": f"Processed: {data.get('text', '')}"}]
+    # RECORD mode: fields are namespaced by upstream action
+    return [{"result": f"Processed: {data['upstream_action']['text']}"}]
 ```
 
 | Parameter | Type | Required | Description |
@@ -66,43 +66,44 @@ Function names must be unique across all tool directories. Move shared code to `
 
 ## Record Mode (Default)
 
-UDF receives one record at a time. The framework resolves observe references and delivers **flat fields** — no namespace wrappers.
+UDF receives one record at a time. The framework resolves observe references and delivers fields **namespaced by action name**.
 
 ```python
 @udf_tool()
 def my_function(data: dict[str, Any]) -> list[dict[str, Any]]:
-    # Fields arrive flat — access directly
-    claims = data.get("claims", [])
-    confidence = data.get("confidence", 0)
+    # Fields are namespaced — access via action name
+    claims = data["extract_claims"]["claims"]
+    confidence = data["extract_claims"]["confidence"]
     return [{"computed_field": some_calculation(claims, confidence)}]
 ```
 
-**What `data` looks like (flat — no namespace wrappers):**
+**What `data` looks like (namespaced by upstream action):**
 
 ```json
 {
-  "claims": ["claim 1", "claim 2"],
-  "confidence": 0.85
+  "extract_claims": {
+    "claims": ["claim 1", "claim 2"],
+    "confidence": 0.85
+  }
 }
 ```
 
-When two upstream actions share a field name, the framework qualifies them to avoid collisions:
+When observing from multiple upstream actions, each action's fields are isolated under its namespace — no collision handling needed:
 
 ```json
 {
-  "extract_claims.text": "claim text",
-  "extract_summary.text": "summary text",
-  "confidence": 0.9
+  "extract_claims": {"text": "claim text", "confidence": 0.9},
+  "extract_summary": {"text": "summary text", "word_count": 42}
 }
 ```
 
 | Input | Output |
 |-------|--------|
-| `dict` — flat business fields | `list[dict]` (or `dict` with passthrough) |
+| `dict` — namespaced business fields | `list[dict]` (or `dict` with passthrough) |
 
 ## File Mode
 
-UDF receives ALL records at once as a list. Each record is a full framework record with `content`, `node_id`, `source_guid`, and `lineage`. Read business data from `record["content"]`. Return records to preserve lineage.
+UDF receives ALL records at once as a list. Each record is a full framework record with `content`, `node_id`, `source_guid`, and `lineage`. Business data is namespaced inside `record["content"]` by action name. Return records to preserve lineage.
 
 ```python
 from agent_actions import udf_tool
@@ -116,7 +117,7 @@ def run_dedup(data: list[dict]) -> list[dict]:
 
     for record in data:
         content = record["content"]
-        fact = content.get("fact", "")
+        fact = content["flatten_claims"]["fact"]
         if fact not in seen:
             seen[fact] = True
             outputs.append(record)  # return the full record, not just content
@@ -132,9 +133,11 @@ def run_dedup(data: list[dict]) -> list[dict]:
   "source_guid": "abc-123",
   "lineage": ["extract_abc", "flatten_claims_abc123_0"],
   "content": {
-    "fact": "The sky is blue",
-    "confidence": 0.9,
-    "source_quote": "..."
+    "flatten_claims": {
+      "fact": "The sky is blue",
+      "confidence": 0.9,
+      "source_quote": "..."
+    }
   }
 }
 ```
@@ -145,7 +148,7 @@ def run_dedup(data: list[dict]) -> list[dict]:
 
 **Two rules for FILE tools:**
 
-1. **Read business data from `record["content"]["field"]`** — not `record["field"]`.
+1. **Read business data from `record["content"]["action_name"]["field"]`** — not `record["field"]` or `record["content"]["field"]`.
 2. **Return the original record dict for passthrough operations** (filter, dedup, sort, transform). This preserves `node_id` and lineage automatically. For aggregation/synthesis (creating new data not from a single input), return a new dict without `node_id` — the framework treats it as a new record.
 
 ```python
@@ -166,76 +169,70 @@ outputs.append({"summary": "merged result", "count": len(data)})  # no node_id =
 
 ## How Observed Fields Arrive
 
-### RECORD mode — flat fields
+### RECORD mode — namespaced fields
 
-In RECORD mode, the framework flattens observed fields before passing them to the tool. You access fields directly:
+In RECORD mode, the framework delivers observed fields namespaced by action name. Each upstream action's output is a nested dict:
 
 ```python
-# CORRECT — flat access
-title = data.get("listing_title", "")
-description = data.get("listing_description", "")
+# CORRECT — namespaced access
+title = data["extract_listing"]["listing_title"]
+description = data["extract_listing"]["listing_description"]
 ```
 
-When two upstream actions share a field name, the framework qualifies them with dot-separated prefixes:
+When observing from multiple upstream actions, each action's fields are isolated under its namespace — no collision handling needed:
 
 ```python
 # observe: [action_a.*, action_b.*]
-# Both have a "title" field → collision → qualified keys
-title_a = data.get("action_a.title", "")
-title_b = data.get("action_b.title", "")
-
-# Unique fields stay bare (no qualification needed)
-confidence = data.get("confidence", 0)
+# Both have a "title" field — no collision, each under its own namespace
+title_a = data["action_a"]["title"]
+title_b = data["action_b"]["title"]
 ```
 
-### FILE mode — content dict
+### FILE mode — namespaced content dict
 
-In FILE mode, observed fields are inside `record["content"]`, also flat:
+In FILE mode, observed fields are inside `record["content"]`, namespaced by action name:
 
 ```python
 for record in data:
     content = record["content"]
-    title = content.get("listing_title", "")
+    title = content["extract_listing"]["listing_title"]
 ```
 
 ### output_field values (json_mode: false)
 
-With `json_mode: false` and `output_field`, the raw text arrives as a flat field:
+With `json_mode: false` and `output_field`, the raw text arrives under the action's namespace:
 
 ```python
 # Config: output_field: severity  (on action "assess_severity")
 # RECORD mode:
-severity = data.get("severity", "")
+severity = data["assess_severity"]["severity"]
 
 # Default output_field is "raw_response"
-raw = data.get("raw_response", "")
+raw = data["assess_severity"]["raw_response"]
 ```
 
 ### Version consumption merge
 
-After `version_consumption: {pattern: merge}`, the access pattern depends on the mode:
+After `version_consumption: {pattern: merge}`, each version is a separate namespace:
 
-**RECORD mode** — version fields collide (e.g., multiple versions all have `score`), so they arrive as dot-qualified flat keys:
+**RECORD mode** — each version's output is nested under its expanded action name:
 
 ```python
-score_1 = data.get("score_quality_1.score")
-score_2 = data.get("score_quality_2.score")
+score_1 = data["score_quality_1"]["score"]
+score_2 = data["score_quality_2"]["score"]
 
 # Iterate all versions:
-scores = [v for k, v in data.items() if k.endswith(".score")]
+scores = [ns["score"] for name, ns in data.items() if name.startswith("score_quality_")]
 ```
 
-**FILE mode** — version namespaces are preserved as nested dicts in `content`, alongside qualified flat keys. Both access patterns work:
+**FILE mode** — version namespaces are nested dicts inside `content`:
 
 ```python
 content = record["content"]
 
-# Nested dict access:
-scorer_1 = content.get("score_quality_1", {})
-score = scorer_1.get("score")
-
-# Qualified flat key access:
-score = content.get("score_quality_1.score")
+# Direct access:
+scorer_1 = content["score_quality_1"]
+score = scorer_1["score"]
 
 # Iterate via nested dicts:
 scores = []
@@ -246,14 +243,14 @@ for key, val in content.items():
 
 ### Seed data
 
-Seed data is flattened like any other namespace. Requires `observe: [seed.*]` in your action config:
+Seed data is under the `seed` namespace. Requires `observe: [seed.*]` in your action config:
 
 ```python
-# RECORD mode — seed namespace is flattened:
-rules = data.get("marketplace_rules", {})
+# RECORD mode — seed namespace:
+rules = data["seed"]["marketplace_rules"]
 
-# FILE mode — seed fields injected into content:
-rules = record["content"].get("marketplace_rules", {})
+# FILE mode — seed namespace inside content:
+rules = record["content"]["seed"]["marketplace_rules"]
 ```
 
 ## Passthrough Pattern
@@ -264,7 +261,7 @@ When the YAML config uses `passthrough`, return a **dict** (not list) with only 
 @udf_tool()
 def inject_random_opener(data: dict) -> dict:
     """Return dict when using passthrough — only new fields."""
-    quiz_type = data.get('quiz_type_used', 'general').lower()
+    quiz_type = data["get_authoring_prompt"]["quiz_type_used"].lower()
     opener = random.choice(OPENERS.get(quiz_type, OPENERS['default']))
     return {"suggested_opener": opener, "quiz_type": quiz_type.upper()}
 ```
@@ -280,16 +277,17 @@ def inject_random_opener(data: dict) -> dict:
 
 ## Version Consumption Merge
 
-Process merged results from parallel versioned actions. In RECORD mode, version fields arrive as dot-qualified flat keys:
+Process merged results from parallel versioned actions. In RECORD mode, each version is a separate namespace:
 
 ```python
 @udf_tool()
 def combine_results(data: dict[str, Any]) -> list[dict[str, Any]]:
-    # Version fields collide (each version has "score", "reasoning") → qualified keys
+    # Each version is a namespace — access via action name
     results = []
     for i in range(1, 4):  # versions 1-3
-        score = data.get(f'score_quality_{i}.score', 0)
-        reasoning = data.get(f'score_quality_{i}.reasoning', '')
+        version_ns = data.get(f'score_quality_{i}', {})
+        score = version_ns.get('score', 0)
+        reasoning = version_ns.get('reasoning', '')
         if score or reasoning:
             results.append({'version': i, 'score': score, 'reasoning': reasoning})
 
@@ -297,18 +295,16 @@ def combine_results(data: dict[str, Any]) -> list[dict[str, Any]]:
     return [{'all_scores': results, 'average_score': avg_score}]
 ```
 
-In FILE mode, version namespaces are nested dicts — both access patterns work:
+In FILE mode, version namespaces are nested dicts inside `content`:
 
 ```python
 @udf_tool(granularity=Granularity.FILE)
 def combine_results_file(data: list[dict]) -> list[dict]:
     for record in data:
         content = record["content"]
-        # Nested dict access:
-        scorer_1 = content.get("score_quality_1", {})
-        score = scorer_1.get("score", 0)
-        # Or qualified flat key:
-        score = content.get("score_quality_1.score", 0)
+        # Direct access:
+        scorer_1 = content["score_quality_1"]
+        score = scorer_1["score"]
     # ...
 ```
 
@@ -358,30 +354,29 @@ def bad_udf(data):
     return [{"name": None}]  # schema says type: string → validation error
     # CORRECT: return [{"name": ""}]
 
-# WRONG: Using old namespaced access (pre-PR #306)
+# WRONG: Using flat access (fields are namespaced)
 def bad_udf(data):
-    result = data.get("upstream_action", {}).get("field")  # None — fields are flat now
-    # CORRECT: result = data.get("field")
+    result = data.get("field")  # None — fields are under action namespaces
+    # CORRECT: result = data["upstream_action"]["field"]
 
-# WRONG: Ignoring collision qualification
+# WRONG: Using old dot-qualified flat keys
 def bad_udf(data):
-    # When two upstreams share "title", bare access returns None
-    title = data.get("title")  # None — collision produces qualified keys
-    # CORRECT: title = data.get("action_a.title")
+    title = data.get("action_a.title")  # None — not flat keys anymore
+    # CORRECT: title = data["action_a"]["title"]
 
-# WRONG: FILE mode forgetting to read from content
+# WRONG: FILE mode forgetting namespace in content
 def bad_udf(data):
     for record in data:
-        fact = record.get("fact")  # None — fact is inside "content"
-    # CORRECT: fact = record["content"].get("fact")
+        fact = record["content"].get("fact")  # None — fact is under action namespace
+    # CORRECT: fact = record["content"]["upstream_action"]["fact"]
 ```
 
 ## Best Practices
 
-- **RECORD mode**: Access fields directly with `data.get("field", default)` — fields are flat
-- **FILE mode**: Read from `record["content"]` — business fields are inside the content dict
-- **Collisions**: When observing from multiple upstreams, check for dot-qualified keys like `data.get("action.field")`
-- Use `.get()` with defaults for all field access: `data.get("score", 0)` prevents `KeyError`
+- **RECORD mode**: Access fields via action namespace with `data["action_name"]["field"]`
+- **FILE mode**: Read from `record["content"]["action_name"]["field"]` — business fields are namespaced inside content
+- **No collisions**: Each action's fields are isolated under its namespace, so field name conflicts cannot occur
+- Use `.get()` with defaults when a field may be absent: `data["action"].get("score", 0)` prevents `KeyError`
 - Use descriptive TypedDict names (`QuestionQualityInput`, not `Input1`)
 - Document expected input/output in the docstring
 

--- a/agent_actions/skills/agent-actions-workflow/references/workflow-patterns.md
+++ b/agent_actions/skills/agent-actions-workflow/references/workflow-patterns.md
@@ -99,7 +99,7 @@ actions:
       Level: {{ assess_reading_level.reading_level }}
 ```
 
-**How matching works:** This is a **fan-in pattern** - `generate_seo` (first in list) is the primary input. The other two are loaded via historical context with lineage matching, ensuring all three come from the same parent record.
+**How matching works:** This is a **fan-in pattern** - `generate_seo` (first in list) is the primary input. The other two are matched via lineage, ensuring all three come from the same parent record. Each action's output is available under its namespace.
 
 ## Multi-enrichment Pattern
 
@@ -175,14 +175,14 @@ actions:
   - name: fast_path
     dependencies: classify
     guard:
-      condition: 'complexity == "low"'
+      condition: 'classify.complexity == "low"'
       on_false: "skip"
     schema: { result: string }
 
   - name: slow_path
     dependencies: classify
     guard:
-      condition: 'complexity == "high"'
+      condition: 'classify.complexity == "high"'
       on_false: "skip"
     schema: { result: string }
 
@@ -203,8 +203,8 @@ Write workflows that consume from multiple different upstream workflows by detec
 @udf_tool()
 def format_options(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Format options differently based on input type."""
-    # RECORD mode: fields arrive flat
-    options = data.get('options', [])
+    # RECORD mode: fields are namespaced by upstream action
+    options = data["upstream_action"]["options"]
     formatted = []
 
     for option in options:
@@ -249,12 +249,12 @@ Run same action multiple times in parallel, then consume all results:
       - process_data.*
 ```
 
-**RECORD mode — version fields collide, so they arrive as dot-qualified flat keys:**
+**RECORD mode — each version is a separate namespace:**
 ```json
 {
-  "process_data_1.result": "output 1", "process_data_1.score": 0.85,
-  "process_data_2.result": "output 2", "process_data_2.score": 0.92,
-  "process_data_3.result": "output 3", "process_data_3.score": 0.88
+  "process_data_1": {"result": "output 1", "score": 0.85},
+  "process_data_2": {"result": "output 2", "score": 0.92},
+  "process_data_3": {"result": "output 3", "score": 0.88}
 }
 ```
 
@@ -262,11 +262,12 @@ Run same action multiple times in parallel, then consume all results:
 ```python
 @udf_tool()
 def combine_parallel_results(data: dict[str, Any]) -> list[dict[str, Any]]:
-    # Version fields are dot-qualified (result/score collide across versions)
+    # Each version is a namespace — access via action name
     results = []
     for i in range(1, 6):
-        result = data.get(f'process_data_{i}.result')
-        score = data.get(f'process_data_{i}.score', 0)
+        version_ns = data.get(f'process_data_{i}', {})
+        result = version_ns.get('result')
+        score = version_ns.get('score', 0)
         if result is not None:
             results.append({'worker_id': i, 'result': result, 'score': score})
 
@@ -325,7 +326,7 @@ def chunk_document(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
     chunks = []
     for record in data:
         source_guid = record.get("source_guid")
-        text = record["content"].get("text", "")
+        text = record["content"]["source"]["text"]
         for i, part in enumerate(split_text(text)):
             chunks.append({
                 "source_guid": source_guid,  # Required for lineage

--- a/agent_actions/skills/agent-actions-workflow/references/yaml-schema.md
+++ b/agent_actions/skills/agent-actions-workflow/references/yaml-schema.md
@@ -133,7 +133,7 @@ actions:
 
   # Conditional
   guard:
-    condition: "facts != []"
+    condition: "prior_action.facts != []"
     on_false: filter
 
   # Debug
@@ -297,7 +297,7 @@ guard:
 
 ```yaml
 guard:
-  condition: 'len(candidate_facts_list) >= 3 and status == "valid"'
+  condition: 'len(upstream_action.candidate_facts_list) >= 3 and upstream_action.status == "valid"'
   on_false: "filter"
 ```
 


### PR DESCRIPTION
## Summary
- Update all 14 skills documentation files (SKILL.md, UDF template, 12 reference docs) for the additive content model
- Tool data access: `data.get("field")` → `data["action_name"]["field"]` (namespaced)
- Guard syntax: flat `condition: 'field == value'` → dotted `condition: 'action.field == value'`
- Observe semantics: "historical lookup / storage recovery" → "namespace selection"
- Remove all `data.get("content", data)` fallback patterns and flat collision handling

## Verification
- `ruff format --check` — 802 files already formatted
- `ruff check` — all checks passed
- `pytest` — 5844 passed, 2 skipped
- Grep verification: zero remaining flat access patterns, zero flat guard conditions, zero dead fallback patterns in skills docs