### PR TITLE
fix: guard-skipped FILE-mode records use original namespaced content

### DIFF
--- a/.changes/unreleased/Bug Fix-20260425-356000.yaml
+++ b/.changes/unreleased/Bug Fix-20260425-356000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Guard-skipped FILE-mode records no longer leak observe-flattened fields into content — uses original namespaced record for tombstones"
+time: 2026-04-25T03:56:00.000000Z

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -583,7 +583,9 @@ def prefilter_by_guard(
             passing.append(item)
             original_passing.append(originals[idx])
         elif behavior == "skip":
-            skipped.append(item)
+            # Use original (pre-observe) record so skipped tombstones
+            # keep namespaced content, not observe-flattened fields.
+            skipped.append(originals[idx])
         # behavior == "filter": record excluded from both lists
 
     logger.info(

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -583,8 +583,7 @@ def prefilter_by_guard(
             passing.append(item)
             original_passing.append(originals[idx])
         elif behavior == "skip":
-            # Use original (pre-observe) record so skipped tombstones
-            # keep namespaced content, not observe-flattened fields.
+            # Use pre-observe original so skipped tombstones keep namespaced content.
             skipped.append(originals[idx])
         # behavior == "filter": record excluded from both lists
 


### PR DESCRIPTION
## Summary
- `prefilter_by_guard()` was appending observe-flattened records to the skipped list, causing tombstones to carry flat field duplicates (e.g., `content["question_text"]` alongside `content["flatten_canonical_questions"]["question_text"]`)
- Fix: use `originals[idx]` for skipped items — the pre-observe record with proper namespaced content. Matches the existing `original_passing` pattern on the same function.

## Verification
- 5932 tests pass, ruff clean
- Validated on qanalabs_quiz_gen `review_consolidated_answers` (HITL guard-skip path)