### PR TITLE
fix: fan-in merges all dependency branches via bus model

### DIFF
--- a/.changes/unreleased/Bug Fix-20260425-355000.yaml
+++ b/.changes/unreleased/Bug Fix-20260425-355000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fan-in dependencies now merge all branches by root_target_id instead of narrowing to primary — aligns with additive content (bus) model"
+time: 2026-04-25T03:55:00.000000Z

--- a/agent_actions/prompt/context/scope_inference.py
+++ b/agent_actions/prompt/context/scope_inference.py
@@ -95,8 +95,7 @@ def _resolve_input_sources_for_fan_in(
     """
     Resolve which dependencies are input sources vs context sources for fan-in pattern.
 
-    This is the shared logic used by both infer_dependencies() and
-    _resolve_dependency_directories() to avoid duplication.
+    Used by infer_dependencies() for prompt context classification.
 
     Args:
         dependencies: List of all dependency action names

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -162,53 +162,18 @@ class ActionRunner:
             DependencyError: If any input source directory is not found.
         """
         from agent_actions.errors import DependencyError
-        from agent_actions.prompt.context.scope_inference import (
-            _is_parallel_branches,
-            _resolve_input_sources_for_fan_in,
-        )
 
         target_dir = agent_folder / "target"
 
-        # Detect fan-in pattern: multiple DIFFERENT dependencies
-        # For fan-in, only resolve the primary dependency directories
-        # Non-primary dependencies are loaded via historical loader (context sources)
-        #
-        # Exception: If reduce_key is set, it's an aggregation pattern - merge all dependencies
-        #
-        # Versioned primary handling: If primary_dependency is a base name (e.g., "research")
-        # that matches version branches (research_1, research_2), ALL matching branches
-        # become input sources.
+        # Multiple dependencies: all become input sources and merge by root_target_id.
+        # With the additive content model (bus), records carry all namespaces —
+        # fan-in just needs to merge records from different branches so the
+        # downstream action sees combined content.
         if len(dependencies) > 1:
-            has_reduce_key = action_config.get("reduce_key") is not None
-            is_parallel = _is_parallel_branches(dependencies)
-
-            if has_reduce_key:
-                # Aggregation pattern with reduce_key - merge all dependencies
-                # Note: This applies regardless of whether deps are parallel branches
-                # (parallel branches merge by default, reduce_key just adds grouping)
-                logger.debug(
-                    f"Action '{agent_name}': Aggregation pattern (reduce_key set). "
-                    f"Merging all {len(dependencies)} dependencies: {dependencies}"
-                )
-            elif not is_parallel:
-                # Fan-in pattern - use shared helper
-                primary_dep = action_config.get("primary_dependency")
-                try:
-                    input_deps, non_primary = _resolve_input_sources_for_fan_in(
-                        dependencies, primary_dep
-                    )
-                except ValueError as e:
-                    raise DependencyError(
-                        f"Action '{agent_name}': {e}",
-                        context={"action": agent_name, "dependencies": dependencies},
-                    ) from e
-
-                logger.debug(
-                    f"Action '{agent_name}': Fan-in pattern detected. "
-                    f"Input sources: {input_deps}. "
-                    f"Context sources (loaded via historical loader): {non_primary}"
-                )
-                dependencies = input_deps
+            logger.debug(
+                f"Action '{agent_name}': Merging all {len(dependencies)} "
+                f"dependency input sources: {dependencies}"
+            )
 
         # Resolve all input source directories
         resolved_dirs = []

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -154,9 +154,12 @@ class ActionRunner:
         return result.directories
 
     def _resolve_dependency_directories(
-        self, agent_folder: Path, dependencies: list[str], action_config: dict, agent_name: str
+        self, agent_folder: Path, dependencies: list[str], agent_name: str
     ) -> list[Path]:
         """Resolve upstream directories from dependencies (input sources).
+
+        All dependencies become input sources. Records from different branches
+        are merged by root_target_id downstream (additive content / bus model).
 
         Raises:
             DependencyError: If any input source directory is not found.
@@ -164,16 +167,6 @@ class ActionRunner:
         from agent_actions.errors import DependencyError
 
         target_dir = agent_folder / "target"
-
-        # Multiple dependencies: all become input sources and merge by root_target_id.
-        # With the additive content model (bus), records carry all namespaces —
-        # fan-in just needs to merge records from different branches so the
-        # downstream action sees combined content.
-        if len(dependencies) > 1:
-            logger.debug(
-                f"Action '{agent_name}': Merging all {len(dependencies)} "
-                f"dependency input sources: {dependencies}"
-            )
 
         # Resolve all input source directories
         resolved_dirs = []
@@ -395,7 +388,6 @@ class ActionRunner:
             upstream_data_dirs = self._resolve_dependency_directories(
                 agent_folder_path,
                 dependencies,
-                action_config,
                 agent_type,  # action_name
             )
         elif previous_action_type:

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -403,12 +403,10 @@ def process_files(runner: ActionRunner, params: FileProcessParams) -> None:
                 warn_no_files_found(params)
             return
         else:
-            # Fan-in pattern: multiple different dependencies
-            # This should have been resolved to primary dependency in _resolve_dependency_directories()
-            # If we reach here, it means all directories should be merged (aggregation pattern)
+            # Multiple dependencies: merge all inputs by root_target_id
             logger.info(
-                f"Multiple dependency directories detected: {dep_names}. "
-                f"Merging all inputs (aggregation pattern)."
+                "Multiple dependency directories detected: %s. Merging all inputs.",
+                dep_names,
             )
             files_processed_count = process_merged_files(runner, params)
             if files_processed_count == 0:

--- a/tests/orchestration/test_agent_runner_dependency_resolution.py
+++ b/tests/orchestration/test_agent_runner_dependency_resolution.py
@@ -1,16 +1,12 @@
 """
 Tests for _resolve_dependency_directories() in ActionRunner.
 
-Tests the 4 dependency patterns:
-1. Single - One dependency, output becomes input
-2. Parallel Branches - Same base name (e.g., classify_1, classify_2), outputs merged
-3. Fan-in - Different actions, first is primary, others via context
-4. Aggregation - Different actions with reduce_key, all merged
+With the additive content (bus) model, all dependencies become input sources.
+Records from different branches are merged by root_target_id downstream.
 
 Also tests:
-- _is_parallel_branches() detection logic
-- Context sources auto-inferred from context_scope
-- primary_dependency override for fan-in
+- _is_parallel_branches() detection logic (used by scope_inference)
+- _resolve_input_sources_for_fan_in() (used by scope_inference)
 """
 
 import shutil
@@ -85,8 +81,7 @@ class TestGetVersionBranches:
 class TestResolveInputSourcesForFanIn:
     """Test _resolve_input_sources_for_fan_in() shared helper.
 
-    This helper is used by both infer_dependencies() and _resolve_dependency_directories()
-    to resolve which dependencies are input sources vs context sources for fan-in patterns.
+    Used by infer_dependencies() for prompt context classification.
     """
 
     def test_base_name_primary_expands_to_all_versions(self):
@@ -137,7 +132,7 @@ class TestDependencyPatterns:
         (temp_folder / "target" / "extract_data").mkdir()
 
         result = agent_runner._resolve_dependency_directories(
-            temp_folder, ["extract_data"], {"dependencies": ["extract_data"]}, "validate_data"
+            temp_folder, ["extract_data"], "validate_data"
         )
 
         assert len(result) == 1
@@ -164,7 +159,6 @@ class TestDependencyPatterns:
         result = agent_runner._resolve_dependency_directories(
             temp_folder,
             ["research_1", "research_2", "research_3"],
-            {"dependencies": ["research_1", "research_2", "research_3"]},
             "synthesize",
         )
 
@@ -193,12 +187,6 @@ class TestDependencyPatterns:
         result = agent_runner._resolve_dependency_directories(
             temp_folder,
             ["analyze_sentiment", "analyze_entities", "analyze_topics"],
-            {
-                "dependencies": ["analyze_sentiment", "analyze_entities", "analyze_topics"],
-                "context_scope": {
-                    "observe": ["analyze_sentiment.*", "analyze_entities.*", "analyze_topics.*"]
-                },
-            },
             "generate_report",
         )
 
@@ -227,10 +215,6 @@ class TestDependencyPatterns:
         result = agent_runner._resolve_dependency_directories(
             temp_folder,
             ["validator_grammar", "validator_accuracy", "validator_style"],
-            {
-                "dependencies": ["validator_grammar", "validator_accuracy", "validator_style"],
-                "reduce_key": "content_id",
-            },
             "aggregate_validations",
         )
 
@@ -263,10 +247,6 @@ class TestDependencyPatterns:
         result = agent_runner._resolve_dependency_directories(
             temp_folder,
             ["classify_1", "classify_2", "classify_3"],
-            {
-                "dependencies": ["classify_1", "classify_2", "classify_3"],
-                "reduce_key": "content_id",
-            },
             "aggregate_classifications",
         )
 
@@ -282,10 +262,6 @@ class TestDependencyPatterns:
         result = agent_runner._resolve_dependency_directories(
             temp_folder,
             ["action_a", "action_b"],
-            {
-                "dependencies": ["action_a", "action_b"],
-                "primary_dependency": "action_c",  # Ignored — not used in bus model
-            },
             "test_action",
         )
 
@@ -305,7 +281,6 @@ class TestDependencyPatterns:
         result = agent_runner._resolve_dependency_directories(
             temp_folder,
             ["research_1", "research_2", "research_3", "summarize"],
-            {"dependencies": ["research_1", "research_2", "research_3", "summarize"]},
             "final_report",
         )
 
@@ -325,33 +300,6 @@ class TestDependencyPatterns:
         result = agent_runner._resolve_dependency_directories(
             temp_folder,
             ["research_1", "research_2", "summarize"],
-            {
-                "dependencies": ["research_1", "research_2", "summarize"],
-                "primary_dependency": "research",
-            },
-            "final_report",
-        )
-
-        # All dependencies are input sources
-        assert len(result) == 3
-        assert {r.name for r in result} == {"research_1", "research_2", "summarize"}
-
-    def test_versioned_primary_explicit_branch_all_input(self, agent_runner, temp_folder):
-        """
-        All dependencies are input sources regardless of explicit primary_dependency.
-
-        Bus model: primary_dependency is ignored at the runner level.
-        """
-        for action in ["research_1", "research_2", "summarize"]:
-            (temp_folder / "target" / action).mkdir()
-
-        result = agent_runner._resolve_dependency_directories(
-            temp_folder,
-            ["research_1", "research_2", "summarize"],
-            {
-                "dependencies": ["research_1", "research_2", "summarize"],
-                "primary_dependency": "research_1",
-            },
             "final_report",
         )
 
@@ -393,10 +341,9 @@ class TestResolveDependencyDirectories:
     def test_single_dependency_returns_single_directory(self, agent_runner, temp_agent_folder):
         """Test single dependency returns its directory."""
         dependencies = ["action_A"]
-        agent_config = {"dependencies": dependencies}
 
         result = agent_runner._resolve_dependency_directories(
-            temp_agent_folder, dependencies, agent_config, "test_action"
+            temp_agent_folder, dependencies, "test_action"
         )
 
         assert len(result) == 1
@@ -405,10 +352,9 @@ class TestResolveDependencyDirectories:
     def test_multiple_dependencies_fan_in_returns_all(self, agent_runner, temp_agent_folder):
         """Test fan-in pattern: all dependencies are input sources (bus model)."""
         dependencies = ["action_A", "action_B", "action_C"]
-        agent_config = {"dependencies": dependencies}
 
         result = agent_runner._resolve_dependency_directories(
-            temp_agent_folder, dependencies, agent_config, "test_action"
+            temp_agent_folder, dependencies, "test_action"
         )
 
         # Bus model: all dependencies are input sources, merged by root_target_id
@@ -424,10 +370,9 @@ class TestResolveDependencyDirectories:
             (temp_agent_folder / "target" / f"classify_{suffix}").mkdir(parents=True, exist_ok=True)
 
         dependencies = ["classify_1", "classify_2", "classify_3"]
-        agent_config = {"dependencies": dependencies}
 
         result = agent_runner._resolve_dependency_directories(
-            temp_agent_folder, dependencies, agent_config, "test_action"
+            temp_agent_folder, dependencies, "test_action"
         )
 
         # Parallel branches: all directories returned for merging
@@ -441,10 +386,8 @@ class TestResolveDependencyDirectories:
     ):
         """Test aggregation pattern: reduce_key set returns all dependencies."""
         dependencies = ["action_A", "action_B", "action_C"]
-        agent_config = {"dependencies": dependencies, "reduce_key": "parent_id"}
-
         result = agent_runner._resolve_dependency_directories(
-            temp_agent_folder, dependencies, agent_config, "test_action"
+            temp_agent_folder, dependencies, "test_action"
         )
 
         # Aggregation with reduce_key: all directories returned for merging
@@ -463,11 +406,10 @@ class TestResolveDependencyDirectories:
             action_a_dir.rmdir()
 
         dependencies = ["action_A", "action_B"]
-        agent_config = {"dependencies": dependencies}
 
         with pytest.raises(DependencyError) as exc_info:
             agent_runner._resolve_dependency_directories(
-                temp_agent_folder, dependencies, agent_config, "test_action"
+                temp_agent_folder, dependencies, "test_action"
             )
 
         assert "action_A" in str(exc_info.value)
@@ -476,13 +418,9 @@ class TestResolveDependencyDirectories:
     def test_primary_dependency_ignored_all_input(self, agent_runner, temp_agent_folder):
         """Test primary_dependency is ignored — all deps are input sources in bus model."""
         dependencies = ["action_A", "action_B", "action_C"]
-        agent_config = {
-            "dependencies": dependencies,
-            "primary_dependency": "action_B",  # Ignored in bus model
-        }
 
         result = agent_runner._resolve_dependency_directories(
-            temp_agent_folder, dependencies, agent_config, "test_action"
+            temp_agent_folder, dependencies, "test_action"
         )
 
         # Bus model: all dependencies are input sources
@@ -492,10 +430,9 @@ class TestResolveDependencyDirectories:
     def test_empty_dependencies_returns_empty_list(self, agent_runner, temp_agent_folder):
         """Test empty dependencies returns empty list."""
         dependencies = []
-        agent_config = {"dependencies": dependencies}
 
         result = agent_runner._resolve_dependency_directories(
-            temp_agent_folder, dependencies, agent_config, "test_action"
+            temp_agent_folder, dependencies, "test_action"
         )
 
         assert result == []
@@ -559,11 +496,10 @@ class TestResolveDependencyDirectoriesIntegration:
         - dependencies: add_answer_text (single input)
         - Context deps (suggest_distractor_counts, write_scenario_question) auto-inferred
         """
-        dependencies = ["add_answer_text"]  # Only input source
-        agent_config = {"dependencies": dependencies}
+        dependencies = ["add_answer_text"]
 
         result = agent_runner_with_workflow._resolve_dependency_directories(
-            temp_workflow_folder, dependencies, agent_config, "generate_distractor_1"
+            temp_workflow_folder, dependencies, "generate_distractor_1"
         )
 
         # Should only return add_answer_text directory
@@ -589,10 +525,8 @@ class TestResolveDependencyDirectoriesIntegration:
         runner.virtual_actions = {}
 
         dependencies = ["validate_1", "validate_2", "validate_3"]
-        agent_config = {"dependencies": dependencies, "reduce_key": "parent_id"}
-
         result = runner._resolve_dependency_directories(
-            temp_workflow_folder, dependencies, agent_config, "aggregate"
+            temp_workflow_folder, dependencies, "aggregate"
         )
 
         # Should return all 3 directories for merging
@@ -607,24 +541,13 @@ class TestResolveDependencyDirectoriesIntegration:
         New: dependencies: get_authoring_prompt (single input)
         Context deps (flatten_raw_questions, classify_question_type) auto-inferred from context_scope.
         """
-        dependencies = ["get_authoring_prompt"]  # Single input after migration
-        agent_config = {
-            "dependencies": dependencies,
-            "context_scope": {
-                "observe": [
-                    "flatten_raw_questions.question_text",
-                    "classify_question_type.quiz_type",
-                    "get_authoring_prompt.authoring_prompt",
-                ]
-            },
-        }
+        dependencies = ["get_authoring_prompt"]
 
         result = agent_runner_with_workflow._resolve_dependency_directories(
-            temp_workflow_folder, dependencies, agent_config, "write_scenario_question"
+            temp_workflow_folder, dependencies, "write_scenario_question"
         )
 
-        # Should only return get_authoring_prompt directory (input source)
-        # Context deps are NOT returned here - they're loaded via historical loader
+        # Single dependency: returns its directory
         assert len(result) == 1
         assert result[0] == temp_workflow_folder / "target" / "get_authoring_prompt"
 

--- a/tests/orchestration/test_agent_runner_dependency_resolution.py
+++ b/tests/orchestration/test_agent_runner_dependency_resolution.py
@@ -185,7 +185,7 @@ class TestDependencyPatterns:
                 - analyze_entities.*
                 - analyze_topics.*
 
-        Result: First is primary input, others available via lineage-matched context
+        Result: All dependencies are input sources — records merge by root_target_id
         """
         for action in ["analyze_sentiment", "analyze_entities", "analyze_topics"]:
             (temp_folder / "target" / action).mkdir()
@@ -202,37 +202,13 @@ class TestDependencyPatterns:
             "generate_report",
         )
 
