### PR TITLE
refactor: fan-in merge uses merge_branch_records()

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260427-205000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260427-205000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Fan-in merge uses merge_branch_records() — each branch contributes only its own namespace, eliminating silent upstream overwrite"
+time: 2026-04-27T20:50:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260427-205000.yaml
+++ b/.changes/unreleased/Under the Hood-20260427-205000.yaml
@@ -1,3 +1,3 @@
-kind: Enhancement or New Feature
+kind: Under the Hood
 body: "Fan-in merge uses merge_branch_records() — each branch contributes only its own namespace, eliminating silent upstream overwrite"
 time: 2026-04-27T20:50:00.000000Z

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -133,12 +133,64 @@ def get_correlation_value(record: dict[str, Any], key_candidates: list[str]) -> 
     return None
 
 
+def _identify_branch_mapping(
+    group: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]] | None:
+    """Identify branch names for a group of fan-in records.
+
+    Returns ``{branch_name: record}`` where each branch_name is a content
+    namespace unique to that record.  Returns ``None`` when branches cannot
+    be distinguished (e.g. identical content schemas) — caller falls back to
+    ``deep_merge_record``.
+
+    When a record owns multiple unique namespaces (diamond dependency), each
+    namespace becomes its own entry pointing to the same record.
+    """
+    if not group:
+        return None
+
+    key_sets: list[set[str]] = []
+    for rec in group:
+        content = get_existing_content(rec)
+        if not content:
+            return None
+        key_sets.append(set(content.keys()))
+
+    shared_keys = key_sets[0].copy()
+    for ks in key_sets[1:]:
+        shared_keys &= ks
+
+    branch_records: dict[str, dict[str, Any]] = {}
+    for rec, ks in zip(group, key_sets, strict=True):
+        unique = ks - shared_keys
+        if not unique:
+            return None  # can't distinguish this record's branch
+        for ns_key in sorted(unique):
+            branch_records[ns_key] = rec
+
+    return branch_records
+
+
+def _merge_group_deep(group: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge a group of records using deep_merge_record (legacy/aggregation path)."""
+    merged: dict[str, Any] = {}
+    for record in group:
+        deep_merge_record(merged, record)
+    return merged
+
+
 def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> list[Any]:
-    """Merge records sharing the same correlation key (reduce_key -> parent_target_id -> source_guid)."""
-    records_by_key: dict[str, dict] = {}
+    """Merge records sharing the same correlation key.
+
+    For same-source fan-in (no ``reduce_key``), uses ``merge_branch_records``
+    so each branch contributes only its own namespace and upstream is preserved
+    from the base record.  For ``reduce_key`` aggregation (different sources
+    grouped together), uses ``deep_merge_record``.
+    """
+    groups_by_key: dict[str, list[dict[str, Any]]] = {}
     records_without_key: list[Any] = []
 
-    key_candidates = []
+    key_candidates: list[str] = []
     if reduce_key:
         key_candidates.append(reduce_key)
     key_candidates.extend(["root_target_id", "parent_target_id", "source_guid"])
@@ -149,15 +201,31 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
             continue
 
         correlation_value = get_correlation_value(record, key_candidates)
-
         if correlation_value:
-            if correlation_value not in records_by_key:
-                records_by_key[correlation_value] = {}
-            deep_merge_record(records_by_key[correlation_value], record)
+            groups_by_key.setdefault(correlation_value, []).append(record)
         else:
             records_without_key.append(record)
 
-    return list(records_by_key.values()) + records_without_key
+    merged_results: list[Any] = []
+    for group in groups_by_key.values():
+        if len(group) == 1:
+            merged_results.append(group[0])
+            continue
+
+        if reduce_key:
+            merged_results.append(_merge_group_deep(group))
+            continue
+
+        branch_mapping = _identify_branch_mapping(group)
+        if branch_mapping is not None:
+            merged = merge_branch_records(branch_mapping, base_record=group[0])
+            for rec in group[1:]:
+                _populate_lineage_sources(merged, rec)
+            merged_results.append(merged)
+        else:
+            merged_results.append(_merge_group_deep(group))
+
+    return merged_results + records_without_key
 
 
 def merge_json_files(file_paths: list[Path], reduce_key: str | None = None) -> list[Any]:

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -184,8 +184,12 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
 
     For same-source fan-in (no ``reduce_key``), uses ``merge_branch_records``
     so each branch contributes only its own namespace and upstream is preserved
-    from the base record.  For ``reduce_key`` aggregation (different sources
-    grouped together), uses ``deep_merge_record``.
+    from the base record (first record in the group).  For ``reduce_key``
+    aggregation (different sources grouped together), uses ``deep_merge_record``.
+
+    Note: When using the branch-records path, ``group[0]`` is the canonical
+    upstream source.  Its shared namespaces survive; other records' versions
+    of the same upstream namespaces are ignored.
     """
     groups_by_key: dict[str, list[dict[str, Any]]] = {}
     records_without_key: list[Any] = []
@@ -219,6 +223,8 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
         branch_mapping = _identify_branch_mapping(group)
         if branch_mapping is not None:
             merged = merge_branch_records(branch_mapping, base_record=group[0])
+            # merge_branch_records handles lineage dedup but not lineage_sources.
+            # merged["node_id"] == group[0]["node_id"] (from {**base, ...}).
             for rec in group[1:]:
                 _populate_lineage_sources(merged, rec)
             merged_results.append(merged)

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from agent_actions.workflow.merge import (
+    _identify_branch_mapping,
+    _merge_group_deep,
     deep_merge_record,
     get_correlation_value,
     merge_json_files,
@@ -479,3 +481,281 @@ class TestMergeJsonFiles:
             assert len(result) == 1
             assert result[0]["a"] == 1
             assert result[0]["b"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Fan-in merge via merge_branch_records (spec 205)
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyBranchMapping:
+    """Tests for _identify_branch_mapping helper."""
+
+    def test_two_branches_with_unique_namespaces(self):
+        """Each record has one unique namespace — clean mapping."""
+        group = [
+            {
+                "content": {
+                    "source": {"url": "x"},
+                    "extract": {"text": "y"},
+                    "classify": {"topic": "z"},
+                }
+            },
+            {
+                "content": {
+                    "source": {"url": "x"},
+                    "extract": {"text": "y"},
+                    "enrich": {"summary": "w"},
+                }
+            },
+        ]
+        mapping = _identify_branch_mapping(group)
+
+        assert mapping is not None
+        assert set(mapping.keys()) == {"classify", "enrich"}
+        assert mapping["classify"] is group[0]
+        assert mapping["enrich"] is group[1]
+
+    def test_three_branches(self):
+        """Three-way fan-in — one unique namespace each."""
+        group = [
+            {"content": {"source": {}, "classify": {"c": 1}}},
+            {"content": {"source": {}, "enrich": {"e": 2}}},
+            {"content": {"source": {}, "sentiment": {"s": 3}}},
+        ]
+        mapping = _identify_branch_mapping(group)
+
+        assert mapping is not None
+        assert set(mapping.keys()) == {"classify", "enrich", "sentiment"}
+
+    def test_multi_namespace_record_diamond(self):
+        """Record with multiple unique namespaces — each becomes a branch entry."""
+        group = [
+            {"content": {"source": {}, "select_pattern": {"p": 1}}},
+            {
+                "content": {
+                    "source": {},
+                    "gen_alt_1": {"a": 2},
+                    "merge_alts": {"m": 3},
+                }
+            },
+        ]
+        mapping = _identify_branch_mapping(group)
+
+        assert mapping is not None
+        assert set(mapping.keys()) == {"select_pattern", "gen_alt_1", "merge_alts"}
+        assert mapping["select_pattern"] is group[0]
+        assert mapping["gen_alt_1"] is group[1]
+        assert mapping["merge_alts"] is group[1]
+
+    def test_identical_schemas_returns_none(self):
+        """Records with identical content keys — cannot identify branches."""
+        group = [
+            {"content": {"source": {}, "action": {"v": 1}}},
+            {"content": {"source": {}, "action": {"v": 2}}},
+        ]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+    def test_no_content_dict_returns_none(self):
+        """Records without content dicts — fallback."""
+        group = [{"field_a": "A"}, {"field_b": "B"}]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+    def test_non_dict_content_returns_none(self):
+        """Records with non-dict content — fallback."""
+        group = [{"content": "string"}, {"content": "other"}]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+    def test_one_record_no_unique_returns_none(self):
+        """If one record has no unique namespace, returns None even if others do."""
+        group = [
+            {"content": {"shared": {}, "unique_a": {}}},
+            {"content": {"shared": {}}},
+        ]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+
+class TestFanInViaPrimitive:
+    """Tests for merge_records_by_key routing fan-in through merge_branch_records."""
+
+    def test_fan_in_preserves_upstream_from_base(self):
+        """The silent overwrite bug: base upstream is canonical, branch upstream ignored."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "node_id": "classify_abc",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello", "_retry_count": 1},
+                "classify": {"topic": "science"},
+            },
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "node_id": "enrich_def",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello"},
+                "enrich": {"summary": "about science"},
+            },
+        }
+
+        result = merge_records_by_key([branch_a, branch_b])
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content["extract"]["_retry_count"] == 1, "Base upstream preserved"
+        assert content["classify"]["topic"] == "science"
+        assert content["enrich"]["summary"] == "about science"
+
+    def test_fan_in_diamond_all_namespaces(self):
+        """Diamond dependency — both branches' unique namespaces present."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "content": {
+                    "source": {"url": "x"},
+                    "generate": {"code": "pass"},
+                    "select_pattern": {"pattern": "scenario"},
+                },
+            },
+            {
+                "source_guid": "sg-1",
+                "content": {
+                    "source": {"url": "x"},
+                    "generate": {"code": "pass"},
+                    "gen_alt_1": {"alt": "A"},
+                    "merge_alts": {"merged": True},
+                },
+            },
+        ]
+
+        result = merge_records_by_key(records)
+        assert len(result) == 1
+
+        content = result[0]["content"]
+        assert set(content.keys()) == {
+            "source",
+            "generate",
+            "select_pattern",
+            "gen_alt_1",
+            "merge_alts",
+        }
+        assert content["select_pattern"]["pattern"] == "scenario"
+        assert content["gen_alt_1"]["alt"] == "A"
+        assert content["merge_alts"]["merged"] is True
+
+    def test_reduce_key_uses_deep_merge(self):
+        """reduce_key aggregation always uses deep_merge_record, not the primitive."""
+        records = [
+            {"custom_id": "123", "source_guid": "s1", "content": {"ns_a": {"v": 1}}},
+            {"custom_id": "123", "source_guid": "s2", "content": {"ns_b": {"v": 2}}},
+        ]
+
+        result = merge_records_by_key(records, reduce_key="custom_id")
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert "ns_a" in content
+        assert "ns_b" in content
+
+    def test_identical_schemas_fallback(self):
+        """Records with identical content keys fall back to deep_merge_record."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "content": {"shared": {"a": 1}, "action": {"v": 1}},
+            },
+            {
+                "source_guid": "sg-1",
+                "content": {"shared": {"a": 1}, "action": {"v": 2}},
+            },
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        # deep_merge_record: last-writer-wins on content.update
+        assert result[0]["content"]["action"]["v"] == 2
+
+    def test_single_record_group_returned_as_is(self):
+        """Single-record group needs no merge — returned directly."""
+        record = {"source_guid": "unique-1", "content": {"ns": {"v": 1}}}
+
+        result = merge_records_by_key([record])
+
+        assert len(result) == 1
+        assert result[0] is record
+
+    def test_fan_in_lineage_sources_populated(self):
+        """lineage_sources tracks leaf node_ids after merge_branch_records."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "branch_a_001",
+                "lineage": ["root_0", "branch_a_001"],
+                "content": {"shared": {}, "field_a": {"a": 1}},
+            },
+            {
+                "source_guid": "sg-1",
+                "node_id": "branch_b_002",
+                "lineage": ["root_0", "branch_b_002"],
+                "content": {"shared": {}, "field_b": {"b": 2}},
+            },
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        merged = result[0]
+        assert merged["lineage_sources"] == ["branch_a_001", "branch_b_002"]
+        assert "branch_a_001" in merged["lineage"]
+        assert "branch_b_002" in merged["lineage"]
+
+    def test_fan_in_three_way_lineage_sources(self):
+        """Three-way fan-in populates all leaf node_ids in lineage_sources."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "node_a",
+                "content": {"upstream": {}, "branch_a": {"a": 1}},
+            },
+            {
+                "source_guid": "sg-1",
+                "node_id": "node_b",
+                "content": {"upstream": {}, "branch_b": {"b": 2}},
+            },
+            {
+                "source_guid": "sg-1",
+                "node_id": "node_c",
+                "content": {"upstream": {}, "branch_c": {"c": 3}},
+            },
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        merged = result[0]
+        assert len(merged["lineage_sources"]) == 3
+        assert "node_a" in merged["lineage_sources"]
+        assert "node_b" in merged["lineage_sources"]
+        assert "node_c" in merged["lineage_sources"]
+
+
+class TestMergeGroupDeep:
+    """Tests for _merge_group_deep helper."""
+
+    def test_merges_group_into_single_record(self):
+        """Group of records merged via deep_merge_record."""
+        group = [
+            {"source_guid": "sg-1", "content": {"ns_a": {"a": 1}}},
+            {"source_guid": "sg-1", "content": {"ns_b": {"b": 2}}},
+        ]
+
+        result = _merge_group_deep(group)
+
+        assert result["content"]["ns_a"]["a"] == 1
+        assert result["content"]["ns_b"]["b"] == 2

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -648,6 +648,34 @@ class TestFanInViaPrimitive:
         assert content["gen_alt_1"]["alt"] == "A"
         assert content["merge_alts"]["merged"] is True
 
+    def test_fan_in_first_record_upstream_is_canonical(self):
+        """First record's upstream is canonical — second record's upstream ignored."""
+        # Record B arrives second: its richer upstream (with _extra) is ignored
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {
+                "upstream": {"base": True},
+                "branch_a": {"a": 1},
+            },
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {
+                "upstream": {"base": True, "_extra": "from_b"},
+                "branch_b": {"b": 2},
+            },
+        }
+
+        result = merge_records_by_key([branch_a, branch_b])
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        # A is first → its upstream is canonical
+        assert content["upstream"] == {"base": True}
+        assert "_extra" not in content["upstream"]
+        assert content["branch_a"]["a"] == 1
+        assert content["branch_b"]["b"] == 2
+
     def test_reduce_key_uses_deep_merge(self):
         """reduce_key aggregation always uses deep_merge_record, not the primitive."""
         records = [
@@ -659,8 +687,8 @@ class TestFanInViaPrimitive:
 
         assert len(result) == 1
         content = result[0]["content"]
-        assert "ns_a" in content
-        assert "ns_b" in content
+        assert content["ns_a"]["v"] == 1
+        assert content["ns_b"]["v"] == 2
 
     def test_identical_schemas_fallback(self):
         """Records with identical content keys fall back to deep_merge_record."""
@@ -688,7 +716,8 @@ class TestFanInViaPrimitive:
         result = merge_records_by_key([record])
 
         assert len(result) == 1
-        assert result[0] is record
+        assert result[0]["content"]["ns"]["v"] == 1
+        assert result[0]["source_guid"] == "unique-1"
 
     def test_fan_in_lineage_sources_populated(self):
         """lineage_sources tracks leaf node_ids after merge_branch_records."""


### PR DESCRIPTION
## Summary
- `merge_records_by_key()` now routes fan-in merges through `merge_branch_records()` instead of `deep_merge_record()`
- `_identify_branch_mapping()` determines each record's unique namespace(s) by diffing content keys across the correlated group
- `reduce_key` aggregation path (different-source grouping) retains `deep_merge_record()` — the primitive's invariant doesn't apply there
- Graceful fallback: when branches can't be distinguished (identical content schemas), falls back to `deep_merge_record()` with no behavior change

## Verification
- Simulation: 17/18 (Test 1 tests `deep_merge_record` directly — known limitation, not in scope)
- 15 new tests: branch mapping (7), fan-in via primitive (7), merge group deep (1)
- Full suite: 6013 passed, ruff clean
- Diamond merge, three-way fan-in, lineage_sources all verified