### PR TITLE
fix: atomic JSON writes prevent crash-corrupted state files

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-172000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-172000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Migrate 13 raw json.dump sites to atomic_json_write to prevent crash-corrupted state files"
+time: 2026-04-26T17:20:00.000000Z

--- a/agent_actions/input/loaders/data_source.py
+++ b/agent_actions/input/loaders/data_source.py
@@ -226,7 +226,7 @@ def _fetch_api_data(config: DataSourceConfig, cache_file: Path) -> None:
 
         parsed = json.loads(data)
 
-        atomic_json_write(cache_file, parsed)
+        atomic_json_write(cache_file, parsed, fsync=False)
 
         logger.info("Fetched and cached API data: %s -> %s", config.url, cache_file)
 

--- a/agent_actions/input/loaders/data_source.py
+++ b/agent_actions/input/loaders/data_source.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from agent_actions.config.defaults import ApiDefaults
 from agent_actions.errors import ConfigurationError, FileSystemError
+from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.project_root import find_project_root
 
 
@@ -225,8 +226,7 @@ def _fetch_api_data(config: DataSourceConfig, cache_file: Path) -> None:
 
         parsed = json.loads(data)
 
-        with open(cache_file, "w", encoding="utf-8") as f:
-            json.dump(parsed, f)
+        atomic_json_write(cache_file, parsed)
 
         logger.info("Fetched and cached API data: %s -> %s", config.url, cache_file)
 

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -22,6 +22,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_SKIPPED,
     NODE_LEVEL_RECORD_ID,
 )
+from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import CHUNK_CONFIG_KEY, MODEL_VENDOR_KEY
 
 if TYPE_CHECKING:
@@ -594,8 +595,7 @@ def _write_batch_placeholder(output_file_path, local_batch_id, result, agent_nam
         "status": "submitted",
         "agent": agent_name,
     }
-    with open(output_file_path, "w", encoding="utf-8") as f:
-        json.dump(placeholder, f)
+    atomic_json_write(output_file_path, placeholder)
 
 
 def _process_batch_mode(ctx: BatchProcessingContext):

--- a/agent_actions/llm/providers/anthropic/batch_client.py
+++ b/agent_actions/llm/providers/anthropic/batch_client.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from agent_actions.llm.providers.anthropic import PROMPT_CACHING_BETA_HEADER
 from agent_actions.prompt.message_builder import MessageBuilder
+from agent_actions.utils.atomic_write import atomic_json_write
 
 from ..batch_base import BaseBatchClient, BatchResult, BatchTask
 
@@ -281,8 +282,7 @@ class AnthropicBatchClient(BaseBatchClient):
         """Write tasks to JSON file for Anthropic."""
         file_name = f"{Path(batch_name).stem}_anthropic_batch_input.json"
         file_path = batch_dir / file_name
-        with open(file_path, "w", encoding="utf-8") as file:
-            json.dump({"requests": tasks}, file, indent=2)
+        atomic_json_write(file_path, {"requests": tasks}, indent=2)
         logger.info("Anthropic batch input saved at: %s", file_path)
         return file_path
 

--- a/agent_actions/llm/providers/anthropic/batch_client.py
+++ b/agent_actions/llm/providers/anthropic/batch_client.py
@@ -282,7 +282,7 @@ class AnthropicBatchClient(BaseBatchClient):
         """Write tasks to JSON file for Anthropic."""
         file_name = f"{Path(batch_name).stem}_anthropic_batch_input.json"
         file_path = batch_dir / file_name
-        atomic_json_write(file_path, {"requests": tasks}, indent=2)
+        atomic_json_write(file_path, {"requests": tasks}, indent=2, fsync=False)
         logger.info("Anthropic batch input saved at: %s", file_path)
         return file_path
 

--- a/agent_actions/logging/events/handlers/run_results.py
+++ b/agent_actions/logging/events/handlers/run_results.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import json
-import os
-import tempfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from agent_actions.utils.atomic_write import atomic_json_write
 
 if TYPE_CHECKING:
     from agent_actions.logging.core.events import BaseEvent