-        # Only primary (first) returned - others via historical loader
-        assert len(result) == 1
-        assert result[0].name == "analyze_sentiment"
-
-    def test_pattern_3_fan_in_with_primary_override(self, agent_runner, temp_folder):
-        """
-        Pattern 3: Fan-in with primary_dependency override
-
-        Config:
-          - name: generate_report
-            dependencies: [analyze_sentiment, analyze_entities, analyze_topics]
-            primary_dependency: analyze_entities
-
-        Result: analyze_entities is primary input
-        """
-        for action in ["analyze_sentiment", "analyze_entities", "analyze_topics"]:
-            (temp_folder / "target" / action).mkdir()
-
-        result = agent_runner._resolve_dependency_directories(
-            temp_folder,
-            ["analyze_sentiment", "analyze_entities", "analyze_topics"],
-            {
-                "dependencies": ["analyze_sentiment", "analyze_entities", "analyze_topics"],
-                "primary_dependency": "analyze_entities",
-            },
-            "generate_report",
-        )
-
-        # Explicit primary returned
-        assert len(result) == 1
-        assert result[0].name == "analyze_entities"
+        # All dependencies returned — bus model merges records by root_target_id
+        assert len(result) == 3
+        assert {r.name for r in result} == {
+            "analyze_sentiment",
+            "analyze_entities",
+            "analyze_topics",
+        }
 
     def test_pattern_4_aggregation(self, agent_runner, temp_folder):
         """
@@ -298,30 +274,30 @@ class TestDependencyPatterns:
         assert len(result) == 3
         assert {r.name for r in result} == {"classify_1", "classify_2", "classify_3"}
 
-    def test_invalid_primary_dependency_raises_error(self, agent_runner, temp_folder):
-        """primary_dependency must be in dependencies list."""
+    def test_fan_in_primary_dependency_ignored(self, agent_runner, temp_folder):
+        """primary_dependency is ignored — all deps are input sources in bus model."""
         for action in ["action_a", "action_b"]:
             (temp_folder / "target" / action).mkdir()
 
-        with pytest.raises(DependencyError) as exc_info:
-            agent_runner._resolve_dependency_directories(
-                temp_folder,
-                ["action_a", "action_b"],
-                {
-                    "dependencies": ["action_a", "action_b"],
-                    "primary_dependency": "action_c",  # Not in list!
-                },
-                "test_action",
-            )
+        result = agent_runner._resolve_dependency_directories(
+            temp_folder,
+            ["action_a", "action_b"],
+            {
+                "dependencies": ["action_a", "action_b"],
+                "primary_dependency": "action_c",  # Ignored — not used in bus model
+            },
+            "test_action",
+        )
 
-        assert "primary_dependency" in str(exc_info.value)
-        assert "action_c" in str(exc_info.value)
+        # All dependencies are input sources regardless of primary_dependency
+        assert len(result) == 2
+        assert {r.name for r in result} == {"action_a", "action_b"}
 
-    def test_versioned_primary_with_fan_in(self, agent_runner, temp_folder):
+    def test_versioned_with_fan_in_all_input(self, agent_runner, temp_folder):
         """
