### PR TITLE
cleanup: remove processor.py re-export shim

### DIFF
--- a/.changes/unreleased/Under the Hood-20260426-174000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-174000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Removed processor.py re-export shim; all callers now import RecordProcessor from record_processor.py directly"
+time: 2026-04-26T17:40:00.000000Z

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -13,7 +13,7 @@ from agent_actions.input.preprocessing.transformation.string_transformer import 
 from agent_actions.output.response.config_fields import get_default
 from agent_actions.output.saver import UnifiedSourceDataSaver
 from agent_actions.output.writer import FileWriter
-from agent_actions.processing.processor import RecordProcessor
+from agent_actions.processing.record_processor import RecordProcessor
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingContext
 from agent_actions.prompt.formatter import PromptFormatter

--- a/agent_actions/processing/_MANIFEST.md
+++ b/agent_actions/processing/_MANIFEST.md
@@ -21,7 +21,7 @@ lineage helpers, recovery flows, and transformation pipelines.
 | `error_handling.py` | Module | `ProcessorErrorHandlerMixin` for wrapping file loading/processing logic. | `logging` |
 | `exhausted_builder.py` | Module | Builds reports once a workflow’s retries are exhausted. | `validation`, `logging` |
 | `helpers.py` | Module | Shared helpers (UUID construction, tuple flattening) for processors. | `processing` |
-| `processor.py` | Module | Base processor that glues loaders, transformers, and error handling. | `input`, `processing` |
+| `record_processor.py` | Module | Base processor that glues loaders, transformers, and error handling. | `input`, `processing` |
 | `result_collector.py` | Module | Collects main vs side outputs, handles duplicates. Counts UNPROCESSED results separately from successes. | `output` |
 | `prepared_task.py` | Module | `GuardStatus` enum (PASSED, SKIPPED, FILTERED, UPSTREAM_UNPROCESSED), `PreparedTask` dataclass, and `PreparationContext` (carries `mode: RunMode` directly). | `typing` |
 | `task_preparer.py` | Module | Unified task preparation (normalize, prompt, guard) for batch/online. Short-circuits upstream-unprocessed records before context loading. | `input`, `prompt` |

--- a/agent_actions/processing/processor.py
+++ b/agent_actions/processing/processor.py
@@ -1,9 +1,0 @@
-"""Thin re-export shim for RecordProcessor.
-
-All production code should import from this module.
-The implementation lives in record_processor.py.
-"""
-
-from .record_processor import RecordProcessor, _is_empty_output
-
-__all__ = ["RecordProcessor", "_is_empty_output"]

--- a/agent_actions/prompt/data_generator.py
+++ b/agent_actions/prompt/data_generator.py
@@ -13,7 +13,7 @@ from agent_actions.config.di.container import registry
 from agent_actions.config.interfaces import IGenerator, ProcessingMode
 from agent_actions.config.types import RunMode
 from agent_actions.errors import GenerationError
-from agent_actions.processing.processor import RecordProcessor
+from agent_actions.processing.record_processor import RecordProcessor
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingStatus,

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -17,7 +17,7 @@ from agent_actions.llm.batch.service import create_registry_manager_factory
 from agent_actions.llm.batch.services.submission import BatchSubmissionService
 from agent_actions.llm.realtime.output import OutputHandler
 from agent_actions.output.writer import FileWriter
-from agent_actions.processing.processor import RecordProcessor
+from agent_actions.processing.record_processor import RecordProcessor
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
 from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode

--- a/tests/core/test_file_granularity.py
+++ b/tests/core/test_file_granularity.py
@@ -3,7 +3,7 @@
 import pytest
 
 from agent_actions.errors import ConfigurationError
-from agent_actions.processing.processor import RecordProcessor
+from agent_actions.processing.record_processor import RecordProcessor
 
 
 class TestFileGranularityValidation:

--- a/tests/core/test_invocation_strategy.py
+++ b/tests/core/test_invocation_strategy.py
@@ -384,7 +384,7 @@ class TestRecordProcessorModeWiring:
 
     def test_batch_mode_without_provider_raises(self):
         """RecordProcessor with mode=BATCH but no provider raises ValueError."""
