### PR TITLE
fix: record mode actions carry forward upstream namespaces

### DIFF
--- a/.changes/unreleased/Bug Fix-20260424-095000.yaml
+++ b/.changes/unreleased/Bug Fix-20260424-095000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Record mode LLM actions carry forward upstream namespaces in content"
+time: 2026-04-24T09:50:00.000000Z

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -223,6 +223,7 @@ def transform_with_passthrough(
     action_name: str = "unknown_action",
     passthrough_fields: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
+    existing_content: dict[str, Any] | None = None,
 ) -> list[Any]:
     """Apply ``context_scope.passthrough`` logic to generated data."""
     transformer = PassthroughTransformer()
@@ -234,4 +235,5 @@ def transform_with_passthrough(
         action_name,
         passthrough_fields=passthrough_fields,
         metadata=metadata,
+        existing_content=existing_content,
     )

--- a/agent_actions/processing/record_processor.py
+++ b/agent_actions/processing/record_processor.py
@@ -24,6 +24,7 @@ from agent_actions.logging.events.data_pipeline_events import (
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
 from agent_actions.output.response.config_fields import get_default
 from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
+from agent_actions.utils.content import get_existing_content
 
 from .enrichment import EnrichmentPipeline
 from .exhausted_builder import ExhaustedRecordBuilder
@@ -293,8 +294,14 @@ class RecordProcessor:
                     },
                 )
 
+        item_existing_content = get_existing_content(item) if isinstance(item, dict) else None
         transformed = self._transform_response(
-            response, content, source_guid or "", passthrough_fields, context
+            response,
+            content,
+            source_guid or "",
+            passthrough_fields,
+            context,
+            existing_content=item_existing_content,
         )
 
         input_size = 1 if not isinstance(response, list) else len(response)
@@ -457,6 +464,7 @@ class RecordProcessor:
         source_guid: str,
         passthrough_fields: dict[str, Any],
         context: ProcessingContext,
+        existing_content: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Transform LLM response to output format."""
         from agent_actions.processing.helpers import (
@@ -470,6 +478,7 @@ class RecordProcessor:
             cast(dict[str, Any], context.agent_config),
             action_name=context.action_name,
             passthrough_fields=passthrough_fields,
+            existing_content=existing_content,
         )
 
     @staticmethod

--- a/agent_actions/utils/transformation/_MANIFEST.md
+++ b/agent_actions/utils/transformation/_MANIFEST.md
@@ -16,4 +16,4 @@ into generated data and ensure outputs remain structured.
 | Name | Type | Description | Signals |
 |------|------|-------------|---------|
 | `passthrough.py` | Module | `PassthroughTransformer` orchestrates context_scope.passthrough + structured vs unstructured data using the strategy list. | `field_management`, `preprocessing` |
-| `PassthroughTransformer` | Class | Applies the first matching strategy, normalizes data to lists, and ensures each item has required IDs/metadata. | `field_management`, `lineage` |
+| `PassthroughTransformer` | Class | Applies the first matching strategy, merges upstream namespaces from existing_content, normalizes data to lists, and ensures each item has required IDs/metadata. | `field_management`, `lineage`, `content` |

--- a/agent_actions/utils/transformation/passthrough.py
+++ b/agent_actions/utils/transformation/passthrough.py
@@ -38,6 +38,7 @@ class PassthroughTransformer:
         action_name: str = "unknown_action",
         passthrough_fields: dict | None = None,
         metadata: dict | None = None,
+        existing_content: dict | None = None,
     ) -> list:
         """Apply context_scope.passthrough logic to generated data.
 
@@ -53,6 +54,9 @@ class PassthroughTransformer:
             passthrough_fields: Optional pre-computed passthrough fields
                 from field_context (enables passthrough from any ancestor).
             metadata: Optional LLM response metadata to add to output items.
+            existing_content: Existing namespaced content from the input
+                record.  Merged into each output item so that upstream
+                action namespaces are carried forward.
 
         Returns:
             Transformed data list with passthrough fields merged.
@@ -72,6 +76,12 @@ class PassthroughTransformer:
 
         if output is None:
             output = []
