### PR TITLE
arch: strategies return flat output, RecordEnvelope handles wrapping

### DIFF
--- a/.changes/unreleased/Under the Hood-20260424-102000.yaml
+++ b/.changes/unreleased/Under the Hood-20260424-102000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Strategies return flat output — RecordEnvelope handles namespace wrapping in PassthroughTransformer"
+time: 2026-04-24T10:20:00.000000Z

--- a/agent_actions/utils/transformation/_MANIFEST.md
+++ b/agent_actions/utils/transformation/_MANIFEST.md
@@ -15,5 +15,5 @@ into generated data and ensure outputs remain structured.
 
 | Name | Type | Description | Signals |
 |------|------|-------------|---------|
-| `passthrough.py` | Module | `PassthroughTransformer` orchestrates context_scope.passthrough + structured vs unstructured data using the strategy list. | `field_management`, `preprocessing` |
-| `PassthroughTransformer` | Class | Applies the first matching strategy, normalizes data to lists, and ensures each item has required IDs/metadata. | `field_management`, `lineage` |
+| `passthrough.py` | Module | `PassthroughTransformer` orchestrates context_scope.passthrough + structured vs unstructured data using the strategy list. Wraps strategy output via `RecordEnvelope.build()`. | `field_management`, `record.envelope` |
+| `PassthroughTransformer` | Class | Applies the first matching strategy (which returns flat action output dicts), wraps each via `RecordEnvelope.build()` to namespace and preserve upstream, and ensures each item has required IDs/metadata. | `field_management`, `record.envelope` |

--- a/agent_actions/utils/transformation/passthrough.py
+++ b/agent_actions/utils/transformation/passthrough.py
@@ -11,6 +11,7 @@ from .strategies import (
     PrecomputedStructuredStrategy,
     PrecomputedUnstructuredStrategy,
 )
+from .strategies.base import ensure_dict_output
 
 
 class PassthroughTransformer:
@@ -89,12 +90,10 @@ class PassthroughTransformer:
         # Build records via RecordEnvelope — wraps under namespace,
         # preserves upstream content.
         input_record = {"source_guid": source_guid, "content": existing_content or {}}