-        from agent_actions.processing.processor import RecordProcessor
+        from agent_actions.processing.record_processor import RecordProcessor
 
         with pytest.raises(ValueError, match="BatchProvider required"):
             RecordProcessor(
@@ -412,7 +412,7 @@ class TestDeferredResultInProcessor:
         branch, discarding queued batch tasks.
         """
         from agent_actions.processing.prepared_task import GuardStatus, PreparedTask
-        from agent_actions.processing.processor import RecordProcessor
+        from agent_actions.processing.record_processor import RecordProcessor
         from agent_actions.processing.types import (
             ProcessingContext,
             ProcessingStatus,

--- a/tests/core/test_record_processor.py
+++ b/tests/core/test_record_processor.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from agent_actions.config.types import RunMode
-from agent_actions.processing.processor import RecordProcessor
+from agent_actions.processing.record_processor import RecordProcessor
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,

--- a/tests/processing/test_empty_output_detection.py
+++ b/tests/processing/test_empty_output_detection.py
@@ -8,7 +8,7 @@ from agent_actions.config.schema import ActionConfig
 from agent_actions.errors import EmptyOutputError
 from agent_actions.logging.events.data_pipeline_events import RecordEmptyOutputEvent
 from agent_actions.logging.events.handlers.run_results import ActionResult, RunResultsCollector
-from agent_actions.processing.processor import _is_empty_output
+from agent_actions.processing.record_processor import _is_empty_output
 
 # =============================================================================
 # _is_empty_output helper tests
@@ -143,7 +143,7 @@ class TestEmptyOutputDetection:
             "agent_actions.processing.record_processor.fire_event",
             side_effect=lambda e: fired_events.append(e),
         ):
-            from agent_actions.processing.processor import RecordProcessor
+            from agent_actions.processing.record_processor import RecordProcessor
             from agent_actions.processing.types import ProcessingContext
 
             # Build a minimal processor with a mock strategy returning empty response
@@ -198,7 +198,7 @@ class TestEmptyOutputDetection:
         with patch(
             "agent_actions.processing.record_processor.fire_event",
         ):
-            from agent_actions.processing.processor import RecordProcessor
+            from agent_actions.processing.record_processor import RecordProcessor
             from agent_actions.processing.types import ProcessingContext
 
             agent_config = {
@@ -249,7 +249,7 @@ class TestEmptyOutputDetection:
             "agent_actions.processing.record_processor.fire_event",
             side_effect=lambda e: fired_events.append(e),
         ):
-            from agent_actions.processing.processor import RecordProcessor
+            from agent_actions.processing.record_processor import RecordProcessor
             from agent_actions.processing.types import ProcessingContext
 
             agent_config = {
@@ -298,7 +298,7 @@ class TestEmptyOutputDetection:
         with patch(
             "agent_actions.processing.record_processor.fire_event",
         ):
-            from agent_actions.processing.processor import RecordProcessor
+            from agent_actions.processing.record_processor import RecordProcessor
             from agent_actions.processing.types import ProcessingContext
 
             agent_config = {

--- a/tests/processing/test_source_guid_none_coercion.py
+++ b/tests/processing/test_source_guid_none_coercion.py
@@ -11,7 +11,7 @@ from agent_actions.logging.events.data_pipeline_events import (
     RecordProcessingStartedEvent,
     RecordTransformedEvent,
 )
-from agent_actions.processing.processor import RecordProcessor
+from agent_actions.processing.record_processor import RecordProcessor
 from agent_actions.processing.types import ProcessingContext
 
 

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -48,7 +48,7 @@ def test_result_collector_aggregates_statuses_first_stage():
         passthrough_data={"content": {"value": 2}}, reason="guard_skip", source_guid="src-2"
     )
 
-    # EXHAUSTED results now arrive pre-enriched from processor.py
+    # EXHAUSTED results now arrive pre-enriched from record_processor.py
     exhausted_data = {
         "source_guid": "src-3",
         "target_id": "t-1",
@@ -106,7 +106,7 @@ def test_result_collector_uses_input_record_downstream():
     """Downstream stages: EXHAUSTED results arrive pre-enriched with correct lineage."""
     agent_config = {"agent_type": "downstream"}
 
-    # Pre-enriched exhausted data (as processor.py would produce)
+    # Pre-enriched exhausted data (as record_processor.py would produce)
     exhausted_data = {
         "source_guid": "src-9",
         "target_id": "t-input",

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -16,7 +16,7 @@ import pytest
 from agent_actions.config.types import RunMode
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
-from agent_actions.processing.processor import RecordProcessor
+from agent_actions.processing.record_processor import RecordProcessor
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.task_preparer import TaskPreparer
 from agent_actions.processing.types import (

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -549,7 +549,7 @@ def test_record_tool_list_return_produces_multiple_output_items():
         → ResultCollector.collect_results() extends output  — 3 items total
     """
     from agent_actions.processing.invocation.result import InvocationResult
-    from agent_actions.processing.processor import RecordProcessor
+    from agent_actions.processing.record_processor import RecordProcessor
     from agent_actions.processing.result_collector import ResultCollector
     from agent_actions.processing.types import ProcessingContext, ProcessingStatus
 
@@ -614,7 +614,7 @@ def test_process_batch_reraises_schema_validation_error():
     """SchemaValidationError from process() should propagate through process_batch."""
     from agent_actions.errors import SchemaValidationError
     from agent_actions.processing.invocation.result import InvocationResult
-    from agent_actions.processing.processor import RecordProcessor
+    from agent_actions.processing.record_processor import RecordProcessor
 
     agent_config = {"kind": "tool", "granularity": "record"}
     agent_name = "schema_test_tool"


### PR DESCRIPTION
## Summary
- Deleted `processing/processor.py` (9-line re-export shim for `RecordProcessor` and `_is_empty_output`)
- Updated 3 production callers and 8 test files to import from `record_processor.py` directly
- Updated `processing/_MANIFEST.md` to reference `record_processor.py`
- Shim had no backward-compat purpose (created in the same commit as the implementation)

## Blast radius
- **1st degree**: `processor.py` (deleted) → 3 production callers + 8 test files (imports updated)
- **2nd degree**: `pipeline.py`, `data_generator.py`, `initial_pipeline.py` all create `RecordProcessor` instances — verified import resolves correctly
- **3rd degree**: `RecordProcessor` processes every record in every workflow — full test suite confirms no breakage
- `processing/__init__.py` has no re-exports — clean

## Verification
- `ruff format --check` — clean
- `ruff check` — clean
- `pytest` — 5864 passed, 2 skipped
- `grep -rn "processing.processor" agent_actions/ tests/` — zero matches