### PR TITLE
feat: complete record disposition tracking

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260426-183000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260426-183000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "record_disposition tracks all outcomes (success, failure detail, exhausted) with new detail column"
+time: 2026-04-26T18:30:00.000000Z

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -21,6 +21,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
     DISPOSITION_PASSTHROUGH,
+    DISPOSITION_SUCCESS,
     DISPOSITION_UNPROCESSED,
 )
 
@@ -140,6 +141,13 @@ class ResultCollector:
                         status="success",
                     )
                 )
+                if storage_backend and result.source_guid:
+                    _safe_set_disposition(
+                        storage_backend,
+                        agent_name,
+                        result.source_guid,
+                        DISPOSITION_SUCCESS,
+                    )
 
             elif status == ProcessingStatus.SKIPPED:
                 data = result.data or []
@@ -191,6 +199,7 @@ class ResultCollector:
                         result.source_guid,
                         DISPOSITION_EXHAUSTED,
                         reason=f"exhausted_after_{attempts}_attempts",
+                        detail=result.error,
                     )
 
             elif status == ProcessingStatus.FAILED:
@@ -229,6 +238,7 @@ class ResultCollector:
                         DISPOSITION_FAILED,
                         reason=result.error or "processing_error",
                         input_snapshot=input_snapshot_str,
+                        detail=result.error,
                     )
 
             elif status == ProcessingStatus.FILTERED:
@@ -385,6 +395,7 @@ class ResultCollector:
                         er.source_guid,
                         DISPOSITION_EXHAUSTED,
                         reason=f"exhausted_after_{_get_retry_attempts(er)}_attempts",
+                        detail=er.error,
                     )
 
         first = exhausted_results[0]

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -14,6 +14,7 @@ DISPOSITION_EXHAUSTED = "exhausted"
 DISPOSITION_FAILED = "failed"
 DISPOSITION_DEFERRED = "deferred"
 DISPOSITION_UNPROCESSED = "unprocessed"
+DISPOSITION_SUCCESS = "success"
 
 
 class Disposition(str, Enum):
@@ -26,6 +27,7 @@ class Disposition(str, Enum):
     FAILED = DISPOSITION_FAILED
     DEFERRED = DISPOSITION_DEFERRED
     UNPROCESSED = DISPOSITION_UNPROCESSED
+    SUCCESS = DISPOSITION_SUCCESS
 
 
 VALID_DISPOSITIONS = frozenset(d.value for d in Disposition)
@@ -121,12 +123,14 @@ class StorageBackend(ABC):
         reason: str | None = None,
         relative_path: str | None = None,
         input_snapshot: str | None = None,
+        detail: str | None = None,
     ) -> None:
         """Write a disposition record (use NODE_LEVEL_RECORD_ID for node-level signals).
 
         Args:
             input_snapshot: JSON-serialized input record for failed items.
                 Implementations SHOULD truncate to a reasonable limit (recommended 10KB).
+            detail: Extended error message or context for the disposition.
         """
         # No-op: subclass must override to persist dispositions.
 

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -203,6 +203,12 @@ class SQLiteBackend(StorageBackend):
                     logger.debug("Added input_snapshot column to record_disposition")
                 except sqlite3.OperationalError:
                     logger.debug("input_snapshot column already exists in record_disposition")
+                # Migration: add detail column for error messages and context
+                try:
+                    cursor.execute("ALTER TABLE record_disposition ADD COLUMN detail TEXT")
+                    logger.debug("Added detail column to record_disposition")
+                except sqlite3.OperationalError:
+                    logger.debug("detail column already exists in record_disposition")
                 # Migration: add run_mode column for existing prompt_trace tables
                 try:
                     cursor.execute("ALTER TABLE prompt_trace ADD COLUMN run_mode TEXT")
@@ -549,6 +555,7 @@ class SQLiteBackend(StorageBackend):
         reason: str | None = None,
         relative_path: str | None = None,
         input_snapshot: str | None = None,