-        output = []
-        for fields in action_outputs:
-            if not isinstance(fields, dict):
-                fields = {"value": fields}
-            record = RecordEnvelope.build(action_name, fields, input_record)
-            output.append(record)
+        output = [
+            RecordEnvelope.build(action_name, ensure_dict_output(fields), input_record)
+            for fields in action_outputs
+        ]
 
         return [
             self.field_manager.ensure_required_fields(

--- a/agent_actions/utils/transformation/passthrough.py
+++ b/agent_actions/utils/transformation/passthrough.py
@@ -1,5 +1,6 @@
 """Orchestrator for passthrough transformations using the Strategy Pattern."""
 
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.utils.field_management import FieldManager
 
 from .strategies import (
@@ -13,7 +14,13 @@ from .strategies import (
 
 
 class PassthroughTransformer:
-    """Orchestrates passthrough transformations using strategy pattern dispatch."""
+    """Orchestrates passthrough transformations using strategy pattern dispatch.
+
+    Strategies return flat action output dicts.  This class assembles
+    the final records via ``RecordEnvelope.build()``, guaranteeing
+    every output wraps under the action namespace and preserves
+    upstream namespaces.
+    """
 
     def __init__(self, field_manager: FieldManager | None = None):
         """Initialize with an optional FieldManager (defaults to a new instance)."""
@@ -38,21 +45,27 @@ class PassthroughTransformer:
         action_name: str = "unknown_action",
         passthrough_fields: dict | None = None,
         metadata: dict | None = None,
+        existing_content: dict | None = None,
     ) -> list:
         """Apply context_scope.passthrough logic to generated data.
 
-        Merges passthrough fields into output items using the appropriate
-        strategy, then ensures all items have required fields.
+        Strategies produce flat action output dicts (just the fields
+        belonging to this action's namespace).  This method wraps each
+        via ``RecordEnvelope.build()`` so the output always has the
+        correct ``{content: {**upstream, action_name: output}}`` shape.
 
         Args:
             data: Generated data list.
             context_data: Context data dictionary containing fields.
             source_guid: Source GUID.
             agent_config: Agent configuration containing context_scope.
-            action_name: Action name for node_id generation.
+            action_name: Action name for namespace wrapping and node_id.
             passthrough_fields: Optional pre-computed passthrough fields
                 from field_context (enables passthrough from any ancestor).
             metadata: Optional LLM response metadata to add to output items.
+            existing_content: Upstream namespaces to preserve in the output.
+                When provided, every output record will carry these namespaces
+                alongside the current action's namespace.
 
         Returns:
             Transformed data list with passthrough fields merged.
@@ -62,16 +75,26 @@ class PassthroughTransformer:
 
         already_structured = self._is_already_structured(data)
 
-        output = None
+        action_outputs = None
         for strategy in self.strategies:
             if strategy.can_handle(data, passthrough_fields, agent_config, already_structured):
-                output = strategy.transform(
+                action_outputs = strategy.transform(
                     data, context_data, source_guid, agent_config, passthrough_fields
                 )
                 break
 
-        if output is None:
-            output = []
+        if action_outputs is None:
+            action_outputs = []
+
+        # Build records via RecordEnvelope — wraps under namespace,
+        # preserves upstream content.
+        input_record = {"source_guid": source_guid, "content": existing_content or {}}
+        output = []
+        for fields in action_outputs:
+            if not isinstance(fields, dict):
+                fields = {"value": fields}
+            record = RecordEnvelope.build(action_name, fields, input_record)
+            output.append(record)
 
         return [
             self.field_manager.ensure_required_fields(

--- a/agent_actions/utils/transformation/strategies/_MANIFEST.md
+++ b/agent_actions/utils/transformation/strategies/_MANIFEST.md
@@ -5,11 +5,15 @@
 Strategy implementations that the passthrough transformer evaluates in priority
 order (precomputed fields, context_scope helpers, default no-op, etc.).
 
+All strategies return flat action output dicts (just the fields belonging to the
+action's namespace).  `PassthroughTransformer` handles namespace wrapping and
+upstream preservation via `RecordEnvelope.build()`.
+
 ## Modules
 
 | Name | Type | Description | Signals |
 |------|------|-------------|---------|
 | `base.py` | Module | `IPassthroughTransformStrategy` interface that defines `can_handle`/`transform`. | `typing`, `abc` |
 | `IPassthroughTransformStrategy` | Interface | Strategy contract for deciding applicability and performing transformations. | `typing` |
-| `context_scope.py` | Module | `ContextScopeStructuredStrategy`, `ContextScopeUnstructuredStrategy`, `NoOpStrategy`, `DefaultStructureStrategy` for context_scope-based passthrough. | `preprocessing`, `prompt.context`, `field_management` |
-| `precomputed.py` | Module | `PrecomputedStructuredStrategy` and `PrecomputedUnstructuredStrategy` that merge precomputed passthrough fields before structuring data. | `field_management`, `preprocessing` |
+| `context_scope.py` | Module | `ContextScopeStructuredStrategy`, `ContextScopeUnstructuredStrategy`, `NoOpStrategy`, `DefaultStructureStrategy` — return flat action output dicts. | `preprocessing`, `prompt.context` |
+| `precomputed.py` | Module | `PrecomputedStructuredStrategy` and `PrecomputedUnstructuredStrategy` — merge precomputed passthrough fields, return flat action output dicts. | — |

--- a/agent_actions/utils/transformation/strategies/__init__.py
+++ b/agent_actions/utils/transformation/strategies/__init__.py
@@ -1,6 +1,6 @@
 """Passthrough transformation strategies."""
 
-from .base import IPassthroughTransformStrategy
+from .base import IPassthroughTransformStrategy, ensure_dict_output
 from .context_scope import (
     ContextScopeStructuredStrategy,
     ContextScopeUnstructuredStrategy,
@@ -10,6 +10,7 @@ from .context_scope import (
 from .precomputed import PrecomputedStructuredStrategy, PrecomputedUnstructuredStrategy
 
 __all__ = [
+    "ensure_dict_output",
     "IPassthroughTransformStrategy",
     "PrecomputedStructuredStrategy",
     "PrecomputedUnstructuredStrategy",

--- a/agent_actions/utils/transformation/strategies/base.py
+++ b/agent_actions/utils/transformation/strategies/base.py
@@ -1,10 +1,26 @@
 """Interface for passthrough transformation strategies."""
 
 from abc import ABC, abstractmethod
+from typing import Any
+
+
+def ensure_dict_output(item: Any) -> dict:
+    """Normalize a strategy output item to a dict.
+
+    Non-dict values are wrapped as ``{"value": item}`` so that
+    ``RecordEnvelope.build()`` always receives a dict.
+    """
+    return item if isinstance(item, dict) else {"value": item}
 
 
 class IPassthroughTransformStrategy(ABC):
-    """Interface for passthrough transformation strategies."""
+    """Interface for passthrough transformation strategies.
+
+    All strategies return ``list[dict]`` — flat action output dicts
+    containing only the fields belonging to the action's namespace.
+    ``PassthroughTransformer`` handles namespace wrapping and upstream
+    preservation via ``RecordEnvelope.build()``.
+    """
 
     @abstractmethod
     def can_handle(
@@ -25,4 +41,4 @@ class IPassthroughTransformStrategy(ABC):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Execute the transformation and return the transformed data list."""
+        """Execute the transformation and return flat action output dicts."""

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -31,7 +31,10 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Extract and merge context_scope passthrough fields."""
+        """Extract and merge context_scope passthrough fields.
+
+        Returns flat action output dicts — RecordEnvelope handles wrapping.
+        """
         fields_to_merge = self.extract_context_scope_fields(agent_config)
 
         context_for_passthrough = context_data
@@ -58,8 +61,7 @@ class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
                         context_for_passthrough, content_dict, fields_to_merge
                     )
                 )
-        action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
+        return updated
 
     @staticmethod
     def has_passthrough_config(agent_config: dict) -> bool:
@@ -107,7 +109,10 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Extract and merge context_scope passthrough fields."""
+        """Extract and merge context_scope passthrough fields.
+
+        Returns flat action output dicts — RecordEnvelope handles wrapping.
+        """
         fields_to_merge = ContextScopeStructuredStrategy.extract_context_scope_fields(agent_config)
 
         context_for_passthrough = context_data
@@ -133,12 +138,11 @@ class ContextScopeUnstructuredStrategy(IPassthroughTransformStrategy):
                         context_for_passthrough, item_dict, fields_to_merge
                     )
                 )
-        action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: updated}], action_name)
+        return updated
 
 
 class NoOpStrategy(IPassthroughTransformStrategy):
