### PR TITLE
fix: preflight warns about observe refs to guard-skippable fields

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-175000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-175000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Preflight now warns when context_scope.observe references a specific field from an action with guard.on_false: skip, since the namespace is null when the guard skips"
+time: 2026-04-26T17:50:00.000000Z

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from agent_actions.errors import ConfigurationError
+from agent_actions.guards.consolidated_guard import GuardBehavior
 from agent_actions.input.context.normalizer import (
     SEED_CONFIG_KEYS,
     detect_orphaned_directives,
@@ -122,6 +123,10 @@ class WorkflowStaticAnalyzer:
                     action.get("context_scope"), version_base_map={}
                 )
 
+        # Guard-skip observe warnings must be computed before wildcard expansion
+        # because expansion turns safe wildcards into specific refs (false positives).
+        guard_skip_observe_warnings = self._check_guard_skipped_observe_refs()
+
         # Step 1: Build data flow graph
         self._build_graph()
 
@@ -171,6 +176,9 @@ class WorkflowStaticAnalyzer:
 
         # Step 2g: Detect guard-nullable fields flowing into tool schemas
         for warning in self._check_guard_nullable_fields():
+            result.add_warning(warning)
+
+        for warning in guard_skip_observe_warnings:
             result.add_warning(warning)
 
         # Step 3: Check for unused dependencies (add as warnings)
@@ -1118,6 +1126,88 @@ class WorkflowStaticAnalyzer:
                             ),
                         )
                     )
+
+        return warnings
+
+    def _check_guard_skipped_observe_refs(self) -> list[StaticTypeWarning]:
+        """Warn when observe refs target specific fields from skip-guarded actions.
+
+        When an action has ``guard.on_false`` set to ``"skip"``, the entire
+        action namespace is ``None`` at runtime (``{action_name: None}``).
+        Observing a specific field like ``action.field`` will crash because
+        ``None["field"]`` doesn't exist.  Wildcards (``action.*``) resolve to
+        empty when skipped and are safe.
+
+        Only ``on_false: "skip"`` is checked — ``"filter"`` removes individual
+        records but the namespace still exists for remaining records.
+        """
+        warnings: list[StaticTypeWarning] = []
+        actions = self.workflow_config.get("actions", [])
+
+        skip_guarded: set[str] = set()
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            name = action.get("name", "")
+            guard = action.get("guard")
+            if not guard:
+                continue
+            if isinstance(guard, dict):
+                behavior = guard.get("on_false", GuardBehavior.FILTER)
+            elif isinstance(guard, str):
+                behavior = GuardBehavior.FILTER
+            else:
+                continue
+            if behavior == GuardBehavior.SKIP:
+                skip_guarded.add(name)
+
+        if not skip_guarded:
+            return warnings
+
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            consumer_name = action.get("name", "unknown")
+            context_scope = action.get("context_scope", {})
+            if not isinstance(context_scope, dict):
+                continue
+            observe_refs = context_scope.get("observe", [])
+            if not isinstance(observe_refs, list):
+                continue
+
+            for ref in observe_refs:
+                if not isinstance(ref, str) or "." not in ref:
+                    continue
+                source_name, field_name = ref.split(".", 1)
+                if field_name == "*":
+                    continue  # wildcards handle null gracefully
+                if source_name not in skip_guarded:
+                    continue
+
+                warnings.append(
+                    StaticTypeWarning(
+                        message=(
+                            f"'{source_name}.{field_name}' may be null at runtime. "
+                            f"Action '{source_name}' has guard with on_false: \"skip\" "
+                            f"— when the guard evaluates to false, the action's "
+                            f"namespace is null. Use wildcard '{source_name}.*' to "
+                            f"handle gracefully, or add null handling in the "
+                            f"downstream prompt/tool."
+                        ),
+                        location=FieldLocation(
+                            agent_name=consumer_name,
+                            config_field="context_scope.observe",
+                            raw_reference=ref,
+                        ),
+                        referenced_agent=source_name,
+                        referenced_field=field_name,
+                        hint=(
+                            f"Use '{source_name}.*' instead of "
+                            f"'{source_name}.{field_name}' to handle the case "
+                            f"when the guard skips."
+                        ),
+                    )
+                )
 
         return warnings
 