+
+        # Carry forward upstream namespaces from the input record.
+        if existing_content:
+            for obj in output:
+                if isinstance(obj, dict) and "content" in obj and isinstance(obj["content"], dict):
+                    obj["content"] = {**existing_content, **obj["content"]}
 
         return [
             self.field_manager.ensure_required_fields(

--- a/tests/unit/utils/test_passthrough_carry_forward.py
+++ b/tests/unit/utils/test_passthrough_carry_forward.py
@@ -1,0 +1,162 @@
+"""Tests for record mode namespace carry-forward in passthrough transformation.
+
+Verifies that upstream action namespaces from the input record are preserved
+in the output when a record mode LLM action processes a record.
+"""
+
+from agent_actions.utils.transformation.passthrough import PassthroughTransformer
+
+
+class TestCarryForwardNamespaces:
+    """PassthroughTransformer.transform_with_passthrough merges existing_content."""
+
+    def _make_agent_config(self, action_name="current_action"):
+        return {"agent_type": action_name}
+
+    def test_upstream_namespaces_carried_forward(self):
+        """Output includes both upstream namespaces and current action's namespace."""
+        transformer = PassthroughTransformer()
+        existing = {
+            "extract": {"text": "hello"},
+            "summarize": {"summary": "hi"},
+        }
+        llm_output = [{"score": 0.9, "label": "positive"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("classify"),
+            action_name="classify",
+            existing_content=existing,
+        )
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content["extract"] == {"text": "hello"}
+        assert content["summarize"] == {"summary": "hi"}
+        assert content["classify"] == {"score": 0.9, "label": "positive"}
+
+    def test_no_existing_content_still_works(self):
+        """When existing_content is None, output is unchanged."""
+        transformer = PassthroughTransformer()
+        llm_output = [{"answer": "42"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("qa"),
+            action_name="qa",
+            existing_content=None,
+        )
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content == {"qa": {"answer": "42"}}
+
+    def test_empty_existing_content_no_effect(self):
+        """Empty dict existing_content has no effect."""
+        transformer = PassthroughTransformer()
+        llm_output = [{"answer": "42"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("qa"),
+            action_name="qa",
+            existing_content={},
+        )
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content == {"qa": {"answer": "42"}}
+
+    def test_three_upstream_actions_all_preserved(self):
+        """Three upstream namespaces plus current action all present in output."""
+        transformer = PassthroughTransformer()
+        existing = {
+            "flatten_canonical_questions": {"questions": ["q1", "q2"]},
+            "deduplicate_across_documents": {"unique": ["q1"]},
+            "filter_learning_quality_1": {"quality": "high"},
+        }
+        llm_output = [{"grade": "A"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("grade_content"),
+            action_name="grade_content",
+            existing_content=existing,
+        )
+
+        content = result[0]["content"]
+        assert set(content.keys()) == {
+            "flatten_canonical_questions",
+            "deduplicate_across_documents",
+            "filter_learning_quality_1",
+            "grade_content",
+        }
+        assert content["grade_content"] == {"grade": "A"}
+
+    def test_current_action_wins_on_namespace_conflict(self):
+        """If the current action name collides with an upstream namespace, current wins."""
+        transformer = PassthroughTransformer()
+        existing = {"rerun": {"old": True}}
+        llm_output = [{"new": True}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("rerun"),
+            action_name="rerun",
+            existing_content=existing,
+        )
+
+        content = result[0]["content"]
+        assert content["rerun"] == {"new": True}
+
+    def test_already_structured_data_gets_merge(self):
+        """Already-structured data (NoOpStrategy path) also gets existing_content merged."""
+        transformer = PassthroughTransformer()
+        existing = {"upstream": {"val": 1}}
+        structured_data = [{"source_guid": "guid-1", "content": {"current": {"result": "ok"}}}]
+
+        result = transformer.transform_with_passthrough(
+            data=structured_data,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("current"),
+            action_name="current",
+            existing_content=existing,
+        )
+
+        content = result[0]["content"]
+        assert content["upstream"] == {"val": 1}
+        assert content["current"] == {"result": "ok"}
+
+    def test_multiple_output_records_all_get_merge(self):
+        """When LLM produces multiple output records, all get upstream namespaces."""
+        transformer = PassthroughTransformer()
+        existing = {"extract": {"text": "hello"}}
+        llm_output = [
+            {"variant": "A"},
+            {"variant": "B"},
+        ]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("generate"),
+            action_name="generate",
+            existing_content=existing,
+        )
+
+        assert len(result) == 2
+        for item in result:
+            assert item["content"]["extract"] == {"text": "hello"}
+            assert "generate" in item["content"]


### PR DESCRIPTION
## Summary
- Record mode LLM actions now carry forward existing upstream namespaces from the input record into output, matching FILE mode behavior
- Threads `existing_content` from `RecordProcessor.process()` through `transform_with_passthrough` to `PassthroughTransformer`, which merges `{**existing, **new}` after strategy runs
- Fixes downstream observe refs to earlier actions failing with "not found at runtime" in multi-action workflows

## Verification
- 7 new tests covering: basic carry-forward, no existing content, empty content, 3 upstream actions, namespace conflict resolution, structured data path, multiple output records
- `ruff format --check` and `ruff check` pass
- `pytest` passes (5861 passed, 2 skipped)