### PR TITLE
refactor: kill shadow passthrough in batch result processor

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-301000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-301000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Kill shadow passthrough: remove fallback re-extraction in _apply_context_passthrough, always store passthrough at preparation time"
+time: 2026-04-28T30:10:00.000000Z

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -164,11 +164,10 @@ class BatchTaskPreparator:
         # ONE guard check with full context (normalize → source → prompt → guard)
         prepared = task_preparer.prepare(row, prep_context, existing_target_id=custom_id)
 
-        # 5. Store passthrough_fields for later merging (always store, even if empty)
-        if custom_id in context_map_builder:
-            BatchContextMetadata.set_passthrough_fields(
-                context_map_builder[custom_id], prepared.passthrough_fields
-            )
+        # 5. Store passthrough_fields for later merging
+        BatchContextMetadata.set_passthrough_fields(
+            context_map_builder[custom_id], prepared.passthrough_fields
+        )
 
         # 6. Handle guard results
         if prepared.guard_status == GuardStatus.UPSTREAM_UNPROCESSED:

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -164,8 +164,8 @@ class BatchTaskPreparator:
         # ONE guard check with full context (normalize → source → prompt → guard)
         prepared = task_preparer.prepare(row, prep_context, existing_target_id=custom_id)
 
-        # 5. Store passthrough_fields for later merging
-        if prepared.passthrough_fields and custom_id in context_map_builder:
+        # 5. Store passthrough_fields for later merging (always store, even if empty)
+        if custom_id in context_map_builder:
             BatchContextMetadata.set_passthrough_fields(
                 context_map_builder[custom_id], prepared.passthrough_fields
             )

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -223,9 +223,7 @@ class BatchResultProcessor:
 
         if ctx.agent_config:
             if custom_id in ctx.context_map:
-                generated_list = self._apply_context_passthrough(
-                    ctx, custom_id, generated_list, original_row
-                )
+                generated_list = self._apply_context_passthrough(ctx, custom_id, generated_list)
             elif ctx.agent_config.get("context_scope", {}).get("passthrough"):
                 # Passthrough configured but custom_id missing from context_map
                 logger.warning(
@@ -286,45 +284,15 @@ class BatchResultProcessor:
         ctx: BatchProcessingContext,
         custom_id: str,
         generated_list: list[Any],
-        original_row: dict[str, Any],
     ) -> list[Any]:
-        """Apply context_scope.passthrough fields to generated items."""
+        """Apply stored context_scope.passthrough fields to generated items."""
         stored_passthrough = BatchContextMetadata.get_passthrough_fields(ctx.context_map[custom_id])
 
         if stored_passthrough:
-            # generated_list contains flat LLM output dicts (no "content" wrapper yet)
             generated_list = [
                 {**item, **stored_passthrough} if isinstance(item, dict) else item
                 for item in generated_list
             ]
-
-        elif ctx.agent_config and ctx.agent_config.get("context_scope", {}).get("passthrough"):
-            passthrough_refs = ctx.agent_config.get("context_scope", {}).get("passthrough", [])
-            original_content = get_existing_content(original_row)
-
-            # Re-extract passthrough values from namespaced content,
-            # matching Path A's {ns_name: {field: value}} structure.
-            passthrough_data: dict[str, Any] = {}
-            for field_ref in passthrough_refs:
-                try:
-                    from agent_actions.prompt.context.scope_parsing import parse_field_reference
-
-                    ns_name, field_name = parse_field_reference(field_ref)
-                    ns_data = original_content.get(ns_name)
-                    if not isinstance(ns_data, dict) or not ns_data:
-                        continue
-                    if field_name == "*":
-                        passthrough_data.setdefault(ns_name, {}).update(ns_data)
-                    elif field_name in ns_data:
-                        passthrough_data.setdefault(ns_name, {})[field_name] = ns_data[field_name]
-                except ValueError:
-                    continue
-
-            if passthrough_data:
-                generated_list = [
-                    {**item, **passthrough_data} if isinstance(item, dict) else item
-                    for item in generated_list
-                ]
 
         return generated_list
 

--- a/tests/unit/llm/batch/test_batch_passthrough_path_b.py
+++ b/tests/unit/llm/batch/test_batch_passthrough_path_b.py
@@ -1,15 +1,13 @@
-"""Tests for _apply_context_passthrough Path B (fallback extraction).
+"""Tests for _apply_context_passthrough — stored passthrough only.
 
