### PR TITLE
fix: guard-skip tombstones should not cascade as upstream_unprocessed

### DIFF
--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -292,10 +292,20 @@ class TaskPreparer:
 
     @staticmethod
     def _is_upstream_unprocessed(item: Any) -> bool:
-        """Return True if item["_unprocessed"] is exactly True (strict identity check)."""
+        """Return True only for cascade-failure tombstones, not guard-skip tombstones.
+
+        Guard-skipped records (reason=guard_skip) are valid pipeline data — the
+        action was intentionally skipped but downstream should still process.
+        Only upstream_unprocessed cascades should propagate as unprocessed.
+        """
         if not isinstance(item, dict):
             return False
-        return item.get("_unprocessed") is True
+        if item.get("_unprocessed") is not True:
+            return False
+        metadata = item.get("metadata")
+        if isinstance(metadata, dict) and metadata.get("reason") == "guard_skip":
+            return False
+        return True
 
     def _generate_target_id(self) -> str:
         """Generate a new target_id."""


### PR DESCRIPTION
## Summary
Guard-skipped records (`on_false: skip`) should NOT cascade as `UPSTREAM_UNPROCESSED`. They are valid pipeline data — the action was skipped but downstream should still process the record.

## What broke
`rewrite_failed_question` skips all 3 records (validation passed). Each tombstone has `metadata.reason: "guard_skip"`. `_is_upstream_unprocessed()` treated ALL `_unprocessed: True` records the same → tombstones cascaded through `add_answer_text` → distractors → `reconstruct_options` → `OptionsCombiner` → `format_quiz_text`. Result: 0 live quiz questions produced despite successful pipeline run.

## Fix
`_is_upstream_unprocessed()` now checks `metadata.reason`. Returns `False` for `guard_skip` tombstones — they flow through as normal data. Only `upstream_unprocessed` (cascade failures) propagate.

## Verification
- `pytest` — 5950 passed, 2 skipped