### PR TITLE
refactor: fan-in merge uses merge_branch_records()

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260427-205000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260427-205000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Fan-in merge uses merge_branch_records() — each branch contributes only its own namespace, eliminating silent upstream overwrite"
+time: 2026-04-27T20:50:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260427-203000.yaml
+++ b/.changes/unreleased/Under the Hood-20260427-203000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Add merge_branch_records() primitive — unified merge for version and fan-in paths where each branch contributes only its own namespace"
+time: 2026-04-27T20:30:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260427-205000.yaml
+++ b/.changes/unreleased/Under the Hood-20260427-205000.yaml
@@ -1,3 +1,3 @@
-kind: Enhancement or New Feature
+kind: Under the Hood
 body: "Fan-in merge uses merge_branch_records() — each branch contributes only its own namespace, eliminating silent upstream overwrite"
 time: 2026-04-27T20:50:00.000000Z

--- a/agent_actions/workflow/_MANIFEST.md
+++ b/agent_actions/workflow/_MANIFEST.md
@@ -20,7 +20,7 @@ Agent Actions.
 | `coordinator.py` | Module | Orchestration-only facade: delegates config, services, and events to extracted modules. Stores `schema_service` for reuse by callers. Raises `ConfigurationError` when `storage_backend` is `None` after service init. | `workflow` |
 | `execution_events.py` | Module | `WorkflowEventLogger` class encapsulating all workflow/action event firing. | `logging`, `events` |
 | `executor.py` | Module | Handles running actions (LLM/tool/HITL) and interfacing with processors. | `llm`, `workflow` |
-| `merge.py` | Module | Shared utilities for merging JSON records by correlation key. | `workflow`, `processing` |
+| `merge.py` | Module | Shared utilities for merging JSON records by correlation key. `merge_branch_records()` is the unified primitive for version merge and fan-in (each branch contributes only its own namespace). | `workflow`, `processing` |
 | `models.py` | Module | Shared data models (WorkflowRuntimeConfig, WorkflowPaths, WorkflowMetadata, ActionLogParams). | `typing`, `workflow` |
 | `pipeline.py` | Module | Builds execution pipelines for run modes (batch/online) with synchronous tool/HITL handling. | `llm.batch`, `processing` |
 | `pipeline_file_mode.py` | Module | FILE-granularity tool and HITL processing handlers extracted from `ProcessingPipeline`. Returns `ProcessingResult.failed()` when a tool returns empty output with non-empty input so the generic zero-success check in `pipeline.py` fires naturally. | `processing`, `workflow` |

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -133,12 +133,64 @@ def get_correlation_value(record: dict[str, Any], key_candidates: list[str]) -> 
     return None
 
 