-    """No-op strategy: returns structured data as-is when no passthrough is needed."""
+    """No-op strategy: extracts content from structured data when no passthrough is needed."""
 
     def can_handle(
         self,
@@ -163,13 +167,27 @@ class NoOpStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Wrap content under action namespace (no passthrough merging needed)."""
-        action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: data}], action_name)
+        """Extract content from structured items, return flat action output.
+
+        Returns flat action output dicts — RecordEnvelope handles wrapping.
+        """
+        results = []
+        for item in data:
+            if isinstance(item, dict) and "content" in item:
+                content = item["content"]
+                if isinstance(content, dict):
+                    results.append(content)
+                else:
+                    results.append({"value": content})
+            elif isinstance(item, dict):
+                results.append(item)
+            else:
+                results.append({"value": item})
+        return results
 
 
 class DefaultStructureStrategy(IPassthroughTransformStrategy):
-    """Default strategy: structures unstructured data without passthrough merging."""
+    """Default strategy: returns unstructured data as flat action output dicts."""
 
     def can_handle(
         self,
@@ -189,6 +207,14 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Structure data without passthrough."""
-        action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: data}], action_name)
+        """Return data as flat action output dicts.
+
+        Returns flat action output dicts — RecordEnvelope handles wrapping.
+        """
+        results = []
+        for item in data:
+            if isinstance(item, dict):
+                results.append(item)
+            else:
+                results.append({"value": item})
+        return results

--- a/agent_actions/utils/transformation/strategies/context_scope.py
+++ b/agent_actions/utils/transformation/strategies/context_scope.py
@@ -2,7 +2,7 @@
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
 
-from .base import IPassthroughTransformStrategy
+from .base import IPassthroughTransformStrategy, ensure_dict_output
 
 
 class ContextScopeStructuredStrategy(IPassthroughTransformStrategy):
@@ -174,15 +174,9 @@ class NoOpStrategy(IPassthroughTransformStrategy):
         results = []
         for item in data:
             if isinstance(item, dict) and "content" in item:
