### PR TITLE
fix: version merge + FILE mode N→M tools namespace handling

### DIFF
--- a/.changes/unreleased/Bug Fix-20260424-093000.yaml
+++ b/.changes/unreleased/Bug Fix-20260424-093000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Version merge no longer double-nests content — version namespaces spread directly into content"
+time: 2026-04-24T09:30:00.000000Z

--- a/agent_actions/input/preprocessing/transformation/transformer.py
+++ b/agent_actions/input/preprocessing/transformation/transformer.py
@@ -57,15 +57,22 @@ class DataTransformer:
         return result
 
     @staticmethod
-    def transform_structure(data: list[dict], action_name: str = "") -> list[dict]:
+    def transform_structure(
+        data: list[dict],
+        action_name: str = "",
+        *,
+        version_merge: bool = False,
+    ) -> list[dict]:
         """Flatten nested {source_guid: contents} structure to list of dicts.
 
-        Content is wrapped under *action_name* namespace (additive model).
+        Content is wrapped under *action_name* namespace (additive model)
+        unless *version_merge* is ``True``, in which case content is used
+        as-is because version namespaces are already the correct format.
 
         Raises:
-            ValueError: If *action_name* is empty.
+            ValueError: If *action_name* is empty and *version_merge* is False.
         """
-        if not action_name:
+        if not action_name and not version_merge:
             raise ValueError("action_name is required for namespaced content wrapping")
 
         from agent_actions.utils.content import wrap_content
@@ -80,15 +87,20 @@ class DataTransformer:
                             result.append(
                                 {
                                     "source_guid": source_guid,
-                                    "content": wrap_content(action_name, content),
+                                    "content": content
+                                    if version_merge
+                                    else wrap_content(action_name, content),
                                 }
                             )
                     else:
-                        wrapped = (
-                            wrap_content(action_name, contents)
-                            if isinstance(contents, dict)
-                            else contents
-                        )
+                        if version_merge:
+                            wrapped = contents
+                        else:
+                            wrapped = (
+                                wrap_content(action_name, contents)
+                                if isinstance(contents, dict)
+                                else contents
+                            )
                         result.append({"source_guid": source_guid, "content": wrapped})
 
         return result

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -233,12 +233,13 @@ class BatchResultProcessor:
 
         if not ctx.agent_config or "action_name" not in ctx.agent_config:
             raise ValueError("agent_config must contain 'action_name' for content namespacing")
+        from agent_actions.utils.content import is_version_merge
+
         action_name = ctx.agent_config["action_name"]
-        version_merge = bool(ctx.agent_config.get("version_consumption_config"))
         structured_items = DataTransformer.transform_structure(
             [{original_source_guid: generated_list}],
             action_name,
-            version_merge=version_merge,
+            version_merge=is_version_merge(ctx.agent_config),
         )
 
         # Batch items inherit target_id from the original input row.

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -234,8 +234,11 @@ class BatchResultProcessor:
         if not ctx.agent_config or "action_name" not in ctx.agent_config:
             raise ValueError("agent_config must contain 'action_name' for content namespacing")
         action_name = ctx.agent_config["action_name"]
+        version_merge = bool(ctx.agent_config.get("version_consumption_config"))
         structured_items = DataTransformer.transform_structure(
-            [{original_source_guid: generated_list}], action_name
+            [{original_source_guid: generated_list}],
+            action_name,
+            version_merge=version_merge,
         )
 
         # Batch items inherit target_id from the original input row.

--- a/agent_actions/utils/content.py
+++ b/agent_actions/utils/content.py
@@ -69,6 +69,11 @@ def get_all_namespaces(record: dict[str, Any]) -> list[str]:
     return list(content.keys())
 
 
