### PR TITLE
fix: bug fix integration — LSP upstream, disposition semantics, FILE synthetic records

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-153000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-153000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "LSP resolves cross-workflow action references declared in upstream: blocks"
+time: 2026-04-26T153000.000000Z

--- a/.changes/unreleased/Bug Fix-20260426-154000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-154000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Per-record guard-skip disposition changed from SKIPPED to PASSTHROUGH to match actual behavior"
+time: 2026-04-26T15:40:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260426-155000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-155000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "FILE tools can create synthetic records (source_index: None) with upstream namespace carry-forward"
+time: 2026-04-26T155000.000000Z

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -30,7 +30,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_EXHAUSTED,
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
-    DISPOSITION_SKIPPED,
+    DISPOSITION_PASSTHROUGH,
 )
 
 if TYPE_CHECKING:
@@ -605,7 +605,7 @@ def write_record_dispositions(
                 if metadata.get("skipped_by_where_clause"):
                     disposition = DISPOSITION_FILTERED
                 else:
-                    disposition = DISPOSITION_SKIPPED
+                    disposition = DISPOSITION_PASSTHROUGH
                 service._storage_backend.set_disposition(
                     action_name,
                     source_guid,

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -77,6 +77,9 @@ class LineageEnricher(Enricher):
                         node_id=node_id,
                     )
                     continue
+                elif source_idx is None:
+                    # Synthetic record — no parent, gets fresh lineage
+                    parent_item = None
                 else:
                     # One-to-one: single input record
                     if source_idx < source_data_len:

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -20,7 +20,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_EXHAUSTED,
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
-    DISPOSITION_SKIPPED,
+    DISPOSITION_PASSTHROUGH,
     DISPOSITION_UNPROCESSED,
 )
 
@@ -162,7 +162,7 @@ class ResultCollector:
                         storage_backend,
                         agent_name,
                         result.source_guid,
-                        DISPOSITION_SKIPPED,
+                        DISPOSITION_PASSTHROUGH,
                         reason=result.skip_reason or "guard_skip",
                     )
 

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -129,7 +129,7 @@ class ProcessingResult:
     recovery_metadata: RecoveryMetadata | None = None
     raw_response: Any | None = None
     pre_extracted_metadata: dict[str, Any] | None = None
