### PR TITLE
refactor: kill shadow observe in FILE tool input

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-300000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-300000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Replace shadow observe implementation in FILE tool input with validated parse_field_reference; drops now respected"
+time: 2026-04-28T30:00:00.000000Z

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -144,17 +144,21 @@ def _resolve_input_record(
     return original_data[input_idx]
 
 
-def _extract_business_fields(record: dict, agent_config: Mapping[str, Any]) -> dict:
-    """Extract observe-filtered business fields from a record for tool input.
+def _extract_tool_input(record: dict, context_scope: Mapping[str, Any]) -> dict:
+    """Extract observed business fields from an enriched record for tool input.
 
-    Strips all framework fields.  Returns only business data from observed
-    namespaces.  When no observe is configured, flattens all content namespaces.
+    Reads from enriched content where drops have already been applied by
+    ``apply_context_scope_for_records()``.  Uses ``parse_field_reference()``
+    for validated ref parsing instead of the former ``str.split()`` shadow.
+
+    When no observe is configured, flattens all content namespaces.
     """
+    from agent_actions.prompt.context.scope_parsing import parse_field_reference
+
     content = record.get("content")
     if not isinstance(content, dict):
         return {}
 
-    context_scope = agent_config.get("context_scope") or {}
     observe_refs = context_scope.get("observe", [])
 
     if not observe_refs:
@@ -165,18 +169,21 @@ def _extract_business_fields(record: dict, agent_config: Mapping[str, Any]) -> d
                 business.update(ns_data)
         return business
 
-    # Extract only observed fields
+    # Extract observed fields from post-drop enriched content.
+    # Drops were already applied by apply_context_scope_for_records().
     business = {}
     for ref in observe_refs:
-        if "." not in ref:
-            continue
-        ns, field = ref.split(".", 1)
-        if ns not in content or not isinstance(content[ns], dict):
+        try:
+            ns, field = parse_field_reference(ref)
+        except ValueError:
+            continue  # Bad ref — already logged by scope application
+        ns_data = content.get(ns)
+        if not isinstance(ns_data, dict):
             continue
         if field == "*":
-            business.update(content[ns])
-        elif field in content[ns]:
-            business[field] = content[ns][field]
+            business.update(ns_data)
+        elif field in ns_data:
+            business[field] = ns_data[field]
 
     return business
 
@@ -274,9 +281,9 @@ def framework_prepare_input(
     observe_refs: list[str] | None = None,
 ) -> list[TrackedItem]:
     """Strip framework fields and wrap in TrackedItem for tool input."""
-    config: dict[str, Any] = {"context_scope": {"observe": observe_refs}} if observe_refs else {}
+    context_scope: dict[str, Any] = {"observe": observe_refs} if observe_refs else {}
     return [
-        TrackedItem(_extract_business_fields(record, config), source_index=i)
+        TrackedItem(_extract_tool_input(record, context_scope), source_index=i)
         for i, record in enumerate(records)
     ]
 
@@ -326,9 +333,10 @@ def process_file_mode_tool(
     transforms).  Plain dicts in list returns are an error.
     """
     try:
+        context_scope = context.agent_config.get("context_scope") or {}
         clean_input: list[TrackedItem] = []
         for i, record in enumerate(data):
-            business = _extract_business_fields(record, context.agent_config)
+            business = _extract_tool_input(record, context_scope)
             clean_input.append(TrackedItem(business, source_index=i))
 
         raw_response, executed = run_dynamic_agent(

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -1229,14 +1229,14 @@ class TestReattachSourceGuid:
         assert structured[2]["source_guid"] == "sg-b"
 
 
-# --- _extract_business_fields unit tests ---
+# --- _extract_tool_input unit tests ---
 
 
-class TestExtractBusinessFields:
-    """Direct unit tests for _extract_business_fields logic."""
+class TestExtractToolInput:
+    """Direct unit tests for _extract_tool_input logic."""
 
     def test_flattens_all_namespaces_no_observe(self):
-        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
 
         record = {
             "source_guid": "sg-1",
@@ -1246,7 +1246,7 @@ class TestExtractBusinessFields:
                 "summarize": {"summary": "Short version"},
             },
         }
-        result = _extract_business_fields(record, {})
+        result = _extract_tool_input(record, {})
         assert result == {
             "question_text": "What?",
             "answer_text": "Yes.",
@@ -1254,7 +1254,7 @@ class TestExtractBusinessFields:
         }
 
     def test_extracts_observed_fields_only(self):
-        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
 
         record = {
             "content": {
@@ -1262,12 +1262,11 @@ class TestExtractBusinessFields:
                 "summarize": {"summary": "Short version"},
             }
         }
-        config = {"context_scope": {"observe": ["extract.question_text"]}}
-        result = _extract_business_fields(record, config)
+        result = _extract_tool_input(record, {"observe": ["extract.question_text"]})
         assert result == {"question_text": "What?"}
 
     def test_wildcard_observe(self):
-        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
 
         record = {
             "content": {
@@ -1275,26 +1274,25 @@ class TestExtractBusinessFields:
                 "other": {"x": 99},
             }
         }
-        config = {"context_scope": {"observe": ["extract.*"]}}
-        result = _extract_business_fields(record, config)
+        result = _extract_tool_input(record, {"observe": ["extract.*"]})
         assert result == {"q": "Q1", "a": "A1"}
 
     def test_no_content_returns_empty(self):
-        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
 
         record = {"source_guid": "sg-1"}
-        result = _extract_business_fields(record, {})
+        result = _extract_tool_input(record, {})
         assert result == {}
 
     def test_non_dict_content_returns_empty(self):
-        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
 
         record = {"content": "string_content"}
-        result = _extract_business_fields(record, {})
+        result = _extract_tool_input(record, {})
         assert result == {}
 
     def test_skips_non_dict_namespace_values(self):
-        from agent_actions.workflow.pipeline_file_mode import _extract_business_fields
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
 
         record = {
             "content": {
@@ -1302,7 +1300,42 @@ class TestExtractBusinessFields:
                 "skipped_action": None,  # guard-skipped action
             }
         }
-        result = _extract_business_fields(record, {})
+        result = _extract_tool_input(record, {})
+        assert result == {"q": "Q1"}
+
+    def test_drop_respected_in_enriched_content(self):
+        """Drops applied by apply_context_scope_for_records are respected.
+
+        When content has already had drops applied (field removed from
+        namespace dict), _extract_tool_input reads from the post-drop
+        namespace and correctly excludes the dropped field.
+        """
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
+
+        # Simulate enriched record where "secret" was dropped from extract namespace
+        record = {
+            "content": {
+                "extract": {"question_text": "What?"},  # "secret" already removed by drop
+                "summarize": {"summary": "Short version"},
+            }
+        }
+        result = _extract_tool_input(
+            record, {"observe": ["extract.question_text", "extract.secret"]}
+        )
+        # secret is absent from namespace — not in output
+        assert result == {"question_text": "What?"}
+
+    def test_invalid_ref_skipped(self):
+        """Invalid observe refs are silently skipped (already logged by scope application)."""
+        from agent_actions.workflow.pipeline_file_mode import _extract_tool_input
+
+        record = {
+            "content": {
+                "extract": {"q": "Q1"},
+            }
+        }
+        # "bad_ref" has no dot — parse_field_reference raises ValueError
+        result = _extract_tool_input(record, {"observe": ["bad_ref", "extract.q"]})
         assert result == {"q": "Q1"}
 
 


### PR DESCRIPTION
## Summary
- Replace `_extract_business_fields()` with `_extract_tool_input()` in `pipeline_file_mode.py`
- Uses `parse_field_reference()` instead of `str.split(".", 1)` for validated ref parsing
- Reads from post-drop enriched content — **drop directives now respected in FILE mode tool input** (previously sensitive fields leaked through)
- Hoists `context_scope` extraction above the per-record loop
- Removes unused `Mapping` import

## Verification
- 6033 tests pass, 2 skipped (pre-existing)
- ruff format + ruff check clean on changed files
- `grep -rn _extract_business_fields` returns zero source matches
- New tests: `test_drop_respected_in_enriched_content`, `test_invalid_ref_skipped`