-Path A: passthrough fields pre-stored in BatchContextMetadata during preparation.
-Path B: no pre-stored fields — extracts from original record's namespaced content at result time.
-
-Path B triggers when context_scope.passthrough is configured but
-BatchContextMetadata has no stored passthrough fields (e.g. recovery batches
-that rebuild context without full preparation).
+Passthrough fields are pre-extracted during batch preparation and stored in
+BatchContextMetadata. At result processing time, stored fields are merged into
+generated items. There is no fallback re-extraction path.
 """
 
 from typing import Any
 
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.processing.result_processor import (
     BatchProcessingContext,
     BatchResultProcessor,
@@ -41,282 +39,126 @@ def _make_context_map_entry(**extra) -> dict[str, Any]:
     return base
 
 
-# ── Path B: merges passthrough fields from namespaced content ────────
+def _store_passthrough(entry: dict[str, Any], fields: dict[str, Any]) -> None:
+    """Store passthrough fields on a context map entry via BatchContextMetadata."""
+    BatchContextMetadata.set_passthrough_fields(entry, fields)
 
 
-class TestPathBPassthroughMerge:
-    """Path B extracts passthrough values from original record's namespaced content."""
+# ── Stored passthrough merges into generated items ───────────────────
 
-    def test_single_field_merges_into_generated_items(self):
-        """Path B merges a single passthrough field from a namespace."""
-        entry = _make_context_map_entry(
-            content={"classify": {"category": "tech", "confidence": 0.9}}
-        )
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["classify.category"]},
-            },
-        )
-        generated = [{"summary": "AI overview"}]
+
+class TestStoredPassthroughMerge:
+    """Stored passthrough fields are merged into every generated item."""
+
+    def test_single_namespace_field(self):
+        entry = _make_context_map_entry()
+        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
+        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "AI overview"}])
 
         assert len(result) == 1
         assert result[0]["summary"] == "AI overview"
         assert result[0]["classify"] == {"category": "tech"}
 
-    def test_multiple_fields_same_namespace(self):
-        """Path B merges multiple fields from the same namespace."""
-        entry = _make_context_map_entry(
-            content={"source": {"text": "hello", "lang": "en", "internal": "x"}}
-        )
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {
-                    "passthrough": ["source.text", "source.lang"],
-                },
-            },
-        )
-        generated = [{"output": "world"}]
-        processor = BatchResultProcessor()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
-
-        assert result[0]["source"] == {"text": "hello", "lang": "en"}
-        assert result[0]["output"] == "world"
-
-    def test_fields_from_multiple_namespaces(self):
-        """Path B merges fields from different namespaces."""
-        entry = _make_context_map_entry(
-            content={
+    def test_multiple_namespaces(self):
+        entry = _make_context_map_entry()
+        _store_passthrough(
+            entry,
+            {
                 "classify": {"category": "tech"},
                 "extract": {"record_id": "abc"},
-            }
-        )
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {
-                    "passthrough": ["classify.category", "extract.record_id"],
-                },
             },
         )
-        generated = [{"summary": "test"}]
+        ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
+        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
 
         assert result[0]["classify"] == {"category": "tech"}
         assert result[0]["extract"] == {"record_id": "abc"}
         assert result[0]["summary"] == "test"
 
-    def test_wildcard_merges_entire_namespace(self):
-        """Path B with wildcard passthrough merges all fields from a namespace."""
-        entry = _make_context_map_entry(
-            content={"source": {"text": "hello", "lang": "en", "count": 5}}
-        )
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["source.*"]},
-            },
-        )
-        generated = [{"output": "result"}]
+    def test_all_generated_items_receive_passthrough(self):
+        entry = _make_context_map_entry()
+        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
-
-        assert result[0]["source"] == {"text": "hello", "lang": "en", "count": 5}
-
-    def test_multiple_generated_items_all_receive_passthrough(self):
-        """All items in generated_list get passthrough fields merged."""
-        entry = _make_context_map_entry(content={"classify": {"category": "tech"}})
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["classify.category"]},
-            },
+        result = processor._apply_context_passthrough(
+            ctx, "rec_001", [{"item": 1}, {"item": 2}, {"item": 3}]
         )
-        generated = [{"item": 1}, {"item": 2}, {"item": 3}]
-        processor = BatchResultProcessor()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
 
         assert len(result) == 3
         for item in result:
             assert item["classify"] == {"category": "tech"}
 
 
-# ── Path B: edge cases and missing data ──────────────────────────────
+# ── Edge cases ───────────────────────────────────────────────────────
 
 
-class TestPathBEdgeCases:
-    """Path B handles missing data gracefully — no crash, no silent corruption."""
+class TestStoredPassthroughEdgeCases:
+    """Edge cases: empty passthrough, non-dict items, empty list."""
 
-    def test_missing_content_key_returns_unchanged(self):
-        """If original record has no content, generated items are returned unchanged."""
-        entry = _make_context_map_entry()  # no "content" key
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["classify.category"]},
-            },
-        )
-        generated = [{"summary": "test"}]
+    def test_empty_stored_passthrough_returns_unchanged(self):
+        """When stored passthrough is empty dict, generated items are unchanged."""
+        entry = _make_context_map_entry()
+        _store_passthrough(entry, {})
+        ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
+        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
 
         assert result == [{"summary": "test"}]
 
