### PR TITLE
test: fill 4 test gaps from review

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-305000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-305000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Add 4 missing test gaps: batch action_name injection, LLM version_merge negative test, conflicting namespace in merge_branch_records, single-branch merge"
+time: 2026-04-28T30:50:00.000000Z

--- a/tests/unit/llm/batch/test_result_processor_version_merge.py
+++ b/tests/unit/llm/batch/test_result_processor_version_merge.py
@@ -1,0 +1,189 @@
+"""Tests for version_merge branching in batch result processor.
+
+kind:llm with version_consumption must wrap output under action_name namespace.
+kind:tool with version_consumption flat-spreads into existing content.
+
+The guard at result_processor.py:244-245 ensures only TOOL actions get flat spread.
+If someone removes the `and is_tool` guard, LLM actions would silently corrupt
+the content namespace structure.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+from agent_actions.llm.batch.processing.result_processor import (
+    BatchProcessingContext,
+    BatchResultProcessor,
+)
+from agent_actions.llm.providers.batch_base import BatchResult
+
+
+def _make_reconciler(custom_id: str, original_row: dict[str, Any]) -> BatchResultReconciler:
+    """Build a reconciler with a single record in its context_map."""
+    return BatchResultReconciler(context_map={custom_id: original_row})
+
+
+def _make_ctx(
+    agent_config: dict[str, Any],
+    custom_id: str,
+    original_row: dict[str, Any],
+) -> BatchProcessingContext:
+    """Build a BatchProcessingContext with reconciler for version_merge testing."""
+    ctx = BatchProcessingContext(
+        batch_results=[],
+        context_map={custom_id: original_row},
+        output_directory="/tmp/output",
+        agent_config=agent_config,
+    )
+    ctx.reconciler = _make_reconciler(custom_id, original_row)
+    return ctx
+
+
+class TestLLMVersionMergeWrapsUnderActionName:
+    """kind:llm with version_consumption must wrap output under action_name, NOT flat spread."""
+
+    def test_llm_version_merge_wraps_under_action_name(self):
+        """LLM action with version_consumption_config wraps output under namespace."""
+        custom_id = "rec_001"
+        original_row = {
+            "source_guid": "src_001",
+            "content": {
+                "source": {"url": "http://example.com"},
+                "voter_1": {"vote": "keep"},
+            },
+        }
+        agent_config = {
+            "action_name": "aggregate",
+            "kind": "llm",
+            "version_consumption_config": {"source": "voter_1", "pattern": "merge"},
+        }
+        ctx = _make_ctx(agent_config, custom_id, original_row)
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content={"decision": "keep", "reason": "majority vote"},
+            success=True,
+        )
+
+        processor = BatchResultProcessor()
+        processor._enrichment_pipeline = MagicMock()
+        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
+
+        result = processor._process_successful_result(ctx, batch_result, custom_id)
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        # LLM output MUST be wrapped under action_name namespace
+        assert "aggregate" in content
+        assert content["aggregate"] == {"decision": "keep", "reason": "majority vote"}
+        # Upstream namespaces preserved
+        assert content["source"] == {"url": "http://example.com"}
+        assert content["voter_1"] == {"vote": "keep"}
+        # Output fields are NOT flat-spread into root
+        assert "decision" not in content
+        assert "reason" not in content
+
+
+class TestToolVersionMergeFlatSpreads:
+    """kind:tool with version_consumption DOES flat spread (existing behavior)."""
+
+    def test_tool_version_merge_flat_spreads(self):
+        """Tool action with version_consumption_config flat-spreads into content."""
+        custom_id = "rec_001"
+        original_row = {
+            "source_guid": "src_001",
+            "content": {
+                "source": {"url": "http://example.com"},
+                "voter_1": {"vote": "keep"},
+                "voter_2": {"vote": "reject"},
+            },
+        }
+        agent_config = {
+            "action_name": "aggregate_votes",
+            "kind": "tool",
+            "version_consumption_config": {"source": "voter_1", "pattern": "merge"},
+        }
+        ctx = _make_ctx(agent_config, custom_id, original_row)
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content={"final_decision": "keep", "confidence": 0.8},
+            success=True,
+        )
+
+        processor = BatchResultProcessor()
+        processor._enrichment_pipeline = MagicMock()
+        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
+
+        result = processor._process_successful_result(ctx, batch_result, custom_id)
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        # Tool output IS flat-spread — fields appear at root level
+        assert content["final_decision"] == "keep"
+        assert content["confidence"] == 0.8
+        # Upstream namespaces also present (merged)
+        assert content["source"] == {"url": "http://example.com"}
+        assert content["voter_1"] == {"vote": "keep"}
+        # Output is NOT nested under action_name
+        assert "aggregate_votes" not in content
+
+
+class TestNoVersionMergeWrapsNormally:
+    """Actions without version_consumption_config always wrap under action_name."""
+
+    def test_llm_no_version_merge_wraps(self):
+        """LLM action without version_consumption wraps under action_name."""
+        custom_id = "rec_001"
+        original_row = {
+            "source_guid": "src_001",
+            "content": {"source": {"url": "http://example.com"}},
+        }
+        agent_config = {
+            "action_name": "classify",
+            "kind": "llm",
+        }
+        ctx = _make_ctx(agent_config, custom_id, original_row)
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content={"category": "tech"},
+            success=True,
+        )
+
+        processor = BatchResultProcessor()
+        processor._enrichment_pipeline = MagicMock()
+        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
+
+        result = processor._process_successful_result(ctx, batch_result, custom_id)
+
+        content = result[0]["content"]
+        assert content["classify"] == {"category": "tech"}
+        assert content["source"] == {"url": "http://example.com"}
+        assert "category" not in content
+
+    def test_tool_no_version_merge_wraps(self):
+        """Tool action without version_consumption wraps under action_name."""
+        custom_id = "rec_001"
+        original_row = {
+            "source_guid": "src_001",
+            "content": {"source": {"url": "http://example.com"}},
+        }
+        agent_config = {
+            "action_name": "extract",
+            "kind": "tool",
+        }
+        ctx = _make_ctx(agent_config, custom_id, original_row)
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content={"entities": ["AI", "ML"]},
+            success=True,
+        )
+
+        processor = BatchResultProcessor()
+        processor._enrichment_pipeline = MagicMock()
+        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
+
+        result = processor._process_successful_result(ctx, batch_result, custom_id)
+
+        content = result[0]["content"]
+        assert content["extract"] == {"entities": ["AI", "ML"]}
+        assert "entities" not in content

--- a/tests/unit/llm/batch/test_result_processor_version_merge.py
+++ b/tests/unit/llm/batch/test_result_processor_version_merge.py
@@ -11,17 +11,14 @@ the content namespace structure.
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.batch.processing.result_processor import (
     BatchProcessingContext,
     BatchResultProcessor,
 )
 from agent_actions.llm.providers.batch_base import BatchResult
-
-
-def _make_reconciler(custom_id: str, original_row: dict[str, Any]) -> BatchResultReconciler:
-    """Build a reconciler with a single record in its context_map."""
-    return BatchResultReconciler(context_map={custom_id: original_row})
 
 
 def _make_ctx(
@@ -36,14 +33,23 @@ def _make_ctx(
         output_directory="/tmp/output",
         agent_config=agent_config,
     )
-    ctx.reconciler = _make_reconciler(custom_id, original_row)
+    ctx.reconciler = BatchResultReconciler(context_map={custom_id: original_row})
     return ctx
+
+
+@pytest.fixture
+def processor():
+    """BatchResultProcessor with enrichment pipeline stubbed to pass through."""
+    p = BatchResultProcessor()
+    p._enrichment_pipeline = MagicMock()
+    p._enrichment_pipeline.enrich.side_effect = lambda result, context: result
+    return p
 
 
 class TestLLMVersionMergeWrapsUnderActionName:
     """kind:llm with version_consumption must wrap output under action_name, NOT flat spread."""
 
-    def test_llm_version_merge_wraps_under_action_name(self):
+    def test_llm_version_merge_wraps_under_action_name(self, processor):
         """LLM action with version_consumption_config wraps output under namespace."""
         custom_id = "rec_001"
         original_row = {
@@ -65,21 +71,13 @@ class TestLLMVersionMergeWrapsUnderActionName:
             success=True,
         )
 
-        processor = BatchResultProcessor()
-        processor._enrichment_pipeline = MagicMock()
-        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
-
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 
         assert len(result) == 1
         content = result[0]["content"]
-        # LLM output MUST be wrapped under action_name namespace
-        assert "aggregate" in content
         assert content["aggregate"] == {"decision": "keep", "reason": "majority vote"}
-        # Upstream namespaces preserved
         assert content["source"] == {"url": "http://example.com"}
         assert content["voter_1"] == {"vote": "keep"}
-        # Output fields are NOT flat-spread into root
         assert "decision" not in content
         assert "reason" not in content
 
@@ -87,7 +85,7 @@ class TestLLMVersionMergeWrapsUnderActionName:
 class TestToolVersionMergeFlatSpreads:
     """kind:tool with version_consumption DOES flat spread (existing behavior)."""
 
-    def test_tool_version_merge_flat_spreads(self):
+    def test_tool_version_merge_flat_spreads(self, processor):
         """Tool action with version_consumption_config flat-spreads into content."""
         custom_id = "rec_001"
         original_row = {
@@ -110,28 +108,21 @@ class TestToolVersionMergeFlatSpreads:
             success=True,
         )
 
-        processor = BatchResultProcessor()
-        processor._enrichment_pipeline = MagicMock()
-        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
-
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 
         assert len(result) == 1
         content = result[0]["content"]
-        # Tool output IS flat-spread — fields appear at root level
         assert content["final_decision"] == "keep"
         assert content["confidence"] == 0.8
-        # Upstream namespaces also present (merged)
         assert content["source"] == {"url": "http://example.com"}
         assert content["voter_1"] == {"vote": "keep"}
-        # Output is NOT nested under action_name
         assert "aggregate_votes" not in content
 
 
 class TestNoVersionMergeWrapsNormally:
     """Actions without version_consumption_config always wrap under action_name."""
 
-    def test_llm_no_version_merge_wraps(self):
+    def test_llm_no_version_merge_wraps(self, processor):
         """LLM action without version_consumption wraps under action_name."""
         custom_id = "rec_001"
         original_row = {
@@ -149,10 +140,6 @@ class TestNoVersionMergeWrapsNormally:
             success=True,
         )
 
-        processor = BatchResultProcessor()
-        processor._enrichment_pipeline = MagicMock()
-        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
-
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 
         content = result[0]["content"]
@@ -160,7 +147,7 @@ class TestNoVersionMergeWrapsNormally:
         assert content["source"] == {"url": "http://example.com"}
         assert "category" not in content
 
-    def test_tool_no_version_merge_wraps(self):
+    def test_tool_no_version_merge_wraps(self, processor):
         """Tool action without version_consumption wraps under action_name."""
         custom_id = "rec_001"
         original_row = {
@@ -177,10 +164,6 @@ class TestNoVersionMergeWrapsNormally:
             content={"entities": ["AI", "ML"]},
             success=True,
         )
-
-        processor = BatchResultProcessor()
-        processor._enrichment_pipeline = MagicMock()
-        processor._enrichment_pipeline.enrich.side_effect = lambda result, context: result
 
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 

--- a/tests/unit/workflow/test_executor_batch.py
+++ b/tests/unit/workflow/test_executor_batch.py
@@ -1,0 +1,112 @@
+"""Tests for batch action_name injection in executor batch-check paths.
+
+The batch result processor needs action_name on action_config for
+RecordEnvelope.build_content() namespacing. executor.py:827 (sync)
+and :913 (async) inject it before calling handle_batch_agent.
+If these lines are removed, batch namespacing breaks silently.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.workflow.executor import (
+    ActionExecutor,
+    ExecutorDependencies,
+)
+from agent_actions.workflow.managers.batch import BatchLifecycleManager
+from agent_actions.workflow.managers.output import ActionOutputManager
+from agent_actions.workflow.managers.skip import SkipEvaluator
+from agent_actions.workflow.managers.state import ActionStateManager, ActionStatus
+
+
+@pytest.fixture
+def mock_deps():
+    """Create mock dependencies matching test_executor_lifecycle conventions."""
+    deps = MagicMock(spec=ExecutorDependencies)
+    deps.state_manager = MagicMock(spec=ActionStateManager)
+    deps.batch_manager = MagicMock(spec=BatchLifecycleManager)
+    deps.action_runner = MagicMock()
+    deps.skip_evaluator = MagicMock(spec=SkipEvaluator)
+    deps.output_manager = MagicMock(spec=ActionOutputManager)
+    deps.action_runner.workflow_name = "test_workflow"
+    deps.action_runner.get_action_folder.return_value = "/tmp/agent_io"
+    deps.action_runner.execution_order = ["my_extract"]
+    deps.action_runner.storage_backend.get_failed_items.return_value = []
+    deps.action_runner.storage_backend.has_disposition.return_value = False
+    deps.state_manager.get_status_details.return_value = {"status": ActionStatus.COMPLETED}
+    return deps
+
+
+@pytest.fixture
+def executor(mock_deps):
+    return ActionExecutor(mock_deps)
+
+
+class TestBatchActionNameInjectionSync:
+    """action_name must be on action_config before handle_batch_agent is called (sync)."""
+
+    def test_batch_check_injects_action_name_into_config(self, executor, mock_deps):
+        """Sync batch-check path injects action_name before calling handle_batch_agent."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
+        mock_deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
+
+        config = {"kind": "llm"}
+
+        with patch("agent_actions.workflow.executor.fire_event"):
+            executor.execute_action_sync(
+                "my_extract", action_idx=0, action_config=config, is_last_action=False
+            )
+
+        # action_name must be present on the config dict that was passed
+        assert config["action_name"] == "my_extract"
+
+        # Verify handle_batch_agent received the config with action_name
+        call_args = mock_deps.batch_manager.handle_batch_agent.call_args
+        passed_config = call_args[0][2]
+        assert passed_config["action_name"] == "my_extract"
+
+    def test_action_name_present_before_handle_batch_agent_called(self, executor, mock_deps):
+        """action_name injection must happen BEFORE handle_batch_agent, not after."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
+        captured_config = {}
+
+        def capture_config(action_name, output_dir, agent_config):
+            # Snapshot the config at the moment handle_batch_agent is called
+            captured_config.update(agent_config)
+            return ("/output", "completed")
+
+        mock_deps.batch_manager.handle_batch_agent.side_effect = capture_config
+
+        with patch("agent_actions.workflow.executor.fire_event"):
+            executor.execute_action_sync(
+                "my_extract",
+                action_idx=0,
+                action_config={"kind": "llm"},
+                is_last_action=False,
+            )
+
+        assert captured_config["action_name"] == "my_extract"
+
+
+class TestBatchActionNameInjectionAsync:
+    """action_name must be on action_config before handle_batch_agent is called (async)."""
+
+    @pytest.mark.asyncio
+    async def test_batch_check_async_injects_action_name_into_config(self, executor, mock_deps):
+        """Async batch-check path injects action_name before calling handle_batch_agent."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
+        mock_deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
+
+        config = {"kind": "llm"}
+
+        with patch("agent_actions.workflow.executor.fire_event"):
+            await executor.execute_action_async(
+                "my_extract", action_idx=0, action_config=config, is_last_action=False
+            )
+
+        assert config["action_name"] == "my_extract"
+
+        call_args = mock_deps.batch_manager.handle_batch_agent.call_args
+        passed_config = call_args[0][2]
+        assert passed_config["action_name"] == "my_extract"

--- a/tests/unit/workflow/test_executor_batch.py
+++ b/tests/unit/workflow/test_executor_batch.py
@@ -58,13 +58,7 @@ class TestBatchActionNameInjectionSync:
                 "my_extract", action_idx=0, action_config=config, is_last_action=False
             )
 
-        # action_name must be present on the config dict that was passed
         assert config["action_name"] == "my_extract"
-
-        # Verify handle_batch_agent received the config with action_name
-        call_args = mock_deps.batch_manager.handle_batch_agent.call_args
-        passed_config = call_args[0][2]
-        assert passed_config["action_name"] == "my_extract"
 
     def test_action_name_present_before_handle_batch_agent_called(self, executor, mock_deps):
         """action_name injection must happen BEFORE handle_batch_agent, not after."""

--- a/tests/unit/workflow/test_merge_branch_records.py
+++ b/tests/unit/workflow/test_merge_branch_records.py
@@ -358,3 +358,124 @@ class TestMergeBranchRecordsBaseRecordPreservation:
 
         assert base == base_copy
         assert branch == branch_copy
+
+
+class TestMergeBranchRecordsConflictingNamespace:
+    """Branch name colliding with an upstream namespace — last-writer-wins."""
+
+    def test_branch_name_collides_with_upstream_namespace(self):
+        """Branch named 'source' overwrites the upstream 'source' namespace."""
+        base = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://original.com"},
+                "extract": {"text": "hello"},
+            },
+        }
+        branch_source = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://overwritten.com"},
+                "extract": {"text": "hello"},
+            },
+        }
+
+        result = merge_branch_records({"source": branch_source}, base_record=base)
+        content = result["content"]
+
+        # Last-writer-wins: branch's namespace replaces base's upstream
+        assert content["source"] == {"url": "http://overwritten.com"}
+        # Non-colliding upstream preserved from base
+        assert content["extract"] == {"text": "hello"}
+
+    def test_branch_with_extra_namespaces_only_contributes_own(self):
+        """Branch with extra namespaces beyond its own: only its own namespace extracted."""
+        base = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+            },
+        }
+        # classify branch accumulated enrich namespace from a prior step,
+        # but only "classify" should be extracted
+        branch_classify = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "classify": {"topic": "science"},
+                "enrich": {"summary": "stale data from branch accumulation"},
+            },
+        }
+
+        result = merge_branch_records({"classify": branch_classify}, base_record=base)
+        content = result["content"]
+
+        # Only the branch's own namespace is contributed
+        assert content["classify"] == {"topic": "science"}
+        # "enrich" from the branch is NOT included — it's not the branch's own namespace
+        assert "enrich" not in content
+
+
+class TestMergeBranchRecordsSingleBranch:
+    """Degenerate case: single branch with no base record."""
+
+    def test_single_branch_no_base_record(self):
+        """Single branch with no base_record uses branch as base, contributes own namespace."""
+        branch = {
+            "source_guid": "guid-1",
+            "node_id": "classify_abc",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "classify": {"topic": "science"},
+            },
+            "lineage": ["source_0", "classify_abc"],
+        }
+
+        result = merge_branch_records({"classify": branch})
+        content = result["content"]
+
+        # Upstream preserved (from branch used as base)
+        assert content["source"] == {"url": "http://doc.com"}
+        # Branch's own namespace present
+        assert content["classify"] == {"topic": "science"}
+        # Metadata preserved
+        assert result["source_guid"] == "guid-1"
+        assert result["node_id"] == "classify_abc"
+        # Lineage preserved
+        assert "source_0" in result["lineage"]
+        assert "classify_abc" in result["lineage"]
+
+    def test_single_branch_with_base_record(self):
+        """Single branch with explicit base_record — base provides upstream."""
+        base = {
+            "source_guid": "guid-1",
+            "target_id": "target-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello", "_retry_count": 2},
+            },
+            "lineage": ["source_0", "extract_1"],
+        }
+        branch = {
+            "source_guid": "guid-1",
+            "content": {
+                "source": {"url": "http://doc.com"},
+                "extract": {"text": "hello"},
+                "classify": {"topic": "science"},
+            },
+            "lineage": ["source_0", "extract_1", "classify_2"],
+        }
+
+        result = merge_branch_records({"classify": branch}, base_record=base)
+        content = result["content"]
+
+        # Upstream from base (not branch) — base has _retry_count
+        assert content["extract"] == {"text": "hello", "_retry_count": 2}
+        assert content["source"] == {"url": "http://doc.com"}
+        # Branch contributes its namespace
+        assert content["classify"] == {"topic": "science"}
+        # Metadata from base
+        assert result["target_id"] == "target-1"
+        # Lineage deduplicated
+        assert result["lineage"].count("source_0") == 1
+        assert "classify_2" in result["lineage"]


### PR DESCRIPTION
## Summary
- **Batch action_name injection** (P1): 3 tests verify executor injects `action_name` into `action_config` before `handle_batch_agent` is called — sync path (executor.py:827), async path (:913), and a timing test confirming injection happens *before* the call
- **LLM version_merge negative test** (P2): 4 tests covering the `kind:llm` vs `kind:tool` branching at result_processor.py:244-245 — LLM wraps under namespace, tool flat-spreads, and both kinds wrap normally without version_consumption
- **Conflicting namespace in merge_branch_records** (P2): 2 tests — branch name colliding with upstream namespace (last-writer-wins documented), and branch with extra accumulated namespaces only contributes its own
- **Single-branch merge_branch_records** (P3): 2 tests — degenerate single-branch case with and without explicit base_record

No production code changes. Tests only.

## Verification
- All 26 new+existing tests in the 3 files pass
- Full suite: 6042 passed, 2 skipped
- `ruff format --check` clean
- `ruff check` clean (1 pre-existing warning in unrelated file)