+        detail: str | None = None,
     ) -> None:
         """Write a disposition record (INSERT OR REPLACE)."""
         action_name = self._validate_identifier(action_name, "action_name")
@@ -573,10 +580,18 @@ class SQLiteBackend(StorageBackend):
                     """
                     INSERT OR REPLACE INTO record_disposition
                     (action_name, record_id, disposition, reason, relative_path,
-                     input_snapshot, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                     input_snapshot, detail, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
                     """,
-                    (action_name, record_id, disposition, reason, relative_path, input_snapshot),
+                    (
+                        action_name,
+                        record_id,
+                        disposition,
+                        reason,
+                        relative_path,
+                        input_snapshot,
+                        detail,
+                    ),
                 )
                 self.connection.commit()
                 logger.debug(
@@ -611,7 +626,7 @@ class SQLiteBackend(StorageBackend):
 
         query = (
             "SELECT action_name, record_id, disposition, reason, relative_path,"
-            " input_snapshot, created_at"
+            " input_snapshot, detail, created_at"
             " FROM record_disposition WHERE action_name = ?"
         )
         params: list[str] = [action_name]

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -250,6 +250,7 @@ def test_result_collector_on_exhausted_raise_writes_disposition_before_raising()
         "src-raise",
         "exhausted",
         reason="exhausted_after_2_attempts",
+        detail="Retry exhausted",
     )
 
 
@@ -356,6 +357,7 @@ class TestResultCollectorDispositions:
             "failed",
             reason="timeout",
             input_snapshot=None,
+            detail="timeout",
         )
 
     def test_failed_result_default_reason(self):
@@ -383,6 +385,7 @@ class TestResultCollectorDispositions:
             "failed",
             reason="processing_error",
             input_snapshot=None,
+            detail="",
         )
 
     def test_skipped_result_writes_disposition(self):
@@ -430,6 +433,7 @@ class TestResultCollectorDispositions:
             "src-ex",
             "exhausted",
             reason="exhausted_after_2_attempts",
+            detail="Retry exhausted",
         )
 
     def test_unprocessed_result_writes_disposition(self):
@@ -456,7 +460,7 @@ class TestResultCollectorDispositions:
             reason="where_clause",
         )
 
-    def test_success_result_no_disposition(self):
+    def test_success_result_writes_disposition(self):
         backend = self._make_backend()
         success = ProcessingResult.success(
             data=[{"content": {"v": 1}}],
@@ -471,7 +475,11 @@ class TestResultCollectorDispositions:
             storage_backend=backend,
         )
 
-        backend.set_disposition.assert_not_called()
+        backend.set_disposition.assert_called_once_with(
+            "agent",
+            "src-ok",
+            "success",
+        )
 
     def test_no_storage_backend_no_crash(self):
         """Dispositions are skipped gracefully when storage_backend is None."""
@@ -579,10 +587,14 @@ class TestResultCollectorDispositions:
             storage_backend=backend,
         )
 
-        assert backend.set_disposition.call_count == 2
+        assert backend.set_disposition.call_count == 3
         calls = backend.set_disposition.call_args_list
-        assert calls[0] == (("agent", "filt", "filtered"), {"reason": "guard_filter"})
-        assert calls[1] == (("agent", "fail", "failed"), {"reason": "err", "input_snapshot": None})
+        assert calls[0] == (("agent", "ok", "success"), {})
+        assert calls[1] == (("agent", "filt", "filtered"), {"reason": "guard_filter"})
+        assert calls[2] == (
+            ("agent", "fail", "failed"),
+            {"reason": "err", "input_snapshot": None, "detail": "err"},
+        )
 
     def test_mixed_with_deferred_writes_all_dispositions(self):
         """DEFERRED + other statuses each write their own disposition."""

