### PR TITLE
refactor: unify shared record assembly helpers

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-303000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-303000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Extract shared record assembly helpers (build_tombstone, carry_framework_fields, apply_version_merge, extract_existing_content) into processing/record_helpers.py — eliminates duplicated tombstone construction, framework field carry-forward, and version-merge logic across online, batch, and FILE processing paths"
+time: 2026-04-28T30:30:00.000000Z

--- a/agent_actions/llm/batch/processing/result_processor.py
+++ b/agent_actions/llm/batch/processing/result_processor.py
@@ -15,8 +15,13 @@ from agent_actions.output.response.config_fields import get_default
 from agent_actions.processing.batch_context_adapter import BatchContextAdapter
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
+from agent_actions.processing.record_helpers import (
+    apply_version_merge,
+    build_exhausted_tombstone,
+    build_tombstone,
+    carry_framework_fields,
+)
 from agent_actions.processing.types import ProcessingResult, RecoveryMetadata
-from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
@@ -235,31 +240,18 @@ class BatchResultProcessor:
 
         if not ctx.agent_config or "action_name" not in ctx.agent_config:
             raise ValueError("agent_config must contain 'action_name' for content namespacing")
-        from agent_actions.utils.content import is_version_merge
 
-        action_name = ctx.agent_config["action_name"]
-        # Version merge spread only applies to TOOL actions that merge pre-namespaced
-        # version data (e.g., aggregate_votes). LLM actions with version_consumption
-        # produce their OWN output that must be wrapped under their namespace.
-        is_tool = ctx.agent_config.get("kind") == "tool"
-        version_merge = is_version_merge(ctx.agent_config) and is_tool
         existing_content = get_existing_content(original_row)
 
         structured_items = []
         for item in generated_list:
             item_dict = item if isinstance(item, dict) else {}
-            if version_merge:
-                content = {**(existing_content or {}), **item_dict}
-            else:
-                content = RecordEnvelope.build_content(action_name, item_dict, existing_content)
+            content = apply_version_merge(ctx.agent_config, item_dict, existing_content)
             structured_items.append({"source_guid": original_source_guid, "content": content})
 
         # Batch items inherit target_id from the original input row.
-        original_target_id = original_row.get("target_id")
-        if original_target_id:
-            for item in structured_items:
-                if "target_id" not in item or not item["target_id"]:
-                    item["target_id"] = original_target_id
+        for item in structured_items:
+            carry_framework_fields(original_row, item, fields=("target_id",))
 
         record_index = ctx.reconciler.get_record_index(custom_id)
 
@@ -450,17 +442,12 @@ class BatchResultProcessor:
                     empty_content = ExhaustedRecordBuilder.build_empty_content(
                         ctx.agent_config or {}
                     )
