### PR TITLE
arch: clean tool interface — TrackedItem + reconciliation 

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260424-phase6000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260424-phase6000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "FILE mode tools receive clean business data — framework fields stripped before, reconciled after via TrackedItem provenance"
+time: 2026-04-24T06:00:00.000000Z

--- a/agent_actions/llm/providers/tools/client.py
+++ b/agent_actions/llm/providers/tools/client.py
@@ -44,7 +44,19 @@ class ToolClient:
         strip = BatchContextMetadata.strip_internal_fields
 
         if isinstance(data, list):
-            return [strip(item) if isinstance(item, dict) else item for item in data]
+            from agent_actions.record.tracking import TrackedItem
+
+            result = []
+            for item in data:
+                if isinstance(item, TrackedItem):
+                    # Preserve TrackedItem type — provenance must survive stripping
+                    stripped = strip(item)
+                    result.append(TrackedItem(stripped, source_index=item._source_index))
+                elif isinstance(item, dict):
+                    result.append(strip(item))
+                else:
+                    result.append(item)
+            return result
 
         if isinstance(data, str):
             try:

--- a/agent_actions/llm/providers/tools/client.py
+++ b/agent_actions/llm/providers/tools/client.py
@@ -46,7 +46,7 @@ class ToolClient:
         if isinstance(data, list):
             from agent_actions.record.tracking import TrackedItem
 
-            result = []
+            result: list[Any] = []
             for item in data:
                 if isinstance(item, TrackedItem):
                     # Preserve TrackedItem type — provenance must survive stripping

--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -7,7 +7,8 @@ Single authority for record content assembly. Every action type, granularity, an
 | Name | Type | Exports | Signals |
 |------|------|---------|---------|
 | `envelope.py` | Module | `RecordEnvelope`, `RecordEnvelopeError` | - |
-| `__init__.py` | Re-export | `RecordEnvelope`, `RecordEnvelopeError` | - |
+| `tracking.py` | Module | `TrackedItem` | - |
+| `__init__.py` | Re-export | `RecordEnvelope`, `RecordEnvelopeError`, `TrackedItem` | - |
 
 ## Project Surface
 
@@ -17,6 +18,7 @@ Single authority for record content assembly. Every action type, granularity, an
 | `RecordEnvelope.build_content()` | `agent_io/target/{action}/` | Writes content dict (no record wrapper) | - |
 | `RecordEnvelope.build_skipped()` | `agent_io/target/{action}/` | Writes record with null namespace for guard skip | - |
 | `RecordEnvelope.build_version_merge()` | `agent_io/target/{action}/` | Writes record merging version namespaces | `version_consumption` |
+| `TrackedItem` | `tools/{workflow}/*.py` | FILE tool input: dict subclass with hidden `_source_index` provenance | - |
 
 ## Dependencies
 
@@ -24,7 +26,8 @@ Single authority for record content assembly. Every action type, granularity, an
 |-----------|--------|-----|
 | **Depended on by** | `utils/content.py` | `wrap_content()` delegates to `build_content()` |
 | **Depended on by** | `utils/transformation/passthrough.py` | (Phase 2) record assembly after strategy |
-| **Depended on by** | `workflow/pipeline_file_mode.py` | (Phase 2) FILE mode tool + HITL assembly |
+| **Depended on by** | `workflow/pipeline_file_mode.py` | FILE mode tool + HITL assembly; TrackedItem wrapping |
+| **Depended on by** | `llm/providers/tools/client.py` | TrackedItem preservation in `_strip_internal_fields` |
 | **Depended on by** | `processing/record_processor.py` | (Phase 2) tombstone builder |
 | **Depended on by** | `processing/exhausted_builder.py` | (Phase 2) exhausted record builder |
 | **Depended on by** | `llm/batch/processing/result_processor.py` | (Phase 2) batch result assembly |

--- a/agent_actions/record/__init__.py
+++ b/agent_actions/record/__init__.py
@@ -1,5 +1,6 @@
 """Unified record envelope -- single authority for record content assembly."""
 
 from agent_actions.record.envelope import RecordEnvelope, RecordEnvelopeError
+from agent_actions.record.tracking import TrackedItem
 
-__all__ = ["RecordEnvelope", "RecordEnvelopeError"]
+__all__ = ["RecordEnvelope", "RecordEnvelopeError", "TrackedItem"]

--- a/agent_actions/record/tracking.py
+++ b/agent_actions/record/tracking.py
@@ -1,0 +1,23 @@
+"""TrackedItem — dict subclass with hidden provenance for FILE mode tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TrackedItem(dict):
+    """Dict subclass that carries provenance. User treats it as a normal dict.
+
+    Framework wraps each input item before calling a FILE tool.
+    User code accesses fields normally: item["question_text"].
+    Framework reads _source_index after tool returns to map output to input.
+
+    If user does {**item}, _source_index is lost (plain dict created).
+    Framework detects this and raises ValueError.
+    """
+
+    __slots__ = ("_source_index",)
+
+    def __init__(self, data: dict[str, Any], source_index: int):
+        super().__init__(data)
+        self._source_index = source_index

--- a/agent_actions/utils/udf_management/registry.py
+++ b/agent_actions/utils/udf_management/registry.py
@@ -4,23 +4,38 @@ import inspect
 import sys
 import threading
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any, cast
 
 from agent_actions.config.types import Granularity
 from agent_actions.errors import DuplicateFunctionError, FunctionNotFoundError
 
 
-@dataclass
 class FileUDFResult:
-    """Result type for FILE-level UDFs.
+    """Explicit provenance for N→M FILE tools.
 
     Tools return business data only.  The framework handles all metadata
     propagation (``source_guid``, lineage, ``node_id``) automatically —
     tools never need to think about it.
+
+    Each output must declare ``source_index`` (which input produced it)
+    and ``data`` (the business fields).
     """
 
-    outputs: list[dict]
+    def __init__(self, outputs: list[dict[str, Any]]):
+        for i, out in enumerate(outputs):
+            if not isinstance(out, dict):
+                raise ValueError(f"FileUDFResult output[{i}] must be a dict")
+            if "source_index" not in out:
+                raise ValueError(
+                    f"FileUDFResult output[{i}] missing 'source_index'. "
+                    f"Every output must declare which input produced it."
+                )
+            if "data" not in out or not isinstance(out["data"], dict):
+                raise ValueError(
+                    f"FileUDFResult output[{i}] missing 'data' dict. "
+                    f"Every output must have a 'data' dict with business fields."
+                )
+        self.outputs = outputs
 
 
 # Thread safety

