### PR TITLE
fix: prompt validator false positive when prompt file differs from workflow

### DIFF
--- a/agent_actions/validation/prompt_validator.py
+++ b/agent_actions/validation/prompt_validator.py
@@ -175,16 +175,20 @@ class PromptValidator(BaseValidator):
         """Return the prompt files that should be validated.
 
         When *workflow_name* is provided, only ``{workflow_name}.md`` is
-        returned.  If the file does not exist the list is empty and the
-        caller emits a specific warning.  Without a workflow name every
-        ``.md`` file in *prompt_dir* is returned.
+        returned.  If the file does not exist, all ``.md`` files in
+        *prompt_dir* are returned as a fallback — the workflow may
+        reference a prompt file whose name differs from the workflow
+        name.  Without a workflow name every ``.md`` file is returned.
         """
         if workflow_name:
             # Guard against path traversal — workflow_name must be a simple name
             if ".." in workflow_name or "/" in workflow_name or "\\" in workflow_name:
                 return []
             target = prompt_dir / f"{workflow_name}.md"
-            return [target] if target.is_file() else []
+            if target.is_file():
+                return [target]
+            # Workflow-named file not found — fall back to all .md files.
+            # The prompt file may have a different name than the workflow.
         return sorted(prompt_dir.glob("*.md"))
 
     def validate(self, data: Any, config: dict[str, Any] | None = None) -> bool:
@@ -226,10 +230,7 @@ class PromptValidator(BaseValidator):
         stats = {"total_files_processed": 0, "files_with_errors": 0, "total_prompts_validated": 0}
         prompt_files = self._resolve_prompt_files(prompt_dir, workflow_name)
         if not prompt_files:
-            if workflow_name:
-                self.add_warning(f"Prompt file '{workflow_name}.md' not found in {prompt_dir}")
-            else:
-                self.add_warning(f"No .md files found in prompt directory: {prompt_dir}")
+            self.add_warning(f"No .md files found in prompt directory: {prompt_dir}")
             return self._complete_validation()
         for prompt_file in prompt_files:
             stats["total_files_processed"] += 1

--- a/tests/unit/validation/test_prompt_validator_coverage.py
+++ b/tests/unit/validation/test_prompt_validator_coverage.py
@@ -237,10 +237,11 @@ class TestResolvePromptFiles:
         assert len(result) == 1
         assert result[0].name == "my_workflow.md"
 
-    def test_workflow_name_missing_file_returns_empty(self, tmp_path):
+    def test_workflow_name_missing_file_falls_back_to_all(self, tmp_path):
         (tmp_path / "other.md").write_text("other")
         result = PromptValidator._resolve_prompt_files(tmp_path, "missing_workflow")
-        assert result == []
+        assert len(result) == 1
+        assert result[0].name == "other.md"
 
     def test_empty_string_workflow_name_returns_all(self, tmp_path):
         (tmp_path / "a.md").write_text("a")
@@ -331,9 +332,10 @@ class TestValidateWorkflowScoping:
         assert result is True
         assert not validator.has_errors()
 
-    def test_workflow_file_missing_warns(self, validator, tmp_path):
-        """When the workflow's prompt file does not exist, emit a warning."""
-        (tmp_path / "other.md").write_text("irrelevant")
+    def test_workflow_file_missing_falls_back_to_all(self, validator, tmp_path):
+        """When the workflow's prompt file does not exist, fall back to all .md files."""
+        (tmp_path / "other.md").write_text("# Title\n{prompt p1}\ncontent\n{end_prompt}")
         result = validator.validate(tmp_path, config={"workflow_name": "nonexistent"})
         assert result is True
-        assert any("nonexistent.md" in w and "not found" in w for w in validator.get_warnings())
+        # Should not warn about missing workflow-named file
+        assert not any("nonexistent.md" in w for w in validator.get_warnings())


### PR DESCRIPTION
## Summary
- `PromptValidator._resolve_prompt_files` assumed prompt files are always named `{workflow_name}.md`
- When a workflow references a prompt file with a different name (e.g. workflow `code_centered_quiz` using `code_options_quiz.md`), the validator emitted a spurious "not found" warning and skipped validation entirely
- Now falls back to validating all `.md` files in the prompt directory when the workflow-named file doesn't exist, so the actual prompt file still gets validated

## Verification
- `pytest tests/unit/validation/test_prompt_validator_coverage.py` — 41 passed
- `pytest` — 5886 passed, 2 skipped
- `ruff check` + `ruff format --check` clean