### PR TITLE
validate: review_analyzer example on gemini-flash-lite

### DIFF
--- a/examples/review_analyzer/agent_actions.yml
+++ b/examples/review_analyzer/agent_actions.yml
@@ -1,9 +1,9 @@
 default_agent_config:
-  api_key: OPENAI_API_KEY
+  api_key: GEMINI_API_KEY
   chunk_config:
     overlap: 500
     chunk_size: 4000
-  model_name: gpt-4o-mini
+  model_name: gemini-flash-lite-latest
   prompt_debug: False
 schema_path: schema
 tool_path: ["tools"]

--- a/examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml
+++ b/examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml
@@ -31,9 +31,9 @@ defaults:
   granularity: Record
   is_operational: true
   run_mode: online
-  model_vendor: openai
-  model_name: gpt-4o-mini
-  api_key: OPENAI_API_KEY
+  model_name: gemini-flash-lite-latest
+  model_vendor: gemini
+  api_key: GEMINI_API_KEY
   is_operational: true
   record_limit: 2      # Remove for full processing
   context_scope:
@@ -60,9 +60,6 @@ actions:
     intent: "Extract factual claims, product aspects, and sentiment signals from review text"
     schema: extract_claims
     prompt: $review_analyzer.Extract_Claims
-    model_vendor: groq
-    model_name: llama-3.1-8b-instant
-    api_key: GROQ_API_KEY
     context_scope:
       observe:
         - source.review_text                    # ← LLM sees only the review body
@@ -93,8 +90,6 @@ actions:
     intent: "Independently score review quality against rubric criteria"
     schema: score_quality
     prompt: $review_analyzer.Score_Quality
-    model_vendor: ollama                          # Numeric scoring — parallel voting compensates for weaker model
-    model_name: llama3.2:latest
     reprompt:
       validation: check_required_fields
       max_attempts: 2
@@ -157,7 +152,7 @@ actions:
     # model_name: claude-sonnet-4-20250514
     # api_key: ANTHROPIC_API_KEY
     guard:
-      condition: 'consensus_score >= 6'         # ← Pre-check gate: skip low quality
+      condition: 'aggregate_scores.consensus_score >= 6'         # ← Pre-check gate: skip low quality
       on_false: "filter"                        #    LLM never fires for junk reviews
     context_scope:
       observe:
@@ -192,7 +187,7 @@ actions:
     schema: extract_product_insights
     prompt: $review_analyzer.Extract_Product_Insights
     guard:
-      condition: 'consensus_score >= 6'         # ← Same gate — skip junk
+      condition: 'aggregate_scores.consensus_score >= 6'         # ← Same gate — skip junk
       on_false: "filter"
     context_scope:
       observe:

--- a/examples/review_analyzer/prompt_store/review_analyzer.md
+++ b/examples/review_analyzer/prompt_store/review_analyzer.md
@@ -26,7 +26,7 @@ Focus on what the reviewer actually said — do not infer or assume claims not p
 {end_prompt}
 
 {prompt Score_Quality}
-You are quality scorer {{ i }} of {{ version.length }} in an independent review quality assessment.
+You are quality scorer {{ version.i }} of {{ version.length }} in an independent review quality assessment.
 
 {% if version.first %}
 **Your focus**: Prioritize HELPFULNESS. Would a potential buyer learn something useful from this review?

--- a/examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py
+++ b/examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py
@@ -32,7 +32,10 @@ def aggregate_quality_scores(data: dict[str, Any]) -> dict[str, Any]:
 
     for i in range(1, 4):
         scorer_key = f"score_quality_{i}"
-        scorer_data = content.get(scorer_key, {})
+        scorer_ns = content.get(scorer_key, {})
+
+        # Namespaced data model: scorer fields are at content[scorer_key][scorer_key]
+        scorer_data = scorer_ns.get(scorer_key, scorer_ns) if isinstance(scorer_ns, dict) else {}
 
         if not isinstance(scorer_data, dict):
             continue

