### PR TITLE
arch: RecordEnvelope dead code removal 

### DIFF
--- a/.changes/unreleased/Under the Hood-20260424-045000.yaml
+++ b/.changes/unreleased/Under the Hood-20260424-045000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove dead code from RecordEnvelope migration, eliminate or \"unknown\" fallback patterns, add grep audit enforcement"
+time: 2026-04-24T04:50:00.000000Z

--- a/agent_actions/input/preprocessing/transformation/transformer.py
+++ b/agent_actions/input/preprocessing/transformation/transformer.py
@@ -75,7 +75,7 @@ class DataTransformer:
         if not action_name and not version_merge:
             raise ValueError("action_name is required for namespaced content wrapping")
 
-        from agent_actions.utils.content import wrap_content
+        from agent_actions.record.envelope import RecordEnvelope
 
         result = []
 
@@ -89,7 +89,7 @@ class DataTransformer:
                                     "source_guid": source_guid,
                                     "content": content
                                     if version_merge
-                                    else wrap_content(action_name, content),
+                                    else RecordEnvelope.build_content(action_name, content),
                                 }
                             )
                     else:
@@ -97,7 +97,7 @@ class DataTransformer:
                             wrapped = contents
                         else:
                             wrapped = (
-                                wrap_content(action_name, contents)
+                                RecordEnvelope.build_content(action_name, contents)
                                 if isinstance(contents, dict)
                                 else contents
                             )

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -287,9 +287,11 @@ class BatchResultProcessor:
         stored_passthrough = BatchContextMetadata.get_passthrough_fields(ctx.context_map[custom_id])
 
         if stored_passthrough:
-            from agent_actions.prompt.context.scope_application import merge_passthrough_fields
-
-            generated_list = merge_passthrough_fields(generated_list, stored_passthrough)
+            # generated_list contains flat LLM output dicts (no "content" wrapper yet)
+            generated_list = [
+                {**item, **stored_passthrough} if isinstance(item, dict) else item
+                for item in generated_list
+            ]
 
         elif ctx.agent_config and ctx.agent_config.get("context_scope", {}).get("passthrough"):
             passthrough_refs = ctx.agent_config.get("context_scope", {}).get("passthrough", [])
@@ -302,10 +304,9 @@ class BatchResultProcessor:
                     _, field_name = parse_field_reference(field_ref)
                     passthrough_fields.append(field_name)
                 except ValueError:
-                    # If parsing fails, use the whole string as field name
                     passthrough_fields.append(field_ref)
 
-            original_content = original_row.get("content", original_row)
+            original_content = original_row.get("content", {})
 
             generated_list = [
                 (
@@ -335,7 +336,7 @@ class BatchResultProcessor:
                 "BatchProcessingContext.reconciler is None; "
                 "reconciler must be initialized before creating error items"
             )
-        source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "unknown")
+        source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "NOT_SET")
 
         error_item: dict[str, Any] = {
             "source_guid": source_guid,
@@ -366,7 +367,7 @@ class BatchResultProcessor:
             )
         from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 