-                content = item["content"]
-                if isinstance(content, dict):
-                    results.append(content)
-                else:
-                    results.append({"value": content})
-            elif isinstance(item, dict):
-                results.append(item)
+                results.append(ensure_dict_output(item["content"]))
             else:
-                results.append({"value": item})
+                results.append(ensure_dict_output(item))
         return results
 
 
@@ -211,10 +205,4 @@ class DefaultStructureStrategy(IPassthroughTransformStrategy):
 
         Returns flat action output dicts — RecordEnvelope handles wrapping.
         """
-        results = []
-        for item in data:
-            if isinstance(item, dict):
-                results.append(item)
-            else:
-                results.append({"value": item})
-        return results
+        return [ensure_dict_output(item) for item in data]

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -1,6 +1,6 @@
 """Passthrough strategies for pre-computed passthrough_fields."""
 
-from .base import IPassthroughTransformStrategy
+from .base import IPassthroughTransformStrategy, ensure_dict_output
 
 
 class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
@@ -41,7 +41,7 @@ class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
             elif isinstance(item, dict):
                 result.append({**item, **(passthrough_fields or {})})
             else:
-                result.append(item)
+                result.append(ensure_dict_output(item))
         return result
 
 
@@ -81,5 +81,5 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
                 merged_item = {**item, **(passthrough_fields or {})}
                 merged.append(merged_item)
             else:
-                merged.append(item)
+                merged.append(ensure_dict_output(item))
         return merged

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -1,7 +1,5 @@
 """Passthrough strategies for pre-computed passthrough_fields."""
 
-from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
-
 from .base import IPassthroughTransformStrategy
 
 
@@ -31,23 +29,24 @@ class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Merge passthrough fields into content, then wrap under action namespace."""
-        from agent_actions.utils.content import wrap_content
+        """Merge passthrough fields into content, return flat action output.
 
-        action_name = agent_config["agent_type"]
-
+        Returns flat action output dicts — RecordEnvelope handles wrapping.
+        """
         result = []
         for item in data:
             if isinstance(item, dict) and "content" in item and isinstance(item["content"], dict):
                 merged_content = {**item["content"], **(passthrough_fields or {})}
-                result.append({**item, "content": wrap_content(action_name, merged_content)})
+                result.append(merged_content)
+            elif isinstance(item, dict):
+                result.append({**item, **(passthrough_fields or {})})
             else:
                 result.append(item)
         return result
 
 
 class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
