### PR TITLE
validate: incident_triage example on gemini-flash-lite

### DIFF
--- a/.changes/unreleased/Under the Hood-20260425-101000.yaml
+++ b/.changes/unreleased/Under the Hood-20260425-101000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Switch incident_triage example to gemini-flash-lite-latest, remove per-action vendor overrides"
+time: 2026-04-25T10:10:00.000000Z

--- a/examples/incident_triage/agent_actions.yml
+++ b/examples/incident_triage/agent_actions.yml
@@ -1,9 +1,9 @@
 default_agent_config:
-  api_key: OPENAI_API_KEY
+  api_key: GEMINI_API_KEY
   chunk_config:
     overlap: 500
     chunk_size: 4000
-  model_name: gpt-4o-mini
+  model_name: gemini-flash-lite-latest
   prompt_debug: False
 schema_path: schema
 tool_path: ["tools"]

--- a/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
+++ b/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
@@ -21,9 +21,9 @@ defaults:
   granularity: Record
   is_operational: true
   run_mode: online
-  model_vendor: openai
-  model_name: gpt-4o-mini
-  api_key: OPENAI_API_KEY
+  model_name: gemini-flash-lite-latest
+  model_vendor: gemini
+  api_key: GEMINI_API_KEY
   record_limit: 2      # Remove for full processing
   context_scope:
     seed_path:
@@ -43,9 +43,6 @@ actions:
     intent: "Extract structured information from raw incident report"
     schema: extract_incident_details
     prompt: $incident_triage.Extract_Incident_Details
-    model_vendor: groq
-    model_name: llama-3.1-8b-instant
-    api_key: GROQ_API_KEY
     reprompt:
       validation: check_required_fields
       max_attempts: 2
@@ -67,8 +64,6 @@ actions:
       mode: parallel
     schema: classify_severity
     prompt: $incident_triage.Classify_Severity
-    model_vendor: ollama                          # Classification from fixed categories — parallel voting compensates
-    model_name: llama3.2:latest
     reprompt:
       validation: check_required_fields
       max_attempts: 2

--- a/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
+++ b/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
@@ -149,6 +149,8 @@ actions:
         - assign_response_team.*
         - extract_incident_details.*
         - assess_customer_impact.customer_impact_level
+        - aggregate_severity.final_severity
+        - assess_system_impact.affected_services
 
   # ==========================================================================
   # STAGE 7: EXECUTIVE NOTIFICATION (SEV1/SEV2 only)

--- a/examples/incident_triage/prompt_store/incident_triage.md
+++ b/examples/incident_triage/prompt_store/incident_triage.md
@@ -50,7 +50,7 @@ Extract and structure key information needed for incident triage:
 {end_prompt}
 
 {prompt Classify_Severity}
-You are classifier {{ i }} of {{ version.length }} in a severity classification ensemble.
+You are classifier {{ version.i }} of {{ version.length }} in a severity classification ensemble.
 
 {% if version.first %}
 **Your role**: Be CONSERVATIVE. When in doubt, classify higher severity.
@@ -211,13 +211,13 @@ Generate an initial incident response plan with actionable steps.
 
 **Description**: {{ extract_incident_details.description }}
 
-**Severity**: {{ assign_response_team.final_severity }}
+**Severity**: {{ aggregate_severity.final_severity }}
 
 **Assigned Teams**: {{ assign_response_team.assigned_teams }}
 
 **Customer Impact**: {{ assess_customer_impact.customer_impact_level }}
 
-**Affected Systems**: {{ assign_response_team.affected_services }}
+**Affected Systems**: {{ assess_system_impact.affected_services }}
 
 **Urgency**: {{ assign_response_team.urgency_level }}
 


### PR DESCRIPTION
## Summary
- Switched incident_triage example to gemini-flash-lite-latest
- Removed per-action vendor overrides (groq, ollama)
- Fixed template refs for namespaced data model: `{{ i }}` → `{{ version.i }}`, wrong-namespace field refs corrected
- Added missing observe refs for generate_response_plan

## Data Model Validation
- [x] All 11 actions produced output (generate_executive_summary correctly filtered by guard)
- [x] Records have envelope fields (content, source_guid, target_id, node_id, lineage, metadata)
- [x] Content is namespaced (every action's output under its own namespace key)
- [x] Parallel voting (classify_severity x3) merged correctly into aggregate_severity
- [x] Parallel branches (assess_customer_impact, assess_system_impact) fan-in with lineage_sources
- [x] Guard on executive_summary filtered by severity (0 records — not SEV1/SEV2)
- [x] No groq/ollama/openai references in config files

## Verification
- 5944 tests pass, ruff clean
- Full end-to-end run completed: 11 OK, 0 errors
- DB inspected: all records have proper envelope structure with namespaced content

## Framework bug discovered
`scope_application.py` context gate (L252-269) filters out top-level version variables (`i`, `idx`) promoted by `scope_builder.py`. Workaround: use `{{ version.i }}` instead of `{{ i }}`.