### PR TITLE
cleanup: additive model audit — remove stale patterns, enforce single RecordEnvelope path

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-160000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-160000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Remove 3 stale content fallback patterns that could leak framework fields to LLM providers"
+time: 2026-04-26T16:00:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260426-161000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-161000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Pipeline skip path now uses RecordEnvelope.build_skipped() instead of inline content mutation, unifying all content assembly under the single authority"
+time: 2026-04-26T16:10:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260426-162000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-162000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove unused storage_backend parameter from apply_observe_for_file_mode — additive model reads from record content, no storage lookup needed"
+time: 2026-04-26T16:20:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260426-163000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-163000.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
-body: "Migrate 10 example tool scripts from banned data.get(\"content\", data) pattern to direct field access"
+body: "Migrate 11 example tool scripts across 6 projects from banned get(\"content\", data) pattern to direct field access"
 time: 2026-04-26T16:30:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260426-163000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-163000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Migrate 10 example tool scripts from banned data.get(\"content\", data) pattern to direct field access"
+time: 2026-04-26T16:30:00.000000Z

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -235,7 +235,7 @@ class BatchResultProcessor:
 
         if not ctx.agent_config or "action_name" not in ctx.agent_config:
             raise ValueError("agent_config must contain 'action_name' for content namespacing")
-        from agent_actions.utils.content import get_existing_content, is_version_merge
+        from agent_actions.utils.content import is_version_merge
 
         action_name = ctx.agent_config["action_name"]
         version_merge = is_version_merge(ctx.agent_config)
@@ -441,8 +441,6 @@ class BatchResultProcessor:
                             "RecoveryMetadata.retry is None for exhausted record "
                             f"custom_id={custom_id}; expected retry metadata with attempt count"
                         )
-                    from agent_actions.utils.content import get_existing_content
-
                     empty_content = ExhaustedRecordBuilder.build_empty_content(
                         ctx.agent_config or {}
                     )

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -17,6 +17,7 @@ from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 from agent_actions.processing.types import ProcessingResult, RecoveryMetadata
 from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
 
@@ -306,7 +307,7 @@ class BatchResultProcessor:
                 except ValueError:
                     passthrough_fields.append(field_ref)
 
