### PR TITLE
feat: render nested JSON as expandable tree nodes in Data Explorer

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260425-141000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260425-141000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "JSON values render as expandable tree nodes with syntax highlighting in Data Explorer"
+time: 2026-04-25T14:10:00.000000Z

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -48,8 +48,9 @@ export function CellValue({ value }: { value: unknown }) {
   }
   if (typeof value === "object") {
     const str = JSON.stringify(value)
+    const preview = str.length > 80 ? str.slice(0, 80) + "\u2026" : str
     return (
-      <span className="font-mono text-muted-foreground break-all">{str}</span>
+      <span className="font-mono text-muted-foreground break-all">{preview}</span>
     )
   }
   const str = String(value)
@@ -278,7 +279,7 @@ function FieldValue({ fieldKey, value }: { fieldKey: string; value: unknown }) {
     return <InlinePills items={value as (string | number)[]} />
   }
   if (getValueType(value) === "object" && !isArrayOfObjects(value)) {
-    return <CodeBlock value={value} />
+    return <JsonHighlighter text={JSON.stringify(value, null, 2)} />
   }
   // Source quote — blockquote treatment
   if (isSourceQuoteField(fieldKey) && typeof value === "string") {
@@ -293,8 +294,40 @@ function FieldValue({ fieldKey, value }: { fieldKey: string; value: unknown }) {
 
 // ── Tree components ────────────────────────────────────────────────────────
 
-function TreeField({ fieldKey, value, defaultOpen = true }: { fieldKey: string; value: unknown; defaultOpen?: boolean }) {
+function TreeField({ fieldKey, value, defaultOpen = true, depth = 0 }: { fieldKey: string; value: unknown; defaultOpen?: boolean; depth?: number }) {
   const [open, setOpen] = useState(defaultOpen)
+  const MAX_DEPTH = 5
+
+  // Nested object — render as expandable tree
+  if (typeof value === "object" && value !== null && !Array.isArray(value) && depth < MAX_DEPTH) {
+    const entries = Object.entries(value as Record<string, unknown>)
+    return (
+      <TreeNode label={fieldKey} badge={`${entries.length} fields`} defaultOpen={defaultOpen}>
+        {entries.map(([k, v]) => (
+          <TreeField key={k} fieldKey={k} value={v} defaultOpen={false} depth={depth + 1} />
+        ))}
+      </TreeNode>
+    )
+  }
+
+  // Array of objects — render with expandable items
+  if (isArrayOfObjects(value) && depth < MAX_DEPTH) {
+    const items = value as Record<string, unknown>[]
+    return (
+      <TreeNode label={fieldKey} badge={`array[${items.length}]`} defaultOpen={defaultOpen}>
+        {items.slice(0, 20).map((item, i) => (
+          <ArrayItemNode key={i} item={item} index={i} defaultOpen={i === 0} depth={depth + 1} />
+        ))}
+        {items.length > 20 && (
+          <span className="text-[0.75em] text-muted-foreground/50 pl-4 py-1 block italic">
+            + {items.length - 20} more items
+          </span>
+        )}
+      </TreeNode>
+    )
+  }
+
+  // Simple values or max depth reached
   const valStr = typeof value === "string" ? value : typeof value === "object" ? JSON.stringify(value) : String(value ?? "")
   const preview = valStr.length > 60 ? valStr.slice(0, 60) + "\u2026" : valStr
 
@@ -357,10 +390,12 @@ function ArrayItemNode({
   item,
   index,
   defaultOpen = false,
+  depth = 0,
 }: {
   item: Record<string, unknown>
   index: number
   defaultOpen?: boolean
+  depth?: number
 }) {
   const [open, setOpen] = useState(defaultOpen)
 
@@ -392,7 +427,7 @@ function ArrayItemNode({
       <div className="data-card-drawer" data-open={open}>
         <div className="pl-4">
           {Object.entries(item).map(([k, v]) => (
-            <TreeField key={k} fieldKey={k} value={v} />
+            <TreeField key={k} fieldKey={k} value={v} depth={depth} />
           ))}
         </div>
       </div>

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -47,10 +47,8 @@ export function CellValue({ value }: { value: unknown }) {
     return <span className="font-mono tabular-nums text-foreground">{value.toLocaleString()}</span>
   }
   if (typeof value === "object") {
-    const str = JSON.stringify(value)
-    const preview = str.length > 80 ? str.slice(0, 80) + "\u2026" : str
     return (
-      <span className="font-mono text-muted-foreground break-all">{preview}</span>
+      <span className="font-mono text-muted-foreground break-all">{formatValue(value, 80)}</span>
     )
   }
   const str = String(value)
@@ -261,14 +259,6 @@ function InlinePills({ items }: { items: (string | number)[] }) {
   )
 }
 
-function CodeBlock({ value }: { value: unknown }) {
-  return (
-    <pre className="rounded-md bg-secondary/40 border border-border/30 px-3 py-2 text-[0.8em] font-mono text-foreground/80 leading-relaxed overflow-x-auto whitespace-pre-wrap">
-      {JSON.stringify(value, null, 2)}
-    </pre>
-  )
-}
-
 function isArrayOfObjects(value: unknown): value is Record<string, unknown>[] {
   if (!Array.isArray(value) || value.length === 0) return false
   return value.every((v) => typeof v === "object" && v !== null && !Array.isArray(v))
@@ -294,12 +284,12 @@ function FieldValue({ fieldKey, value }: { fieldKey: string; value: unknown }) {
 
 // ── Tree components ────────────────────────────────────────────────────────
 
+const TREE_MAX_DEPTH = 5
+
 function TreeField({ fieldKey, value, defaultOpen = true, depth = 0 }: { fieldKey: string; value: unknown; defaultOpen?: boolean; depth?: number }) {
   const [open, setOpen] = useState(defaultOpen)
-  const MAX_DEPTH = 5
 
-  // Nested object — render as expandable tree
-  if (typeof value === "object" && value !== null && !Array.isArray(value) && depth < MAX_DEPTH) {
+  if (typeof value === "object" && value !== null && !Array.isArray(value) && depth < TREE_MAX_DEPTH) {
     const entries = Object.entries(value as Record<string, unknown>)
     return (
       <TreeNode label={fieldKey} badge={`${entries.length} fields`} defaultOpen={defaultOpen}>
@@ -310,8 +300,7 @@ function TreeField({ fieldKey, value, defaultOpen = true, depth = 0 }: { fieldKe
     )
   }
 
-  // Array of objects — render with expandable items
-  if (isArrayOfObjects(value) && depth < MAX_DEPTH) {
+  if (isArrayOfObjects(value) && depth < TREE_MAX_DEPTH) {
     const items = value as Record<string, unknown>[]
     return (
       <TreeNode label={fieldKey} badge={`array[${items.length}]`} defaultOpen={defaultOpen}>
@@ -327,7 +316,6 @@ function TreeField({ fieldKey, value, defaultOpen = true, depth = 0 }: { fieldKe
     )
   }
 
-  // Simple values or max depth reached
   const valStr = typeof value === "string" ? value : typeof value === "object" ? JSON.stringify(value) : String(value ?? "")
   const preview = valStr.length > 60 ? valStr.slice(0, 60) + "\u2026" : valStr
 


### PR DESCRIPTION
## Summary
- **TreeField**: Nested objects render as collapsible tree nodes (via `TreeNode`) instead of `JSON.stringify()` on one line. Arrays of objects within nested fields also render as expandable items, capped at 20 with "show more" indicator.
- **FieldValue**: Objects use `JsonHighlighter` (syntax-colored, line-numbered) instead of plain `CodeBlock`.
- **CellValue**: Table-view JSON truncated to 80 chars with ellipsis.
- **Safety**: Depth limit of 5 levels prevents infinite recursion. `ArrayItemNode` passes depth through to child `TreeField` nodes.

## Verification
- `npm run build` passes (Next.js 16.1.6 Turbopack)
- `pytest` — 5856 passed, 2 skipped
- `ruff format --check` / `ruff check` — clean