### PR TITLE
fix: version merge upstream preservation + first-stage source namespace

### DIFF
--- a/.changes/unreleased/Bug Fix-20260424-348000.yaml
+++ b/.changes/unreleased/Bug Fix-20260424-348000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Version merge preserves upstream namespaces; first-stage records wrap raw input under source namespace"
+time: 2026-04-24T03:48:00.000000Z

--- a/agent_actions/processing/record_processor.py
+++ b/agent_actions/processing/record_processor.py
@@ -23,7 +23,7 @@ from agent_actions.logging.events.data_pipeline_events import (
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
 from agent_actions.output.response.config_fields import get_default
-from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS, RecordEnvelope
 from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
 from agent_actions.utils.content import get_existing_content
 
@@ -299,6 +299,10 @@ class RecordProcessor:
                 )
 
         item_existing_content = get_existing_content(item) if isinstance(item, dict) else None
+        if not item_existing_content and isinstance(item, dict) and context.is_first_stage:
+            raw = {k: v for k, v in item.items() if k not in RECORD_FRAMEWORK_FIELDS}
+            if raw:
+                item_existing_content = {"source": raw}
         transformed = self._transform_response(
             response,
             content,

--- a/agent_actions/record/__init__.py
+++ b/agent_actions/record/__init__.py
@@ -1,6 +1,10 @@
 """Unified record envelope -- single authority for record content assembly."""
 
-from agent_actions.record.envelope import RecordEnvelope, RecordEnvelopeError
+from agent_actions.record.envelope import (
+    RECORD_FRAMEWORK_FIELDS,
+    RecordEnvelope,
+    RecordEnvelopeError,
+)
 from agent_actions.record.tracking import TrackedItem
 
-__all__ = ["RecordEnvelope", "RecordEnvelopeError", "TrackedItem"]
+__all__ = ["RECORD_FRAMEWORK_FIELDS", "RecordEnvelope", "RecordEnvelopeError", "TrackedItem"]

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -4,6 +4,26 @@ from __future__ import annotations
 
 from typing import Any
 
+# Canonical set of framework fields that are NOT user business data.
+# Used by record_processor (first-stage source wrapping), pipeline_file_mode
+# (tool input stripping), and scope_namespace (metadata exclusion).
+RECORD_FRAMEWORK_FIELDS: frozenset[str] = frozenset(
+    {
+        "source_guid",
+        "target_id",
+        "node_id",
+        "lineage",
+        "metadata",
+        "content",
+        "_unprocessed",
+        "_recovery",
+        "parent_target_id",
+        "root_target_id",
+        "chunk_info",
+        "version_correlation_id",
+    }
+)
+
 
 class RecordEnvelopeError(Exception):
     """Raised when a record envelope contract is violated."""

--- a/agent_actions/workflow/managers/loop.py
+++ b/agent_actions/workflow/managers/loop.py
@@ -357,7 +357,7 @@ class VersionOutputCorrelator:
                 "merged record will have source_guid=None"
             )
         version_namespaces = self._merge_with_pattern(agent_records)
-        merged = RecordEnvelope.build_version_merge(version_namespaces)
+        merged = RecordEnvelope.build_version_merge(version_namespaces, base_record)
         merged_record = {
             "source_guid": source_guid,
             "target_id": base_record.get("target_id"),

--- a/tests/core/graph/test_version_correlator.py
+++ b/tests/core/graph/test_version_correlator.py
@@ -307,17 +307,19 @@ class TestVersionOutputCorrelator:
         result = correlator._correlate_by_source_record(version_outputs)
         assert len(result) == 2
         rec_a = next(r for r in result if r["source_guid"] == "guid-a")
-        # Content is now nested by agent name (not flattened)
-        assert rec_a["content"] == {
-            "loop_1": {"f1": "v1"},
-            "loop_2": {"f2": "v3"},
-            "loop_3": {"f3": "v5"},
-        }
+        # Version namespaces + upstream from base_record (first version's content)
+        # Base record loop_1 has content {"f1": "v1"}, so "f1" appears as upstream
+        assert rec_a["content"]["loop_1"] == {"f1": "v1"}
+        assert rec_a["content"]["loop_2"] == {"f2": "v3"}
+        assert rec_a["content"]["loop_3"] == {"f3": "v5"}
+        # Verify no unexpected keys leaked (upstream + 3 versions)
+        expected_a = {"f1", "loop_1", "loop_2", "loop_3"}
+        assert set(rec_a["content"].keys()) == expected_a
         rec_b = next(r for r in result if r["source_guid"] == "guid-b")
-        assert rec_b["content"] == {
-            "loop_1": {"f1": "v2"},
-            "loop_2": {"f2": "v4"},
-        }
+        assert rec_b["content"]["loop_1"] == {"f1": "v2"}
+        assert rec_b["content"]["loop_2"] == {"f2": "v4"}
+        expected_b = {"f1", "loop_1", "loop_2"}
+        assert set(rec_b["content"].keys()) == expected_b
 
     def test_error_handling_in_correlation(self, correlator, temp_agent_folder):
         """Test error handling during correlation."""


### PR DESCRIPTION
## Summary
- `build_version_merge` now passes `base_record` so upstream namespaces survive version correlation merges
- First-stage records (raw input, no `content` key) get fields wrapped under `source` namespace
- Without these fixes, `select_approved_questions` fails with "summarize_page_content.summary not found at runtime" in qanalabs

## Changes
- `loop.py:360` — `build_version_merge(versions)` → `build_version_merge(versions, base_record)`
- `record_processor.py:301-319` — wrap first-stage raw fields under `source` namespace
- `test_version_correlator.py` — updated assertion for upstream namespace preservation

## Verification
- `pytest` — 5950 passed, 2 skipped
- `ruff format --check` + `ruff check` — clean