### PR TITLE
refactor: unify guard evaluation to single entry point

### DIFF
--- a/.changes/unreleased/Under the Hood-20260425-110000.yaml
+++ b/.changes/unreleased/Under the Hood-20260425-110000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Unified guard evaluation to single entry point with GuardBehavior enum"
+time: 2026-04-25T11:00:00.000000Z

--- a/agent_actions/input/preprocessing/filtering/_MANIFEST.md
+++ b/agent_actions/input/preprocessing/filtering/_MANIFEST.md
@@ -11,5 +11,5 @@
 | Name | Type | Description | Signals |
 |------|------|-------------|---------|
 | `__init__.py` | Module | Module docstring describing the filtering package. | `preprocessing` |
-| `evaluator.py` | Module | `GuardEvaluator`, `GuardResult`, and two-phase guard evaluation (early + with-context) with thread-safe global singleton. | `filtering`, `processing`, `workflow` |
+| `evaluator.py` | Module | `GuardBehavior` enum, `GuardEvaluator`, `GuardResult`, and unified guard evaluation with optional context and thread-safe global singleton. | `filtering`, `processing`, `workflow` |
 | `guard_filter.py` | Module | `GuardFilter`, `FilterResult`, and helper functions that securely evaluate WHERE clauses with timeouts, caching, and metrics. Thread-safe global singleton with double-checked locking. | `filtering`, `processing`, `logging` |

