### PR TITLE
fix: NoOp and PrecomputedStructured strategies wrap content under namespace

### DIFF
--- a/.changes/unreleased/Bug Fix-20260424-029000.yaml
+++ b/.changes/unreleased/Bug Fix-20260424-029000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "NoOp and PrecomputedStructured strategies now wrap content under action namespace instead of returning flat"
+time: 2026-04-24T02:90:00.000000Z

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -170,8 +170,12 @@ class NoOpStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Return data unchanged."""
-        return data
+        """Wrap content under action namespace (no passthrough merging needed)."""
+        action_name = agent_config["agent_type"]
+        version_merge = is_version_merge(agent_config)
+        return DataTransformer.transform_structure(
+            [{source_guid: data}], action_name, version_merge=version_merge
+        )
 
 
 class DefaultStructureStrategy(IPassthroughTransformStrategy):

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -59,9 +59,7 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure(
-            [{source_guid: updated}], action_name
-        )
+        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
 
     @staticmethod
     def has_passthrough_config(agent_config: dict) -> bool:
@@ -136,9 +134,7 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure(
-            [{source_guid: updated}], action_name
-        )
+        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
 
 
 class NoOpStrategy(IPassthroughTransformStrategy):
@@ -169,9 +165,7 @@ class NoOpStrategy(IPassthroughTransformStrategy):
     ) -> list:
         """Wrap content under action namespace (no passthrough merging needed)."""
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure(
-            [{source_guid: data}], action_name
-        )
+        return DataTransformer.transform_structure([{source_guid: data}], action_name)
 
 
 class DefaultStructureStrategy(IPassthroughTransformStrategy):
@@ -197,6 +191,4 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
     ) -> list:
         """Structure data without passthrough."""
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure(
-            [{source_guid: data}], action_name
-        )
+        return DataTransformer.transform_structure([{source_guid: data}], action_name)

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -1,7 +1,6 @@
 """Passthrough strategies that extract fields from context_scope.passthrough config."""
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
-from agent_actions.utils.content import is_version_merge
 
 from .base import IPassthroughTransformStrategy
 
@@ -60,9 +59,8 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
-            [{source_guid: updated}], action_name, version_merge=version_merge
+            [{source_guid: updated}], action_name
         )
 
     @staticmethod
@@ -138,9 +136,8 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
                     )
                 )
         action_name = agent_config["agent_type"]
-        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
-            [{source_guid: updated}], action_name, version_merge=version_merge
+            [{source_guid: updated}], action_name
         )
 
 
@@ -172,9 +169,8 @@ class NoOpStrategy(IPassthroughTransformStrategy):
     ) -> list:
         """Wrap content under action namespace (no passthrough merging needed)."""
         action_name = agent_config["agent_type"]
-        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
-            [{source_guid: data}], action_name, version_merge=version_merge
+            [{source_guid: data}], action_name
         )
 
 
@@ -201,7 +197,6 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
     ) -> list:
         """Structure data without passthrough."""
         action_name = agent_config["agent_type"]
-        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
-            [{source_guid: data}], action_name, version_merge=version_merge
+            [{source_guid: data}], action_name
         )

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -81,6 +81,4 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
             else:
                 merged.append(item)
         action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure(
-            [{source_guid: merged}], action_name
-        )
+        return DataTransformer.transform_structure([{source_guid: merged}], action_name)

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -1,7 +1,6 @@
 """Passthrough strategies for pre-computed passthrough_fields."""
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
-from agent_actions.utils.content import is_version_merge
 
 from .base import IPassthroughTransformStrategy
 
@@ -33,20 +32,15 @@ class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
         passthrough_fields: dict | None = None,
     ) -> list:
         """Merge passthrough fields into content, then wrap under action namespace."""
-        from agent_actions.utils.content import is_version_merge, wrap_content
+        from agent_actions.utils.content import wrap_content
 
         action_name = agent_config["agent_type"]
-        version_merge = is_version_merge(agent_config)
 
         result = []
         for item in data:
             if isinstance(item, dict) and "content" in item and isinstance(item["content"], dict):
                 merged_content = {**item["content"], **(passthrough_fields or {})}
-                if version_merge:
-                    namespaced = merged_content
-                else:
-                    namespaced = wrap_content(action_name, merged_content)
-                result.append({**item, "content": namespaced})
+                result.append({**item, "content": wrap_content(action_name, merged_content)})
             else:
                 result.append(item)
         return result
@@ -87,7 +81,6 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
             else:
                 merged.append(item)
         action_name = agent_config["agent_type"]
-        version_merge = is_version_merge(agent_config)
         return DataTransformer.transform_structure(
-            [{source_guid: merged}], action_name, version_merge=version_merge
+            [{source_guid: merged}], action_name
         )

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -32,12 +32,21 @@ class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Merge passthrough fields into each item's content."""
+        """Merge passthrough fields into content, then wrap under action namespace."""
+        from agent_actions.utils.content import is_version_merge, wrap_content
+
+        action_name = agent_config["agent_type"]
+        version_merge = is_version_merge(agent_config)
+
         result = []
         for item in data:
             if isinstance(item, dict) and "content" in item and isinstance(item["content"], dict):
-                merged = {**item, "content": {**item["content"], **(passthrough_fields or {})}}
-                result.append(merged)
+                merged_content = {**item["content"], **(passthrough_fields or {})}
+                if version_merge:
+                    namespaced = merged_content
+                else:
+                    namespaced = wrap_content(action_name, merged_content)
+                result.append({**item, "content": namespaced})
             else:
                 result.append(item)
         return result


### PR DESCRIPTION
## Summary
Two passthrough strategies bypassed namespace wrapping, storing flat content instead of namespaced:

- **NoOpStrategy** — returned data unchanged for LLM actions with no passthrough config
- **PrecomputedStructuredStrategy** — merged passthrough fields but didn't namespace the result

LLM actions like `canonicalize_qa` got flat content `{"canonical_questions": [...]}` instead of `{"canonicalize_qa": {"canonical_questions": [...]}}`. Downstream observe refs (`canonicalize_qa.*`) found nothing — tools received empty data.

## Verification
- 5854 tests pass
- `ruff check` clean