### PR TITLE
fix: user fields named metadata/node_id visible after unwrap

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-171000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-171000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "User output fields named metadata/node_id no longer hidden in data explorer after namespace unwrap"
+time: 2026-04-26T17:10:00.000000Z

--- a/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
+++ b/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
@@ -17,7 +17,6 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { CellValue, DataCard, getDisplayFields, type ActionInfo } from "@/components/ui/data-card"
-import { classifyField } from "@/lib/data-card-utils"
 import { useCatalogData } from "@/lib/catalog-context"
 import type { DataNode, WorkflowDataSummary } from "@/lib/mock-data"
 
@@ -445,9 +444,7 @@ function NodeDetail({
     for (const row of node.preview) {
       const fields = getDisplayFields(row)
       for (const key of Object.keys(fields)) {
-        if (classifyField(key) === "content") {
-          colSet.add(key)
-        }
+        colSet.add(key)
       }
     }
     return Array.from(colSet)

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm"
 import { ChevronRight, Copy, Check } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import {
-  classifyField,
+  METADATA_KEYS,
   classifyRecord,
   humanizeKey,
   isInlineArray,
@@ -486,17 +486,26 @@ export function getDisplayFields(record: Record<string, unknown>): Record<string
   if (contentVal && typeof contentVal === "object" && !Array.isArray(contentVal)) {
     return contentVal as Record<string, unknown>
   }
-  return record
+  // Fallback: record has no namespaced content dict. Strip framework keys so only
+  // user content fields are returned — downstream no longer applies classifyField.
+  const result: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(record)) {
+    if (!METADATA_KEYS.has(k)) {
+      result[k] = v
+    }
+  }
+  return result
 }
 
 export function DataCard({ record, index, fontSize, defaultOpen = true, actionInfo }: DataCardProps) {
   const [recordOpen, setRecordOpen] = useState(defaultOpen)
   const displayRecord = getDisplayFields(record)
-  const guardSkipped = Object.keys(displayRecord).filter(k => classifyField(k) === "content").length === 0
+  // After namespace unwrap, all displayRecord keys are user content — classifyField
+  // is not used here because a user field named "metadata" is content, not framework metadata.
+  const guardSkipped = Object.values(displayRecord).every(v => v === null)
   const { identity, metadata } = classifyRecord(record)
 
   const outputFields = Object.entries(displayRecord)
-    .filter(([key]) => classifyField(key) === "content")
     .map(([key, value]) => ({ key, value }))
 
   const trace =


### PR DESCRIPTION
## Summary
- After getDisplayFields() unwraps namespaced content, all keys are user content
- Removed classifyField filtering on unwrapped display fields in DataCard and data-screen
- Guard-skip detection now checks for empty/all-null instead of classifyField
- Closes cross-clone #13

## Blast Radius
- `data-card.tsx`: DataCard component — card view now shows all unwrapped fields as content
- `data-screen.tsx`: table view columns — all unwrapped fields become columns
- `data-card-utils.ts`: NOT modified — classifyField is correct for raw records
- Identity/metadata sections unaffected — classifyRecord still runs on the raw record

## Verification
- `npm run build` passes (frontend compiles clean)
- `ruff format --check` / `ruff check` pass
- `pytest` — 5882 passed, 2 skipped