+def _identify_branch_mapping(
+    group: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]] | None:
+    """Identify branch names for a group of fan-in records.
+
+    Returns ``{branch_name: record}`` where each branch_name is a content
+    namespace unique to that record.  Returns ``None`` when branches cannot
+    be distinguished (e.g. identical content schemas) — caller falls back to
+    ``deep_merge_record``.
+
+    When a record owns multiple unique namespaces (diamond dependency), each
+    namespace becomes its own entry pointing to the same record.
+    """
+    if not group:
+        return None
+
+    key_sets: list[set[str]] = []
+    for rec in group:
+        content = get_existing_content(rec)
+        if not content:
+            return None
+        key_sets.append(set(content.keys()))
+
+    shared_keys = key_sets[0].copy()
+    for ks in key_sets[1:]:
+        shared_keys &= ks
+
+    branch_records: dict[str, dict[str, Any]] = {}
+    for rec, ks in zip(group, key_sets, strict=True):
+        unique = ks - shared_keys
+        if not unique:
+            return None  # can't distinguish this record's branch
+        for ns_key in sorted(unique):
+            branch_records[ns_key] = rec
+
+    return branch_records
+
+
+def _merge_group_deep(group: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge a group of records using deep_merge_record (legacy/aggregation path)."""
+    merged: dict[str, Any] = {}
+    for record in group:
+        deep_merge_record(merged, record)
+    return merged
+
+
 def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> list[Any]:
-    """Merge records sharing the same correlation key (reduce_key -> parent_target_id -> source_guid)."""
-    records_by_key: dict[str, dict] = {}
+    """Merge records sharing the same correlation key.
+
+    For same-source fan-in (no ``reduce_key``), uses ``merge_branch_records``
+    so each branch contributes only its own namespace and upstream is preserved
+    from the base record.  For ``reduce_key`` aggregation (different sources
+    grouped together), uses ``deep_merge_record``.
+    """
+    groups_by_key: dict[str, list[dict[str, Any]]] = {}
     records_without_key: list[Any] = []
 
-    key_candidates = []
+    key_candidates: list[str] = []
     if reduce_key:
         key_candidates.append(reduce_key)
     key_candidates.extend(["root_target_id", "parent_target_id", "source_guid"])
@@ -149,15 +201,31 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
             continue
 
         correlation_value = get_correlation_value(record, key_candidates)
-
         if correlation_value:
-            if correlation_value not in records_by_key:
-                records_by_key[correlation_value] = {}
-            deep_merge_record(records_by_key[correlation_value], record)
+            groups_by_key.setdefault(correlation_value, []).append(record)
         else:
             records_without_key.append(record)
 
-    return list(records_by_key.values()) + records_without_key
+    merged_results: list[Any] = []
+    for group in groups_by_key.values():
+        if len(group) == 1:
+            merged_results.append(group[0])
+            continue
+
+        if reduce_key:
+            merged_results.append(_merge_group_deep(group))
+            continue
+
+        branch_mapping = _identify_branch_mapping(group)
+        if branch_mapping is not None:
+            merged = merge_branch_records(branch_mapping, base_record=group[0])
+            for rec in group[1:]:
+                _populate_lineage_sources(merged, rec)
+            merged_results.append(merged)
+        else:
+            merged_results.append(_merge_group_deep(group))
+
+    return merged_results + records_without_key
 
 
 def merge_json_files(file_paths: list[Path], reduce_key: str | None = None) -> list[Any]:

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -184,8 +184,12 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
 
     For same-source fan-in (no ``reduce_key``), uses ``merge_branch_records``
     so each branch contributes only its own namespace and upstream is preserved
-    from the base record.  For ``reduce_key`` aggregation (different sources
-    grouped together), uses ``deep_merge_record``.
+    from the base record (first record in the group).  For ``reduce_key``
+    aggregation (different sources grouped together), uses ``deep_merge_record``.
+
+    Note: When using the branch-records path, ``group[0]`` is the canonical
+    upstream source.  Its shared namespaces survive; other records' versions
+    of the same upstream namespaces are ignored.
     """
     groups_by_key: dict[str, list[dict[str, Any]]] = {}
     records_without_key: list[Any] = []
@@ -219,6 +223,8 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
         branch_mapping = _identify_branch_mapping(group)
         if branch_mapping is not None:
             merged = merge_branch_records(branch_mapping, base_record=group[0])
+            # merge_branch_records handles lineage dedup but not lineage_sources.
+            # merged["node_id"] == group[0]["node_id"] (from {**base, ...}).
             for rec in group[1:]:
                 _populate_lineage_sources(merged, rec)
             merged_results.append(merged)

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -7,6 +7,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from agent_actions.utils.content import get_existing_content
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,6 +77,47 @@ def _populate_lineage_sources(existing: dict[str, Any], new_record: dict[str, An
             existing["lineage_sources"].append(new_node_id)
     else:
         existing["lineage_sources"] = [existing_node_id, new_node_id]
+
+
+def merge_branch_records(
+    branch_records: dict[str, dict[str, Any]],
+    base_record: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Merge N branch records into one, each contributing only its own namespace.
+
+    Args:
+        branch_records: {branch_name: record} — each record has accumulated bus
+        base_record: Optional base for upstream content. If None, uses first branch.
+
+    Returns:
+        Merged record with upstream namespaces once + each branch's own namespace.
+        Lineage is deduplicated across all branches.
+    """
+    if not branch_records:
+        return base_record or {}
+
+    base = base_record or next(iter(branch_records.values()))
+    merged_content = dict(get_existing_content(base))
+
+    for branch_name, branch_record in branch_records.items():
+        branch_content = get_existing_content(branch_record)
+        if branch_name not in branch_content:
+            logger.warning(
+                "Branch '%s' missing own namespace in content. Keys: %s",
+                branch_name,
+                sorted(branch_content.keys()),
+            )
+        else:
+            merged_content[branch_name] = branch_content[branch_name]
+
+    result = {**base, "content": merged_content}
+    # Copy lineage list so _merge_lineage doesn't mutate the input base_record
+    if "lineage" in result and isinstance(result["lineage"], list):
+        result["lineage"] = list(result["lineage"])
+    for branch_record in branch_records.values():
+        _merge_lineage(result, branch_record.get("lineage", []))
+
+    return result
 
 
 def get_correlation_value(record: dict[str, Any], key_candidates: list[str]) -> str | None:

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from agent_actions.workflow.merge import (
+    _identify_branch_mapping,
+    _merge_group_deep,
     deep_merge_record,
     get_correlation_value,
     merge_json_files,
@@ -479,3 +481,281 @@ class TestMergeJsonFiles:
             assert len(result) == 1
             assert result[0]["a"] == 1
             assert result[0]["b"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Fan-in merge via merge_branch_records (spec 205)
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyBranchMapping:
+    """Tests for _identify_branch_mapping helper."""
+
+    def test_two_branches_with_unique_namespaces(self):
+        """Each record has one unique namespace — clean mapping."""
+        group = [
+            {
+                "content": {
+                    "source": {"url": "x"},
+                    "extract": {"text": "y"},
+                    "classify": {"topic": "z"},
+                }
+            },
+            {
+                "content": {
+                    "source": {"url": "x"},
+                    "extract": {"text": "y"},
+                    "enrich": {"summary": "w"},
+                }
+            },
+        ]
+        mapping = _identify_branch_mapping(group)
+
+        assert mapping is not None
+        assert set(mapping.keys()) == {"classify", "enrich"}
+        assert mapping["classify"] is group[0]
+        assert mapping["enrich"] is group[1]
+
+    def test_three_branches(self):
+        """Three-way fan-in — one unique namespace each."""
+        group = [
+            {"content": {"source": {}, "classify": {"c": 1}}},
+            {"content": {"source": {}, "enrich": {"e": 2}}},
+            {"content": {"source": {}, "sentiment": {"s": 3}}},
+        ]
+        mapping = _identify_branch_mapping(group)
+
+        assert mapping is not None
+        assert set(mapping.keys()) == {"classify", "enrich", "sentiment"}
+
+    def test_multi_namespace_record_diamond(self):
+        """Record with multiple unique namespaces — each becomes a branch entry."""
+        group = [
+            {"content": {"source": {}, "select_pattern": {"p": 1}}},
+            {
+                "content": {
+                    "source": {},
+                    "gen_alt_1": {"a": 2},
+                    "merge_alts": {"m": 3},
+                }
+            },
+        ]
+        mapping = _identify_branch_mapping(group)
+
+        assert mapping is not None
+        assert set(mapping.keys()) == {"select_pattern", "gen_alt_1", "merge_alts"}
+        assert mapping["select_pattern"] is group[0]
+        assert mapping["gen_alt_1"] is group[1]
+        assert mapping["merge_alts"] is group[1]
+
+    def test_identical_schemas_returns_none(self):
+        """Records with identical content keys — cannot identify branches."""
+        group = [
+            {"content": {"source": {}, "action": {"v": 1}}},
+            {"content": {"source": {}, "action": {"v": 2}}},
+        ]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+    def test_no_content_dict_returns_none(self):
+        """Records without content dicts — fallback."""
+        group = [{"field_a": "A"}, {"field_b": "B"}]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+    def test_non_dict_content_returns_none(self):
+        """Records with non-dict content — fallback."""
+        group = [{"content": "string"}, {"content": "other"}]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+    def test_one_record_no_unique_returns_none(self):
+        """If one record has no unique namespace, returns None even if others do."""
+        group = [
+            {"content": {"shared": {}, "unique_a": {}}},
+            {"content": {"shared": {}}},
+        ]
+        result = _identify_branch_mapping(group)
+        assert result is None
+
+
+class TestFanInViaPrimitive:
+    """Tests for merge_records_by_key routing fan-in through merge_branch_records."""
+
+    def test_fan_in_preserves_upstream_from_base(self):
+        """The silent overwrite bug: base upstream is canonical, branch upstream ignored."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "node_id": "classify_abc",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello", "_retry_count": 1},
+                "classify": {"topic": "science"},
+            },
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "node_id": "enrich_def",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello"},
+                "enrich": {"summary": "about science"},
+            },
+        }
+
+        result = merge_records_by_key([branch_a, branch_b])
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content["extract"]["_retry_count"] == 1, "Base upstream preserved"
+        assert content["classify"]["topic"] == "science"
+        assert content["enrich"]["summary"] == "about science"
+
+    def test_fan_in_diamond_all_namespaces(self):
+        """Diamond dependency — both branches' unique namespaces present."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "content": {
+                    "source": {"url": "x"},
+                    "generate": {"code": "pass"},
+                    "select_pattern": {"pattern": "scenario"},
+                },
+            },
+            {
+                "source_guid": "sg-1",
+                "content": {
+                    "source": {"url": "x"},
+                    "generate": {"code": "pass"},
+                    "gen_alt_1": {"alt": "A"},
+                    "merge_alts": {"merged": True},
+                },
+            },
+        ]
+
+        result = merge_records_by_key(records)
+        assert len(result) == 1
+
+        content = result[0]["content"]
+        assert set(content.keys()) == {
+            "source",
+            "generate",
+            "select_pattern",
+            "gen_alt_1",
+            "merge_alts",
+        }
+        assert content["select_pattern"]["pattern"] == "scenario"
+        assert content["gen_alt_1"]["alt"] == "A"
+        assert content["merge_alts"]["merged"] is True
+
+    def test_reduce_key_uses_deep_merge(self):
+        """reduce_key aggregation always uses deep_merge_record, not the primitive."""
+        records = [
+            {"custom_id": "123", "source_guid": "s1", "content": {"ns_a": {"v": 1}}},
+            {"custom_id": "123", "source_guid": "s2", "content": {"ns_b": {"v": 2}}},
+        ]
+
+        result = merge_records_by_key(records, reduce_key="custom_id")
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert "ns_a" in content
+        assert "ns_b" in content
+
+    def test_identical_schemas_fallback(self):
+        """Records with identical content keys fall back to deep_merge_record."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "content": {"shared": {"a": 1}, "action": {"v": 1}},
+            },
+            {
+                "source_guid": "sg-1",
+                "content": {"shared": {"a": 1}, "action": {"v": 2}},
+            },
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        # deep_merge_record: last-writer-wins on content.update
+        assert result[0]["content"]["action"]["v"] == 2
+
+    def test_single_record_group_returned_as_is(self):
+        """Single-record group needs no merge — returned directly."""
+        record = {"source_guid": "unique-1", "content": {"ns": {"v": 1}}}
+
+        result = merge_records_by_key([record])
+
+        assert len(result) == 1
+        assert result[0] is record
+
+    def test_fan_in_lineage_sources_populated(self):
+        """lineage_sources tracks leaf node_ids after merge_branch_records."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "branch_a_001",
+                "lineage": ["root_0", "branch_a_001"],
+                "content": {"shared": {}, "field_a": {"a": 1}},
+            },
+            {
+                "source_guid": "sg-1",
+                "node_id": "branch_b_002",
+                "lineage": ["root_0", "branch_b_002"],
+                "content": {"shared": {}, "field_b": {"b": 2}},
+            },
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        merged = result[0]
+        assert merged["lineage_sources"] == ["branch_a_001", "branch_b_002"]
+        assert "branch_a_001" in merged["lineage"]
+        assert "branch_b_002" in merged["lineage"]
+
+    def test_fan_in_three_way_lineage_sources(self):
+        """Three-way fan-in populates all leaf node_ids in lineage_sources."""
+        records = [
+            {
+                "source_guid": "sg-1",
+                "node_id": "node_a",
+                "content": {"upstream": {}, "branch_a": {"a": 1}},
+            },
+            {
+                "source_guid": "sg-1",
+                "node_id": "node_b",
+                "content": {"upstream": {}, "branch_b": {"b": 2}},
+            },
+            {
+                "source_guid": "sg-1",
+                "node_id": "node_c",
+                "content": {"upstream": {}, "branch_c": {"c": 3}},
+            },
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        merged = result[0]
+        assert len(merged["lineage_sources"]) == 3
+        assert "node_a" in merged["lineage_sources"]
+        assert "node_b" in merged["lineage_sources"]
+        assert "node_c" in merged["lineage_sources"]
+
+
+class TestMergeGroupDeep:
+    """Tests for _merge_group_deep helper."""
+
+    def test_merges_group_into_single_record(self):
+        """Group of records merged via deep_merge_record."""
+        group = [
+            {"source_guid": "sg-1", "content": {"ns_a": {"a": 1}}},
+            {"source_guid": "sg-1", "content": {"ns_b": {"b": 2}}},
+        ]
+
+        result = _merge_group_deep(group)
+
+        assert result["content"]["ns_a"]["a"] == 1
+        assert result["content"]["ns_b"]["b"] == 2

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -648,6 +648,34 @@ class TestFanInViaPrimitive:
         assert content["gen_alt_1"]["alt"] == "A"
         assert content["merge_alts"]["merged"] is True
 
+    def test_fan_in_first_record_upstream_is_canonical(self):
+        """First record's upstream is canonical — second record's upstream ignored."""
+        # Record B arrives second: its richer upstream (with _extra) is ignored
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {
+                "upstream": {"base": True},
+                "branch_a": {"a": 1},
+            },
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {
+                "upstream": {"base": True, "_extra": "from_b"},
+                "branch_b": {"b": 2},
+            },
+        }
+
+        result = merge_records_by_key([branch_a, branch_b])
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        # A is first → its upstream is canonical
+        assert content["upstream"] == {"base": True}
+        assert "_extra" not in content["upstream"]
+        assert content["branch_a"]["a"] == 1
+        assert content["branch_b"]["b"] == 2
+
     def test_reduce_key_uses_deep_merge(self):
         """reduce_key aggregation always uses deep_merge_record, not the primitive."""
         records = [
@@ -659,8 +687,8 @@ class TestFanInViaPrimitive:
 
         assert len(result) == 1
         content = result[0]["content"]
-        assert "ns_a" in content
-        assert "ns_b" in content
+        assert content["ns_a"]["v"] == 1
+        assert content["ns_b"]["v"] == 2
 
     def test_identical_schemas_fallback(self):
         """Records with identical content keys fall back to deep_merge_record."""
@@ -688,7 +716,8 @@ class TestFanInViaPrimitive:
         result = merge_records_by_key([record])
 
         assert len(result) == 1
-        assert result[0] is record
+        assert result[0]["content"]["ns"]["v"] == 1
+        assert result[0]["source_guid"] == "unique-1"
 
     def test_fan_in_lineage_sources_populated(self):
         """lineage_sources tracks leaf node_ids after merge_branch_records."""

--- a/tests/unit/workflow/test_merge_branch_records.py
+++ b/tests/unit/workflow/test_merge_branch_records.py
@@ -1,0 +1,360 @@
+"""Unit tests for merge_branch_records() primitive."""
+
+from copy import deepcopy
+
+from agent_actions.workflow.merge import merge_branch_records
+
+
+class TestMergeBranchRecordsTwoBranches:
+    """Two parallel branches merging (fan-in pattern)."""
+
+    def test_each_branch_contributes_own_namespace(self):
+        """Each branch contributes only its own namespace to the merged result."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "node_id": "classify_abc",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello"},
+                "classify": {"topic": "science"},
+            },
+            "lineage": ["source_abc", "extract_abc", "classify_abc"],
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "node_id": "enrich_def",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello"},
+                "enrich": {"summary": "about science"},
+            },
+            "lineage": ["source_abc", "extract_abc", "enrich_def"],
+        }
+
+        result = merge_branch_records(
+            {"classify": branch_a, "enrich": branch_b}, base_record=branch_a
+        )
+        content = result["content"]
+
+        assert content["classify"] == {"topic": "science"}
+        assert content["enrich"] == {"summary": "about science"}
+
+    def test_upstream_from_base_record_preserved(self):
+        """Upstream namespaces come from base_record, not overwritten by branches."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello", "_retry_count": 1},
+                "classify": {"topic": "science"},
+            },
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello"},
+                "enrich": {"summary": "about science"},
+            },
+        }
+
+        result = merge_branch_records(
+            {"classify": branch_a, "enrich": branch_b}, base_record=branch_a
+        )
+        content = result["content"]
+
+        # Upstream preserved from base (branch_a)
+        assert content["source"] == {"url": "http://doc.com"}
+        assert content["extract"] == {"text": "hello", "_retry_count": 1}
+
+    def test_base_record_upstream_not_overwritten_by_branch_upstream(self):
+        """Branches cannot overwrite upstream namespaces — only contribute their own."""
+        base = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello", "_retry_count": 1},
+            },
+        }
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello"},  # missing _retry_count
+                "classify": {"topic": "science"},
+            },
+        }
+
+        result = merge_branch_records({"classify": branch_a}, base_record=base)
+        content = result["content"]
+
+        # Base upstream wins — branch's stale upstream is ignored
+        assert content["extract"]["_retry_count"] == 1
+
+
+class TestMergeBranchRecordsVersionPattern:
+    """Three version branches (voter pattern)."""
+
+    def test_three_versions_merge(self):
+        """Three version branches each contribute only their own namespace."""
+        upstream_content = {
+            "source": {"url": "http://doc.com"},
+            "upstream_action": {"question": "What is X?"},
+        }
+        voter_1 = {
+            "source_guid": "guid-1",
+            "content": {**upstream_content, "voter_1": {"vote": "keep", "confidence": 0.8}},
+            "lineage": [{"node_id": "source_0"}, {"node_id": "voter_1_abc"}],
+        }
+        voter_2 = {
+            "source_guid": "guid-1",
+            "content": {**upstream_content, "voter_2": {"vote": "reject", "confidence": 0.3}},
+            "lineage": [{"node_id": "source_0"}, {"node_id": "voter_2_def"}],
+        }
+        voter_3 = {
+            "source_guid": "guid-1",
+            "content": {**upstream_content, "voter_3": {"vote": "keep", "confidence": 0.9}},
+            "lineage": [{"node_id": "source_0"}, {"node_id": "voter_3_ghi"}],
+        }
+
+        result = merge_branch_records(
+            {"voter_1": voter_1, "voter_2": voter_2, "voter_3": voter_3},
+            base_record=voter_1,
+        )
+        content = result["content"]
+
+        # Each version namespace present with correct data
+        assert content["voter_1"] == {"vote": "keep", "confidence": 0.8}
+        assert content["voter_2"] == {"vote": "reject", "confidence": 0.3}
+        assert content["voter_3"] == {"vote": "keep", "confidence": 0.9}
+
+        # Upstream present exactly once
+        assert content["source"] == {"url": "http://doc.com"}
+        assert content["upstream_action"] == {"question": "What is X?"}
+
+    def test_version_namespaces_do_not_contain_upstream(self):
+        """Version namespace values contain only their own output, not nested upstream."""
+        voter_1 = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "voter_1": {"vote": "keep"},
+            },
+        }
+        voter_2 = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "voter_2": {"vote": "reject"},
+            },
+        }
+
+        result = merge_branch_records({"voter_1": voter_1, "voter_2": voter_2}, base_record=voter_1)
+        content = result["content"]
+
+        assert "source" not in content["voter_1"]
+        assert "source" not in content["voter_2"]
+
+
+class TestMergeBranchRecordsMissingNamespace:
+    """Branch missing its own namespace — warning logged, others proceed."""
+
+    def test_missing_namespace_logs_warning(self, mocker):
+        """Branch without own namespace in content logs a warning."""
+        mock_warn = mocker.patch("agent_actions.workflow.merge.logger.warning")
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "classify": {"topic": "science"},
+            },
+        }
+        # branch_b is named "enrich" but doesn't have "enrich" in content
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "unexpected": {"data": "oops"},
+            },
+        }
+
+        result = merge_branch_records(
+            {"classify": branch_a, "enrich": branch_b}, base_record=branch_a
+        )
+
+        mock_warn.assert_called_once()
+        assert "enrich" in mock_warn.call_args[0][1]
+        # classify still merged successfully
+        assert result["content"]["classify"] == {"topic": "science"}
+        # enrich was not merged (not present)
+        assert "enrich" not in result["content"]
+
+    def test_other_branches_still_merge_when_one_missing(self):
+        """Other branches' namespaces merge even if one branch is malformed."""
+        good_branch = {
+            "source_guid": "guid-1",
+            "content": {"source": {"url": "x"}, "good": {"data": "yes"}},
+        }
+        bad_branch = {
+            "source_guid": "guid-1",
+            "content": {"source": {"url": "x"}, "wrong_name": {"data": "no"}},
+        }
+
+        result = merge_branch_records(
+            {"good": good_branch, "bad": bad_branch}, base_record=good_branch
+        )
+
+        assert result["content"]["good"] == {"data": "yes"}
+        assert "bad" not in result["content"]
+
+
+class TestMergeBranchRecordsEmptyInput:
+    """Empty or edge-case inputs."""
+
+    def test_empty_branch_records_returns_base(self):
+        """Empty branch_records returns base_record unchanged."""
+        base = {"source_guid": "guid-1", "content": {"source": {"url": "x"}}}
+
+        result = merge_branch_records({}, base_record=base)
+
+        assert result == base
+
+    def test_empty_branch_records_no_base_returns_empty(self):
+        """Empty branch_records with no base returns empty dict."""
+        result = merge_branch_records({})
+
+        assert result == {}
+
+    def test_no_base_record_uses_first_branch(self):
+        """When base_record is None, first branch is used for upstream content."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "branch_a": {"data": "A"},
+            },
+            "lineage": ["source_0"],
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "branch_b": {"data": "B"},
+            },
+            "lineage": ["source_0", "branch_b_node"],
+        }
+
+        result = merge_branch_records({"branch_a": branch_a, "branch_b": branch_b})
+        content = result["content"]
+
+        assert content["source"] == {"url": "http://doc.com"}
+        assert content["branch_a"] == {"data": "A"}
+        assert content["branch_b"] == {"data": "B"}
+
+
+class TestMergeBranchRecordsLineage:
+    """Lineage deduplication across branches."""
+
+    def test_lineage_deduplicated_string_entries(self):
+        """String lineage entries are deduplicated across branches."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "a": {"data": "A"}},
+            "lineage": ["source_0", "extract_1", "a_node"],
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "b": {"data": "B"}},
+            "lineage": ["source_0", "extract_1", "b_node"],
+        }
+
+        result = merge_branch_records({"a": branch_a, "b": branch_b}, base_record=branch_a)
+
+        lineage = result["lineage"]
+        # shared entries appear once, branch-specific appear once each
+        assert lineage.count("source_0") == 1
+        assert lineage.count("extract_1") == 1
+        assert "a_node" in lineage
+        assert "b_node" in lineage
+        assert len(lineage) == 4
+
+    def test_lineage_deduplicated_dict_entries(self):
+        """Dict lineage entries are deduplicated by node_id."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "a": {"data": "A"}},
+            "lineage": [{"node_id": "shared"}, {"node_id": "a_only"}],
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "b": {"data": "B"}},
+            "lineage": [{"node_id": "shared"}, {"node_id": "b_only"}],
+        }
+
+        result = merge_branch_records({"a": branch_a, "b": branch_b}, base_record=branch_a)
+
+        lineage = result["lineage"]
+        node_ids = [e["node_id"] for e in lineage if isinstance(e, dict)]
+        assert node_ids.count("shared") == 1
+        assert "a_only" in node_ids
+        assert "b_only" in node_ids
+
+    def test_branch_without_lineage(self):
+        """Branches without lineage field don't cause errors."""
+        branch_a = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "a": {"data": "A"}},
+            "lineage": ["source_0"],
+        }
+        branch_b = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "b": {"data": "B"}},
+            # no lineage field
+        }
+
+        result = merge_branch_records({"a": branch_a, "b": branch_b}, base_record=branch_a)
+
+        assert "source_0" in result["lineage"]
+
+
+class TestMergeBranchRecordsBaseRecordPreservation:
+    """Base record metadata fields are preserved in result."""
+
+    def test_preserves_source_guid(self):
+        """source_guid from base_record is in the result."""
+        base = {
+            "source_guid": "guid-1",
+            "target_id": "target-1",
+            "node_id": "node-1",
+            "content": {"source": {"x": 1}},
+        }
+        branch = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "branch": {"data": "yes"}},
+        }
+
+        result = merge_branch_records({"branch": branch}, base_record=base)
+
+        assert result["source_guid"] == "guid-1"
+        assert result["target_id"] == "target-1"
+        assert result["node_id"] == "node-1"
+
+    def test_does_not_mutate_inputs(self):
+        """merge_branch_records does not mutate the input records."""
+        base = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}},
+            "lineage": ["node_0"],
+        }
+        branch = {
+            "source_guid": "guid-1",
+            "content": {"source": {"x": 1}, "branch": {"data": "yes"}},
+            "lineage": ["node_0", "branch_1"],
+        }
+        base_copy = deepcopy(base)
+        branch_copy = deepcopy(branch)
+
+        merge_branch_records({"branch": branch}, base_record=base)
+
+        assert base == base_copy
+        assert branch == branch_copy


### PR DESCRIPTION
## Summary
- `merge_records_by_key()` now routes same-source fan-in through `merge_branch_records()` instead of `deep_merge_record()`, eliminating the silent upstream overwrite bug
- Branch identification via content-key set difference: namespaces unique to a record are its contributions, shared namespaces are upstream
- `reduce_key` aggregation path unchanged (uses `deep_merge_record`)
- Graceful fallback to `deep_merge_record` when branches can't be identified (identical content schemas)
- `lineage_sources` tracking preserved via `_populate_lineage_sources` after primitive call

## Verification
- 6014 tests pass (16 new), 2 skipped
- `ruff check` and `ruff format --check` clean
- Simulation: 17/18 (Test 1 calls `deep_merge_record` directly — kept for aggregation. The pipeline-level fix is verified by new `test_fan_in_preserves_upstream_from_base`)
- All existing `TestMergeRecordsByKey`, `TestParallelBranchLineageSources`, and `TestFanInDiamondBus` tests pass unchanged