### PR TITLE
fix: parse error records dispositioned as failed

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-182000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-182000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Records with _parse_error from LLM JSON parse failures now get DISPOSITION_FAILED instead of flowing downstream as SUCCESS"
+time: 2026-04-26T18:20:00.000000Z

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -64,6 +64,27 @@ class CollectionStats:
         return bool((self.skipped + self.filtered) == total)
 
 
+def _data_has_parse_error(data: list[dict[str, Any]]) -> bool:
+    """Check if any data item contains a ``_parse_error`` from the LLM provider.
+
+    The error dict produced by ``JSONResponseMixin`` flows through the transform
+    pipeline and lands inside ``content.{action_namespace}._parse_error``.
+    """
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        # Check inside content namespaces (post-transform shape)
+        content = item.get("content")
+        if isinstance(content, dict):
+            for ns_value in content.values():
+                if isinstance(ns_value, dict) and "_parse_error" in ns_value:
+                    return True
+        # Check top-level (raw shape before transform)
+        if "_parse_error" in item:
+            return True
+    return False
+
+
 def _safe_set_disposition(
     backend: "StorageBackend",
     action_name: str,
@@ -126,6 +147,41 @@ class ResultCollector:
 
             if status == ProcessingStatus.SUCCESS:
                 data = result.data or []
+
+                # Detect parse-error records masquerading as SUCCESS.
+                # The LLM provider returns {"_parse_error": ...} on JSON
+                # parse failure, which flows through as SUCCESS data.
+                # Reprompt has already had its chance to repair (it runs
+                # during invocation, before result collection).
+                if data and _data_has_parse_error(data):
+                    for d in data:
+                        d["_unprocessed"] = True
+                    output.extend(data)
+                    stats[status_key] -= 1
+                    stats["failed"] += 1
+                    logger.warning(
+                        "[%s] SUCCESS result source_guid=%s contains _parse_error "
+                        "— dispositioned as FAILED",
+                        agent_name,
+                        result.source_guid,
+                    )
+                    fire_event(
+                        ResultCollectedEvent(
+                            action_name=agent_name,
+                            result_index=idx,
+                            status="failed",
+                        )
+                    )
+                    if storage_backend and result.source_guid:
+                        _safe_set_disposition(
+                            storage_backend,
+                            agent_name,
+                            result.source_guid,
+                            DISPOSITION_FAILED,
+                            reason="parse_error",
+                        )
+                    continue
+
                 if data:
                     output.extend(data)
                 logger.debug(

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -71,9 +71,6 @@ def _data_has_parse_error(data: list[dict[str, Any]]) -> bool:
     pipeline and lands inside ``content.{action_namespace}._parse_error``.
     """
     for item in data:
-        if not isinstance(item, dict):
-            continue
-        # Check inside content namespaces (post-transform shape)
         content = item.get("content")
         if isinstance(content, dict):
             for ns_value in content.values():

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -295,16 +295,18 @@ def test_result_collector_on_exhausted_return_last_does_not_raise():
 # ---------------------------------------------------------------------------
 
 
+def _make_backend():
+    """Create a mock StorageBackend with a mocked set_disposition method."""
+    backend = MagicMock()
+    backend.set_disposition = MagicMock()
+    return backend
+
+
 class TestResultCollectorDispositions:
     """Tests for per-record disposition writes in ResultCollector."""
 
-    def _make_backend(self):
-        backend = MagicMock()
-        backend.set_disposition = MagicMock()
-        return backend
-
     def test_filtered_result_writes_disposition(self):
-        backend = self._make_backend()
+        backend = _make_backend()
         filtered = ProcessingResult.filtered(source_guid="src-f1")
         filtered.skip_reason = "low_confidence"
 
@@ -324,7 +326,7 @@ class TestResultCollectorDispositions:
         )
 
     def test_filtered_result_default_reason(self):
-        backend = self._make_backend()
+        backend = _make_backend()
         filtered = ProcessingResult.filtered(source_guid="src-f2")
 
         ResultCollector.collect_results(
@@ -343,7 +345,7 @@ class TestResultCollectorDispositions:
         )
 
     def test_failed_result_writes_disposition(self):
-        backend = self._make_backend()
+        backend = _make_backend()
         failed = ProcessingResult.failed(error="timeout", source_guid="src-fail")
 
         ResultCollector.collect_results(
@@ -364,7 +366,7 @@ class TestResultCollectorDispositions:
 
     def test_failed_result_default_reason(self):
         """When error field is empty string, falls back to 'processing_error'."""
-        backend = self._make_backend()
+        backend = _make_backend()
         failed = ProcessingResult(
             status=ProcessingStatus.FAILED,
             data=[],
@@ -390,7 +392,7 @@ class TestResultCollectorDispositions:
         )
 
     def test_skipped_result_writes_disposition(self):
-        backend = self._make_backend()
+        backend = _make_backend()
         skipped = ProcessingResult.skipped(
             passthrough_data={"content": {}},
             reason="guard_skip",
@@ -413,7 +415,7 @@ class TestResultCollectorDispositions:
         )
 
     def test_exhausted_result_writes_disposition(self):
-        backend = self._make_backend()
+        backend = _make_backend()
         exhausted = ProcessingResult.exhausted(
             error="Retry exhausted",
             source_guid="src-ex",
@@ -437,7 +439,7 @@ class TestResultCollectorDispositions:
         )
 
     def test_unprocessed_result_writes_disposition(self):
-        backend = self._make_backend()
+        backend = _make_backend()
         unprocessed = ProcessingResult(
             status=ProcessingStatus.UNPROCESSED,
             source_guid="src-un",
@@ -461,7 +463,7 @@ class TestResultCollectorDispositions:
         )
 
     def test_success_result_no_disposition(self):
-        backend = self._make_backend()
+        backend = _make_backend()
         success = ProcessingResult.success(
             data=[{"content": {"v": 1}}],
             source_guid="src-ok",
@@ -494,7 +496,7 @@ class TestResultCollectorDispositions:
 
     def test_no_source_guid_no_disposition(self):
         """Records without source_guid should not attempt disposition writes."""
-        backend = self._make_backend()
+        backend = _make_backend()
         filtered = ProcessingResult.filtered(source_guid=None)
 
         ResultCollector.collect_results(
@@ -509,7 +511,7 @@ class TestResultCollectorDispositions:
 
     def test_deferred_result_writes_disposition(self):
         """DEFERRED records write a disposition with source_guid as record_id."""
-        backend = self._make_backend()
+        backend = _make_backend()
         deferred = ProcessingResult.deferred(
             task_id="task-123",
             source_guid="src-def",
@@ -532,7 +534,7 @@ class TestResultCollectorDispositions:
 
     def test_deferred_result_no_source_guid_no_disposition(self):
         """DEFERRED records without source_guid skip the disposition write."""
-        backend = self._make_backend()
+        backend = _make_backend()
         deferred = ProcessingResult.deferred(
             task_id="task-456",
             source_guid=None,
@@ -567,7 +569,7 @@ class TestResultCollectorDispositions:
 
     def test_mixed_statuses_write_correct_dispositions(self):
         """Multiple statuses in one batch write the right dispositions."""
-        backend = self._make_backend()
+        backend = _make_backend()
 
         results = [
             ProcessingResult.success(data=[{"content": {}}], source_guid="ok"),
@@ -590,7 +592,7 @@ class TestResultCollectorDispositions:
 
     def test_mixed_with_deferred_writes_all_dispositions(self):
         """DEFERRED + other statuses each write their own disposition."""
-        backend = self._make_backend()
+        backend = _make_backend()
 
         results = [
             ProcessingResult.deferred(task_id="t-1", source_guid="src-d"),
@@ -714,14 +716,9 @@ class TestDataHasParseError:
 class TestParseErrorDisposition:
     """Tests for parse error detection in the SUCCESS branch of ResultCollector."""
 
-    def _make_backend(self):
-        backend = MagicMock()
-        backend.set_disposition = MagicMock()
-        return backend
-
     def test_parse_error_record_gets_failed_disposition(self):
         """SUCCESS result with _parse_error in content gets DISPOSITION_FAILED."""
-        backend = self._make_backend()
+        backend = _make_backend()
         result = ProcessingResult.success(
             data=[
                 {
@@ -788,7 +785,7 @@ class TestParseErrorDisposition:
 
     def test_normal_success_not_affected(self):
         """Normal SUCCESS records are not reclassified by parse error detection."""
-        backend = self._make_backend()
+        backend = _make_backend()
         result = ProcessingResult.success(
             data=[{"content": {"action": {"question": "What?", "answer": "42"}}}],
             source_guid="guid-ok",
@@ -809,7 +806,7 @@ class TestParseErrorDisposition:
 
     def test_mixed_parse_error_and_normal(self):
         """Batch with both parse error and normal records handles each correctly."""
-        backend = self._make_backend()
+        backend = _make_backend()
         results = [
             ProcessingResult.success(
                 data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
@@ -845,7 +842,7 @@ class TestParseErrorDisposition:
 
     def test_parse_error_no_source_guid_no_disposition(self):
         """Parse error without source_guid marks items but skips disposition write."""
-        backend = self._make_backend()
+        backend = _make_backend()
         result = ProcessingResult.success(
             data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
             source_guid=None,

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -689,9 +689,6 @@ class TestDataHasParseError:
     def test_empty_data_returns_false(self):
         assert _data_has_parse_error([]) is False
 
-    def test_non_dict_items_skipped(self):
-        assert _data_has_parse_error(["string_item", 42]) is False  # type: ignore[list-item]
-
     def test_content_with_non_dict_namespace_skipped(self):
         data = [{"content": {"action": "just a string"}}]
         assert _data_has_parse_error(data) is False

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -7,7 +7,11 @@ import pytest
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
-from agent_actions.processing.result_collector import CollectionStats, ResultCollector
+from agent_actions.processing.result_collector import (
+    CollectionStats,
+    ResultCollector,
+    _data_has_parse_error,
+)
 from agent_actions.processing.types import (
     ProcessingResult,
     ProcessingStatus,
@@ -649,3 +653,230 @@ class TestCollectionStatsOnlyGuardOutcomes:
 
     def test_mixed_skipped_with_success_blocks(self):
         assert CollectionStats(skipped=2, success=1).only_guard_outcomes is False
+
+
+# ---------------------------------------------------------------------------
+# _data_has_parse_error helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataHasParseError:
+    """Tests for _data_has_parse_error detection helper."""
+
+    def test_detects_parse_error_in_content_namespace(self):
+        data = [
+            {
+                "content": {
+                    "my_action": {
+                        "_parse_error": "Extra data: line 15",
+                        "raw_response": "bad json",
+                    }
+                }
+            }
+        ]
+        assert _data_has_parse_error(data) is True
+
+    def test_detects_parse_error_at_top_level(self):
+        data = [{"_parse_error": "Expecting value", "raw_response": "not json"}]
+        assert _data_has_parse_error(data) is True
+
+    def test_normal_record_no_false_positive(self):
+        data = [{"content": {"my_action": {"question": "What is X?", "answer": "Y"}}}]
+        assert _data_has_parse_error(data) is False
+
+    def test_empty_data_returns_false(self):
+        assert _data_has_parse_error([]) is False
+
+    def test_non_dict_items_skipped(self):
+        assert _data_has_parse_error(["string_item", 42]) is False  # type: ignore[list-item]
+
+    def test_content_with_non_dict_namespace_skipped(self):
+        data = [{"content": {"action": "just a string"}}]
+        assert _data_has_parse_error(data) is False
+
+    def test_multiple_items_one_has_error(self):
+        data = [
+            {"content": {"action": {"field": "ok"}}},
+            {"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}},
+        ]
+        assert _data_has_parse_error(data) is True
+
+    def test_no_content_key(self):
+        data = [{"source_guid": "abc", "metadata": {}}]
+        assert _data_has_parse_error(data) is False
+
+
+# ---------------------------------------------------------------------------
+# Parse error disposition tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseErrorDisposition:
+    """Tests for parse error detection in the SUCCESS branch of ResultCollector."""
+
+    def _make_backend(self):
+        backend = MagicMock()
+        backend.set_disposition = MagicMock()
+        return backend
+
+    def test_parse_error_record_gets_failed_disposition(self):
+        """SUCCESS result with _parse_error in content gets DISPOSITION_FAILED."""
+        backend = self._make_backend()
+        result = ProcessingResult.success(
+            data=[
+                {
+                    "source_guid": "guid-pe",
+                    "content": {
+                        "my_action": {
+                            "_parse_error": "Expecting value: line 1",
+                            "raw_response": "not json",
+                        }
+                    },
+                }
+            ],
+            source_guid="guid-pe",
+        )
+
+        output, stats = ResultCollector.collect_results(
+            [result],
+            {},
+            "my_action",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        backend.set_disposition.assert_called_once_with(
+            "my_action",
+            "guid-pe",
+            "failed",
+            reason="parse_error",
+        )
+
+    def test_parse_error_record_marked_unprocessed(self):
+        """Parse error items get _unprocessed=True so downstream guards skip them."""
+        result = ProcessingResult.success(
+            data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
+            source_guid="guid-pe",
+        )
+
+        output, _ = ResultCollector.collect_results(
+            [result],
+            {},
+            "action",
+            is_first_stage=False,
+        )
+
+        assert len(output) == 1
+        assert output[0]["_unprocessed"] is True
+
+    def test_parse_error_stats_counted_as_failed(self):
+        """Parse error reclassifies from success to failed in stats."""
+        result = ProcessingResult.success(
+            data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
+            source_guid="guid-pe",
+        )
+
+        _, stats = ResultCollector.collect_results(
+            [result],
+            {},
+            "action",
+            is_first_stage=False,
+        )
+
+        assert stats.failed == 1
+        assert stats.success == 0
+
+    def test_normal_success_not_affected(self):
+        """Normal SUCCESS records are not reclassified by parse error detection."""
+        backend = self._make_backend()
+        result = ProcessingResult.success(
+            data=[{"content": {"action": {"question": "What?", "answer": "42"}}}],
+            source_guid="guid-ok",
+        )
+
+        output, stats = ResultCollector.collect_results(
+            [result],
+            {},
+            "action",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        assert stats.success == 1
+        assert stats.failed == 0
+        assert "_unprocessed" not in output[0]
+        backend.set_disposition.assert_not_called()
+
+    def test_mixed_parse_error_and_normal(self):
+        """Batch with both parse error and normal records handles each correctly."""
+        backend = self._make_backend()
+        results = [
+            ProcessingResult.success(
+                data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
+                source_guid="guid-pe",
+            ),
+            ProcessingResult.success(
+                data=[{"content": {"action": {"field": "ok"}}}],
+                source_guid="guid-ok",
+            ),
+        ]
+
+        output, stats = ResultCollector.collect_results(
+            results,
+            {},
+            "action",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        assert stats.failed == 1
+        assert stats.success == 1
+        assert len(output) == 2
+        # Parse error item is marked, normal is not
+        assert output[0]["_unprocessed"] is True
+        assert "_unprocessed" not in output[1]
+        # Only parse error gets a disposition
+        backend.set_disposition.assert_called_once_with(
+            "action",
+            "guid-pe",
+            "failed",
+            reason="parse_error",
+        )
+
+    def test_parse_error_no_source_guid_no_disposition(self):
+        """Parse error without source_guid marks items but skips disposition write."""
+        backend = self._make_backend()
+        result = ProcessingResult.success(
+            data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
+            source_guid=None,
+        )
+
+        output, stats = ResultCollector.collect_results(
+            [result],
+            {},
+            "action",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        assert stats.failed == 1
+        assert output[0]["_unprocessed"] is True
+        backend.set_disposition.assert_not_called()
+
+    def test_parse_error_no_backend_no_crash(self):
+        """Parse error detection works gracefully without storage backend."""
+        result = ProcessingResult.success(
+            data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
+            source_guid="guid-pe",
+        )
+
+        output, stats = ResultCollector.collect_results(
+            [result],
+            {},
+            "action",
+            is_first_stage=False,
+            storage_backend=None,
+        )
+
+        assert stats.failed == 1
+        assert output[0]["_unprocessed"] is True


### PR DESCRIPTION
## Summary
- Records with `_parse_error` from LLM JSON parse failures now get `DISPOSITION_FAILED` with `reason="parse_error"` instead of flowing downstream as SUCCESS
- Affected records are marked with `_unprocessed=True` so downstream guards skip them
- Stats correctly reclassify parse error results from success to failed

## Blast Radius
- **Modified**: `agent_actions/processing/result_collector.py` — added `_data_has_parse_error()` helper and parse error detection in SUCCESS branch
- **Not touched**: `llm/providers/mixins.py` (error dict pattern preserved for RepromptEngine), `llm/batch/services/reprompt_ops.py` (repair still sees parse errors during invocation, before result collection)
- **Callers of ResultCollector.collect_results**: batch runner, online runner — behavior unchanged for normal SUCCESS results

## Verification
- Manual repro test: 3/3 pass (`python ../../tests/manual/repro_parse_error_not_dispositioned.py`)
- `pytest`: 5921 passed, 2 skipped
- `ruff format --check`: clean
- `ruff check`: clean
- 17 new unit tests covering: detection helper, disposition writes, stats reclassification, _unprocessed marking, edge cases (no backend, no source_guid, mixed batches)