--- a/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
+++ b/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
@@ -18,27 +18,32 @@ def format_analysis_output(data: dict[str, Any]) -> dict[str, Any]:
     """
     content = data.get("content", data)
 
-    # Source metadata (passthrough fields arrive flat)
+    # Namespaced data model: fields are at content[namespace][field]
+    source_ns = content.get("source", {})
+    extract_ns = content.get("extract_claims", {})
+    agg_ns = content.get("aggregate_scores", {})
+    response_ns = content.get("generate_response", {})
+    insights_ns = content.get("extract_product_insights", {})
+
     source = {
-        "review_id": content.get("review_id", ""),
-        "product_name": content.get("product_name", ""),
-        "product_category": content.get("product_category", ""),
-        "reviewer_name": content.get("reviewer_name", ""),
-        "review_date": content.get("review_date", ""),
+        "review_id": source_ns.get("review_id", ""),
+        "product_name": source_ns.get("product_name", ""),
+        "product_category": source_ns.get("product_category", ""),
+        "reviewer_name": source_ns.get("reviewer_name", ""),
+        "review_date": source_ns.get("review_date", ""),
     }
 
-    # Analysis — fields from extract_claims and aggregate_scores arrive flat
     analysis = {
-        "quality_score": content.get("consensus_score", 0),
-        "is_split_decision": content.get("is_split_decision", False),
-        "claims_extracted": len(content.get("factual_claims", [])),
-        "aspects_covered": content.get("product_aspects", []),
+        "quality_score": agg_ns.get("consensus_score", 0),
+        "is_split_decision": agg_ns.get("is_split_decision", False),
+        "claims_extracted": len(extract_ns.get("factual_claims", [])),
+        "aspects_covered": extract_ns.get("product_aspects", []),
         "sentiment": (
-            content.get("sentiment_signals", {}).get("overall_tone", "unknown")
-            if isinstance(content.get("sentiment_signals"), dict)
+            extract_ns.get("sentiment_signals", {}).get("overall_tone", "unknown")
+            if isinstance(extract_ns.get("sentiment_signals"), dict)
             else "unknown"
         ),
-        "red_flags": content.get("red_flags", []),
+        "red_flags": agg_ns.get("red_flags", []),
     }
 
     result = {
@@ -47,20 +52,20 @@ def format_analysis_output(data: dict[str, Any]) -> dict[str, Any]:
     }
 
     # Only include merchant_response if the guard passed
-    response_text = content.get("response_text")
+    response_text = response_ns.get("response_text") if isinstance(response_ns, dict) else None
     if response_text:
         result["merchant_response"] = {
             "response_text": response_text,
-            "response_tone": content.get("response_tone", ""),
+            "response_tone": response_ns.get("response_tone", ""),
         }
 
     # Only include product_insights if the guard passed
-    feedback_items = content.get("feedback_items")
+    feedback_items = insights_ns.get("feedback_items") if isinstance(insights_ns, dict) else None
     if feedback_items:
         result["product_insights"] = {
             "feedback_items": feedback_items,
-            "improvement_priority": content.get("improvement_priority", ""),
-            "positive_differentiators": content.get("positive_differentiators", []),
+            "improvement_priority": insights_ns.get("improvement_priority", ""),
+            "positive_differentiators": insights_ns.get("positive_differentiators", []),
         }
 
     return result


### PR DESCRIPTION
## Summary
- Switched review_analyzer example to gemini-flash-lite-latest
- Removed per-action vendor overrides (groq, ollama)
- Fixed guard conditions to use namespaced `aggregate_scores.consensus_score` instead of flat `consensus_score`
- Fixed prompt template `{{ i }}` → `{{ version.i }}` for version namespace
- Fixed UDF tools (aggregate_quality_scores, format_analysis_output) to navigate namespaced content instead of flat field access

## Data Model Validation
- [x] All 8 actions produced output (2 records each)
- [x] Records have envelope fields (content, source_guid, target_id, node_id, lineage, metadata)
- [x] Content is namespaced (action_name → {fields}), no flat field leaks
- [x] Fan-in merge (score_quality parallel voting) produces combined namespaces (6 namespaces in aggregate_scores)
- [x] Guard passes with real scores (9.1, 8.5 — both ≥ 6)
- [x] generate_response and extract_product_insights LLM calls fire after guard passes
- [x] format_output fan-in merges both parallel branches (9 namespaces in final output)
- [x] format_output reads quality_score correctly from aggregate_scores namespace

## Verification
- `agac run -a review_analyzer --fresh` — 8/8 actions completed in 10.6s
- `pytest` — 5948 passed, 2 skipped
- `ruff format --check` + `ruff check` — clean