-        source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "unknown")
+        source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "NOT_SET")
 
         return ExhaustedRecordBuilder.build_exhausted_item(
             source_guid=source_guid,
@@ -400,7 +401,7 @@ class BatchResultProcessor:
 
                 record_index = ctx.reconciler.get_record_index(custom_id)
                 source_guid = ctx.reconciler.get_source_guid(
-                    custom_id, fallback=custom_id or "unknown"
+                    custom_id, fallback=custom_id or "NOT_SET"
                 )
 
                 if not ctx.agent_config or "action_name" not in ctx.agent_config:

--- a/agent_actions/logging/errors/formatters/template.py
+++ b/agent_actions/logging/errors/formatters/template.py
@@ -17,7 +17,7 @@ class TemplateErrorFormatter(ErrorFormatter):
     def format(
         self, exc: Exception, root: Exception, message: str, context: dict[str, Any]
     ) -> UserError:
-        agent_name = context.get("agent") or context.get("agent_name") or "unknown"
+        agent_name = context.get("agent") or context.get("agent_name") or "NOT_SET"
         missing = context.get("missing_variables", [])
         available = context.get("available_variables", [])
 

--- a/agent_actions/processing/invocation/online.py
+++ b/agent_actions/processing/invocation/online.py
@@ -114,7 +114,7 @@ class OnlineStrategy(InvocationStrategy):
                 attempts=retry_result.attempts,
                 failures=failures,
                 succeeded=succeeded,
-                reason=retry_result.reason or "unknown",
+                reason=retry_result.reason or "NOT_SET",
                 timestamp=datetime.now(UTC).isoformat(),
             )
 

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -245,7 +245,7 @@ class RepromptService:
         )
         fire_event(
             RepromptValidationFailedEvent(
-                action_name=context or "unknown",
+                action_name=context or "NOT_SET",
                 attempt=attempts,
                 error=f"Validation '{self.validation_name}' failed after {attempts} attempts",
             )

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -31,7 +31,6 @@ FRAMEWORK_NAMESPACES = frozenset({"version", "seed", "workflow", "loop"})
 __all__ = [
     "apply_context_scope",
     "format_llm_context",
-    "merge_passthrough_fields",
 ]
 
 
@@ -302,26 +301,3 @@ def format_llm_context(llm_context: dict) -> str:
             lines.append(f"{ns_name}.{field}: {value_str}")
 
     return "\n".join(lines)
-
-
-def merge_passthrough_fields(llm_response: list[dict], passthrough_fields: dict) -> list[dict]:
-    """Merge passthrough fields into LLM response.
-
-    Returns a new structure -- the caller's original is never mutated.
-    """
-    if not passthrough_fields:
-        return llm_response
-
-    # Handle list of items
-    result = []
-    for item in llm_response:
-        if isinstance(item, dict):
-            item_copy = dict(item)
-            if "content" in item_copy and isinstance(item_copy["content"], dict):
-                item_copy["content"] = {**item_copy["content"], **passthrough_fields}
-            else:
-                item_copy.update(passthrough_fields)
-            result.append(item_copy)
-        else:
-            result.append(item)  # type: ignore[unreachable]
-    return result

--- a/agent_actions/tooling/docs/generator.py
+++ b/agent_actions/tooling/docs/generator.py
@@ -355,7 +355,7 @@ class CatalogGenerator:
         if runs_data:
             for wf_data in runs_data.values():
                 for evt in wf_data.get("runtime_warnings", []):
-                    target = evt.get("action_name") or evt.get("event_type") or "unknown"
+                    target = evt.get("action_name") or evt.get("event_type") or "NOT_SET"
                     entry = {
                         "target": target,
                         "message": evt.get("message", ""),
@@ -375,7 +375,7 @@ class CatalogGenerator:
                         {
                             "target": exec_rec.get("workflow_name")
                             or exec_rec.get("workflow_id")
-                            or "unknown",
+                            or "NOT_SET",
                             "message": exec_rec.get("error_message")
                             or f"Run {exec_rec.get('id', '?')} failed",
                             "timestamp": exec_rec.get("ended_at")

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -148,7 +148,7 @@ def _inject_upstream_virtual_actions(
         from agent_actions.workflow.orchestrator import WorkflowOrchestrator
 
         orchestrator = WorkflowOrchestrator(manager.project_root)
-        orchestrator.validate_upstream_refs(manager.agent_name or "unknown", parsed_refs)
+        orchestrator.validate_upstream_refs(manager.agent_name or "NOT_SET", parsed_refs)
 
     virtual_actions: dict[str, VirtualAction] = {}
     for ref in parsed_refs:

--- a/tests/integration/test_context_scope_audit.py
+++ b/tests/integration/test_context_scope_audit.py
@@ -21,7 +21,6 @@ from agent_actions.prompt.context.scope_application import (
     FRAMEWORK_NAMESPACES,
     apply_context_scope,
     format_llm_context,
-    merge_passthrough_fields,
 )
 from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode
 from agent_actions.prompt.context.scope_inference import infer_dependencies
@@ -124,13 +123,6 @@ class TestPassthroughDirective:
         _, llm_ctx, pt = apply_context_scope(field_context, scope, action_name="act")
         assert "score" not in llm_ctx.get("dep", {})
         assert pt["dep"]["score"] == 0.8
-
-    def test_passthrough_appears_in_output_via_merge(self):
-        """passthrough fields get merged into LLM response output."""
-        llm_response = [{"content": {"answer": "42"}}]
-        passthrough = {"dep": {"original_id": "abc"}}
-        result = merge_passthrough_fields(llm_response, passthrough)
-        assert result[0]["content"]["dep"] == {"original_id": "abc"}
 
     def test_passthrough_wildcard(self):
         field_context = _fc(dep={"a": 1, "b": 2})
@@ -525,7 +517,7 @@ class TestFieldParsing:
 
 
 class TestFormatAndMerge:
-    """format_llm_context and merge_passthrough_fields utilities."""
+    """format_llm_context utility."""
 
     def test_format_empty_returns_empty(self):
         assert format_llm_context({}) == ""
@@ -535,24 +527,6 @@ class TestFormatAndMerge:
         result = format_llm_context(llm_ctx)
         assert "dep.summary" in result
         assert "hello world" in result
-
-    def test_merge_passthrough_into_content(self):
-        response = [{"content": {"answer": "42"}}]
-        pt = {"dep": {"original_id": "abc"}}
-        result = merge_passthrough_fields(response, pt)
-        assert result[0]["content"]["dep"] == {"original_id": "abc"}
-        assert result[0]["content"]["answer"] == "42"
-
-    def test_merge_passthrough_empty_noop(self):
-        response = [{"content": {"answer": "42"}}]
-        result = merge_passthrough_fields(response, {})
-        assert result == response
-
-    def test_merge_does_not_mutate_original(self):
-        response = [{"content": {"answer": "42"}}]
-        pt = {"dep": {"id": "x"}}
-        merge_passthrough_fields(response, pt)
-        assert "dep" not in response[0]["content"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_context_scope_integrity.py
+++ b/tests/integration/test_context_scope_integrity.py
@@ -13,7 +13,6 @@ from agent_actions.errors import ConfigurationError
 from agent_actions.prompt.context.scope_application import (
     FRAMEWORK_NAMESPACES,
     apply_context_scope,
-    merge_passthrough_fields,
 )
 from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode
 from agent_actions.prompt.context.scope_parsing import parse_field_reference
@@ -591,29 +590,6 @@ class TestPassthroughIntegrity:
 
         assert "secret_field" not in llm_context.get("dep", {})
         assert passthrough["dep"]["secret_field"] == "hidden_value"
-
-    def test_passthrough_merged_into_output(self):
-        """passthrough fields merged into output record via merge_passthrough_fields()."""
-        llm_response = [{"content": {"result": "processed", "score": 0.9}}]
-        passthrough_fields = {"dep": {"record_id": "rec-42", "source": "api"}}
-
-        merged = merge_passthrough_fields(llm_response, passthrough_fields)
-
-        assert merged[0]["content"]["result"] == "processed"
-        assert merged[0]["content"]["score"] == 0.9
-        assert merged[0]["content"]["dep"] == {"record_id": "rec-42", "source": "api"}
-
-    def test_passthrough_does_not_overwrite_output_fields(self):
-        """If output already has a field with same key as passthrough namespace,
-        passthrough overwrites it (last-writer wins via dict.update)."""
-        llm_response = [{"content": {"result": "ok", "dep": {"old": "data"}}}]
-        passthrough_fields = {"dep": {"new_field": "new_value"}}
-
-        merged = merge_passthrough_fields(llm_response, passthrough_fields)
-
-        # Passthrough overwrites the dep key in content (dict.update semantics)
-        assert merged[0]["content"]["dep"] == {"new_field": "new_value"}
-        assert merged[0]["content"]["result"] == "ok"
 
     def test_passthrough_and_observe_same_namespace(self):
         """observe: ['dep.public'], passthrough: ['dep.internal'] ->

--- a/tests/unit/prompt/context/test_scope_application.py
+++ b/tests/unit/prompt/context/test_scope_application.py
@@ -11,7 +11,6 @@ from agent_actions.errors import ConfigurationError
 from agent_actions.prompt.context.scope_application import (
     apply_context_scope,
     format_llm_context,
-    merge_passthrough_fields,
 )
 
 
@@ -418,7 +417,7 @@ class TestPassthroughNamespacing:
 
 
 class TestFormatAndMerge:
-    """format_llm_context and merge_passthrough_fields."""
+    """format_llm_context utility."""
 
     def test_format_namespaced(self):
         lc = {"dep_1": {"score": 8}, "dep_2": {"score": 7}}
@@ -433,24 +432,6 @@ class TestFormatAndMerge:
     def test_format_single_namespace(self):
         text = format_llm_context({"dep": {"name": "test"}})
         assert "dep.name:" in text
-
-    def test_merge_namespaced_into_content(self):
-        response = [{"content": {"result": "ok"}}]
-        pt = {"dep": {"id": "rec-1"}}
-        merged = merge_passthrough_fields(response, pt)
-        assert merged[0]["content"]["dep"] == {"id": "rec-1"}
-        assert merged[0]["content"]["result"] == "ok"
-
-    def test_merge_empty_passthrough_unchanged(self):
-        response = [{"content": {"r": 1}}]
-        assert merge_passthrough_fields(response, {}) == response
-
-    def test_merge_into_flat_response(self):
-        response = [{"result": "ok"}]
-        pt = {"dep": {"id": "rec-1"}}
-        merged = merge_passthrough_fields(response, pt)
-        assert merged[0]["dep"] == {"id": "rec-1"}
-        assert merged[0]["result"] == "ok"
 
 
 class TestDropVersioned:

--- a/tests/unit/record/test_no_manual_assembly.py
+++ b/tests/unit/record/test_no_manual_assembly.py
@@ -1,0 +1,83 @@
+"""Grep-based architectural tests enforcing RecordEnvelope as the single
+authority for record content assembly.
+
+These tests scan the source tree for patterns that bypass RecordEnvelope.
+They act as a CI gate — if a new module manually builds content dicts,
+these tests fail before the PR can merge.
+"""
+
+import subprocess
+from pathlib import Path
+
+AGENT_ACTIONS = str(Path(__file__).resolve().parents[3] / "agent_actions")
+
+
+def _grep_count(pattern: str, path: str, *exclude_globs: str) -> tuple[int, str]:
+    """Return (match_count, matching_lines) using grep."""
+    cmd = ["grep", "-rn", "-P", pattern, path, "--include=*.py"]
+    for glob in exclude_globs:
+        cmd.extend(["--exclude", glob])
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        return 0, ""
+    lines = result.stdout.strip()
+    count = len(lines.splitlines()) if lines else 0
+    return count, lines
+
+
+class TestNoManualContentAssembly:
+    """No module should spread **existing_content outside RecordEnvelope."""
+
+    def test_no_existing_content_spreading(self):
+        count, lines = _grep_count(
+            r"\*\*existing_content",
+            AGENT_ACTIONS,
+        )
+        # Only allowed in record/envelope.py
+        filtered = [line for line in lines.splitlines() if "record/envelope" not in line]
+        assert not filtered, "Found **existing_content outside record/envelope.py:\n" + "\n".join(
+            filtered
+        )
+
+
+class TestNoDirectWrapContentCalls:
+    """wrap_content() should only exist in content.py (as alias) and tests."""
+
+    def test_no_wrap_content_outside_alias(self):
+        count, lines = _grep_count(
+            r"wrap_content\(",
+            AGENT_ACTIONS,
+        )
+        filtered = [
+            line
+            for line in lines.splitlines()
+            if "content.py" not in line and "_MANIFEST" not in line
+        ]
+        assert not filtered, "Found wrap_content() calls outside content.py:\n" + "\n".join(
+            filtered
+        )
+
+
+class TestNoUnknownFallbacks:
+    """'or \"unknown\"' hides missing data — use 'or \"NOT_SET\"' instead."""
+
+    def test_no_or_unknown_pattern(self):
+        count, lines = _grep_count(
+            r'or "unknown"',
+            AGENT_ACTIONS,
+        )
+        assert count == 0, f"Found {count} 'or \"unknown\"' pattern(s):\n{lines}"
+
+
+class TestNoDeadMergePassthroughFields:
+    """merge_passthrough_fields was removed from scope_application.py."""
+
+    def test_merge_passthrough_fields_removed(self):
+        import inspect
+
+        from agent_actions.prompt.context import scope_application
+
+        source = inspect.getsource(scope_application)
+        assert "def merge_passthrough_fields" not in source, (
+            "Dead function merge_passthrough_fields still exists in scope_application.py"
+        )

--- a/tests/utilities/test_context_scope_processor.py
+++ b/tests/utilities/test_context_scope_processor.py
@@ -6,7 +6,6 @@ from agent_actions.errors import ConfigurationError
 from agent_actions.prompt.context.scope_application import (
     apply_context_scope,
     format_llm_context,
-    merge_passthrough_fields,
 )
 from agent_actions.prompt.context.scope_namespace import (
     _extract_allowed_fields_per_dependency,
@@ -131,53 +130,6 @@ class TestContextScopeProcessor:
         # llm_context should have observe fields but NOT seed data
         assert llm_context["source"]["page_content"] == "text"
         assert "exam_syllabus" not in llm_context.get("seed", {})
-
-    def test_merge_passthrough_fields(self):
-        """Test merging passthrough fields into LLM response."""
-        # Test with structured response (with 'content' key)
-        structured_response = [
-            {
-                "source_guid": "guid-abc-123",
-                "node_id": "node_1_classifier",
-                "content": {"classification": "positive", "confidence": 0.92},
-            },
-            {
-                "source_guid": "guid-def-456",
-                "node_id": "node_1_classifier",
-                "content": {"classification": "negative", "confidence": 0.88},
-            },
-        ]
-
-        passthrough_fields = {"document_id": "doc-123", "original_filename": "report.pdf"}
-
-        # Execute
-        result = merge_passthrough_fields(structured_response, passthrough_fields)
-
-        # Validate - passthrough fields merged into content
-        assert result[0]["content"]["classification"] == "positive"
-        assert result[0]["content"]["confidence"] == 0.92
-        assert result[0]["content"]["document_id"] == "doc-123"
-        assert result[0]["content"]["original_filename"] == "report.pdf"
-
-        assert result[1]["content"]["classification"] == "negative"
-        assert result[1]["content"]["confidence"] == 0.88
-        assert result[1]["content"]["document_id"] == "doc-123"
-        assert result[1]["content"]["original_filename"] == "report.pdf"
-
-        # Test with flat response (no 'content' key)
-        flat_response = [{"classification": "positive", "confidence": 0.95}]
-
-        flat_result = merge_passthrough_fields(flat_response, passthrough_fields)
-
-        # Validate - passthrough fields merged directly
-        assert flat_result[0]["classification"] == "positive"
-        assert flat_result[0]["confidence"] == 0.95
-        assert flat_result[0]["document_id"] == "doc-123"
-        assert flat_result[0]["original_filename"] == "report.pdf"
-
-        # Test with empty passthrough returns response unchanged
-        unchanged = merge_passthrough_fields(structured_response, {})
-        assert unchanged == structured_response
 
     def test_apply_context_scope_observe_wildcard(self):
         """Test wildcard expansion for observe directive in apply_context_scope."""


### PR DESCRIPTION
## Summary
- Remove dead `merge_passthrough_fields()` from `scope_application.py` — replaced by inline flat merge in batch `result_processor._apply_context_passthrough()`
- Replace last external `wrap_content()` calls in `transformer.transform_structure()` with `RecordEnvelope.build_content()`
- Eliminate all 9 `or "unknown"` fallback patterns → `or "NOT_SET"` across 6 files
- Add architectural grep audit test (`test_no_manual_assembly.py`) enforcing RecordEnvelope as the single authority for content assembly

## Verification
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- `pytest` — 5925 passed, 2 skipped
- Grep gates: 0 `wrap_content(` outside `content.py`, 0 `**existing_content` outside `envelope.py`, 0 `or "unknown"` patterns