### PR TITLE
cleanup: remove dead params from FILE-mode observe

### DIFF
--- a/.changes/unreleased/Under the Hood-20260426-173000.yaml
+++ b/.changes/unreleased/Under the Hood-20260426-173000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove unused agent_indices and file_path params from apply_observe_for_file_mode"
+time: 2026-04-26T17:30:00.000000Z

--- a/agent_actions/prompt/context/scope_file_mode.py
+++ b/agent_actions/prompt/context/scope_file_mode.py
@@ -62,8 +62,6 @@ def apply_observe_for_file_mode(
     data: list[dict],
     agent_config: dict,
     agent_name: str,
-    agent_indices: dict[str, int] | None = None,
-    file_path: str | None = None,
     source_data: list[dict] | None = None,
 ) -> list[dict]:
     """Namespace-aware observe filter for file-mode (array-level) data.

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -541,8 +541,6 @@ class ProcessingPipeline:
                 data=data,
                 agent_config=cast(dict[str, Any], self.config.action_config),
                 agent_name=self.config.action_name,
-                agent_indices=agent_indices,
-                file_path=file_path,
                 source_data=source_data,
             )
 

--- a/tests/integration/test_context_scope_audit.py
+++ b/tests/integration/test_context_scope_audit.py
@@ -307,7 +307,6 @@ class TestFileModeObserve:
             data,
             agent_config,
             agent_name="act",
-            agent_indices={"dep": 0, "act": 1},
         )
         assert len(result) == 2
         # Observed fields extracted from namespace
@@ -334,7 +333,6 @@ class TestFileModeObserve:
             data,
             agent_config,
             agent_name="act",
-            agent_indices={"dep": 0, "act": 1},
         )
         assert len(result) == 2
         assert result[0]["content"]["q"] == "What?"
@@ -362,7 +360,6 @@ class TestFileModeObserve:
             data,
             agent_config,
             agent_name="act",
-            agent_indices={"dep_a": 0, "dep_b": 1, "act": 2},
         )
         assert len(result) == 1
         # dep_a wildcard extracts all fields (qualified because 2 wildcards? no, only 1)

--- a/tests/manual/repro_bug_03_version_merge_tool.py
+++ b/tests/manual/repro_bug_03_version_merge_tool.py
@@ -47,20 +47,10 @@ def test_version_wildcard_expansion():
         },
     }
 
-    agent_indices = {
-        "source": 0,
-        "gen_code_1": 1,
-        "gen_code_2": 2,
-        "gen_code_3": 3,
-        "aggregate": 4,
-    }
-
     result = apply_observe_for_file_mode(
         data=data,
         agent_config=agent_config,
         agent_name="aggregate",
-        agent_indices=agent_indices,
-        file_path="/tmp/test.json",
     )
 
     content = result[0].get("content", result[0])
@@ -102,19 +92,10 @@ def test_version_specific_field_resolution():
         },
     }
 
-    agent_indices = {
-        "source": 0,
-        "gen_code_1": 1,
-        "gen_code_2": 2,
-        "aggregate": 3,
-    }
-
     result = apply_observe_for_file_mode(
         data=data,
         agent_config=agent_config,
         agent_name="aggregate",
-        agent_indices=agent_indices,
-        file_path="/tmp/test.json",
     )
 
     content = result[0].get("content", result[0])
@@ -173,14 +154,10 @@ def test_content_empty_fallback_trap():
         },
     }
 
-    agent_indices = {"source": 0, "upstream": 1, "downstream": 2}
-
     result = apply_observe_for_file_mode(
         data=data,
         agent_config=agent_config,
         agent_name="downstream",
-        agent_indices=agent_indices,
-        file_path="/tmp/test.json",
         source_data=source_data,
     )
 

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -274,8 +274,7 @@ class TestApplyObserveForFileMode:
     def test_no_storage_lookup(self):
         """With namespaced content, no historical storage lookup is needed.
 
-        All dependency data is on the record. This test verifies the function
-        works without agent_indices or file_path.
+        All dependency data is on the record.
         """
         data = [
             {
@@ -290,8 +289,6 @@ class TestApplyObserveForFileMode:
             data=data,
             agent_config=config,
             agent_name="summarize",
-            agent_indices=None,
-            file_path=None,
         )
         assert result[0]["content"]["text"] == "hello"
         assert result[0]["content"]["topic"] == "science"

--- a/tests/unit/prompt/context/test_observe_tool_udf_namespace.py
+++ b/tests/unit/prompt/context/test_observe_tool_udf_namespace.py
@@ -134,8 +134,6 @@ class TestFileModeObserveToolUdf:
             data=data,
             agent_config=agent_config,
             agent_name="tool_b",
-            agent_indices={"upstream": 0, "tool_b": 1},
-            file_path="/tmp/test.json",
         )
 
         content = filtered[0].get("content", filtered[0])

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -437,9 +437,8 @@ def test_new_observe_wildcard_returns_all_content_fields():
 def test_new_observe_collision_uses_qualified_keys():
     """When two refs share the same bare key with NiFi enrichment.
 
-    NOTE: No agent_indices/file_path provided, so dep_b cannot load
-    historically and falls through to content lookup. With NiFi enrichment,
-    the original content fields are preserved as-is (no qualified key
+    With namespaced content, observe reads directly from record namespaces.
+    The original content fields are preserved as-is (no qualified key
     renaming for input-source fields). The original 'title' and 'body'
     remain in content.
     """


### PR DESCRIPTION
## Summary
- Removed unused `agent_indices` and `file_path` from `apply_observe_for_file_mode()`
- Removed args from caller in pipeline.py and test files
- Same class of cleanup as PR #386 (storage_backend removal)
- Closes bug #33

## Blast Radius
- **1st degree**: function signature in `scope_file_mode.py`
- **2nd degree**: 1 production caller (`pipeline.py:539`), 5 test files
- **3rd degree**: return value unchanged — params were never read in function body
- **Dynamic callers**: none (all imports are direct)

## Verification
- `ruff format --check` — clean
- `ruff check` — clean
- `pytest` — 5882 passed, 0 failures
- `grep agent_indices\|file_path scope_file_mode.py` — zero matches