### PR TITLE
cleanup: remove vestigial storage_backend param from FILE-mode observe

### DIFF
--- a/.changes/unreleased/Under the Hood-20260426-162000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-162000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove unused storage_backend parameter from apply_observe_for_file_mode — additive model reads from record content, no storage lookup needed"
+time: 2026-04-26T16:20:00.000000Z

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -70,7 +70,7 @@ def apply_observe_for_file_mode(
 
     With the additive content model, every previous action's output is
     stored under its namespace on each record.  Observe refs select
-    fields from these namespaces — no storage backend lookup required.
+    fields from these namespaces directly.
 
     The ``source`` namespace is the only cross-record reference: it is
     resolved from *source_data* (the original input file records).

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -2,10 +2,6 @@
 
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, Optional
-
-if TYPE_CHECKING:
-    from agent_actions.storage.backend import StorageBackend
 
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
@@ -69,7 +65,6 @@ def apply_observe_for_file_mode(
     agent_indices: dict[str, int] | None = None,
     file_path: str | None = None,
     source_data: list[dict] | None = None,
-    storage_backend: Optional["StorageBackend"] = None,
 ) -> list[dict]:
     """Namespace-aware observe filter for file-mode (array-level) data.
 

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -543,7 +543,6 @@ class ProcessingPipeline:
                 agent_indices=agent_indices,
                 file_path=file_path,
                 source_data=source_data,
-                storage_backend=self.config.storage_backend,
             )
 
             # Guards must run before FILE-mode processing because FILE mode

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -275,7 +275,7 @@ class TestApplyObserveForFileMode:
         """With namespaced content, no historical storage lookup is needed.
 
         All dependency data is on the record. This test verifies the function
-        works without agent_indices, file_path, or storage_backend.
+        works without agent_indices or file_path.
         """
         data = [
             {
@@ -292,7 +292,6 @@ class TestApplyObserveForFileMode:
             agent_name="summarize",
             agent_indices=None,
             file_path=None,
-            storage_backend=None,
         )
         assert result[0]["content"]["text"] == "hello"
         assert result[0]["content"]["topic"] == "science"


### PR DESCRIPTION
## Summary
- Removed unused `storage_backend` parameter from `apply_observe_for_file_mode()`
- Removed `storage_backend=` argument from caller in `pipeline.py`
- Removed vestigial `StorageBackend` TYPE_CHECKING import and unused `Optional` import
- Additive model reads from record content — no storage lookup needed

## Verification
- `pytest tests/unit/prompt/context/test_file_mode_observe.py` — 29/29 pass
- `pytest tests/integration/test_context_scope_audit.py tests/integration/test_context_scope_integrity.py` — 96/96 pass
- `pytest` — 5876 pass (2 pre-existing flakes: HITL server port conflict, unrelated)
- `ruff format --check` and `ruff check` — clean
- `grep -n "storage_backend" agent_actions/prompt/context/scope_file_mode.py` returns zero