### PR TITLE
Remove dead RecordEnvelope.build_version_merge()

### DIFF
--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -17,7 +17,6 @@ Single authority for record content assembly. Every action type, granularity, an
 | `RecordEnvelope.build()` | `agent_io/target/{action}/` | Writes record with action output under namespace | - |
 | `RecordEnvelope.build_content()` | `agent_io/target/{action}/` | Writes content dict (no record wrapper) | - |
 | `RecordEnvelope.build_skipped()` | `agent_io/target/{action}/` | Writes record with null namespace for guard skip | - |
-| `RecordEnvelope.build_version_merge()` | `agent_io/target/{action}/` | Writes record merging version namespaces | `version_consumption` |
 | `TrackedItem` | `tools/{workflow}/*.py` | FILE tool input: dict subclass with hidden `_source_index` provenance | - |
 
 ## Dependencies

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -88,22 +88,6 @@ class RecordEnvelope:
         result: dict[str, Any] = {"content": {**existing, action_name: None}}
         return _carry_source_guid(result, input_record)
 
-    @staticmethod
-    def build_version_merge(
-        version_contents: dict[str, dict[str, Any]],
-        input_record: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Build a record merging multiple version namespaces."""
-        if not version_contents:
-            raise RecordEnvelopeError("version_contents is empty -- nothing to merge")
-        for key, value in version_contents.items():
-            if not isinstance(value, dict):
-                raise RecordEnvelopeError(
-                    f"version_contents['{key}'] must be a dict, got {type(value).__name__}"
-                )
-        existing = _extract_existing(input_record)
-        result: dict[str, Any] = {"content": {**existing, **version_contents}}
-        return _carry_source_guid(result, input_record)
 
 
 def _carry_source_guid(

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -89,7 +89,6 @@ class RecordEnvelope:
         return _carry_source_guid(result, input_record)
 
 
-
 def _carry_source_guid(
     result: dict[str, Any], input_record: dict[str, Any] | None
 ) -> dict[str, Any]:

--- a/tests/manual/repro_bug_03_version_merge_tool.py
+++ b/tests/manual/repro_bug_03_version_merge_tool.py
@@ -1,6 +1,6 @@
 """Reproduction script for version_consumption merge bug in FILE mode tools.
 
-Bug 1: apply_observe_for_file_mode failed to expand version namespace fields
+Bug 1: apply_context_scope_for_records failed to expand version namespace fields
        because it either took the fast path (skipping wildcard expansion) or
        tried historical lookup (which failed — version keys aren't ancestors).
        Fixed: unified apply_context_scope_for_records reads from record namespaces directly.
@@ -25,7 +25,7 @@ from agent_actions.prompt.context.scope_application import apply_context_scope_f
 def test_version_wildcard_expansion():
     """Bug 1a: Wildcard observe on version namespaces not expanded."""
     # Simulated version-correlated merged data (3 version sources).
-    # This is what VersionOutputCorrelator._merge_with_pattern produces.
+    # This is what merge_branch_records produces.
     data = [
         {
             "source_guid": "sg-001",

--- a/tests/unit/record/test_envelope.py
+++ b/tests/unit/record/test_envelope.py
@@ -127,43 +127,6 @@ class TestBuildSkipped:
             RecordEnvelope.build_skipped("")
 
 
-# ── build_version_merge() ───────────────────────────────────────────────────
-
-
-class TestBuildVersionMerge:
-    def test_all_versions_present(self):
-        versions = {
-            "score_1": {"s": 8},
-            "score_2": {"s": 9},
-            "score_3": {"s": 7},
-        }
-        result = RecordEnvelope.build_version_merge(versions)
-        assert result["content"]["score_1"] == {"s": 8}
-        assert result["content"]["score_2"] == {"s": 9}
-        assert result["content"]["score_3"] == {"s": 7}
-
-    def test_preserves_upstream(self):
-        inp = {
-            "source_guid": "g1",
-            "content": {"source": {"x": 1}, "summarize": {"y": 2}},
-        }
-        versions = {"action_1": {"q": "Q1"}, "action_2": {"q": "Q2"}}
-        result = RecordEnvelope.build_version_merge(versions, inp)
-        assert result["content"]["source"] == {"x": 1}
-        assert result["content"]["summarize"] == {"y": 2}
-        assert result["content"]["action_1"] == {"q": "Q1"}
-        assert result["content"]["action_2"] == {"q": "Q2"}
-        assert result["source_guid"] == "g1"
-
-    def test_empty_raises(self):
-        with pytest.raises(RecordEnvelopeError, match="empty"):
-            RecordEnvelope.build_version_merge({})
-
-    def test_non_dict_version_value_raises(self):
-        with pytest.raises(RecordEnvelopeError, match="must be a dict"):
-            RecordEnvelope.build_version_merge({"v1": "not a dict"})
-
-
 # ── Cross-method interaction ─────────────────────────────────────────────────
 
 
@@ -184,18 +147,3 @@ class TestInteractions:
         assert r3["content"]["source"] == {"raw": "data"}
         assert r3["content"]["summarize"] == {"summary": "short"}
         assert r3["content"]["review"] == {"score": 9}
-
-    def test_version_merge_preserves_upstream_from_build(self):
-        """The critical test from the spec: version merge must preserve
-        upstream namespaces from the base record."""
-        base = RecordEnvelope.build("summarize", {"text": "sum"})
-        base["source_guid"] = "g1"
-        base["content"]["source"] = {"raw": "data"}
-
-        versions = {"extract_1": {"q": "Q1"}, "extract_2": {"q": "Q2"}}
-        result = RecordEnvelope.build_version_merge(versions, base)
-
-        assert "source" in result["content"]
-        assert "summarize" in result["content"]
-        assert "extract_1" in result["content"]
-        assert "extract_2" in result["content"]


### PR DESCRIPTION
## Summary
- Delete `RecordEnvelope.build_version_merge()` -- zero production callers after `_merge_with_pattern` was removed and version merge moved to `merge_branch_records()`.
- Remove its unit tests (`TestBuildVersionMerge` and the interaction test that called it) and its `_MANIFEST.md` entry.
- Update stale function name references in `tests/manual/repro_bug_03_version_merge_tool.py`: `apply_observe_for_file_mode` -> `apply_context_scope_for_records`, `VersionOutputCorrelator._merge_with_pattern` -> `merge_branch_records`.

## Verification
- `pytest tests/unit/record/test_envelope.py` -- 22 tests pass
- `ruff check agent_actions/record/envelope.py` -- clean
- Grepped the entire codebase for `build_version_merge` to confirm zero production callers before deletion