-    def test_missing_namespace_skips_field(self):
-        """If the referenced namespace doesn't exist, that field is skipped."""
-        entry = _make_context_map_entry(content={"classify": {"category": "tech"}})
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {
-                    "passthrough": ["classify.category", "nonexistent.field"],
-                },
-            },
-        )
-        generated = [{"summary": "test"}]
+    def test_no_stored_passthrough_returns_unchanged(self):
+        """When no passthrough was stored at all, generated items are unchanged."""
+        entry = _make_context_map_entry()
+        ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
-
-        assert result[0]["classify"] == {"category": "tech"}
-        assert "nonexistent" not in result[0]
-
-    def test_missing_field_in_existing_namespace_skips(self):
-        """If the namespace exists but the field doesn't, that field is skipped."""
-        entry = _make_context_map_entry(content={"classify": {"category": "tech"}})
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {
-                    "passthrough": ["classify.no_such_field"],
-                },
-            },
-        )
-        generated = [{"summary": "test"}]
-        processor = BatchResultProcessor()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
+        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
 
         assert result == [{"summary": "test"}]
 
-    def test_non_dict_items_skipped(self):
+    def test_non_dict_items_passed_through(self):
         """Non-dict items in generated_list are passed through unchanged."""
-        entry = _make_context_map_entry(content={"classify": {"category": "tech"}})
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["classify.category"]},
-            },
-        )
-        generated = [{"summary": "test"}, "raw_string", 42]
+        entry = _make_context_map_entry()
+        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
+        result = processor._apply_context_passthrough(
+            ctx, "rec_001", [{"summary": "test"}, "raw_string", 42]
+        )
 
         assert result[0]["classify"] == {"category": "tech"}
         assert result[1] == "raw_string"
         assert result[2] == 42
 
-    def test_empty_generated_list_returns_empty(self):
+    def test_empty_generated_list(self):
         """Empty generated_list returns empty list."""
-        entry = _make_context_map_entry(content={"classify": {"category": "tech"}})
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["classify.category"]},
-            },
-        )
+        entry = _make_context_map_entry()
+        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", [], entry)
+        result = processor._apply_context_passthrough(ctx, "rec_001", [])
 
         assert result == []
 
-    def test_namespace_value_not_dict_skipped(self):
-        """If a namespace maps to a non-dict value, it's skipped."""
-        entry = _make_context_map_entry(content={"classify": "not_a_dict"})
+    def test_passthrough_does_not_fire_without_context_scope_config(self):
+        """Even with agent_config having no context_scope, stored passthrough still applies."""
+        entry = _make_context_map_entry()
+        _store_passthrough(entry, {"source": {"id": "123"}})
         ctx = _make_context(
             context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["classify.category"]},
-            },
+            agent_config={"action_name": "test"},
         )
-        generated = [{"summary": "test"}]
         processor = BatchResultProcessor()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
+        result = processor._apply_context_passthrough(ctx, "rec_001", [{"output": "val"}])
 
-        assert result == [{"summary": "test"}]
-
-    def test_malformed_field_ref_skipped(self):
-        """Malformed refs (no dot) are skipped; valid sibling refs still merge."""
-        entry = _make_context_map_entry(content={"classify": {"category": "tech"}})
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {
-                    "passthrough": ["no_dot_here", "classify.category", ""],
-                },
-            },
-        )
-        generated = [{"summary": "test"}]
-        processor = BatchResultProcessor()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
-
-        assert result[0]["classify"] == {"category": "tech"}
-        assert result[0]["summary"] == "test"
-
-    def test_wildcard_on_empty_namespace_skipped(self):
-        """Wildcard on an empty namespace produces no merge."""
-        entry = _make_context_map_entry(content={"source": {}})
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["source.*"]},
-            },
-        )
-        generated = [{"output": "result"}]
-        processor = BatchResultProcessor()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
-
-        # Empty namespace produces empty passthrough_data → no merge
-        assert result == [{"output": "result"}]
-
-
-# ── Path A takes precedence over Path B ──────────────────────────────
-
-
-class TestPathAPrecedence:
-    """When pre-stored passthrough fields exist, Path A is used (not Path B)."""
-
-    def test_stored_passthrough_used_over_fallback(self):
-        """Path A passthrough from BatchContextMetadata takes priority."""
-        entry = _make_context_map_entry(
-            content={"classify": {"category": "tech"}},
-            _passthrough_fields={"classify": {"category": "STORED_VALUE"}},
-        )
-        ctx = _make_context(
-            context_map={"rec_001": entry},
-            agent_config={
-                "context_scope": {"passthrough": ["classify.category"]},
-            },
-        )
-        generated = [{"summary": "test"}]
-        processor = BatchResultProcessor()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", generated, entry)
-
-        # Path A's stored value wins, not Path B's extraction from content
-        assert result[0]["classify"] == {"category": "STORED_VALUE"}
+        assert result[0]["source"] == {"id": "123"}
+        assert result[0]["output"] == "val"

