### PR TITLE
fix: action output shows only own namespace

### DIFF
--- a/.changes/unreleased/Bug Fix-20260425-140000.yaml
+++ b/.changes/unreleased/Bug Fix-20260425-140000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Action Output now shows only the current action's fields, not the entire data bus"
+time: 2026-04-25T14:00:00.000000Z

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -440,6 +440,9 @@ function useSectionState(nodeKey: string) {
 
 // ── DataCard ──────────────────────────────────────────────────────────────
 
+/** Sentinel returned by getDisplayFields when the action was guard-skipped (namespace is null). */
+const GUARD_SKIPPED: Record<string, unknown> = Object.freeze({})
+
 export interface ActionInfo {
   name: string
   kind: string
@@ -465,15 +468,13 @@ export function getDisplayFields(record: Record<string, unknown>, actionName?: s
     if (actionName && actionName in content) {
       const ns = content[actionName]
       if (ns === null) {
-        return {}  // Guard-skipped — no output produced
+        return GUARD_SKIPPED
       }
       if (typeof ns === "object" && !Array.isArray(ns)) {
         return ns as Record<string, unknown>
       }
-      // Scalar or array — wrap for display
       return { [actionName]: ns }
     }
-    // actionName not in content — legacy data, show as-is
     return content
   }
   return record
@@ -482,14 +483,7 @@ export function getDisplayFields(record: Record<string, unknown>, actionName?: s
 export function DataCard({ record, index, fontSize, defaultOpen = true, actionInfo }: DataCardProps) {
   const [recordOpen, setRecordOpen] = useState(defaultOpen)
   const displayRecord = getDisplayFields(record, actionInfo?.name)
-  const guardSkipped = !!(
-    actionInfo?.name &&
-    record.content &&
-    typeof record.content === "object" &&
-    !Array.isArray(record.content) &&
-    actionInfo.name in (record.content as Record<string, unknown>) &&
-    (record.content as Record<string, unknown>)[actionInfo.name] === null
-  )
+  const guardSkipped = displayRecord === GUARD_SKIPPED
   const { identity, metadata } = classifyRecord(record)
 
   const outputFields = Object.entries(displayRecord)
@@ -561,7 +555,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true, actionIn
         )}
         {!recordOpen && (
           <span className="text-[10px] text-foreground/50 ml-auto">
-            {guardSkipped ? "guard skipped" : <>{trace ? "trace + " : ""}{plural(outputFields.length, "field")}</>}
+            {guardSkipped ? "guard skipped" : `${trace ? "trace + " : ""}${plural(outputFields.length, "field")}`}
           </span>
         )}
       </button>

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -464,10 +464,16 @@ export function getDisplayFields(record: Record<string, unknown>, actionName?: s
     // { action_a: {...}, action_b: {...} }. Show only this action's fields.
     if (actionName && actionName in content) {
       const ns = content[actionName]
-      if (ns && typeof ns === "object" && !Array.isArray(ns)) {
+      if (ns === null) {
+        return {}  // Guard-skipped — no output produced
+      }
+      if (typeof ns === "object" && !Array.isArray(ns)) {
         return ns as Record<string, unknown>
       }
+      // Scalar or array — wrap for display
+      return { [actionName]: ns }
     }
+    // actionName not in content — legacy data, show as-is
     return content
   }
   return record
@@ -476,6 +482,14 @@ export function getDisplayFields(record: Record<string, unknown>, actionName?: s
 export function DataCard({ record, index, fontSize, defaultOpen = true, actionInfo }: DataCardProps) {
   const [recordOpen, setRecordOpen] = useState(defaultOpen)
   const displayRecord = getDisplayFields(record, actionInfo?.name)
+  const guardSkipped = !!(
+    actionInfo?.name &&
+    record.content &&
+    typeof record.content === "object" &&
+    !Array.isArray(record.content) &&
+    actionInfo.name in (record.content as Record<string, unknown>) &&
+    (record.content as Record<string, unknown>)[actionInfo.name] === null
+  )
   const { identity, metadata } = classifyRecord(record)
 
   const outputFields = Object.entries(displayRecord)
@@ -547,7 +561,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true, actionIn
         )}
         {!recordOpen && (
           <span className="text-[10px] text-foreground/50 ml-auto">
-            {trace ? "trace + " : ""}{plural(outputFields.length, "field")}
+            {guardSkipped ? "guard skipped" : <>{trace ? "trace + " : ""}{plural(outputFields.length, "field")}</>}
           </span>
         )}
       </button>
@@ -661,44 +675,50 @@ export function DataCard({ record, index, fontSize, defaultOpen = true, actionIn
       )}
 
       {/* Section 3: Action Output */}
-      {outputFields.length > 0 && (
+      {(outputFields.length > 0 || guardSkipped) && (
         <CollapsibleSection
           label="Action Output"
 
-          hint={plural(outputFields.length, "field")}
+          hint={guardSkipped ? "guard skipped" : plural(outputFields.length, "field")}
           open={sec.actionOutput}
           onToggle={() => toggle("actionOutput")}
-          copyText={outputJson}
+          copyText={guardSkipped ? undefined : outputJson}
         >
           <div className="pb-2 pl-4">
-            {outputFields.map((f) => {
-              if (isArrayOfObjects(f.value)) {
-                const items = f.value as Record<string, unknown>[]
-                return (
-                  <TreeNode
-                    key={f.key}
-                    label={f.key}
-                    badge={`array[${items.length}]`}
-                    defaultOpen={true}
-                  >
-                    {items.map((item, i) => (
-                      <ArrayItemNode
-                        key={i}
-                        item={item}
-                        index={i}
-                        defaultOpen={i === 0}
-                      />
-                    ))}
-                  </TreeNode>
-                )
-              }
-              return <TreeField key={f.key} fieldKey={f.key} value={f.value} />
-            })}
+            {guardSkipped ? (
+              <div className="px-4 pb-3 text-xs text-muted-foreground italic">
+                Guard skipped — no output produced
+              </div>
+            ) : (
+              outputFields.map((f) => {
+                if (isArrayOfObjects(f.value)) {
+                  const items = f.value as Record<string, unknown>[]
+                  return (
+                    <TreeNode
+                      key={f.key}
+                      label={f.key}
+                      badge={`array[${items.length}]`}
+                      defaultOpen={true}
+                    >
+                      {items.map((item, i) => (
+                        <ArrayItemNode
+                          key={i}
+                          item={item}
+                          index={i}
+                          defaultOpen={i === 0}
+                        />
+                      ))}
+                    </TreeNode>
+                  )
+                }
+                return <TreeField key={f.key} fieldKey={f.key} value={f.value} />
+              })
+            )}
           </div>
         </CollapsibleSection>
       )}
 
-      {outputFields.length === 0 && (
+      {outputFields.length === 0 && !guardSkipped && (
         <div className="px-4 pb-3 text-xs text-muted-foreground italic">No content fields</div>
       )}
 


### PR DESCRIPTION
## Summary
- `getDisplayFields()` now correctly unwraps the action's namespace from the additive content model instead of showing the entire data bus
- Guard-skipped actions (null namespace) show "Guard skipped — no output produced" instead of dumping 25+ upstream namespaces
- Scalar/array namespace values are wrapped for display instead of silently ignored
- Legacy records without namespaces still render correctly (fallback preserved)

## Verification
- `npm run build` passes (frontend compiles clean)
- `ruff format --check` / `ruff check` clean
- `pytest` — 5856 passed, 2 skipped