-                    existing = get_existing_content(original_row)
-                    exhausted_item = {
-                        "content": RecordEnvelope.build_content(
-                            stage6_action_name, empty_content, existing
-                        ),
-                        "source_guid": source_guid,
-                        "metadata": {"retry_exhausted": True, "agent_type": "tombstone"},
-                        "_unprocessed": True,
-                    }
-                    if original_row.get("target_id"):
-                        exhausted_item["target_id"] = original_row["target_id"]
+                    exhausted_item = build_exhausted_tombstone(
+                        stage6_action_name,
+                        original_row,
+                        empty_content,
+                        source_guid=source_guid,
+                    )
 
                     processing_context = BatchContextAdapter.to_processing_context(
                         agent_config=ctx.agent_config or {},
@@ -491,17 +478,12 @@ class BatchResultProcessor:
                     else:
                         reason = "batch_not_returned"
 
-                    passthrough_item = RecordEnvelope.build_skipped(
-                        stage6_action_name, original_row
+                    passthrough_item = build_tombstone(
+                        stage6_action_name,
+                        original_row,
+                        reason,
+                        source_guid=source_guid,
                     )
-                    passthrough_item["source_guid"] = source_guid
-                    passthrough_item["metadata"] = {
-                        "reason": reason,
-                        "agent_type": "tombstone",
-                    }
-                    passthrough_item["_unprocessed"] = True
-                    if original_row.get("target_id"):
-                        passthrough_item["target_id"] = original_row["target_id"]
 
                     processing_context = BatchContextAdapter.to_processing_context(
                         agent_config=ctx.agent_config or {},

--- a/agent_actions/processing/_MANIFEST.md
+++ b/agent_actions/processing/_MANIFEST.md
@@ -21,6 +21,7 @@ lineage helpers, recovery flows, and transformation pipelines.
 | `error_handling.py` | Module | `ProcessorErrorHandlerMixin` for wrapping file loading/processing logic. | `logging` |
 | `exhausted_builder.py` | Module | Builds reports once a workflow’s retries are exhausted. | `validation`, `logging` |
 | `helpers.py` | Module | Shared helpers (UUID construction, tuple flattening) for processors. | `processing` |
+| `record_helpers.py` | Module | Shared record assembly helpers: `build_tombstone`, `build_exhausted_tombstone`, `carry_framework_fields`, `apply_version_merge`, `extract_existing_content`. Used by all processing paths (online, batch, FILE). | `record`, `processing` |
 | `record_processor.py` | Module | Base processor that glues loaders, transformers, and error handling. | `input`, `processing` |
 | `result_collector.py` | Module | Collects main vs side outputs, handles duplicates. Counts UNPROCESSED results separately from successes. | `output` |
 | `prepared_task.py` | Module | `GuardStatus` enum (PASSED, SKIPPED, FILTERED, UPSTREAM_UNPROCESSED), `PreparedTask` dataclass, and `PreparationContext` (carries `mode: RunMode` directly). | `typing` |

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -1,0 +1,145 @@
+"""Shared record assembly helpers — used by all processing paths.
+
+Centralises tombstone construction, version-merge content assembly,
+framework-field carry-forward, and existing-content extraction so that
+every processing path (online, batch, FILE) behaves identically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS, RecordEnvelope
+from agent_actions.utils.content import get_existing_content, is_version_merge
+
+# Framework fields that should be carried from an input record to an output
+# record when the envelope builder does not manage them automatically.
+CARRY_FORWARD_FIELDS: tuple[str, ...] = (
+    "target_id",
+    "_unprocessed",
+    "_recovery",
+    "metadata",
+)
+
+
+def build_tombstone(
+    action_name: str,
+    input_record: dict[str, Any] | None,
+    reason: str,
+    *,
+    source_guid: str | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a tombstone record for skipped/exhausted/guard-filtered records.
+
+    For ``guard_*`` reasons the record gets a null namespace via
+    :meth:`RecordEnvelope.build_skipped`.  For non-guard reasons (e.g.
+    ``retry_exhausted``) the record is built with an empty action output via
+    :meth:`RecordEnvelope.build_skipped` as well — all tombstones are
+    "skipped" records from the envelope perspective.
+
+    Always sets ``metadata.reason``, ``metadata.agent_type = "tombstone"``,
+    and ``_unprocessed = True``.  Carries ``target_id`` from *input_record*.
+    """
+    item = RecordEnvelope.build_skipped(action_name, input_record)
+    item["source_guid"] = source_guid
+    item["metadata"] = {"reason": reason, "agent_type": "tombstone"}
+    item["_unprocessed"] = True
+    if extra_metadata:
+        item["metadata"].update(extra_metadata)
+    carry_framework_fields(input_record, item, fields=("target_id",))
+    return item
+
+
+def build_exhausted_tombstone(
+    action_name: str,
+    input_record: dict[str, Any] | None,
+    empty_content: dict[str, Any],
+    *,
+    source_guid: str | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an exhausted-retry tombstone that preserves existing content.
+
+    Unlike :func:`build_tombstone`, exhausted records need to carry
+    the existing content (upstream namespaces) merged with an empty
+    action output so downstream can see what was accumulated before
+    exhaustion.
+    """
+    existing = get_existing_content(input_record) if input_record else {}
+    content = RecordEnvelope.build_content(action_name, empty_content, existing)
+    item: dict[str, Any] = {
+        "content": content,
+        "source_guid": source_guid,
+        "metadata": {
+            "reason": "retry_exhausted",
+            "retry_exhausted": True,
+            "agent_type": "tombstone",
+        },
+        "_unprocessed": True,
+    }
+    if extra_metadata:
+        item["metadata"].update(extra_metadata)
+    carry_framework_fields(input_record, item, fields=("target_id",))
+    return item
+
+
+def carry_framework_fields(
+    source: dict[str, Any] | None,
+    target: dict[str, Any],
+    *,
+    fields: tuple[str, ...] = CARRY_FORWARD_FIELDS,
+) -> dict[str, Any]:
+    """Copy framework fields from *source* to *target* when present.
+
+    Copies unconditionally when the field exists in *source* — callers
+    that need to protect explicit values should pass a restricted
+    *fields* tuple (e.g. ``fields=("target_id",)``).
+
+    Returns *target* for convenience (mutates in-place).
+    """
+    if source is None or not isinstance(source, dict):
+        return target
+    for field in fields:
+        if field in source:
+            target[field] = source[field]
+    return target
+
+
+def apply_version_merge(
+    agent_config: dict[str, Any],
+    action_output: dict[str, Any],
+    existing_content: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build content dict applying version-merge spread when appropriate.
+
+    Version-merge spread (flat merge of existing + new) only applies to
+    **tool** actions with ``version_consumption_config``.  LLM actions
+    produce their own namespaced output even when consuming versions.
+
+    Returns a content dict (not a full record envelope).
+    """
+    is_tool = agent_config.get("kind") == "tool"
+    if is_version_merge(agent_config) and is_tool:
+        return {**(existing_content or {}), **action_output}
+    action_name = agent_config["action_name"]
+    return RecordEnvelope.build_content(action_name, action_output, existing_content)
+
+
+def extract_existing_content(
+    record: dict[str, Any],
+    *,
+    is_first_stage: bool = False,
+) -> dict[str, Any]:
+    """Extract existing content with consistent first-stage fallback.
+
+    On first-stage records that have no ``content`` dict, the raw
+    non-framework fields are wrapped under ``{"source": ...}`` so
+    downstream actions can reference source data.
+    """
+    existing = get_existing_content(record)
+    if not existing and is_first_stage:
+        raw = {k: v for k, v in record.items() if k not in RECORD_FRAMEWORK_FIELDS}
+        if raw:
+            return {"source": raw}
+    return existing

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -30,16 +30,16 @@ def build_tombstone(
     source_guid: str | None = None,
     extra_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build a tombstone record for skipped/exhausted/guard-filtered records.
+    """Build a tombstone record for guard-skipped or unprocessed records.
 
-    For ``guard_*`` reasons the record gets a null namespace via
-    :meth:`RecordEnvelope.build_skipped`.  For non-guard reasons (e.g.
-    ``retry_exhausted``) the record is built with an empty action output via
-    :meth:`RecordEnvelope.build_skipped` as well — all tombstones are
-    "skipped" records from the envelope perspective.
+    Uses :meth:`RecordEnvelope.build_skipped` to add a null namespace
+    marker (``action_name: None``) while preserving upstream content.
 
     Always sets ``metadata.reason``, ``metadata.agent_type = "tombstone"``,
     and ``_unprocessed = True``.  Carries ``target_id`` from *input_record*.
+
+    For retry-exhausted records that need empty content under the
+    namespace (not null), use :func:`build_exhausted_tombstone` instead.
     """
     item = RecordEnvelope.build_skipped(action_name, input_record)
     item["source_guid"] = source_guid

--- a/agent_actions/processing/record_processor.py
+++ b/agent_actions/processing/record_processor.py
@@ -23,14 +23,13 @@ from agent_actions.logging.events.data_pipeline_events import (
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
 from agent_actions.output.response.config_fields import get_default
-from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS, RecordEnvelope
 from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
-from agent_actions.utils.content import get_existing_content
 
 from .enrichment import EnrichmentPipeline
 from .exhausted_builder import ExhaustedRecordBuilder
 from .invocation import BatchProvider, InvocationStrategy, InvocationStrategyFactory
 from .prepared_task import GuardStatus, PreparationContext
+from .record_helpers import build_exhausted_tombstone, build_tombstone, extract_existing_content
 from .task_preparer import TaskPreparer, get_task_preparer
 from .types import (
     ProcessingContext,
@@ -182,12 +181,11 @@ class RecordProcessor:
                     filter_reason=f"guard_{prepared.guard_behavior}",
                 )
             )
-            tombstone = self._build_tombstone_item(
-                content,
-                source_guid,
-                f"guard_{prepared.guard_behavior}",
-                input_record,
+            tombstone = build_tombstone(
                 context.action_name,
+                input_record,
+                f"guard_{prepared.guard_behavior}",
+                source_guid=source_guid,
             )
             result = ProcessingResult.skipped(
                 passthrough_data=tombstone,
@@ -230,13 +228,11 @@ class RecordProcessor:
                     empty_content = ExhaustedRecordBuilder.build_empty_content(
                         cast(dict[str, Any], context.agent_config)
                     )
-                    tombstone = self._build_tombstone_item(
-                        empty_content,
-                        source_guid,
-                        "retry_exhausted",
-                        input_record,
+                    tombstone = build_exhausted_tombstone(
                         context.action_name,
-                        extra_metadata={"retry_exhausted": True},
+                        input_record,
+                        empty_content,
+                        source_guid=source_guid,
                     )
                     result = ProcessingResult.exhausted(
                         error=f"Retry exhausted after {recovery_metadata.retry.attempts} attempts",
@@ -269,12 +265,11 @@ class RecordProcessor:
                         filter_reason="llm_layer_guard_skip",
                     )
                 )
-                tombstone = self._build_tombstone_item(
-                    response,
-                    source_guid,
-                    "guard_skip",
-                    input_record,
+                tombstone = build_tombstone(
                     context.action_name,
+                    input_record,
+                    "guard_skip",
+                    source_guid=source_guid,
                 )
                 result = ProcessingResult.unprocessed(
                     data=[tombstone],
@@ -311,11 +306,11 @@ class RecordProcessor:
                     },
                 )
 
-        item_existing_content = get_existing_content(item) if isinstance(item, dict) else None
-        if not item_existing_content and isinstance(item, dict) and context.is_first_stage:
-            raw = {k: v for k, v in item.items() if k not in RECORD_FRAMEWORK_FIELDS}
-            if raw:
-                item_existing_content = {"source": raw}
+        item_existing_content = (
+            extract_existing_content(item, is_first_stage=context.is_first_stage)
+            if isinstance(item, dict)
+            else None
+        )
         transformed = self._transform_response(
             response,
             content,
@@ -437,31 +432,6 @@ class RecordProcessor:
         )
 
         return results
-
-    @staticmethod
-    def _build_tombstone_item(
-        content: Any,
-        source_guid: str | None,
-        reason: str,
-        input_record: dict[str, Any] | None,
-        action_name: str,
-        *,
-        extra_metadata: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Build a tombstone item for guard-skipped, exhausted, or unprocessed records."""
-        if reason.startswith("guard_"):
-            item = RecordEnvelope.build_skipped(action_name, input_record)
-        else:
-            action_output = content if isinstance(content, dict) else {"value": content}
-            item = RecordEnvelope.build(action_name, action_output, input_record)
-        item["source_guid"] = source_guid
-        item["metadata"] = {"reason": reason, "agent_type": "tombstone"}
-        item["_unprocessed"] = True
-        if extra_metadata:
-            item["metadata"].update(extra_metadata)
-        if input_record and isinstance(input_record, dict) and "target_id" in input_record:
-            item["target_id"] = input_record["target_id"]
-        return item
 
     def _finalize_result(
         self,

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.processing.helpers import run_dynamic_agent
+from agent_actions.processing.record_helpers import carry_framework_fields
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
@@ -488,11 +489,7 @@ def process_file_mode_hitl(
                                 hitl_output[key] = review_payload[key]
 
                 record = RecordEnvelope.build(context.agent_name, hitl_output, item)
-
-                # Carry framework fields that RecordEnvelope doesn't manage.
-                for field in ("target_id", "_unprocessed", "_recovery", "metadata"):
-                    if field in item:
-                        record[field] = item[field]
+                carry_framework_fields(item, record)
                 structured_data.append(record)
 
         # HITL FILE mode is always 1:1 — identity source_mapping ensures the

--- a/tests/unit/processing/test_record_helpers.py
+++ b/tests/unit/processing/test_record_helpers.py
@@ -234,6 +234,13 @@ class TestApplyVersionMerge:
         result = apply_version_merge(config, {"b": 2}, {"a": {"x": 1}})
         assert result == {"a": {"x": 1}, "act": {"b": 2}}
 
+    def test_missing_action_name_raises_key_error(self):
+        """action_name is required — callers must validate before calling."""
+        import pytest
+
+        with pytest.raises(KeyError, match="action_name"):
+            apply_version_merge({"kind": "llm"}, {"b": 2}, None)
+
 
 # ---------------------------------------------------------------------------
 # extract_existing_content

--- a/tests/unit/processing/test_record_helpers.py
+++ b/tests/unit/processing/test_record_helpers.py
@@ -1,0 +1,287 @@
+"""Tests for shared record assembly helpers in processing.record_helpers."""
+
+from agent_actions.processing.record_helpers import (
+    CARRY_FORWARD_FIELDS,
+    apply_version_merge,
+    build_exhausted_tombstone,
+    build_tombstone,
+    carry_framework_fields,
+    extract_existing_content,
+)
+
+# ---------------------------------------------------------------------------
+# build_tombstone
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTombstone:
+    """Tests for build_tombstone()."""
+
+    def test_guard_skip_sets_null_namespace(self):
+        input_record = {"content": {"prev_action": {"a": 1}}, "source_guid": "sg1"}
+        result = build_tombstone("my_action", input_record, "guard_skip", source_guid="sg1")
+
+        assert result["content"]["my_action"] is None
+        assert result["content"]["prev_action"] == {"a": 1}
+
+    def test_metadata_has_reason_and_agent_type(self):
+        result = build_tombstone("act", None, "guard_filter")
+        assert result["metadata"]["reason"] == "guard_filter"
+        assert result["metadata"]["agent_type"] == "tombstone"
+
+    def test_unprocessed_flag_set(self):
+        result = build_tombstone("act", None, "guard_skip")
+        assert result["_unprocessed"] is True
+
+    def test_source_guid_set_explicitly(self):
+        result = build_tombstone("act", None, "guard_skip", source_guid="guid-123")
+        assert result["source_guid"] == "guid-123"
+
+    def test_source_guid_defaults_to_none(self):
+        result = build_tombstone("act", None, "guard_skip")
+        assert result["source_guid"] is None
+
+    def test_extra_metadata_merged(self):
+        result = build_tombstone("act", None, "guard_skip", extra_metadata={"retry_count": 3})
+        assert result["metadata"]["reason"] == "guard_skip"
+        assert result["metadata"]["retry_count"] == 3
+
+    def test_target_id_carried_from_input(self):
+        input_record = {"content": {}, "target_id": "tid-1"}
+        result = build_tombstone("act", input_record, "guard_skip")
+        assert result["target_id"] == "tid-1"
+
+    def test_target_id_not_set_when_missing_from_input(self):
+        input_record = {"content": {}}
+        result = build_tombstone("act", input_record, "guard_skip")
+        assert "target_id" not in result
+
+    def test_none_input_record(self):
+        result = build_tombstone("act", None, "guard_skip", source_guid="sg")
+        assert result["content"] == {"act": None}
+        assert result["_unprocessed"] is True
+
+    def test_preserves_upstream_namespaces(self):
+        input_record = {"content": {"ns_a": {"x": 1}, "ns_b": {"y": 2}}}
+        result = build_tombstone("ns_c", input_record, "guard_skip")
+        assert result["content"]["ns_a"] == {"x": 1}
+        assert result["content"]["ns_b"] == {"y": 2}
+        assert result["content"]["ns_c"] is None
+
+
+# ---------------------------------------------------------------------------
+# build_exhausted_tombstone
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExhaustedTombstone:
+    """Tests for build_exhausted_tombstone()."""
+
+    def test_wraps_empty_content_under_namespace(self):
+        input_record = {"content": {"prev": {"a": 1}}, "source_guid": "sg"}
+        empty = {"field_a": None, "field_b": None}
+        result = build_exhausted_tombstone("my_action", input_record, empty, source_guid="sg")
+
+        assert result["content"]["my_action"] == empty
+        assert result["content"]["prev"] == {"a": 1}
+
+    def test_metadata_has_retry_exhausted_and_reason(self):
+        result = build_exhausted_tombstone("act", None, {})
+        assert result["metadata"]["retry_exhausted"] is True
+        assert result["metadata"]["agent_type"] == "tombstone"
+        assert result["metadata"]["reason"] == "retry_exhausted"
+
+    def test_unprocessed_flag_set(self):
+        result = build_exhausted_tombstone("act", None, {})
+        assert result["_unprocessed"] is True
+
+    def test_source_guid_set(self):
+        result = build_exhausted_tombstone("act", None, {}, source_guid="sg-1")
+        assert result["source_guid"] == "sg-1"
+
+    def test_target_id_carried(self):
+        input_record = {"content": {}, "target_id": "tid-2"}
+        result = build_exhausted_tombstone("act", input_record, {})
+        assert result["target_id"] == "tid-2"
+
+    def test_extra_metadata_merged(self):
+        result = build_exhausted_tombstone("act", None, {}, extra_metadata={"custom_key": "val"})
+        assert result["metadata"]["custom_key"] == "val"
+        assert result["metadata"]["retry_exhausted"] is True
+
+    def test_none_input_record_produces_empty_existing(self):
+        result = build_exhausted_tombstone("act", None, {"f": None})
+        assert result["content"] == {"act": {"f": None}}
+
+
+# ---------------------------------------------------------------------------
+# carry_framework_fields
+# ---------------------------------------------------------------------------
+
+
+class TestCarryFrameworkFields:
+    """Tests for carry_framework_fields()."""
+
+    def test_carries_target_id(self):
+        source = {"target_id": "tid-1", "content": {"x": 1}}
+        target: dict = {}
+        carry_framework_fields(source, target, fields=("target_id",))
+        assert target["target_id"] == "tid-1"
+
+    def test_carries_all_default_fields(self):
+        source = {
+            "target_id": "tid",
+            "_unprocessed": True,
+            "_recovery": {"attempt": 1},
+            "metadata": {"reason": "test"},
+        }
+        target: dict = {}
+        carry_framework_fields(source, target)
+        assert target["target_id"] == "tid"
+        assert target["_unprocessed"] is True
+        assert target["_recovery"] == {"attempt": 1}
+        assert target["metadata"]["reason"] == "test"
+
+    def test_skips_missing_fields(self):
+        source = {"content": {"x": 1}}
+        target: dict = {}
+        carry_framework_fields(source, target)
+        assert "target_id" not in target
+        assert "_unprocessed" not in target
+
+    def test_overwrites_existing_target_value(self):
+        source = {"target_id": "new"}
+        target = {"target_id": "old"}
+        carry_framework_fields(source, target, fields=("target_id",))
+        assert target["target_id"] == "new"
+
+    def test_none_source_is_noop(self):
+        target = {"x": 1}
+        result = carry_framework_fields(None, target)
+        assert result == {"x": 1}
+
+    def test_non_dict_source_is_noop(self):
+        target = {"x": 1}
+        result = carry_framework_fields("not a dict", target)  # type: ignore[arg-type]
+        assert result == {"x": 1}
+
+    def test_returns_target_for_chaining(self):
+        target: dict = {}
+        result = carry_framework_fields({"target_id": "t"}, target, fields=("target_id",))
+        assert result is target
+
+    def test_default_fields_match_constant(self):
+        assert CARRY_FORWARD_FIELDS == ("target_id", "_unprocessed", "_recovery", "metadata")
+
+
+# ---------------------------------------------------------------------------
+# apply_version_merge
+# ---------------------------------------------------------------------------
+
+
+class TestApplyVersionMerge:
+    """Tests for apply_version_merge()."""
+
+    def test_tool_with_version_merge_does_flat_spread(self):
+        config = {
+            "action_name": "aggregate",
+            "kind": "tool",
+            "version_consumption_config": {"field": "version"},
+        }
+        existing = {"ns_a": {"x": 1}}
+        output = {"ns_b": {"y": 2}}
+        result = apply_version_merge(config, output, existing)
+        assert result == {"ns_a": {"x": 1}, "ns_b": {"y": 2}}
+
+    def test_llm_with_version_merge_wraps_under_namespace(self):
+        config = {
+            "action_name": "review",
+            "kind": "llm",
+            "version_consumption_config": {"field": "version"},
+        }
+        existing = {"ns_a": {"x": 1}}
+        output = {"rating": 5}
+        result = apply_version_merge(config, output, existing)
+        assert result == {"ns_a": {"x": 1}, "review": {"rating": 5}}
+
+    def test_no_version_merge_wraps_under_namespace(self):
+        config = {"action_name": "my_action", "kind": "tool"}
+        output = {"field": "value"}
+        result = apply_version_merge(config, output, None)
+        assert result == {"my_action": {"field": "value"}}
+
+    def test_existing_content_none_treated_as_empty(self):
+        config = {
+            "action_name": "agg",
+            "kind": "tool",
+            "version_consumption_config": {"f": "v"},
+        }
+        result = apply_version_merge(config, {"k": 1}, None)
+        assert result == {"k": 1}
+
+    def test_existing_content_preserved_for_non_version_merge(self):
+        config = {"action_name": "act"}
+        existing = {"prev": {"a": 1}}
+        result = apply_version_merge(config, {"b": 2}, existing)
+        assert result == {"prev": {"a": 1}, "act": {"b": 2}}
+
+    def test_no_kind_key_defaults_to_non_tool(self):
+        """Missing 'kind' means is_tool is False → namespace wrapping."""
+        config = {
+            "action_name": "act",
+            "version_consumption_config": {"f": "v"},
+        }
+        result = apply_version_merge(config, {"b": 2}, {"a": {"x": 1}})
+        assert result == {"a": {"x": 1}, "act": {"b": 2}}
+
+
+# ---------------------------------------------------------------------------
+# extract_existing_content
+# ---------------------------------------------------------------------------
+
+
+class TestExtractExistingContent:
+    """Tests for extract_existing_content()."""
+
+    def test_returns_content_dict(self):
+        record = {"content": {"ns_a": {"x": 1}}, "source_guid": "sg"}
+        assert extract_existing_content(record) == {"ns_a": {"x": 1}}
+
+    def test_returns_empty_dict_when_no_content(self):
+        assert extract_existing_content({"source_guid": "sg"}) == {}
+
+    def test_returns_empty_dict_when_content_is_not_dict(self):
+        assert extract_existing_content({"content": "string_value"}) == {}
+
+    def test_first_stage_wraps_raw_fields(self):
+        record = {"field_a": 1, "field_b": "two", "source_guid": "sg"}
+        result = extract_existing_content(record, is_first_stage=True)
+        assert result == {"source": {"field_a": 1, "field_b": "two"}}
+
+    def test_first_stage_excludes_framework_fields(self):
+        record = {
+            "source_guid": "sg",
+            "target_id": "tid",
+            "node_id": "nid",
+            "metadata": {},
+            "user_field": "val",
+        }
+        result = extract_existing_content(record, is_first_stage=True)
+        assert result == {"source": {"user_field": "val"}}
+
+    def test_first_stage_with_existing_content_returns_content(self):
+        """First-stage fallback only applies when content is missing."""
+        record = {"content": {"ns": {"x": 1}}, "field_a": 1}
+        result = extract_existing_content(record, is_first_stage=True)
+        assert result == {"ns": {"x": 1}}
+
+    def test_first_stage_empty_raw_fields_returns_empty(self):
+        """If only framework fields remain after filtering, return {}."""
+        record = {"source_guid": "sg", "target_id": "tid"}
+        result = extract_existing_content(record, is_first_stage=True)
+        assert result == {}
+
+    def test_non_first_stage_ignores_raw_fields(self):
+        record = {"field_a": 1, "field_b": "two"}
+        result = extract_existing_content(record, is_first_stage=False)
+        assert result == {}


### PR DESCRIPTION
## Summary
- Created `processing/record_helpers.py` with 5 shared helpers: `build_tombstone`, `build_exhausted_tombstone`, `carry_framework_fields`, `apply_version_merge`, `extract_existing_content`
- Migrated all callers in `record_processor.py`, `result_processor.py`, and `pipeline_file_mode.py` to use the shared helpers — eliminates duplicated tombstone construction (3→1 location), framework field carry-forward (5→1 location), version-merge detection (inlined→shared), and first-stage content extraction (inlined→shared)
- Net -50 lines across modified files; 39 new unit tests covering all 5 helpers including edge cases
- Batch exhausted tombstones now include `metadata.reason = "retry_exhausted"` for consistency with online path (previously batch path omitted this field)

## Verification
- `pytest`: 6066 passed, 2 skipped (up from 6027 — 39 new tests)
- `ruff format --check`: clean
- `ruff check`: clean (on changed files)
- Grep audit: inline tombstone construction, `_unprocessed = True` assignments, and framework field carry-forward loops are now centralised