@@ -136,17 +135,7 @@ class RunResultsCollector:
         }
 
         output_path = target_dir / "run_results.json"
-        fd, tmp = tempfile.mkstemp(dir=str(target_dir), suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(output, f, indent=2, default=str)
-            os.replace(tmp, str(output_path))
-        except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        atomic_json_write(output_path, output, indent=2, default=str)
 
     def _handle_workflow_start(self, event: BaseEvent) -> None:
         self._metadata["workflow_name"] = event.data.get("workflow_name", "")

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import csv
 import json
-import os
-import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -17,6 +15,7 @@ from agent_actions.logging.events import (
     FileWriteStartedEvent,
 )
 from agent_actions.processing.error_handling import ProcessorErrorHandlerMixin
+from agent_actions.utils.atomic_write import atomic_json_write
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -84,18 +83,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
         def do_write() -> int:
             Path(self.file_path).parent.mkdir(parents=True, exist_ok=True)
             if self.file_type == ".json":
-                dir_path = os.path.dirname(self.file_path) or "."
-                fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
-                try:
-                    with os.fdopen(fd, "w", encoding="utf-8") as file:
-                        json.dump(data, file, indent=4)
-                    os.replace(tmp_path, self.file_path)
-                except BaseException:
-                    try:
-                        os.unlink(tmp_path)
-                    except OSError:
-                        pass
-                    raise
+                atomic_json_write(Path(self.file_path), data, indent=4)
             elif self.file_type == ".txt":
                 with open(self.file_path, "w", encoding="utf-8") as file:
                     if isinstance(data, list):
@@ -147,15 +135,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
 
         def do_write() -> int:
             Path(self.file_path).parent.mkdir(parents=True, exist_ok=True)
-            dir_path = os.path.dirname(self.file_path) or "."
-            fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as file:
-                    json.dump(data, file, indent=4)
-                os.replace(tmp_path, self.file_path)
-            except BaseException:
-                os.unlink(tmp_path)
-                raise
+            atomic_json_write(Path(self.file_path), data, indent=4)
             return Path(self.file_path).stat().st_size
 
         self._execute_write("Write source file", do_write)

--- a/agent_actions/tooling/docs/generator.py
+++ b/agent_actions/tooling/docs/generator.py
@@ -2,10 +2,8 @@
 
 import json
 import logging
-import os
 import re
 import shutil
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -14,6 +12,7 @@ import click
 
 from agent_actions.config.path_config import get_tool_dirs
 from agent_actions.models.action_schema import ActionSchema, FieldInfo, FieldSource
+from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import DEFAULT_ACTION_KIND
 from agent_actions.workflow.schema_service import WorkflowSchemaService
 
@@ -493,25 +492,13 @@ def generate_docs(project_path: str, output_dir: Path) -> bool:
 
     # Write catalog.json (atomic write to prevent corruption on crash)
     catalog_path = output_dir / "catalog.json"
-    dir_path = str(output_dir)
-    fd, tmp = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(catalog, f, indent=2)
-        os.replace(tmp, str(catalog_path))
-    except BaseException:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+    atomic_json_write(catalog_path, catalog, indent=2, fsync=False)
 
     # Initialize runs.json only if it doesn't exist
     # (RunTracker manages all updates to this file during workflow execution)
     runs_path = output_dir / "runs.json"
     if not runs_path.exists():
-        with open(runs_path, "w", encoding="utf-8") as f:
-            json.dump(_empty_runs_data(), f, indent=2)
+        atomic_json_write(runs_path, _empty_runs_data(), indent=2, fsync=False)
 
     # Print summary
     stats = catalog["stats"]

--- a/agent_actions/tooling/docs/generator.py
+++ b/agent_actions/tooling/docs/generator.py
@@ -490,7 +490,7 @@ def generate_docs(project_path: str, output_dir: Path) -> bool:
     # Ensure output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write catalog.json (atomic write to prevent corruption on crash)
+    # Write catalog.json
     catalog_path = output_dir / "catalog.json"
     atomic_json_write(catalog_path, catalog, indent=2, fsync=False)
 

--- a/agent_actions/workflow/managers/loop.py
+++ b/agent_actions/workflow/managers/loop.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from agent_actions.errors import DataValidationError
 from agent_actions.input.preprocessing.staging.initial_pipeline import _should_save_source_items
 from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.utils.atomic_write import atomic_json_write
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -429,8 +430,7 @@ class VersionOutputCorrelator:
                 )
         else:
             output_file = output_dir / filename