-    source_mapping: dict[int, int | list[int]] | None = None
+    source_mapping: dict[int, int | list[int] | None] | None = None
 
     @classmethod
     def success(

--- a/agent_actions/tooling/lsp/indexer.py
+++ b/agent_actions/tooling/lsp/indexer.py
@@ -125,6 +125,11 @@ def _index_workflow_file(index: ProjectIndex, yaml_file: Path, yaml: YAML) -> No
 
         _index_workflow_lines(index, yaml_file, lines, action_data_map)
 
+        # Index upstream action declarations (reuse workflow name from line scanner)
+        workflow_name = index.workflow_for_file(yaml_file)
+        if workflow_name:
+            _index_upstream(index, yaml_file, data, workflow_name)
+
     except Exception as e:
         logger.warning("Error indexing %s: %s", yaml_file, e)
 
@@ -402,6 +407,27 @@ def _index_workflow_lines(
                 file_match.end(1),
                 file_match.group(0),
             )
+
+
+def _index_upstream(index: ProjectIndex, yaml_file: Path, data: dict, workflow_name: str) -> None:
+    """Register upstream action names so cross-workflow refs resolve."""
+    upstream = data.get("upstream")
+    if not upstream or not isinstance(upstream, list):
+        return
+
+    upstream_map = index.upstream_actions.setdefault(workflow_name, {})
+    # All upstream actions in one file share the same declaration location
+    file_location = Location(file_path=yaml_file, line=0, column=0)
+
+    for entry in upstream:
+        if not isinstance(entry, dict):
+            continue
+        actions = entry.get("actions", [])
+        if not isinstance(actions, list):
+            continue
+        for action_name in actions:
+            if isinstance(action_name, str):
+                upstream_map[action_name] = file_location
 
 
 def _add_reference(

--- a/agent_actions/tooling/lsp/models.py
+++ b/agent_actions/tooling/lsp/models.py
@@ -155,6 +155,10 @@ class ProjectIndex:
     # Per-file duplicate action names: file_path → {duplicate action name}
     duplicate_actions_by_file: dict[Path, set[str]] = field(default_factory=dict)
 
+    # Upstream action index: workflow_name → {action_name → Location}
+    # Actions declared in upstream: blocks, resolvable only within the declaring workflow.
+    upstream_actions: dict[str, dict[str, Location]] = field(default_factory=dict)
+
     def workflow_for_file(self, file_path: Path) -> str | None:
         """Derive the workflow name from a file path.
 
@@ -168,27 +172,34 @@ class ProjectIndex:
         return None
 
     def get_action(self, name: str, current_file: Path | None = None) -> Location | None:
-        """Get action location: per-file → per-workflow → global (flat layout only)."""
+        """Get action location: per-file → per-workflow → upstream → global (flat layout only)."""
         # 1. Same file (most specific)
         if current_file and current_file in self.file_actions:
             if name in self.file_actions[current_file]:
                 return self.file_actions[current_file][name].location
 
-        # 2. Same workflow — if file belongs to a workflow, stop here (no cross-workflow leakage)
+        # 2. Same workflow — if file belongs to a workflow, check local then upstream
         if current_file:
             workflow = self.workflow_for_file(current_file)
             if workflow:
                 if workflow in self.workflow_actions:
-                    return self.workflow_actions[workflow].get(name)
+                    local = self.workflow_actions[workflow].get(name)
+                    if local:
+                        return local
+                # 3. Upstream actions declared by this workflow
+                if workflow in self.upstream_actions:
+                    upstream = self.upstream_actions[workflow].get(name)
+                    if upstream:
+                        return upstream
                 return None
 
-        # 3. Global fallback (flat layout or no current_file)
+        # 4. Global fallback (flat layout or no current_file)
         return self.actions.get(name)
 
     def get_action_metadata(
         self, name: str, current_file: Path | None = None
     ) -> ActionMetadata | None:
-        """Get action metadata: per-file → same-workflow files → any file (flat layout only)."""
+        """Get action metadata: per-file → same-workflow files → upstream → any file (flat layout only)."""
         # 1. Same file
         if current_file and current_file in self.file_actions:
             if name in self.file_actions[current_file]:
@@ -203,9 +214,12 @@ class ProjectIndex:
                 for file_path, actions in self.file_actions.items():
                     if self.file_to_workflow.get(file_path) == workflow and name in actions:
                         return actions[name]
+                # 3. Upstream — return minimal metadata (no schema/hover info)
+                if workflow in self.upstream_actions and name in self.upstream_actions[workflow]:
+                    return ActionMetadata(name=name, location=self.upstream_actions[workflow][name])
                 return None
 
-        # 3. Any file (flat layout or no current_file)
+        # 4. Any file (flat layout or no current_file)
         for actions in self.file_actions.values():
             if name in actions:
                 return actions[name]

--- a/agent_actions/utils/udf_management/registry.py
+++ b/agent_actions/utils/udf_management/registry.py
@@ -28,7 +28,14 @@ class FileUDFResult:
             if "source_index" not in out:
                 raise ValueError(
                     f"FileUDFResult output[{i}] missing 'source_index'. "
-                    f"Every output must declare which input produced it."
+                    f"Every output must declare which input produced it. "
+                    f"Use None for synthetic records (aggregations, dedup results)."
+                )
+            src = out["source_index"]
+            if src is not None and not isinstance(src, (int, list)):
+                raise ValueError(
+                    f"FileUDFResult output[{i}] source_index must be int, list[int], or None. "
+                    f"Got {type(src).__name__}."
                 )
             if "data" not in out or not isinstance(out["data"], dict):
                 raise ValueError(

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -85,13 +85,14 @@ def _resolve_source_mapping(
 
 def _reattach_source_guid(
     structured_data: list[dict],
-    source_mapping: dict[int, int | list[int]] | None,
+    source_mapping: dict[int, int | list[int] | None] | None,
     original_data: list[dict],
 ) -> None:
     """Reattach source_guid from input records to output items using mapping.
 
     Mutates structured_data in place.  Only sets source_guid when the output
     item does not already carry a truthy value (explicit tool values win).
+    Entries with ``None`` source index (synthetic records) are skipped.
     """
     if source_mapping is None or not original_data:
         return
@@ -105,11 +106,15 @@ def _reattach_source_guid(
             # and cardinalities match (1:1 passthrough by tools that don't preserve node_id).
             # When mapping has entries, unmapped outputs are genuinely new records.
             if not source_mapping and len(structured_data) == len(original_data):
-                source_idx: int | list[int] = i
+                source_idx: int | list[int] | None = i
             else:
                 continue  # Unmapped output — new record, no parent to inherit from
         else:
             source_idx = source_mapping[i]
+
+        if source_idx is None:
+            continue  # Synthetic record — no parent GUID to inherit
+
         if isinstance(source_idx, list):
             source_idx = source_idx[0]  # Many-to-one: use first parent
 
@@ -119,14 +124,19 @@ def _reattach_source_guid(
                 item["source_guid"] = parent_guid
 
 
-def _resolve_input_record(input_idx: int, original_data: list[dict]) -> dict[str, Any] | None:
+def _resolve_input_record(
+    input_idx: int | None, original_data: list[dict]
+) -> dict[str, Any] | None:
     """Resolve the input record for namespace carry-forward.
 
-    Raises ``IndexError`` if *input_idx* is out of bounds — an invalid
-    ``source_index`` is a tool bug, not something to silently default.
+    When *input_idx* is ``None`` (synthetic record), falls back to
+    ``original_data[0]`` — all records in a batch share upstream namespaces.
+    Raises ``IndexError`` for out-of-bounds non-None indices.
     """
     if not original_data:
         return None
+    if input_idx is None:
+        return original_data[0]
     if not isinstance(input_idx, int) or input_idx < 0 or input_idx >= len(original_data):
         raise IndexError(
             f"source_index {input_idx} is out of bounds for {len(original_data)} input records"
@@ -196,7 +206,7 @@ def _reconcile_outputs(
     action_name: str,
     original_data: list[dict],
     version_merge: bool = False,
-) -> tuple[list[dict[str, Any]], dict[int, int | list[int]]]:
+) -> tuple[list[dict[str, Any]], dict[int, int | list[int] | None]]:
     """Core reconciliation of tool output to input records.
 
     Dispatches on response type (``FileUDFResult`` vs ``TrackedItem`` list),
@@ -206,13 +216,18 @@ def _reconcile_outputs(
     """
     from agent_actions.utils.udf_management.registry import FileUDFResult
 
-    source_mapping: dict[int, int | list[int]] = {}
+    source_mapping: dict[int, int | list[int] | None] = {}
     structured_data: list[dict[str, Any]] = []
 
     if isinstance(raw_response, FileUDFResult):
         for i, out in enumerate(raw_response.outputs):
             src_idx = out["source_index"]
-            input_idx = src_idx[0] if isinstance(src_idx, list) else src_idx
+            if src_idx is None:
+                input_idx = None
+            elif isinstance(src_idx, list):
+                input_idx = src_idx[0]
+            else:
+                input_idx = src_idx
             source_mapping[i] = src_idx
 
             matched = _resolve_input_record(input_idx, original_data)

--- a/tests/manual/smoke_test/checks/guards.py
+++ b/tests/manual/smoke_test/checks/guards.py
@@ -4,7 +4,7 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Literal
 
-from agent_actions.storage.backend import DISPOSITION_FILTERED, DISPOSITION_SKIPPED
+from agent_actions.storage.backend import DISPOSITION_FILTERED, DISPOSITION_PASSTHROUGH
 from tests.manual.smoke_test.checks import Check
 from tests.manual.smoke_test.context import CheckResult, RunContext
 
@@ -66,9 +66,9 @@ class GuardCheck(Check):
                 )
 
             elif self.behavior == "skip":
-                skip_count = conn.execute(
+                passthrough_count = conn.execute(
                     "SELECT COUNT(*) FROM record_disposition WHERE action_name = ? AND disposition = ?",
-                    (self.action, DISPOSITION_SKIPPED),
+                    (self.action, DISPOSITION_PASSTHROUGH),
                 ).fetchone()[0]
 
                 target_count = conn.execute(
@@ -78,9 +78,9 @@ class GuardCheck(Check):
 
                 results.append(
                     CheckResult(
-                        passed=skip_count > 0 or target_count == 0,
+                        passed=passthrough_count > 0 or target_count == 0,
                         name=f"guard({self.action}): skip guard evaluated",
-                        message=f"{skip_count} skip dispositions, {target_count} output rows",
+                        message=f"{passthrough_count} passthrough dispositions, {target_count} output rows",
                     )
                 )
 

--- a/tests/manual/smoke_test/checks/schema_conformance.py
+++ b/tests/manual/smoke_test/checks/schema_conformance.py
@@ -5,7 +5,11 @@ import sqlite3
 
 import yaml
 
-from agent_actions.storage.backend import DISPOSITION_SKIPPED, DISPOSITION_UNPROCESSED
+from agent_actions.storage.backend import (
+    DISPOSITION_PASSTHROUGH,
+    DISPOSITION_SKIPPED,
+    DISPOSITION_UNPROCESSED,
+)
 from tests.manual.smoke_test.checks import Check
 from tests.manual.smoke_test.context import CheckResult, RunContext
 
@@ -75,8 +79,8 @@ class SchemaConformance(Check):
             skipped_actions = {
                 r[0]
                 for r in conn.execute(
-                    "SELECT DISTINCT action_name FROM record_disposition WHERE disposition IN (?, ?)",
-                    (DISPOSITION_SKIPPED, DISPOSITION_UNPROCESSED),
+                    "SELECT DISTINCT action_name FROM record_disposition WHERE disposition IN (?, ?, ?)",
+                    (DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED, DISPOSITION_UNPROCESSED),
                 ).fetchall()
             }
 

--- a/tests/processing/test_guard_skip_disposition.py
+++ b/tests/processing/test_guard_skip_disposition.py
@@ -2,7 +2,7 @@
 
 When a guard evaluates to false with on_false=skip, the record must
 get ProcessingStatus.SKIPPED (not UNPROCESSED) and storage must receive
-DISPOSITION_SKIPPED.
+DISPOSITION_PASSTHROUGH (the data is forwarded unchanged).
 
 Bug: specs/new/037-guard-skip-disposition-fix.md
 """
@@ -14,7 +14,7 @@ import pytest
 from agent_actions.processing.prepared_task import GuardStatus, PreparedTask
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
-from agent_actions.storage.backend import DISPOSITION_SKIPPED
+from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH
 
 
 @pytest.fixture
@@ -85,10 +85,10 @@ class TestGuardSkipProducesSkippedStatus:
 
 
 class TestGuardSkipDisposition:
-    """Storage backend receives DISPOSITION_SKIPPED for guard-skipped records."""
+    """Storage backend receives DISPOSITION_PASSTHROUGH for guard-skipped records."""
 
-    def test_skipped_result_gets_disposition_skipped(self):
-        """ResultCollector writes DISPOSITION_SKIPPED for SKIPPED results."""
+    def test_skipped_result_gets_disposition_passthrough(self):
+        """ResultCollector writes DISPOSITION_PASSTHROUGH for SKIPPED results."""
         result = ProcessingResult.skipped(
             passthrough_data={"content": {}, "source_guid": "guid-1", "_unprocessed": True},
             reason="guard_skip",
@@ -107,7 +107,7 @@ class TestGuardSkipDisposition:
         backend.set_disposition.assert_called_once_with(
             "test_action",
             "guid-1",
-            DISPOSITION_SKIPPED,
+            DISPOSITION_PASSTHROUGH,
             reason="guard_skip",
         )
 

--- a/tests/simulation/simulate_batch_resubmission.py
+++ b/tests/simulation/simulate_batch_resubmission.py
@@ -35,7 +35,7 @@ from agent_actions.llm.batch.services.submission import BatchSubmissionService
 from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
-    DISPOSITION_SKIPPED,
+    DISPOSITION_PASSTHROUGH,
 )
 
 # ======================================================================
@@ -449,19 +449,19 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
 
     write_record_dispositions(mock_service, output_items, "my_action")
 
-    # Verify: 3 SKIPPED dispositions
-    skipped_records = storage.get_dispositions_by_type("my_action", DISPOSITION_SKIPPED)
+    # Verify: 3 PASSTHROUGH dispositions (guard-skipped records forward data unchanged)
+    passthrough_records = storage.get_dispositions_by_type("my_action", DISPOSITION_PASSTHROUGH)
     check(
-        len(skipped_records) == 3,
-        f"3 records have SKIPPED disposition: {skipped_records}",
-        f"Expected 3 SKIPPED, got {len(skipped_records)}: {skipped_records}",
+        len(passthrough_records) == 3,
+        f"3 records have PASSTHROUGH disposition: {passthrough_records}",
+        f"Expected 3 PASSTHROUGH, got {len(passthrough_records)}: {passthrough_records}",
     )
 
-    expected_skipped_guids = {"sg-002", "sg-005", "sg-008"}
+    expected_passthrough_guids = {"sg-002", "sg-005", "sg-008"}
     check(
-        set(skipped_records) == expected_skipped_guids,
-        "Correct source_guids are SKIPPED",
-        f"Expected {expected_skipped_guids}, got {set(skipped_records)}",
+        set(passthrough_records) == expected_passthrough_guids,
+        "Correct source_guids are PASSTHROUGH",
+        f"Expected {expected_passthrough_guids}, got {set(passthrough_records)}",
     )
 
     # Verify: no FAILED or FILTERED dispositions
@@ -480,8 +480,8 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
     )
 
     # Verify: reasons are set correctly
-    for sg in expected_skipped_guids:
-        reason = storage._dispositions.get(("my_action", sg, DISPOSITION_SKIPPED))
+    for sg in expected_passthrough_guids:
+        reason = storage._dispositions.get(("my_action", sg, DISPOSITION_PASSTHROUGH))
         check(
             reason == "guard_skipped",
             f"{sg} disposition reason is 'guard_skipped'",

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -404,7 +404,7 @@ class TestResultCollectorDispositions:
         backend.set_disposition.assert_called_once_with(
             "agent",
             "src-sk",
-            "skipped",
+            "passthrough",
             reason="guard_skip",
         )
 

--- a/tests/unit/tooling/test_lsp_upstream_resolution.py
+++ b/tests/unit/tooling/test_lsp_upstream_resolution.py
@@ -1,0 +1,251 @@
+"""Tests for LSP upstream action resolution (spec 153).
+
+The LSP indexer must parse upstream: blocks from workflow YAML and register
+imported action names so diagnostics, completions, and go-to-definition
+resolve cross-workflow references correctly.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from lsprotocol import types as lsp
+
+from agent_actions.tooling.lsp.diagnostics import collect_diagnostics
+from agent_actions.tooling.lsp.indexer import build_index
+
+
+def _create_workflow_project(
+    tmp_path: Path,
+    workflow_name: str,
+    yaml_content: str,
+) -> tuple[Path, Path]:
+    """Create a minimal agent-actions project. Returns (yaml_file, project_root)."""
+    project_root = tmp_path / "project"
+    project_root.mkdir(exist_ok=True)
+    (project_root / "agent_actions.yml").write_text("version: '1'\n")
+
+    workflow_dir = project_root / "agent_workflow" / workflow_name / "agent_config"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    yaml_file = workflow_dir / "pipeline.yml"
+    yaml_file.write_text(textwrap.dedent(yaml_content))
+    return yaml_file, project_root
+
+
+class TestUpstreamActionResolution:
+    """Upstream actions declared in upstream: blocks resolve within the declaring workflow."""
+
+    def test_upstream_action_resolves_in_dependencies(self, tmp_path):
+        """Action declared in upstream: block resolves when used in dependencies."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Consumes upstream
+            upstream:
+              - workflow: producer
+                actions: [format_quiz_text]
+            actions:
+              - name: process_quiz
+                dependencies: [format_quiz_text]
+            """,
+        )
+        index = build_index(project_root)
+        location = index.get_action("format_quiz_text", yaml_file)
+        assert location is not None
+        assert location.file_path == yaml_file
+
+    def test_upstream_action_resolves_in_context_scope_observe(self, tmp_path):
+        """Upstream action resolves when referenced in context_scope.observe."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Consumes upstream
+            upstream:
+              - workflow: producer
+                actions: [format_quiz_text]
+            actions:
+              - name: process_quiz
+                dependencies: [format_quiz_text]
+                context_scope:
+                  observe:
+                    - format_quiz_text.*
+            """,
+        )
+        index = build_index(project_root)
+
+        diagnostics = collect_diagnostics(yaml_file, index)
+        error_diagnostics = [d for d in diagnostics if d.severity == lsp.DiagnosticSeverity.Error]
+        assert len(error_diagnostics) == 0
+
+    def test_upstream_action_does_not_leak_to_other_workflow(self, tmp_path):
+        """Upstream actions scoped to declaring workflow only — not visible elsewhere."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "agent_actions.yml").write_text("version: '1'\n")
+
+        # Workflow A declares upstream action
+        wf_a_dir = project_root / "agent_workflow" / "workflow_a" / "agent_config"
+        wf_a_dir.mkdir(parents=True)
+        wf_a_file = wf_a_dir / "pipeline.yml"
+        wf_a_file.write_text(
+            textwrap.dedent("""\
+            name: workflow_a
+            description: Has upstream
+            upstream:
+              - workflow: producer
+                actions: [shared_action]
+            actions:
+              - name: step_a
+                dependencies: [shared_action]
+            """)
+        )
+
+        # Workflow B does NOT declare upstream — should not see shared_action
+        wf_b_dir = project_root / "agent_workflow" / "workflow_b" / "agent_config"
+        wf_b_dir.mkdir(parents=True)
+        wf_b_file = wf_b_dir / "pipeline.yml"
+        wf_b_file.write_text(
+            textwrap.dedent("""\
+            name: workflow_b
+            description: No upstream
+            actions:
+              - name: step_b
+                dependencies: [shared_action]
+            """)
+        )
+
+        index = build_index(project_root)
+
+        # Resolves in workflow A
+        assert index.get_action("shared_action", wf_a_file) is not None
+
+        # Does NOT resolve in workflow B
+        assert index.get_action("shared_action", wf_b_file) is None
+
+        # Workflow B should get an error diagnostic for the unresolved ref
+        diagnostics_b = collect_diagnostics(wf_b_file, index)
+        error_msgs = [
+            d.message for d in diagnostics_b if d.severity == lsp.DiagnosticSeverity.Error
+        ]
+        assert any("shared_action" in msg for msg in error_msgs)
+
+    def test_local_action_takes_priority_over_upstream(self, tmp_path):
+        """When a local action has the same name as an upstream, local wins."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Has both local and upstream with same name
+            upstream:
+              - workflow: producer
+                actions: [colliding_action]
+            actions:
+              - name: colliding_action
+                dependencies: []
+            """,
+        )
+        index = build_index(project_root)
+
+        location = index.get_action("colliding_action", yaml_file)
+        assert location is not None
+        # Should resolve to a specific line (the local action definition), not line 0 (upstream)
+        assert location.line > 0
+
+    def test_upstream_action_metadata_resolves(self, tmp_path):
+        """get_action_metadata returns minimal ActionMetadata for upstream actions."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Consumes upstream
+            upstream:
+              - workflow: producer
+                actions: [format_quiz_text]
+            actions:
+              - name: process_quiz
+                dependencies: [format_quiz_text]
+            """,
+        )
+        index = build_index(project_root)
+
+        meta = index.get_action_metadata("format_quiz_text", yaml_file)
+        assert meta is not None
+        assert meta.name == "format_quiz_text"
+        assert meta.location.file_path == yaml_file
+
+    def test_multiple_upstream_workflows(self, tmp_path):
+        """Actions from multiple upstream workflows all resolve."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Multi-upstream
+            upstream:
+              - workflow: producer_a
+                actions: [action_from_a]
+              - workflow: producer_b
+                actions: [action_from_b]
+            actions:
+              - name: process
+                dependencies: [action_from_a, action_from_b]
+            """,
+        )
+        index = build_index(project_root)
+
+        assert index.get_action("action_from_a", yaml_file) is not None
+        assert index.get_action("action_from_b", yaml_file) is not None
+
+    def test_no_upstream_block_unchanged_behavior(self, tmp_path):
+        """Workflows without upstream: continue to work exactly as before."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "simple",
+            """\
+            name: simple
+            description: No upstream
+            actions:
+              - name: step_one
+                dependencies: []
+              - name: step_two
+                dependencies: [step_one]
+            """,
+        )
+        index = build_index(project_root)
+
+        assert index.get_action("step_one", yaml_file) is not None
+        assert index.get_action("step_two", yaml_file) is not None
+        assert "simple" not in index.upstream_actions
+
+    def test_malformed_upstream_ignored(self, tmp_path):
+        """Malformed upstream entries are silently skipped, not crashes."""
+        yaml_file, project_root = _create_workflow_project(
+            tmp_path,
+            "consumer",
+            """\
+            name: consumer
+            description: Bad upstream
+            upstream:
+              - not_a_dict
+              - workflow: producer
+                actions: not_a_list
+              - workflow: valid_producer
+                actions: [valid_action]
+            actions:
+              - name: process
+                dependencies: [valid_action]
+            """,
+        )
+        index = build_index(project_root)
+
+        # Only the valid entry should be indexed
+        assert index.get_action("valid_action", yaml_file) is not None
+        # The index should have exactly 1 upstream action for this workflow
+        assert len(index.upstream_actions.get("consumer", {})) == 1

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -187,6 +187,133 @@ def test_file_udf_result_list_source_index():
     assert results[0].data[0]["content"]["my_file_tool"]["merged"] is True
 
 
+# --- FileUDFResult synthetic records (source_index=None) ---
+
+
+def test_synthetic_record_carries_forward_namespaces():
+    """FileUDFResult with source_index=None gets namespaces from first input."""
+    pipeline, context = _make_pipeline_and_context()
+
+    udf_result = FileUDFResult(
+        outputs=[
+            {"source_index": None, "data": {"summary": "Combined result"}},
+        ],
+    )
+
+    input_data = [
+        {
+            "source_guid": "guid-1",
+            "content": {"upstream_action": {"question": "What is X?"}},
+        },
+        {
+            "source_guid": "guid-2",
+            "content": {"upstream_action": {"question": "What is Y?"}},
+        },
+    ]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(udf_result, True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.status == ProcessingStatus.SUCCESS
+    assert len(result.data) == 1
+    content = result.data[0]["content"]
+    # Upstream namespace carried forward from original_data[0]
+    assert "upstream_action" in content
+    assert content["upstream_action"]["question"] == "What is X?"
+    # Current action's namespace present
+    assert "my_file_tool" in content
+    assert content["my_file_tool"]["summary"] == "Combined result"
+    # Synthetic record does NOT inherit parent's source_guid
+    assert result.data[0].get("source_guid") != "guid-1"
+    assert result.data[0].get("source_guid") != "guid-2"
+
+
+def test_synthetic_record_empty_original_data():
+    """FileUDFResult with source_index=None and empty original_data does not crash."""
+    pipeline, context = _make_pipeline_and_context()
+
+    udf_result = FileUDFResult(
+        outputs=[
+            {"source_index": None, "data": {"summary": "Generated"}},
+        ],
+    )
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(udf_result, True),
+    ):
+        results = pipeline._process_file_mode_tool([], [], context)
+
+    assert len(results) == 1
+    result = results[0]
+    content = result.data[0]["content"]
+    # No upstream namespaces (nothing to carry forward)
+    assert "my_file_tool" in content
+    assert content["my_file_tool"]["summary"] == "Generated"
+
+
+def test_synthetic_mixed_with_sourced_records():
+    """FileUDFResult with both sourced and synthetic records in same batch."""
+    pipeline, context = _make_pipeline_and_context()
+
+    udf_result = FileUDFResult(
+        outputs=[
+            {"source_index": 0, "data": {"kept": True}},
+            {"source_index": None, "data": {"summary": "Aggregated"}},
+            {"source_index": 1, "data": {"kept": True}},
+        ],
+    )
+
+    input_data = [
+        {
+            "source_guid": "sg-1",
+            "content": {"prev": {"q": "Q1"}},
+        },
+        {
+            "source_guid": "sg-2",
+            "content": {"prev": {"q": "Q2"}},
+        },
+    ]
+
+    with patch(
+        "agent_actions.workflow.pipeline_file_mode.run_dynamic_agent",
+        return_value=(udf_result, True),
+    ):
+        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+
+    result = results[0]
+    assert len(result.data) == 3
+    assert result.source_mapping == {0: 0, 1: None, 2: 1}
+
+    # Sourced records inherit source_guid (via _reattach_source_guid)
+    assert result.data[0].get("source_guid") == "sg-1"
+    assert result.data[2].get("source_guid") == "sg-2"
+    # Synthetic record does NOT inherit parent's source_guid
+    assert result.data[1].get("source_guid") not in ("sg-1", "sg-2")
+
+    # All records have both upstream and action namespaces
+    for item in result.data:
+        assert "prev" in item["content"]
+        assert "my_file_tool" in item["content"]
+
+
+def test_file_udf_result_validates_source_index_type():
+    """FileUDFResult rejects non-int/non-list/non-None source_index."""
+    with pytest.raises(ValueError, match="must be int, list"):
+        FileUDFResult(outputs=[{"source_index": "bad", "data": {"x": 1}}])
+
+
+def test_file_udf_result_accepts_none_source_index():
+    """FileUDFResult accepts source_index=None without error."""
+    result = FileUDFResult(outputs=[{"source_index": None, "data": {"x": 1}}])
+    assert result.outputs[0]["source_index"] is None
+
+
 # --- Plain dict rejection ---
 
 
@@ -1082,6 +1209,24 @@ class TestReattachSourceGuid:
         # Cardinality mismatch (3 vs 2): no safe positional fallback
         for item in structured:
             assert "source_guid" not in item
+
+    def test_none_source_index_skips_guid_attachment(self):
+        """Synthetic records (source_index=None) do not inherit source_guid."""
+        from agent_actions.workflow.pipeline_file_mode import _reattach_source_guid
+
+        structured = [
+            {"content": {"val": 1}},  # mapped to input 0
+            {"content": {"val": 2}},  # synthetic (None)
+            {"content": {"val": 3}},  # mapped to input 1
+        ]
+        mapping = {0: 0, 1: None, 2: 1}
+        original = [{"source_guid": "sg-a"}, {"source_guid": "sg-b"}]
+
+        _reattach_source_guid(structured, mapping, original)
+
+        assert structured[0]["source_guid"] == "sg-a"
+        assert "source_guid" not in structured[1]  # Synthetic — skipped
+        assert structured[2]["source_guid"] == "sg-b"
 
 
 # --- _extract_business_fields unit tests ---


### PR DESCRIPTION
## Summary

Three bug fixes developed in parallel across clones 3, 4, and 5, merged into integration branch, staff-reviewed by 5 parallel agents, regression-tested (5878 tests pass).

### PR #381 — LSP upstream action resolution (Bug #11)
- LSP indexer now parses `upstream:` blocks from workflow YAML
- `get_action()` and `get_action_metadata()` check upstream after local actions
- Cross-workflow dependencies and context_scope refs no longer produce false error markers
- 8 new tests covering scoping, isolation, priority, malformed input

### PR #382 — Per-record disposition semantics (Bug #13)
- Guard-skipped records now write `DISPOSITION_PASSTHROUGH` instead of `DISPOSITION_SKIPPED`
- Aligns per-record semantics with node-level convention (data forwarded = PASSTHROUGH)
- Node-level `DISPOSITION_SKIPPED` unchanged (correct for "action produced no output")
- Updated smoke tests, simulation, and unit tests

### PR #383 — FILE tool synthetic records (Bug #29)
- `FileUDFResult` accepts `source_index: None` for synthetic output records
- `_resolve_input_record()` falls back to `original_data[0]` for namespace carry-forward
- `_reattach_source_guid()` skips GUID inheritance for synthetic records
- `LineageEnricher` gives synthetic records fresh lineage
- 7 new tests covering synthetic, mixed, empty, and validation scenarios

### Integration fixes (post-review)
- Smoke test `guards.py`: queries `DISPOSITION_PASSTHROUGH` for guard-skip checks
- Smoke test `schema_conformance.py`: excludes `DISPOSITION_PASSTHROUGH` from schema validation
- `ProcessingResult.source_mapping` type annotation widened to allow `None` values

## Verification

- 5878 tests pass, 0 failures
- `ruff format --check` clean
- `ruff check` clean
- 5 parallel staff-engineer reviews: correctness, blast radius, test quality, cross-PR interaction, CI
- All 3 PRs touch orthogonal subsystems — no cross-contamination

## Review findings addressed
- Smoke tests updated (would have reported false failures)
- Type annotation gap fixed on `ProcessingResult.source_mapping`
- LSP completions gap noted as future enhancement (not regression)