### PR TITLE
refactor: pipeline skip path uses RecordEnvelope

### DIFF
--- a/.changes/unreleased/Under the Hood-20260426-161000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-161000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Pipeline skip path now uses RecordEnvelope.build_skipped() instead of inline content mutation, unifying all content assembly under the single authority"
+time: 2026-04-26T16:10:00.000000Z

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -21,6 +21,7 @@ from agent_actions.processing.processor import RecordProcessor
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
 from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.storage.backend import (
     DISPOSITION_PASSTHROUGH,
     DISPOSITION_SKIPPED,
@@ -641,7 +642,11 @@ def _build_skipped_results(
         if action_name and isinstance(item, dict):
             content = item.get("content")
             if isinstance(content, dict) and action_name not in content:
-                item = {**item, "content": {**content, action_name: None}}
+                skipped_record = RecordEnvelope.build_skipped(action_name, item)
+                for key in item:
+                    if key not in skipped_record:
+                        skipped_record[key] = item[key]
+                item = skipped_record
         results.append(
             ProcessingResult.unprocessed(
                 data=[item],

--- a/tests/unit/workflow/test_file_mode_guard_prefilter.py
+++ b/tests/unit/workflow/test_file_mode_guard_prefilter.py
@@ -308,3 +308,50 @@ class TestBuildSkippedResults:
         assert len(results) == 1
         assert results[0].source_guid is None
         assert results[0].status == ProcessingStatus.UNPROCESSED
+
+    def test_action_name_adds_null_namespace(self):
+        """With action_name, adds null namespace via RecordEnvelope."""
+        skipped = [{"content": {"prev_action": {"key": "val"}}, "source_guid": "sg-1"}]
+        results = _build_skipped_results(skipped, action_name="my_action")
+
+        assert len(results) == 1
+        item = results[0].data[0]
+        assert item["content"]["my_action"] is None
+        assert item["content"]["prev_action"] == {"key": "val"}
+        assert item["source_guid"] == "sg-1"
+
+    def test_action_name_preserves_framework_fields(self):
+        """Framework fields (target_id, _unprocessed, metadata, batch_id) survive the envelope merge."""
+        skipped = [
+            {
+                "content": {"prev": {}},
+                "source_guid": "sg-1",
+                "target_id": "t-1",
+                "_unprocessed": True,
+                "metadata": {"key": "val"},
+                "batch_id": "b-1",
+            }
+        ]
+        results = _build_skipped_results(skipped, action_name="act")
+
+        item = results[0].data[0]
+        assert item["content"]["act"] is None
+        assert item["target_id"] == "t-1"
+        assert item["_unprocessed"] is True
+        assert item["metadata"] == {"key": "val"}
+        assert item["batch_id"] == "b-1"
+
+    def test_action_name_skips_when_already_present(self):
+        """If action_name already in content, no mutation occurs."""
+        skipped = [{"content": {"my_action": {"existing": True}}, "source_guid": "sg-1"}]
+        results = _build_skipped_results(skipped, action_name="my_action")
+
+        item = results[0].data[0]
+        assert item["content"]["my_action"] == {"existing": True}
+
+    def test_no_action_name_no_mutation(self):
+        """Without action_name, items pass through unmodified."""
+        original = {"content": {"score": 40}, "source_guid": "sg-1"}
+        results = _build_skipped_results([original])
+
+        assert results[0].data[0] is original


### PR DESCRIPTION
## Summary
- `_build_skipped_results` now uses `RecordEnvelope.build_skipped()` instead of inline `{**content, action_name: None}`
- All content assembly paths now use the single RecordEnvelope authority
- Framework fields from original item preserved via merge

## Verification
- 5882 tests pass, 0 failures
- ruff format + ruff check clean
- 4 new tests covering: null namespace via envelope, framework field preservation, already-present skip, no-mutation passthrough