-            with open(output_file, "w", encoding="utf-8") as f:
-                json.dump(cleaned_data, f, indent=2)
+            atomic_json_write(output_file, cleaned_data, indent=2)
             self._create_correlation_source_data(output_file, cleaned_data)
 
     def _create_correlation_source_data(
@@ -472,8 +472,7 @@ class VersionOutputCorrelator:
                 )
                 return
 
-            with open(source_path, "w", encoding="utf-8") as f:
-                json.dump(source_records, f, indent=2)
+            atomic_json_write(source_path, source_records, indent=2)
         except (OSError, ValueError) as e:
             logger.warning("Could not create correlation source data: %s", e)
 

--- a/agent_actions/workflow/managers/manifest.py
+++ b/agent_actions/workflow/managers/manifest.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
 import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
 from agent_actions.errors import ConfigurationError
+from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.workflow.managers.state import COMPLETED_STATUSES, ActionStatus
 
 logger = logging.getLogger(__name__)
@@ -150,18 +149,7 @@ class ManifestManager:
 
         self.target_dir.mkdir(parents=True, exist_ok=True)
 
-        # Atomic write using temp file + rename
-        fd, tmp_path = tempfile.mkstemp(dir=str(self.target_dir), prefix=".manifest_tmp_")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(self._manifest, f, indent=2)
-            Path(tmp_path).replace(self.manifest_path)
-        except Exception:
-            try:
-                os.unlink(tmp_path)
-            except OSError as cleanup_err:
-                logger.debug("Failed to clean up temp file %s: %s", tmp_path, cleanup_err)
-            raise
+        atomic_json_write(self.manifest_path, self._manifest, indent=2)
 
     def get_output_directory(self, action_name: str) -> Path:
         """Return the output directory path for an action.

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -1,6 +1,5 @@
 """Module for orchestrating data processing pipelines through configured agents."""
 
-import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -27,6 +26,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_SKIPPED,
     NODE_LEVEL_RECORD_ID,
 )
+from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 from agent_actions.utils.safe_format import safe_format_error
 from agent_actions.workflow.pipeline_file_mode import (
@@ -261,8 +261,7 @@ class ProcessingPipeline:
             "status": "submitted",
             "agent": params.pipeline_action_name,
         }
-        with open(output_file_path, "w", encoding="utf-8") as f:
-            json.dump(placeholder, f)
+        atomic_json_write(output_file_path, placeholder)
         return str(output_file_path)
 
     @staticmethod

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -8,12 +8,12 @@ in tests (e.g. test_runner_merge.py) continues to work.
 
 from __future__ import annotations
 
-import json
 import logging
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.workflow.merge import merge_json_files, merge_records_by_key
 
 if TYPE_CHECKING:
@@ -205,8 +205,7 @@ def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> int
             with tempfile.TemporaryDirectory() as td:
                 tmp_file = Path(td) / relative_path
                 tmp_file.parent.mkdir(parents=True, exist_ok=True)
-                with open(tmp_file, "w", encoding="utf-8") as f:
-                    json.dump(merged_data, f)
+                atomic_json_write(tmp_file, merged_data, fsync=False)
 
                 runner._process_single_file(
                     SingleFileProcessParams(

--- a/tests/orchestration/test_manifest_manager.py
+++ b/tests/orchestration/test_manifest_manager.py
@@ -426,7 +426,7 @@ class TestPersistence:
         manifest_manager.mark_action_completed("extract")
 
         final_files = set(manifest_manager.target_dir.glob("*"))
-        temp_files = [f for f in final_files if ".manifest_tmp_" in f.name]
+        temp_files = [f for f in final_files if f.suffix == ".tmp"]
 
         assert len(temp_files) == 0, "Temp files should be cleaned up"
 

--- a/tests/unit/logging/test_atomic_write.py
+++ b/tests/unit/logging/test_atomic_write.py
@@ -1,9 +1,9 @@
 """Tests for atomic write exception-path (F-6 / I-7): temp-file cleanup on failure.
 
