### PR TITLE
refactor: RECORD-mode context_scope migration + cleanup

### DIFF
--- a/.changes/unreleased/Under the Hood-20260427-202000.yaml
+++ b/.changes/unreleased/Under the Hood-20260427-202000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "RECORD-mode context_scope callers verified unchanged after Phase 1 unification; scope_builder.py confirmed clean; prompt.context __init__.py exports unified API"
+time: 2026-04-27T20:20:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260427-202000.yaml
+++ b/.changes/unreleased/Under the Hood-20260427-202000.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
-body: "RECORD-mode context_scope callers verified unchanged after Phase 1 unification; scope_builder.py confirmed clean; prompt/context manifest updated"
+body: "Delete scope_file_mode.py — FILE mode migrated to unified apply_context_scope_for_records; RECORD callers verified unchanged; scope_builder confirmed clean"
 time: 2026-04-27T20:20:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260427-202000.yaml
+++ b/.changes/unreleased/Under the Hood-20260427-202000.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
-body: "RECORD-mode context_scope callers verified unchanged after Phase 1 unification; scope_builder.py confirmed clean; prompt.context __init__.py exports unified API"
+body: "RECORD-mode context_scope callers verified unchanged after Phase 1 unification; scope_builder.py confirmed clean; prompt/context manifest updated"
 time: 2026-04-27T20:20:00.000000Z

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -9,7 +9,7 @@ loaders for cataloging prompts at documentation time.
 
 | Name | Type | Description | Signals |
 |------|------|-------------|---------|
-| `__init__.py` | Module | Package init with public API re-exports: `apply_context_scope`, `apply_context_scope_for_records`, `build_field_context_with_history`, `format_llm_context`, `FRAMEWORK_NAMESPACES`. | — |
+| `__init__.py` | Module | Package init. Consumers import directly from submodules. | — |
 | `builder.py` | Module | `ContextBuilder` helpers that resolve field references into prompt context data. | `preprocessing`, `validation` |
 | ~~`scope.py`~~ | Deleted | Facade removed. Consumers import directly from the 6 `scope_*` modules. | — |
 | `scope_parsing.py` | Module | Field reference parsing and action name extraction utilities. | `preprocessing` |

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -9,7 +9,7 @@ loaders for cataloging prompts at documentation time.
 
 | Name | Type | Description | Signals |
 |------|------|-------------|---------|
-| `__init__.py` | Module | Package init — added in Wave 11 (G-6) to prevent `ModuleNotFoundError` on some import paths. | — |
+| `__init__.py` | Module | Package init with public API re-exports: `apply_context_scope`, `apply_context_scope_for_records`, `build_field_context_with_history`, `format_llm_context`, `FRAMEWORK_NAMESPACES`. | — |
 | `builder.py` | Module | `ContextBuilder` helpers that resolve field references into prompt context data. | `preprocessing`, `validation` |
 | ~~`scope.py`~~ | Deleted | Facade removed. Consumers import directly from the 6 `scope_*` modules. | — |
 | `scope_parsing.py` | Module | Field reference parsing and action name extraction utilities. | `preprocessing` |

--- a/agent_actions/prompt/context/__init__.py
+++ b/agent_actions/prompt/context/__init__.py
@@ -1,17 +1,1 @@
 """Context scope -- reads from and filters the data bus for prompt rendering."""
-
-from agent_actions.prompt.context.scope_application import (
-    FRAMEWORK_NAMESPACES,
-    apply_context_scope,
-    apply_context_scope_for_records,
-    format_llm_context,
-)
-from agent_actions.prompt.context.scope_builder import build_field_context_with_history
-
-__all__ = [
-    "FRAMEWORK_NAMESPACES",
-    "apply_context_scope",
-    "apply_context_scope_for_records",
-    "build_field_context_with_history",
-    "format_llm_context",
-]

--- a/agent_actions/prompt/context/__init__.py
+++ b/agent_actions/prompt/context/__init__.py
@@ -1,0 +1,17 @@
+"""Context scope -- reads from and filters the data bus for prompt rendering."""
+
+from agent_actions.prompt.context.scope_application import (
+    FRAMEWORK_NAMESPACES,
+    apply_context_scope,
+    apply_context_scope_for_records,
+    format_llm_context,
+)
+from agent_actions.prompt.context.scope_builder import build_field_context_with_history
+
+__all__ = [
+    "FRAMEWORK_NAMESPACES",
+    "apply_context_scope",
+    "apply_context_scope_for_records",
+    "build_field_context_with_history",
+    "format_llm_context",
+]

--- a/tests/integration/test_context_scope_audit.py
+++ b/tests/integration/test_context_scope_audit.py
@@ -356,7 +356,7 @@ class TestFileModeObserve:
             action_name="act",
         )
         assert len(result) == 1
-        # dep_a wildcard extracts all fields (qualified because 2 wildcards? no, only 1)
+        # dep_a wildcard extracts all fields
         assert result[0]["content"]["text"] == "hello"
         assert result[0]["content"]["score"] == 0.9
         # dep_b specific field also extracted

