### PR TITLE
fix: diamond dependency preserves non-version branch namespaces

### DIFF
--- a/.changes/unreleased/Bug Fix-20260426-191000.yaml
+++ b/.changes/unreleased/Bug Fix-20260426-191000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Diamond dependency with version merge now preserves all branch namespaces during parallel execution"
+time: 2026-04-26T19:10:00.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -539,22 +538,9 @@ class ActionExecutor:
             metrics=ExecutionMetrics(duration=duration),
         )
 
-    def _cleanup_correlation(
-        self, params: ActionRunParams, original_setup: Callable | None
-    ) -> None:
-        """Restore original setup_directories after correlation setup."""
-        if original_setup:
-            try:
-                self.deps.action_runner.setup_directories = original_setup
-            except (AttributeError, TypeError) as cleanup_error:
-                logger.warning(
-                    "Failed to restore original setup_directories",
-                    extra={
-                        "operation": "action_cleanup",
-                        "action_name": params.action_name,
-                        "error": str(cleanup_error),
-                    },
-                )
+    def _resolve_correlated_input(self, action_idx: int) -> list[str] | None:
+        """Return correlated input directories for version consumers, or None."""
+        return self.deps.output_manager.resolve_correlated_input(action_idx)
 
     def _check_upstream_health(
         self, action_name: str, action_config: ActionConfigDict
@@ -997,7 +983,7 @@ class ActionExecutor:
         """Execute action run (synchronous)."""
         self.deps.state_manager.update_status(params.action_name, ActionStatus.RUNNING)
         self._track_action_start(params)
-        original_setup = self._setup_correlation(params.action_idx)
+        correlated_input = self._resolve_correlated_input(params.action_idx)
 
         try:
             output_folder = self.deps.action_runner.run_action(
@@ -1005,6 +991,7 @@ class ActionExecutor:
                 params.action_name,
                 None,
                 params.action_idx,
+                input_directories_override=correlated_input,
             )
             duration = (datetime.now() - params.start_time).total_seconds()
             batch_status = self._check_batch_submission(
@@ -1017,14 +1004,11 @@ class ActionExecutor:
         except Exception as e:
             return self._handle_run_failure(params, e)
 
-        finally:
-            self._cleanup_correlation(params, original_setup)
-
     async def _execute_action_run_async(self, params: ActionRunParams) -> ActionExecutionResult:
         """Execute action run (asynchronous)."""
         self.deps.state_manager.update_status(params.action_name, ActionStatus.RUNNING)
         self._track_action_start(params)
-        original_setup = self._setup_correlation(params.action_idx)
+        correlated_input = self._resolve_correlated_input(params.action_idx)
 
         try:
             output_folder = await asyncio.to_thread(
@@ -1033,6 +1017,7 @@ class ActionExecutor:
                 params.action_name,
                 None,
                 params.action_idx,
+                input_directories_override=correlated_input,
             )
             duration = (datetime.now() - params.start_time).total_seconds()
             batch_status = self._check_batch_submission(
@@ -1045,22 +1030,8 @@ class ActionExecutor:
         except Exception as e:
             return self._handle_run_failure(params, e)
 
-        finally:
-            self._cleanup_correlation(params, original_setup)
-
     def __repr__(self):
         return f"ActionExecutor(deps={self.deps})"
-
-    def _setup_correlation(self, action_idx: int) -> Callable | None:
-        """Setup loop correlation if needed, return original setup function."""
-        correlation_wrapper = self.deps.output_manager.setup_correlation_wrapper(action_idx)
-
-        if correlation_wrapper:
-            original = self.deps.action_runner.setup_directories
-            self.deps.action_runner.setup_directories = correlation_wrapper
-            return cast(Callable, original)
-
-        return None
 
     def _check_batch_submission(
         self,

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -538,10 +538,6 @@ class ActionExecutor:
             metrics=ExecutionMetrics(duration=duration),
         )
 
-    def _resolve_correlated_input(self, action_idx: int) -> list[str] | None:
-        """Return correlated input directories for version consumers, or None."""
-        return self.deps.output_manager.resolve_correlated_input(action_idx)
-
     def _check_upstream_health(
         self, action_name: str, action_config: ActionConfigDict
     ) -> str | None:
@@ -983,7 +979,7 @@ class ActionExecutor:
         """Execute action run (synchronous)."""
         self.deps.state_manager.update_status(params.action_name, ActionStatus.RUNNING)
         self._track_action_start(params)
-        correlated_input = self._resolve_correlated_input(params.action_idx)
+        correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
 
         try:
             output_folder = self.deps.action_runner.run_action(
@@ -1008,7 +1004,7 @@ class ActionExecutor:
         """Execute action run (asynchronous)."""
         self.deps.state_manager.update_status(params.action_name, ActionStatus.RUNNING)
         self._track_action_start(params)
-        correlated_input = self._resolve_correlated_input(params.action_idx)
+        correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
 
         try:
             output_folder = await asyncio.to_thread(

--- a/agent_actions/workflow/managers/output.py
+++ b/agent_actions/workflow/managers/output.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import threading
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -185,8 +184,14 @@ class ActionOutputManager:
                 )
         return outputs, list(target_files)
 
-    def setup_correlation_wrapper(self, idx: int) -> Callable | None:
-        """Create a correlation-aware setup_directories wrapper if needed."""
+    def resolve_correlated_input(self, idx: int) -> list[str] | None:
+        """Return correlated input directories for version consumers, or None.
+
+        Unlike the old ``setup_correlation_wrapper`` approach, this method does
+        **not** monkey-patch ``runner.setup_directories``.  The caller passes
+        the returned directories to ``run_action`` as an override, which is
+        safe for parallel execution.
+        """
         current_agent = self.execution_order[idx]
 
         if self._version_consumption_map is None:
@@ -205,39 +210,29 @@ class ActionOutputManager:
         version_sources = consumption_config["version_agents"]
         pattern = consumption_config["pattern"]
 
-        def correlation_setup_directories(
-            agent_folder, agent_config, previous_agent_type, agent_idx
-        ):
-            """Wrapper that uses correlated input for version consumers."""
-            correlated_dir = self.version_correlator.prepare_correlated_input(
-                current_agent, version_sources, agent_idx
+        correlated_dir = self.version_correlator.prepare_correlated_input(
+            current_agent, version_sources, idx
+        )
+
+        if correlated_dir:
+            self.console.print(
+                f"[blue]🔗 Using correlated input for {current_agent} from "
+                f"{len(version_sources)} version sources (pattern: {pattern})[/blue]"
             )
+            return [str(correlated_dir)]
 
-            if correlated_dir:
-                self.console.print(
-                    f"[blue]🔗 Using correlated input for {current_agent} from "
-                    f"{len(version_sources)} version sources (pattern: {pattern})[/blue]"
-                )
-                input_directory = correlated_dir
-                # Setup output directory (simple name, no index prefix)
-                agent_type = agent_config["agent_type"]
-                output_directory = Path(agent_folder) / "target" / agent_type
-                return ([str(input_directory)], str(output_directory))
+        from agent_actions.errors import ConfigurationError
 
-            from agent_actions.errors import ConfigurationError
-
-            raise ConfigurationError(
-                f"Version correlation failed for '{current_agent}'. "
-                f"Could not load outputs from version sources: {version_sources}. "
-                f"Check that all version agents completed successfully.",
-                context={
-                    "agent": current_agent,
-                    "version_sources": version_sources,
-                    "pattern": pattern,
-                },
-            )
-
-        return correlation_setup_directories
+        raise ConfigurationError(
+            f"Version correlation failed for '{current_agent}'. "
+            f"Could not load outputs from version sources: {version_sources}. "
+            f"Check that all version agents completed successfully.",
+            context={
+                "agent": current_agent,
+                "version_sources": version_sources,
+                "pattern": pattern,
+            },
+        )
 
 
 # Backward-compatible alias

--- a/agent_actions/workflow/managers/output.py
+++ b/agent_actions/workflow/managers/output.py
@@ -187,10 +187,8 @@ class ActionOutputManager:
     def resolve_correlated_input(self, idx: int) -> list[str] | None:
         """Return correlated input directories for version consumers, or None.
 
-        Unlike the old ``setup_correlation_wrapper`` approach, this method does
-        **not** monkey-patch ``runner.setup_directories``.  The caller passes
-        the returned directories to ``run_action`` as an override, which is
-        safe for parallel execution.
+        Safe for parallel execution — the caller passes the returned
+        directories to ``run_action`` as an override parameter.
         """
         current_agent = self.execution_order[idx]
 

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -95,6 +95,7 @@ class ProcessGenerateParams:
     strategy: ActionStrategy
     previous_action_type: str | None
     idx: int
+    input_directories_override: list[str] | None = None
 
 
 class ActionRunner:
@@ -478,9 +479,15 @@ class ActionRunner:
     def process_and_generate_for_action(self, params: ProcessGenerateParams) -> str:
         """Process and generate data for an action using the provided strategy."""
         agent_folder: str = self.get_action_folder(params.action_name)
-        input_directories, output_directory = self.setup_directories(
-            agent_folder, params.action_config, params.previous_action_type, params.idx
-        )
+
+        if params.input_directories_override is not None:
+            input_directories = params.input_directories_override
+            agent_type = params.action_config["agent_type"]
+            output_directory = str(Path(agent_folder) / "target" / agent_type)
+        else:
+            input_directories, output_directory = self.setup_directories(
+                agent_folder, params.action_config, params.previous_action_type, params.idx
+            )
 
         # Resolve file_type_filter for start nodes
         file_type_filter = None
@@ -510,6 +517,8 @@ class ActionRunner:
         action_name: str,
         previous_action_type: str | None,
         idx: int,
+        *,
+        input_directories_override: list[str] | None = None,
     ) -> str:
         """Run an action with the appropriate strategy based on its position in the workflow."""
         dependencies = action_config.get("dependencies", [])
@@ -526,6 +535,7 @@ class ActionRunner:
                 strategy=strategy,
                 previous_action_type=previous_action_type,
                 idx=idx,
+                input_directories_override=input_directories_override,
             )
         )
         return output_folder

--- a/tests/core/graph/test_version_correlator.py
+++ b/tests/core/graph/test_version_correlator.py
@@ -698,27 +698,19 @@ class TestVersionCorrelationFailureError:
             )
             output_manager = AgentOutputManager(config)
 
-            # Get the correlation wrapper for consumer (idx=2)
-            correlation_wrapper = output_manager.setup_correlation_wrapper(
-                idx=2,
-            )
-
-            # The wrapper should exist since consumer has version_consumption_config
-            assert correlation_wrapper is not None
-
-            # Calling the wrapper when no version outputs exist should raise ConfigurationError
+            # Resolve correlated input for consumer (idx=2) — no version
+            # outputs exist so this should raise ConfigurationError
             with pytest.raises(ConfigurationError) as exc_info:
-                correlation_wrapper(
-                    agent_folder=str(agent_folder),
-                    agent_config=agent_configs["consumer"],
-                    previous_agent_type="action_2",
-                    agent_idx=2,
-                )
+                output_manager.resolve_correlated_input(idx=2)
 
             # Verify error message contains helpful context
             error_msg = str(exc_info.value)
             assert "consumer" in error_msg
             assert "Version correlation failed" in error_msg
+
+            # Non-consumer should return None
+            result = output_manager.resolve_correlated_input(idx=0)
+            assert result is None
 
 
 if __name__ == "__main__":

--- a/tests/unit/workflow/test_diamond_merge_parallel.py
+++ b/tests/unit/workflow/test_diamond_merge_parallel.py
@@ -98,11 +98,9 @@ class TestParallelCorrelationIsolation:
             input_directories_override=correlated,
         )
 
