### PR TITLE
fix: remove dead compiled_schema field from ActionConfigDict

### DIFF
--- a/.changes/unreleased/Under the Hood-20260427-042000.yaml
+++ b/.changes/unreleased/Under the Hood-20260427-042000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove dead `compiled_schema` field from ActionConfigDict — never populated by config expander"
+time: 2026-04-27T04:20:00.000000Z

--- a/agent_actions/config/types.py
+++ b/agent_actions/config/types.py
@@ -132,7 +132,6 @@ class ActionConfigDict(TypedDict, total=False):
     prompt: str
     schema_name: str
     schema: dict[str, Any]
-    compiled_schema: dict[str, Any]
     json_output_schema: dict[str, Any]
     prompt_debug: bool
 


### PR DESCRIPTION
## Summary
- Remove `compiled_schema` from `ActionConfigDict` TypedDict — the config expander never populates it (writes `json_output_schema` instead)
- The batch path uses `compiled_schema` as a transport key on a **local copy** of the config (`preparator.py` → `batch_base.py`), which works correctly without the TypedDict field
- Closes bug #42 (dead field, no runtime impact)

## Verification
- `ruff format --check` clean, `ruff check` clean (1 pre-existing unrelated warning)
- `pytest`: 6027 passed, 0 failures
- Grep confirmed: no production code reads `compiled_schema` from the canonical `ActionConfigDict` — only from the batch preparator's local copy