### PR TITLE
refactor: unified context_scope — FILE mode gains drop + passthrough

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260427-200000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260427-200000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Unified context_scope processing: FILE mode now enforces drop and passthrough directives via apply_context_scope_for_records()"
+time: 2026-04-27T20:00:00.000000Z

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -14,7 +14,7 @@ loaders for cataloging prompts at documentation time.
 | ~~`scope.py`~~ | Deleted | Facade removed. Consumers import directly from the 6 `scope_*` modules. | — |
 | `scope_parsing.py` | Module | Field reference parsing and action name extraction utilities. | `preprocessing` |
 | `scope_inference.py` | Module | Dependency inference: fan-in detection, version branch expansion, input/context source resolution. | `preprocessing` |
-| `scope_application.py` | Module | Context scope application: observe/passthrough/drop filtering, LLM context formatting. | `preprocessing` |
+| `scope_application.py` | Module | Context scope application: observe/passthrough/drop filtering for RECORD mode (`apply_context_scope`) and FILE mode (`apply_context_scope_for_records`), LLM context formatting. | `preprocessing` |
 | `scope_namespace.py` | Module | Namespace enrichment, field filtering, and allowed-fields extraction. | `preprocessing` |
 | `scope_builder.py` | Module | `build_field_context_with_history`: assembles source/dependency/version/workflow namespaces. | `preprocessing` |
 | `scope_file_mode.py` | Module | File-mode observe filtering with cross-namespace resolution. | `preprocessing` |

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -461,8 +461,11 @@ def apply_context_scope_for_records(
         return records
 
     # Check if any directive references the source namespace
-    all_refs = observe_refs + passthrough_refs + drop_refs
-    has_source_refs = any(ref.startswith("source.") for ref in all_refs)
+    has_source_refs = (
+        any(ref.startswith("source.") for ref in observe_refs)
+        or any(ref.startswith("source.") for ref in passthrough_refs)
+        or any(ref.startswith("source.") for ref in drop_refs)
+    )
 
     source_index = _build_source_index(source_data) if has_source_refs else {}
     resolved_observe, qualify_wildcards = (
@@ -476,11 +479,11 @@ def apply_context_scope_for_records(
 
     for record in records:
         content = get_existing_content(record)
+        sguid = record.get("source_guid")
 
         # Build field_context with source namespace resolved
         field_context = dict(content)
         if has_source_refs:
-            sguid = record.get("source_guid")
             if sguid not in source_cache:
                 source_cache[sguid] = _resolve_source_content(sguid, source_index, source_data)
             source_content = source_cache[sguid]
@@ -492,8 +495,8 @@ def apply_context_scope_for_records(
 
         # Rebuild enriched record: ALL namespaces preserved, drops applied, flat keys
         enriched_content = deepcopy(content)
-        if has_source_refs and source_cache.get(record.get("source_guid")):
-            enriched_content["source"] = deepcopy(source_cache[record.get("source_guid")])
+        if has_source_refs and source_cache.get(sguid):
+            enriched_content["source"] = deepcopy(source_cache[sguid])
         _apply_drops_to_content(enriched_content, drop_refs)
         _inject_flat_observed_keys(enriched_content, resolved_observe, qualify_wildcards)
 

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections import Counter
 from copy import deepcopy
 from typing import Any
 
@@ -11,11 +12,13 @@ from agent_actions.logging.events.io_events import (
     ContextFieldSkippedEvent,
     ContextScopeAppliedEvent,
 )
+from agent_actions.prompt.context.scope_namespace import _extract_content_data
 from agent_actions.prompt.context.scope_parsing import (
     extract_action_fields,
     extract_field_value,
     parse_field_reference,
 )
+from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +33,7 @@ FRAMEWORK_NAMESPACES = frozenset({"version", "seed", "workflow", "loop"})
 
 __all__ = [
     "apply_context_scope",
+    "apply_context_scope_for_records",
     "format_llm_context",
 ]
 
@@ -55,6 +59,15 @@ def apply_context_scope(
     Returns:
         Tuple of (prompt_context, llm_context, passthrough_fields)
     """
+    # Early return: no directive keys declared at all = pass everything through.
+    # Distinct from {"observe": []} which means "gate to framework namespaces only".
+    if (
+        "observe" not in context_scope
+        and "passthrough" not in context_scope
+        and "drop" not in context_scope
+    ):
+        return (deepcopy(field_context), {}, {})
+
     # Deep copy to avoid mutating original field_context
     prompt_context = deepcopy(field_context)
     llm_context: dict[str, dict[str, Any]] = {}
@@ -301,3 +314,189 @@ def format_llm_context(llm_context: dict) -> str:
             lines.append(f"{ns_name}.{field}: {value_str}")
 
     return "\n".join(lines)
+
+
+# ── FILE mode helpers ──────────────────────────────────────────────────
+
+
+def _build_source_index(source_data: list[dict] | None) -> dict[str | None, dict]:
+    """Build source_guid -> source record index for cross-record source resolution."""
+    index: dict[str | None, dict] = {}
+    if not source_data:
+        return index
+    for src in source_data:
+        sguid = src.get("source_guid") if isinstance(src, dict) else None
+        if sguid:
+            index[sguid] = src
+    return index
+
+
+def _resolve_source_content(
+    source_guid: str | None,
+    source_index: dict[str | None, dict],
+    source_data: list[dict] | None,
+) -> dict:
+    """Resolve source namespace content for a record via source_guid.
+
+    Falls back to first source record if source_guid not found in index.
+    """
+    matched = source_index.get(source_guid)
+    if not matched and source_data:
+        matched = source_data[0]
+    if matched:
+        return _extract_content_data(matched)
+    return {}
+
+
+def _resolve_observe_refs_for_flat_keys(
+    observe_refs: list[str],
+    action_name: str = "unknown",
+) -> tuple[list[tuple[str, str, str]], bool]:
+    """Parse observe refs and detect bare-key collisions for FILE mode flat key injection.
+
+    Returns (resolved, qualify_wildcards) where resolved is a list of
+    (namespace, field_name, output_key) triples. output_key is
+    namespace-qualified when bare-key collisions are detected.
+    qualify_wildcards is True when multiple wildcard namespaces exist.
+    """
+    valid_pairs: list[tuple[str, str]] = []
+
+    for ref in observe_refs:
+        try:
+            ns, field = parse_field_reference(ref)
+            valid_pairs.append((ns, field))
+        except ValueError as e:
+            fire_event(
+                ContextFieldSkippedEvent(
+                    action_name=action_name,
+                    field_ref=ref,
+                    reason=str(e),
+                    directive="resolve_observe_refs",
+                )
+            )
+            continue
+
+    bare_counts = Counter(field for _, field in valid_pairs)
+    collisions = {k for k, v in bare_counts.items() if v > 1}
+
+    wildcard_ns: set[str] = set()
+    resolved: list[tuple[str, str, str]] = []
+    for ns, field in valid_pairs:
+        if field == "*":
+            wildcard_ns.add(ns)
+        output_key = f"{ns}.{field}" if field in collisions else field
+        resolved.append((ns, field, output_key))
+
+    return resolved, len(wildcard_ns) > 1
+
+
+def _apply_drops_to_content(content: dict, drop_refs: list[str]) -> None:
+    """Apply drop directives to content dict in-place.
+
+    Silently skips unparseable refs or missing namespaces.
+    """
+    for ref in drop_refs:
+        try:
+            ns, field = parse_field_reference(ref)
+        except ValueError:
+            continue
+        if ns not in content or not isinstance(content[ns], dict):
+            continue
+        if field == "*":
+            content[ns].clear()
+        else:
+            content[ns].pop(field, None)
+
+
+def _inject_flat_observed_keys(
+    content: dict,
+    resolved_observe: list[tuple[str, str, str]],
+    qualify_wildcards: bool,
+) -> None:
+    """Inject flat observed keys into content for FILE mode enrichment.
+
+    Reads values from post-drop content namespaces and injects them as
+    top-level keys. Wildcard refs expand to all fields in the namespace.
+    Keys are namespace-qualified when collisions are detected.
+    """
+    for ns, field, output_key in resolved_observe:
+        ns_data = content.get(ns)
+        if not isinstance(ns_data, dict):
+            continue
+
+        if field == "*":
+            for f, v in ns_data.items():
+                key = f"{ns}.{f}" if qualify_wildcards else f
+                content[key] = v
+        elif field in ns_data:
+            content[output_key] = ns_data[field]
+
+
+# ── FILE mode wrapper ──────────────────────────────────────────────────
+
+
+def apply_context_scope_for_records(
+    records: list[dict],
+    context_scope: dict,
+    action_name: str = "unknown",
+    source_data: list[dict] | None = None,
+) -> list[dict]:
+    """Apply context_scope to a list of records (FILE mode).
+
+    For each record:
+    1. Extract namespaced content
+    2. Resolve source namespace via source_guid cross-reference
+    3. Call apply_context_scope() for observe/drop/passthrough processing
+    4. Rebuild enriched record: original content + drops applied + flat observed keys
+
+    Unlike apply_context_scope() which gates prompt_context to observed namespaces
+    only (correct for Jinja), this function preserves ALL original namespaces in the
+    enriched record because downstream guards need full namespace visibility.
+    """
+    observe_refs = context_scope.get("observe", [])
+    passthrough_refs = context_scope.get("passthrough", [])
+    drop_refs = context_scope.get("drop", [])
+
+    if not observe_refs and not passthrough_refs and not drop_refs:
+        return records
+
+    # Check if any directive references the source namespace
+    all_refs = observe_refs + passthrough_refs + drop_refs
+    has_source_refs = any(ref.startswith("source.") for ref in all_refs)
+
+    source_index = _build_source_index(source_data) if has_source_refs else {}
+    resolved_observe, qualify_wildcards = (
+        _resolve_observe_refs_for_flat_keys(observe_refs, action_name)
+        if observe_refs
+        else ([], False)
+    )
+
+    source_cache: dict[str | None, dict] = {}
+    enriched: list[dict] = []
+
+    for record in records:
+        content = get_existing_content(record)
+
+        # Build field_context with source namespace resolved
+        field_context = dict(content)
+        if has_source_refs:
+            sguid = record.get("source_guid")
+            if sguid not in source_cache:
+                source_cache[sguid] = _resolve_source_content(sguid, source_index, source_data)
+            source_content = source_cache[sguid]
+            if source_content:
+                field_context["source"] = source_content
+
+        # Call unified bus filter (validates refs, fires events)
+        apply_context_scope(field_context, context_scope, action_name=action_name)
+
+        # Rebuild enriched record: ALL namespaces preserved, drops applied, flat keys
+        enriched_content = deepcopy(content)
+        if has_source_refs and source_cache.get(record.get("source_guid")):
+            enriched_content["source"] = deepcopy(source_cache[record.get("source_guid")])
+        _apply_drops_to_content(enriched_content, drop_refs)
+        _inject_flat_observed_keys(enriched_content, resolved_observe, qualify_wildcards)
+
+        enriched.append({**record, "content": enriched_content})
+
+    return enriched

--- a/tests/unit/prompt/context/test_scope_application_file_mode.py
+++ b/tests/unit/prompt/context/test_scope_application_file_mode.py
@@ -1,0 +1,316 @@
+"""Tests for apply_context_scope_for_records (FILE mode context_scope).
+
+Covers all 3 directives (observe/drop/passthrough), collision detection,
+source resolution, empty observe, None namespace, and directive interactions.
+"""
+
+from copy import deepcopy
+
+import pytest
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.prompt.context.scope_application import (
+    apply_context_scope_for_records,
+)
+
+# ── Test data ──────────────────────────────────────────────────────────
+
+RECORD = {
+    "source_guid": "guid-1",
+    "node_id": "node_123",
+    "content": {
+        "extract_qa": {"question": "What is X?", "answer": "Y", "confidence": 0.9},
+        "validate": {"pass": True, "violations": [], "internal_token_count": 450},
+    },
+}
+
+SOURCE_DATA = [
+    {
+        "source_guid": "guid-1",
+        "content": {"page_content": "Doc text", "url": "http://1.com"},
+    },
+    {
+        "source_guid": "guid-2",
+        "content": {"page_content": "Other doc", "url": "http://2.com"},
+    },
+]
+
+
+# ── All 3 directives ──────────────────────────────────────────────────
+
+
+class TestAllDirectives:
+    def test_drop_removes_field_from_namespace(self):
+        """drop: [validate.internal_token_count] removes field from validate namespace."""
+        scope = {
+            "observe": ["extract_qa.question"],
+            "drop": ["validate.internal_token_count"],
+        }
+        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        validate = result[0]["content"]["validate"]
+        assert "internal_token_count" not in validate
+        assert validate["pass"] is True
+
+    def test_passthrough_fields_preserved_in_namespaces(self):
+        """Passthrough fields stay in namespaced content (FILE keeps ALL namespaces)."""
+        scope = {
+            "observe": ["extract_qa.question"],
+            "passthrough": ["extract_qa.confidence"],
+        }
+        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        assert result[0]["content"]["extract_qa"]["confidence"] == 0.9
+
+    def test_observe_injects_flat_keys(self):
+        """Observe refs inject flat keys at the top level of content."""
+        scope = {"observe": ["extract_qa.question", "extract_qa.answer"]}
+        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        content = result[0]["content"]
+        assert content["question"] == "What is X?"
+        assert content["answer"] == "Y"
+
+    def test_all_three_directives_combined(self):
+        """observe + drop + passthrough all work together."""
+        scope = {
+            "observe": ["extract_qa.question", "source.url"],
+            "drop": ["validate.internal_token_count"],
+            "passthrough": ["extract_qa.confidence"],
+        }
+        result = apply_context_scope_for_records(
+            [deepcopy(RECORD)], scope, action_name="test", source_data=SOURCE_DATA
+        )
+        content = result[0]["content"]
+        # Drop applied
+        assert "internal_token_count" not in content["validate"]
+        # Observe injected
+        assert content["question"] == "What is X?"
+        assert content["url"] == "http://1.com"
+        # Passthrough preserved in namespace
+        assert content["extract_qa"]["confidence"] == 0.9
+
+
+# ── Guard visibility ──────────────────────────────────────────────────
+
+
+class TestGuardVisibility:
+    def test_all_namespaces_preserved(self):
+        """Guards see ALL namespaces, not gated to observed ones only."""
+        scope = {"observe": ["extract_qa.question"]}
+        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        content = result[0]["content"]
+        assert "extract_qa" in content
+        assert "validate" in content
+
+    def test_metadata_fields_preserved_on_record(self):
+        """source_guid, node_id, etc. preserved on the record envelope."""
+        scope = {"observe": ["extract_qa.question"]}
+        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        assert result[0]["source_guid"] == "guid-1"
+        assert result[0]["node_id"] == "node_123"
+
+
+# ── Collision detection ───────────────────────────────────────────────
+
+
+class TestCollisionDetection:
+    def test_multi_wildcard_qualifies_all_keys(self):
+        """Two wildcard namespaces with same field names -> keys qualified."""
+        record = {
+            "content": {
+                "action_a": {"name": "Alice", "score": 10},
+                "action_b": {"name": "Bob", "grade": "A"},
+            },
+        }
+        scope = {"observe": ["action_a.*", "action_b.*"]}
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        content = result[0]["content"]
+        assert content["action_a.name"] == "Alice"
+        assert content["action_b.name"] == "Bob"
+        assert content["action_a.score"] == 10
+        assert content["action_b.grade"] == "A"
+
+    def test_specific_field_collision_qualifies(self):
+        """Same bare field name from two namespaces -> qualified keys."""
+        record = {
+            "content": {
+                "ns_a": {"id": "a1", "extra": "x"},
+                "ns_b": {"id": "b1", "other": "y"},
+            },
+        }
+        scope = {"observe": ["ns_a.id", "ns_b.id"]}
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        content = result[0]["content"]
+        assert content["ns_a.id"] == "a1"
+        assert content["ns_b.id"] == "b1"
+
+    def test_no_collision_uses_bare_keys(self):
+        """Different field names across namespaces -> bare keys."""
+        record = {
+            "content": {
+                "ns_a": {"name": "Alice"},
+                "ns_b": {"score": 10},
+            },
+        }
+        scope = {"observe": ["ns_a.name", "ns_b.score"]}
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        content = result[0]["content"]
+        assert content["name"] == "Alice"
+        assert content["score"] == 10
+
+    def test_single_wildcard_no_qualification(self):
+        """Single wildcard namespace -> bare keys (no qualification needed)."""
+        record = {"content": {"dep": {"a": 1, "b": 2}}}
+        scope = {"observe": ["dep.*"]}
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        content = result[0]["content"]
+        assert content["a"] == 1
+        assert content["b"] == 2
+
+
+# ── Empty observe ─────────────────────────────────────────────────────
+
+
+class TestEmptyObserve:
+    def test_empty_scope_returns_records_unchanged(self):
+        """No directives = records returned as-is (identity)."""
+        records = [deepcopy(RECORD)]
+        result = apply_context_scope_for_records(records, {}, action_name="test")
+        assert result is records  # same list reference (no copy)
+
+    def test_empty_lists_returns_records_unchanged(self):
+        """Explicit empty lists = records returned as-is."""
+        records = [deepcopy(RECORD)]
+        scope = {"observe": [], "drop": [], "passthrough": []}
+        result = apply_context_scope_for_records(records, scope, action_name="test")
+        assert result is records
+
+    def test_empty_records_list(self):
+        """Empty input list returns empty output."""
+        result = apply_context_scope_for_records([], {"observe": ["x.y"]}, action_name="test")
+        assert result == []
+
+
+# ── Source resolution ─────────────────────────────────────────────────
+
+
+class TestSourceResolution:
+    def test_source_resolved_per_record_via_guid(self):
+        """Each record gets its own source namespace via source_guid."""
+        records = [
+            {"source_guid": "guid-1", "content": {"dep": {"f": 1}}},
+            {"source_guid": "guid-2", "content": {"dep": {"f": 2}}},
+        ]
+        scope = {"observe": ["source.url", "dep.f"]}
+        result = apply_context_scope_for_records(
+            records, scope, action_name="test", source_data=SOURCE_DATA
+        )
+        assert result[0]["content"]["url"] == "http://1.com"
+        assert result[1]["content"]["url"] == "http://2.com"
+
+    def test_source_guid_not_found_falls_back_to_first(self):
+        """Unknown source_guid falls back to first source record."""
+        records = [{"source_guid": "unknown", "content": {"dep": {"f": 1}}}]
+        scope = {"observe": ["source.url", "dep.f"]}
+        result = apply_context_scope_for_records(
+            records, scope, action_name="test", source_data=SOURCE_DATA
+        )
+        assert result[0]["content"]["url"] == "http://1.com"
+
+    def test_no_source_data_with_source_refs_raises(self):
+        """Explicit source ref without source_data raises ConfigurationError."""
+        records = [{"content": {"dep": {"f": 1}}}]
+        scope = {"observe": ["source.url"]}
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope_for_records(records, scope, action_name="test", source_data=None)
+
+    def test_no_source_refs_skips_resolution(self):
+        """If no directive references source, source_data is ignored."""
+        records = [deepcopy(RECORD)]
+        scope = {"observe": ["extract_qa.question"]}
+        result = apply_context_scope_for_records(
+            records, scope, action_name="test", source_data=SOURCE_DATA
+        )
+        # Source not injected since no source.* refs
+        assert "url" not in result[0]["content"]
+
+
+# ── None namespace (guard-skipped) ────────────────────────────────────
+
+
+class TestNoneNamespace:
+    def test_wildcard_on_none_namespace_graceful(self):
+        """Wildcard on guard-skipped (None) namespace resolves to empty."""
+        record = {
+            "content": {
+                "active": {"field": "value"},
+                "skipped": None,
+            },
+        }
+        scope = {"observe": ["skipped.*", "active.field"]}
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        content = result[0]["content"]
+        assert content["field"] == "value"
+        assert "skipped" in content  # None namespace preserved for guards
+
+    def test_explicit_ref_on_none_namespace_raises(self):
+        """Explicit field ref on guard-skipped namespace raises ConfigurationError."""
+        record = {"content": {"skipped": None}}
+        scope = {"observe": ["skipped.field"]}
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope_for_records([record], scope, action_name="test")
+
+
+# ── Drop + passthrough interaction ────────────────────────────────────
+
+
+class TestDropPassthroughInteraction:
+    def test_drop_wins_over_passthrough_on_same_field(self):
+        """Drop on same field as passthrough removes it (drop is nuclear)."""
+        record = {"content": {"dep": {"secret": "s", "public": "p"}}}
+        scope = {
+            "passthrough": ["dep.secret", "dep.public"],
+            "drop": ["dep.secret"],
+        }
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        assert "secret" not in result[0]["content"]["dep"]
+        assert result[0]["content"]["dep"]["public"] == "p"
+
+    def test_wildcard_drop_clears_namespace(self):
+        """drop: [dep.*] clears all fields from the namespace."""
+        record = {"content": {"dep": {"a": 1, "b": 2}, "other": {"c": 3}}}
+        scope = {"observe": ["other.c"], "drop": ["dep.*"]}
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        assert result[0]["content"]["dep"] == {}
+        assert result[0]["content"]["other"]["c"] == 3
+
+    def test_drop_does_not_leak_to_flat_keys(self):
+        """Dropped fields must not appear as flat observed keys."""
+        record = {"content": {"dep": {"secret": "s", "name": "n"}}}
+        scope = {"observe": ["dep.*"], "drop": ["dep.secret"]}
+        result = apply_context_scope_for_records([record], scope, action_name="test")
+        content = result[0]["content"]
+        assert "secret" not in {k for k in content if not isinstance(content[k], dict)}
+        assert content["name"] == "n"
+
+
+# ── Multiple records ──────────────────────────────────────────────────
+
+
+class TestMultipleRecords:
+    def test_each_record_processed_independently(self):
+        """Each record in the list is processed independently."""
+        records = [
+            {"content": {"dep": {"field": "A"}}},
+            {"content": {"dep": {"field": "B"}}},
+        ]
+        scope = {"observe": ["dep.field"]}
+        result = apply_context_scope_for_records(records, scope, action_name="test")
+        assert result[0]["content"]["field"] == "A"
+        assert result[1]["content"]["field"] == "B"
+
+    def test_input_records_not_mutated(self):
+        """Input records must not be mutated."""
+        original = deepcopy(RECORD)
+        records = [deepcopy(RECORD)]
+        scope = {"drop": ["validate.internal_token_count"], "observe": ["extract_qa.*"]}
+        apply_context_scope_for_records(records, scope, action_name="test")
+        assert records[0]["content"] == original["content"]


### PR DESCRIPTION
## Summary
- Add `apply_context_scope_for_records()` to `scope_application.py` — FILE mode wrapper that calls `apply_context_scope()` per-record, giving FILE mode all 3 context_scope directives (observe, drop, passthrough)
- Add early return in `apply_context_scope()` for empty context_scope (no directive keys = pass everything through)
- Port collision detection and source resolution from `scope_file_mode.py` as internal helpers

**Before:** FILE mode silently ignored `drop` and `passthrough` — sensitive fields leaked to tools.
**After:** Both RECORD and FILE mode use the same bus filter. One spot for reads, one spot for writes.

## Behavioral changes
1. FILE mode now enforces `drop` (removes fields) and `passthrough` (preserved in namespaces)
2. Empty `context_scope: {}` returns all namespaces unchanged (was gating to empty)
3. Explicit field refs to guard-skipped (None) namespaces now raise ConfigurationError in FILE mode (was silent skip)

## What this does NOT change
- `apply_context_scope()` signature and behavior unchanged — zero RECORD mode migration
- `scope_file_mode.py` untouched — Clone 2 migrates the call site and deletes it
- `scope_builder.py` untouched — Clone 3 cleans up dead branches

## Verification
- Simulation: `simulate_unified_context_scope.py` → **11/11 passed** (was 4/11)
- 24 new tests covering all directives, collision detection, source resolution, None namespace, input immutability
- 6007 tests pass, 0 failures
- `ruff format` + `ruff check` clean