-            original_content = original_row.get("content", {})
+            original_content = get_existing_content(original_row)
 
             generated_list = [
                 (

--- a/agent_actions/llm/providers/batch_base.py
+++ b/agent_actions/llm/providers/batch_base.py
@@ -97,7 +97,7 @@ class BaseBatchClient(ABC):
             batch_task = BatchTask(
                 custom_id=row.get("target_id", row.get("id", "")),
                 prompt=row.get("prompt", agent_config.get("prompt", "")),
-                user_content=json.dumps(row.get("content", row)),
+                user_content=json.dumps(row.get("content", {})),
                 model_config={
                     "model_name": agent_config.get("model_name", self._get_default_model()),
                     "temperature": agent_config.get("temperature", self._get_default_temperature()),

--- a/agent_actions/llm/providers/batch_base.py
+++ b/agent_actions/llm/providers/batch_base.py
@@ -94,10 +94,15 @@ class BaseBatchClient(ABC):
         schema = agent_config.get("compiled_schema") if json_mode else None
 
         for row in data:
+            if "content" not in row:
+                raise ValueError(
+                    f"Record {row.get('target_id', row.get('id', '?'))} missing 'content' key. "
+                    "Every record must have namespaced content in the additive model."
+                )
             batch_task = BatchTask(
                 custom_id=row.get("target_id", row.get("id", "")),
                 prompt=row.get("prompt", agent_config.get("prompt", "")),
-                user_content=json.dumps(row.get("content", {})),
+                user_content=json.dumps(row["content"]),
                 model_config={
                     "model_name": agent_config.get("model_name", self._get_default_model()),
                     "temperature": agent_config.get("temperature", self._get_default_temperature()),

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -70,7 +70,7 @@ def apply_observe_for_file_mode(
 
     With the additive content model, every previous action's output is
     stored under its namespace on each record.  Observe refs select
-    fields from these namespaces — no storage backend lookup required.
+    fields from these namespaces directly.
 
     The ``source`` namespace is the only cross-record reference: it is
     resolved from *source_data* (the original input file records).

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -2,10 +2,6 @@
 
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, Optional
-
-if TYPE_CHECKING:
-    from agent_actions.storage.backend import StorageBackend
 
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
@@ -69,7 +65,6 @@ def apply_observe_for_file_mode(
     agent_indices: dict[str, int] | None = None,
     file_path: str | None = None,
     source_data: list[dict] | None = None,
-    storage_backend: Optional["StorageBackend"] = None,
 ) -> list[dict]:
     """Namespace-aware observe filter for file-mode (array-level) data.
 

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -543,7 +543,6 @@ class ProcessingPipeline:
                 agent_indices=agent_indices,
                 file_path=file_path,
                 source_data=source_data,
-                storage_backend=self.config.storage_backend,
             )
 
             # Guards must run before FILE-mode processing because FILE mode

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -21,6 +21,7 @@ from agent_actions.processing.processor import RecordProcessor
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
 from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.storage.backend import (
     DISPOSITION_PASSTHROUGH,
     DISPOSITION_SKIPPED,
@@ -641,7 +642,11 @@ def _build_skipped_results(
         if action_name and isinstance(item, dict):
             content = item.get("content")
             if isinstance(content, dict) and action_name not in content:
-                item = {**item, "content": {**content, action_name: None}}
+                skipped_record = RecordEnvelope.build_skipped(action_name, item)
+                for key in item:
+                    if key not in skipped_record:
+                        skipped_record[key] = item[key]
+                item = skipped_record
         results.append(
             ProcessingResult.unprocessed(
                 data=[item],

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -554,6 +554,7 @@ def prefilter_by_guard(
         GuardBehavior,
         get_guard_evaluator,
     )
+    from agent_actions.utils.content import get_existing_content
 
     evaluator = get_guard_evaluator()
     # The config expander normalizes user-facing "on_false" into "behavior"
@@ -563,8 +564,7 @@ def prefilter_by_guard(
     skipped: list[dict] = []
     original_passing: list[dict] = []
     for idx, item in enumerate(data):
-        content = item.get("content", {})
-        eval_item = content if isinstance(content, dict) else {}
+        eval_item = get_existing_content(item)
 
         # context={} — see Note in docstring.
         result = evaluator.evaluate(

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -563,8 +563,8 @@ def prefilter_by_guard(
     skipped: list[dict] = []
     original_passing: list[dict] = []
     for idx, item in enumerate(data):
-        content = item.get("content", item)
-        eval_item = content if isinstance(content, dict) else {"_raw": content}
+        content = item.get("content", {})
+        eval_item = content if isinstance(content, dict) else {}
 
         # context={} — see Note in docstring.
         result = evaluator.evaluate(

--- a/examples/book_catalog_enrichment/tools/book_catalog_enrichment/select_for_users.py
+++ b/examples/book_catalog_enrichment/tools/book_catalog_enrichment/select_for_users.py
@@ -6,49 +6,47 @@ from agent_actions import udf_tool
 @udf_tool()
 def select_for_users(data: dict) -> dict:
     """Build SEO, management, and developer views from the enriched catalog entry."""
-    content = data.get("content", data)
-
     seo_view = {
-        "isbn": content.get("isbn", ""),
-        "title": content.get("title", ""),
-        "meta_title": content.get("meta_title", ""),
-        "meta_description": content.get("meta_description", ""),
-        "seo_keywords": content.get("seo_keywords", []),
-        "target_audience": content.get("target_audience", ""),
-        "marketing_description": content.get("full_description", ""),
-        "hook_sentence": content.get("short_description", ""),
-        "key_selling_points": content.get("key_selling_points", []),
+        "isbn": data.get("isbn", ""),
+        "title": data.get("title", ""),
+        "meta_title": data.get("meta_title", ""),
+        "meta_description": data.get("meta_description", ""),
+        "seo_keywords": data.get("seo_keywords", []),
+        "target_audience": data.get("target_audience", ""),
+        "marketing_description": data.get("full_description", ""),
+        "hook_sentence": data.get("short_description", ""),
+        "key_selling_points": data.get("key_selling_points", []),
     }
 
     management_view = {
-        "isbn": content.get("isbn", ""),
-        "title": content.get("title", ""),
-        "catalog_id": content.get("catalog_id", ""),
-        "quality_score": content.get("quality_score", 0),
-        "publication_ready": content.get("publication_ready", False),
-        "primary_category": content.get("primary_category", ""),
-        "target_audience": content.get("target_audience", ""),
-        "enriched_fields": content.get("enriched_fields", []),
-        "enrichment_version": content.get("enrichment_version", ""),
-        "filter_reason": content.get("filter_reason", ""),
+        "isbn": data.get("isbn", ""),
+        "title": data.get("title", ""),
+        "catalog_id": data.get("catalog_id", ""),
+        "quality_score": data.get("quality_score", 0),
+        "publication_ready": data.get("publication_ready", False),
+        "primary_category": data.get("primary_category", ""),
+        "target_audience": data.get("target_audience", ""),
+        "enriched_fields": data.get("enriched_fields", []),
+        "enrichment_version": data.get("enrichment_version", ""),
+        "filter_reason": data.get("filter_reason", ""),
     }
 
     developer_view = {
-        "isbn": content.get("isbn", ""),
-        "title": content.get("title", ""),
-        "bisac_codes": content.get("bisac_codes", []),
-        "primary_category": content.get("primary_category", ""),
-        "difficulty_level": content.get("difficulty_level", ""),
-        "experience_required": content.get("experience_required", ""),
-        "prerequisites": content.get("prerequisites", []),
-        "reading_time_hours": content.get("reading_time_hours", ""),
-        "similar_titles": content.get("similar_titles", []),
-        "reading_path": content.get("reading_path", ""),
+        "isbn": data.get("isbn", ""),
+        "title": data.get("title", ""),
+        "bisac_codes": data.get("bisac_codes", []),
+        "primary_category": data.get("primary_category", ""),
+        "difficulty_level": data.get("difficulty_level", ""),
+        "experience_required": data.get("experience_required", ""),
+        "prerequisites": data.get("prerequisites", []),
+        "reading_time_hours": data.get("reading_time_hours", ""),
+        "similar_titles": data.get("similar_titles", []),
+        "reading_path": data.get("reading_path", ""),
     }
 
     return {
-        "isbn": content.get("isbn", ""),
-        "title": content.get("title", ""),
+        "isbn": data.get("isbn", ""),
+        "title": data.get("title", ""),
         "seo_view": seo_view,
         "management_view": management_view,
         "developer_view": developer_view,

--- a/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
+++ b/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
@@ -1,8 +1,8 @@
 """
 Aggregate all clause-level risk analyses into a unified contract risk report.
 
-FILE granularity — receives ALL clause records at once (full records with
-content, node_id, lineage) and emits a single aggregated summary. This is
+FILE granularity — receives ALL clause records at once and emits a single
+aggregated summary. This is
 the REDUCE step of the Map-Reduce pattern.
 
 Since this tool creates a NEW record (not derived from a single input),
@@ -49,8 +49,7 @@ def aggregate_clause_analyses(data: list[dict[str, Any]]) -> list[dict[str, Any]
         ]
 
     # Extract contract metadata from the first record's source namespace
-    first_content = data[0].get("content", data[0])
-    first_source = first_content.get("source", {})
+    first_source = data[0].get("source", {})
     contract_id = first_source.get("contract_id", "unknown")
     contract_title = first_source.get("title", "unknown")
     parties = first_source.get("parties", [])
@@ -64,9 +63,8 @@ def aggregate_clause_analyses(data: list[dict[str, Any]]) -> list[dict[str, Any]
     negotiation_items: list[dict[str, Any]] = []
 
     for record in data:
-        content = record.get("content", record)
-        analysis = content.get("analyze_clause", {})
-        clause_meta = content.get("split_into_clauses", {})
+        analysis = record.get("analyze_clause", {})
+        clause_meta = record.get("split_into_clauses", {})
 
         risk_level = analysis.get("risk_level", "low")
         risk_score = analysis.get("risk_score", 0.0)

--- a/examples/incident_triage/docs/PATTERNS.md
+++ b/examples/incident_triage/docs/PATTERNS.md
@@ -37,12 +37,10 @@ These workflows showcase **production-ready patterns** inspired by [Incident.io]
 ```python
 @udf_tool()
 def aggregate_severity_votes(data: Dict[str, Any]) -> Dict[str, Any]:
-    content = data.get('content', data)
-
     # Collect from all versions
     votes = []
     for i in range(1, 4):
-        classifier_data = content.get(f'classify_severity_{i}', {})
+        classifier_data = data.get(f'classify_severity_{i}', {})
         votes.append({
             'severity': classifier_data.get('severity'),
             'confidence': classifier_data.get('confidence')
@@ -96,11 +94,9 @@ def assign_team_based_on_impact(data: Dict) -> Dict:
     """
     With passthrough: Return dict (not list) with ONLY new fields
     """
-    content = data.get('content', data)
-
     # Extract what you need
-    severity = content.get('final_severity')
-    affected = content.get('affected_services')
+    severity = data.get('final_severity')
+    affected = data.get('affected_services')
 
     # Compute dynamic values
     teams = route_to_teams(severity, affected)
@@ -245,18 +241,16 @@ version_consumption:
 @udf_tool()
 def format_incident_triage(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Format complete triage output"""
-    content = data.get('content', data)
-
     # Build structured output
     result = {
-        "triage_id": content.get('source_guid'),
+        "triage_id": data.get('source_guid'),
         "incident": {
-            "title": content.get('title'),
-            "severity": content.get('final_severity')
+            "title": data.get('title'),
+            "severity": data.get('final_severity')
         },
         "teams": {
-            "assigned_teams": content.get('assigned_teams'),
-            "urgency_level": content.get('urgency_level')
+            "assigned_teams": data.get('assigned_teams'),
+            "urgency_level": data.get('urgency_level')
         }
     }
 

--- a/examples/incident_triage/tools/incident_triage/aggregate_severity_votes.py
+++ b/examples/incident_triage/tools/incident_triage/aggregate_severity_votes.py
@@ -24,13 +24,11 @@ def aggregate_severity_votes(data: dict[str, Any]) -> dict[str, Any]:
     Pattern: Version consumption with merge pattern
     Returns: Dict (not list) when using passthrough
     """
-    content = data.get("content", data)
-
     # Collect votes from all classifiers
     votes = []
     for i in range(1, 4):
         classifier_key = f"classify_severity_{i}"
-        classifier_data = content.get(classifier_key, {})
+        classifier_data = data.get(classifier_key, {})
 
         if isinstance(classifier_data, dict):
             severity = classifier_data.get("severity", "SEV5")

--- a/examples/incident_triage/tools/incident_triage/assign_team_based_on_impact.py
+++ b/examples/incident_triage/tools/incident_triage/assign_team_based_on_impact.py
@@ -53,15 +53,13 @@ def assign_team_based_on_impact(data: dict[str, Any]) -> dict[str, Any]:
     Pattern: Content injection with passthrough + seed data enrichment
     Returns: Dict with ONLY new fields (passthrough handles the rest)
     """
-    content = data.get("content", data)
-
     # Extract context
-    severity = content.get("final_severity", "SEV3")
-    affected_services = content.get("affected_services", [])
+    severity = data.get("final_severity", "SEV3")
+    affected_services = data.get("affected_services", [])
 
     # Get seed data for enrichment
-    team_roster = content.get("team_roster", {}).get("oncall_teams", {})
-    service_catalog = content.get("service_catalog", {}).get("services", {})
+    team_roster = data.get("team_roster", {}).get("oncall_teams", {})
+    service_catalog = data.get("service_catalog", {}).get("services", {})
 
     # Initialize variables with defaults to avoid unbound errors
     primary_team = None

--- a/examples/incident_triage/tools/incident_triage/format_incident_triage.py
+++ b/examples/incident_triage/tools/incident_triage/format_incident_triage.py
@@ -16,67 +16,65 @@ def format_incident_triage(data: dict[str, Any]) -> list[dict[str, Any]]:
     Pattern: Field forwarding with structured output
     Returns: List[Dict] (standard pattern)
     """
-    content = data.get("content", data)
-
     # Extract all components
     incident_details = {
-        "title": content.get("title", "Unknown Incident"),
-        "description": content.get("description", ""),
-        "affected_systems": content.get("affected_systems", []),
-        "reporter_priority": content.get("reporter_priority", "UNKNOWN"),
+        "title": data.get("title", "Unknown Incident"),
+        "description": data.get("description", ""),
+        "affected_systems": data.get("affected_systems", []),
+        "reporter_priority": data.get("reporter_priority", "UNKNOWN"),
     }
 
     severity_assessment = {
-        "final_severity": content.get("final_severity", "SEV5"),
-        "confidence_score": content.get("confidence_score", 0.0),
-        "is_split_decision": content.get("is_split_decision", False),
-        "vote_summary": content.get("vote_summary", ""),
+        "final_severity": data.get("final_severity", "SEV5"),
+        "confidence_score": data.get("confidence_score", 0.0),
+        "is_split_decision": data.get("is_split_decision", False),
+        "vote_summary": data.get("vote_summary", ""),
     }
 
     impact_assessment = {
         "customer_impact": {
-            "level": content.get("customer_impact_level", "UNKNOWN"),
-            "affected_count": content.get("affected_customer_count_estimate", ""),
-            "revenue_impact": content.get("revenue_impact_estimate", ""),
-            "customer_facing": content.get("customer_facing", False),
+            "level": data.get("customer_impact_level", "UNKNOWN"),
+            "affected_count": data.get("affected_customer_count_estimate", ""),
+            "revenue_impact": data.get("revenue_impact_estimate", ""),
+            "customer_facing": data.get("customer_facing", False),
         },
         "system_impact": {
-            "level": content.get("system_impact_level", "UNKNOWN"),
-            "affected_services": content.get("affected_services", []),
-            "degradation": content.get("degradation_percentage", ""),
-            "cascading_risk": content.get("cascading_failure_risk", ""),
+            "level": data.get("system_impact_level", "UNKNOWN"),
+            "affected_services": data.get("affected_services", []),
+            "degradation": data.get("degradation_percentage", ""),
+            "cascading_risk": data.get("cascading_failure_risk", ""),
         },
     }
 
     team_assignment = {
-        "assigned_teams": content.get("assigned_teams", []),
-        "primary_system": content.get("primary_system", "unknown"),
-        "urgency_level": content.get("urgency_level", ""),
-        "escalation_path": content.get("escalation_path", []),
+        "assigned_teams": data.get("assigned_teams", []),
+        "primary_system": data.get("primary_system", "unknown"),
+        "urgency_level": data.get("urgency_level", ""),
+        "escalation_path": data.get("escalation_path", []),
     }
 
     response_plan = {
-        "immediate_actions": content.get("immediate_actions", []),
-        "investigation_steps": content.get("investigation_steps", []),
-        "communication_plan": content.get("communication_plan", ""),
-        "escalation_criteria": content.get("escalation_criteria", []),
-        "estimated_tte": content.get("estimated_tte", "TBD"),
+        "immediate_actions": data.get("immediate_actions", []),
+        "investigation_steps": data.get("investigation_steps", []),
+        "communication_plan": data.get("communication_plan", ""),
+        "escalation_criteria": data.get("escalation_criteria", []),
+        "estimated_tte": data.get("estimated_tte", "TBD"),
     }
 
     # Executive summary (if present, empty object if not — schema requires object type)
     executive_summary = {}
-    if content.get("executive_summary"):
+    if data.get("executive_summary"):
         executive_summary = {
-            "summary": content.get("executive_summary", ""),
-            "business_impact": content.get("business_impact_summary", ""),
-            "response_status": content.get("response_status", ""),
-            "stakeholders": content.get("key_stakeholders", []),
+            "summary": data.get("executive_summary", ""),
+            "business_impact": data.get("business_impact_summary", ""),
+            "response_status": data.get("response_status", ""),
+            "stakeholders": data.get("key_stakeholders", []),
         }
 
     # Build complete triage output
     result = {
-        "triage_id": content.get("source_guid", "unknown"),
-        "timestamp": content.get("timestamp", ""),
+        "triage_id": data.get("source_guid", "unknown"),
+        "timestamp": data.get("timestamp", ""),
         "incident": incident_details,
         "severity": severity_assessment,
         "impact": impact_assessment,
@@ -85,9 +83,7 @@ def format_incident_triage(data: dict[str, Any]) -> list[dict[str, Any]]:
         "executive_summary": executive_summary,
         "metadata": {
             "workflow_version": "1.0.0",
-            "requires_executive_notification": content.get(
-                "requires_executive_notification", False
-            ),
+            "requires_executive_notification": data.get("requires_executive_notification", False),
             "triage_completed": True,
         },
     }

--- a/examples/product_listing_enrichment/tools/product_listing_enrichment/fetch_competitor_prices.py
+++ b/examples/product_listing_enrichment/tools/product_listing_enrichment/fetch_competitor_prices.py
@@ -69,11 +69,9 @@ def fetch_competitor_prices(data: dict[str, Any]) -> dict[str, Any]:
     Produces 3-5 competitor entries with realistic price variance and
     a market positioning summary.
     """
-    content = data.get("content", data)
-
-    current_price = float(content.get("current_price", 100.0))
-    category = content.get("product_category", "general")
-    keywords = content.get("search_keywords", [])
+    current_price = float(data.get("current_price", 100.0))
+    category = data.get("product_category", "general")
+    keywords = data.get("search_keywords", [])
 
     # Use keywords as part of the seed for deterministic but varied results
     keyword_seed = "_".join(sorted(keywords[:3])) if keywords else category

--- a/examples/product_listing_enrichment/tools/product_listing_enrichment/format_marketplace_listing.py
+++ b/examples/product_listing_enrichment/tools/product_listing_enrichment/format_marketplace_listing.py
@@ -22,23 +22,21 @@ def format_marketplace_listing(data: dict[str, Any]) -> dict[str, Any]:
     Combines outputs from all upstream actions into a single structured
     listing ready for marketplace upload.
     """
-    content = data.get("content", data)
-
     # Source metadata (via passthrough)
-    product_id = content.get("product_id", "")
-    product_name = content.get("product_name", "")
-    brand = content.get("brand", "")
-    current_price = content.get("current_price", 0)
-    category = content.get("product_category", "")
+    product_id = data.get("product_id", "")
+    product_name = data.get("product_name", "")
+    brand = data.get("brand", "")
+    current_price = data.get("current_price", 0)
+    category = data.get("product_category", "")
 
     # Helper: the framework flattens observed fields into content directly.
     # content["listing_title"] not content["write_marketing_copy"]["listing_title"].
     # Try nested (action namespace) first, fall back to flat (direct fields).
     def _ns(action_name: str, field: str, default=None):
-        nested = content.get(action_name, {})
+        nested = data.get(action_name, {})
         if isinstance(nested, dict) and field in nested:
             return nested[field]
-        return content.get(field, default)
+        return data.get(field, default)
 
     # Marketing copy from write_marketing_copy
     listing_title = _ns("write_marketing_copy", "listing_title", "")

--- a/examples/product_listing_enrichment/tools/product_listing_enrichment/format_marketplace_listing.py
+++ b/examples/product_listing_enrichment/tools/product_listing_enrichment/format_marketplace_listing.py
@@ -29,8 +29,8 @@ def format_marketplace_listing(data: dict[str, Any]) -> dict[str, Any]:
     current_price = data.get("current_price", 0)
     category = data.get("product_category", "")
 
-    # Helper: the framework flattens observed fields into content directly.
-    # content["listing_title"] not content["write_marketing_copy"]["listing_title"].
+    # Helper: the framework flattens observed fields into data directly.
+    # data["listing_title"] not data["write_marketing_copy"]["listing_title"].
     # Try nested (action namespace) first, fall back to flat (direct fields).
     def _ns(action_name: str, field: str, default=None):
         nested = data.get(action_name, {})

--- a/examples/product_listing_enrichment/tools/product_listing_enrichment/validate_marketplace_compliance.py
+++ b/examples/product_listing_enrichment/tools/product_listing_enrichment/validate_marketplace_compliance.py
@@ -19,32 +19,30 @@ def validate_marketplace_compliance(data: dict[str, Any]) -> dict[str, Any]:
     Reads write_marketing_copy output and seed_data.marketplace_rules.
     Returns per-field results and overall compliance status.
     """
-    content = data.get("content", data)
-
     # Extract marketing copy fields
     # Fields from observe: write_marketing_copy.* are flattened into content
     # Try nested first (action namespace), then flat (direct fields)
-    write_marketing_copy = content.get("write_marketing_copy", {})
+    write_marketing_copy = data.get("write_marketing_copy", {})
     if isinstance(write_marketing_copy, dict) and write_marketing_copy:
         listing_title = write_marketing_copy.get("listing_title", "")
         listing_description = write_marketing_copy.get("listing_description", "")
         bullet_points = write_marketing_copy.get("bullet_points", [])
         search_keywords = write_marketing_copy.get("search_keywords", [])
     else:
-        listing_title = content.get("listing_title", "")
-        listing_description = content.get("listing_description", "")
-        bullet_points = content.get("bullet_points", [])
-        search_keywords = content.get("search_keywords", [])
+        listing_title = data.get("listing_title", "")
+        listing_description = data.get("listing_description", "")
+        bullet_points = data.get("bullet_points", [])
+        search_keywords = data.get("search_keywords", [])
 
     # Extract marketplace rules (seed data arrives under "seed" namespace)
-    seed = content.get("seed", {})
+    seed = data.get("seed", {})
     if isinstance(seed, dict):
         marketplace_rules = seed.get("marketplace_rules", {})
     else:
         marketplace_rules = {}
     # Fallback: try top-level for backwards compatibility
     if not marketplace_rules:
-        marketplace_rules = content.get("marketplace_rules", {})
+        marketplace_rules = data.get("marketplace_rules", {})
     if not isinstance(marketplace_rules, dict):
         marketplace_rules = {}
 
@@ -53,7 +51,6 @@ def validate_marketplace_compliance(data: dict[str, Any]) -> dict[str, Any]:
     bullet_rules = marketplace_rules.get("bullet_points", {})
     keyword_rules = marketplace_rules.get("search_keywords", {})
     required_fields = marketplace_rules.get("required_fields", [])
-    prohibited_content = marketplace_rules.get("prohibited_content", [])
 
     field_results = []
     violations = []
@@ -207,8 +204,22 @@ def validate_marketplace_compliance(data: dict[str, Any]) -> dict[str, Any]:
     all_text_lower = all_text.lower()
 
     prohibited_patterns = {
-        "unsubstantiated superlatives": ["best", "#1", "top-rated", "number one", "world's best", "industry-leading"],
-        "pricing or discount language": ["% off", "discount", "sale", "limited time", "free shipping", "buy now"],
+        "unsubstantiated superlatives": [
+            "best",
+            "#1",
+            "top-rated",
+            "number one",
+            "world's best",
+            "industry-leading",
+        ],
+        "pricing or discount language": [
+            "% off",
+            "discount",
+            "sale",
+            "limited time",
+            "free shipping",
+            "buy now",
+        ],
         "contact information or external URLs": ["http://", "https://", "www.", ".com", "@"],
     }
 
@@ -217,40 +228,46 @@ def validate_marketplace_compliance(data: dict[str, Any]) -> dict[str, Any]:
             if pattern.lower() in all_text_lower:
                 all_passed = False
                 violations.append(f"Prohibited content ({category}): found '{pattern}'")
-                field_results.append({
-                    "field_name": "prohibited_content",
-                    "passed": False,
-                    "actual_length": 0,
-                    "max_allowed": 0,
-                    "message": f"Prohibited content: '{pattern}' found ({category})",
-                })
+                field_results.append(
+                    {
+                        "field_name": "prohibited_content",
+                        "passed": False,
+                        "actual_length": 0,
+                        "max_allowed": 0,
+                        "message": f"Prohibited content: '{pattern}' found ({category})",
+                    }
+                )
                 break  # one violation per category is enough
 
     # --- Brand name in title check ---
-    brand = content.get("brand", "") or content.get("write_marketing_copy", {}).get("brand", "")
+    brand = data.get("brand", "") or data.get("write_marketing_copy", {}).get("brand", "")
     if brand and brand.lower() not in listing_title.lower():
         all_passed = False
         violations.append(f"Title must include brand name '{brand}'")
-        field_results.append({
-            "field_name": "title_brand_name",
-            "passed": False,
-            "actual_length": 0,
-            "max_allowed": 0,
-            "message": f"Brand name '{brand}' not found in title",
-        })
+        field_results.append(
+            {
+                "field_name": "title_brand_name",
+                "passed": False,
+                "actual_length": 0,
+                "max_allowed": 0,
+                "message": f"Brand name '{brand}' not found in title",
+            }
+        )
 
     # --- Bullet capitalization check ---
     for idx, bullet in enumerate(bullet_points):
         if bullet and not bullet[0].isupper():
             all_passed = False
             violations.append(f"Bullet {idx + 1} must start with a capitalized keyword")
-            field_results.append({
-                "field_name": f"bullet_{idx + 1}_capitalization",
-                "passed": False,
-                "actual_length": 0,
-                "max_allowed": 0,
-                "message": f"Bullet {idx + 1} does not start with a capital letter",
-            })
+            field_results.append(
+                {
+                    "field_name": f"bullet_{idx + 1}_capitalization",
+                    "passed": False,
+                    "actual_length": 0,
+                    "max_allowed": 0,
+                    "message": f"Bullet {idx + 1} does not start with a capital letter",
+                }
+            )
 
     # --- Required fields check ---
     present_fields = set()

--- a/examples/product_listing_enrichment/tools/product_listing_enrichment/validate_marketplace_compliance.py
+++ b/examples/product_listing_enrichment/tools/product_listing_enrichment/validate_marketplace_compliance.py
@@ -20,7 +20,7 @@ def validate_marketplace_compliance(data: dict[str, Any]) -> dict[str, Any]:
     Returns per-field results and overall compliance status.
     """
     # Extract marketing copy fields
-    # Fields from observe: write_marketing_copy.* are flattened into content
+    # Fields from observe: write_marketing_copy.* are flattened into data
     # Try nested first (action namespace), then flat (direct fields)
     write_marketing_copy = data.get("write_marketing_copy", {})
     if isinstance(write_marketing_copy, dict) and write_marketing_copy:
@@ -240,7 +240,7 @@ def validate_marketplace_compliance(data: dict[str, Any]) -> dict[str, Any]:
                 break  # one violation per category is enough
 
     # --- Brand name in title check ---
-    brand = data.get("brand", "") or data.get("write_marketing_copy", {}).get("brand", "")
+    brand = data.get("brand", "") or write_marketing_copy.get("brand", "")
     if brand and brand.lower() not in listing_title.lower():
         all_passed = False
         violations.append(f"Title must include brand name '{brand}'")

--- a/examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py
+++ b/examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py
@@ -32,7 +32,7 @@ def aggregate_quality_scores(data: dict[str, Any]) -> dict[str, Any]:
         scorer_key = f"score_quality_{i}"
         scorer_ns = data.get(scorer_key, {})
 
-        # Namespaced data model: scorer fields are at content[scorer_key][scorer_key]
+        # Namespaced data model: scorer fields are at data[scorer_key][scorer_key]
         scorer_data = scorer_ns.get(scorer_key, scorer_ns) if isinstance(scorer_ns, dict) else {}
 
         if not isinstance(scorer_data, dict):

--- a/examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py
+++ b/examples/review_analyzer/tools/review_analyzer/aggregate_quality_scores.py
@@ -23,8 +23,6 @@ def aggregate_quality_scores(data: dict[str, Any]) -> dict[str, Any]:
     Accesses versioned outputs: score_quality_1, score_quality_2, score_quality_3.
     Returns consensus score, spread, and combined insights.
     """
-    content = data.get("content", data)
-
     # Collect scores from all scorers
     scores = []
     all_reasoning = []
@@ -32,7 +30,7 @@ def aggregate_quality_scores(data: dict[str, Any]) -> dict[str, Any]:
 
     for i in range(1, 4):
         scorer_key = f"score_quality_{i}"
-        scorer_ns = content.get(scorer_key, {})
+        scorer_ns = data.get(scorer_key, {})
 
         # Namespaced data model: scorer fields are at content[scorer_key][scorer_key]
         scorer_data = scorer_ns.get(scorer_key, scorer_ns) if isinstance(scorer_ns, dict) else {}

--- a/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
+++ b/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
@@ -16,7 +16,7 @@ def format_analysis_output(data: dict[str, Any]) -> dict[str, Any]:
     Fields arrive flat in content from context_scope.observe — not nested
     under action names.
     """
-    # Namespaced data model: fields are at content[namespace][field]
+    # Namespaced data model: fields are at data[namespace][field]
     source_ns = data.get("source", {})
     extract_ns = data.get("extract_claims", {})
     agg_ns = data.get("aggregate_scores", {})

--- a/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
+++ b/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
@@ -13,7 +13,7 @@ from agent_actions import udf_tool
 def format_analysis_output(data: dict[str, Any]) -> dict[str, Any]:
     """Package review analysis, merchant response, and product insights.
 
-    Fields arrive flat in content from context_scope.observe — not nested
+    Fields arrive flat in data from context_scope.observe — not nested
     under action names.
     """
     # Namespaced data model: fields are at data[namespace][field]

--- a/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
+++ b/examples/review_analyzer/tools/review_analyzer/format_analysis_output.py
@@ -16,14 +16,12 @@ def format_analysis_output(data: dict[str, Any]) -> dict[str, Any]:
     Fields arrive flat in content from context_scope.observe — not nested
     under action names.
     """
-    content = data.get("content", data)
-
     # Namespaced data model: fields are at content[namespace][field]
-    source_ns = content.get("source", {})
-    extract_ns = content.get("extract_claims", {})
-    agg_ns = content.get("aggregate_scores", {})
-    response_ns = content.get("generate_response", {})
-    insights_ns = content.get("extract_product_insights", {})
+    source_ns = data.get("source", {})
+    extract_ns = data.get("extract_claims", {})
+    agg_ns = data.get("aggregate_scores", {})
+    response_ns = data.get("generate_response", {})
+    insights_ns = data.get("extract_product_insights", {})
 
     source = {
         "review_id": source_ns.get("review_id", ""),

--- a/examples/support_resolution/tools/support_resolution/package_triage_result.py
+++ b/examples/support_resolution/tools/support_resolution/package_triage_result.py
@@ -6,36 +6,36 @@ from agent_actions import udf_tool
 @udf_tool()
 def package_triage_result(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Assemble all upstream fields into a final triage record."""
-    content = data.get("content", data)
-
     # Source fields (flattened from source.*)
-    source = content.get("source", {})
+    source = data.get("source", {})
     if isinstance(source, dict):
-        ticket_id = source.get("id", content.get("id", "unknown"))
-        title = source.get("title", content.get("title", ""))
-        reporter = source.get("reporter", content.get("reporter", ""))
+        ticket_id = source.get("id", data.get("id", "unknown"))
+        title = source.get("title", data.get("title", ""))
+        reporter = source.get("reporter", data.get("reporter", ""))
     else:
-        ticket_id = content.get("id", "unknown")
-        title = content.get("title", "")
-        reporter = content.get("reporter", "")
+        ticket_id = data.get("id", "unknown")
+        title = data.get("title", "")
+        reporter = data.get("reporter", "")
 
     # output_field values arrive under the ACTION name, not the field name
-    issue_type = content.get("classify_issue", content.get("issue_type", "unclassified"))
-    severity = content.get("assess_severity", content.get("severity", "medium"))
-    product_area = content.get("identify_area", content.get("product_area", "unknown"))
-    assigned_team = content.get("assign_team", content.get("assigned_team", "support"))
-    summary = content.get("summarize_issue", content.get("summary", ""))
-    suggested_response = content.get("draft_response", content.get("suggested_response", ""))
+    issue_type = data.get("classify_issue", data.get("issue_type", "unclassified"))
+    severity = data.get("assess_severity", data.get("severity", "medium"))
+    product_area = data.get("identify_area", data.get("product_area", "unknown"))
+    assigned_team = data.get("assign_team", data.get("assigned_team", "support"))
+    summary = data.get("summarize_issue", data.get("summary", ""))
+    suggested_response = data.get("draft_response", data.get("suggested_response", ""))
 
-    return [{
-        "ticket_id": ticket_id,
-        "title": title,
-        "reporter": reporter,
-        "issue_type": issue_type,
-        "severity": severity,
-        "product_area": product_area,
-        "assigned_team": assigned_team,
-        "summary": summary,
-        "suggested_response": suggested_response,
-        "status": "triaged",
-    }]
+    return [
+        {
+            "ticket_id": ticket_id,
+            "title": title,
+            "reporter": reporter,
+            "issue_type": issue_type,
+            "severity": severity,
+            "product_area": product_area,
+            "assigned_team": assigned_team,
+            "summary": summary,
+            "suggested_response": suggested_response,
+            "status": "triaged",
+        }
+    ]

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -275,7 +275,7 @@ class TestApplyObserveForFileMode:
         """With namespaced content, no historical storage lookup is needed.
 
         All dependency data is on the record. This test verifies the function
-        works without agent_indices, file_path, or storage_backend.
+        works without agent_indices or file_path.
         """
         data = [
             {
@@ -292,7 +292,6 @@ class TestApplyObserveForFileMode:
             agent_name="summarize",
             agent_indices=None,
             file_path=None,
-            storage_backend=None,
         )
         assert result[0]["content"]["text"] == "hello"
         assert result[0]["content"]["topic"] == "science"

--- a/tests/unit/workflow/test_file_mode_guard_prefilter.py
+++ b/tests/unit/workflow/test_file_mode_guard_prefilter.py
@@ -308,3 +308,50 @@ class TestBuildSkippedResults:
         assert len(results) == 1
         assert results[0].source_guid is None
         assert results[0].status == ProcessingStatus.UNPROCESSED
+
+    def test_action_name_adds_null_namespace(self):
+        """With action_name, adds null namespace via RecordEnvelope."""
+        skipped = [{"content": {"prev_action": {"key": "val"}}, "source_guid": "sg-1"}]
+        results = _build_skipped_results(skipped, action_name="my_action")
+
+        assert len(results) == 1
+        item = results[0].data[0]
+        assert item["content"]["my_action"] is None
+        assert item["content"]["prev_action"] == {"key": "val"}
+        assert item["source_guid"] == "sg-1"
+
+    def test_action_name_preserves_framework_fields(self):
+        """Framework fields (target_id, _unprocessed, metadata, batch_id) survive the envelope merge."""
+        skipped = [
+            {
+                "content": {"prev": {}},
+                "source_guid": "sg-1",
+                "target_id": "t-1",
+                "_unprocessed": True,
+                "metadata": {"key": "val"},
+                "batch_id": "b-1",
+            }
+        ]
+        results = _build_skipped_results(skipped, action_name="act")
+
+        item = results[0].data[0]
+        assert item["content"]["act"] is None
+        assert item["target_id"] == "t-1"
+        assert item["_unprocessed"] is True
+        assert item["metadata"] == {"key": "val"}
+        assert item["batch_id"] == "b-1"
+
+    def test_action_name_skips_when_already_present(self):
+        """If action_name already in content, no mutation occurs."""
+        skipped = [{"content": {"my_action": {"existing": True}}, "source_guid": "sg-1"}]
+        results = _build_skipped_results(skipped, action_name="my_action")
+
+        item = results[0].data[0]
+        assert item["content"]["my_action"] == {"existing": True}
+
+    def test_no_action_name_no_mutation(self):
+        """Without action_name, items pass through unmodified."""
+        original = {"content": {"score": 40}, "source_guid": "sg-1"}
+        results = _build_skipped_results([original])
+
+        assert results[0].data[0] is original

--- a/tests/unit/workflow/test_file_mode_guard_prefilter.py
+++ b/tests/unit/workflow/test_file_mode_guard_prefilter.py
@@ -249,10 +249,10 @@ class TestPrefilterByGuard:
         assert original_passing == []
 
     def test_non_dict_content(self):
-        """Non-dict content wraps as {_raw: content} for evaluation."""
+        """Non-dict content yields empty eval_item — guard cannot match."""
         data = [{"content": "plain-text-value"}]
         config = {"guard": {"clause": "always_true", "behavior": "filter"}}
-        evaluator = _make_evaluator(lambda item: "_raw" in item)
+        evaluator = _make_evaluator(lambda item: bool(item))
 
         with patch(
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
@@ -260,11 +260,10 @@ class TestPrefilterByGuard:
         ):
             passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
 
-        assert len(passing) == 1
-        assert passing[0]["content"] == "plain-text-value"
+        assert len(passing) == 0
 
     def test_missing_content_key(self):
-        """Item without content key -> item itself used as eval_item."""
+        """Item without content key yields empty eval_item — guard cannot match."""
         data = [{"score": 90, "name": "Alice"}]
         config = {"guard": {"clause": "score >= 80", "behavior": "filter"}}
         evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
@@ -275,7 +274,7 @@ class TestPrefilterByGuard:
         ):
             passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
 
-        assert len(passing) == 1
+        assert len(passing) == 0
 
 
 class TestBuildSkippedResults:


### PR DESCRIPTION
## Summary

Post-migration audit of the additive content model found 4 items. Fixed by 4 clones in parallel, staff-reviewed, regression-tested (5882 pass).

### PR #386 — Remove vestigial `storage_backend` param (Clone 3)
- Removed unused param from `apply_observe_for_file_mode()` + caller + TYPE_CHECKING import
- Found 2 more dead params (`agent_indices`, `file_path`) — filed as follow-up #14

### PR #385 — Pipeline skip uses RecordEnvelope (Clone 2)
- `_build_skipped_results()` was the last content assembly bypassing RecordEnvelope
- Now uses `RecordEnvelope.build_skipped()` + framework field merge
- 4 new tests, output structurally identical

### PR #387 — Remove 3 stale content fallback patterns (Clone 1)
- `batch_base.py:100`: upgraded from silent fallback to `raise ValueError` — missing content is invariant violation
- `pipeline_file_mode.py:566`: `get_existing_content()` for guard prefilter
- `result_processor.py:309`: `get_existing_content()` for passthrough
- Found pre-existing bug #15: batch passthrough Path B reads wrong key (filed, not introduced here)

### PR #388 — Migrate 11 example tools (Clone 4)
- Removed banned `data.get("content", data)` from 11 tools across 6 projects (spec said 10/5 — sibling grep caught the miss)
- Updated stale PATTERNS.md docs teaching the banned pattern

## Audit results after merge
- `grep 'get("content", item/row/data/record)' agent_actions/` → **zero matches**
- `grep 'get("content", ...)' examples/` → **zero matches**
- `grep storage_backend scope_file_mode.py` → **zero matches**
- All content assembly uses RecordEnvelope — **single path confirmed**

## Open follow-ups (not blocking)
- #15: `_apply_context_passthrough` Path B reads wrong key — batch passthrough silently no-op (pre-existing)
- #14: `agent_indices` + `file_path` dead params — same class as `storage_backend` just removed
- #13: `classifyField` drops output fields named metadata/node_id after unwrap

## Verification
- 5882 tests pass, 0 failures
- ruff format + check clean
- 5 parallel staff-engineer reviews from prior round validated the additive model is complete