-    """Merge precomputed passthrough fields into unstructured data, then structure."""
+    """Merge precomputed passthrough fields into unstructured data."""
 
     def can_handle(
         self,
@@ -72,7 +71,10 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Merge passthrough fields directly into items."""
+        """Merge passthrough fields directly into items, return flat action output.
+
+        Returns flat action output dicts — RecordEnvelope handles wrapping.
+        """
         merged = []
         for item in data:
             if isinstance(item, dict):
@@ -80,5 +82,4 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
                 merged.append(merged_item)
             else:
                 merged.append(item)
-        action_name = agent_config["agent_type"]
-        return DataTransformer.transform_structure([{source_guid: merged}], action_name)
+        return merged

--- a/tests/unit/utils/test_passthrough_strategies.py
+++ b/tests/unit/utils/test_passthrough_strategies.py
@@ -1,0 +1,467 @@
+"""Tests for passthrough strategies returning flat action output dicts.
+
+After the RecordEnvelope migration, strategies return flat dicts containing
+only the action's output fields.  PassthroughTransformer calls
+RecordEnvelope.build() to wrap them under the action namespace and
+preserve upstream namespaces.
+"""
+
+from agent_actions.utils.transformation.passthrough import PassthroughTransformer
+from agent_actions.utils.transformation.strategies.context_scope import (
+    ContextScopeStructuredStrategy,
+    ContextScopeUnstructuredStrategy,
+    DefaultStructureStrategy,
+    NoOpStrategy,
+)
+from agent_actions.utils.transformation.strategies.precomputed import (
+    PrecomputedStructuredStrategy,
+    PrecomputedUnstructuredStrategy,
+)
+
+
+def _agent_config(action_name="test_action", passthrough=None):
+    config = {"agent_type": action_name}
+    if passthrough:
+        config["context_scope"] = {"passthrough": passthrough}
+    return config
+
+
+# ---------------------------------------------------------------------------
+# DefaultStructureStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultStructureStrategy:
+    """DefaultStructureStrategy returns flat action output dicts."""
+
+    def test_returns_flat_dict(self):
+        strategy = DefaultStructureStrategy()
+        result = strategy.transform([{"vote": "keep", "score": 8}], {}, "g1", _agent_config())
+        assert len(result) == 1
+        assert result[0] == {"vote": "keep", "score": 8}
+
+    def test_no_source_guid_in_output(self):
+        strategy = DefaultStructureStrategy()
+        result = strategy.transform([{"x": 1}], {}, "g1", _agent_config())
+        assert "source_guid" not in result[0]
+        assert "content" not in result[0]
+
+    def test_non_dict_wrapped_in_value(self):
+        strategy = DefaultStructureStrategy()
+        result = strategy.transform(["plain text"], {}, "g1", _agent_config())
+        assert result[0] == {"value": "plain text"}
+
+    def test_multiple_items(self):
+        strategy = DefaultStructureStrategy()
+        result = strategy.transform([{"a": 1}, {"b": 2}], {}, "g1", _agent_config())
+        assert len(result) == 2
+        assert result[0] == {"a": 1}
+        assert result[1] == {"b": 2}
+
+    def test_can_handle_always_true(self):
+        strategy = DefaultStructureStrategy()
+        assert strategy.can_handle([], None, _agent_config(), False) is True
+        assert strategy.can_handle([], None, _agent_config(), True) is True
+
+
+# ---------------------------------------------------------------------------
+# NoOpStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpStrategy:
+    """NoOpStrategy extracts content from structured items, returns flat."""
+
+    def test_extracts_content_from_structured(self):
+        strategy = NoOpStrategy()
+        structured = [{"source_guid": "g1", "content": {"vote": "keep", "score": 9}}]
+        result = strategy.transform(structured, {}, "g1", _agent_config())
+        assert len(result) == 1
+        assert result[0] == {"vote": "keep", "score": 9}
+
+    def test_no_source_guid_in_output(self):
+        strategy = NoOpStrategy()
+        structured = [{"source_guid": "g1", "content": {"x": 1}}]
+        result = strategy.transform(structured, {}, "g1", _agent_config())
+        assert "source_guid" not in result[0]
+
+    def test_non_dict_content_wrapped(self):
+        strategy = NoOpStrategy()
+        structured = [{"source_guid": "g1", "content": "plain"}]
+        result = strategy.transform(structured, {}, "g1", _agent_config())
+        assert result[0] == {"value": "plain"}
+
+    def test_multiple_structured_items(self):
+        strategy = NoOpStrategy()
+        structured = [
+            {"source_guid": "g1", "content": {"a": 1}},
+            {"source_guid": "g2", "content": {"b": 2}},
+        ]
+        result = strategy.transform(structured, {}, "g1", _agent_config())
+        assert len(result) == 2
+        assert result[0] == {"a": 1}
+        assert result[1] == {"b": 2}
+
+    def test_can_handle_requires_structured_no_passthrough(self):
+        strategy = NoOpStrategy()
+        structured = [{"source_guid": "g1", "content": {"x": 1}}]
+        assert strategy.can_handle(structured, None, _agent_config(), True) is True
+        assert strategy.can_handle(structured, None, _agent_config(), False) is False
+        assert (
+            strategy.can_handle(structured, None, _agent_config(passthrough=["ns.field"]), True)
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# ContextScopeStructuredStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestContextScopeStructuredStrategy:
+    """ContextScopeStructuredStrategy returns flat dicts with passthrough merged."""
+
+    def test_returns_flat_output(self):
+        strategy = ContextScopeStructuredStrategy()
+        config = _agent_config("action", passthrough=["ctx.extra_field"])
+        data = [{"source_guid": "g1", "content": {"vote": "keep"}}]
+        context = {"extra_field": "extra_val"}
+
+        result = strategy.transform(data, context, "g1", config)
+
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+        assert "source_guid" not in result[0]
+
+    def test_no_transform_structure_in_output(self):
+        """Output must not be wrapped records from transform_structure."""
+        strategy = ContextScopeStructuredStrategy()
+        config = _agent_config("action", passthrough=["ctx.field"])
+        data = [{"source_guid": "g1", "content": {"x": 1}}]
+
+        result = strategy.transform(data, {}, "g1", config)
+        # Should not have source_guid or content wrapper
+        for item in result:
+            assert "source_guid" not in item
+
+
+# ---------------------------------------------------------------------------
+# ContextScopeUnstructuredStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestContextScopeUnstructuredStrategy:
+    """ContextScopeUnstructuredStrategy returns flat dicts with passthrough merged."""
+
+    def test_returns_flat_output(self):
+        strategy = ContextScopeUnstructuredStrategy()
+        config = _agent_config("action", passthrough=["ctx.extra_field"])
+        data = [{"vote": "keep"}]
+        context = {"extra_field": "extra_val"}
+
+        result = strategy.transform(data, context, "g1", config)
+
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+        assert "source_guid" not in result[0]
+
+
+# ---------------------------------------------------------------------------
+# PrecomputedStructuredStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestPrecomputedStructuredStrategy:
+    """PrecomputedStructuredStrategy merges passthrough, returns flat."""
+
+    def test_merges_passthrough_returns_flat(self):
+        strategy = PrecomputedStructuredStrategy()
+        data = [{"source_guid": "g1", "content": {"vote": "keep"}}]
+        passthrough = {"extra": "value"}
+
+        result = strategy.transform(data, {}, "g1", _agent_config(), passthrough)
+
+        assert len(result) == 1
+        assert result[0]["vote"] == "keep"
+        assert result[0]["extra"] == "value"
+        assert "source_guid" not in result[0]
+        assert "content" not in result[0]
+
+    def test_no_wrap_content_in_output(self):
+        """Output should not be wrapped under action namespace."""
+        strategy = PrecomputedStructuredStrategy()
+        data = [{"source_guid": "g1", "content": {"x": 1}}]
+        passthrough = {"y": 2}
+
+        result = strategy.transform(data, {}, "g1", _agent_config("act"), passthrough)
+
+        # Flat — no action namespace wrapping
+        assert "act" not in result[0]
+        assert result[0]["x"] == 1
+        assert result[0]["y"] == 2
+
+    def test_item_without_content_key(self):
+        strategy = PrecomputedStructuredStrategy()
+        data = [{"source_guid": "g1", "content": {"x": 1}}, {"other": "val"}]
+        passthrough = {"y": 2}
+
+        result = strategy.transform(data, {}, "g1", _agent_config(), passthrough)
+
+        assert result[0] == {"x": 1, "y": 2}
+        assert result[1] == {"other": "val", "y": 2}
+
+
+# ---------------------------------------------------------------------------
+# PrecomputedUnstructuredStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestPrecomputedUnstructuredStrategy:
+    """PrecomputedUnstructuredStrategy merges passthrough, returns flat."""
+
+    def test_merges_passthrough_returns_flat(self):
+        strategy = PrecomputedUnstructuredStrategy()
+        data = [{"vote": "keep"}]
+        passthrough = {"extra": "value"}
+
+        result = strategy.transform(data, {}, "g1", _agent_config(), passthrough)
+
+        assert len(result) == 1
+        assert result[0] == {"vote": "keep", "extra": "value"}
+        assert "source_guid" not in result[0]
+
+    def test_non_dict_items_passed_through(self):
+        strategy = PrecomputedUnstructuredStrategy()
+        result = strategy.transform(["text"], {}, "g1", _agent_config(), {"k": "v"})
+        assert result[0] == "text"
+
+
+# ---------------------------------------------------------------------------
+# PassthroughTransformer — RecordEnvelope integration
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughTransformerEnvelope:
+    """PassthroughTransformer wraps strategy output via RecordEnvelope."""
+
+    def _make_agent_config(self, action_name="current_action"):
+        return {"agent_type": action_name}
+
+    def test_output_wrapped_under_namespace(self):
+        transformer = PassthroughTransformer()
+        result = transformer.transform_with_passthrough(
+            data=[{"score": 0.9}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("classify"),
+            action_name="classify",
+        )
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert "classify" in content
+        assert content["classify"] == {"score": 0.9}
+
+    def test_upstream_namespaces_preserved(self):
+        transformer = PassthroughTransformer()
+        existing = {
+            "extract": {"text": "hello"},
+            "summarize": {"summary": "hi"},
+        }
+        result = transformer.transform_with_passthrough(
+            data=[{"score": 0.9, "label": "positive"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("classify"),
+            action_name="classify",
+            existing_content=existing,
+        )
+        content = result[0]["content"]
+        assert content["extract"] == {"text": "hello"}
+        assert content["summarize"] == {"summary": "hi"}
+        assert content["classify"] == {"score": 0.9, "label": "positive"}
+
+    def test_no_existing_content_works(self):
+        transformer = PassthroughTransformer()
+        result = transformer.transform_with_passthrough(
+            data=[{"answer": "42"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("qa"),
+            action_name="qa",
+            existing_content=None,
+        )
+        content = result[0]["content"]
+        assert content == {"qa": {"answer": "42"}}
+
+    def test_empty_existing_content(self):
+        transformer = PassthroughTransformer()
+        result = transformer.transform_with_passthrough(
+            data=[{"answer": "42"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("qa"),
+            action_name="qa",
+            existing_content={},
+        )
+        content = result[0]["content"]
+        assert content == {"qa": {"answer": "42"}}
+
+    def test_three_upstream_all_preserved(self):
+        transformer = PassthroughTransformer()
+        existing = {
+            "flatten": {"questions": ["q1"]},
+            "dedup": {"unique": ["q1"]},
+            "filter_1": {"quality": "high"},
+        }
+        result = transformer.transform_with_passthrough(
+            data=[{"grade": "A"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("grade"),
+            action_name="grade",
+            existing_content=existing,
+        )
+        content = result[0]["content"]
+        assert set(content.keys()) == {"flatten", "dedup", "filter_1", "grade"}
+        assert content["grade"] == {"grade": "A"}
+
+    def test_namespace_collision_current_wins(self):
+        transformer = PassthroughTransformer()
+        existing = {"rerun": {"old": True}}
+        result = transformer.transform_with_passthrough(
+            data=[{"new": True}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("rerun"),
+            action_name="rerun",
+            existing_content=existing,
+        )
+        content = result[0]["content"]
+        assert content["rerun"] == {"new": True}
+
+    def test_structured_data_gets_upstream_merge(self):
+        """Already-structured data (NoOp path) also preserves upstream."""
+        transformer = PassthroughTransformer()
+        existing = {"upstream": {"val": 1}}
+        structured = [{"source_guid": "g1", "content": {"result": "ok"}}]
+
+        result = transformer.transform_with_passthrough(
+            data=structured,
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("current"),
+            action_name="current",
+            existing_content=existing,
+        )
+        content = result[0]["content"]
+        assert content["upstream"] == {"val": 1}
+        assert "current" in content
+
+    def test_multiple_output_items_all_get_upstream(self):
+        transformer = PassthroughTransformer()
+        existing = {"extract": {"text": "hello"}}
+        result = transformer.transform_with_passthrough(
+            data=[{"variant": "A"}, {"variant": "B"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("generate"),
+            action_name="generate",
+            existing_content=existing,
+        )
+        assert len(result) == 2
+        for item in result:
+            assert item["content"]["extract"] == {"text": "hello"}
+            assert "generate" in item["content"]
+
+    def test_source_guid_carried_forward(self):
+        transformer = PassthroughTransformer()
+        result = transformer.transform_with_passthrough(
+            data=[{"x": 1}],
+            context_data={},
+            source_guid="my-guid",
+            agent_config=self._make_agent_config("act"),
+            action_name="act",
+        )
+        assert result[0]["source_guid"] == "my-guid"
+
+    def test_non_dict_output_wrapped_in_value(self):
+        """Non-dict strategy output gets wrapped as {value: ...}."""
+        transformer = PassthroughTransformer()
+        # PrecomputedUnstructured with non-dict items returns them as-is,
+        # but the transformer wraps non-dict in {"value": ...}
+        result = transformer.transform_with_passthrough(
+            data=[{"score": 5}],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("act"),
+            action_name="act",
+        )
+        # Should be wrapped under namespace
+        assert "act" in result[0]["content"]
+
+    def test_empty_data_returns_empty(self):
+        transformer = PassthroughTransformer()
+        result = transformer.transform_with_passthrough(
+            data=[],
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("act"),
+            action_name="act",
+        )
+        assert result == []
+
+    def test_none_data_returns_empty(self):
+        transformer = PassthroughTransformer()
+        result = transformer.transform_with_passthrough(
+            data=None,
+            context_data={},
+            source_guid="g1",
+            agent_config=self._make_agent_config("act"),
+            action_name="act",
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# No is_version_merge in strategies
+# ---------------------------------------------------------------------------
+
+
+class TestNoVersionMergeInStrategies:
+    """Strategies must not import or use is_version_merge."""
+
+    def test_context_scope_no_version_merge(self):
+        import inspect
+
+        from agent_actions.utils.transformation.strategies import context_scope
+
+        source = inspect.getsource(context_scope)
+        assert "is_version_merge" not in source
+
+    def test_precomputed_no_version_merge(self):
+        import inspect
+
+        from agent_actions.utils.transformation.strategies import precomputed
+
+        source = inspect.getsource(precomputed)
+        assert "is_version_merge" not in source
+
+    def test_no_transform_structure_in_strategies(self):
+        """Strategies should not call DataTransformer.transform_structure."""
+        import inspect
+
+        from agent_actions.utils.transformation.strategies import context_scope, precomputed
+
+        cs_source = inspect.getsource(context_scope)
+        pc_source = inspect.getsource(precomputed)
+        assert "transform_structure" not in cs_source
+        assert "transform_structure" not in pc_source
+
+    def test_no_wrap_content_in_strategies(self):
+        """Strategies should not call wrap_content."""
+        import inspect
+
+        from agent_actions.utils.transformation.strategies import precomputed
+
+        source = inspect.getsource(precomputed)
+        assert "wrap_content" not in source

--- a/tests/unit/utils/test_passthrough_strategies.py
+++ b/tests/unit/utils/test_passthrough_strategies.py
@@ -7,6 +7,7 @@ preserve upstream namespaces.
 """
 
 from agent_actions.utils.transformation.passthrough import PassthroughTransformer
+from agent_actions.utils.transformation.strategies.base import ensure_dict_output
 from agent_actions.utils.transformation.strategies.context_scope import (
     ContextScopeStructuredStrategy,
     ContextScopeUnstructuredStrategy,
@@ -24,6 +25,30 @@ def _agent_config(action_name="test_action", passthrough=None):
     if passthrough:
         config["context_scope"] = {"passthrough": passthrough}
     return config
+
+
+# ---------------------------------------------------------------------------
+# ensure_dict_output helper
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDictOutput:
+    """ensure_dict_output normalizes items to dicts."""
+
+    def test_dict_passes_through(self):
+        assert ensure_dict_output({"x": 1}) == {"x": 1}
+
+    def test_string_wrapped(self):
+        assert ensure_dict_output("text") == {"value": "text"}
+
+    def test_int_wrapped(self):
+        assert ensure_dict_output(42) == {"value": 42}
+
+    def test_none_wrapped(self):
+        assert ensure_dict_output(None) == {"value": None}
+
+    def test_list_wrapped(self):
+        assert ensure_dict_output([1, 2]) == {"value": [1, 2]}
 
 
 # ---------------------------------------------------------------------------
@@ -230,10 +255,10 @@ class TestPrecomputedUnstructuredStrategy:
         assert result[0] == {"vote": "keep", "extra": "value"}
         assert "source_guid" not in result[0]
 
-    def test_non_dict_items_passed_through(self):
+    def test_non_dict_items_normalized(self):
         strategy = PrecomputedUnstructuredStrategy()
         result = strategy.transform(["text"], {}, "g1", _agent_config(), {"k": "v"})
-        assert result[0] == "text"
+        assert result[0] == {"value": "text"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- All 6 passthrough strategies now return flat action output dicts (just the fields belonging to the action's namespace) instead of wrapped records
- PassthroughTransformer calls RecordEnvelope.build() after strategy dispatch to wrap under namespace and preserve upstream namespaces
- Removed transform_structure calls, wrap_content calls, and is_version_merge usage from all strategies
- Added existing_content parameter to PassthroughTransformer for upstream namespace preservation

## Verification
- Clone 2 acceptance test: 22/22 pass
- New unit tests: 34 tests covering all 6 strategies + transformer integration
- Full suite: 5915 passed, 0 failed
- Lint: ruff format + ruff check clean