+def is_version_merge(agent_config: dict[str, Any]) -> bool:
+    """True when the action consumes version output (content is pre-namespaced)."""
+    return bool(agent_config.get("version_consumption_config"))
+
+
 def get_existing_content(record: dict[str, Any]) -> dict[str, Any]:
     """Return the existing namespaced content dict from a record.
 

--- a/agent_actions/utils/content.py
+++ b/agent_actions/utils/content.py
@@ -21,6 +21,7 @@ Usage::
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 
@@ -69,7 +70,7 @@ def get_all_namespaces(record: dict[str, Any]) -> list[str]:
     return list(content.keys())
 
 
-def is_version_merge(agent_config: dict[str, Any]) -> bool:
+def is_version_merge(agent_config: Mapping[str, Any]) -> bool:
     """True when the action consumes version output (content is pre-namespaced)."""
     return bool(agent_config.get("version_consumption_config"))
 

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -59,7 +59,10 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
+        version_merge = bool(agent_config.get("version_consumption_config"))
+        return DataTransformer.transform_structure(
+            [{source_guid: updated}], action_name, version_merge=version_merge
+        )
 
     @staticmethod
     def has_passthrough_config(agent_config: dict) -> bool:
@@ -134,7 +137,10 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
+        version_merge = bool(agent_config.get("version_consumption_config"))
+        return DataTransformer.transform_structure(
+            [{source_guid: updated}], action_name, version_merge=version_merge
+        )
 
 
 class NoOpStrategy(IPassthroughTransformStrategy):
@@ -190,4 +196,7 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
     ) -> list:
         """Structure data without passthrough."""
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: data}], action_name)
+        version_merge = bool(agent_config.get("version_consumption_config"))
+        return DataTransformer.transform_structure(
+            [{source_guid: data}], action_name, version_merge=version_merge
+        )

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -1,6 +1,7 @@
 """Passthrough strategies that extract fields from context_scope.passthrough config."""
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
+from agent_actions.utils.content import is_version_merge
 
 from .base import IPassthroughTransformStrategy
 
@@ -59,7 +60,7 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        version_merge = bool(agent_config.get("version_consumption_config"))
+        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
             [{source_guid: updated}], action_name, version_merge=version_merge
         )
@@ -137,7 +138,7 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        version_merge = bool(agent_config.get("version_consumption_config"))
+        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
             [{source_guid: updated}], action_name, version_merge=version_merge
         )
@@ -196,7 +197,7 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
     ) -> list:
         """Structure data without passthrough."""
         action_name = agent_config["agent_type"]
-        version_merge = bool(agent_config.get("version_consumption_config"))
+        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
             [{source_guid: data}], action_name, version_merge=version_merge
         )

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -77,4 +77,7 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
             else:
                 merged.append(item)
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: merged}], action_name)
+        version_merge = bool(agent_config.get("version_consumption_config"))
+        return DataTransformer.transform_structure(
+            [{source_guid: merged}], action_name, version_merge=version_merge
+        )

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -1,6 +1,7 @@
 """Passthrough strategies for pre-computed passthrough_fields."""
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
+from agent_actions.utils.content import is_version_merge
 
 from .base import IPassthroughTransformStrategy
 
@@ -77,7 +78,7 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
             else:
                 merged.append(item)
         action_name = agent_config["agent_type"]
-        version_merge = bool(agent_config.get("version_consumption_config"))
+        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
             [{source_guid: merged}], action_name, version_merge=version_merge
         )

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -230,12 +230,18 @@ def process_file_mode_tool(
                     data_fields = {k: v for k, v in item.items() if k not in _TOOL_RESERVED_FIELDS}
 
                 # Carry forward existing namespaces from the input record.
+                # For N→M tools (dedup, filter), source_mapping may not resolve.
+                # Fall back to the first input record — all records in a FILE
+                # batch share the same upstream namespaces.
                 input_idx = source_mapping.get(idx) if source_mapping else None
                 if isinstance(input_idx, list):
                     input_idx = input_idx[0]
-                existing = {}
                 if isinstance(input_idx, int) and input_idx < len(original_data):
                     existing = get_existing_content(original_data[input_idx])
+                elif original_data:
+                    existing = get_existing_content(original_data[0])
+                else:
+                    existing = {}
 
                 if version_merge:
                     content = {**existing, **data_fields}

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -211,7 +211,11 @@ def process_file_mode_tool(
         # Separate business data from framework fields in tool output.
         # Additive model: wrap tool output under action namespace, preserve
         # existing namespaces from the input record.
+        # Version merge: version namespaces are already the correct additive
+        # format — spread instead of wrapping under the action name.
         from agent_actions.utils.content import get_existing_content, wrap_content
+
+        is_version_merge = bool(context.agent_config.get("version_consumption_config"))
 
         structured_data = []
         for idx, item in enumerate(raw_response):
@@ -229,8 +233,13 @@ def process_file_mode_tool(
                 if isinstance(input_idx, int) and input_idx < len(original_data):
                     existing = get_existing_content(original_data[input_idx])
 
+                if is_version_merge:
+                    content = {**existing, **data_fields}
+                else:
+                    content = wrap_content(context.agent_name, data_fields, existing)
+
                 structured_item: dict[str, Any] = {
-                    "content": wrap_content(context.agent_name, data_fields, existing),
+                    "content": content,
                 }
 
                 if "source_guid" in item:

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -213,9 +213,13 @@ def process_file_mode_tool(
         # existing namespaces from the input record.
         # Version merge: version namespaces are already the correct additive
         # format — spread instead of wrapping under the action name.
-        from agent_actions.utils.content import get_existing_content, wrap_content
+        from agent_actions.utils.content import (
+            get_existing_content,
+            is_version_merge,
+            wrap_content,
+        )
 
-        is_version_merge = bool(context.agent_config.get("version_consumption_config"))
+        version_merge = is_version_merge(context.agent_config)
 
         structured_data = []
         for idx, item in enumerate(raw_response):
@@ -233,7 +237,7 @@ def process_file_mode_tool(
                 if isinstance(input_idx, int) and input_idx < len(original_data):
                     existing = get_existing_content(original_data[input_idx])
 
-                if is_version_merge:
+                if version_merge:
                     content = {**existing, **data_fields}
                 else:
                     content = wrap_content(context.agent_name, data_fields, existing)

--- a/tests/manual/repro_093_version_double_nesting.py
+++ b/tests/manual/repro_093_version_double_nesting.py
@@ -1,0 +1,116 @@
+"""Reproduction script for version merge double-nesting bug.
+
+Bug: The version correlator creates namespaced content
+     {v1: {fields}, v2: {fields}} — already the correct additive format.
+     Then wrap_content wraps it AGAIN under the consuming action's name:
+     {action_name: {v1: {fields}, v2: {fields}}}.
+     Downstream tools see double-nested data.
+
+Run:  python tests/manual/repro_093_version_double_nesting.py
+Expected: FAIL before fix, PASS after fix.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+sys.path.insert(0, project_root)
+
+from agent_actions.utils.content import get_existing_content, wrap_content
+
+
+def test_file_mode_double_nesting():
+    """FILE mode: version merge should spread, not wrap under action name.
+
+    The pipeline checks version_consumption_config and decides whether to
+    wrap or spread.  This test simulates both paths to show the difference.
+    """
+    version_merged = {
+        "source_guid": "sg-1",
+        "content": {
+            "filter_learning_quality_1": {"vote": "keep", "score": 8},
+            "filter_learning_quality_2": {"vote": "drop", "score": 3},
+            "filter_learning_quality_3": {"vote": "keep", "score": 7},
+        },
+    }
+
+    existing = get_existing_content(version_merged)
+    tool_output = {"consensus": "keep", "total_score": 18}
+
+    # Broken path (what wrap_content does — wraps under action name):
+    broken = wrap_content("aggregate_votes", tool_output, existing)
+    assert "aggregate_votes" in broken, "wrap_content should wrap under action name"
+
+    # Fixed path (what the pipeline now does for version merge — spread):
+    fixed = {**existing, **tool_output}
+    if "aggregate_votes" in fixed:
+        print("BUG CONFIRMED (FILE mode): Tool output wrapped under action name")
+        return False
+
+    assert "filter_learning_quality_1" in fixed, "version namespace missing"
+    assert "consensus" in fixed, "tool output field missing"
+    assert fixed["filter_learning_quality_1"]["vote"] == "keep"
+    assert fixed["consensus"] == "keep"
+
+    print("BUG FIXED (FILE mode): Version namespaces + tool output spread at top level")
+    print(f"  fixed keys: {sorted(fixed.keys())}")
+    return True
+
+
+def test_transformer_double_nesting():
+    """LLM path: transform_structure with version_merge=True skips wrapping."""
+    from agent_actions.input.preprocessing.transformation.transformer import (
+        DataTransformer,
+    )
+
+    llm_response = [{"sg-1": {"consensus": "keep", "total_score": 18}}]
+
+    # Broken path (version_merge=False — wraps under action name):
+    broken = DataTransformer.transform_structure(llm_response, "aggregate_votes")
+    assert "aggregate_votes" in broken[0]["content"], "should wrap without version_merge"
+
+    # Fixed path (version_merge=True — content used directly):
+    fixed = DataTransformer.transform_structure(
+        [{"sg-1": {"consensus": "keep", "total_score": 18}}],
+        "aggregate_votes",
+        version_merge=True,
+    )
+    content = fixed[0]["content"]
+
+    if "aggregate_votes" in content:
+        print("BUG CONFIRMED (LLM path): LLM output wrapped under action name")
+        return False
+
+    assert content["consensus"] == "keep"
+    assert content["total_score"] == 18
+
+    print("BUG FIXED (LLM path): LLM output used directly with version_merge=True")
+    print(f"  content keys: {sorted(content.keys())}")
+    return True
+
+
+def main():
+    print("=" * 70)
+    print("Reproduction: version merge double-nesting bug (spec 093)")
+    print("=" * 70)
+
+    results = []
+
+    print("\n--- FILE mode: version merge spread vs. wrap ---")
+    results.append(test_file_mode_double_nesting())
+
+    print("\n--- LLM path: transform_structure with version_merge ---")
+    results.append(test_transformer_double_nesting())
+
+    print("\n" + "=" * 70)
+    if all(results):
+        print("ALL TESTS PASS — double-nesting bug is fixed")
+        return 0
+    else:
+        failed = sum(1 for r in results if not r)
+        print(f"{failed} bug(s) still present")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/workflow/test_version_merge_content.py
+++ b/tests/unit/workflow/test_version_merge_content.py
@@ -1,0 +1,263 @@
+"""Tests for version merge content format — spread instead of double-nesting.
+
+Version consumption actions receive records whose content is already
+namespaced by the version correlator: {v1: {fields}, v2: {fields}}.
+The pipeline writer must spread version namespaces directly instead
+of wrapping them under the consuming action's name.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.input.preprocessing.transformation.transformer import (
+    DataTransformer,
+)
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.workflow.pipeline import PipelineConfig, ProcessingPipeline
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_version_merge_pipeline_and_context():
+    """Create pipeline and context for a version consumption FILE-mode tool."""
+    config = {
+        "kind": "tool",
+        "granularity": "file",
+        "version_consumption_config": {
+            "source": "filter_learning_quality",
+            "pattern": "merge",
+        },
+    }
+    pipeline = ProcessingPipeline(
+        config=PipelineConfig(
+            action_config=config,
+            action_name="aggregate_votes",
+            idx=0,
+        ),
+        processor_factory=object(),
+    )
+    context = ProcessingContext(agent_config=config, agent_name="aggregate_votes")
+    return pipeline, context
+
+
+def _make_normal_pipeline_and_context():
+    """Create pipeline and context for a normal (non-version-merge) FILE-mode tool."""
+    pipeline = ProcessingPipeline(
+        config=PipelineConfig(
+            action_config={"kind": "tool", "granularity": "file"},
+            action_name="summarize",
+            idx=0,
+        ),
+        processor_factory=object(),
+    )
+    context = ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file"},
+        agent_name="summarize",
+    )
+    return pipeline, context
+
+
+# ---------------------------------------------------------------------------
+# FILE mode: pipeline_file_mode.py
+# ---------------------------------------------------------------------------
+
+
+class TestFileModePipelineVersionMerge:
+    """Version merge FILE mode: spread instead of wrap."""
+
+    def test_version_merge_spreads_tool_output(self):
+        """Version merge action: tool output spread at top level, not wrapped."""
+        pipeline, context = _make_version_merge_pipeline_and_context()
+
+        # Version-correlated input record (what the version correlator produces)
+        input_data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "n1",
+                "content": {
+                    "filter_learning_quality_1": {"vote": "keep", "score": 8},
+                    "filter_learning_quality_2": {"vote": "drop", "score": 3},
+                },
+            }
+        ]
+
+        # Tool returns aggregated output
+        tool_output = [{"consensus": "keep", "total_score": 11, "node_id": "n1"}]
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(tool_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+        assert results[0].status == ProcessingStatus.SUCCESS
+        content = results[0].data[0]["content"]
+
+        # Version namespaces at top level (from existing)
+        assert "filter_learning_quality_1" in content
+        assert "filter_learning_quality_2" in content
+        assert content["filter_learning_quality_1"]["vote"] == "keep"
+        assert content["filter_learning_quality_2"]["vote"] == "drop"
+
+        # Tool output spread at top level — NOT wrapped under action name
+        assert "aggregate_votes" not in content
+        assert content["consensus"] == "keep"
+        assert content["total_score"] == 11
+
+    def test_version_merge_preserves_version_namespaces(self):
+        """Version namespaces from input are preserved in the output content."""
+        pipeline, context = _make_version_merge_pipeline_and_context()
+
+        input_data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "n1",
+                "content": {
+                    "filter_learning_quality_1": {"vote": "keep", "score": 8},
+                    "filter_learning_quality_2": {"vote": "drop", "score": 3},
+                    "filter_learning_quality_3": {"vote": "keep", "score": 7},
+                },
+            }
+        ]
+
+        tool_output = [{"summary": "2/3 keep", "node_id": "n1"}]
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(tool_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+        content = results[0].data[0]["content"]
+        assert len([k for k in content if k.startswith("filter_learning_quality")]) == 3
+        assert content["summary"] == "2/3 keep"
+
+    def test_normal_action_still_wraps_under_action_name(self):
+        """Non-version-merge action: tool output wrapped under action name."""
+        pipeline, context = _make_normal_pipeline_and_context()
+
+        input_data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "n1",
+                "content": {"upstream_action": {"text": "hello"}},
+            }
+        ]
+
+        tool_output = [{"summary": "world", "node_id": "n1"}]
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(tool_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+        content = results[0].data[0]["content"]
+        # Normal action wraps under action name
+        assert "summarize" in content
+        assert content["summarize"]["summary"] == "world"
+        # Existing namespace preserved
+        assert "upstream_action" in content
+
+    def test_version_merge_tool_returns_content_key(self):
+        """Version merge tool returning {"content": {...}} is handled correctly."""
+        pipeline, context = _make_version_merge_pipeline_and_context()
+
+        input_data = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "n1",
+                "content": {
+                    "filter_learning_quality_1": {"vote": "keep"},
+                    "filter_learning_quality_2": {"vote": "drop"},
+                },
+            }
+        ]
+
+        # Tool returns output nested under "content" key
+        tool_output = [{"content": {"consensus": "keep"}, "node_id": "n1"}]
+
+        with patch(
+            "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+            return_value=(tool_output, True),
+        ):
+            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+        content = results[0].data[0]["content"]
+        assert "aggregate_votes" not in content
+        assert content["consensus"] == "keep"
+        assert content["filter_learning_quality_1"]["vote"] == "keep"
+
+
+# ---------------------------------------------------------------------------
+# LLM path: transformer.py
+# ---------------------------------------------------------------------------
+
+
+class TestTransformStructureVersionMerge:
+    """transform_structure with version_merge parameter."""
+
+    def test_version_merge_skips_wrapping(self):
+        """version_merge=True: content used directly, not wrapped."""
+        data = [{"sg-1": {"consensus": "keep", "total_score": 18}}]
+
+        result = DataTransformer.transform_structure(data, "aggregate_votes", version_merge=True)
+
+        assert len(result) == 1
+        assert result[0]["source_guid"] == "sg-1"
+        content = result[0]["content"]
+        assert "aggregate_votes" not in content
+        assert content["consensus"] == "keep"
+        assert content["total_score"] == 18
+
+    def test_normal_wraps_under_action_name(self):
+        """version_merge=False (default): content wrapped under action name."""
+        data = [{"sg-1": {"consensus": "keep"}}]
+
+        result = DataTransformer.transform_structure(data, "aggregate_votes")
+
+        content = result[0]["content"]
+        assert "aggregate_votes" in content
+        assert content["aggregate_votes"]["consensus"] == "keep"
+
+    def test_version_merge_list_contents(self):
+        """version_merge=True with list contents: each item used directly."""
+        data = [
+            {
+                "sg-1": [
+                    {"consensus": "keep"},
+                    {"consensus": "drop"},
+                ]
+            }
+        ]
+
+        result = DataTransformer.transform_structure(data, "aggregate_votes", version_merge=True)
+
+        assert len(result) == 2
+        assert result[0]["content"] == {"consensus": "keep"}
+        assert result[1]["content"] == {"consensus": "drop"}
+        assert all(r["source_guid"] == "sg-1" for r in result)
+
+    def test_version_merge_empty_action_name_allowed(self):
+        """version_merge=True allows empty action_name."""
+        data = [{"sg-1": {"consensus": "keep"}}]
+
+        result = DataTransformer.transform_structure(data, "", version_merge=True)
+
+        assert result[0]["content"]["consensus"] == "keep"
+
+    def test_empty_action_name_raises_without_version_merge(self):
+        """Empty action_name raises ValueError when version_merge is False."""
+        with pytest.raises(ValueError, match="action_name is required"):
+            DataTransformer.transform_structure([{"sg-1": {"x": 1}}], "")
+
+    def test_version_merge_non_dict_passthrough(self):
+        """version_merge=True with non-dict contents passes them through."""
+        data = [{"sg-1": "raw_string_value"}]
+
+        result = DataTransformer.transform_structure(data, "action", version_merge=True)
+
+        assert result[0]["content"] == "raw_string_value"


### PR DESCRIPTION
## Summary
Two related fixes for additive model content namespacing:

1. **Version merge double-nesting** — version correlator already namespaces under version names, additive writer was wrapping again. Now version namespaces spread directly into content.
2. **FILE mode N→M tools lose namespaces** — dedup/filter/aggregate tools where source_mapping can't resolve output→input lost all upstream namespaces. Now falls back to first input record (all records share same upstream namespaces).

## What was broken
- `aggregate_votes` got `data["filter_1"]["filter_1"]["vote"]` — double nested
- `select_approved_questions` got `observe field 'flatten_canonical_questions.question_text' not found` — namespace lost after deduplicate

## Verification
- 5834 tests pass
- `ruff check` and `ruff format --check` clean
- CI all green (Lint, Tests, Build, Changelog, CLA)