--- a/agent_actions/input/preprocessing/filtering/__init__.py
+++ b/agent_actions/input/preprocessing/filtering/__init__.py
@@ -1,6 +1,7 @@
 """Filtering submodule - Dataset filtering logic."""
 
 from agent_actions.input.preprocessing.filtering.evaluator import (
+    GuardBehavior,
     GuardEvaluator,
     GuardResult,
     get_guard_evaluator,
@@ -16,6 +17,7 @@ from agent_actions.input.preprocessing.filtering.guard_filter import (
 
 __all__ = [
     # Primary API (unified evaluator)
+    "GuardBehavior",
     "GuardEvaluator",
     "GuardResult",
     "get_guard_evaluator",

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -3,6 +3,7 @@
 import logging
 import threading
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 from agent_actions.errors.configuration import ConfigValidationError
@@ -20,12 +21,20 @@ _UNSUPPORTED_BEHAVIORS = frozenset({"write_to", "reprocess"})
 logger = logging.getLogger(__name__)
 
 
+class GuardBehavior(StrEnum):
+    """Guard evaluation behavior when condition is not met."""
+
+    SKIP = "skip"
+    FILTER = "filter"
+    WARN = "warn"
+
+
 @dataclass
 class GuardResult:
     """Result of guard evaluation."""
 
     should_execute: bool
-    behavior: str | None = None  # 'skip' | 'filter' | 'warn' | None
+    behavior: GuardBehavior | None = None
     error: str | None = None
     matched: bool = True
 
@@ -37,21 +46,21 @@ class GuardResult:
     @classmethod
     def skipped(cls, error: str | None = None) -> "GuardResult":
         """Guard failed with skip behavior - use passthrough."""
-        return cls(should_execute=False, behavior="skip", matched=False, error=error)
+        return cls(should_execute=False, behavior=GuardBehavior.SKIP, matched=False, error=error)
 
     @classmethod
     def filtered(cls, error: str | None = None) -> "GuardResult":
         """Guard failed with filter behavior - exclude entirely."""
-        return cls(should_execute=False, behavior="filter", matched=False, error=error)
+        return cls(should_execute=False, behavior=GuardBehavior.FILTER, matched=False, error=error)
 
     @classmethod
     def warned(cls) -> "GuardResult":
         """Guard failed with warn behavior - proceed but flag for logging."""
-        return cls(should_execute=True, behavior="warn", matched=False)
+        return cls(should_execute=True, behavior=GuardBehavior.WARN, matched=False)
 
     @classmethod
     def from_filter_result(
-        cls, filter_result: FilterResult, behavior: str, passthrough_on_error: bool
+        cls, filter_result: FilterResult, behavior: GuardBehavior, passthrough_on_error: bool
     ) -> "GuardResult":
         """Create GuardResult from FilterResult."""
         if not filter_result.success:
@@ -62,9 +71,9 @@ class GuardResult:
                     behavior,
                     filter_result.error,
                 )
-                if behavior == "warn":
+                if behavior == GuardBehavior.WARN:
                     return cls.warned()
-                if behavior == "skip":
+                if behavior == GuardBehavior.SKIP:
                     return cls.skipped(error=filter_result.error)
                 return cls.filtered(error=filter_result.error)
 
@@ -80,17 +89,17 @@ class GuardResult:
                 behavior,
                 filter_result.error,
             )
-            if behavior == "warn":
+            if behavior == GuardBehavior.WARN:
                 return cls.warned()
-            if behavior == "skip":
+            if behavior == GuardBehavior.SKIP:
                 return cls.skipped(error=filter_result.error)
             return cls.filtered(error=filter_result.error)
 
         if not filter_result.matched:
             logger.debug("Guard: condition not matched, behavior='%s'", behavior)
-            if behavior == "warn":
+            if behavior == GuardBehavior.WARN:
                 return cls.warned()
-            if behavior == "skip":
+            if behavior == GuardBehavior.SKIP:
                 return cls.skipped()
             return cls.filtered()
 
@@ -98,38 +107,29 @@ class GuardResult:
 
 
 class GuardEvaluator:
-    """Unified guard evaluation with two-phase support (early and with-context)."""
+    """Unified guard evaluation for batch and online modes."""
 
     def __init__(self, guard_filter: GuardFilter | None = None):
         """Initialize GuardEvaluator."""
         self._filter = guard_filter or get_global_guard_filter()
 
-    def evaluate_early(
+    def evaluate(
         self,
         item: Any,
         guard_config: dict[str, Any] | None,
+        context: dict[str, Any] | None = None,
         conditional_clause: str | None = None,
     ) -> GuardResult:
-        """Phase 1: Evaluate guards on raw content before prompt preparation.
+        """Evaluate guard conditions, optionally with full context.
 
-        Cannot access passthrough fields or {source.*} references (not resolved yet).
+        When *context* is provided, item content is merged with context data
+        (passthrough fields, source data) before evaluation.  When *context*
+        is ``None``, evaluation uses the item directly.
         """
-        if conditional_clause:
-            result = self._evaluate_conditional_clause(item, conditional_clause)
-            if result is not None:
-                return result
-
-        return self._evaluate_guard(item, guard_config)
-
-    def evaluate_with_context(
-        self,
-        item: Any,
-        guard_config: dict[str, Any] | None,
-        context: dict[str, Any],
-        conditional_clause: str | None = None,
-    ) -> GuardResult:
-        """Phase 2: Evaluate guards with full context (passthrough fields, source data)."""
-        eval_data = self._build_evaluation_context(item, context)
+        if context is not None:
+            eval_data = self._build_evaluation_context(item, context)
+        else:
+            eval_data = item
 
         if conditional_clause:
             result = self._evaluate_conditional_clause(eval_data, conditional_clause)
@@ -137,16 +137,6 @@ class GuardEvaluator:
                 return result
 
         return self._evaluate_guard(eval_data, guard_config)
-
-    def evaluate(
-        self,
-        item: Any,
-        guard_config: dict[str, Any] | None,
-        conditional_clause: str | None = None,
-    ) -> tuple[bool, str | None]:
-        """Backward-compatible evaluation returning (should_execute, behavior) tuple."""
-        result = self.evaluate_early(item, guard_config, conditional_clause)
-        return (result.should_execute, result.behavior)
 
     def _evaluate_conditional_clause(
         self, context: Any, conditional_clause: str
@@ -179,14 +169,15 @@ class GuardEvaluator:
         if not clause:
             return GuardResult.passed()
 
-        behavior = guard_config.get("behavior", "filter")
-        if behavior in _UNSUPPORTED_BEHAVIORS:
+        behavior_str = guard_config.get("behavior", "filter")
+        if behavior_str in _UNSUPPORTED_BEHAVIORS:
             raise ConfigValidationError(
                 "behavior",
-                f"Guard behavior '{behavior}' is not supported in guard evaluation. "
+                f"Guard behavior '{behavior_str}' is not supported in guard evaluation. "
                 f"Only 'skip', 'filter', and 'warn' are valid on_false values for guards.",
-                context={"behavior": behavior},
+                context={"behavior": behavior_str},
             )
+        behavior = GuardBehavior(behavior_str)
         passthrough_on_error = guard_config.get("passthrough_on_error", True)
 
         try:
@@ -203,9 +194,9 @@ class GuardEvaluator:
             logger.warning("Guard: guard condition evaluation exception: %s", e)
             if passthrough_on_error:
                 return GuardResult.passed()
-            if behavior == "warn":
+            if behavior == GuardBehavior.WARN:
                 return GuardResult.warned()
-            if behavior == "skip":
+            if behavior == GuardBehavior.SKIP:
                 return GuardResult.skipped(error=str(e))
             return GuardResult.filtered(error=str(e))
 
@@ -312,7 +303,7 @@ class GuardEvaluator:
     def should_skip(self, agent_config: dict[str, Any], context: Any) -> bool:
         """Check if agent should be skipped based on guard with skip behavior."""
         guard_config = agent_config.get("guard")
-        if not guard_config or guard_config.get("behavior") != "skip":
+        if not guard_config or guard_config.get("behavior") != GuardBehavior.SKIP:
             return False
 
         result = self._evaluate_guard(context, guard_config)
@@ -321,7 +312,7 @@ class GuardEvaluator:
     def should_filter(self, agent_config: dict[str, Any], context: Any) -> bool:
         """Check if item should be filtered based on guard with filter behavior."""
         guard_config = agent_config.get("guard")
-        if not guard_config or guard_config.get("behavior") != "filter":
+        if not guard_config or guard_config.get("behavior") != GuardBehavior.FILTER:
             return False
 
         result = self._evaluate_guard(context, guard_config)

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -300,24 +300,6 @@ class GuardEvaluator:
 
         return eval_data
 
-    def should_skip(self, agent_config: dict[str, Any], context: Any) -> bool:
-        """Check if agent should be skipped based on guard with skip behavior."""
-        guard_config = agent_config.get("guard")
-        if not guard_config or guard_config.get("behavior") != GuardBehavior.SKIP:
-            return False
-
-        result = self._evaluate_guard(context, guard_config)
-        return not result.should_execute
-
-    def should_filter(self, agent_config: dict[str, Any], context: Any) -> bool:
-        """Check if item should be filtered based on guard with filter behavior."""
-        guard_config = agent_config.get("guard")
-        if not guard_config or guard_config.get("behavior") != GuardBehavior.FILTER:
-            return False
-
-        result = self._evaluate_guard(context, guard_config)
-        return not result.should_execute
-
 
 # Thread-safe singleton
 _GLOBAL_GUARD_EVALUATOR: GuardEvaluator | None = None

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class GuardBehavior(StrEnum):
-    """Guard evaluation behavior when condition is not met."""
+    """Evaluation-valid guard behaviors; see also guards.consolidated_guard.GuardBehavior for config-layer."""
 
     SKIP = "skip"
     FILTER = "filter"

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -8,7 +8,6 @@ from typing import Any
 from agent_actions.errors import SchemaValidationError
 from agent_actions.utils.constants import ON_SCHEMA_MISMATCH_KEY, SCHEMA_KEY, STRICT_SCHEMA_KEY
 from agent_actions.utils.transformation import PassthroughTransformer
-from agent_actions.utils.udf_management.tooling import execute_user_defined_function
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +32,20 @@ def run_dynamic_agent(
     When skip conditions are met, returns the original context without executing.
     """
     if not skip_guard_eval:
-        if _should_skip_legacy_conditional(agent_config, context):
+        from agent_actions.input.preprocessing.filtering.evaluator import (
+            GuardBehavior,
+            get_guard_evaluator,
+        )
+
+        guard_result = get_guard_evaluator().evaluate(
+            item=context,
+            guard_config=agent_config.get("guard"),
+            conditional_clause=agent_config.get("conditional_clause"),
+        )
+        if not guard_result.should_execute:
+            if guard_result.behavior == GuardBehavior.FILTER:
+                return (None, False)
             return (context, False)
-        if _should_skip_guard(agent_config, context):
-            return (context, False)
-        if _should_filter_guard(agent_config, context):
-            return (None, False)
 
     from agent_actions.llm.realtime import builder as agent_builder
 
@@ -177,30 +184,6 @@ def _validate_llm_output_schema(
         logger.warning("Schema validation failed with error: %s", e, exc_info=True)
 
     return response
-
-
-def _should_skip_legacy_conditional(agent_config: dict[str, Any], context: Any) -> bool:
-    """Return True if the legacy conditional_clause evaluates to False."""
-    conditional_clause = (agent_config.get("conditional_clause") or "").lower()
-    if conditional_clause and (not execute_user_defined_function(conditional_clause, context)):
-        return True
-    return False
-
-
-def _should_skip_guard(agent_config: dict[str, Any], context: Any) -> bool:
-    """Return True if guard evaluates to skip behavior."""
-    from agent_actions.input.preprocessing.filtering.evaluator import get_guard_evaluator
-
-    evaluator = get_guard_evaluator()
-    return evaluator.should_skip(agent_config, context)
-
-
-def _should_filter_guard(agent_config: dict[str, Any], context: Any) -> bool:
-    """Return True if guard evaluates to filter behavior."""
-    from agent_actions.input.preprocessing.filtering.evaluator import get_guard_evaluator
-
-    evaluator = get_guard_evaluator()
-    return evaluator.should_filter(agent_config, context)
 
 
 def transform_with_passthrough(

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -13,18 +13,6 @@ from agent_actions.utils.udf_management.tooling import execute_user_defined_func
 logger = logging.getLogger(__name__)
 
 
-def evaluate_guard_condition(agent_config: dict[str, Any], context: Any) -> tuple[bool, str | None]:
-    """Evaluate guard conditions, returning (should_execute, skip_behavior)."""
-    from agent_actions.input.preprocessing.filtering.evaluator import get_guard_evaluator
-
-    evaluator = get_guard_evaluator()
-    return evaluator.evaluate(
-        item=context,
-        guard_config=agent_config.get("guard"),
-        conditional_clause=agent_config.get("conditional_clause"),
-    )
-
-
 def run_dynamic_agent(
     agent_config: dict[str, Any],
     agent_name: str,

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Callable
 from typing import Any
 
+from agent_actions.input.preprocessing.filtering.evaluator import GuardBehavior
 from agent_actions.processing.prepared_task import (
     GuardStatus,
     PreparationContext,
@@ -81,12 +82,12 @@ class TaskPreparer:
                     source_content=source_content,
                     source_snapshot=source_snapshot,
                     guard_status=GuardStatus.SKIPPED
-                    if guard_result.behavior == "skip"
+                    if guard_result.behavior == GuardBehavior.SKIP
                     else GuardStatus.FILTERED,
                     guard_behavior=guard_result.behavior,
                     prompt_context=field_context,
                 )
-            if guard_result.behavior == "warn":
+            if guard_result.behavior == GuardBehavior.WARN:
                 guard_clause = (
                     (guard_config.get("clause", "") if isinstance(guard_config, dict) else "")
                     or conditional_clause
@@ -263,7 +264,7 @@ class TaskPreparer:
 
         if not isinstance(content, dict):
             logger.debug("Wrapping non-dict content as {'_raw': ...} for guard evaluation")
-        return evaluator.evaluate_with_context(
+        return evaluator.evaluate(
             item=content if isinstance(content, dict) else {"_raw": content},
             guard_config=guard_config,
             context=field_context,

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -542,7 +542,7 @@ def prefilter_by_guard(
 
     evaluator = get_guard_evaluator()
     # The config expander normalizes user-facing "on_false" into "behavior"
-    behavior = GuardBehavior(str(guard_config.get("behavior", "filter")).lower())
+    behavior = GuardBehavior(guard_config.get("behavior", "filter"))
 
     passing: list[dict] = []
     skipped: list[dict] = []

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -535,11 +535,14 @@ def prefilter_by_guard(
     if not guard_config:
         return data, [], originals
 
-    from agent_actions.input.preprocessing.filtering.evaluator import get_guard_evaluator
+    from agent_actions.input.preprocessing.filtering.evaluator import (
+        GuardBehavior,
+        get_guard_evaluator,
+    )
 
     evaluator = get_guard_evaluator()
     # The config expander normalizes user-facing "on_false" into "behavior"
-    behavior = str(guard_config.get("behavior", "filter")).lower()
+    behavior = GuardBehavior(str(guard_config.get("behavior", "filter")).lower())
 
     passing: list[dict] = []
     skipped: list[dict] = []
@@ -549,20 +552,19 @@ def prefilter_by_guard(
         eval_item = content if isinstance(content, dict) else {"_raw": content}
 
         # context={} — see Note in docstring.
-        result = evaluator.evaluate_with_context(
+        result = evaluator.evaluate(
             item=eval_item,
             guard_config=guard_config,
             context={},
-            conditional_clause=None,
         )
 
         if result.should_execute:
             passing.append(item)
             original_passing.append(originals[idx])
-        elif behavior == "skip":
+        elif behavior == GuardBehavior.SKIP:
             # Use pre-observe original so skipped tombstones keep namespaced content.
             skipped.append(originals[idx])
-        # behavior == "filter": record excluded from both lists
+        # behavior == GuardBehavior.FILTER: record excluded from both lists
 
     logger.info(
         "Guard pre-filter for '%s': %d passed, %d skipped, %d filtered of %d total",

--- a/tests/manual/repro_085_guard_namespaced.py
+++ b/tests/manual/repro_085_guard_namespaced.py
@@ -33,7 +33,7 @@ def test_scenario_1_dotted_path_pass_true():
         "behavior": "skip",
     }
 
-    result = evaluator.evaluate_early(record, guard_config)
+    result = evaluator.evaluate(record, guard_config)
 
     # pass is True, condition says == false → not matched → should NOT execute
     assert result.should_execute is False
@@ -59,7 +59,7 @@ def test_scenario_2_dotted_path_pass_false():
         "behavior": "skip",
     }
 
-    result = evaluator.evaluate_early(record, guard_config)
+    result = evaluator.evaluate(record, guard_config)
 
     # pass is False, condition says == false → matched → should execute
     assert result.should_execute is True
@@ -81,7 +81,7 @@ def test_scenario_3_cross_namespace_field():
         "behavior": "skip",
     }
 
-    result = evaluator.evaluate_early(record, guard_config)
+    result = evaluator.evaluate(record, guard_config)
 
     # question_type is "scenario" → matched → should execute
     assert result.should_execute is True
@@ -103,7 +103,7 @@ def test_scenario_4_missing_namespace_no_crash():
         "passthrough_on_error": False,
     }
 
-    result = evaluator.evaluate_early(record, guard_config)
+    result = evaluator.evaluate(record, guard_config)
 
     # Field doesn't exist → should not crash, should not execute
     assert result.should_execute is False
@@ -126,7 +126,7 @@ def test_scenario_5_multiple_namespaces():
         "behavior": "filter",
     }
 
-    result = evaluator.evaluate_early(record, guard_config)
+    result = evaluator.evaluate(record, guard_config)
 
     # topic is "science" → matched → should execute
     assert result.should_execute is True

--- a/tests/preprocessing/test_guard_evaluator.py
+++ b/tests/preprocessing/test_guard_evaluator.py
@@ -72,64 +72,64 @@ class TestGuardEvaluator:
         """Create evaluator with mock filter."""
         return GuardEvaluator(guard_filter=mock_guard_filter)
 
-    def test_evaluate_early_no_guard(self, evaluator, mock_guard_filter):
+    def test_evaluate_no_guard(self, evaluator, mock_guard_filter):
         """No guard config returns passed."""
-        result = evaluator.evaluate_early({"field": "value"}, None)
+        result = evaluator.evaluate({"field": "value"}, None)
         assert result.should_execute is True
         mock_guard_filter.filter_item.assert_not_called()
 
-    def test_evaluate_early_no_clause(self, evaluator, mock_guard_filter):
+    def test_evaluate_no_clause(self, evaluator, mock_guard_filter):
         """Guard config without clause returns passed."""
-        result = evaluator.evaluate_early({"field": "value"}, {"behavior": "filter"})
+        result = evaluator.evaluate({"field": "value"}, {"behavior": "filter"})
         assert result.should_execute is True
         mock_guard_filter.filter_item.assert_not_called()
 
-    def test_evaluate_early_action_scope_skipped(self, evaluator, mock_guard_filter):
+    def test_evaluate_action_scope_skipped(self, evaluator, mock_guard_filter):
         """Action-scope guards are skipped (only item-level guards evaluated)."""
         guard_config = {"clause": "x > 1", "scope": "action"}
-        result = evaluator.evaluate_early({"x": 5}, guard_config)
+        result = evaluator.evaluate({"x": 5}, guard_config)
         assert result.should_execute is True
         mock_guard_filter.filter_item.assert_not_called()
 
-    def test_evaluate_early_guard_passes(self, evaluator, mock_guard_filter):
+    def test_evaluate_guard_passes(self, evaluator, mock_guard_filter):
         """Guard that matches returns passed."""
         mock_guard_filter.filter_item.return_value = FilterResult(success=True, matched=True)
         guard_config = {"clause": "x > 1", "scope": "item", "behavior": "filter"}
 
-        result = evaluator.evaluate_early({"x": 5}, guard_config)
+        result = evaluator.evaluate({"x": 5}, guard_config)
 
         assert result.should_execute is True
         mock_guard_filter.filter_item.assert_called_once()
 
-    def test_evaluate_early_guard_filters(self, evaluator, mock_guard_filter):
+    def test_evaluate_guard_filters(self, evaluator, mock_guard_filter):
         """Guard that doesn't match with filter behavior returns filtered."""
         mock_guard_filter.filter_item.return_value = FilterResult(success=True, matched=False)
         guard_config = {"clause": "x > 10", "scope": "item", "behavior": "filter"}
 
-        result = evaluator.evaluate_early({"x": 5}, guard_config)
+        result = evaluator.evaluate({"x": 5}, guard_config)
 
         assert result.should_execute is False
         assert result.behavior == "filter"
 
-    def test_evaluate_early_guard_skips(self, evaluator, mock_guard_filter):
+    def test_evaluate_guard_skips(self, evaluator, mock_guard_filter):
         """Guard that doesn't match with skip behavior returns skipped."""
         mock_guard_filter.filter_item.return_value = FilterResult(success=True, matched=False)
         guard_config = {"clause": "x > 10", "scope": "item", "behavior": "skip"}
 
-        result = evaluator.evaluate_early({"x": 5}, guard_config)
+        result = evaluator.evaluate({"x": 5}, guard_config)
 
         assert result.should_execute is False
         assert result.behavior == "skip"
 
-    def test_evaluate_backward_compatible_format(self, evaluator, mock_guard_filter):
-        """evaluate() returns (should_execute, behavior) tuple format."""
+    def test_evaluate_returns_guard_result(self, evaluator, mock_guard_filter):
+        """evaluate() returns GuardResult."""
         mock_guard_filter.filter_item.return_value = FilterResult(success=True, matched=False)
         guard_config = {"clause": "x > 10", "scope": "item", "behavior": "skip"}
 
-        should_execute, behavior = evaluator.evaluate({"x": 5}, guard_config)
+        result = evaluator.evaluate({"x": 5}, guard_config)
 
-        assert should_execute is False
-        assert behavior == "skip"
+        assert result.should_execute is False
+        assert result.behavior == "skip"
 
     def test_should_skip_with_skip_behavior(self, evaluator, mock_guard_filter):
         """should_skip returns True when guard fails with skip behavior."""
@@ -237,7 +237,7 @@ class TestGuardEvaluator:
         assert "content" not in result
 
     def test_build_evaluation_context_with_non_dict_item(self, evaluator):
-        """Non-dict item is preserved in _raw key (parity with evaluate_early)."""
+        """Non-dict item is preserved in _raw key."""
         item = "raw string content"
         context = {"ctx_field": "ctx_value"}
 
@@ -319,7 +319,7 @@ class TestOutputFieldPromotion:
         }
         guard_config = {"clause": 'severity != "low"', "scope": "item", "behavior": "skip"}
 
-        evaluator.evaluate_with_context(
+        evaluator.evaluate(
             item={"content": {}},
             guard_config=guard_config,
             context=context,
@@ -549,7 +549,7 @@ class TestNamespacedContentGuardEvaluation:
         }
         guard = {"clause": "validate.pass == true", "scope": "item", "behavior": "skip"}
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is True
         assert result.matched is True
@@ -562,7 +562,7 @@ class TestNamespacedContentGuardEvaluation:
         }
         guard = {"clause": "validate.pass == false", "scope": "item", "behavior": "skip"}
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is False
         assert result.behavior == "skip"
@@ -579,7 +579,7 @@ class TestNamespacedContentGuardEvaluation:
         }
         guard = {"clause": "classify.confidence > 0.9", "scope": "item", "behavior": "filter"}
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is True
 
@@ -599,7 +599,7 @@ class TestNamespacedContentGuardEvaluation:
             "behavior": "skip",
         }
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is False
         assert result.behavior == "skip"
@@ -618,7 +618,7 @@ class TestNamespacedContentGuardEvaluation:
             "behavior": "filter",
         }
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is False
         assert result.behavior == "filter"
@@ -639,7 +639,7 @@ class TestNamespacedContentGuardEvaluation:
             "behavior": "skip",
         }
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is False
         assert result.behavior == "skip"
@@ -656,7 +656,7 @@ class TestNamespacedContentGuardEvaluation:
             "behavior": "filter",
         }
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is False
         assert result.behavior == "filter"
@@ -673,7 +673,7 @@ class TestNamespacedContentGuardEvaluation:
             "behavior": "warn",
         }
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         assert result.should_execute is True
         assert result.behavior == "warn"
@@ -687,7 +687,7 @@ class TestNamespacedContentGuardEvaluation:
         context = {"assess": {"severity": "high"}}
         guard = {"clause": "validate.pass == false", "scope": "item", "behavior": "skip"}
 
-        result = evaluator.evaluate_with_context(item, guard, context)
+        result = evaluator.evaluate(item, guard, context)
 
         assert result.should_execute is True
 
@@ -697,7 +697,7 @@ class TestNamespacedContentGuardEvaluation:
         context = {"assess": {"severity": "high"}}
         guard = {"clause": 'assess.severity == "high"', "scope": "item", "behavior": "skip"}
 
-        result = evaluator.evaluate_with_context(item, guard, context)
+        result = evaluator.evaluate(item, guard, context)
 
         assert result.should_execute is True
 
@@ -798,7 +798,7 @@ class TestNamespacedContentGuardEvaluation:
             "behavior": "skip",
         }
 