-    def test_parallel_execution_no_shared_state_mutation(self, executor, mock_deps):
-        """Simulates parallel execution: runner.setup_directories must not be mutated."""
-        original_setup = mock_deps.action_runner.setup_directories
+    def test_each_action_gets_its_own_override(self, executor, mock_deps):
+        """Consumer and non-consumer executed sequentially get independent overrides."""
 
-        # Version consumer gets correlated input
         def resolve_side_effect(idx):
             if idx == 4:  # merge_code_alternatives
                 return ["/correlated"]
@@ -129,10 +127,6 @@ class TestParallelCorrelationIsolation:
             executor._execute_action_run(consumer_params)
             executor._execute_action_run(non_consumer_params)
 
-        # runner.setup_directories was never replaced
-        assert mock_deps.action_runner.setup_directories is original_setup
-
-        # Each action got the right override
         calls = mock_deps.action_runner.run_action.call_args_list
         assert calls[0].kwargs["input_directories_override"] == ["/correlated"]
         assert calls[1].kwargs["input_directories_override"] is None

--- a/tests/unit/workflow/test_diamond_merge_parallel.py
+++ b/tests/unit/workflow/test_diamond_merge_parallel.py
@@ -1,0 +1,177 @@
+"""Regression: parallel execution must not leak correlated input between actions.
+
+Before the fix, _setup_correlation() monkey-patched runner.setup_directories
+(shared mutable state).  When a version consumer and a non-consumer ran in the
+same execution level, the non-consumer could see the patched wrapper and receive
+the wrong input directories.
+
+The fix passes correlated input as a parameter to run_action, making each
+action's input resolution independent of other parallel tasks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.workflow.executor import ActionExecutor, ActionRunParams
+
+
+@pytest.fixture
+def mock_deps():
+    """Build executor dependencies with mocked output manager."""
+    from agent_actions.workflow.executor import ExecutorDependencies
+
+    deps = MagicMock(spec=ExecutorDependencies)
+    deps.state_manager = MagicMock()
+    deps.action_runner = MagicMock()
+    deps.output_manager = MagicMock()
+    deps.batch_manager = MagicMock()
+    deps.batch_manager.check_batch_submission.return_value = None
+    deps.action_runner.run_action.return_value = "/output"
+    deps.output_manager.execution_order = [
+        "generate_optimal_code",
+        "select_code_pattern",
+        "generate_code_alternatives_1",
+        "generate_code_alternatives_2",
+        "merge_code_alternatives",
+        "pick_code_pattern",
+    ]
+    return deps
+
+
+@pytest.fixture
+def executor(mock_deps):
+    return ActionExecutor(mock_deps)
+
+
+class TestParallelCorrelationIsolation:
+    """Version-consumer correlation must not leak to non-consumers in the same level."""
+
+    def test_non_consumer_gets_no_override(self, executor, mock_deps):
+        """Non-version-consumer should receive input_directories_override=None."""
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
+
+        params = ActionRunParams(
+            action_name="pick_code_pattern",
+            action_idx=5,
+            action_config={},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            executor._execute_action_run(params)
+
+        mock_deps.action_runner.run_action.assert_called_once_with(
+            params.action_config,
+            "pick_code_pattern",
+            None,
+            5,
+            input_directories_override=None,
+        )
+
+    def test_version_consumer_gets_correlated_dirs(self, executor, mock_deps):
+        """Version consumer should receive correlated input directories."""
+        correlated = ["/path/to/correlated"]
+        mock_deps.output_manager.resolve_correlated_input.return_value = correlated
+
+        params = ActionRunParams(
+            action_name="merge_code_alternatives",
+            action_idx=4,
+            action_config={},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            executor._execute_action_run(params)
+
+        mock_deps.action_runner.run_action.assert_called_once_with(
+            params.action_config,
+            "merge_code_alternatives",
+            None,
+            4,
+            input_directories_override=correlated,
+        )
+
+    def test_parallel_execution_no_shared_state_mutation(self, executor, mock_deps):
+        """Simulates parallel execution: runner.setup_directories must not be mutated."""
+        original_setup = mock_deps.action_runner.setup_directories
+
+        # Version consumer gets correlated input
+        def resolve_side_effect(idx):
+            if idx == 4:  # merge_code_alternatives
+                return ["/correlated"]
+            return None  # pick_code_pattern
+
+        mock_deps.output_manager.resolve_correlated_input.side_effect = resolve_side_effect
+
+        consumer_params = ActionRunParams(
+            action_name="merge_code_alternatives",
+            action_idx=4,
+            action_config={},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+        non_consumer_params = ActionRunParams(
+            action_name="pick_code_pattern",
+            action_idx=5,
+            action_config={},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            executor._execute_action_run(consumer_params)
+            executor._execute_action_run(non_consumer_params)
+
+        # runner.setup_directories was never replaced
+        assert mock_deps.action_runner.setup_directories is original_setup
+
+        # Each action got the right override
+        calls = mock_deps.action_runner.run_action.call_args_list
+        assert calls[0].kwargs["input_directories_override"] == ["/correlated"]
+        assert calls[1].kwargs["input_directories_override"] is None
+
+    @pytest.mark.asyncio
+    async def test_async_parallel_no_bleed(self, executor, mock_deps):
+        """Async parallel execution: each task gets its own correlated input."""
+
+        def resolve_side_effect(idx):
+            if idx == 4:
+                return ["/correlated"]
+            return None
+
+        mock_deps.output_manager.resolve_correlated_input.side_effect = resolve_side_effect
+
+        consumer_params = ActionRunParams(
+            action_name="merge_code_alternatives",
+            action_idx=4,
+            action_config={},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+        non_consumer_params = ActionRunParams(
+            action_name="pick_code_pattern",
+            action_idx=5,
+            action_config={},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            await asyncio.gather(
+                executor._execute_action_run_async(consumer_params),
+                executor._execute_action_run_async(non_consumer_params),
+            )
+
+        calls = mock_deps.action_runner.run_action.call_args_list
+        overrides = [c.kwargs["input_directories_override"] for c in calls]
+
+        # One call got correlated dirs, the other got None — regardless of order
+        assert ["/correlated"] in overrides
+        assert None in overrides

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -84,7 +84,7 @@ class TestExecuteAgentSync:
 
         mock_deps.skip_evaluator.should_skip_action.return_value = False
         mock_deps.action_runner.run_action.return_value = "/output"
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
         mock_deps.batch_manager.check_batch_submission.return_value = None
 
         with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
@@ -110,7 +110,7 @@ class TestExecuteAgentSync:
 
         mock_deps.skip_evaluator.should_skip_action.return_value = False
         mock_deps.action_runner.run_action.return_value = "/output"
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
         mock_deps.batch_manager.check_batch_submission.return_value = None
 
         with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
@@ -201,7 +201,7 @@ class TestExecuteAgentSync:
         mock_deps.state_manager.get_status.return_value = ActionStatus.PENDING
         mock_deps.skip_evaluator.should_skip_action.return_value = False
         mock_deps.action_runner.run_action.return_value = "/output"
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
         mock_deps.batch_manager.check_batch_submission.return_value = None
 
         with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
@@ -218,7 +218,7 @@ class TestExecuteAgentSync:
         mock_deps.state_manager.get_status.return_value = ActionStatus.PENDING
         mock_deps.skip_evaluator.should_skip_action.return_value = False
         mock_deps.action_runner.run_action.side_effect = RuntimeError("agent crashed")
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
 
         result = executor.execute_action_sync(
             "agent_a", action_idx=0, action_config={}, is_last_action=False
@@ -409,7 +409,7 @@ class TestExecuteAgentRun:
     def test_status_transitions_running_to_completed(self, executor, mock_deps):
         """Should transition from running → completed on success."""
         mock_deps.action_runner.run_action.return_value = "/output"
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
         mock_deps.batch_manager.check_batch_submission.return_value = None
         params = ActionRunParams(
             action_name="agent_a",
@@ -428,7 +428,7 @@ class TestExecuteAgentRun:
     def test_failure_calls_handle_run_failure(self, executor, mock_deps):
         """Exception should result in _handle_run_failure path."""
         mock_deps.action_runner.run_action.side_effect = RuntimeError("boom")
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
         params = ActionRunParams(
             action_name="agent_a",
             action_idx=0,
@@ -442,12 +442,10 @@ class TestExecuteAgentRun:
         assert result.success is False
         assert result.status == ActionStatus.FAILED
 
-    def test_correlation_setup_and_cleanup(self, executor, mock_deps):
-        """Correlation wrapper should be set up and cleaned up."""
-        original_fn = MagicMock()
-        mock_deps.action_runner.setup_directories = original_fn
-        wrapper = MagicMock()
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = wrapper
+    def test_correlated_input_passed_to_run_action(self, executor, mock_deps):
+        """Correlated input directories should be passed to run_action, not monkey-patched."""
+        correlated_dirs = ["/correlated/dir"]
+        mock_deps.output_manager.resolve_correlated_input.return_value = correlated_dirs
         mock_deps.action_runner.run_action.return_value = "/output"
         mock_deps.batch_manager.check_batch_submission.return_value = None
         params = ActionRunParams(
@@ -461,8 +459,14 @@ class TestExecuteAgentRun:
         with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
             executor._execute_action_run(params)
 
-        # Correlation wrapper was installed, then original restored
-        assert mock_deps.action_runner.setup_directories == original_fn
+        # Correlated input passed as keyword arg, not via monkey-patching
+        mock_deps.action_runner.run_action.assert_called_once_with(
+            params.action_config,
+            params.action_name,
+            None,
+            params.action_idx,
+            input_directories_override=correlated_dirs,
+        )
 
 
 # ── _verify_completion_status ──────────────────────────────────────────

--- a/tests/unit/workflow/test_rename_regression.py
+++ b/tests/unit/workflow/test_rename_regression.py
@@ -149,7 +149,7 @@ class TestExecutorCallsRunAction:
     def test_sync_run_calls_run_action(self, executor, mock_deps):
         """_execute_action_run must call action_runner.run_action, not run_agent."""
         mock_deps.action_runner.run_action.return_value = "/output"
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
         mock_deps.batch_manager.check_batch_submission.return_value = None
 
         params = ActionRunParams(
@@ -171,7 +171,7 @@ class TestExecutorCallsRunAction:
     def test_async_run_calls_run_action(self, executor, mock_deps):
         """_execute_action_run_async must call action_runner.run_action, not run_agent."""
         mock_deps.action_runner.run_action.return_value = "/output"
-        mock_deps.output_manager.setup_correlation_wrapper.return_value = None
+        mock_deps.output_manager.resolve_correlated_input.return_value = None
         mock_deps.batch_manager.check_batch_submission.return_value = None
 
         params = ActionRunParams(


### PR DESCRIPTION
## Summary
- When a version consumer and non-consumer ran in the same parallel execution level, `_setup_correlation()` monkey-patched `runner.setup_directories` (shared mutable state). The non-consumer saw the patched wrapper and received version-correlated input instead of its declared dependency's output.
- Replaced monkey-patching with parameter passing: `resolve_correlated_input()` returns directories directly, executor passes them to `run_action` as `input_directories_override`. Each action's input resolution is now independent of other parallel tasks.

## Root Cause
`executor._setup_correlation()` replaced `runner.setup_directories` with a closure for version consumers. With `asyncio.gather` parallel execution, the monkey-patch leaked to non-consumers in the same level. In `code_centered_quiz`, `pick_code_pattern` received `merge_code_alternatives`' version-correlated input instead of `select_code_pattern`'s output.

## Changes
| File | Change |
|------|--------|
| `workflow/managers/output.py` | `setup_correlation_wrapper()` → `resolve_correlated_input()` (returns dirs, not closure) |
| `workflow/runner.py` | `input_directories_override` param on `run_action` / `ProcessGenerateParams` |
| `workflow/executor.py` | Removed `_setup_correlation`/`_cleanup_correlation`, passes override to `run_action` |

## Verification
- `pytest`: 5970 passed, 0 failed
- `ruff format --check` + `ruff check`: clean
- New regression test (`test_diamond_merge_parallel.py`) verifies parallel isolation with sync and async execution
- Manual repro test reads from pre-existing DB (produced by prior buggy run) — requires workflow re-run to validate end-to-end