--- a/tests/unit/validation/test_guard_skipped_observe_refs.py
+++ b/tests/unit/validation/test_guard_skipped_observe_refs.py
@@ -1,0 +1,284 @@
+"""Tests for _check_guard_skipped_observe_refs() preflight warnings.
+
+Validates that preflight warns when context_scope.observe references a specific
+field from an action with guard.on_false: "skip".  The entire namespace is null
+when the guard skips, so specific field access crashes at runtime.
+"""
+
+from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+    WorkflowStaticAnalyzer,
+)
+
+
+def _make_workflow(*actions):
+    """Build a minimal workflow config from action dicts."""
+    return {"actions": list(actions)}
+
+
+def _llm_action(name, *, schema_fields=None, guard=None, depends_on=None, observe=None):
+    """Build an LLM action config."""
+    action = {"name": name, "prompt": f"Process {name}"}
+    if schema_fields:
+        action["schema"] = {
+            "type": "object",
+            "properties": {f: {"type": "string"} for f in schema_fields},
+        }
+    if guard:
+        action["guard"] = guard
+    if depends_on:
+        action["depends_on"] = depends_on
+    if observe:
+        action["context_scope"] = {"observe": observe}
+    return action
+
+
+class TestGuardSkippedObserveRefs:
+    """Preflight warns when observing specific field from skip-guarded action."""
+
+    def test_observe_specific_field_from_skip_guarded_warns(self):
+        """Observing action.field where action has on_false: skip -> warns."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [w for w in result.warnings if "may be null" in w.message]
+        assert len(skip_warnings) == 1
+        assert "review.hitl_status" in skip_warnings[0].message
+        assert 'on_false: "skip"' in skip_warnings[0].message
+
+    def test_observe_wildcard_from_skip_guarded_no_warning(self):
+        """Observing action.* where action has on_false: skip -> no warning."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.*"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 0
+
+    def test_observe_specific_field_from_filter_guarded_no_warning(self):
+        """Observing action.field where action has on_false: filter -> no warning.
+
+        Filter removes individual records but the namespace still exists.
+        """
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard={"condition": "score >= 6", "on_false": "filter"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 0
+
+    def test_observe_specific_field_from_non_guarded_no_warning(self):
+        """Observing action.field where action has no guard -> no warning."""
+        workflow = _make_workflow(
+            _llm_action("review", schema_fields=["hitl_status"]),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 0
+
+    def test_string_guard_defaults_to_filter_no_skip_warning(self):
+        """String-style guard defaults to filter, not skip -> no skip warning."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard="score >= 6",
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 0
+
+    def test_multiple_fields_from_skip_guarded_each_warn(self):
+        """Multiple specific field refs to same skip-guarded action -> one warning each."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status", "reviewer_notes"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status", "review.reviewer_notes"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 2
+        warned_fields = {w.referenced_field for w in skip_warnings}
+        assert warned_fields == {"hitl_status", "reviewer_notes"}
+
+    def test_warning_includes_wildcard_hint(self):
+        """Warning hint suggests using wildcard instead."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 1
+        assert skip_warnings[0].hint is not None
+        assert "review.*" in skip_warnings[0].hint
+
+    def test_warning_location_references_consumer(self):
+        """Warning location points to the consumer action, not the guarded one."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert skip_warnings[0].location.agent_name == "downstream"
+        assert skip_warnings[0].referenced_agent == "review"
+
+    def test_llm_consumer_also_warns(self):
+        """LLM (non-tool) consumer observing skip-guarded field also warns.
+
+        Unlike the existing _check_guard_nullable_fields which only checks tool
+        actions, this check applies to ALL downstream actions.
+        """
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "summarizer",
+                schema_fields=["summary"],
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 1
+
+    def test_mixed_wildcard_and_specific_only_warns_for_specific(self):
+        """Mixed refs: wildcard safe, specific field warns."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status", "notes"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.*", "review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 1
+        assert "hitl_status" in skip_warnings[0].message


### PR DESCRIPTION
## Summary
- Preflight now warns when context_scope.observe references a specific field from an action with guard.on_false: "skip"
- Warning suggests using wildcard (action.*) or adding null handling
- No warning for on_false: "filter" (different semantics — filter removes records, skip nulls the namespace)
- Check runs before wildcard expansion to avoid false positives on expanded refs

## Blast radius
- 1st degree: `_check_guard_skipped_observe_refs()` added to `WorkflowStaticAnalyzer`
- 2nd degree: `analyze()` calls it — runs during preflight for every `agac run`
- 3rd degree: New warning appears in CLI output and VS Code diagnostics. Verified no false positives on existing example workflows (support_resolution has the pattern and correctly warns; product_listing_enrichment uses wildcards and does not warn)

## Verification
- 10 new tests covering: skip warns, filter no warning, wildcard no warning, non-guarded no warning, multiple fields, hint content, location metadata, LLM consumer, mixed refs
- All 53 guard-related tests pass
- Full suite: 5873 passed, 0 failures
- ruff format + ruff check clean