--- a/agent_actions/utils/udf_management/tooling.py
+++ b/agent_actions/utils/udf_management/tooling.py
@@ -102,7 +102,8 @@ def _validate_udf_output(udf_name: str, result: Any, json_output_schema: dict[st
     """Validate UDF output against a per-item JSON Schema."""
     from agent_actions.utils.udf_management.registry import FileUDFResult
 
-    items = result.outputs if isinstance(result, FileUDFResult) else result
+    # FileUDFResult outputs carry source_index + data; validate data only.
+    items = [out["data"] for out in result.outputs] if isinstance(result, FileUDFResult) else result
 
     if isinstance(items, list):
         for idx, item in enumerate(items):

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -193,43 +193,39 @@ def _extract_business_fields(record: dict, agent_config: dict) -> dict:
     return business
 
 
-# ---------------------------------------------------------------------------
-# Public API — standalone helpers for testing / simulation
-# ---------------------------------------------------------------------------
+def _build_record(
+    action_name: str,
+    data_fields: dict,
+    matched: dict[str, Any] | None,
+    version_merge: bool,
+) -> dict[str, Any]:
+    """Build a single output record, either namespaced or version-merge spread."""
+    if version_merge:
+        from agent_actions.utils.content import get_existing_content
+
+        existing = get_existing_content(matched) if matched else {}
+        record: dict[str, Any] = {"content": {**existing, **data_fields}}
+    else:
+        from agent_actions.record.envelope import RecordEnvelope
+
+        record = RecordEnvelope.build(action_name, data_fields, matched)
+    record.pop("source_guid", None)
+    return record
 
 
-def framework_prepare_input(
-    records: list[dict],
-    observe_refs: list[str] | None = None,
-) -> list[TrackedItem]:
-    """Strip framework fields and wrap in TrackedItem for tool input.
-
-    Called by ``process_file_mode_tool`` and available standalone for
-    design tests and simulations.
-    """
-    config: dict[str, Any] = {"context_scope": {"observe": observe_refs}} if observe_refs else {}
-    clean: list[TrackedItem] = []
-    for i, record in enumerate(records):
-        business = _extract_business_fields(record, config)
-        clean.append(TrackedItem(business, source_index=i))
-    return clean
-
-
-def framework_reconcile(
+def _reconcile_outputs(
     raw_response: Any,
     action_name: str,
     original_data: list[dict],
-) -> list[dict[str, Any]]:
-    """Reconcile tool output to input records via provenance.
+    version_merge: bool = False,
+) -> tuple[list[dict[str, Any]], dict[int, int | list[int]]]:
+    """Core reconciliation of tool output to input records.
 
-    Handles ``TrackedItem`` list returns (N→N passthrough/filter) and
-    ``FileUDFResult`` (N→M merge/expand/dedup).  Plain dicts in list
-    returns are an error.
+    Dispatches on response type (``FileUDFResult`` vs ``TrackedItem`` list),
+    builds records, and reattaches ``source_guid``.
 
-    Called by ``process_file_mode_tool`` for the non-version-merge path
-    and available standalone for design tests and simulations.
+    Returns ``(structured_data, source_mapping)``.
     """
-    from agent_actions.record.envelope import RecordEnvelope
     from agent_actions.utils.udf_management.registry import FileUDFResult
 
     source_mapping: dict[int, int | list[int]] = {}
@@ -238,30 +234,20 @@ def framework_reconcile(
     if isinstance(raw_response, FileUDFResult):
         for i, out in enumerate(raw_response.outputs):
             src_idx = out["source_index"]
-            data_fields = out["data"]
-            if isinstance(src_idx, list):
-                input_idx = src_idx[0]
-                source_mapping[i] = src_idx
-            else:
-                input_idx = src_idx
-                source_mapping[i] = src_idx
+            input_idx = src_idx[0] if isinstance(src_idx, list) else src_idx
+            source_mapping[i] = src_idx
 
             matched = _resolve_input_record(input_idx, original_data)
-            record = RecordEnvelope.build(action_name, data_fields, matched)
-            record.pop("source_guid", None)
-            structured_data.append(record)
+            structured_data.append(_build_record(action_name, out["data"], matched, version_merge))
 
     elif isinstance(raw_response, list):
         for i, item in enumerate(raw_response):
             if isinstance(item, TrackedItem):
-                input_idx = item._source_index
-                source_mapping[i] = input_idx
-                data_fields = dict(item)
-
-                matched = _resolve_input_record(input_idx, original_data)
-                record = RecordEnvelope.build(action_name, data_fields, matched)
-                record.pop("source_guid", None)
-                structured_data.append(record)
+                source_mapping[i] = item._source_index
+                matched = _resolve_input_record(item._source_index, original_data)
+                structured_data.append(
+                    _build_record(action_name, dict(item), matched, version_merge)
+                )
             elif isinstance(item, dict):
                 raise ValueError(
                     f"FILE tool '{action_name}' returned plain dict at "
@@ -282,12 +268,54 @@ def framework_reconcile(
         )
 
     _reattach_source_guid(structured_data, source_mapping, original_data)
-    return structured_data
+    return structured_data, source_mapping
+
+
+# ---------------------------------------------------------------------------
+# Public API — standalone helpers for testing / simulation
+# ---------------------------------------------------------------------------
+
+
+def framework_prepare_input(
+    records: list[dict],
+    observe_refs: list[str] | None = None,
+) -> list[TrackedItem]:
+    """Strip framework fields and wrap in TrackedItem for tool input."""
+    config: dict[str, Any] = {"context_scope": {"observe": observe_refs}} if observe_refs else {}
+    return [
+        TrackedItem(_extract_business_fields(record, config), source_index=i)
+        for i, record in enumerate(records)
+    ]
+
+
+def framework_reconcile(
+    raw_response: Any,
+    action_name: str,
+    original_data: list[dict],
+) -> list[dict[str, Any]]:
+    """Reconcile tool output to input records via provenance.
+
+    Standalone wrapper over ``_reconcile_outputs`` for design tests and
+    simulations.
+    """
+    data, _ = _reconcile_outputs(raw_response, action_name, original_data)
+    return data
 
 
 # ---------------------------------------------------------------------------
 # Pipeline integration
 # ---------------------------------------------------------------------------
+
+
+def _is_empty_response(raw_response: Any) -> bool:
+    """Check if tool returned an empty response."""
+    from agent_actions.utils.udf_management.registry import FileUDFResult
+
+    if isinstance(raw_response, FileUDFResult):
+        return not raw_response.outputs
+    if isinstance(raw_response, list):
+        return not raw_response
+    return False
 
 
 def process_file_mode_tool(
@@ -303,20 +331,8 @@ def process_file_mode_tool(
     framework reconciles output to input via ``TrackedItem._source_index``
     (for N→N list returns) or ``FileUDFResult.source_index`` (for N→M
     transforms).  Plain dicts in list returns are an error.
-
-    Args:
-        pipeline: The parent ``ProcessingPipeline`` instance.
-        data: Observe-filtered records (framework fields stripped before tool).
-        original_data: Unfiltered records (used for namespace carry-forward).
-        context: Processing context.
-
-    Returns:
-        List with single ProcessingResult containing all outputs.
     """
     try:
-        tools_path = context.agent_config.get("tools_path")
-
-        # Strip framework fields, wrap in TrackedItem for provenance tracking.
         clean_input: list[TrackedItem] = []
         for i, record in enumerate(data):
             business = _extract_business_fields(record, context.agent_config)
@@ -327,96 +343,27 @@ def process_file_mode_tool(
             agent_name=context.agent_name,
             context=clean_input,
             formatted_prompt="",
-            tools_path=tools_path,
+            tools_path=context.agent_config.get("tools_path"),
         )
 
-        from agent_actions.record.envelope import RecordEnvelope
-        from agent_actions.utils.content import get_existing_content, is_version_merge
-        from agent_actions.utils.udf_management.registry import FileUDFResult
+        if _is_empty_response(raw_response) and data:
+            return [
+                ProcessingResult.failed(
+                    error=(
+                        f"Tool '{context.agent_name}' returned empty result "
+                        f"from {len(data)} input record(s)"
+                    ),
+                )
+            ]
 
-        version_merge = is_version_merge(context.agent_config)
-        source_mapping: dict[int, int | list[int]] = {}
-        structured_data: list[dict[str, Any]] = []
+        from agent_actions.utils.content import is_version_merge
 
-        if isinstance(raw_response, FileUDFResult):
-            # Explicit provenance — tool declared source_index for each output.
-            if not raw_response.outputs and data:
-                return [
-                    ProcessingResult.failed(
-                        error=(
-                            f"Tool '{context.agent_name}' returned empty result "
-                            f"from {len(data)} input record(s)"
-                        ),
-                    )
-                ]
-
-            for i, out in enumerate(raw_response.outputs):
-                src_idx = out["source_index"]
-                data_fields = out["data"]
-                if isinstance(src_idx, list):
-                    input_idx = src_idx[0]
-                    source_mapping[i] = src_idx
-                else:
-                    input_idx = src_idx
-                    source_mapping[i] = src_idx
-
-                matched = _resolve_input_record(input_idx, original_data)
-
-                if version_merge:
-                    existing = get_existing_content(matched) if matched else {}
-                    record: dict[str, Any] = {"content": {**existing, **data_fields}}
-                else:
-                    record = RecordEnvelope.build(context.agent_name, data_fields, matched)
-                record.pop("source_guid", None)
-                structured_data.append(record)
-
-        elif isinstance(raw_response, list):
-            if not raw_response and data:
-                return [
-                    ProcessingResult.failed(
-                        error=(
-                            f"Tool '{context.agent_name}' returned empty result "
-                            f"from {len(data)} input record(s)"
-                        ),
-                    )
-                ]
-
-            for i, item in enumerate(raw_response):
-                if isinstance(item, TrackedItem):
-                    input_idx = item._source_index
-                    source_mapping[i] = input_idx
-                    data_fields = dict(item)
-
-                    matched = _resolve_input_record(input_idx, original_data)
-
-                    if version_merge:
-                        existing = get_existing_content(matched) if matched else {}
-                        record = {"content": {**existing, **data_fields}}
-                    else:
-                        record = RecordEnvelope.build(context.agent_name, data_fields, matched)
-                    record.pop("source_guid", None)
-                    structured_data.append(record)
-                elif isinstance(item, dict):
-                    raise ValueError(
-                        f"FILE tool '{context.agent_name}' returned plain dict at "
-                        f"output[{i}]. Tool created a new dict instead of returning "
-                        f"an input item. For merge/expand, use FileUDFResult with "
-                        f"source_index."
-                    )
-                else:
-                    raise ValueError(
-                        f"FILE tool '{context.agent_name}' output[{i}] is "
-                        f"{type(item).__name__}, expected TrackedItem. "
-                        f"For N→M transforms, use FileUDFResult."
-                    )
-        else:
-            raise ValueError(
-                f"FILE tool '{context.agent_name}' must return list or FileUDFResult, "
-                f"got {type(raw_response).__name__}"
-            )
-
-        # Reattach source_guid from input records.
-        _reattach_source_guid(structured_data, source_mapping, original_data)
+        structured_data, source_mapping = _reconcile_outputs(
+            raw_response,
+            context.agent_name,
+            original_data,
+            version_merge=is_version_merge(context.agent_config),
+        )
 
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from collections.abc import Mapping
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -156,7 +157,7 @@ def _resolve_input_record(input_idx: int, original_data: list[dict]) -> dict[str
     return original_data[input_idx]
 
 
-def _extract_business_fields(record: dict, agent_config: dict) -> dict:
+def _extract_business_fields(record: dict, agent_config: Mapping[str, Any]) -> dict:
     """Extract observe-filtered business fields from a record for tool input.
 
     Strips all framework fields.  Returns only business data from observed

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -24,6 +24,7 @@ from agent_actions.processing.types import (
     ProcessingStatus,
 )
 from agent_actions.prompt.context.scope_parsing import parse_field_reference
+from agent_actions.record.tracking import TrackedItem
 
 if TYPE_CHECKING:
     from agent_actions.workflow.pipeline import ProcessingPipeline
@@ -140,6 +141,57 @@ def _reattach_source_guid(
                 item["source_guid"] = parent_guid
 
 
+def _resolve_input_record(input_idx: int, original_data: list[dict]) -> dict[str, Any] | None:
+    """Resolve the input record for namespace carry-forward.
+
+    Falls back to the first record in *original_data* when the index is
+    out of bounds — all records in a FILE batch share the same upstream
+    namespaces.
+    """
+    if isinstance(input_idx, int) and 0 <= input_idx < len(original_data):
+        return original_data[input_idx]
+    if original_data:
+        return original_data[0]
+    return None
+
+
+def _extract_business_fields(record: dict, agent_config: dict) -> dict:
+    """Extract observe-filtered business fields from a record for tool input.
+
+    Strips all framework fields.  Returns only business data from observed
+    namespaces.  When no observe is configured, flattens all content namespaces.
+    """
+    content = record.get("content")
+    if not isinstance(content, dict):
+        return {}
+
+    context_scope = agent_config.get("context_scope") or {}
+    observe_refs = context_scope.get("observe", [])
+
+    if not observe_refs:
+        # No observe declared — flatten all content namespaces
+        business: dict = {}
+        for ns_data in content.values():
+            if isinstance(ns_data, dict):
+                business.update(ns_data)
+        return business
+
+    # Extract only observed fields
+    business = {}
+    for ref in observe_refs:
+        if "." not in ref:
+            continue
+        ns, field = ref.split(".", 1)
+        if ns not in content or not isinstance(content[ns], dict):
+            continue
+        if field == "*":
+            business.update(content[ns])
+        elif field in content[ns]:
+            business[field] = content[ns][field]
+
+    return business
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -153,15 +205,16 @@ def process_file_mode_tool(
 ) -> list:
     """Process tool in FILE granularity mode.
 
-    Invokes tool once with full array instead of looping per-record.
-    Tool receives array WITH existing IDs/lineage.
-    Tool returns array of outputs (N→M transformation allowed).
-    Enrichment assigns new IDs/lineage to each output.
+    Tools receive clean business data wrapped in ``TrackedItem`` — no
+    framework fields leak into user code.  After the tool returns, the
+    framework reconciles output to input via ``TrackedItem._source_index``
+    (for N→N list returns) or ``FileUDFResult.source_index`` (for N→M
+    transforms).  Plain dicts in list returns are an error.
 
     Args:
         pipeline: The parent ``ProcessingPipeline`` instance.
-        data: Observe-filtered records (passed to tool).
-        original_data: Unfiltered records (available for enrichment).
+        data: Observe-filtered records (framework fields stripped before tool).
+        original_data: Unfiltered records (used for namespace carry-forward).
         context: Processing context.
 
     Returns:
@@ -170,99 +223,106 @@ def process_file_mode_tool(
     try:
         tools_path = context.agent_config.get("tools_path")
 
+        # Strip framework fields, wrap in TrackedItem for provenance tracking.
+        clean_input: list[TrackedItem] = []
+        for i, record in enumerate(data):
+            business = _extract_business_fields(record, context.agent_config)
+            clean_input.append(TrackedItem(business, source_index=i))
+
         raw_response, executed = run_dynamic_agent(
             agent_config=cast(dict[str, Any], context.agent_config),
             agent_name=context.agent_name,
-            context=data,
+            context=clean_input,
             formatted_prompt="",
             tools_path=tools_path,
         )
 
+        from agent_actions.record.envelope import RecordEnvelope
+        from agent_actions.utils.content import get_existing_content, is_version_merge
         from agent_actions.utils.udf_management.registry import FileUDFResult
 
-        if isinstance(raw_response, FileUDFResult):
-            raw_response = raw_response.outputs
+        version_merge = is_version_merge(context.agent_config)
+        source_mapping: dict[int, int | list[int]] = {}
+        structured_data: list[dict[str, Any]] = []
 
-        if not isinstance(raw_response, list):
+        if isinstance(raw_response, FileUDFResult):
+            # Explicit provenance — tool declared source_index for each output.
+            if not raw_response.outputs and data:
+                return [
+                    ProcessingResult.failed(
+                        error=(
+                            f"Tool '{context.agent_name}' returned empty result "
+                            f"from {len(data)} input record(s)"
+                        ),
+                    )
+                ]
+
+            for i, out in enumerate(raw_response.outputs):
+                src_idx = out["source_index"]
+                data_fields = out["data"]
+                if isinstance(src_idx, list):
+                    input_idx = src_idx[0]
+                    source_mapping[i] = src_idx
+                else:
+                    input_idx = src_idx
+                    source_mapping[i] = src_idx
+
+                matched = _resolve_input_record(input_idx, original_data)
+
+                if version_merge:
+                    existing = get_existing_content(matched) if matched else {}
+                    record: dict[str, Any] = {"content": {**existing, **data_fields}}
+                else:
+                    record = RecordEnvelope.build(context.agent_name, data_fields, matched)
+                record.pop("source_guid", None)
+                structured_data.append(record)
+
+        elif isinstance(raw_response, list):
+            if not raw_response and data:
+                return [
+                    ProcessingResult.failed(
+                        error=(
+                            f"Tool '{context.agent_name}' returned empty result "
+                            f"from {len(data)} input record(s)"
+                        ),
+                    )
+                ]
+
+            for i, item in enumerate(raw_response):
+                if isinstance(item, TrackedItem):
+                    input_idx = item._source_index
+                    source_mapping[i] = input_idx
+                    data_fields = dict(item)
+
+                    matched = _resolve_input_record(input_idx, original_data)
+
+                    if version_merge:
+                        existing = get_existing_content(matched) if matched else {}
+                        record = {"content": {**existing, **data_fields}}
+                    else:
+                        record = RecordEnvelope.build(context.agent_name, data_fields, matched)
+                    record.pop("source_guid", None)
+                    structured_data.append(record)
+                elif isinstance(item, dict):
+                    raise ValueError(
+                        f"FILE tool '{context.agent_name}' returned plain dict at "
+                        f"output[{i}]. Tool created a new dict instead of returning "
+                        f"an input item. For merge/expand, use FileUDFResult with "
+                        f"source_index."
+                    )
+                else:
+                    raise ValueError(
+                        f"FILE tool '{context.agent_name}' output[{i}] is "
+                        f"{type(item).__name__}, expected TrackedItem. "
+                        f"For N→M transforms, use FileUDFResult."
+                    )
+        else:
             raise ValueError(
-                f"FILE mode tool must return a list (or FileUDFResult), "
+                f"FILE tool '{context.agent_name}' must return list or FileUDFResult, "
                 f"got {type(raw_response).__name__}"
             )
 
-        if not raw_response and data:
-            return [
-                ProcessingResult.failed(
-                    error=(
-                        f"Tool '{context.agent_name}' returned empty result "
-                        f"from {len(data)} input record(s)"
-                    ),
-                )
-            ]
-
-        # Framework-managed: resolve which input produced each output by node_id.
-        source_mapping: dict[int, int | list[int]] | None = None
-        if original_data:
-            source_mapping = _resolve_source_mapping(
-                raw_outputs=raw_response,
-                input_data=original_data,
-                action_name=context.agent_name,
-            )
-
-        # Separate business data from framework fields in tool output.
-        # Additive model: wrap tool output under action namespace, preserve
-        # existing namespaces from the input record.
-        # Version merge: version namespaces are already the correct additive
-        # format — spread instead of wrapping under the action name.
-        from agent_actions.record.envelope import RecordEnvelope
-        from agent_actions.utils.content import get_existing_content, is_version_merge
-
-        version_merge = is_version_merge(context.agent_config)
-
-        structured_data = []
-        for idx, item in enumerate(raw_response):
-            if isinstance(item, dict):
-                if isinstance(item.get("content"), dict):
-                    data_fields = item["content"]
-                else:
-                    data_fields = {k: v for k, v in item.items() if k not in _TOOL_RESERVED_FIELDS}
-
-                # Resolve the input record for namespace carry-forward.
-                # For N→M tools (dedup, filter), source_mapping may not resolve.
-                # Fall back to the first input record — all records in a FILE
-                # batch share the same upstream namespaces.
-                input_idx = source_mapping.get(idx) if source_mapping else None
-                if isinstance(input_idx, list):
-                    input_idx = input_idx[0]
-                input_record: dict[str, Any] | None = None
-                if isinstance(input_idx, int) and input_idx < len(original_data):
-                    input_record = original_data[input_idx]
-                elif original_data:
-                    input_record = original_data[0]
-
-                if version_merge:
-                    # build_version_merge validates all values are dicts,
-                    # but version merge tools return flat business data
-                    # (strings, ints) to spread alongside version namespaces.
-                    existing = get_existing_content(input_record) if input_record else {}
-                    record: dict[str, Any] = {"content": {**existing, **data_fields}}
-                else:
-                    record = RecordEnvelope.build(context.agent_name, data_fields, input_record)
-
-                # Source_guid is managed by _reattach_source_guid below, not
-                # RecordEnvelope.  Remove it here so the existing handling
-                # works: tool explicit value first, then mapping-based.
-                record.pop("source_guid", None)
-
-                if "source_guid" in item:
-                    record["source_guid"] = item["source_guid"]
-
-                structured_data.append(record)
-            else:
-                structured_data.append(RecordEnvelope.build(context.agent_name, {"value": item}))
-
-        # Reattach source_guid from input records — authoritative for FILE mode.
-        # LineageBuilder._propagate_ancestry_chain and RequiredFieldsEnricher
-        # also set source_guid but are idempotent backstops; this is the primary setter.
+        # Reattach source_guid from input records.
         _reattach_source_guid(structured_data, source_mapping, original_data)
 
         result = ProcessingResult(
@@ -280,9 +340,6 @@ def process_file_mode_tool(
         return [result]
 
     except Exception as e:
-        # NOTE: Intentional behavioral change — FILE mode tool errors now raise
-        # instead of returning FAILED silently. Workflows relying on partial-failure
-        # tolerance should use try/except or error handling at the caller level.
         logger.error("FILE mode tool '%s' failed: %s", context.agent_name, e)
         raise AgentActionsError(
             f"FILE mode tool '{context.agent_name}' failed: {e}",

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -144,15 +144,16 @@ def _reattach_source_guid(
 def _resolve_input_record(input_idx: int, original_data: list[dict]) -> dict[str, Any] | None:
     """Resolve the input record for namespace carry-forward.
 
-    Falls back to the first record in *original_data* when the index is
-    out of bounds — all records in a FILE batch share the same upstream
-    namespaces.
+    Raises ``IndexError`` if *input_idx* is out of bounds — an invalid
+    ``source_index`` is a tool bug, not something to silently default.
     """
-    if isinstance(input_idx, int) and 0 <= input_idx < len(original_data):
-        return original_data[input_idx]
-    if original_data:
-        return original_data[0]
-    return None
+    if not original_data:
+        return None
+    if not isinstance(input_idx, int) or input_idx < 0 or input_idx >= len(original_data):
+        raise IndexError(
+            f"source_index {input_idx} is out of bounds for {len(original_data)} input records"
+        )
+    return original_data[input_idx]
 
 
 def _extract_business_fields(record: dict, agent_config: dict) -> dict:
@@ -193,7 +194,99 @@ def _extract_business_fields(record: dict, agent_config: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Public API
+# Public API — standalone helpers for testing / simulation
+# ---------------------------------------------------------------------------
+
+
+def framework_prepare_input(
+    records: list[dict],
+    observe_refs: list[str] | None = None,
+) -> list[TrackedItem]:
+    """Strip framework fields and wrap in TrackedItem for tool input.
+
+    Called by ``process_file_mode_tool`` and available standalone for
+    design tests and simulations.
+    """
+    config: dict[str, Any] = {"context_scope": {"observe": observe_refs}} if observe_refs else {}
+    clean: list[TrackedItem] = []
+    for i, record in enumerate(records):
+        business = _extract_business_fields(record, config)
+        clean.append(TrackedItem(business, source_index=i))
+    return clean
+
+
+def framework_reconcile(
+    raw_response: Any,
+    action_name: str,
+    original_data: list[dict],
+) -> list[dict[str, Any]]:
+    """Reconcile tool output to input records via provenance.
+
+    Handles ``TrackedItem`` list returns (N→N passthrough/filter) and
+    ``FileUDFResult`` (N→M merge/expand/dedup).  Plain dicts in list
+    returns are an error.
+
+    Called by ``process_file_mode_tool`` for the non-version-merge path
+    and available standalone for design tests and simulations.
+    """
+    from agent_actions.record.envelope import RecordEnvelope
+    from agent_actions.utils.udf_management.registry import FileUDFResult
+
+    source_mapping: dict[int, int | list[int]] = {}
+    structured_data: list[dict[str, Any]] = []
+
+    if isinstance(raw_response, FileUDFResult):
+        for i, out in enumerate(raw_response.outputs):
+            src_idx = out["source_index"]
+            data_fields = out["data"]
+            if isinstance(src_idx, list):
+                input_idx = src_idx[0]
+                source_mapping[i] = src_idx
+            else:
+                input_idx = src_idx
+                source_mapping[i] = src_idx
+
+            matched = _resolve_input_record(input_idx, original_data)
+            record = RecordEnvelope.build(action_name, data_fields, matched)
+            record.pop("source_guid", None)
+            structured_data.append(record)
+
+    elif isinstance(raw_response, list):
+        for i, item in enumerate(raw_response):
+            if isinstance(item, TrackedItem):
+                input_idx = item._source_index
+                source_mapping[i] = input_idx
+                data_fields = dict(item)
+
+                matched = _resolve_input_record(input_idx, original_data)
+                record = RecordEnvelope.build(action_name, data_fields, matched)
+                record.pop("source_guid", None)
+                structured_data.append(record)
+            elif isinstance(item, dict):
+                raise ValueError(
+                    f"FILE tool '{action_name}' returned plain dict at "
+                    f"output[{i}]. Tool created a new dict instead of returning "
+                    f"an input item. For merge/expand, use FileUDFResult with "
+                    f"source_index."
+                )
+            else:
+                raise ValueError(
+                    f"FILE tool '{action_name}' output[{i}] is "
+                    f"{type(item).__name__}, expected TrackedItem. "
+                    f"For N→M transforms, use FileUDFResult."
+                )
+    else:
+        raise ValueError(
+            f"FILE tool '{action_name}' must return list or FileUDFResult, "
+            f"got {type(raw_response).__name__}"
+        )
+
+    _reattach_source_guid(structured_data, source_mapping, original_data)
+    return structured_data
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/record/test_tracking.py
+++ b/tests/unit/record/test_tracking.py
@@ -1,0 +1,100 @@
+"""Tests for TrackedItem — hidden provenance for FILE mode tools."""
+
+import pytest
+
+from agent_actions.record.tracking import TrackedItem
+from agent_actions.utils.udf_management.registry import FileUDFResult
+
+
+class TestTrackedItem:
+    def test_acts_as_dict(self):
+        item = TrackedItem({"q": "test"}, source_index=0)
+        assert item["q"] == "test"
+
+    def test_source_index_hidden(self):
+        item = TrackedItem({"q": "test"}, source_index=3)
+        assert item._source_index == 3
+        assert "source_index" not in item
+        assert "_source_index" not in item
+
+    def test_survives_modification(self):
+        item = TrackedItem({"q": "test"}, source_index=3)
+        item["q"] = "modified"
+        item["new"] = "added"
+        assert item._source_index == 3
+
+    def test_spread_loses_provenance(self):
+        item = TrackedItem({"q": "test"}, source_index=3)
+        spread = {**item}
+        assert not isinstance(spread, TrackedItem)
+        assert not hasattr(spread, "_source_index")
+
+    def test_iteration_works(self):
+        item = TrackedItem({"a": 1, "b": 2}, source_index=0)
+        assert list(item.keys()) == ["a", "b"]
+        assert list(item.values()) == [1, 2]
+
+    def test_len_works(self):
+        item = TrackedItem({"a": 1, "b": 2}, source_index=0)
+        assert len(item) == 2
+
+    def test_del_works(self):
+        item = TrackedItem({"a": 1, "b": 2}, source_index=0)
+        del item["a"]
+        assert "a" not in item
+        assert item._source_index == 0
+
+    def test_copy_returns_plain_dict(self):
+        item = TrackedItem({"q": "test"}, source_index=3)
+        copied = item.copy()
+        # dict.copy() returns a plain dict, not TrackedItem
+        assert isinstance(copied, dict)
+        assert not hasattr(copied, "_source_index")
+
+    def test_is_dict_subclass(self):
+        item = TrackedItem({"q": "test"}, source_index=0)
+        assert isinstance(item, dict)
+
+    def test_empty_data(self):
+        item = TrackedItem({}, source_index=5)
+        assert len(item) == 0
+        assert item._source_index == 5
+
+
+class TestFileUDFResultValidation:
+    def test_valid_outputs(self):
+        result = FileUDFResult(
+            outputs=[
+                {"source_index": 0, "data": {"q": "Q1"}},
+                {"source_index": 1, "data": {"q": "Q2"}},
+            ]
+        )
+        assert len(result.outputs) == 2
+
+    def test_missing_source_index_raises(self):
+        with pytest.raises(ValueError, match="missing 'source_index'"):
+            FileUDFResult(outputs=[{"data": {"q": "Q1"}}])
+
+    def test_missing_data_raises(self):
+        with pytest.raises(ValueError, match="missing 'data' dict"):
+            FileUDFResult(outputs=[{"source_index": 0}])
+
+    def test_non_dict_data_raises(self):
+        with pytest.raises(ValueError, match="missing 'data' dict"):
+            FileUDFResult(outputs=[{"source_index": 0, "data": "a string"}])
+
+    def test_non_dict_output_raises(self):
+        with pytest.raises(ValueError, match="must be a dict"):
+            FileUDFResult(outputs=["not a dict"])
+
+    def test_empty_outputs_allowed(self):
+        result = FileUDFResult(outputs=[])
+        assert len(result.outputs) == 0
+
+    def test_list_source_index_allowed(self):
+        result = FileUDFResult(
+            outputs=[
+                {"source_index": [0, 1], "data": {"merged": True}},
+            ]
+        )
+        assert result.outputs[0]["source_index"] == [0, 1]

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -7,6 +7,7 @@ import pytest
 from agent_actions.errors import AgentActionsError
 from agent_actions.llm.providers.tools.client import ToolClient
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.udf_management.registry import FileUDFResult
 from agent_actions.workflow.pipeline import PipelineConfig, ProcessingPipeline
 
@@ -28,20 +29,98 @@ def _make_pipeline_and_context():
     return pipeline, context
 
 
-# --- FileUDFResult unwrapping ---
+# --- TrackedItem list return ---
 
 
-def test_file_udf_result_unwrapped():
-    """FILE tool returning FileUDFResult should have .outputs extracted."""
+def test_tracked_item_list_works():
+    """FILE tool returning TrackedItem list wraps output under action namespace."""
+    pipeline, context = _make_pipeline_and_context()
+
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+    ]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(
+            [
+                TrackedItem({"name": "alice"}, source_index=0),
+                TrackedItem({"name": "bob"}, source_index=1),
+            ],
+            True,
+        ),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.status == ProcessingStatus.SUCCESS
+    assert len(result.data) == 2
+    assert result.data[0]["content"]["my_file_tool"]["name"] == "alice"
+    assert result.data[1]["content"]["my_file_tool"]["name"] == "bob"
+
+
+def test_tracked_item_source_mapping():
+    """TrackedItem list return derives source_mapping from _source_index."""
+    pipeline, context = _make_pipeline_and_context()
+
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([TrackedItem({"score": 0.9}, source_index=0)], True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    assert results[0].source_mapping == {0: 0}
+
+
+def test_tracked_item_preserves_upstream_namespaces():
+    """TrackedItem output preserves upstream namespaces from input record."""
+    pipeline, context = _make_pipeline_and_context()
+
+    input_data = [
+        {
+            "source_guid": "sg-1",
+            "content": {
+                "source": {"page_content": "doc text"},
+                "extract": {"question_text": "Why?"},
+            },
+        },
+    ]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=([TrackedItem({"score": 0.95}, source_index=0)], True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    content = results[0].data[0]["content"]
+    # Upstream namespaces preserved
+    assert content["source"]["page_content"] == "doc text"
+    assert content["extract"]["question_text"] == "Why?"
+    # Tool output under action namespace
+    assert content["my_file_tool"]["score"] == 0.95
+
+
+# --- FileUDFResult reconciliation ---
+
+
+def test_file_udf_result_reconciled():
+    """FILE tool returning FileUDFResult reconciles via source_index."""
     pipeline, context = _make_pipeline_and_context()
 
     udf_result = FileUDFResult(
-        outputs=[{"name": "alice"}, {"name": "bob"}],
+        outputs=[
+            {"source_index": 0, "data": {"name": "alice"}},
+            {"source_index": 1, "data": {"name": "bob"}},
+        ],
     )
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "content": {"id": 2}},
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
 
     with patch(
@@ -58,17 +137,20 @@ def test_file_udf_result_unwrapped():
     assert result.data[1]["content"]["my_file_tool"]["name"] == "bob"
 
 
-def test_file_udf_result_source_mapping_auto_inferred():
-    """Framework resolves source_mapping by node_id — tools never provide it."""
+def test_file_udf_result_source_mapping():
+    """FileUDFResult source_mapping derived from source_index declarations."""
     pipeline, context = _make_pipeline_and_context()
 
     udf_result = FileUDFResult(
-        outputs=[{"name": "alice", "node_id": "n1"}, {"name": "bob", "node_id": "n2"}],
+        outputs=[
+            {"source_index": 0, "data": {"name": "alice"}},
+            {"source_index": 1, "data": {"name": "bob"}},
+        ],
     )
 
     input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
 
     with patch(
@@ -77,33 +159,23 @@ def test_file_udf_result_source_mapping_auto_inferred():
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Framework resolved mapping via node_id
     assert results[0].source_mapping == {0: 0, 1: 1}
 
 
-def test_file_tool_plain_list_auto_infers_identity_mapping():
-    """Plain list return with node_id resolves source_mapping via node_id match."""
+def test_file_udf_result_list_source_index():
+    """FileUDFResult with list source_index (many-to-one merge)."""
     pipeline, context = _make_pipeline_and_context()
 
-    input_data = [{"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}}]
+    udf_result = FileUDFResult(
+        outputs=[
+            {"source_index": [0, 1], "data": {"merged": True}},
+        ],
+    )
 
-    with patch(
-        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"score": 0.9, "node_id": "n1"}], True),
-    ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
-
-    # Resolved mapping via node_id
-    assert results[0].source_mapping == {0: 0}
-
-
-def test_file_udf_result_mapping_always_inferred():
-    """FileUDFResult resolves mapping via node_id like plain lists."""
-    pipeline, context = _make_pipeline_and_context()
-
-    udf_result = FileUDFResult(outputs=[{"name": "alice", "node_id": "n1"}])
-
-    input_data = [{"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}}]
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"q": "A"}}},
+        {"source_guid": "sg-2", "content": {"prev": {"q": "B"}}},
+    ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
@@ -111,25 +183,53 @@ def test_file_udf_result_mapping_always_inferred():
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Framework resolved mapping via node_id
-    assert results[0].source_mapping == {0: 0}
+    assert results[0].source_mapping == {0: [0, 1]}
+    assert results[0].data[0]["content"]["my_file_tool"]["merged"] is True
 
 
-def test_file_tool_plain_list_still_works():
-    """FILE tool returning a plain list should still work (backwards compat)."""
+# --- Plain dict rejection ---
+
+
+def test_file_tool_plain_dict_rejected():
+    """FILE tool returning plain dicts (not TrackedItem) raises ValueError."""
     pipeline, context = _make_pipeline_and_context()
 
-    input_data = [{"source_guid": "sg-1", "content": {"id": 1}}]
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=([{"score": 0.9}], True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        with pytest.raises(AgentActionsError, match="plain dict"):
+            pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    assert len(results) == 1
-    assert results[0].status == ProcessingStatus.SUCCESS
-    assert results[0].data[0]["content"]["my_file_tool"]["score"] == 0.9
+
+def test_file_tool_non_dict_rejected():
+    """FILE tool returning non-dict items raises ValueError."""
+    pipeline, context = _make_pipeline_and_context()
+
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(["just a string"], True),
+    ):
+        with pytest.raises(AgentActionsError, match="expected TrackedItem"):
+            pipeline._process_file_mode_tool(input_data, input_data, context)
+
+
+def test_file_tool_non_list_non_fileudfresult_rejected():
+    """FILE tool returning non-list, non-FileUDFResult raises ValueError."""
+    pipeline, context = _make_pipeline_and_context()
+
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=({"single": "dict"}, True),
+    ):
+        with pytest.raises(AgentActionsError, match="must return list or FileUDFResult"):
+            pipeline._process_file_mode_tool(input_data, input_data, context)
 
 
 # --- Empty tool output detection ---
@@ -140,8 +240,8 @@ def test_file_tool_empty_response_with_input_returns_failed():
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "content": {"id": 2}},
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
 
     with patch(
@@ -176,7 +276,10 @@ def test_file_tool_empty_response_feeds_existing_failure_check():
     from agent_actions.processing.result_collector import ResultCollector
 
     pipeline, context = _make_pipeline_and_context()
-    input_data = [{"content": {"a": 1}}, {"content": {"b": 2}}]
+    input_data = [
+        {"content": {"prev": {"a": 1}}},
+        {"content": {"prev": {"b": 2}}},
+    ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
@@ -196,6 +299,22 @@ def test_file_tool_empty_response_feeds_existing_failure_check():
     assert output == []
 
 
+def test_file_udf_result_empty_with_input_returns_failed():
+    """FileUDFResult with empty outputs and non-empty input returns FAILED."""
+    pipeline, context = _make_pipeline_and_context()
+
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(FileUDFResult(outputs=[]), True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    assert results[0].status == ProcessingStatus.FAILED
+    assert "returned empty result" in results[0].error
+
+
 # --- Error surfacing ---
 
 
@@ -203,7 +322,7 @@ def test_file_mode_error_surfaces():
     """FILE tool raising exception should propagate, not produce empty output."""
     pipeline, context = _make_pipeline_and_context()
 
-    input_data = [{"source_guid": "sg-1", "content": {"id": 1}}]
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
@@ -217,7 +336,10 @@ def test_file_mode_error_includes_context():
     """The surfaced error should include agent_name and record_count."""
     pipeline, context = _make_pipeline_and_context()
 
-    input_data = [{"content": {"a": 1}}, {"content": {"b": 2}}]
+    input_data = [
+        {"content": {"prev": {"a": 1}}},
+        {"content": {"prev": {"b": 2}}},
+    ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
@@ -277,6 +399,23 @@ def test_strip_internal_fields_str_unchanged():
     assert "alice" in result
 
 
+def test_strip_internal_fields_preserves_tracked_item():
+    """TrackedItem should survive _strip_internal_fields with provenance intact."""
+    data = [
+        TrackedItem({"name": "alice", "_batch_filter_status": "included"}, source_index=0),
+        TrackedItem({"name": "bob"}, source_index=1),
+    ]
+
+    result = ToolClient._strip_internal_fields(data)
+
+    assert isinstance(result[0], TrackedItem)
+    assert result[0]._source_index == 0
+    assert "_batch_filter_status" not in result[0]
+    assert result[0]["name"] == "alice"
+    assert isinstance(result[1], TrackedItem)
+    assert result[1]._source_index == 1
+
+
 # --- _validate_udf_output list handling across granularities ---
 
 
@@ -298,14 +437,17 @@ def test_validate_udf_output_handles_list_for_record_granularity():
 
 
 def test_validate_udf_output_handles_list_for_file_granularity():
-    """FILE UDF returning a FileUDFResult with list validates each item (regression)."""
+    """FILE UDF returning a FileUDFResult validates data field of each output."""
     from agent_actions.utils.udf_management.tooling import _validate_udf_output
 
     result = FileUDFResult(
-        outputs=[{"name": "alice"}, {"name": "bob"}],
+        outputs=[
+            {"source_index": 0, "data": {"name": "alice"}},
+            {"source_index": 1, "data": {"name": "bob"}},
+        ],
     )
 
-    # Should not raise — FileUDFResult.outputs unwrapped, each item validated
+    # Should not raise — each output's data is valid against the schema
     _validate_udf_output("my_tool", result, _SIMPLE_SCHEMA)
 
 
@@ -545,22 +687,27 @@ def test_result_collector_does_not_raise_when_all_filtered():
     assert output == []
 
 
-# --- FILE-mode source_guid metadata sovereignty ---
+# --- FILE-mode source_guid via TrackedItem ---
 
 
-def test_file_tool_plain_list_preserves_source_guid():
-    """Plain list tool output gets source_guid from input via node_id mapping."""
+def test_tracked_item_preserves_source_guid():
+    """TrackedItem output gets source_guid from input via source_index mapping."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
 
-    # Tool returns plain list with node_id — no source_guid, no FileUDFResult
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"score": 0.9, "node_id": "n1"}, {"score": 0.8, "node_id": "n2"}], True),
+        return_value=(
+            [
+                TrackedItem({"score": 0.9}, source_index=0),
+                TrackedItem({"score": 0.8}, source_index=1),
+            ],
+            True,
+        ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -569,73 +716,61 @@ def test_file_tool_plain_list_preserves_source_guid():
     assert result.data[1]["source_guid"] == "sg-2"
 
 
-def test_file_tool_filter_fewer_outputs_with_node_id():
-    """When tool filters N→fewer, outputs with node_id get correct source_guid."""
+def test_tracked_item_filter_fewer_outputs():
+    """When tool filters N→fewer, TrackedItem._source_index resolves correct source_guid."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
-        {"source_guid": "sg-3", "node_id": "n3", "content": {"id": 3}},
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+        {"source_guid": "sg-3", "content": {"prev": {"id": 3}}},
     ]
 
-    # Tool filters 3→2, passes through node_id for matched records
+    # Tool filters 3→2, keeping items 0 and 2
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
         return_value=(
-            [{"name": "alice", "node_id": "n1"}, {"name": "charlie", "node_id": "n3"}],
+            [
+                TrackedItem({"name": "alice"}, source_index=0),
+                TrackedItem({"name": "charlie"}, source_index=2),
+            ],
             True,
         ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
     result = results[0]
-    # node_id-based mapping resolves correct source_guids
     assert result.data[0]["source_guid"] == "sg-1"
     assert result.data[1]["source_guid"] == "sg-3"
+    assert result.source_mapping == {0: 0, 1: 2}
 
 
-def test_file_tool_new_records_without_node_id_get_no_source_guid():
-    """Tool outputs without node_id are new records — no source_guid reattached."""
+def test_file_udf_result_preserves_source_guid():
+    """FileUDFResult outputs get source_guid from input via source_index."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-shared", "node_id": "n1", "content": {"q": "A"}},
-        {"source_guid": "sg-shared", "node_id": "n2", "content": {"q": "B"}},
+        {"source_guid": "sg-1", "content": {"prev": {"q": "A"}}},
+        {"source_guid": "sg-2", "content": {"prev": {"q": "B"}}},
     ]
 
-    # Tool returns new records (no node_id) — these are new, not passthrough
+    udf_result = FileUDFResult(
+        outputs=[
+            {"source_index": 1, "data": {"q": "B_modified"}},
+            {"source_index": 0, "data": {"q": "A_modified"}},
+        ],
+    )
+
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"q": "A1"}, {"q": "A2"}, {"q": "B1"}], True),
+        return_value=(udf_result, True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # No node_id in outputs → empty mapping (new records, no parent)
-    assert results[0].source_mapping == {}
-    # Enrichment pipeline sets source_guid="" on new records (no parent to inherit from)
-    for item in results[0].data:
-        assert item.get("source_guid") == ""
-
-
-def test_file_tool_cardinality_change_new_records_get_empty_mapping():
-    """N→M with new records (no node_id) produces empty source_mapping."""
-    pipeline, context = _make_pipeline_and_context()
-
-    input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"q": "A"}},
-        {"source_guid": "sg-2", "node_id": "n2", "content": {"q": "B"}},
-    ]
-
-    # Tool returns different count, no node_id → all new records
-    with patch(
-        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"q": "X"}, {"q": "Y"}, {"q": "Z"}], True),
-    ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
-
-    # No node_id → empty mapping (new records, no parent)
-    assert results[0].source_mapping == {}
+    result = results[0]
+    # Reordered outputs map to correct source_guid
+    assert result.data[0]["source_guid"] == "sg-2"
+    assert result.data[1]["source_guid"] == "sg-1"
 
 
 def test_file_tool_source_guid_never_empty_string():
@@ -643,12 +778,12 @@ def test_file_tool_source_guid_never_empty_string():
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
     ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"result": "ok", "node_id": "n1"}], True),
+        return_value=([TrackedItem({"result": "ok"}, source_index=0)], True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -657,59 +792,7 @@ def test_file_tool_source_guid_never_empty_string():
         assert item.get("source_guid") == "sg-1"
 
 
-def test_file_tool_tool_explicit_source_guid_respected():
-    """If tool explicitly returns source_guid, framework respects it."""
-    pipeline, context = _make_pipeline_and_context()
-
-    input_data = [
-        {"source_guid": "sg-input", "content": {"id": 1}},
-    ]
-
-    # Tool explicitly sets source_guid in its output
-    with patch(
-        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"result": "ok", "source_guid": "sg-tool-set"}], True),
-    ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
-
-    # Tool's explicit value wins over framework reattachment
-    assert results[0].data[0]["source_guid"] == "sg-tool-set"
-
-
-# --- Hardening: edge cases that must never break source_guid ---
-
-
-def test_file_tool_mixed_source_guid_some_set_some_not():
-    """Tool returns mix of items with and without source_guid — framework fills gaps via node_id."""
-    pipeline, context = _make_pipeline_and_context()
-
-    input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
-        {"source_guid": "sg-2", "node_id": "n2", "content": {"id": 2}},
-        {"source_guid": "sg-3", "node_id": "n3", "content": {"id": 3}},
-    ]
-
-    # Tool sets source_guid on item[1] but not on [0] or [2]; node_id on [0] and [2]
-    with patch(
-        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=(
-            [
-                {"val": "a", "node_id": "n1"},
-                {"val": "b", "source_guid": "sg-tool-explicit"},
-                {"val": "c", "node_id": "n3"},
-            ],
-            True,
-        ),
-    ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
-
-    result = results[0]
-    # Item 0: no explicit source_guid, node_id matched → framework reattaches from input[0]
-    assert result.data[0]["source_guid"] == "sg-1"
-    # Item 1: tool explicitly set it → respected (no node_id, so not in mapping)
-    assert result.data[1]["source_guid"] == "sg-tool-explicit"
-    # Item 2: no explicit source_guid, node_id matched → framework reattaches from input[2]
-    assert result.data[2]["source_guid"] == "sg-3"
+# --- Hardening: edge cases ---
 
 
 def test_file_tool_empty_input_empty_output():
@@ -727,87 +810,81 @@ def test_file_tool_empty_input_empty_output():
 
 
 def test_file_tool_input_without_source_guid():
-    """Input records missing source_guid entirely — no crash, outputs have empty/absent source_guid."""
+    """Input records missing source_guid — no crash, outputs have absent source_guid."""
     pipeline, context = _make_pipeline_and_context()
 
-    # Input records with no source_guid at all (possible in edge cases)
     input_data = [
-        {"content": {"id": 1}},
-        {"content": {"id": 2}},
+        {"content": {"prev": {"id": 1}}},
+        {"content": {"prev": {"id": 2}}},
     ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"score": 0.9}, {"score": 0.8}], True),
+        return_value=(
+            [
+                TrackedItem({"score": 0.9}, source_index=0),
+                TrackedItem({"score": 0.8}, source_index=1),
+            ],
+            True,
+        ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # Should not crash — source_guid just won't be set by reattachment
     assert results[0].status == ProcessingStatus.SUCCESS
     assert len(results[0].data) == 2
 
 
-def test_file_tool_non_dict_output_items():
-    """Non-dict items in tool output don't crash source_guid reattachment."""
+def test_file_udf_result_merge_reduces_to_fewer():
+    """N→fewer merge via FileUDFResult: each output maps to its declared source."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"id": 1}},
+        {"source_guid": "sg-1", "content": {"prev": {"q": "A"}}},
+        {"source_guid": "sg-2", "content": {"prev": {"q": "B"}}},
+        {"source_guid": "sg-3", "content": {"prev": {"q": "C"}}},
     ]
 
-    # Tool returns a non-dict item (string) — no node_id possible, treated as new record
+    # Tool merges 3→2
+    udf_result = FileUDFResult(
+        outputs=[
+            {"source_index": [0, 1], "data": {"merged": "AB"}},
+            {"source_index": 2, "data": {"single": "C"}},
+        ],
+    )
+
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=(["just a string"], True),
-    ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
-
-    # Non-dict wrapped as {"content": {"value": ...}} — no node_id, so no mapping
-    assert results[0].data[0]["content"]["my_file_tool"]["value"] == "just a string"
-    # Same cardinality (1:1) — positional fallback propagates source_guid from input
-    assert results[0].data[0].get("source_guid") == "sg-1"
-
-
-def test_file_tool_merge_reduces_to_fewer_outputs():
-    """N→fewer merge: new records (no node_id) get empty mapping."""
-    pipeline, context = _make_pipeline_and_context()
-
-    input_data = [
-        {"source_guid": "sg-1", "node_id": "n1", "content": {"q": "A"}},
-        {"source_guid": "sg-2", "node_id": "n2", "content": {"q": "B"}},
-        {"source_guid": "sg-3", "node_id": "n3", "content": {"q": "C"}},
-    ]
-
-    # Tool merges 3→2 — new records with no node_id (aggregation results)
-    with patch(
-        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"merged": "AB"}, {"single": "C"}], True),
+        return_value=(udf_result, True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
     result = results[0]
-    # New records — no node_id → empty mapping, no source_guid reattached
-    assert result.source_mapping == {}
+    assert result.source_mapping == {0: [0, 1], 1: 2}
+    assert len(result.data) == 2
 
 
-def test_file_tool_large_cardinality_expansion():
-    """1→N expansion: outputs with node_id inherit source_guid, others are new."""
+def test_file_udf_result_expansion():
+    """1→N expansion via FileUDFResult: each output traces to source."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
-        {"source_guid": "sg-only", "node_id": "n1", "content": {"nested": [1, 2, 3, 4, 5]}},
+        {"source_guid": "sg-only", "content": {"prev": {"nested": [1, 2, 3, 4, 5]}}},
     ]
 
-    # Tool explodes 1 input into 5 new outputs (no node_id — aggregation/expansion)
+    udf_result = FileUDFResult(
+        outputs=[{"source_index": 0, "data": {"val": i}} for i in range(5)],
+    )
+
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"val": i} for i in range(5)], True),
+        return_value=(udf_result, True),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
-    # No node_id on outputs → empty mapping (new records)
-    assert results[0].source_mapping == {}
     assert len(results[0].data) == 5
+    for i, item in enumerate(results[0].data):
+        assert item["content"]["my_file_tool"]["val"] == i
+        assert results[0].source_mapping[i] == 0
 
 
 # --- Hardening: _resolve_source_mapping unit tests ---
@@ -1007,51 +1084,118 @@ class TestReattachSourceGuid:
             assert "source_guid" not in item
 
 
-# --- Bug 1: Content preservation when tool returns full records ---
+# --- _extract_business_fields unit tests ---
 
 
-def test_file_tool_full_record_content_preserved():
-    """FILE tool returning records with node_id + populated content must preserve content.
+class TestExtractBusinessFields:
+    """Direct unit tests for _extract_business_fields logic."""
 
-    Regression test for content stripping bug: framework must not replace
-    the tool's content dict with {} when re-wrapping the record.
-    """
+    def test_flattens_all_namespaces_no_observe(self):
+        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+
+        record = {
+            "source_guid": "sg-1",
+            "node_id": "n1",
+            "content": {
+                "extract": {"question_text": "What?", "answer_text": "Yes."},
+                "summarize": {"summary": "Short version"},
+            },
+        }
+        result = _extract_business_fields(record, {})
+        assert result == {
+            "question_text": "What?",
+            "answer_text": "Yes.",
+            "summary": "Short version",
+        }
+
+    def test_extracts_observed_fields_only(self):
+        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+
+        record = {
+            "content": {
+                "extract": {"question_text": "What?", "answer_text": "Yes."},
+                "summarize": {"summary": "Short version"},
+            }
+        }
+        config = {"context_scope": {"observe": ["extract.question_text"]}}
+        result = _extract_business_fields(record, config)
+        assert result == {"question_text": "What?"}
+
+    def test_wildcard_observe(self):
+        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+
+        record = {
+            "content": {
+                "extract": {"q": "Q1", "a": "A1"},
+                "other": {"x": 99},
+            }
+        }
+        config = {"context_scope": {"observe": ["extract.*"]}}
+        result = _extract_business_fields(record, config)
+        assert result == {"q": "Q1", "a": "A1"}
+
+    def test_no_content_returns_empty(self):
+        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+
+        record = {"source_guid": "sg-1"}
+        result = _extract_business_fields(record, {})
+        assert result == {}
+
+    def test_non_dict_content_returns_empty(self):
+        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+
+        record = {"content": "string_content"}
+        result = _extract_business_fields(record, {})
+        assert result == {}
+
+    def test_skips_non_dict_namespace_values(self):
+        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+
+        record = {
+            "content": {
+                "extract": {"q": "Q1"},
+                "skipped_action": None,  # guard-skipped action
+            }
+        }
+        result = _extract_business_fields(record, {})
+        assert result == {"q": "Q1"}
+
+
+# --- Content preservation regression ---
+
+
+def test_file_tool_content_preserved_via_tracked_item():
+    """FILE tool content is correctly preserved when using TrackedItem reconciliation."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
         {
             "source_guid": "sg-1",
-            "node_id": "flatten_q_0",
-            "lineage": ["extract_abc_0", "flatten_q_0"],
-            "content": {"question_text": "What is X?", "answer_text": "X is Y."},
+            "content": {
+                "extract": {"question_text": "What is X?", "answer_text": "X is Y."},
+            },
         },
         {
             "source_guid": "sg-1",
-            "node_id": "flatten_q_1",
-            "lineage": ["extract_abc_0", "flatten_q_1"],
-            "content": {"question_text": "What is Z?", "answer_text": "Z is W."},
-        },
-    ]
-
-    # Tool returns original records (passthrough/filter pattern) — content populated
-    tool_output = [
-        {
-            "node_id": "flatten_q_0",
-            "source_guid": "sg-1",
-            "lineage": ["extract_abc_0", "flatten_q_0"],
-            "content": {"question_text": "What is X?", "answer_text": "X is Y."},
-        },
-        {
-            "node_id": "flatten_q_1",
-            "source_guid": "sg-1",
-            "lineage": ["extract_abc_0", "flatten_q_1"],
-            "content": {"question_text": "What is Z?", "answer_text": "Z is W."},
+            "content": {
+                "extract": {"question_text": "What is Z?", "answer_text": "Z is W."},
+            },
         },
     ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=(tool_output, True),
+        return_value=(
+            [
+                TrackedItem(
+                    {"question_text": "What is X?", "answer_text": "X is Y."}, source_index=0
+                ),
+                TrackedItem(
+                    {"question_text": "What is Z?", "answer_text": "Z is W."}, source_index=1
+                ),
+            ],
+            True,
+        ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -1065,34 +1209,29 @@ def test_file_tool_full_record_content_preserved():
     assert result.data[1]["content"]["my_file_tool"]["answer_text"] == "Z is W."
 
 
-# --- Bug 2: Lineage collision with shared source_guid ---
+# --- Shared source_guid lineage ---
 
 
 def test_file_tool_shared_source_guid_each_output_gets_correct_mapping():
-    """When inputs share source_guid, node_id-based mapping must resolve each correctly.
-
-    Regression test for lineage collision: shared source_guid must NOT cause
-    all outputs to inherit the first input's lineage.
-    """
+    """When inputs share source_guid, TrackedItem._source_index resolves each correctly."""
     pipeline, context = _make_pipeline_and_context()
 
-    # 5 inputs from same source page (shared source_guid), each with unique node_id
     input_data = [
-        {"source_guid": "sg-shared", "node_id": f"flatten_q_{i}", "content": {"q": f"Q{i}"}}
-        for i in range(5)
+        {"source_guid": "sg-shared", "content": {"prev": {"q": f"Q{i}"}}} for i in range(5)
     ]
 
-    # Tool deduplicates 5→4, returns records with original node_ids
-    tool_output = [
-        {"node_id": "flatten_q_0", "source_guid": "sg-shared", "content": {"q": "Q0"}},
-        {"node_id": "flatten_q_1", "source_guid": "sg-shared", "content": {"q": "Q1"}},
-        {"node_id": "flatten_q_3", "source_guid": "sg-shared", "content": {"q": "Q3"}},
-        {"node_id": "flatten_q_4", "source_guid": "sg-shared", "content": {"q": "Q4"}},
-    ]
-
+    # Tool deduplicates 5→4, returns TrackedItems skipping index 2
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=(tool_output, True),
+        return_value=(
+            [
+                TrackedItem({"q": "Q0"}, source_index=0),
+                TrackedItem({"q": "Q1"}, source_index=1),
+                TrackedItem({"q": "Q3"}, source_index=3),
+                TrackedItem({"q": "Q4"}, source_index=4),
+            ],
+            True,
+        ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -1103,16 +1242,11 @@ def test_file_tool_shared_source_guid_each_output_gets_correct_mapping():
         assert item["source_guid"] == "sg-shared"
 
 
-# --- Bug 3: Synthesis lineage via copy pattern ---
+# --- Lineage extension via TrackedItem ---
 
 
-def test_file_tool_copy_pattern_preserves_lineage():
-    """Tool using copy pattern (copy record + replace content) must extend lineage.
-
-    The copy pattern preserves node_id from the input record, so the framework
-    matches the output to its input and extends the lineage chain. This is the
-    recommended approach for mid-pipeline FILE tools that transform data.
-    """
+def test_file_tool_tracked_item_extends_lineage():
+    """TrackedItem-based reconciliation extends parent lineage correctly."""
     pipeline, context = _make_pipeline_and_context()
 
     input_data = [
@@ -1120,42 +1254,32 @@ def test_file_tool_copy_pattern_preserves_lineage():
             "source_guid": "sg-1",
             "node_id": "extract_abc_0",
             "lineage": ["ingest_xyz_0", "extract_abc_0"],
-            "content": {"raw_text": "original content"},
+            "content": {"extract": {"raw_text": "original content"}},
         },
         {
             "source_guid": "sg-2",
             "node_id": "extract_abc_1",
             "lineage": ["ingest_xyz_1", "extract_abc_1"],
-            "content": {"raw_text": "other content"},
+            "content": {"extract": {"raw_text": "other content"}},
         },
     ]
 
-    # Enrichment needs source_data for parent lookup (set by pipeline.py in real flow)
     context.source_data = input_data
-
-    # Tool copies input records and replaces content (synthesis-via-copy pattern)
-    tool_output = [
-        {
-            "node_id": "extract_abc_0",  # preserved from input
-            "source_guid": "sg-1",
-            "content": {"transformed": "new value from original"},  # replaced content
-        },
-        {
-            "node_id": "extract_abc_1",  # preserved from input
-            "source_guid": "sg-2",
-            "content": {"transformed": "new value from other"},  # replaced content
-        },
-    ]
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=(tool_output, True),
+        return_value=(
+            [
+                TrackedItem({"transformed": "new value from original"}, source_index=0),
+                TrackedItem({"transformed": "new value from other"}, source_index=1),
+            ],
+            True,
+        ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
-
     assert result.source_mapping == {0: 0, 1: 1}
 
     assert result.data[0]["content"]["my_file_tool"]["transformed"] == "new value from original"
@@ -1167,7 +1291,6 @@ def test_file_tool_copy_pattern_preserves_lineage():
     # Lineage must be extended from parent, not truncated to just [self]
     for i, item in enumerate(result.data):
         lineage = item.get("lineage", [])
-        # Parent lineage had 2 entries; enrichment appends new node_id → at least 3
         assert len(lineage) >= 3, f"item[{i}] lineage not extended from parent: {lineage}"
 
 
@@ -1345,7 +1468,6 @@ def test_file_tool_version_merge_spreads_not_wraps():
     input_data = [
         {
             "source_guid": "sg-1",
-            "node_id": "n1",
             "content": {
                 "extract_1": {"vote": "keep"},
                 "extract_2": {"vote": "drop"},
@@ -1355,7 +1477,10 @@ def test_file_tool_version_merge_spreads_not_wraps():
 
     with patch(
         "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-        return_value=([{"consensus": "keep", "score": 11, "node_id": "n1"}], True),
+        return_value=(
+            [TrackedItem({"consensus": "keep", "score": 11}, source_index=0)],
+            True,
+        ),
     ):
         results = pipeline._process_file_mode_tool(input_data, input_data, context)
 

--- a/tests/unit/workflow/test_version_merge_content.py
+++ b/tests/unit/workflow/test_version_merge_content.py
@@ -14,6 +14,7 @@ from agent_actions.input.preprocessing.transformation.transformer import (
     DataTransformer,
 )
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.tracking import TrackedItem
 from agent_actions.workflow.pipeline import PipelineConfig, ProcessingPipeline
 
 # ---------------------------------------------------------------------------
@@ -84,12 +85,13 @@ class TestFileModePipelineVersionMerge:
             }
         ]
 
-        # Tool returns aggregated output
-        tool_output = [{"consensus": "keep", "total_score": 11, "node_id": "n1"}]
-
+        # Tool returns aggregated output via TrackedItem
         with patch(
             "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-            return_value=(tool_output, True),
+            return_value=(
+                [TrackedItem({"consensus": "keep", "total_score": 11}, source_index=0)],
+                True,
+            ),
         ):
             results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -123,11 +125,12 @@ class TestFileModePipelineVersionMerge:
             }
         ]
 
-        tool_output = [{"summary": "2/3 keep", "node_id": "n1"}]
-
         with patch(
             "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-            return_value=(tool_output, True),
+            return_value=(
+                [TrackedItem({"summary": "2/3 keep"}, source_index=0)],
+                True,
+            ),
         ):
             results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -147,11 +150,12 @@ class TestFileModePipelineVersionMerge:
             }
         ]
 
-        tool_output = [{"summary": "world", "node_id": "n1"}]
-
         with patch(
             "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-            return_value=(tool_output, True),
+            return_value=(
+                [TrackedItem({"summary": "world"}, source_index=0)],
+                True,
+            ),
         ):
             results = pipeline._process_file_mode_tool(input_data, input_data, context)
 
@@ -177,12 +181,13 @@ class TestFileModePipelineVersionMerge:
             }
         ]
 
-        # Tool returns output nested under "content" key
-        tool_output = [{"content": {"consensus": "keep"}, "node_id": "n1"}]
-
+        # Tool returns output via TrackedItem
         with patch(
             "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
-            return_value=(tool_output, True),
+            return_value=(
+                [TrackedItem({"consensus": "keep"}, source_index=0)],
+                True,
+            ),
         ):
             results = pipeline._process_file_mode_tool(input_data, input_data, context)
 


### PR DESCRIPTION
## Summary

FILE mode tools now receive clean business data — no framework fields leak into user code.

- **TrackedItem** (`agent_actions/record/tracking.py`): dict subclass with hidden `_source_index` slot. Framework wraps each input item before calling the tool. Tool code uses it as a normal dict. Framework reads `_source_index` after to map output to input.
- **`_extract_business_fields()`**: Strips framework fields and flattens observe-filtered content namespaces into a flat dict of business data.
- **`process_file_mode_tool()`**: Strips framework fields before tool call (wraps in TrackedItem), reconciles after via `TrackedItem._source_index` (N→N) or `FileUDFResult.source_index` (N→M). Plain dict returns are now an error.
- **`FileUDFResult`**: Converted from dataclass to validated class — every output must declare `source_index` (int or list) and `data` (dict). Validated on construction.
- **`ToolClient._strip_internal_fields`**: Preserves TrackedItem type through batch metadata stripping.

### Breaking changes

- `FileUDFResult` outputs must include `source_index` and `data` keys
- FILE tools returning plain dicts in a list raise `ValueError` (must return TrackedItems or `FileUDFResult`)

## Verification

```
pytest — 5956 passed, 2 skipped
ruff format --check — clean
ruff check — clean
```

- 17 new tests (TrackedItem unit + FileUDFResult validation)
- 67 FILE mode pipeline tests (updated for TrackedItem/FileUDFResult interface)
- 10 version merge tests (updated for TrackedItem returns)
- Self-review fixes: negative source_index rejection, FileUDFResult data type validation