### PR TITLE
fix: remove fragile VS Code activation event

### DIFF
--- a/.changes/unreleased/Bug Fix-20260425-152000.yaml
+++ b/.changes/unreleased/Bug Fix-20260425-152000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Remove fragile VS Code activation event that depended on runtime-generated gitignored directory"
+time: 2026-04-25T152000.000000Z

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -39,8 +39,7 @@
     "workspaceContains:**/agent_actions.yml",
     "workspaceContains:**/agent_config/*.yml",
     "workspaceContains:**/agent_config/*.yaml",
-    "workspaceContains:**/prompt_store/*.md",
-    "workspaceContains:**/agent_io/target/.manifest.json"
+    "workspaceContains:**/prompt_store/*.md"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
## Summary
- Removed `workspaceContains:**/agent_io/target/.manifest.json` activation event
- This path is runtime-generated, gitignored, and superseded by the store/ layout from PR #307
- The 4 config-based activation events provide complete, durable coverage

## Verification
- package.json is valid JSON (no trailing comma issues)
- Remaining activation events cover all project types (3 onView + 4 workspaceContains)
- 5863 tests pass, ruff clean, VS Code extension compiles