-Both run_results.py and generator.py use mkstemp+os.replace with a BaseException
-cleanup block. These tests verify that when the write fails:
+run_results.py and generator.py use atomic_json_write (temp file + rename).
+These tests verify that when the write fails:
   - the temp file is deleted (no orphans left on disk)
-  - the original exception propagates unchanged
+  - the error propagates
 """
 
 from __future__ import annotations
@@ -37,17 +37,15 @@ class TestRunResultsAtomicWrite:
         assert "metadata" in data
 
     def test_flush_cleans_up_tmp_on_write_failure(self, tmp_path):
-        """If json.dump raises, the .tmp file must be deleted and the error re-raised."""
+        """If json.dump raises inside atomic_json_write, temp file is cleaned up."""
         handler = self._make_handler(tmp_path)
         (tmp_path / "target").mkdir(parents=True, exist_ok=True)
-
-        _original_dump = json.dump
 
         def boom(*args, **kwargs):
             raise TypeError("unserializable sentinel")
 
-        with patch("agent_actions.logging.events.handlers.run_results.json.dump", boom):
-            with pytest.raises(TypeError, match="unserializable sentinel"):
+        with patch("agent_actions.utils.atomic_write.json.dump", boom):
+            with pytest.raises(OSError, match="unserializable sentinel"):
                 handler.flush()
 
         # No orphaned .tmp files should remain in the target dir
@@ -55,15 +53,19 @@ class TestRunResultsAtomicWrite:
         tmp_files = list(target.glob("*.tmp"))
         assert tmp_files == [], f"Orphaned temp files found: {tmp_files}"
 
-    def test_flush_cleans_up_tmp_on_os_replace_failure(self, tmp_path):
-        """If os.replace raises, the .tmp file must be deleted and the error re-raised."""
+    def test_flush_cleans_up_tmp_on_rename_failure(self, tmp_path):
+        """If rename raises inside atomic_json_write, temp file is cleaned up."""
         handler = self._make_handler(tmp_path)
         (tmp_path / "target").mkdir(parents=True, exist_ok=True)
 
-        def failing_replace(src, dst):
-            raise OSError("disk full")
+        _orig = Path.replace
 
-        with patch("agent_actions.logging.events.handlers.run_results.os.replace", failing_replace):
+        def failing_replace(self_path, target):
+            if str(self_path).endswith(".json.tmp"):
+                raise OSError("disk full")
+            return _orig(self_path, target)
+
+        with patch.object(Path, "replace", failing_replace):
             with pytest.raises(OSError, match="disk full"):
                 handler.flush()
 


### PR DESCRIPTION
## Summary
- Migrated 13 raw json.dump() sites to atomic_json_write() across 10 framework files
- Critical state files (manifest, loop output, pipeline placeholders, output writer, seed data cache, batch request files) use fsync=True (default)
- Non-critical files (docs catalog, run results, temp-dir merged data) use fsync=False
- Removed ~57 lines of inline tempfile+rename boilerplate replaced by single-line utility calls
- Updated test_atomic_write.py to patch through the utility instead of removed inline code

### Exemptions (6 sites left as raw json.dump)
- **hitl/server.py** (1 site): Custom `response_event.is_set()` check between write and rename — concurrent submit/approve guard that atomic_json_write cannot express
- **run_tracker.py** (5 sites): Write to portalocker-locked file handles via `f.seek(0); f.truncate(); json.dump()` — atomic rename would break lock semantics since the lock is on the original inode

## Verification
- pytest: 5882 passed, 2 skipped
- ruff check: clean
- ruff format: clean
- grep confirms only 7 remaining raw json.dump() in framework code: 1 in atomic_write.py itself, 1 in hitl/server.py, 5 in run_tracker.py