### PR TITLE
fix: executor skip-reason terminology matches pipeline

### DIFF
--- a/.changes/unreleased/Bug Fix-20260425-150000.yaml
+++ b/.changes/unreleased/Bug Fix-20260425-150000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Executor skip-reason now says 'guard-filtered' instead of 'guard-skipped' to match pipeline terminology"
+time: 2026-04-25T150000.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -362,7 +362,7 @@ class ActionExecutor:
                 metrics=ExecutionMetrics(duration=duration),
             )
 
-        # Normal completion — check for guard-all-skipped or partial item failures
+        # Normal completion — check for guard-all-filtered or partial item failures
         final_status = self._resolve_completion_status(params.action_name)
 
         if final_status == ActionStatus.SKIPPED:
@@ -370,7 +370,7 @@ class ActionExecutor:
                 params.action_name,
                 ActionStatus.SKIPPED,
                 execution_time=duration,
-                skip_reason="All records guard-skipped",
+                skip_reason="All records guard-filtered — no output produced",
             )
             total_actions = (
                 len(self.deps.action_runner.execution_order)
@@ -382,7 +382,7 @@ class ActionExecutor:
                     action_name=params.action_name,
                     action_index=params.action_idx,
                     total_actions=total_actions,
-                    skip_reason="All records guard-skipped",
+                    skip_reason="All records guard-filtered — no output produced",
                     mode=params.action_config.get("run_mode", ""),
                 )
             )
@@ -392,7 +392,7 @@ class ActionExecutor:
                     action_name=params.action_name,
                     status="skipped",
                     duration_seconds=duration,
-                    skip_reason="All records guard-skipped",
+                    skip_reason="All records guard-filtered — no output produced",
                 )
                 self.run_tracker.record_action_complete(config=config)
             return ActionExecutionResult(
@@ -472,7 +472,7 @@ class ActionExecutor:
                 )
 
     def _resolve_completion_status(self, action_name: str) -> ActionStatus:
-        """Return SKIPPED if all records guard-skipped, COMPLETED_WITH_FAILURES if item-level failures exist, else COMPLETED."""
+        """Return SKIPPED if all records guard-filtered, COMPLETED_WITH_FAILURES if item-level failures exist, else COMPLETED."""
         storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
         if storage_backend is None:
             return ActionStatus.COMPLETED
@@ -483,7 +483,7 @@ class ActionExecutor:
                 target_files = storage_backend.list_target_files(action_name)
                 if not target_files:
                     logger.info(
-                        "Action '%s' had all records guard-skipped — marking as skipped",
+                        "Action '%s' had all records guard-filtered — marking as skipped",
                         action_name,
                     )
                     return ActionStatus.SKIPPED

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -334,7 +334,7 @@ class TestHandleRunSuccess:
             call for call in mock_fire.call_args_list if isinstance(call[0][0], ActionSkipEvent)
         ]
         assert len(skip_events) == 1
-        assert skip_events[0][0][0].skip_reason == "All records guard-skipped"
+        assert skip_events[0][0][0].skip_reason == "All records guard-filtered — no output produced"
         assert skip_events[0][0][0].action_index == 0
         assert skip_events[0][0][0].total_actions == 2  # from execution_order fixture
 
@@ -354,7 +354,7 @@ class TestHandleRunSuccess:
         call_kwargs = executor.run_tracker.record_action_complete.call_args
         config = call_kwargs[1]["config"] if "config" in call_kwargs[1] else call_kwargs[0][0]
         assert config.status == "skipped"
-        assert config.skip_reason == "All records guard-skipped"
+        assert config.skip_reason == "All records guard-filtered — no output produced"
 
 
 # ── _handle_run_failure ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Changed 3 skip_reason strings and 1 log message in executor.py from "All records guard-skipped" to "All records guard-filtered — no output produced"
- The pipeline writes DISPOSITION_SKIPPED with reason "All records filtered — no output produced" — the executor's terminology now matches
- Updated docstring and comment to use "guard-filtered" consistently
- Updated 2 test assertions

## Verification
- pytest: 5863 passed, 2 skipped
- ruff format + ruff check: clean
- grep confirms zero remaining "guard-skipped" in executor.py