### PR TITLE
arch: add RecordEnvelope module — single authority for record content assembly

### DIFF
--- a/.changes/unreleased/Under the Hood-20260424-100100.yaml
+++ b/.changes/unreleased/Under the Hood-20260424-100100.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Add RecordEnvelope module — single authority for record content assembly"
+time: 2026-04-24T10:01:00.000000Z

--- a/agent_actions/_MANIFEST.md
+++ b/agent_actions/_MANIFEST.md
@@ -15,6 +15,7 @@
 | [output](output/_MANIFEST.md) | Output serialization, schema loading, and response helpers. |
 | [processing](processing/_MANIFEST.md) | Shared processing helpers (enrichment, error handling, recovery). |
 | [prompt](prompt/_MANIFEST.md) | Prompt rendering, context building, and formatting helpers. |
+| [record](record/_MANIFEST.md) | Single authority for record content assembly. |
 | [skills](skills/_MANIFEST.md) | Reusable skills and templates for agent workflows. |
 | [storage](storage/_MANIFEST.md) | Extensible storage backend module for workflow data persistence. |
 | [tooling](tooling/_MANIFEST.md) | Documentation generation and IDE tooling (docs site + LSP). |

--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -1,0 +1,41 @@
+# Record
+
+Single authority for record content assembly. Every action type, granularity, and strategy converges here.
+
+## Modules
+
+| Name | Type | Exports | Signals |
+|------|------|---------|---------|
+| `envelope.py` | Module | `RecordEnvelope`, `RecordEnvelopeError` | - |
+| `__init__.py` | Re-export | `RecordEnvelope`, `RecordEnvelopeError` | - |
+
+## Project Surface
+
+| Symbol | File | Interaction | Config Key |
+|--------|------|-------------|------------|
+| `RecordEnvelope.build()` | `agent_io/target/{action}/` | Writes record with action output under namespace | - |
+| `RecordEnvelope.build_content()` | `agent_io/target/{action}/` | Writes content dict (no record wrapper) | - |
+| `RecordEnvelope.build_skipped()` | `agent_io/target/{action}/` | Writes record with null namespace for guard skip | - |
+| `RecordEnvelope.build_version_merge()` | `agent_io/target/{action}/` | Writes record merging version namespaces | `version_consumption` |
+
+## Dependencies
+
+| Direction | Module | Why |
+|-----------|--------|-----|
+| **Depended on by** | `utils/content.py` | `wrap_content()` delegates to `build_content()` |
+| **Depended on by** | `utils/transformation/passthrough.py` | (Phase 2) record assembly after strategy |
+| **Depended on by** | `workflow/pipeline_file_mode.py` | (Phase 2) FILE mode tool + HITL assembly |
+| **Depended on by** | `processing/record_processor.py` | (Phase 2) tombstone builder |
+| **Depended on by** | `processing/exhausted_builder.py` | (Phase 2) exhausted record builder |
+| **Depended on by** | `llm/batch/processing/result_processor.py` | (Phase 2) batch result assembly |
+| **Depended on by** | `workflow/managers/loop.py` | (Phase 2) version correlator |
+
+## Notes
+
+RecordEnvelope is a stateless utility -- all methods are `@staticmethod` and return plain dicts. There is no `RecordEnvelope` instance.
+
+The module does NOT own:
+- Framework metadata (`_unprocessed`, `metadata`, `_recovery`) -- callers add these after assembly
+- Enrichment (lineage, node_id, target_id) -- `EnrichmentPipeline` handles post-assembly
+- Initial source structuring -- `initial_pipeline.py` creates the first `source` namespace
+- Observe/passthrough resolution -- `scope_application.py` reads FROM content

--- a/agent_actions/record/__init__.py
+++ b/agent_actions/record/__init__.py
@@ -1,0 +1,5 @@
+"""Unified record envelope -- single authority for record content assembly."""
+
+from agent_actions.record.envelope import RecordEnvelope, RecordEnvelopeError
+
+__all__ = ["RecordEnvelope", "RecordEnvelopeError"]

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -12,10 +12,7 @@ class RecordEnvelopeError(Exception):
 
 
 class RecordEnvelope:
