### PR TITLE
fix: LSP resolves cross-workflow upstream action references

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-153000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-153000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "LSP resolves cross-workflow action references declared in upstream: blocks"
+time: 2026-04-26T153000.000000Z

--- a/agent_actions/tooling/lsp/indexer.py
+++ b/agent_actions/tooling/lsp/indexer.py
@@ -125,6 +125,11 @@ def _index_workflow_file(index: ProjectIndex, yaml_file: Path, yaml: YAML) -> No
 
         _index_workflow_lines(index, yaml_file, lines, action_data_map)
 
+        # Index upstream action declarations (reuse workflow name from line scanner)
+        workflow_name = index.workflow_for_file(yaml_file)
+        if workflow_name:
+            _index_upstream(index, yaml_file, data, workflow_name)
+
     except Exception as e:
         logger.warning("Error indexing %s: %s", yaml_file, e)
 
@@ -402,6 +407,27 @@ def _index_workflow_lines(
                 file_match.end(1),
                 file_match.group(0),
             )
+
+
+def _index_upstream(index: ProjectIndex, yaml_file: Path, data: dict, workflow_name: str) -> None:
+    """Register upstream action names so cross-workflow refs resolve."""
+    upstream = data.get("upstream")
+    if not upstream or not isinstance(upstream, list):
+        return
+
+    upstream_map = index.upstream_actions.setdefault(workflow_name, {})
+    # All upstream actions in one file share the same declaration location
+    file_location = Location(file_path=yaml_file, line=0, column=0)
+
+    for entry in upstream:
+        if not isinstance(entry, dict):
+            continue
+        actions = entry.get("actions", [])
+        if not isinstance(actions, list):
+            continue
+        for action_name in actions:
+            if isinstance(action_name, str):
+                upstream_map[action_name] = file_location
 
 
 def _add_reference(

--- a/agent_actions/tooling/lsp/models.py
+++ b/agent_actions/tooling/lsp/models.py
@@ -155,6 +155,10 @@ class ProjectIndex:
     # Per-file duplicate action names: file_path → {duplicate action name}
     duplicate_actions_by_file: dict[Path, set[str]] = field(default_factory=dict)
 
+    # Upstream action index: workflow_name → {action_name → Location}
+    # Actions declared in upstream: blocks, resolvable only within the declaring workflow.
+    upstream_actions: dict[str, dict[str, Location]] = field(default_factory=dict)
+
     def workflow_for_file(self, file_path: Path) -> str | None:
         """Derive the workflow name from a file path.
 
@@ -168,27 +172,34 @@ class ProjectIndex:
         return None
 
     def get_action(self, name: str, current_file: Path | None = None) -> Location | None:
-        """Get action location: per-file → per-workflow → global (flat layout only)."""
+        """Get action location: per-file → per-workflow → upstream → global (flat layout only)."""
         # 1. Same file (most specific)
         if current_file and current_file in self.file_actions:
             if name in self.file_actions[current_file]:
                 return self.file_actions[current_file][name].location
 
-        # 2. Same workflow — if file belongs to a workflow, stop here (no cross-workflow leakage)
+        # 2. Same workflow — if file belongs to a workflow, check local then upstream
         if current_file:
             workflow = self.workflow_for_file(current_file)
             if workflow:
                 if workflow in self.workflow_actions:
-                    return self.workflow_actions[workflow].get(name)
+                    local = self.workflow_actions[workflow].get(name)
+                    if local:
+                        return local
+                # 3. Upstream actions declared by this workflow
+                if workflow in self.upstream_actions:
+                    upstream = self.upstream_actions[workflow].get(name)
+                    if upstream:
+                        return upstream
                 return None
 
-        # 3. Global fallback (flat layout or no current_file)
+        # 4. Global fallback (flat layout or no current_file)
         return self.actions.get(name)
 
     def get_action_metadata(
         self, name: str, current_file: Path | None = None
     ) -> ActionMetadata | None:
-        """Get action metadata: per-file → same-workflow files → any file (flat layout only)."""
+        """Get action metadata: per-file → same-workflow files → upstream → any file (flat layout only)."""
         # 1. Same file
         if current_file and current_file in self.file_actions:
             if name in self.file_actions[current_file]:
@@ -203,9 +214,12 @@ class ProjectIndex:
                 for file_path, actions in self.file_actions.items():
                     if self.file_to_workflow.get(file_path) == workflow and name in actions:
                         return actions[name]
+                # 3. Upstream — return minimal metadata (no schema/hover info)
+                if workflow in self.upstream_actions and name in self.upstream_actions[workflow]:
+                    return ActionMetadata(name=name, location=self.upstream_actions[workflow][name])
                 return None
 
-        # 3. Any file (flat layout or no current_file)
+        # 4. Any file (flat layout or no current_file)
         for actions in self.file_actions.values():
             if name in actions:
                 return actions[name]

--- a/tests/unit/tooling/test_lsp_upstream_resolution.py
+++ b/tests/unit/tooling/test_lsp_upstream_resolution.py
@@ -1,0 +1,251 @@
+"""Tests for LSP upstream action resolution (spec 153).
+
+The LSP indexer must parse upstream: blocks from workflow YAML and register
+imported action names so diagnostics, completions, and go-to-definition
+resolve cross-workflow references correctly.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from lsprotocol import types as lsp
+
+from agent_actions.tooling.lsp.diagnostics import collect_diagnostics
+from agent_actions.tooling.lsp.indexer import build_index
+
+
+def _create_workflow_project(
+    tmp_path: Path,
+    workflow_name: str,
+    yaml_content: str,
+) -> tuple[Path, Path]:
+    """Create a minimal agent-actions project. Returns (yaml_file, project_root)."""
+    project_root = tmp_path / "project"
+    project_root.mkdir(exist_ok=True)
+    (project_root / "agent_actions.yml").write_text("version: '1'\n")
+
+    workflow_dir = project_root / "agent_workflow" / workflow_name / "agent_config"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    yaml_file = workflow_dir / "pipeline.yml"
+    yaml_file.write_text(textwrap.dedent(yaml_content))
+    return yaml_file, project_root
+
+
+class TestUpstreamActionResolution:
+    """Upstream actions declared in upstream: blocks resolve within the declaring workflow."""
+
+    def test_upstream_action_resolves_in_dependencies(self, tmp_path):
+        """Action declared in upstream: block resolves when used in dependencies."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Consumes upstream
+            upstream:
+              - workflow: producer
+                actions: [format_quiz_text]
+            actions:
+              - name: process_quiz
+                dependencies: [format_quiz_text]
+            """,
+        )
+        index = build_index(project_root)
+        location = index.get_action("format_quiz_text", yaml_file)
+        assert location is not None
+        assert location.file_path == yaml_file
+
+    def test_upstream_action_resolves_in_context_scope_observe(self, tmp_path):
+        """Upstream action resolves when referenced in context_scope.observe."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Consumes upstream
+            upstream:
+              - workflow: producer
+                actions: [format_quiz_text]
+            actions:
+              - name: process_quiz
+                dependencies: [format_quiz_text]
+                context_scope:
+                  observe:
+                    - format_quiz_text.*
+            """,
+        )
+        index = build_index(project_root)
+
+        diagnostics = collect_diagnostics(yaml_file, index)
+        error_diagnostics = [d for d in diagnostics if d.severity == lsp.DiagnosticSeverity.Error]
+        assert len(error_diagnostics) == 0
+
+    def test_upstream_action_does_not_leak_to_other_workflow(self, tmp_path):
+        """Upstream actions scoped to declaring workflow only — not visible elsewhere."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "agent_actions.yml").write_text("version: '1'\n")
+
+        # Workflow A declares upstream action
+        wf_a_dir = project_root / "agent_workflow" / "workflow_a" / "agent_config"
+        wf_a_dir.mkdir(parents=True)
+        wf_a_file = wf_a_dir / "pipeline.yml"
+        wf_a_file.write_text(
+            textwrap.dedent("""\
+            name: workflow_a
+            description: Has upstream
+            upstream:
+              - workflow: producer
+                actions: [shared_action]
+            actions:
+              - name: step_a
+                dependencies: [shared_action]
+            """)
+        )
+
+        # Workflow B does NOT declare upstream — should not see shared_action
+        wf_b_dir = project_root / "agent_workflow" / "workflow_b" / "agent_config"
+        wf_b_dir.mkdir(parents=True)
+        wf_b_file = wf_b_dir / "pipeline.yml"
+        wf_b_file.write_text(
+            textwrap.dedent("""\
+            name: workflow_b
+            description: No upstream
+            actions:
+              - name: step_b
+                dependencies: [shared_action]
+            """)
+        )
+
+        index = build_index(project_root)
+
+        # Resolves in workflow A
+        assert index.get_action("shared_action", wf_a_file) is not None
+
+        # Does NOT resolve in workflow B
+        assert index.get_action("shared_action", wf_b_file) is None
+
+        # Workflow B should get an error diagnostic for the unresolved ref
+        diagnostics_b = collect_diagnostics(wf_b_file, index)
+        error_msgs = [
+            d.message for d in diagnostics_b if d.severity == lsp.DiagnosticSeverity.Error
+        ]
+        assert any("shared_action" in msg for msg in error_msgs)
+
+    def test_local_action_takes_priority_over_upstream(self, tmp_path):
+        """When a local action has the same name as an upstream, local wins."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Has both local and upstream with same name
+            upstream:
+              - workflow: producer
+                actions: [colliding_action]
+            actions:
+              - name: colliding_action
+                dependencies: []
+            """,
+        )
+        index = build_index(project_root)
+
+        location = index.get_action("colliding_action", yaml_file)
+        assert location is not None
+        # Should resolve to a specific line (the local action definition), not line 0 (upstream)
+        assert location.line > 0
+
+    def test_upstream_action_metadata_resolves(self, tmp_path):
+        """get_action_metadata returns minimal ActionMetadata for upstream actions."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Consumes upstream
+            upstream:
+              - workflow: producer
+                actions: [format_quiz_text]
+            actions:
+              - name: process_quiz
+                dependencies: [format_quiz_text]
+            """,
+        )
+        index = build_index(project_root)
+
+        meta = index.get_action_metadata("format_quiz_text", yaml_file)
+        assert meta is not None
+        assert meta.name == "format_quiz_text"
+        assert meta.location.file_path == yaml_file
+
+    def test_multiple_upstream_workflows(self, tmp_path):
+        """Actions from multiple upstream workflows all resolve."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Multi-upstream
+            upstream:
+              - workflow: producer_a
+                actions: [action_from_a]
+              - workflow: producer_b
+                actions: [action_from_b]
+            actions:
+              - name: process
+                dependencies: [action_from_a, action_from_b]
+            """,
+        )
+        index = build_index(project_root)
+
+        assert index.get_action("action_from_a", yaml_file) is not None
+        assert index.get_action("action_from_b", yaml_file) is not None
+
+    def test_no_upstream_block_unchanged_behavior(self, tmp_path):
+        """Workflows without upstream: continue to work exactly as before."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "simple",
+            """\
+            name: simple
+            description: No upstream
+            actions:
+              - name: step_one
+                dependencies: []
+              - name: step_two
+                dependencies: [step_one]
+            """,
+        )
+        index = build_index(project_root)
+
+        assert index.get_action("step_one", yaml_file) is not None
+        assert index.get_action("step_two", yaml_file) is not None
+        assert "simple" not in index.upstream_actions
+
+    def test_malformed_upstream_ignored(self, tmp_path):
+        """Malformed upstream entries are silently skipped, not crashes."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Bad upstream
+            upstream:
+              - not_a_dict
+              - workflow: producer
+                actions: not_a_list
+              - workflow: valid_producer
+                actions: [valid_action]
+            actions:
+              - name: process
+                dependencies: [valid_action]
+            """,
+        )
+        index = build_index(project_root)
+
+        # Only the valid entry should be indexed
+        assert index.get_action("valid_action", yaml_file) is not None
+        # The index should have exactly 1 upstream action for this workflow
+        assert len(index.upstream_actions.get("consumer", {})) == 1


### PR DESCRIPTION
## Summary
- LSP indexer now parses `upstream:` blocks from workflow YAML
- Upstream action names are registered per-workflow on `ProjectIndex.upstream_actions`
- `get_action()` and `get_action_metadata()` check upstream after local actions
- Dependencies and context_scope refs to upstream actions no longer produce false error markers

## Verification
- 8 new tests covering: resolution in dependencies, context_scope.observe, no cross-workflow leakage, local-over-upstream priority, multiple upstream workflows, malformed input handling
- 5872 tests pass, ruff format + check clean