### PR TITLE
fix: per-record guard-skip disposition uses PASSTHROUGH

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-154000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-154000.yaml
@@ -1,3 +1,3 @@
 kind: Bug Fix
 body: "Per-record guard-skip disposition changed from SKIPPED to PASSTHROUGH to match actual behavior"
-time: 2026-04-26T154000.000000Z
+time: 2026-04-26T15:40:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260426-154000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-154000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Per-record guard-skip disposition changed from SKIPPED to PASSTHROUGH to match actual behavior"
+time: 2026-04-26T154000.000000Z

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -30,7 +30,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_EXHAUSTED,
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
-    DISPOSITION_SKIPPED,
+    DISPOSITION_PASSTHROUGH,
 )
 
 if TYPE_CHECKING:
@@ -605,7 +605,7 @@ def write_record_dispositions(
                 if metadata.get("skipped_by_where_clause"):
                     disposition = DISPOSITION_FILTERED
                 else:
-                    disposition = DISPOSITION_SKIPPED
+                    disposition = DISPOSITION_PASSTHROUGH
                 service._storage_backend.set_disposition(
                     action_name,
                     source_guid,

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -20,7 +20,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_EXHAUSTED,
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
-    DISPOSITION_SKIPPED,
+    DISPOSITION_PASSTHROUGH,
     DISPOSITION_UNPROCESSED,
 )
 
@@ -162,7 +162,7 @@ class ResultCollector:
                         storage_backend,
                         agent_name,
                         result.source_guid,
-                        DISPOSITION_SKIPPED,
+                        DISPOSITION_PASSTHROUGH,
                         reason=result.skip_reason or "guard_skip",
                     )
 

--- a/tests/processing/test_guard_skip_disposition.py
+++ b/tests/processing/test_guard_skip_disposition.py
@@ -2,7 +2,7 @@
 
 When a guard evaluates to false with on_false=skip, the record must
 get ProcessingStatus.SKIPPED (not UNPROCESSED) and storage must receive
-DISPOSITION_SKIPPED.
+DISPOSITION_PASSTHROUGH (the data is forwarded unchanged).
 
 Bug: specs/new/037-guard-skip-disposition-fix.md
 """
@@ -14,7 +14,7 @@ import pytest
 from agent_actions.processing.prepared_task import GuardStatus, PreparedTask
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
-from agent_actions.storage.backend import DISPOSITION_SKIPPED
+from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH
 
 
 @pytest.fixture
@@ -85,10 +85,10 @@ class TestGuardSkipProducesSkippedStatus:
 
 
 class TestGuardSkipDisposition:
-    """Storage backend receives DISPOSITION_SKIPPED for guard-skipped records."""
+    """Storage backend receives DISPOSITION_PASSTHROUGH for guard-skipped records."""
 
-    def test_skipped_result_gets_disposition_skipped(self):
-        """ResultCollector writes DISPOSITION_SKIPPED for SKIPPED results."""
+    def test_skipped_result_gets_disposition_passthrough(self):
+        """ResultCollector writes DISPOSITION_PASSTHROUGH for SKIPPED results."""
         result = ProcessingResult.skipped(
             passthrough_data={"content": {}, "source_guid": "guid-1", "_unprocessed": True},
             reason="guard_skip",
@@ -107,7 +107,7 @@ class TestGuardSkipDisposition:
         backend.set_disposition.assert_called_once_with(
             "test_action",
             "guid-1",
-            DISPOSITION_SKIPPED,
+            DISPOSITION_PASSTHROUGH,
             reason="guard_skip",
         )
 

--- a/tests/simulation/simulate_batch_resubmission.py
+++ b/tests/simulation/simulate_batch_resubmission.py
@@ -35,7 +35,7 @@ from agent_actions.llm.batch.services.submission import BatchSubmissionService
 from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
-    DISPOSITION_SKIPPED,
+    DISPOSITION_PASSTHROUGH,
 )
 
 # ======================================================================
@@ -449,19 +449,19 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
 
     write_record_dispositions(mock_service, output_items, "my_action")
 
-    # Verify: 3 SKIPPED dispositions
-    skipped_records = storage.get_dispositions_by_type("my_action", DISPOSITION_SKIPPED)
+    # Verify: 3 PASSTHROUGH dispositions (guard-skipped records forward data unchanged)
+    passthrough_records = storage.get_dispositions_by_type("my_action", DISPOSITION_PASSTHROUGH)
     check(
-        len(skipped_records) == 3,
-        f"3 records have SKIPPED disposition: {skipped_records}",
-        f"Expected 3 SKIPPED, got {len(skipped_records)}: {skipped_records}",
+        len(passthrough_records) == 3,
+        f"3 records have PASSTHROUGH disposition: {passthrough_records}",
+        f"Expected 3 PASSTHROUGH, got {len(passthrough_records)}: {passthrough_records}",
     )
 
-    expected_skipped_guids = {"sg-002", "sg-005", "sg-008"}
+    expected_passthrough_guids = {"sg-002", "sg-005", "sg-008"}
     check(
-        set(skipped_records) == expected_skipped_guids,
-        "Correct source_guids are SKIPPED",
-        f"Expected {expected_skipped_guids}, got {set(skipped_records)}",
+        set(passthrough_records) == expected_passthrough_guids,
+        "Correct source_guids are PASSTHROUGH",
+        f"Expected {expected_passthrough_guids}, got {set(passthrough_records)}",
     )
 
     # Verify: no FAILED or FILTERED dispositions
@@ -480,8 +480,8 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
     )
 
     # Verify: reasons are set correctly
-    for sg in expected_skipped_guids:
-        reason = storage._dispositions.get(("my_action", sg, DISPOSITION_SKIPPED))
+    for sg in expected_passthrough_guids:
+        reason = storage._dispositions.get(("my_action", sg, DISPOSITION_PASSTHROUGH))
         check(
             reason == "guard_skipped",
             f"{sg} disposition reason is 'guard_skipped'",

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -404,7 +404,7 @@ class TestResultCollectorDispositions:
         backend.set_disposition.assert_called_once_with(
             "agent",
             "src-sk",
-            "skipped",
+            "passthrough",
             reason="guard_skip",
         )
 


### PR DESCRIPTION
## Summary
- Per-record guard-skips now write DISPOSITION_PASSTHROUGH instead of DISPOSITION_SKIPPED
- Aligns per-record semantics with node-level convention: data forwarded = PASSTHROUGH
- Changed in result_collector.py and processing_recovery.py
- No production behavior change (per-record dispositions are telemetry-only today)
- Prevents future bugs from misinterpreting "skipped" as "no data produced"

## Verification
- pytest: 5829 passed, 0 failed (HITL server port conflict excluded — pre-existing)
- ruff format + check: clean
- grep confirms zero DISPOSITION_SKIPPED in result_collector.py and processing_recovery.py
- All node-level DISPOSITION_SKIPPED in executor.py unchanged (all use NODE_LEVEL_RECORD_ID)
- Sibling patterns in simulation test updated