### PR TITLE
arch: record processor, exhausted builder, batch processor, version correlator use RecordEnvelope

### DIFF
--- a/.changes/unreleased/Under the Hood-20260424-102400.yaml
+++ b/.changes/unreleased/Under the Hood-20260424-102400.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Record processor, exhausted builder, batch processor, version correlator use RecordEnvelope"
+time: 2026-04-24T10:24:00.000000Z

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -234,12 +234,11 @@ class BatchResultProcessor:
 
         if not ctx.agent_config or "action_name" not in ctx.agent_config:
             raise ValueError("agent_config must contain 'action_name' for content namespacing")
-        from agent_actions.utils.content import is_version_merge
+        from agent_actions.utils.content import get_existing_content, is_version_merge
 
         action_name = ctx.agent_config["action_name"]
         version_merge = is_version_merge(ctx.agent_config)
-        existing = original_row.get("content") if isinstance(original_row, dict) else None
-        existing_content = existing if isinstance(existing, dict) else None
+        existing_content = get_existing_content(original_row) or None
 
         structured_items = []
         for item in generated_list:
@@ -405,6 +404,12 @@ class BatchResultProcessor:
                     custom_id, fallback=custom_id or "unknown"
                 )
 
+                if not ctx.agent_config or "action_name" not in ctx.agent_config:
+                    raise ValueError(
+                        "agent_config must contain 'action_name' for content namespacing"
+                    )
+                stage6_action_name = ctx.agent_config["action_name"]
+
                 if is_exhausted:
                     if ctx.exhausted_recovery is None:
                         raise RuntimeError(
@@ -441,11 +446,6 @@ class BatchResultProcessor:
                         ctx.agent_config or {}
                     )
                     existing = get_existing_content(original_row)
