### PR TITLE
fix: use root_target_id for fan-in merge correlation

### DIFF
--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -98,7 +98,7 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
     key_candidates = []
     if reduce_key:
         key_candidates.append(reduce_key)
-    key_candidates.extend(["parent_target_id", "source_guid"])
+    key_candidates.extend(["root_target_id", "parent_target_id", "source_guid"])
 
     for record in records:
         if not isinstance(record, dict):


### PR DESCRIPTION
## Summary
When OptionsCombiner depends on both reconstruct_options and generate_concept_explanation, records from different branches must merge by a shared key.

- parent_target_id: differs per branch (immediate parent)
- source_guid: too coarse (same for all questions from same source doc)
- root_target_id: shared by records for the same question across all branches

One-line fix in merge.py: add root_target_id to key_candidates before parent_target_id.

## Verification
pytest — 5950 passed, 2 skipped