### PR TITLE
fix: skip redundant guard eval in FILE-mode tool/HITL paths

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-302000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-302000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Skip redundant guard evaluation in FILE-mode tool and HITL paths (already evaluated by prefilter_by_guard)"
+time: 2026-04-28T30:20:00.000000Z

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -337,6 +337,7 @@ def process_file_mode_tool(
             context=clean_input,
             formatted_prompt="",
             tools_path=context.agent_config.get("tools_path"),
+            skip_guard_eval=True,
         )
 
         if _is_empty_response(raw_response) and data:
@@ -424,6 +425,7 @@ def process_file_mode_hitl(
             context=data,
             formatted_prompt="",
             tools_path=cast(str | None, hitl_agent_config.get("tools_path")),
+            skip_guard_eval=True,
         )
 
         # Unwrap single-item list from invocation service


### PR DESCRIPTION
## Summary
- Pass `skip_guard_eval=True` to `run_dynamic_agent()` in both FILE-mode call sites (`process_file_mode_tool` and `process_file_mode_hitl`)
- Guard is already evaluated by `prefilter_by_guard()` in the pipeline before records reach these functions — the second evaluation is redundant and operates on a different input shape, risking divergent guard outcomes
- Matches the pattern already used by `OnlineStrategy._call_llm()` which passes `skip_guard_eval=True` for the same reason

## Verification
- `pytest`: 6031 passed, 2 skipped
- `ruff format --check`: clean (no new issues)
- `ruff check`: 1 pre-existing issue in unrelated file (`test_tool_input_namespaced.py`), no new issues
- No behavioral change — this is a performance fix that eliminates wasteful re-evaluation