### PR TITLE
refactor: centralize disposition writing into result_collector

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-304000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-304000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Centralize disposition writing: node-level and batch record dispositions now route through result_collector.py instead of being scattered across pipeline, initial_pipeline, and processing_recovery modules"
+time: 2026-04-28T30:40:00.000000Z

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -14,14 +14,10 @@ from agent_actions.output.response.config_fields import get_default
 from agent_actions.output.saver import UnifiedSourceDataSaver
 from agent_actions.output.writer import FileWriter
 from agent_actions.processing.record_processor import RecordProcessor
-from agent_actions.processing.result_collector import ResultCollector
+from agent_actions.processing.result_collector import ResultCollector, write_node_level_disposition
 from agent_actions.processing.types import ProcessingContext
 from agent_actions.prompt.formatter import PromptFormatter
-from agent_actions.storage.backend import (
-    DISPOSITION_PASSTHROUGH,
-    DISPOSITION_SKIPPED,
-    NODE_LEVEL_RECORD_ID,
-)
+from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import CHUNK_CONFIG_KEY, MODEL_VENDOR_KEY
 
@@ -579,11 +575,11 @@ def _write_passthrough_result(
         output_directory=output_directory,
     )
     file_writer.write_target(result_data)
-    storage_backend.set_disposition(
+    write_node_level_disposition(
+        storage_backend,
         action_name,
-        NODE_LEVEL_RECORD_ID,
         DISPOSITION_PASSTHROUGH,
-        reason="All records tombstoned (initial stage)",
+        "All records tombstoned (initial stage)",
     )
 
 
@@ -677,20 +673,12 @@ def _process_online_mode_with_record_processor(
     # `not processed_items` prevents cascade-blocking when passthrough
     # data exists.
     if data_chunk and stats.only_guard_outcomes and not processed_items:
-        if ctx.storage_backend is not None:
-            try:
-                ctx.storage_backend.set_disposition(
-                    ctx.agent_name,
-                    NODE_LEVEL_RECORD_ID,
-                    DISPOSITION_SKIPPED,
-                    reason="All records filtered — no output produced",
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to write guard-skip disposition for %s: %s",
-                    ctx.agent_name,
-                    e,
-                )
+        write_node_level_disposition(
+            ctx.storage_backend,
+            ctx.agent_name,
+            DISPOSITION_SKIPPED,
+            "All records filtered — no output produced",
+        )
 
     # Zero-success failure: raise so executor marks FAILED and circuit
     # breaker skips downstream.  See _MANIFEST.md design note for rationale.

--- a/agent_actions/llm/batch/services/_MANIFEST.md
+++ b/agent_actions/llm/batch/services/_MANIFEST.md
@@ -9,7 +9,7 @@ Services that coordinate batch submission, retrieval, and processing updates.
 | Name | Type | Description | Signals |
 |------|------|-------------|---------|
 | `processing.py` | Module | Service that orchestrates batch processing pipelines (load, transform, execute). Delegates retry/reprompt to `retry.py` and recovery/finalization to `processing_recovery.py`. | `processing`, `logging` |
-| `processing_recovery.py` | Module | Recovery and finalization functions extracted from `BatchProcessingService`: recovery batch handling, retry/reprompt recovery, reprompt submission, output finalization, record dispositions. | `processing`, `retry`, `logging` |
+| `processing_recovery.py` | Module | Recovery and finalization functions extracted from `BatchProcessingService`: recovery batch handling, retry/reprompt recovery, reprompt submission, output finalization. Record dispositions delegated to `processing.result_collector.write_record_dispositions`. | `processing`, `retry`, `logging` |
 | `retrieval.py` | Module | Pulls completed batch results and cleans up state. | `output`, `workflow` |
 | `retry.py` | Module | Facade for `BatchRetryService`. Delegates to `retry_ops`, `reprompt_ops`, `retry_serialization`, and `retry_polling`. Re-exports module-level names for backward compatibility. | `retry_ops`, `reprompt_ops`, `retry_serialization`, `retry_polling` |
 | `retry_ops.py` | Module | Retry-specific operations: submit retry batches, resubmit missing records, process retry results, build exhausted recovery metadata. | `retry_polling`, `llm.providers`, `processing` |

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -39,13 +39,13 @@ from agent_actions.llm.batch.services.processing_recovery import (
 from agent_actions.llm.batch.services.processing_recovery import (
     process_recovery_batch as _process_recovery_batch_impl,
 )
-from agent_actions.llm.batch.services.processing_recovery import (
-    write_record_dispositions as _write_record_dispositions_impl,
-)
 from agent_actions.llm.batch.services.retry import BatchRetryService
 from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.writer import FileWriter
+from agent_actions.processing.result_collector import (
+    write_record_dispositions as _write_record_dispositions_impl,
+)
 from agent_actions.processing.types import RecoveryMetadata
 from agent_actions.utils.path_utils import ensure_directory_exists
 
@@ -604,9 +604,9 @@ class BatchProcessingService:
     def _write_record_dispositions(self, items: list[dict[str, Any]], action_name: str) -> None:
         """Write dispositions for non-success records in batch output.
 
-        Delegates to processing_recovery.write_record_dispositions.
+        Delegates to result_collector.write_record_dispositions.
         """
-        _write_record_dispositions_impl(self, items, action_name)
+        _write_record_dispositions_impl(self._storage_backend, items, action_name)
 
     def _update_prompt_trace_responses(self, items: list[dict[str, Any]], action_name: str) -> None:
         """Update prompt traces with batch responses. Telemetry — non-fatal."""

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -24,14 +24,8 @@ from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import BatchCompleteEvent
+from agent_actions.processing.result_collector import write_record_dispositions
 from agent_actions.processing.types import RecoveryMetadata
-from agent_actions.storage.backend import (
-    DISPOSITION_DEFERRED,
-    DISPOSITION_EXHAUSTED,
-    DISPOSITION_FAILED,
-    DISPOSITION_FILTERED,
-    DISPOSITION_PASSTHROUGH,
-)
 
 if TYPE_CHECKING:
     from agent_actions.llm.batch.services.processing import BatchProcessingService
@@ -507,7 +501,7 @@ def finalize_batch_output(
 
     effective_action_name = action_name if action_name is not None else service._action_name
     if service._storage_backend and effective_action_name:
-        write_record_dispositions(service, processed_data, effective_action_name)
+        write_record_dispositions(service._storage_backend, processed_data, effective_action_name)
         service._update_prompt_trace_responses(processed_data, effective_action_name)
 
     output_file = service._determine_output_path(output_directory, file_name, batch_id)
@@ -536,92 +530,4 @@ def finalize_batch_output(
 
 
 # ---------------------------------------------------------------------------
-# Record dispositions
-# ---------------------------------------------------------------------------
-
-
-def write_record_dispositions(
-    service: "BatchProcessingService",
-    items: list[dict[str, Any]],
-    action_name: str,
-) -> None:
-    """Write dispositions for non-success records in batch output.
-
-    Called from both process_batch_results() (single-batch legacy API) and
-    finalize_batch_output() (multi-batch collection path).  These are
-    mutually exclusive entry points — a given batch never flows through both.
-
-    Also clears any prior DEFERRED disposition for each record, since the
-    batch result represents the final status (ARCH-003).
-
-    Disposition writes are telemetry — errors are logged but never propagated.
-    """
-    if not service._storage_backend:
-        return
-    for item in items:
-        source_guid = item.get("source_guid")
-        if not source_guid:
-            continue
-        metadata = item.get("metadata", {})
-
-        try:
-            # Clear the DEFERRED disposition now that the batch result has
-            # arrived.  For success records this is the only disposition
-            # action; for non-success records the final disposition is
-            # written immediately below.
-            service._storage_backend.clear_disposition(
-                action_name,
-                disposition=DISPOSITION_DEFERRED,
-                record_id=source_guid,
-            )
-        except Exception:
-            logger.debug(
-                "Could not clear DEFERRED disposition for %s (may not exist)",
-                source_guid,
-                exc_info=True,
-            )
-
-        try:
-            # Check for evaluation/reprompt exhaustion via _recovery metadata.
-            recovery = item.get("_recovery", {})
-            reprompt_recovery = recovery.get("reprompt", {})
-            if reprompt_recovery.get("passed") is False:
-                validation = reprompt_recovery.get("validation", "unknown")
-                service._storage_backend.set_disposition(
-                    action_name,
-                    source_guid,
-                    DISPOSITION_EXHAUSTED,
-                    reason=f"evaluation_exhausted:{validation}",
-                )
-            elif metadata.get("retry_exhausted"):
-                service._storage_backend.set_disposition(
-                    action_name,
-                    source_guid,
-                    DISPOSITION_EXHAUSTED,
-                    reason="retry_exhausted",
-                )
-            elif item.get("_unprocessed"):
-                reason = metadata.get("reason", "unprocessed")
-                if metadata.get("skipped_by_where_clause"):
-                    disposition = DISPOSITION_FILTERED
-                else:
-                    disposition = DISPOSITION_PASSTHROUGH
-                service._storage_backend.set_disposition(
-                    action_name,
-                    source_guid,
-                    disposition,
-                    reason=reason,
-                )
-            elif item.get("error"):
-                service._storage_backend.set_disposition(
-                    action_name,
-                    source_guid,
-                    DISPOSITION_FAILED,
-                    reason=str(item["error"])[:500],
-                )
-        except Exception:
-            logger.warning(
-                "Failed to write disposition for record %s",
-                source_guid,
-                exc_info=True,
-            )
+# Record dispositions — delegated to result_collector.write_record_dispositions

--- a/agent_actions/processing/_MANIFEST.md
+++ b/agent_actions/processing/_MANIFEST.md
@@ -22,7 +22,7 @@ lineage helpers, recovery flows, and transformation pipelines.
 | `exhausted_builder.py` | Module | Builds reports once a workflow’s retries are exhausted. | `validation`, `logging` |
 | `helpers.py` | Module | Shared helpers (UUID construction, tuple flattening) for processors. | `processing` |
 | `record_processor.py` | Module | Base processor that glues loaders, transformers, and error handling. | `input`, `processing` |
-| `result_collector.py` | Module | Collects main vs side outputs, handles duplicates. Counts UNPROCESSED results separately from successes. | `output` |
+| `result_collector.py` | Module | Collects main vs side outputs, handles duplicates. Counts UNPROCESSED results separately from successes. Exports `write_node_level_disposition` (node-level skip/passthrough) and `write_record_dispositions` (batch record dispositions). All `set_disposition` calls (except executor-level) are centralized here. | `output` |
 | `prepared_task.py` | Module | `GuardStatus` enum (PASSED, SKIPPED, FILTERED, UPSTREAM_UNPROCESSED), `PreparedTask` dataclass, and `PreparationContext` (carries `mode: RunMode` directly). | `typing` |
 | `task_preparer.py` | Module | Unified task preparation (normalize, prompt, guard) for batch/online. Short-circuits upstream-unprocessed records before context loading. | `input`, `prompt` |
 | `types.py` | Module | `ProcessingStatus` enum (SUCCESS, SKIPPED, FILTERED, FAILED, EXHAUSTED, DEFERRED, UNPROCESSED), `ProcessingResult` factories, and `ProcessingContext` (uses `RunMode` for mode). | `typing` |

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -23,6 +23,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_PASSTHROUGH,
     DISPOSITION_SUCCESS,
     DISPOSITION_UNPROCESSED,
+    NODE_LEVEL_RECORD_ID,
 )
 
 if TYPE_CHECKING:
@@ -104,6 +105,106 @@ def _safe_set_disposition(
             disposition,
             exc_info=True,
         )
+
+
+def write_node_level_disposition(
+    storage_backend: Optional["StorageBackend"],
+    action_name: str,
+    disposition: str,
+    reason: str,
+) -> None:
+    """Write a node-level disposition for an entire action.
+
+    Used when all records in an action were skipped or passthroughed,
+    so there is no per-record output to disposition.
+    """
+    if storage_backend is None:
+        return
+    _safe_set_disposition(
+        storage_backend, action_name, NODE_LEVEL_RECORD_ID, disposition, reason=reason
+    )
+
+
+def write_record_dispositions(
+    storage_backend: Optional["StorageBackend"],
+    items: list[dict[str, Any]],
+    action_name: str,
+) -> None:
+    """Write dispositions for batch output records.
+
+    Called after batch results have been converted to workflow format.
+    Clears any prior DEFERRED disposition for each record, then writes
+    the final status (EXHAUSTED, FAILED, FILTERED, PASSTHROUGH).
+    Success records only get their DEFERRED cleared — no new disposition.
+
+    Disposition writes are telemetry — errors are logged but never propagated.
+    """
+    if not storage_backend:
+        return
+    for item in items:
+        source_guid = item.get("source_guid")
+        if not source_guid:
+            continue
+        metadata = item.get("metadata", {})
+
+        try:
+            # Clear the DEFERRED disposition now that the batch result has
+            # arrived.  For success records this is the only disposition
+            # action; for non-success records the final disposition is
+            # written immediately below.
+            storage_backend.clear_disposition(
+                action_name,
+                disposition=DISPOSITION_DEFERRED,
+                record_id=source_guid,
+            )
+        except Exception:
+            logger.debug(
+                "Could not clear DEFERRED disposition for %s (may not exist)",
+                source_guid,
+                exc_info=True,
+            )
+
+        # Check for evaluation/reprompt exhaustion via _recovery metadata.
+        recovery = item.get("_recovery", {})
+        reprompt_recovery = recovery.get("reprompt", {})
+        if reprompt_recovery.get("passed") is False:
+            validation = reprompt_recovery.get("validation", "unknown")
+            _safe_set_disposition(
+                storage_backend,
+                action_name,
+                source_guid,
+                DISPOSITION_EXHAUSTED,
+                reason=f"evaluation_exhausted:{validation}",
+            )
+        elif metadata.get("retry_exhausted"):
+            _safe_set_disposition(
+                storage_backend,
+                action_name,
+                source_guid,
+                DISPOSITION_EXHAUSTED,
+                reason="retry_exhausted",
+            )
+        elif item.get("_unprocessed"):
+            reason = metadata.get("reason", "unprocessed")
+            if metadata.get("skipped_by_where_clause"):
+                disposition = DISPOSITION_FILTERED
+            else:
+                disposition = DISPOSITION_PASSTHROUGH
+            _safe_set_disposition(
+                storage_backend,
+                action_name,
+                source_guid,
+                disposition,
+                reason=reason,
+            )
+        elif item.get("error"):
+            _safe_set_disposition(
+                storage_backend,
+                action_name,
+                source_guid,
+                DISPOSITION_FAILED,
+                reason=str(item["error"])[:500],
+            )
 
 
 class ResultCollector:

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -17,15 +17,11 @@ from agent_actions.llm.batch.services.submission import BatchSubmissionService
 from agent_actions.llm.realtime.output import OutputHandler
 from agent_actions.output.writer import FileWriter
 from agent_actions.processing.record_processor import RecordProcessor
-from agent_actions.processing.result_collector import ResultCollector
+from agent_actions.processing.result_collector import ResultCollector, write_node_level_disposition
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
 from agent_actions.prompt.context.scope_file_mode import apply_observe_for_file_mode
 from agent_actions.record.envelope import RecordEnvelope
-from agent_actions.storage.backend import (
-    DISPOSITION_PASSTHROUGH,
-    DISPOSITION_SKIPPED,
-    NODE_LEVEL_RECORD_ID,
-)
+from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 from agent_actions.utils.safe_format import safe_format_error
@@ -245,13 +241,12 @@ class ProcessingPipeline:
                 output_directory=params.batch_output_directory,
             )
             file_writer.write_target(result.passthrough["data"])
-            if params.storage_backend:
-                params.storage_backend.set_disposition(
-                    params.pipeline_action_name,
-                    NODE_LEVEL_RECORD_ID,
-                    DISPOSITION_PASSTHROUGH,
-                    reason="All records tombstoned",
-                )
+            write_node_level_disposition(
+                params.storage_backend,
+                params.pipeline_action_name,
+                DISPOSITION_PASSTHROUGH,
+                "All records tombstoned",
+            )
             return str(output_file_path)
 
         # Batch job placeholder - always JSON (tracking file, not data)
@@ -583,21 +578,12 @@ class ProcessingPipeline:
         # records with passthrough data ARE in `output`, so `not output`
         # prevents cascade-blocking when passthrough data exists.
         if data and stats.only_guard_outcomes and not output:
-            storage_backend = self.config.storage_backend
-            if storage_backend is not None:
-                try:
-                    storage_backend.set_disposition(
-                        self.config.action_name,
-                        NODE_LEVEL_RECORD_ID,
-                        DISPOSITION_SKIPPED,
-                        reason="All records filtered — no output produced",
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Failed to write guard-skip disposition for %s: %s",
-                        self.config.action_name,
-                        e,
-                    )
+            write_node_level_disposition(
+                self.config.storage_backend,
+                self.config.action_name,
+                DISPOSITION_SKIPPED,
+                "All records filtered — no output produced",
+            )
 
         # Zero-success failure: raise so executor marks FAILED and circuit
         # breaker skips downstream.  Uses stats.success (not `not output`)

--- a/tests/simulation/simulate_batch_resubmission.py
+++ b/tests/simulation/simulate_batch_resubmission.py
@@ -415,7 +415,7 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
     print("\n--- Scenario 8: Disposition writer marks guard-skipped records ---")
     print("  Setup: 10 output items — 7 processed, 3 guard-skipped with _unprocessed=True")
 
-    from agent_actions.llm.batch.services.processing_recovery import write_record_dispositions
+    from agent_actions.processing.result_collector import write_record_dispositions
 
     storage = MockStorageBackend()
     mock_service = MagicMock()
@@ -447,7 +447,7 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
             }
         )
 
-    write_record_dispositions(mock_service, output_items, "my_action")
+    write_record_dispositions(mock_service._storage_backend, output_items, "my_action")
 
     # Verify: 3 PASSTHROUGH dispositions (guard-skipped records forward data unchanged)
     passthrough_records = storage.get_dispositions_by_type("my_action", DISPOSITION_PASSTHROUGH)

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -390,11 +390,11 @@ class TestWriteRecordDispositionsEvaluationExhausted:
             }
         ]
 