-                    if not ctx.agent_config or "action_name" not in ctx.agent_config:
-                        raise ValueError(
-                            "agent_config must contain 'action_name' for content namespacing"
-                        )
-                    stage6_action_name = ctx.agent_config["action_name"]
                     exhausted_item = {
                         "content": RecordEnvelope.build_content(
                             stage6_action_name, empty_content, existing
@@ -486,13 +486,8 @@ class BatchResultProcessor:
                     else:
                         reason = "batch_not_returned"
 
-                    if not ctx.agent_config or "action_name" not in ctx.agent_config:
-                        raise ValueError(
-                            "agent_config must contain 'action_name' for content namespacing"
-                        )
-                    passthrough_action_name = ctx.agent_config["action_name"]
                     passthrough_item = RecordEnvelope.build_skipped(
-                        passthrough_action_name, original_row
+                        stage6_action_name, original_row
                     )
                     passthrough_item["source_guid"] = source_guid
                     passthrough_item["metadata"] = {

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -16,6 +16,7 @@ from agent_actions.processing.batch_context_adapter import BatchContextAdapter
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 from agent_actions.processing.types import ProcessingResult, RecoveryMetadata
+from agent_actions.record.envelope import RecordEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -236,11 +237,18 @@ class BatchResultProcessor:
         from agent_actions.utils.content import is_version_merge
 
         action_name = ctx.agent_config["action_name"]
-        structured_items = DataTransformer.transform_structure(
-            [{original_source_guid: generated_list}],
-            action_name,
-            version_merge=is_version_merge(ctx.agent_config),
-        )
+        version_merge = is_version_merge(ctx.agent_config)
+        existing = original_row.get("content") if isinstance(original_row, dict) else None
+        existing_content = existing if isinstance(existing, dict) else None
+
+        structured_items = []
+        for item in generated_list:
+            item_dict = item if isinstance(item, dict) else {}
+            if version_merge:
+                content = {**(existing_content or {}), **item_dict}
+            else:
+                content = RecordEnvelope.build_content(action_name, item_dict, existing_content)
+            structured_items.append({"source_guid": original_source_guid, "content": content})
 
         # Batch items inherit target_id from the original input row.
         # transform_structure() doesn't carry it over, so set it before enrichment.
@@ -427,7 +435,7 @@ class BatchResultProcessor:
                             "RecoveryMetadata.retry is None for exhausted record "
                             f"custom_id={custom_id}; expected retry metadata with attempt count"
                         )
-                    from agent_actions.utils.content import get_existing_content, wrap_content
+                    from agent_actions.utils.content import get_existing_content
 
                     empty_content = ExhaustedRecordBuilder.build_empty_content(
                         ctx.agent_config or {}
@@ -439,7 +447,9 @@ class BatchResultProcessor:
                         )
                     stage6_action_name = ctx.agent_config["action_name"]
                     exhausted_item = {
-                        "content": wrap_content(stage6_action_name, empty_content, existing),
+                        "content": RecordEnvelope.build_content(
+                            stage6_action_name, empty_content, existing
+                        ),
                         "source_guid": source_guid,
                         "metadata": {"retry_exhausted": True, "agent_type": "tombstone"},
                         "_unprocessed": True,
@@ -476,17 +486,20 @@ class BatchResultProcessor:
                     else:
                         reason = "batch_not_returned"
 
-                    from agent_actions.utils.content import get_existing_content
-
-                    passthrough_item = {
-                        "content": get_existing_content(original_row),
-                        "source_guid": source_guid,
-                        "metadata": {
-                            "reason": reason,
-                            "agent_type": "tombstone",
-                        },
-                        "_unprocessed": True,
+                    if not ctx.agent_config or "action_name" not in ctx.agent_config:
+                        raise ValueError(
+                            "agent_config must contain 'action_name' for content namespacing"
+                        )
+                    passthrough_action_name = ctx.agent_config["action_name"]
+                    passthrough_item = RecordEnvelope.build_skipped(
+                        passthrough_action_name, original_row
+                    )
+                    passthrough_item["source_guid"] = source_guid
+                    passthrough_item["metadata"] = {
+                        "reason": reason,
+                        "agent_type": "tombstone",
                     }
+                    passthrough_item["_unprocessed"] = True
                     if original_row.get("target_id"):
                         passthrough_item["target_id"] = original_row["target_id"]
 

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -238,7 +238,7 @@ class BatchResultProcessor:
 
         action_name = ctx.agent_config["action_name"]
         version_merge = is_version_merge(ctx.agent_config)
-        existing_content = get_existing_content(original_row) or None
+        existing_content = get_existing_content(original_row)
 
         structured_items = []
         for item in generated_list:
@@ -250,7 +250,6 @@ class BatchResultProcessor:
             structured_items.append({"source_guid": original_source_guid, "content": content})
 
         # Batch items inherit target_id from the original input row.
-        # transform_structure() doesn't carry it over, so set it before enrichment.
         original_target_id = original_row.get("target_id")
         if original_target_id:
             for item in structured_items:

--- a/agent_actions/processing/exhausted_builder.py
+++ b/agent_actions/processing/exhausted_builder.py
@@ -3,7 +3,8 @@
 from typing import Any
 
 from agent_actions.processing.types import RecoveryMetadata
-from agent_actions.utils.content import get_existing_content, wrap_content
+from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.utils.content import get_existing_content
 from agent_actions.utils.id_generation import IDGenerator
 
 
@@ -52,7 +53,7 @@ class ExhaustedRecordBuilder:
         node_id = IDGenerator.generate_node_id(action_name)
         exhausted_item: dict[str, Any] = {
             "source_guid": resolved_source_guid,
-            "content": wrap_content(action_name, empty_content, existing),
+            "content": RecordEnvelope.build_content(action_name, empty_content, existing),
             "node_id": node_id,
             "metadata": {"retry_exhausted": True, "agent_type": "tombstone"},
             "_recovery": recovery_metadata.to_dict(),

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -223,6 +223,7 @@ def transform_with_passthrough(
     action_name: str = "unknown_action",
     passthrough_fields: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
+    existing_content: dict[str, Any] | None = None,
 ) -> list[Any]:
     """Apply ``context_scope.passthrough`` logic to generated data."""
     transformer = PassthroughTransformer()
@@ -234,4 +235,5 @@ def transform_with_passthrough(
         action_name,
         passthrough_fields=passthrough_fields,
         metadata=metadata,
+        existing_content=existing_content,
     )

--- a/agent_actions/processing/record_processor.py
+++ b/agent_actions/processing/record_processor.py
@@ -23,6 +23,7 @@ from agent_actions.logging.events.data_pipeline_events import (
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
 from agent_actions.output.response.config_fields import get_default
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
 
 from .enrichment import EnrichmentPipeline
@@ -172,6 +173,7 @@ class RecordProcessor:
                 source_guid,
                 f"guard_{prepared.guard_behavior}",
                 input_record,
+                context.action_name,
             )
             result = ProcessingResult.skipped(
                 passthrough_data=tombstone,
@@ -219,6 +221,7 @@ class RecordProcessor:
                         source_guid,
                         "retry_exhausted",
                         input_record,
+                        context.action_name,
                         extra_metadata={"retry_exhausted": True},
                     )
                     result = ProcessingResult.exhausted(
@@ -257,6 +260,7 @@ class RecordProcessor:
                     source_guid,
                     "guard_skip",
                     input_record,
+                    context.action_name,
                 )
                 result = ProcessingResult.unprocessed(
                     data=[tombstone],
@@ -416,16 +420,19 @@ class RecordProcessor:
         source_guid: str | None,
         reason: str,
         input_record: dict[str, Any] | None,
+        action_name: str,
         *,
         extra_metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Build a tombstone item for guard-skipped, exhausted, or unprocessed records."""
-        item: dict[str, Any] = {
-            "content": content,
-            "source_guid": source_guid,
-            "metadata": {"reason": reason, "agent_type": "tombstone"},
-            "_unprocessed": True,
-        }
+        if reason.startswith("guard_"):
+            item = RecordEnvelope.build_skipped(action_name, input_record)
+        else:
+            action_output = content if isinstance(content, dict) else {"value": content}
+            item = RecordEnvelope.build(action_name, action_output, input_record)
+        item["source_guid"] = source_guid
+        item["metadata"] = {"reason": reason, "agent_type": "tombstone"}
+        item["_unprocessed"] = True
         if extra_metadata:
             item["metadata"].update(extra_metadata)
         if input_record and isinstance(input_record, dict) and "target_id" in input_record:

--- a/agent_actions/processing/record_processor.py
+++ b/agent_actions/processing/record_processor.py
@@ -25,6 +25,7 @@ from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
 from agent_actions.output.response.config_fields import get_default
 from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
+from agent_actions.utils.content import get_existing_content
 
 from .enrichment import EnrichmentPipeline
 from .exhausted_builder import ExhaustedRecordBuilder
@@ -297,8 +298,14 @@ class RecordProcessor:
                     },
                 )
 
+        item_existing_content = get_existing_content(item) if isinstance(item, dict) else None
         transformed = self._transform_response(
-            response, content, source_guid or "", passthrough_fields, context
+            response,
+            content,
+            source_guid or "",
+            passthrough_fields,
+            context,
+            existing_content=item_existing_content,
         )
 
         input_size = 1 if not isinstance(response, list) else len(response)
@@ -464,6 +471,7 @@ class RecordProcessor:
         source_guid: str,
         passthrough_fields: dict[str, Any],
         context: ProcessingContext,
+        existing_content: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Transform LLM response to output format."""
         from agent_actions.processing.helpers import (
@@ -477,6 +485,7 @@ class RecordProcessor:
             cast(dict[str, Any], context.agent_config),
             action_name=context.action_name,
             passthrough_fields=passthrough_fields,
+            existing_content=existing_content,
         )
 
     @staticmethod

--- a/agent_actions/utils/passthrough_builder.py
+++ b/agent_actions/utils/passthrough_builder.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.utils.field_management.manager import FieldManager
 from agent_actions.utils.id_generation.generator import IDGenerator
 from agent_actions.utils.lineage.builder import LineageBuilder
@@ -42,7 +43,8 @@ class PassthroughItemBuilder:
         node_id = IDGenerator.generate_node_id(action_name)
 
         lineage = LineageBuilder.build_lineage(row, node_id)
-        content = row.get("content", {})
+        skipped_record = RecordEnvelope.build_skipped(action_name, row)
+        content = skipped_record["content"]
 
         processed_item = FieldManager().create_processed_item(
             source_guid=resolved_source_guid,

--- a/agent_actions/utils/transformation/passthrough.py
+++ b/agent_actions/utils/transformation/passthrough.py
@@ -38,6 +38,7 @@ class PassthroughTransformer:
         action_name: str = "unknown_action",
         passthrough_fields: dict | None = None,
         metadata: dict | None = None,
+        existing_content: dict | None = None,
     ) -> list:
         """Apply context_scope.passthrough logic to generated data.
 
@@ -53,6 +54,9 @@ class PassthroughTransformer:
             passthrough_fields: Optional pre-computed passthrough fields
                 from field_context (enables passthrough from any ancestor).
             metadata: Optional LLM response metadata to add to output items.
+            existing_content: Existing namespaced content from the input
+                record.  Merged into each output item so that upstream
+                action namespaces are carried forward.
 
         Returns:
             Transformed data list with passthrough fields merged.
@@ -72,6 +76,11 @@ class PassthroughTransformer:
 
         if output is None:
             output = []
+
+        if existing_content:
+            for obj in output:
+                if isinstance(obj, dict) and "content" in obj and isinstance(obj["content"], dict):
+                    obj["content"] = {**existing_content, **obj["content"]}
 
         return [
             self.field_manager.ensure_required_fields(

--- a/agent_actions/workflow/managers/loop.py
+++ b/agent_actions/workflow/managers/loop.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from agent_actions.errors import DataValidationError
 from agent_actions.input.preprocessing.staging.initial_pipeline import _should_save_source_items
+from agent_actions.record.envelope import RecordEnvelope
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -355,13 +356,15 @@ class VersionOutputCorrelator:
                 "Missing 'source_guid' in base record during version output correlation; "
                 "merged record will have source_guid=None"
             )
+        version_namespaces = self._merge_with_pattern(agent_records)
+        merged = RecordEnvelope.build_version_merge(version_namespaces)
         merged_record = {
             "source_guid": source_guid,
             "target_id": base_record.get("target_id"),
             "node_id": base_record.get("node_id"),
             "lineage": merged_lineage,
             "version_correlation_id": base_record.get("version_correlation_id"),
-            "content": self._merge_with_pattern(agent_records),
+            "content": merged["content"],
             "_correlation_sources": list(agent_records.keys()),
         }
         all_expected_versions = set(version_outputs.keys())

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -281,7 +281,7 @@ class TestBatchPathReasonDetection:
             batch_results=[],
             context_map={},
             output_directory=None,
-            agent_config={"agent_type": "test_batch"},
+            agent_config={"agent_type": "test_batch", "action_name": "test_batch"},
             reconciler=reconciler,
             exhausted_recovery=None,
         )
@@ -292,7 +292,7 @@ class TestBatchPathReasonDetection:
         from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
 
         row = {
-            "content": "stale",
+            "content": {"upstream_action": {"field": "value"}},
             "source_guid": "sg_batch_1",
             ContextMetaKeys.FILTER_PHASE: "upstream_unprocessed",
         }
@@ -305,6 +305,9 @@ class TestBatchPathReasonDetection:
         assert item["metadata"]["reason"] == "upstream_unprocessed"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
+        # build_skipped adds null namespace for this action, preserves upstream
+        assert item["content"]["test_batch"] is None
+        assert item["content"]["upstream_action"] == {"field": "value"}
 
     def test_guard_skipped_reason(self):
         """Records with SKIPPED filter status get reason=guard_skipped."""
@@ -312,7 +315,7 @@ class TestBatchPathReasonDetection:
         from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
         from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
 
-        row = {"content": "data", "source_guid": "sg_batch_2"}
+        row = {"content": {"prev": {"x": 1}}, "source_guid": "sg_batch_2"}
         BatchContextMetadata.set_filter_status(row, FilterStatus.SKIPPED)
         ctx = self._make_ctx(passthrough_records=[("cid_2", row)])
         processor = BatchResultProcessor()
@@ -323,12 +326,13 @@ class TestBatchPathReasonDetection:
         assert item["metadata"]["reason"] == "guard_skipped"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
+        assert item["content"]["test_batch"] is None
 
     def test_batch_not_returned_reason(self):
         """Records without filter metadata get reason=batch_not_returned."""
         from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
 
-        row = {"content": "data", "source_guid": "sg_batch_3"}
+        row = {"content": {"prev": {"x": 1}}, "source_guid": "sg_batch_3"}
         ctx = self._make_ctx(passthrough_records=[("cid_3", row)])
         processor = BatchResultProcessor()
         result_ctx = processor._stage_6_merge_passthroughs(ctx)
@@ -338,6 +342,7 @@ class TestBatchPathReasonDetection:
         assert item["metadata"]["reason"] == "batch_not_returned"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
+        assert item["content"]["test_batch"] is None
 
     def test_upstream_unprocessed_uses_unprocessed_status(self):
         """upstream_unprocessed records should use ProcessingResult.unprocessed(), not .skipped()."""
@@ -345,7 +350,7 @@ class TestBatchPathReasonDetection:
         from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
 
         row = {
-            "content": "stale",
+            "content": {"upstream": {"data": "stale"}},
             "source_guid": "sg_batch_4",
             ContextMetaKeys.FILTER_PHASE: "upstream_unprocessed",
         }
@@ -370,7 +375,7 @@ class TestBatchPathReasonDetection:
         """batch_not_returned records should use ProcessingResult.unprocessed(), not .skipped()."""
         from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
 
-        row = {"content": "data", "source_guid": "sg_batch_5"}
+        row = {"content": {"prev": {"x": 1}}, "source_guid": "sg_batch_5"}
         ctx = self._make_ctx(passthrough_records=[("cid_5", row)])
         processor = BatchResultProcessor()
 

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -305,7 +305,6 @@ class TestBatchPathReasonDetection:
         assert item["metadata"]["reason"] == "upstream_unprocessed"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
-        # build_skipped adds null namespace for this action, preserves upstream
         assert item["content"]["test_batch"] is None
         assert item["content"]["upstream_action"] == {"field": "value"}
 

--- a/tests/unit/utils/test_passthrough_builder.py
+++ b/tests/unit/utils/test_passthrough_builder.py
@@ -138,7 +138,6 @@ class TestBuildItemBatchMode:
             item = PassthroughItemBuilder.build_item(
                 row=row, reason="where_clause_not_matched", action_name="a"
             )
-        # build_skipped preserves upstream + adds null namespace for skipped action
         assert item["content"]["text"] == "payload"
         assert item["content"]["a"] is None
 

--- a/tests/unit/utils/test_passthrough_builder.py
+++ b/tests/unit/utils/test_passthrough_builder.py
@@ -131,33 +131,37 @@ class TestBuildItemBatchMode:
         assert item["source_guid"] == "tid-fallback"
 
     def test_content_extracted_from_row(self):
-        """When row has a 'content' key, that value is used as content."""
+        """When row has a 'content' key, upstream content is preserved plus null namespace."""
         inner = {"text": "payload"}
         row = {"content": inner}
         with _patch_id_gen():
             item = PassthroughItemBuilder.build_item(
                 row=row, reason="where_clause_not_matched", action_name="a"
             )
-        assert item["content"] == inner
+        # build_skipped preserves upstream + adds null namespace for skipped action
+        assert item["content"]["text"] == "payload"
+        assert item["content"]["a"] is None
 
     def test_namespaced_content_preserved(self):
-        """Namespaced content is preserved in the tombstone item."""
+        """Namespaced content is preserved in the tombstone item with null namespace added."""
         namespaced = {"action_a": {"field_a": "val_a"}, "action_b": {"field_b": "val_b"}}
         row = {"content": namespaced, "target_id": "tid-1", "source_guid": "sg-1"}
         with _patch_id_gen():
             item = PassthroughItemBuilder.build_item(
                 row=row, reason="where_clause_not_matched", action_name="action_c"
             )
-        assert item["content"] == namespaced
+        assert item["content"]["action_a"] == {"field_a": "val_a"}
+        assert item["content"]["action_b"] == {"field_b": "val_b"}
+        assert item["content"]["action_c"] is None
 
-    def test_content_defaults_to_empty_dict_when_missing(self):
-        """When row has no 'content' key, content defaults to empty dict."""
+    def test_content_defaults_to_empty_with_null_namespace(self):
+        """When row has no 'content' key, content has only the null namespace."""
         row = {"field1": "val1", "field2": "val2"}
         with _patch_id_gen():
             item = PassthroughItemBuilder.build_item(
                 row=row, reason="where_clause_not_matched", action_name="a"
             )
-        assert item["content"] == {}
+        assert item["content"] == {"a": None}
 
     def test_conditional_clause_flag_in_batch(self):
         """Batch mode with conditional_clause_failed sets the right flag."""
@@ -265,7 +269,7 @@ class TestBuildItemEdgeCases:
     """Edge cases: empty rows, falsy target_ids, etc."""
 
     def test_empty_row(self):
-        """An empty row still produces a valid passthrough item with empty content."""
+        """An empty row still produces a valid passthrough item with null namespace."""
         with _patch_id_gen():
             item = PassthroughItemBuilder.build_item(
                 row={}, reason="where_clause_not_matched", action_name="a"
@@ -273,7 +277,7 @@ class TestBuildItemEdgeCases:
         assert item["_unprocessed"] is True
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item["target_id"] == FIXED_TARGET_ID
-        assert item["content"] == {}
+        assert item["content"] == {"a": None}
 
     def test_falsy_target_id_in_row(self):
         """A falsy (empty string) target_id in the row is treated as missing."""

--- a/tests/unit/utils/test_passthrough_carry_forward.py
+++ b/tests/unit/utils/test_passthrough_carry_forward.py
@@ -1,0 +1,143 @@
+"""Tests for record mode namespace carry-forward in passthrough transformation.
+
+Verifies that upstream action namespaces from the input record are preserved
+in the output when a record mode LLM action processes a record.
+"""
+
+from agent_actions.utils.transformation.passthrough import PassthroughTransformer
+
+
+class TestCarryForwardNamespaces:
+    """PassthroughTransformer.transform_with_passthrough merges existing_content."""
+
+    def _make_agent_config(self, action_name="current_action"):
+        return {"agent_type": action_name}
+
+    def test_upstream_namespaces_carried_forward(self):
+        """Output includes both upstream namespaces and current action's namespace."""
+        transformer = PassthroughTransformer()
+        existing = {
+            "extract": {"text": "hello"},
+            "summarize": {"summary": "hi"},
+        }
+        llm_output = [{"score": 0.9, "label": "positive"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("classify"),
+            action_name="classify",
+            existing_content=existing,
+        )
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content["extract"] == {"text": "hello"}
+        assert content["summarize"] == {"summary": "hi"}
+        assert content["classify"] == {"score": 0.9, "label": "positive"}
+
+    def test_no_existing_content_still_works(self):
+        """When existing_content is None, output is unchanged."""
+        transformer = PassthroughTransformer()
+        llm_output = [{"answer": "42"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("qa"),
+            action_name="qa",
+            existing_content=None,
+        )
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content == {"qa": {"answer": "42"}}
+
+    def test_empty_existing_content_no_effect(self):
+        """Empty dict existing_content has no effect."""
+        transformer = PassthroughTransformer()
+        llm_output = [{"answer": "42"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("qa"),
+            action_name="qa",
+            existing_content={},
+        )
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content == {"qa": {"answer": "42"}}
+
+    def test_three_upstream_actions_all_preserved(self):
+        """Three upstream namespaces plus current action all present in output."""
+        transformer = PassthroughTransformer()
+        existing = {
+            "flatten_canonical_questions": {"questions": ["q1", "q2"]},
+            "deduplicate_across_documents": {"unique": ["q1"]},
+            "filter_learning_quality_1": {"quality": "high"},
+        }
+        llm_output = [{"grade": "A"}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("grade_content"),
+            action_name="grade_content",
+            existing_content=existing,
+        )
+
+        content = result[0]["content"]
+        assert set(content.keys()) == {
+            "flatten_canonical_questions",
+            "deduplicate_across_documents",
+            "filter_learning_quality_1",
+            "grade_content",
+        }
+        assert content["grade_content"] == {"grade": "A"}
+
+    def test_current_action_wins_on_namespace_conflict(self):
+        """If the current action name collides with an upstream namespace, current wins."""
+        transformer = PassthroughTransformer()
+        existing = {"rerun": {"old": True}}
+        llm_output = [{"new": True}]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("rerun"),
+            action_name="rerun",
+            existing_content=existing,
+        )
+
+        content = result[0]["content"]
+        assert content["rerun"] == {"new": True}
+
+    def test_multiple_output_records_all_get_merge(self):
+        """When LLM produces multiple output records, all get upstream namespaces."""
+        transformer = PassthroughTransformer()
+        existing = {"extract": {"text": "hello"}}
+        llm_output = [
+            {"variant": "A"},
+            {"variant": "B"},
+        ]
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="guid-1",
+            agent_config=self._make_agent_config("generate"),
+            action_name="generate",
+            existing_content=existing,
+        )
+
+        assert len(result) == 2
+        for item in result:
+            assert item["content"]["extract"] == {"text": "hello"}
+            assert "generate" in item["content"]


### PR DESCRIPTION
## Summary
- Migrate 5 content assembly locations to RecordEnvelope (Phase 2C of unified record envelope architecture)
- **record_processor._build_tombstone_item**: guard skips use `build_skipped` (null namespace), retry exhausted uses `build()` (namespaced output)
- **exhausted_builder**: `wrap_content` → `RecordEnvelope.build_content`
- **result_processor**: `transform_structure` → `RecordEnvelope.build_content` with upstream namespace preservation; passthrough items use `build_skipped`
- **version correlator**: `build_version_merge` for content validation
- **passthrough_builder**: `build_skipped` for tombstone content with null namespace + upstream preservation

## Verification
- `ruff format --check` — clean
- `ruff check` — clean
- `pytest` — 5881 passed, 2 skipped
- Clone 4 external verification tests — 16/16 passed