--- a/tests/unit/storage/test_sqlite_dispositions.py
+++ b/tests/unit/storage/test_sqlite_dispositions.py
@@ -11,6 +11,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_FILTERED,
     DISPOSITION_PASSTHROUGH,
     DISPOSITION_SKIPPED,
+    DISPOSITION_SUCCESS,
     DISPOSITION_UNPROCESSED,
     VALID_DISPOSITIONS,
     Disposition,
@@ -75,6 +76,7 @@ class TestDispositionEnum:
         assert Disposition.EXHAUSTED.value == DISPOSITION_EXHAUSTED
         assert Disposition.FAILED.value == DISPOSITION_FAILED
         assert Disposition.UNPROCESSED.value == DISPOSITION_UNPROCESSED
+        assert Disposition.SUCCESS.value == DISPOSITION_SUCCESS
 
     def test_valid_dispositions_contains_all_enum_values(self):
         for member in Disposition:
@@ -102,6 +104,39 @@ class TestDispositionEnum:
         )
         rows = backend.get_disposition("action_b", "rec_002")
         assert rows[0]["disposition"] == "filtered"
+
+    def test_set_disposition_stores_detail(self, backend):
+        backend.set_disposition(
+            action_name="action_c",
+            record_id="rec_003",
+            disposition="failed",
+            reason="processing_error",
+            detail="ValueError: invalid input format",
+        )
+        rows = backend.get_disposition("action_c", "rec_003")
+        assert len(rows) == 1
+        assert rows[0]["detail"] == "ValueError: invalid input format"
+        assert rows[0]["reason"] == "processing_error"
+
+    def test_set_disposition_detail_defaults_to_none(self, backend):
+        backend.set_disposition(
+            action_name="action_d",
+            record_id="rec_004",
+            disposition="success",
+        )
+        rows = backend.get_disposition("action_d", "rec_004")
+        assert len(rows) == 1
+        assert rows[0]["detail"] is None
+
+    def test_set_disposition_success_value(self, backend):
+        backend.set_disposition(
+            action_name="action_e",
+            record_id="rec_005",
+            disposition=Disposition.SUCCESS,
+        )
+        rows = backend.get_disposition("action_e", "rec_005")
+        assert len(rows) == 1
+        assert rows[0]["disposition"] == "success"
 
 
 # ── T2-3: write_source executemany dedup ────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `DISPOSITION_SUCCESS` constant and `Disposition.SUCCESS` enum member to `backend.py`
- Add `detail` column to `record_disposition` table via ALTER TABLE migration for storing extended error messages
- Write `success` disposition for every successfully processed record in `result_collector.py`
- Pass `detail=result.error` for FAILED and EXHAUSTED dispositions
- Every record × every action now has a disposition row, enabling full audit trail: `write_q: success → validate_q: success → rewrite_q: skipped (guard) → add_answer: success`

## Blast Radius
- **Circuit breaker** (`executor.py:_check_upstream_health`): Queries `DISPOSITION_FAILED` and `DISPOSITION_SKIPPED` with `NODE_LEVEL_RECORD_ID` only — unaffected by new SUCCESS rows
- **Output manager** (`output.py`): Queries `DISPOSITION_PASSTHROUGH` and `DISPOSITION_SKIPPED` with `NODE_LEVEL_RECORD_ID` only — unaffected
- **Batch manager** (`batch.py`): Queries `DISPOSITION_PASSTHROUGH` and `DISPOSITION_DEFERRED` — unaffected
- **Existing databases**: ALTER TABLE migration adds nullable `detail` column — no data loss

## Verification
- Manual repro test: 3/3 pass (`python ../../tests/manual/repro_record_disposition_incomplete.py`)
- `ruff format --check`: clean
- `ruff check`: clean
- `pytest`: 5909 passed, 2 skipped
- `pytest tests/unit/storage/ tests/unit/processing/ tests/unit/core/test_result_collector.py -v`: 218 passed