### PR TITLE
fix: revert tombstone filter — breaks guard-skip pipeline flow

### DIFF
--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -533,9 +533,9 @@ class ProcessingPipeline:
         )
 
         # Process via RecordProcessor
-        # Filter out upstream tombstones — preserved for lineage but not for re-processing.
-        data = [d for d in data if not (isinstance(d, dict) and d.get("_unprocessed") is True)]
-
+        # NOTE: Do NOT filter _unprocessed records here. Guard-skipped records
+        # (on_false: skip) produce _unprocessed tombstones that are valid pipeline
+        # data. task_preparer._is_upstream_unprocessed() handles them per-record.
         if self.granularity == "file" and (self.is_tool_action or self.is_hitl_action):
             # For FILE mode, use the input data as source for parent lookup
             # (not source_data which points to original source folder)


### PR DESCRIPTION
## Summary
Reverts the tombstone filter from PR #351. The filter removed ALL `_unprocessed` records from downstream input, breaking guard-skip scenarios.

## What broke
`rewrite_failed_question` has `guard: {on_false: skip}`. When all 3 records pass validation, all 3 are guard-skipped (tombstones). The filter removed all 3, leaving `add_answer_text` with zero input → empty output cascaded through distractors → `reconstruct_options` → `OptionsCombiner` failure.

## Why the filter was wrong
Guard-skip tombstones and cascade-failure tombstones both have `_unprocessed: True`. The filter couldn't distinguish them. Guard-skipped records ARE valid pipeline data — they just didn't go through one action.

## The correct handling
`task_preparer._is_upstream_unprocessed()` already handles tombstones per-record. It detects `_unprocessed: True` and returns `UPSTREAM_UNPROCESSED` status, which preserves the record. This was the existing behavior before the filter.

## Verification
- `pytest` — 5950 passed, 2 skipped