-        Fan-in with versioned primary: research_1, research_2, research_3 + summarize
+        Fan-in with versioned + non-versioned: all are input sources.
 
-        When primary is a version branch, ALL sibling branches become input sources.
+        Bus model: all dependencies become input sources, merged by root_target_id.
         """
         for action in ["research_1", "research_2", "research_3", "summarize"]:
             (temp_folder / "target" / action).mkdir()
@@ -333,17 +309,38 @@ class TestDependencyPatterns:
             "final_report",
         )
 
-        # All research branches should be input sources (3 dirs), summarize is context
+        # All dependencies are input sources in bus model
+        assert len(result) == 4
+        assert {r.name for r in result} == {"research_1", "research_2", "research_3", "summarize"}
+
+    def test_versioned_primary_base_name_all_input(self, agent_runner, temp_folder):
+        """
+        All dependencies are input sources regardless of primary_dependency.
+
+        Bus model: primary_dependency is ignored at the runner level.
+        """
+        for action in ["research_1", "research_2", "summarize"]:
+            (temp_folder / "target" / action).mkdir()
+
+        result = agent_runner._resolve_dependency_directories(
+            temp_folder,
+            ["research_1", "research_2", "summarize"],
+            {
+                "dependencies": ["research_1", "research_2", "summarize"],
+                "primary_dependency": "research",
+            },
+            "final_report",
+        )
+
+        # All dependencies are input sources
         assert len(result) == 3
-        assert {r.name for r in result} == {"research_1", "research_2", "research_3"}
+        assert {r.name for r in result} == {"research_1", "research_2", "summarize"}
 
-    def test_versioned_primary_base_name_expansion(self, agent_runner, temp_folder):
+    def test_versioned_primary_explicit_branch_all_input(self, agent_runner, temp_folder):
         """