--- a/tests/unit/llm/batch/test_batch_passthrough_stored.py
+++ b/tests/unit/llm/batch/test_batch_passthrough_stored.py
@@ -1,8 +1,8 @@
-"""Tests for _apply_context_passthrough — stored passthrough only.
+"""Tests for _apply_context_passthrough — stored passthrough merge.
 
 Passthrough fields are pre-extracted during batch preparation and stored in
 BatchContextMetadata. At result processing time, stored fields are merged into
-generated items. There is no fallback re-extraction path.
+generated items.
 """
 
 from typing import Any
@@ -39,11 +39,6 @@ def _make_context_map_entry(**extra) -> dict[str, Any]:
     return base
 
 
-def _store_passthrough(entry: dict[str, Any], fields: dict[str, Any]) -> None:
-    """Store passthrough fields on a context map entry via BatchContextMetadata."""
-    BatchContextMetadata.set_passthrough_fields(entry, fields)
-
-
 # ── Stored passthrough merges into generated items ───────────────────
 
 
@@ -52,7 +47,7 @@ class TestStoredPassthroughMerge:
 
     def test_single_namespace_field(self):
         entry = _make_context_map_entry()
-        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
@@ -64,7 +59,7 @@ class TestStoredPassthroughMerge:
 
     def test_multiple_namespaces(self):
         entry = _make_context_map_entry()
-        _store_passthrough(
+        BatchContextMetadata.set_passthrough_fields(
             entry,
             {
                 "classify": {"category": "tech"},
@@ -82,7 +77,7 @@ class TestStoredPassthroughMerge:
 
     def test_all_generated_items_receive_passthrough(self):
         entry = _make_context_map_entry()
-        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
@@ -104,7 +99,7 @@ class TestStoredPassthroughEdgeCases:
     def test_empty_stored_passthrough_returns_unchanged(self):
         """When stored passthrough is empty dict, generated items are unchanged."""
         entry = _make_context_map_entry()
-        _store_passthrough(entry, {})
+        BatchContextMetadata.set_passthrough_fields(entry, {})
         ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
@@ -125,7 +120,7 @@ class TestStoredPassthroughEdgeCases:
     def test_non_dict_items_passed_through(self):
         """Non-dict items in generated_list are passed through unchanged."""
         entry = _make_context_map_entry()
-        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
@@ -140,7 +135,7 @@ class TestStoredPassthroughEdgeCases:
     def test_empty_generated_list(self):
         """Empty generated_list returns empty list."""
         entry = _make_context_map_entry()
-        _store_passthrough(entry, {"classify": {"category": "tech"}})
+        BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
         processor = BatchResultProcessor()
 
@@ -151,7 +146,7 @@ class TestStoredPassthroughEdgeCases:
     def test_passthrough_does_not_fire_without_context_scope_config(self):
         """Even with agent_config having no context_scope, stored passthrough still applies."""
         entry = _make_context_map_entry()
-        _store_passthrough(entry, {"source": {"id": "123"}})
+        BatchContextMetadata.set_passthrough_fields(entry, {"source": {"id": "123"}})
         ctx = _make_context(
             context_map={"rec_001": entry},
             agent_config={"action_name": "test"},


### PR DESCRIPTION
## Summary
- **preparator.py**: Always store passthrough_fields during batch preparation (even if empty dict), removing the truthiness guard that caused the fallback path to fire
- **result_processor.py**: Delete the 27-line fallback re-extraction path (Path B) from `_apply_context_passthrough()`. The method now only uses pre-stored passthrough fields from `BatchContextMetadata`
- **Tests**: Rewrite `test_batch_passthrough_path_b.py` — 8 tests covering stored passthrough merge, edge cases (empty, no-stored, non-dict items, empty list). Path B extraction tests deleted since that code path no longer exists

Path B duplicated extraction logic from `scope_application.py`, read from `original_content` instead of `field_context` (different source), did not apply `drop` gating, and could not extract from framework namespaces. Net: -187 lines.

## Verification
- `pytest` — 6025 passed, 2 skipped
- `ruff format --check` — clean (1 pre-existing error in unrelated file)
- `ruff check` — clean (same pre-existing error)
- `parse_field_reference` no longer appears in `result_processor.py`
- `_apply_context_passthrough` reduced from 46 lines to 16 (including signature)