### PR TITLE
fix: FILE mode tool + HITL use RecordEnvelope

### DIFF
--- a/.changes/unreleased/Bug Fix-20260424-phase2b000.yaml
+++ b/.changes/unreleased/Bug Fix-20260424-phase2b000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "FILE mode HITL wraps output under action namespace instead of flat-merging into content"
+time: 2026-04-24T02:00:00.000000Z

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -233,17 +233,16 @@ def process_file_mode_tool(
                 input_idx = source_mapping.get(idx) if source_mapping else None
                 if isinstance(input_idx, list):
                     input_idx = input_idx[0]
+                input_record: dict[str, Any] | None = None
                 if isinstance(input_idx, int) and input_idx < len(original_data):
                     input_record = original_data[input_idx]
                 elif original_data:
                     input_record = original_data[0]
-                else:
-                    input_record = None
 
                 if version_merge:
-                    # Version merge tools return flat business data to be
-                    # spread alongside existing version namespaces — not
-                    # namespace dicts, so build_version_merge is wrong here.
+                    # build_version_merge validates all values are dicts,
+                    # but version merge tools return flat business data
+                    # (strings, ints) to spread alongside version namespaces.
                     existing = get_existing_content(input_record) if input_record else {}
                     record: dict[str, Any] = {"content": {**existing, **data_fields}}
                 else:
@@ -398,21 +397,12 @@ def process_file_mode_hitl(
                             if key in review_payload:
                                 hitl_output[key] = review_payload[key]
 
-                if isinstance(item, dict):
-                    record = RecordEnvelope.build(context.agent_name, hitl_output, item)
-                else:
-                    record = RecordEnvelope.build(context.agent_name, hitl_output)
+                record = RecordEnvelope.build(context.agent_name, hitl_output, item)
 
                 # Carry framework fields that RecordEnvelope doesn't manage.
-                if isinstance(item, dict):
-                    for field in (
-                        "target_id",
-                        "_unprocessed",
-                        "_recovery",
-                        "metadata",
-                    ):
-                        if field in item:
-                            record[field] = item[field]
+                for field in ("target_id", "_unprocessed", "_recovery", "metadata"):
+                    if field in item:
+                        record[field] = item[field]
                 structured_data.append(record)
 
         # HITL FILE mode is always 1:1 — identity source_mapping ensures the

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -213,11 +213,8 @@ def process_file_mode_tool(
         # existing namespaces from the input record.
         # Version merge: version namespaces are already the correct additive
         # format — spread instead of wrapping under the action name.
-        from agent_actions.utils.content import (
-            get_existing_content,
-            is_version_merge,
-            wrap_content,
-        )
+        from agent_actions.record.envelope import RecordEnvelope
+        from agent_actions.utils.content import get_existing_content, is_version_merge
 
         version_merge = is_version_merge(context.agent_config)
 
@@ -229,7 +226,7 @@ def process_file_mode_tool(
                 else:
                     data_fields = {k: v for k, v in item.items() if k not in _TOOL_RESERVED_FIELDS}
 
-                # Carry forward existing namespaces from the input record.
+                # Resolve the input record for namespace carry-forward.
                 # For N→M tools (dedup, filter), source_mapping may not resolve.
                 # Fall back to the first input record — all records in a FILE
                 # batch share the same upstream namespaces.
@@ -237,34 +234,32 @@ def process_file_mode_tool(
                 if isinstance(input_idx, list):
                     input_idx = input_idx[0]
                 if isinstance(input_idx, int) and input_idx < len(original_data):
-                    existing = get_existing_content(original_data[input_idx])
+                    input_record = original_data[input_idx]
                 elif original_data:
-                    existing = get_existing_content(original_data[0])
+                    input_record = original_data[0]
                 else:
-                    existing = {}
+                    input_record = None
 
                 if version_merge:
-                    content = {**existing, **data_fields}
+                    # Version merge tools return flat business data to be
+                    # spread alongside existing version namespaces — not
+                    # namespace dicts, so build_version_merge is wrong here.
+                    existing = get_existing_content(input_record) if input_record else {}
+                    record: dict[str, Any] = {"content": {**existing, **data_fields}}
                 else:
-                    content = wrap_content(context.agent_name, data_fields, existing)
+                    record = RecordEnvelope.build(context.agent_name, data_fields, input_record)
 
-                if version_merge:
-                    content = {**existing, **data_fields}
-                else:
-                    content = wrap_content(context.agent_name, data_fields, existing)
-
-                structured_item: dict[str, Any] = {
-                    "content": content,
-                }
+                # Source_guid is managed by _reattach_source_guid below, not
+                # RecordEnvelope.  Remove it here so the existing handling
+                # works: tool explicit value first, then mapping-based.
+                record.pop("source_guid", None)
 
                 if "source_guid" in item:
-                    structured_item["source_guid"] = item["source_guid"]
+                    record["source_guid"] = item["source_guid"]
 
-                structured_data.append(structured_item)
+                structured_data.append(record)
             else:
-                structured_data.append(
-                    {"content": wrap_content(context.agent_name, {"value": item})}
-                )
+                structured_data.append(RecordEnvelope.build(context.agent_name, {"value": item}))
 
         # Reattach source_guid from input records — authoritative for FILE mode.
         # LineageBuilder._propagate_ancestry_chain and RequiredFieldsEnricher
@@ -390,55 +385,35 @@ def process_file_mode_hitl(
         # Propagate one file-level decision across all input records so
         # downstream processing keeps record cardinality intact.
         # Use original_data for the merge to preserve all upstream fields.
+        from agent_actions.record.envelope import RecordEnvelope
+
         structured_data = []
         if original_data:
-            reserved_fields = {
-                "source_guid",
-                "target_id",
-                "node_id",
-                "lineage",
-                "metadata",
-                "content",
-                "_unprocessed",
-                "_recovery",
-            }
             for idx, item in enumerate(original_data):
-                if isinstance(item, dict):
-                    if isinstance(item.get("content"), dict):
-                        base_content = dict(item["content"])
-                    else:
-                        base_content = {
-                            key: value for key, value in item.items() if key not in reserved_fields
-                        }
-                        raw_content = item.get("content")
-                        if not base_content and raw_content is not None:
-                            base_content = {"value": raw_content}
-                else:
-                    base_content = {"value": item}  # type: ignore[unreachable]
-
-                merged_content = dict(base_content)
-                merged_content.update(decision_common)
+                hitl_output = dict(decision_common)
                 if record_reviews and idx < len(record_reviews):
                     review_payload = record_reviews[idx]
                     if isinstance(review_payload, dict):
-                        normalized_review_payload = {
-                            key: value
-                            for key, value in review_payload.items()
-                            if key in {"hitl_status", "user_comment"}
-                        }
-                        merged_content.update(normalized_review_payload)
-                structured_item = {"content": merged_content}
+                        for key in ("hitl_status", "user_comment"):
+                            if key in review_payload:
+                                hitl_output[key] = review_payload[key]
+
+                if isinstance(item, dict):
+                    record = RecordEnvelope.build(context.agent_name, hitl_output, item)
+                else:
+                    record = RecordEnvelope.build(context.agent_name, hitl_output)
+
+                # Carry framework fields that RecordEnvelope doesn't manage.
                 if isinstance(item, dict):
                     for field in (
-                        "source_guid",
                         "target_id",
                         "_unprocessed",
                         "_recovery",
                         "metadata",
                     ):
                         if field in item:
-                            structured_item[field] = item[field]
-                structured_data.append(structured_item)
+                            record[field] = item[field]
+                structured_data.append(record)
 
         # HITL FILE mode is always 1:1 — identity source_mapping ensures the
         # enricher extends parent lineage rather than truncating to [node_id].

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -1169,3 +1169,201 @@ def test_file_tool_copy_pattern_preserves_lineage():
         lineage = item.get("lineage", [])
         # Parent lineage had 2 entries; enrichment appends new node_id → at least 3
         assert len(lineage) >= 3, f"item[{i}] lineage not extended from parent: {lineage}"
+
+
+# --- FILE HITL RecordEnvelope tests ---
+
+
+def _make_hitl_pipeline_and_context():
+    """Create a minimal pipeline and context for FILE-mode HITL tests."""
+    pipeline = ProcessingPipeline(
+        config=PipelineConfig(
+            action_config={"kind": "hitl", "granularity": "file"},
+            action_name="review_answers",
+            idx=0,
+        ),
+        processor_factory=object(),
+    )
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_answers",
+    )
+    return pipeline, context
+
+
+def test_file_hitl_namespaces_output_under_action():
+    """FILE HITL wraps output under action namespace, not flat into content."""
+    pipeline, context = _make_hitl_pipeline_and_context()
+
+    input_data = [
+        {
+            "source_guid": "sg-1",
+            "content": {
+                "source": {"page_content": "..."},
+                "extract": {"question_text": "Why?"},
+            },
+        },
+    ]
+
+    decision = {"hitl_status": "approved", "user_comment": "Looks good", "timestamp": "2026-01-01"}
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([decision], True),
+    ):
+        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+
+    result = results[0]
+    assert result.status == ProcessingStatus.SUCCESS
+    content = result.data[0]["content"]
+
+    # HITL output is under the action namespace
+    assert "review_answers" in content
+    ns = content["review_answers"]
+    assert ns["hitl_status"] == "approved"
+    assert ns["user_comment"] == "Looks good"
+
+    # HITL fields are NOT flat in content
+    assert "hitl_status" not in content
+    assert "user_comment" not in content
+
+
+def test_file_hitl_preserves_upstream_namespaces():
+    """FILE HITL preserves all upstream namespaces from input records."""
+    pipeline, context = _make_hitl_pipeline_and_context()
+
+    input_data = [
+        {
+            "source_guid": "sg-1",
+            "content": {
+                "source": {"page_content": "doc text"},
+                "extract": {"question_text": "Why?"},
+                "summarize": {"summary": "short version"},
+            },
+        },
+    ]
+
+    decision = {"hitl_status": "approved"}
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([decision], True),
+    ):
+        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+
+    content = results[0].data[0]["content"]
+    assert "source" in content
+    assert "extract" in content
+    assert "summarize" in content
+    assert content["source"]["page_content"] == "doc text"
+    assert content["extract"]["question_text"] == "Why?"
+    assert content["summarize"]["summary"] == "short version"
+
+
+def test_file_hitl_per_record_review_in_namespace():
+    """Per-record review fields go under the action namespace, not flat."""
+    pipeline, context = _make_hitl_pipeline_and_context()
+
+    input_data = [
+        {"source_guid": "sg-1", "content": {"source": {"a": 1}}},
+        {"source_guid": "sg-2", "content": {"source": {"a": 2}}},
+    ]
+
+    decision = {
+        "hitl_status": "approved",
+        "record_reviews": [
+            {"hitl_status": "approved", "user_comment": "Good"},
+            {"hitl_status": "rejected", "user_comment": "Bad"},
+        ],
+    }
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([decision], True),
+    ):
+        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+
+    result = results[0]
+    # Per-record review overrides file-level decision within the namespace
+    ns0 = result.data[0]["content"]["review_answers"]
+    assert ns0["hitl_status"] == "approved"
+    assert ns0["user_comment"] == "Good"
+
+    ns1 = result.data[1]["content"]["review_answers"]
+    assert ns1["hitl_status"] == "rejected"
+    assert ns1["user_comment"] == "Bad"
+
+
+def test_file_hitl_carries_framework_fields():
+    """Framework fields (source_guid, target_id, _unprocessed) are preserved from input."""
+    pipeline, context = _make_hitl_pipeline_and_context()
+
+    input_data = [
+        {
+            "source_guid": "sg-1",
+            "target_id": "tid-1",
+            "_unprocessed": True,
+            "_recovery": {"reason": "tombstone"},
+            "content": {"source": {"a": 1}},
+        },
+    ]
+
+    decision = {"hitl_status": "approved"}
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([decision], True),
+    ):
+        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+
+    item = results[0].data[0]
+    assert item["source_guid"] == "sg-1"
+    assert item["target_id"] == "tid-1"
+    assert item["_unprocessed"] is True
+    assert item["_recovery"] == {"reason": "tombstone"}
+
+
+def test_file_tool_version_merge_spreads_not_wraps():
+    """Version merge tool output is spread flat, not wrapped under action name."""
+    pipeline = ProcessingPipeline(
+        config=PipelineConfig(
+            action_config={
+                "kind": "tool",
+                "granularity": "file",
+                "version_consumption_config": {"source": "extract", "pattern": "merge"},
+            },
+            action_name="aggregate",
+            idx=0,
+        ),
+        processor_factory=object(),
+    )
+    context = ProcessingContext(
+        agent_config=pipeline.config.action_config,
+        agent_name="aggregate",
+    )
+
+    input_data = [
+        {
+            "source_guid": "sg-1",
+            "node_id": "n1",
+            "content": {
+                "extract_1": {"vote": "keep"},
+                "extract_2": {"vote": "drop"},
+            },
+        }
+    ]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([{"consensus": "keep", "score": 11, "node_id": "n1"}], True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    content = results[0].data[0]["content"]
+    # Flat spread, NOT wrapped under action name
+    assert "aggregate" not in content
+    assert content["consensus"] == "keep"
+    assert content["score"] == 11
+    # Existing version namespaces preserved
+    assert content["extract_1"]["vote"] == "keep"
+    assert content["extract_2"]["vote"] == "drop"

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -44,9 +44,13 @@ def test_file_mode_hitl_applies_file_decision_to_each_input_record():
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
     assert len(result.data) == 2
-    assert result.data[0]["content"]["hitl_status"] == "approved"
-    assert result.data[1]["content"]["hitl_status"] == "approved"
+    # HITL output is namespaced under the action name
+    assert result.data[0]["content"]["review_data"]["hitl_status"] == "approved"
+    assert result.data[1]["content"]["review_data"]["hitl_status"] == "approved"
+    # Upstream content fields preserved alongside the HITL namespace
+    assert result.data[0]["content"]["id"] == 1
     assert result.data[0]["content"]["question"] == "Q1"
+    assert result.data[1]["content"]["id"] == 2
     assert result.data[1]["content"]["question"] == "Q2"
     assert result.data[0]["source_guid"] == "sg-1"
     assert result.data[1]["source_guid"] == "sg-2"
@@ -91,10 +95,11 @@ def test_file_mode_hitl_applies_per_record_decisions_when_provided():
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
     assert len(result.data) == 2
-    assert result.data[0]["content"]["hitl_status"] == "approved"
-    assert result.data[0]["content"]["user_comment"] == "Looks good"
-    assert result.data[1]["content"]["hitl_status"] == "rejected"
-    assert result.data[1]["content"]["user_comment"] == "Needs revision"
+    # Per-record review fields are under the action namespace
+    assert result.data[0]["content"]["review_data"]["hitl_status"] == "approved"
+    assert result.data[0]["content"]["review_data"]["user_comment"] == "Looks good"
+    assert result.data[1]["content"]["review_data"]["hitl_status"] == "rejected"
+    assert result.data[1]["content"]["review_data"]["user_comment"] == "Needs revision"
 
 
 def test_file_mode_hitl_preserves_existing_status_field():
@@ -132,8 +137,10 @@ def test_file_mode_hitl_preserves_existing_status_field():
     assert len(results) == 1
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
+    # Upstream 'status' field is preserved in existing content
     assert result.data[0]["content"]["status"] == "pending"
-    assert result.data[0]["content"]["hitl_status"] == "approved"
+    # HITL decision is under the action namespace — no collision
+    assert result.data[0]["content"]["review_data"]["hitl_status"] == "approved"
 
 
 def test_file_mode_hitl_empty_input_returns_empty_output():
@@ -383,10 +390,12 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
     assert len(result.data) == 2
+    # Upstream content fields preserved
     assert result.data[0]["content"]["question"] == "What is X?"
     assert result.data[0]["content"]["selectedAnswerer"] == "Alice"
     assert result.data[0]["content"]["validity"] == "valid"
-    assert result.data[0]["content"]["hitl_status"] == "approved"
+    # HITL decision under the action namespace
+    assert result.data[0]["content"]["review_data"]["hitl_status"] == "approved"
     assert result.data[1]["content"]["answer"] == "Z is W"
     assert result.data[1]["content"]["selectedAnswerer"] == "Bob"
 


### PR DESCRIPTION
## Summary
- FILE mode tool: replaced `wrap_content()` with `RecordEnvelope.build()`, removed duplicate `if version_merge:` block (copy-paste bug). Version merge path keeps manual content spread since tools return flat business data, not namespace dicts.
- FILE mode HITL: replaced `dict.update()` flat-merge with `RecordEnvelope.build()`. HITL output is now wrapped under the action namespace instead of being flat-merged into content, fixing the HITL flat-merge bug where decision fields (`hitl_status`, `user_comment`) collided with upstream field names.
- Updated existing HITL tests for namespaced output format.
- Added 5 new tests: HITL namespace wrapping, upstream preservation, per-record review namespacing, framework field carry-through, version merge behavioral assertion.

## Verification
- External clone test: 11/11 passed (was 6/11 before changes)
- Full test suite: 5886 passed, 0 failed
- Lint: ruff format + ruff check clean