-        result = evaluator.evaluate_early(record, guard)
+        result = evaluator.evaluate(record, guard)
 
         # First clause matches, but second field is missing → whole condition not matched
         assert result.should_execute is False
@@ -845,15 +845,6 @@ class TestNamespacedContentGuardEvaluation:
 
 class TestHelpersIntegration:
     """Tests for integration with processing/helpers.py."""
-
-    def test_evaluate_guard_condition_delegates_to_evaluator(self):
-        """evaluate_guard_condition uses GuardEvaluator internally."""
-        from agent_actions.processing.helpers import evaluate_guard_condition
-
-        # No guard config should pass
-        should_execute, behavior = evaluate_guard_condition({}, {"field": "value"})
-        assert should_execute is True
-        assert behavior is None
 
     def test_should_skip_guard_delegates_to_evaluator(self):
         """_should_skip_guard uses GuardEvaluator internally."""

--- a/tests/preprocessing/test_guard_evaluator.py
+++ b/tests/preprocessing/test_guard_evaluator.py
@@ -131,42 +131,6 @@ class TestGuardEvaluator:
         assert result.should_execute is False
         assert result.behavior == "skip"
 
-    def test_should_skip_with_skip_behavior(self, evaluator, mock_guard_filter):
-        """should_skip returns True when guard fails with skip behavior."""
-        mock_guard_filter.filter_item.return_value = FilterResult(success=True, matched=False)
-        agent_config = {"guard": {"clause": "x > 10", "scope": "item", "behavior": "skip"}}
-
-        result = evaluator.should_skip(agent_config, {"x": 5})
-
-        assert result is True
-
-    def test_should_skip_with_filter_behavior(self, evaluator, mock_guard_filter):
-        """should_skip returns False for filter behavior (not a skip)."""
-        agent_config = {"guard": {"clause": "x > 10", "scope": "item", "behavior": "filter"}}
-
-        result = evaluator.should_skip(agent_config, {"x": 5})
-
-        assert result is False  # Not skip behavior
-        mock_guard_filter.filter_item.assert_not_called()
-
-    def test_should_filter_with_filter_behavior(self, evaluator, mock_guard_filter):
-        """should_filter returns True when guard fails with filter behavior."""
-        mock_guard_filter.filter_item.return_value = FilterResult(success=True, matched=False)
-        agent_config = {"guard": {"clause": "x > 10", "scope": "item", "behavior": "filter"}}
-
-        result = evaluator.should_filter(agent_config, {"x": 5})
-
-        assert result is True
-
-    def test_should_filter_with_skip_behavior(self, evaluator, mock_guard_filter):
-        """should_filter returns False for skip behavior (not a filter)."""
-        agent_config = {"guard": {"clause": "x > 10", "scope": "item", "behavior": "skip"}}
-
-        result = evaluator.should_filter(agent_config, {"x": 5})
-
-        assert result is False  # Not filter behavior
-        mock_guard_filter.filter_item.assert_not_called()
-
     def test_prepare_eval_context_with_nested_content(self, evaluator):
         """Nested content structure is properly extracted with ALL top-level metadata."""
         context = {
@@ -803,61 +767,3 @@ class TestNamespacedContentGuardEvaluation:
         # First clause matches, but second field is missing → whole condition not matched
         assert result.should_execute is False
         assert result.behavior == "skip"
-
-    def test_should_skip_with_namespaced_content(self, evaluator):
-        """should_skip applies guard behavior on namespaced content with dotted paths."""
-        record = {
-            "content": {"validate": {"pass": True}},
-            "source_guid": "sg-1",
-        }
-        agent_config = {
-            "guard": {
-                "clause": "validate.pass == false",
-                "scope": "item",
-                "behavior": "skip",
-            }
-        }
-
-        result = evaluator.should_skip(agent_config, record)
-
-        # pass is True, condition says == false → not matched → should skip
-        assert result is True
-
-    def test_should_filter_with_namespaced_content(self, evaluator):
-        """should_filter applies guard behavior on namespaced content with dotted paths."""
-        record = {
-            "content": {"classify": {"topic": "science"}},
-            "source_guid": "sg-1",
-        }
-        agent_config = {
-            "guard": {
-                "clause": 'classify.topic == "math"',
-                "scope": "item",
-                "behavior": "filter",
-            }
-        }
-
-        result = evaluator.should_filter(agent_config, record)
-
-        # topic is "science", condition says == "math" → not matched → should filter
-        assert result is True
-
-
-class TestHelpersIntegration:
-    """Tests for integration with processing/helpers.py."""
-
-    def test_should_skip_guard_delegates_to_evaluator(self):
-        """_should_skip_guard uses GuardEvaluator internally."""
-        from agent_actions.processing.helpers import _should_skip_guard
-
-        # No guard config should not skip
-        result = _should_skip_guard({}, {"field": "value"})
-        assert result is False
-
-    def test_should_filter_guard_delegates_to_evaluator(self):
-        """_should_filter_guard uses GuardEvaluator internally."""
-        from agent_actions.processing.helpers import _should_filter_guard
-
-        # No guard config should not filter
-        result = _should_filter_guard({}, {"field": "value"})
-        assert result is False

--- a/tests/unit/workflow/test_file_mode_guard_prefilter.py
+++ b/tests/unit/workflow/test_file_mode_guard_prefilter.py
@@ -9,18 +9,18 @@ from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 
 def _make_evaluator(pass_fn):
-    """Create a mock evaluator whose evaluate_with_context delegates to pass_fn.
+    """Create a mock evaluator whose evaluate delegates to pass_fn.
 
     pass_fn receives the eval_item dict and returns True if the item should pass.
     """
     evaluator = MagicMock()
 
-    def side_effect(*, item, guard_config, context, conditional_clause):
+    def side_effect(*, item, guard_config, context=None, conditional_clause=None):
         if pass_fn(item):
             return GuardResult.passed()
         return GuardResult.filtered()
 
-    evaluator.evaluate_with_context.side_effect = side_effect
+    evaluator.evaluate.side_effect = side_effect
     return evaluator
 
 


### PR DESCRIPTION
## Summary
- Merged 5 GuardEvaluator entry points into single evaluate()
- Created GuardBehavior enum (SKIP | FILTER | WARN)
- Migrated run_dynamic_agent to use unified evaluate() (was 3 fragmented checks)
- Deleted should_skip(), should_filter() from GuardEvaluator
- Deleted evaluate_guard_condition() wrapper, 3 helper functions from helpers.py

## Verification
- All tests pass (5856 passed)
- Validation script passes: test_110_guard_evaluation_unified.py (4/4)
- ruff format/check clean
- grep confirms zero remaining references to old entry points