-        from agent_actions.llm.batch.services.processing_recovery import (
+        from agent_actions.processing.result_collector import (
             write_record_dispositions,
         )
 
-        write_record_dispositions(service, items, "my_action")
+        write_record_dispositions(service._storage_backend, items, "my_action")
         service._storage_backend.set_disposition.assert_called_once_with(
             "my_action", "sg-1", DISPOSITION_EXHAUSTED, reason="evaluation_exhausted:check_schema"
         )
@@ -412,11 +412,11 @@ class TestWriteRecordDispositionsEvaluationExhausted:
             }
         ]
 
-        from agent_actions.llm.batch.services.processing_recovery import (
+        from agent_actions.processing.result_collector import (
             write_record_dispositions,
         )
 
-        write_record_dispositions(service, items, "my_action")
+        write_record_dispositions(service._storage_backend, items, "my_action")
         service._storage_backend.set_disposition.assert_called_once()
         reason = service._storage_backend.set_disposition.call_args.kwargs["reason"]
         assert reason == "evaluation_exhausted:check_output"
@@ -426,11 +426,11 @@ class TestWriteRecordDispositionsEvaluationExhausted:
         service = _make_service()
         items = [{"source_guid": "sg-1", "metadata": {"retry_exhausted": True}}]
 
-        from agent_actions.llm.batch.services.processing_recovery import (
+        from agent_actions.processing.result_collector import (
             write_record_dispositions,
         )
 
-        write_record_dispositions(service, items, "my_action")
+        write_record_dispositions(service._storage_backend, items, "my_action")
         service._storage_backend.set_disposition.assert_called_once_with(
             "my_action", "sg-1", DISPOSITION_EXHAUSTED, reason="retry_exhausted"
         )
@@ -442,11 +442,11 @@ class TestWriteRecordDispositionsEvaluationExhausted:
             {"source_guid": "sg-1", "metadata": {}, "_recovery": {"reprompt": {"passed": False}}}
         ]
 
-        from agent_actions.llm.batch.services.processing_recovery import (
+        from agent_actions.processing.result_collector import (
             write_record_dispositions,
         )
 
-        write_record_dispositions(service, items, "my_action")
+        write_record_dispositions(service._storage_backend, items, "my_action")
         reason = service._storage_backend.set_disposition.call_args.kwargs["reason"]
         assert reason == "evaluation_exhausted:unknown"
 
@@ -461,9 +461,9 @@ class TestWriteRecordDispositionsEvaluationExhausted:
             }
         ]
 
-        from agent_actions.llm.batch.services.processing_recovery import (
+        from agent_actions.processing.result_collector import (
             write_record_dispositions,
         )
 
-        write_record_dispositions(service, items, "my_action")
+        write_record_dispositions(service._storage_backend, items, "my_action")
         service._storage_backend.set_disposition.assert_not_called()


### PR DESCRIPTION
## Summary
- Extracted `write_node_level_disposition()` helper into `result_collector.py`, replacing copy-pasted node-level SKIPPED/PASSTHROUGH blocks in `pipeline.py` and `initial_pipeline.py`
- Moved `write_record_dispositions()` from `processing_recovery.py` to `result_collector.py`, replacing direct `set_disposition` calls with the shared `_safe_set_disposition` wrapper
- `set_disposition` calls now only exist in `result_collector.py` (centralized) and `executor.py` (executor-level failure/skip)
- Net -19 lines across 9 files

## Verification
- `ruff format --check` and `ruff check` clean (1 pre-existing unrelated lint warning)
- `pytest` — 6027 passed, 2 skipped
- `grep -rn 'set_disposition' agent_actions/ --include='*.py'` confirms calls only in `result_collector.py`, `executor.py`, and `storage/` (definitions)