### PR TITLE
fix: action type reads "kind" key instead of wrong "type" key

### DIFF
--- a/.changes/unreleased/Bug Fix-20260427-041000.yaml
+++ b/.changes/unreleased/Bug Fix-20260427-041000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix action type tracking reading wrong config key (\"type\" instead of \"kind\"), causing empty/default values in execution events and error context"
+time: 2026-04-27T04:10:00.000000Z

--- a/agent_actions/processing/error_handling.py
+++ b/agent_actions/processing/error_handling.py
@@ -58,7 +58,7 @@ class ProcessorErrorHandlerMixin:
         if hasattr(self, "agent_name"):
             context["agent_name"] = self.agent_name
         if hasattr(self, "agent_config"):
-            context["agent_type"] = self.agent_config.get("type", "unknown")
+            context["agent_type"] = self.agent_config.get("kind", "unknown")
         context.update(kwargs)
         return context
 

--- a/agent_actions/tooling/docs/generator.py
+++ b/agent_actions/tooling/docs/generator.py
@@ -251,7 +251,7 @@ class CatalogGenerator:
                 enriched_action = self._enrich_action_with_fields(action, action_schema)
 
                 # Attach tool function details for tool actions
-                if action.get("type") == "tool" and tool_functions_data:
+                if action.get("kind") == "tool" and tool_functions_data:
                     impl_name = action.get("implementation")
                     if impl_name and impl_name in tool_functions_data:
                         enriched_action["tool_function"] = tool_functions_data[impl_name]
@@ -319,9 +319,9 @@ class CatalogGenerator:
 
             # Count action types, schemas, and prompts
             for action in workflow["actions"].values():
-                if action.get("type") == DEFAULT_ACTION_KIND:
+                if action.get("kind") == DEFAULT_ACTION_KIND:
                     catalog["stats"]["llm_actions"] += 1
-                elif action.get("type") == "tool":
+                elif action.get("kind") == "tool":
                     catalog["stats"]["tool_actions"] += 1
 
                 # Count unique schemas (only string references, not inline dicts)
@@ -331,7 +331,7 @@ class CatalogGenerator:
 
                 # Count actions with prompts (LLM actions typically have prompts)
                 if action.get("prompt") or (
-                    action.get("type") == DEFAULT_ACTION_KIND and action.get("intent")
+                    action.get("kind") == DEFAULT_ACTION_KIND and action.get("intent")
                 ):
                     actions_with_prompts += 1
 

--- a/agent_actions/workflow/execution_events.py
+++ b/agent_actions/workflow/execution_events.py
@@ -72,7 +72,7 @@ class WorkflowEventLogger:
                 action_name=action_name,
                 action_index=idx,
                 total_actions=total_actions,
-                action_type=action_config.get("type", ""),
+                action_type=action_config.get("kind", ""),
                 mode=action_config.get("run_mode", ""),
             )
         )

--- a/tests/unit/processing/test_error_handler_mixin.py
+++ b/tests/unit/processing/test_error_handler_mixin.py
@@ -36,7 +36,7 @@ class _StubProcessorWithAttrs(ProcessorErrorHandlerMixin):
 
     def __init__(self):
         self.agent_name = "my_agent"
-        self.agent_config = {"type": "llm"}
+        self.agent_config = {"kind": "llm"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflow/test_execution_events.py
+++ b/tests/unit/workflow/test_execution_events.py
@@ -91,7 +91,7 @@ class TestLogWorkflowStart:
 class TestFireAgentStart:
     def test_fires_agent_start_event(self, event_logger):
         with patch(FIRE_EVENT_PATH) as mock_fire:
-            event_logger.fire_action_start(0, "agent_a", 2, {"type": "llm"})
+            event_logger.fire_action_start(0, "agent_a", 2, {"kind": "llm"})
 
         event = mock_fire.call_args[0][0]
         assert isinstance(event, ActionStartEvent)


### PR DESCRIPTION
## Summary
- Fix `execution_events.py`, `error_handling.py`, and `generator.py` reading the wrong config key (`"type"` instead of `"kind"`), causing action type tracking to always emit empty/default values
- Sibling pattern in `generator.py` (4 occurrences) also fixed — action kind comparisons for tool vs LLM classification were silently broken

## Verification
- `pytest` — 6027 passed, 2 skipped
- `ruff format --check` — clean
- `ruff check` — clean (1 pre-existing unused import in unrelated file)