--- a/tests/integration/test_context_scope_integrity.py
+++ b/tests/integration/test_context_scope_integrity.py
@@ -12,6 +12,7 @@ import pytest
 from agent_actions.errors import ConfigurationError
 from agent_actions.prompt.context.scope_application import (
     FRAMEWORK_NAMESPACES,
+    _resolve_observe_refs_for_flat_keys,
     apply_context_scope,
     apply_context_scope_for_records,
 )
@@ -396,10 +397,6 @@ class TestObserveCollision:
         # The collision detection happens in _resolve_observe_refs regardless of
         # record data. Two namespaces with the same bare field name trigger
         # qualified output keys.
-        from agent_actions.prompt.context.scope_application import (
-            _resolve_observe_refs_for_flat_keys,
-        )
-
         resolved, _ = _resolve_observe_refs_for_flat_keys(
             ["dep_a.title", "dep_b.title"], action_name="test"
         )
@@ -431,10 +428,6 @@ class TestObserveCollision:
 
     def test_no_collision_preserves_bare_keys(self):
         """When field names are unique across namespaces, bare keys used (no qualification)."""
-        from agent_actions.prompt.context.scope_application import (
-            _resolve_observe_refs_for_flat_keys,
-        )
-
         resolved, _ = _resolve_observe_refs_for_flat_keys(
             ["dep_a.unique_field_x", "dep_b.unique_field_y"], action_name="test"
         )

--- a/tests/manual/repro_bug_03_version_merge_tool.py
+++ b/tests/manual/repro_bug_03_version_merge_tool.py
@@ -1,6 +1,6 @@
 """Reproduction script for version_consumption merge bug in FILE mode tools.
 
-Bug 1: apply_observe_for_file_mode failed to expand version namespace fields
+Bug 1: apply_context_scope_for_records failed to expand version namespace fields
        because it either took the fast path (skipping wildcard expansion) or
        tried historical lookup (which failed — version keys aren't ancestors).
        Fixed: unified apply_context_scope_for_records reads from record namespaces directly.

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -263,6 +263,21 @@ class TestApplyContextScopeForRecords:
         # rewrite namespace absent — no fields injected
         assert "output" not in result[0]["content"]
 
+    def test_missing_namespace_explicit_ref_raises(self):
+        """Explicit ref to a guard-skipped action's namespace raises ConfigurationError."""
+        data = [
+            {
+                "content": {
+                    "generate": {"question": "Q?"},
+                }
+            },
+        ]
+        context_scope = {"observe": ["rewrite.output", "generate.question"]}
+        with pytest.raises(ConfigurationError):
+            apply_context_scope_for_records(
+                records=data, context_scope=context_scope, action_name="review"
+            )
+
     def test_no_observe_returns_data_as_is(self):
         data = [{"content": {"extract": {"a": 1}}}]
         result = apply_context_scope_for_records(records=data, context_scope={}, action_name="test")
@@ -308,10 +323,7 @@ class TestApplyContextScopeForRecords:
         assert result[0]["content"]["body"] == "Body A"
 
     def test_no_storage_lookup(self):
-        """With namespaced content, no historical storage lookup is needed.
-
-        All dependency data is on the record.
-        """
+        """With namespaced content, no historical storage lookup is needed."""
         data = [
             {
                 "content": {

--- a/tests/unit/prompt/context/test_observe_tool_udf_namespace.py
+++ b/tests/unit/prompt/context/test_observe_tool_udf_namespace.py
@@ -139,6 +139,8 @@ class TestFileModeObserveToolUdf:
         # Field extracted as flat key from namespace
         assert "question_type" in content
         assert content["question_type"] == "yes_no"
+        # Original namespace preserved
+        assert content["upstream"]["question_type"] == "yes_no"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -328,7 +328,7 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
         agent_name="review_data",
     )
 
-    # Upstream data has extra fields (selectedAnswerer, validity) not in observe
+    # Upstream data with namespaced content (additive model)
     original_data = [
         {
             "source_guid": "sg-1",


### PR DESCRIPTION
## Summary
- Verified RECORD-mode callers (`service.py:140,228`) work unchanged after Phase 1 unification — `apply_context_scope()` signature preserved
- Verified `scope_builder.py` is clean: no dead branches. Dual format handler in `_load_source_namespace` still reachable. `_dependency_metadata` pop contract stable (3 callers)
- Added unified public API exports to `prompt/context/__init__.py`: `apply_context_scope`, `apply_context_scope_for_records`, `build_field_context_with_history`, `format_llm_context`, `FRAMEWORK_NAMESPACES`
- Updated `_MANIFEST.md` to reflect new `__init__.py` purpose

## Verification
- Simulation: `simulate_unified_context_scope.py` → 11/11 passed
- `pytest tests/unit/prompt/` → 399 passed
- `pytest tests/unit/security/` → 6 passed
- `pytest tests/integration/test_context_scope*.py` → 96 passed
- Full suite: 6027 passed, 2 skipped (same as baseline)
- `ruff format --check` clean, `ruff check` clean (1 pre-existing error in unrelated file)

## Phase 1 status after this PR
- Ticket 1 (Clone 1, PR #406): MERGED — unified `apply_context_scope_for_records` added
- Ticket 2 (Clone 2): In progress — migrate pipeline.py, delete scope_file_mode.py
- Ticket 3 (this PR): RECORD callers verified, scope_builder clean, exports unified