-        primary_dependency as base name expands to all version branches.
+        All dependencies are input sources regardless of explicit primary_dependency.
 
-        Config: primary_dependency: research (base name)
-        Deps: [research_1, research_2, summarize]
-        Result: research_1, research_2 are inputs, summarize is context
+        Bus model: primary_dependency is ignored at the runner level.
         """
         for action in ["research_1", "research_2", "summarize"]:
             (temp_folder / "target" / action).mkdir()
@@ -353,39 +350,14 @@ class TestDependencyPatterns:
             ["research_1", "research_2", "summarize"],
             {
                 "dependencies": ["research_1", "research_2", "summarize"],
-                "primary_dependency": "research",  # Base name, not in list directly
+                "primary_dependency": "research_1",
             },
             "final_report",
         )
 
-        # research expands to research_1, research_2 as inputs
-        assert len(result) == 2
-        assert {r.name for r in result} == {"research_1", "research_2"}
-
-    def test_versioned_primary_explicit_branch(self, agent_runner, temp_folder):
-        """
-        Explicit primary_dependency pointing to a version branch includes all siblings.
-
-        Config: primary_dependency: research_1
-        Deps: [research_1, research_2, summarize]
-        Result: research_1, research_2 are inputs (siblings), summarize is context
-        """
-        for action in ["research_1", "research_2", "summarize"]:
-            (temp_folder / "target" / action).mkdir()
-
-        result = agent_runner._resolve_dependency_directories(
-            temp_folder,
-            ["research_1", "research_2", "summarize"],
-            {
-                "dependencies": ["research_1", "research_2", "summarize"],
-                "primary_dependency": "research_1",  # Explicit branch
-            },
-            "final_report",
-        )
-
-        # research_1's siblings (research_2) also become inputs
-        assert len(result) == 2
-        assert {r.name for r in result} == {"research_1", "research_2"}
+        # All dependencies are input sources
+        assert len(result) == 3
+        assert {r.name for r in result} == {"research_1", "research_2", "summarize"}
 
 
 class TestResolveDependencyDirectories:
@@ -430,10 +402,8 @@ class TestResolveDependencyDirectories:
         assert len(result) == 1
         assert result[0] == temp_agent_folder / "target" / "action_A"
 
-    def test_multiple_dependencies_fan_in_returns_primary_only(
-        self, agent_runner, temp_agent_folder
-    ):
-        """Test fan-in pattern: multiple different dependencies returns only primary."""
+    def test_multiple_dependencies_fan_in_returns_all(self, agent_runner, temp_agent_folder):
+        """Test fan-in pattern: all dependencies are input sources (bus model)."""
         dependencies = ["action_A", "action_B", "action_C"]
         agent_config = {"dependencies": dependencies}
 
@@ -441,10 +411,9 @@ class TestResolveDependencyDirectories:
             temp_agent_folder, dependencies, agent_config, "test_action"
         )
 
-        # Fan-in: only primary (first) dependency returned
-        # Non-primary deps are loaded via historical loader as context sources
-        assert len(result) == 1
-        assert result[0] == temp_agent_folder / "target" / "action_A"
+        # Bus model: all dependencies are input sources, merged by root_target_id
+        assert len(result) == 3
+        assert {r.name for r in result} == {"action_A", "action_B", "action_C"}
 
     def test_multiple_dependencies_parallel_returns_all_directories(
         self, agent_runner, temp_agent_folder
@@ -504,21 +473,21 @@ class TestResolveDependencyDirectories:
         assert "action_A" in str(exc_info.value)
         assert "not found" in str(exc_info.value)
 
-    def test_primary_dependency_selects_primary_in_fan_in(self, agent_runner, temp_agent_folder):
-        """Test primary_dependency field selects which dep is primary in fan-in."""
+    def test_primary_dependency_ignored_all_input(self, agent_runner, temp_agent_folder):
+        """Test primary_dependency is ignored — all deps are input sources in bus model."""
         dependencies = ["action_A", "action_B", "action_C"]
         agent_config = {
             "dependencies": dependencies,
-            "primary_dependency": "action_B",  # Explicit primary selection
+            "primary_dependency": "action_B",  # Ignored in bus model
         }
 
         result = agent_runner._resolve_dependency_directories(
             temp_agent_folder, dependencies, agent_config, "test_action"
         )
 
-        # Fan-in with explicit primary: only action_B returned
-        assert len(result) == 1
-        assert result[0] == temp_agent_folder / "target" / "action_B"
+        # Bus model: all dependencies are input sources
+        assert len(result) == 3
+        assert {r.name for r in result} == {"action_A", "action_B", "action_C"}
 
     def test_empty_dependencies_returns_empty_list(self, agent_runner, temp_agent_folder):
         """Test empty dependencies returns empty list."""

--- a/tests/unit/workflow/test_virtual_actions.py
+++ b/tests/unit/workflow/test_virtual_actions.py
@@ -206,7 +206,6 @@ class TestRunnerVirtualActionResolution:
         result = runner._resolve_dependency_directories(
             local_io,
             ["extract"],
-            {"dependencies": ["extract"]},
             "enrich_text",
         )
 


### PR DESCRIPTION
## Summary
- Fan-in actions (multiple different-named dependencies like `[generate_concept_explanation, reconstruct_options]`) previously narrowed input to only the primary dependency, loading others via the historical loader
- With the additive content model (bus), records carry all namespaces — fan-in just needs to merge records from different branches by `root_target_id` so the downstream action sees combined content
- Removes the fan-in narrowing logic from `_resolve_dependency_directories` and the `_is_parallel_branches` / `_resolve_input_sources_for_fan_in` imports

## Verification
- All 5933 tests pass (36 dependency resolution tests updated)
- `ruff check` and `ruff format` clean
- Validated end-to-end with qanalabs_quiz_gen workflow — `OptionsCombiner` (fan-in of `reconstruct_options` + `generate_concept_explanation`) now receives merged records with both namespaces