-    """Builds record content dicts. The ONLY place this happens.
-
-    Every action type, every granularity, every strategy calls this.
-    """
+    """Single authority for record content assembly."""
 
     @staticmethod
     def build(
@@ -23,30 +20,13 @@ class RecordEnvelope:
         action_output: dict[str, Any],
         input_record: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Build a complete record with action output under its namespace.
+        """Build a record wrapping *action_output* under *action_name*.
 
-        This is the primary entry point. Every code path that produces
-        a record with action output calls this.
-
-        When input_record is None (first action in pipeline, or test setup),
-        returns ``{"content": {action_name: action_output}}`` with no
-        source_guid.
-
-        When input_record is provided, returns::
-
-            {
-                "source_guid": <from input_record>,
-                "content": {
-                    <...all upstream namespaces from input_record...>,
-                    <action_name>: <action_output>
-                }
-            }
-
-        If action_name already exists in content (retry/reprocessing),
-        the new output overwrites the previous. This is intentional.
+        Preserves upstream namespaces from *input_record* and carries
+        ``source_guid``.  Collision on *action_name* overwrites.
         """
         if not action_name:
-            raise RecordEnvelopeError("action_name is required -- cannot build record without it")
+            raise RecordEnvelopeError("action_name is required")
         if not isinstance(action_output, dict):
             raise RecordEnvelopeError(
                 f"action_output must be a dict, got {type(action_output).__name__} "
@@ -55,9 +35,7 @@ class RecordEnvelope:
 
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, action_name: action_output}}
-        if input_record and "source_guid" in input_record:
-            result["source_guid"] = input_record["source_guid"]
-        return result
+        return _carry_source_guid(result, input_record)
 
     @staticmethod
     def build_content(
@@ -65,12 +43,9 @@ class RecordEnvelope:
         action_output: dict[str, Any],
         existing_content: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Build just the content dict (no source_guid, no record wrapper).
+        """Return a content dict with *action_output* under *action_name*.
 
-        For callers that already extracted existing_content from the record
-        and operate at the content-dict level.
-
-        Returns: ``{**existing_content, action_name: action_output}``
+        No record wrapper or ``source_guid`` -- content level only.
         """
         if not action_name:
             raise RecordEnvelopeError("action_name is required")
@@ -83,40 +58,36 @@ class RecordEnvelope:
         action_name: str,
         input_record: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Build a record for a guard-skipped action.
+        """Build a record with a null namespace for a guard-skipped action.
 
-        Null-valued namespace: ``content[action_name] = None``.
-        All upstream namespaces preserved.
-
-        Does NOT set ``_unprocessed`` or ``metadata`` -- those are framework
-        concerns. Callers that need tombstone behavior add those fields
-        after this call.
+        Does NOT set ``_unprocessed`` or ``metadata`` -- callers add those.
         """
         if not action_name:
             raise RecordEnvelopeError("action_name is required")
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, action_name: None}}
-        if input_record and "source_guid" in input_record:
-            result["source_guid"] = input_record["source_guid"]
-        return result
+        return _carry_source_guid(result, input_record)
 
     @staticmethod
     def build_version_merge(
         version_contents: dict[str, dict[str, Any]],
         input_record: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Build a record for version fan-in merge.
-
-        Each key in version_contents becomes a namespace, each value
-        becomes that namespace's output.
-        """
+        """Build a record merging multiple version namespaces."""
         if not version_contents:
             raise RecordEnvelopeError("version_contents is empty -- nothing to merge")
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, **version_contents}}
-        if input_record and "source_guid" in input_record:
-            result["source_guid"] = input_record["source_guid"]
-        return result
+        return _carry_source_guid(result, input_record)
+
+
+def _carry_source_guid(
+    result: dict[str, Any], input_record: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Copy source_guid from input_record to result if present."""
+    if input_record and "source_guid" in input_record:
+        result["source_guid"] = input_record["source_guid"]
+    return result
 
 
 def _extract_existing(input_record: dict[str, Any] | None) -> dict[str, Any]:

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -1,0 +1,133 @@
+"""Unified record envelope -- single authority for record content assembly."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RecordEnvelopeError(Exception):
+    """Raised when a record envelope contract is violated."""
+
+    pass
+
+
+class RecordEnvelope:
+    """Builds record content dicts. The ONLY place this happens.
+
+    Every action type, every granularity, every strategy calls this.
+    """
+
+    @staticmethod
+    def build(
+        action_name: str,
+        action_output: dict[str, Any],
+        input_record: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build a complete record with action output under its namespace.
+
+        This is the primary entry point. Every code path that produces
+        a record with action output calls this.
+
+        When input_record is None (first action in pipeline, or test setup),
+        returns ``{"content": {action_name: action_output}}`` with no
+        source_guid.
+
+        When input_record is provided, returns::
+
+            {
+                "source_guid": <from input_record>,
+                "content": {
+                    <...all upstream namespaces from input_record...>,
+                    <action_name>: <action_output>
+                }
+            }
+
+        If action_name already exists in content (retry/reprocessing),
+        the new output overwrites the previous. This is intentional.
+        """
+        if not action_name:
+            raise RecordEnvelopeError("action_name is required -- cannot build record without it")
+        if not isinstance(action_output, dict):
+            raise RecordEnvelopeError(
+                f"action_output must be a dict, got {type(action_output).__name__} "
+                f"for action '{action_name}'"
+            )
+
+        existing = _extract_existing(input_record)
+        result: dict[str, Any] = {"content": {**existing, action_name: action_output}}
+        if input_record and "source_guid" in input_record:
+            result["source_guid"] = input_record["source_guid"]
+        return result
+
+    @staticmethod
+    def build_content(
+        action_name: str,
+        action_output: dict[str, Any],
+        existing_content: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build just the content dict (no source_guid, no record wrapper).
+
+        For callers that already extracted existing_content from the record
+        and operate at the content-dict level.
+
+        Returns: ``{**existing_content, action_name: action_output}``
+        """
+        if not action_name:
+            raise RecordEnvelopeError("action_name is required")
+        content = dict(existing_content) if existing_content else {}
+        content[action_name] = action_output
+        return content
+
+    @staticmethod
+    def build_skipped(
+        action_name: str,
+        input_record: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build a record for a guard-skipped action.
+
+        Null-valued namespace: ``content[action_name] = None``.
+        All upstream namespaces preserved.
+
+        Does NOT set ``_unprocessed`` or ``metadata`` -- those are framework
+        concerns. Callers that need tombstone behavior add those fields
+        after this call.
+        """
+        if not action_name:
+            raise RecordEnvelopeError("action_name is required")
+        existing = _extract_existing(input_record)
+        result: dict[str, Any] = {"content": {**existing, action_name: None}}
+        if input_record and "source_guid" in input_record:
+            result["source_guid"] = input_record["source_guid"]
+        return result
+
+    @staticmethod
+    def build_version_merge(
+        version_contents: dict[str, dict[str, Any]],
+        input_record: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build a record for version fan-in merge.
+
+        Each key in version_contents becomes a namespace, each value
+        becomes that namespace's output.
+        """
+        if not version_contents:
+            raise RecordEnvelopeError("version_contents is empty -- nothing to merge")
+        existing = _extract_existing(input_record)
+        result: dict[str, Any] = {"content": {**existing, **version_contents}}
+        if input_record and "source_guid" in input_record:
+            result["source_guid"] = input_record["source_guid"]
+        return result
+
+
+def _extract_existing(input_record: dict[str, Any] | None) -> dict[str, Any]:
+    """Extract the existing content dict from an input record."""
+    if input_record is None:
+        return {}
+    content = input_record.get("content")
+    if content is None:
+        return {}
+    if not isinstance(content, dict):
+        raise RecordEnvelopeError(
+            f"input_record['content'] must be a dict, got {type(content).__name__}"
+        )
+    return content

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -79,8 +79,7 @@ class RecordEnvelope:
         for key, value in version_contents.items():
             if not isinstance(value, dict):
                 raise RecordEnvelopeError(
-                    f"version_contents['{key}'] must be a dict, "
-                    f"got {type(value).__name__}"
+                    f"version_contents['{key}'] must be a dict, got {type(value).__name__}"
                 )
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, **version_contents}}

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -76,6 +76,12 @@ class RecordEnvelope:
         """Build a record merging multiple version namespaces."""
         if not version_contents:
             raise RecordEnvelopeError("version_contents is empty -- nothing to merge")
+        for key, value in version_contents.items():
+            if not isinstance(value, dict):
+                raise RecordEnvelopeError(
+                    f"version_contents['{key}'] must be a dict, "
+                    f"got {type(value).__name__}"
+                )
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, **version_contents}}
         return _carry_source_guid(result, input_record)

--- a/agent_actions/utils/content.py
+++ b/agent_actions/utils/content.py
@@ -32,11 +32,12 @@ def wrap_content(
 ) -> dict[str, Any]:
     """Add *action_output* under *action_name*, preserving existing namespaces.
 
-    Returns a new dict — does not mutate *existing_content*.
+    Alias for ``RecordEnvelope.build_content()``.  Prefer
+    ``RecordEnvelope`` directly for new code.
     """
-    content = dict(existing_content) if existing_content else {}
-    content[action_name] = action_output
-    return content
+    from agent_actions.record.envelope import RecordEnvelope
+
+    return RecordEnvelope.build_content(action_name, action_output, existing_content)
 
 
 def read_namespace(

--- a/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
+++ b/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
@@ -1,9 +1,8 @@
-"""Regression tests for bugfixes introduced in PR #1108.
+"""Batch processing and LLM provider edge cases.
 
-Covers three fixes:
-1. _create_exhausted_item() — missing action_name argument
-2. _submit_to_provider() — ExternalServiceError constructor fix
-3. Cohere/Mistral token extraction — nullable token values default to 0
+1. _create_exhausted_item() — action_name validation
+2. _submit_to_provider() — ExternalServiceError wrapping
+3. Cohere/Mistral token extraction — nullable token values
 """
 
 from unittest.mock import MagicMock, patch

--- a/tests/unit/llm_invocation/test_pr1108_bugfix_regressions.py
+++ b/tests/unit/llm_invocation/test_pr1108_bugfix_regressions.py
@@ -56,12 +56,13 @@ class TestCreateExhaustedItemActionName:
         assert item["metadata"]["retry_exhausted"] is True
         assert item["_unprocessed"] is True
 
-    def test_action_name_defaults_to_empty_when_missing(self):
-        """When agent_config has no action_name, defaults to empty string (no crash)."""
+    def test_action_name_missing_raises(self):
+        """When agent_config has no action_name, RecordEnvelopeError is raised (empty names are banned)."""
         from agent_actions.llm.batch.processing.result_processor import (
             BatchProcessingContext,
             BatchResultProcessor,
         )
+        from agent_actions.record.envelope import RecordEnvelopeError
 
         ctx = BatchProcessingContext(
             batch_results=[],
@@ -77,17 +78,16 @@ class TestCreateExhaustedItemActionName:
         )
         processor = BatchResultProcessor()
 
-        item = processor._create_exhausted_item(ctx, "custom-2", {"text": "world"}, recovery)
+        with pytest.raises(RecordEnvelopeError, match="action_name is required"):
+            processor._create_exhausted_item(ctx, "custom-2", {"text": "world"}, recovery)
 
-        assert item["source_guid"] == "sg-456"
-        assert "_recovery" in item
-
-    def test_action_name_defaults_when_agent_config_is_none(self):
-        """When agent_config is None, action_name defaults to '' (no crash)."""
+    def test_action_name_missing_when_agent_config_is_none_raises(self):
+        """When agent_config is None, RecordEnvelopeError is raised (empty names are banned)."""
         from agent_actions.llm.batch.processing.result_processor import (
             BatchProcessingContext,
             BatchResultProcessor,
         )
+        from agent_actions.record.envelope import RecordEnvelopeError
 
         ctx = BatchProcessingContext(
             batch_results=[],
@@ -103,10 +103,8 @@ class TestCreateExhaustedItemActionName:
         )
         processor = BatchResultProcessor()
 
-        # agent_config is None — the or {} fallback and ternary must handle it
-        item = processor._create_exhausted_item(ctx, "custom-3", {"text": "data"}, recovery)
-
-        assert item["source_guid"] == "sg-789"
+        with pytest.raises(RecordEnvelopeError, match="action_name is required"):
+            processor._create_exhausted_item(ctx, "custom-3", {"text": "data"}, recovery)
 
 
 # =============================================================================

--- a/tests/unit/record/test_envelope.py
+++ b/tests/unit/record/test_envelope.py
@@ -159,6 +159,10 @@ class TestBuildVersionMerge:
         with pytest.raises(RecordEnvelopeError, match="empty"):
             RecordEnvelope.build_version_merge({})
 
+    def test_non_dict_version_value_raises(self):
+        with pytest.raises(RecordEnvelopeError, match="must be a dict"):
+            RecordEnvelope.build_version_merge({"v1": "not a dict"})
+
 
 # ── Cross-method interaction ─────────────────────────────────────────────────
 

--- a/tests/unit/record/test_envelope.py
+++ b/tests/unit/record/test_envelope.py
@@ -1,0 +1,197 @@
+"""Unit tests for RecordEnvelope — the single authority for record content assembly."""
+
+import pytest
+
+from agent_actions.record.envelope import RecordEnvelope, RecordEnvelopeError
+
+# ── build() ──────────────────────────────────────────────────────────────────
+
+
+class TestBuild:
+    def test_wraps_under_namespace(self):
+        result = RecordEnvelope.build("action_a", {"x": 1})
+        assert result["content"] == {"action_a": {"x": 1}}
+
+    def test_preserves_all_upstream(self):
+        inp = {
+            "source_guid": "g1",
+            "content": {"source": {"y": 2}, "summarize": {"z": 3}},
+        }
+        result = RecordEnvelope.build("review", {"score": 8}, inp)
+        assert result["content"]["source"] == {"y": 2}
+        assert result["content"]["summarize"] == {"z": 3}
+        assert result["content"]["review"] == {"score": 8}
+
+    def test_never_flat_merges(self):
+        result = RecordEnvelope.build("action_a", {"x": 1, "y": 2})
+        assert "x" not in result["content"]
+        assert "y" not in result["content"]
+        assert result["content"]["action_a"] == {"x": 1, "y": 2}
+
+    def test_carries_source_guid(self):
+        inp = {"source_guid": "guid-42", "content": {}}
+        result = RecordEnvelope.build("act", {"v": 1}, inp)
+        assert result["source_guid"] == "guid-42"
+
+    def test_no_input_record(self):
+        result = RecordEnvelope.build("first", {"a": 1})
+        assert result == {"content": {"first": {"a": 1}}}
+        assert "source_guid" not in result
+
+    def test_empty_action_name_raises(self):
+        with pytest.raises(RecordEnvelopeError, match="action_name is required"):
+            RecordEnvelope.build("", {"x": 1})
+
+    def test_non_dict_output_raises(self):
+        with pytest.raises(RecordEnvelopeError, match="must be a dict"):
+            RecordEnvelope.build("action", "not a dict")
+
+    def test_action_name_collision_overwrites(self):
+        inp = {"content": {"source": {}, "action_a": {"old": True}}}
+        result = RecordEnvelope.build("action_a", {"new": True}, inp)
+        assert result["content"]["action_a"] == {"new": True}
+        assert "old" not in result["content"]["action_a"]
+
+    def test_does_not_mutate_input_record(self):
+        inp = {"source_guid": "g1", "content": {"source": {"x": 1}}}
+        original_content = dict(inp["content"])
+        RecordEnvelope.build("action_a", {"y": 2}, inp)
+        assert inp["content"] == original_content
+
+    def test_input_record_with_non_dict_content_raises(self):
+        inp = {"content": "not a dict"}
+        with pytest.raises(RecordEnvelopeError, match="must be a dict"):
+            RecordEnvelope.build("action", {"x": 1}, inp)
+
+    def test_input_record_with_no_content_key(self):
+        inp = {"source_guid": "g1"}
+        result = RecordEnvelope.build("action", {"x": 1}, inp)
+        assert result["content"] == {"action": {"x": 1}}
+        assert result["source_guid"] == "g1"
+
+
+# ── build_content() ─────────────────────────────────────────────────────────
+
+
+class TestBuildContent:
+    def test_wraps_under_namespace(self):
+        result = RecordEnvelope.build_content("action_a", {"x": 1})
+        assert result == {"action_a": {"x": 1}}
+
+    def test_preserves_existing(self):
+        existing = {"source": {"y": 2}, "summarize": {"z": 3}}
+        result = RecordEnvelope.build_content("review", {"score": 8}, existing)
+        assert result["source"] == {"y": 2}
+        assert result["summarize"] == {"z": 3}
+        assert result["review"] == {"score": 8}
+
+    def test_does_not_mutate_existing(self):
+        existing = {"source": {"x": 1}}
+        RecordEnvelope.build_content("action_a", {"y": 2}, existing)
+        assert "action_a" not in existing
+
+    def test_empty_action_name_raises(self):
+        with pytest.raises(RecordEnvelopeError, match="action_name is required"):
+            RecordEnvelope.build_content("", {"x": 1})
+
+
+# ── build_skipped() ─────────────────────────────────────────────────────────
+
+
+class TestBuildSkipped:
+    def test_null_namespace(self):
+        result = RecordEnvelope.build_skipped("review")
+        assert result["content"]["review"] is None
+
+    def test_preserves_upstream(self):
+        inp = {
+            "source_guid": "g1",
+            "content": {"source": {"x": 1}, "summarize": {"y": 2}},
+        }
+        result = RecordEnvelope.build_skipped("review", inp)
+        assert result["content"]["source"] == {"x": 1}
+        assert result["content"]["summarize"] == {"y": 2}
+        assert result["content"]["review"] is None
+        assert result["source_guid"] == "g1"
+
+    def test_does_not_set_unprocessed(self):
+        result = RecordEnvelope.build_skipped("action")
+        assert "_unprocessed" not in result
+
+    def test_does_not_set_metadata(self):
+        result = RecordEnvelope.build_skipped("action")
+        assert "metadata" not in result
+
+    def test_empty_action_name_raises(self):
+        with pytest.raises(RecordEnvelopeError, match="action_name is required"):
+            RecordEnvelope.build_skipped("")
+
+
+# ── build_version_merge() ───────────────────────────────────────────────────
+
+
+class TestBuildVersionMerge:
+    def test_all_versions_present(self):
+        versions = {
+            "score_1": {"s": 8},
+            "score_2": {"s": 9},
+            "score_3": {"s": 7},
+        }
+        result = RecordEnvelope.build_version_merge(versions)
+        assert result["content"]["score_1"] == {"s": 8}
+        assert result["content"]["score_2"] == {"s": 9}
+        assert result["content"]["score_3"] == {"s": 7}
+
+    def test_preserves_upstream(self):
+        inp = {
+            "source_guid": "g1",
+            "content": {"source": {"x": 1}, "summarize": {"y": 2}},
+        }
+        versions = {"action_1": {"q": "Q1"}, "action_2": {"q": "Q2"}}
+        result = RecordEnvelope.build_version_merge(versions, inp)
+        assert result["content"]["source"] == {"x": 1}
+        assert result["content"]["summarize"] == {"y": 2}
+        assert result["content"]["action_1"] == {"q": "Q1"}
+        assert result["content"]["action_2"] == {"q": "Q2"}
+        assert result["source_guid"] == "g1"
+
+    def test_empty_raises(self):
+        with pytest.raises(RecordEnvelopeError, match="empty"):
+            RecordEnvelope.build_version_merge({})
+
+
+# ── Cross-method interaction ─────────────────────────────────────────────────
+
+
+class TestInteractions:
+    def test_build_then_build_skipped_chain(self):
+        """Simulate: action_a produces output, action_b is guard-skipped."""
+        r1 = RecordEnvelope.build("action_a", {"x": 1})
+        r2 = RecordEnvelope.build_skipped("action_b", r1)
+        assert r2["content"]["action_a"] == {"x": 1}
+        assert r2["content"]["action_b"] is None
+
+    def test_build_chain_three_actions(self):
+        """Simulate: three sequential actions building on each other."""
+        r1 = RecordEnvelope.build("source", {"raw": "data"})
+        r2 = RecordEnvelope.build("summarize", {"summary": "short"}, r1)
+        r3 = RecordEnvelope.build("review", {"score": 9}, r2)
+        assert set(r3["content"].keys()) == {"source", "summarize", "review"}
+        assert r3["content"]["source"] == {"raw": "data"}
+        assert r3["content"]["summarize"] == {"summary": "short"}
+        assert r3["content"]["review"] == {"score": 9}
+
+    def test_version_merge_preserves_upstream_from_build(self):
+        """The critical test from the spec: version merge must preserve
+        upstream namespaces from the base record."""
+        base = RecordEnvelope.build("summarize", {"text": "sum"})
+        base["source_guid"] = "g1"
+        base["content"]["source"] = {"raw": "data"}
+
+        versions = {"extract_1": {"q": "Q1"}, "extract_2": {"q": "Q2"}}
+        result = RecordEnvelope.build_version_merge(versions, base)
+
+        assert "source" in result["content"]
+        assert "summarize" in result["content"]
+        assert "extract_1" in result["content"]
+        assert "extract_2" in result["content"]


### PR DESCRIPTION
## Summary
- Add `agent_actions/record/envelope.py` — `RecordEnvelope` with 4 static methods (`build`, `build_content`, `build_skipped`, `build_version_merge`) that enforce the additive content model structurally
- `wrap_content()` in `utils/content.py` now delegates to `RecordEnvelope.build_content()`
- Empty `action_name` is now a contract violation (`RecordEnvelopeError`), not a silent fallback
- 26 unit tests covering all methods, validation, immutability, chaining, and version merge
- Phase 1 of the unified record envelope architecture — no existing callers change except `wrap_content` (alias) and 2 tests that asserted silent-fallback behavior

## Verification
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- `pytest tests/unit/record/test_envelope.py` — 26 passed
- `pytest` (full suite) — 5880 passed, 0 failed
- External clone1 test — 30 passed, 0 failed