### PR TITLE
refactor: add UnifiedProcessor skeleton with ProcessingStrategy protocol

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-306000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-306000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Add UnifiedProcessor skeleton with ProcessingStrategy protocol for unified record processing pipeline"
+time: 2026-04-28T03:06:00.000000Z

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -1,0 +1,164 @@
+"""Unified record processing pipeline.
+
+Provides the shared skeleton that all processing paths (online LLM, FILE tool,
+HITL, batch result) pass through. Each path supplies a ProcessingStrategy
+that controls the actual invocation step; everything else (guard filtering,
+enrichment, result collection) is handled uniformly by UnifiedProcessor.
+"""
+
+import logging
+from typing import Any, Protocol, cast, runtime_checkable
+
+from agent_actions.processing.enrichment import EnrichmentPipeline
+from agent_actions.processing.record_helpers import build_tombstone
+from agent_actions.processing.result_collector import CollectionStats, ResultCollector
+from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ProcessingStrategy(Protocol):
+    """Strategy protocol for the unified processing pipeline.
+
+    Each concrete strategy handles its own domain-specific logic:
+    - Prompt rendering and LLM calls (online)
+    - Tool invocation with TrackedItem wrapping (FILE tool)
+    - HITL state management and decision broadcast (FILE HITL)
+    - Batch result reconciliation (batch)
+
+    The strategy receives only records that passed the guard filter.
+    It returns one ProcessingResult per logical output (may be 1:1 or N:M
+    depending on the strategy).
+    """
+
+    def invoke(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+    ) -> list[ProcessingResult]:
+        """Process records and return results."""
+        ...
+
+
+class UnifiedProcessor:
+    """Unified record processing pipeline.
+
+    Shared skeleton: guard -> invoke -> enrich -> collect.
+    The strategy controls only the invocation step.
+    """
+
+    def __init__(
+        self,
+        *,
+        enrichment_pipeline: EnrichmentPipeline | None = None,
+    ) -> None:
+        self._enrichment_pipeline = enrichment_pipeline or EnrichmentPipeline()
+
+    def process(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+        strategy: ProcessingStrategy,
+    ) -> tuple[list[dict[str, Any]], CollectionStats]:
+        """Run records through the full processing pipeline.
+
+        Steps:
+            1. Guard filter — split records into passing/skipped/filtered
+            2. Invoke strategy — process passing records
+            3. Enrich — add lineage, metadata, version IDs, passthrough fields
+            4. Collect — flatten results into output records with dispositions
+
+        Returns:
+            Tuple of (output_records, stats).
+        """
+        passing, guard_results = self._guard_filter(records, context)
+
+        invocation_results = strategy.invoke(passing, context) if passing else []
+
+        enriched = self._enrich(guard_results + invocation_results, context)
+
+        return self._collect(enriched, context)
+
+    def _guard_filter(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+    ) -> tuple[list[dict[str, Any]], list[ProcessingResult]]:
+        """Apply guard filtering and return (passing_records, guard_results).
+
+        Records that fail the guard become ProcessingResult objects immediately
+        (SKIPPED or FILTERED). Records that pass are forwarded to the strategy.
+        """
+        config = cast(dict[str, Any], context.agent_config)
+        passing, skipped, _original_passing = prefilter_by_guard(
+            records,
+            config,
+            context.agent_name,
+        )
+
+        guard_results: list[ProcessingResult] = []
+
+        for item in skipped:
+            source_guid = item.get("source_guid")
+            tombstone = build_tombstone(
+                context.action_name,
+                item,
+                "guard_skip",
+                source_guid=source_guid,
+            )
+            guard_results.append(
+                ProcessingResult.skipped(
+                    passthrough_data=tombstone,
+                    reason="guard_skip",
+                    source_guid=source_guid,
+                )
+            )
+
+        filtered_count = len(records) - len(passing) - len(skipped)
+        for _i in range(filtered_count):
+            guard_results.append(ProcessingResult.filtered(source_guid=None))
+
+        return passing, guard_results
+
+    def _enrich(
+        self,
+        results: list[ProcessingResult],
+        context: ProcessingContext,
+    ) -> list[ProcessingResult]:
+        """Run enrichment pipeline on each result."""
+        return [self._enrichment_pipeline.enrich(r, context) for r in results]
+
+    def _collect(
+        self,
+        results: list[ProcessingResult],
+        context: ProcessingContext,
+    ) -> tuple[list[dict[str, Any]], CollectionStats]:
+        """Collect results into output records with stats."""
+        return ResultCollector.collect_results(
+            results,
+            cast(dict[str, Any], context.agent_config),
+            context.agent_name,
+            is_first_stage=context.is_first_stage,
+            storage_backend=context.storage_backend,
+        )
+
+
+class NoOpStrategy:
+    """Pass-through strategy for testing the skeleton in isolation.
+
+    Returns each input record as a successful ProcessingResult with
+    no transformation applied.
+    """
+
+    def invoke(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+    ) -> list[ProcessingResult]:
+        """Return each record as-is wrapped in a success result."""
+        return [
+            ProcessingResult.success(data=[record], source_guid=record.get("source_guid"))
+            for record in records
+        ]

--- a/tests/unit/processing/test_unified_processor.py
+++ b/tests/unit/processing/test_unified_processor.py
@@ -1,0 +1,414 @@
+"""Tests for UnifiedProcessor skeleton and ProcessingStrategy protocol."""
+
+from typing import Any
+from unittest.mock import patch
+
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+)
+from agent_actions.processing.unified import (
+    NoOpStrategy,
+    ProcessingStrategy,
+    UnifiedProcessor,
+)
+
+
+def _make_context(
+    agent_name: str = "test_action",
+    *,
+    guard: dict | None = None,
+    is_first_stage: bool = False,
+) -> ProcessingContext:
+    """Create a minimal ProcessingContext for testing."""
+    config: dict[str, Any] = {
+        "agent_type": agent_name,
+        "name": agent_name,
+    }
+    if guard is not None:
+        config["guard"] = guard
+    return ProcessingContext(
+        agent_config=config,
+        agent_name=agent_name,
+        is_first_stage=is_first_stage,
+    )
+
+
+def _make_record(source_guid: str = "sg-1", **content: Any) -> dict[str, Any]:
+    """Create a minimal record dict."""
+    return {
+        "source_guid": source_guid,
+        "content": {**content} if content else {"source": {"field": "value"}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# NoOpStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpStrategy:
+    """Tests for the NoOpStrategy pass-through implementation."""
+
+    def test_conforms_to_protocol(self):
+        assert isinstance(NoOpStrategy(), ProcessingStrategy)
+
+    def test_returns_one_success_per_record(self):
+        strategy = NoOpStrategy()
+        records = [_make_record("sg-1"), _make_record("sg-2")]
+        context = _make_context()
+
+        results = strategy.invoke(records, context)
+
+        assert len(results) == 2
+        assert all(r.status == ProcessingStatus.SUCCESS for r in results)
+
+    def test_preserves_record_data(self):
+        strategy = NoOpStrategy()
+        record = _make_record("sg-1", source={"x": 42})
+        context = _make_context()
+
+        results = strategy.invoke([record], context)
+
+        assert results[0].data == [record]
+
+    def test_preserves_source_guid(self):
+        strategy = NoOpStrategy()
+        record = _make_record("my-guid")
+        context = _make_context()
+
+        results = strategy.invoke([record], context)
+
+        assert results[0].source_guid == "my-guid"
+
+    def test_empty_input_returns_empty(self):
+        strategy = NoOpStrategy()
+        context = _make_context()
+
+        results = strategy.invoke([], context)
+
+        assert results == []
+
+    def test_record_without_source_guid(self):
+        strategy = NoOpStrategy()
+        record = {"content": {"source": {"val": 1}}}
+        context = _make_context()
+
+        results = strategy.invoke([record], context)
+
+        assert results[0].source_guid is None
+        assert results[0].data == [record]
+
+
+# ---------------------------------------------------------------------------
+# UnifiedProcessor — no guard configured
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedProcessorNoGuard:
+    """Tests for UnifiedProcessor when no guard is configured."""
+
+    def test_all_records_pass_through_to_strategy(self):
+        processor = UnifiedProcessor()
+        strategy = NoOpStrategy()
+        records = [_make_record("sg-1"), _make_record("sg-2"), _make_record("sg-3")]
+        context = _make_context()
+
+        output, stats = processor.process(records, context, strategy)
+
+        assert stats.success == 3
+        assert stats.skipped == 0
+        assert stats.filtered == 0
+
+    def test_output_contains_record_data(self):
+        processor = UnifiedProcessor()
+        strategy = NoOpStrategy()
+        record = _make_record("sg-1", source={"key": "val"})
+        context = _make_context()
+
+        output, _stats = processor.process([record], context, strategy)
+
+        assert len(output) == 1
+        assert output[0]["content"]["source"] == {"key": "val"}
+
+    def test_empty_input_produces_empty_output(self):
+        processor = UnifiedProcessor()
+        strategy = NoOpStrategy()
+        context = _make_context()
+
+        output, stats = processor.process([], context, strategy)
+
+        assert output == []
+        assert stats.success == 0
+
+    def test_strategy_not_invoked_when_all_filtered(self):
+        """When guard filters everything, strategy.invoke is never called."""
+
+        class TrackingStrategy:
+            def __init__(self):
+                self.called = False
+
+            def invoke(self, records, context):
+                self.called = True
+                return []
+
+        processor = UnifiedProcessor()
+        tracking = TrackingStrategy()
+        context = _make_context(guard={"clause": "item.impossible == true", "behavior": "filter"})
+        records = [_make_record("sg-1")]
+
+        # Guard will filter all records
+        with patch(
+            "agent_actions.processing.unified.prefilter_by_guard",
+            return_value=([], [], []),
+        ):
+            processor.process(records, context, tracking)
+
+        assert not tracking.called
+
+
+# ---------------------------------------------------------------------------
+# UnifiedProcessor — guard filtering
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedProcessorGuardFilter:
+    """Tests for guard filtering behavior in UnifiedProcessor."""
+
+    def test_skipped_records_produce_tombstones(self):
+        processor = UnifiedProcessor()
+        strategy = NoOpStrategy()
+        context = _make_context(guard={"clause": "item.flag == true", "behavior": "skip"})
+
+        skipped_record = _make_record("sg-skip")
+
+        with patch(
+            "agent_actions.processing.unified.prefilter_by_guard",
+            return_value=([], [skipped_record], []),
+        ):
+            output, stats = processor.process([skipped_record], context, strategy)
+
+        assert stats.skipped == 1
+        assert stats.success == 0
+
+    def test_filtered_records_excluded_from_output(self):
+        processor = UnifiedProcessor()
+        strategy = NoOpStrategy()
+        context = _make_context(guard={"clause": "item.flag == true", "behavior": "filter"})
+
+        record = _make_record("sg-filter")
+
+        with patch(
+            "agent_actions.processing.unified.prefilter_by_guard",
+            return_value=([], [], []),
+        ):
+            output, stats = processor.process([record], context, strategy)
+
+        assert stats.filtered == 1
+        assert stats.success == 0
+
+    def test_mixed_guard_outcomes(self):
+        """Some records pass, some skip, some filter."""
+        processor = UnifiedProcessor()
+        strategy = NoOpStrategy()
+        context = _make_context(guard={"clause": "item.x > 0", "behavior": "skip"})
+
+        passing = _make_record("sg-pass")
+        skipped = _make_record("sg-skip")
+        # 3 total records: 1 passes, 1 skipped, 1 filtered
+        all_records = [passing, skipped, _make_record("sg-filter")]
+
+        with patch(
+            "agent_actions.processing.unified.prefilter_by_guard",
+            return_value=([passing], [skipped], [passing]),
+        ):
+            output, stats = processor.process(all_records, context, strategy)
+
+        assert stats.success == 1
+        assert stats.skipped == 1
+        assert stats.filtered == 1
+
+
+# ---------------------------------------------------------------------------
+# UnifiedProcessor — enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedProcessorEnrichment:
+    """Tests for the enrichment step in UnifiedProcessor."""
+
+    def test_enrichment_pipeline_is_applied(self):
+        """Verify enrichment is called for every result."""
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        class CountingEnricher(Enricher):
+            def __init__(self):
+                self.count = 0
+
+            def enrich(self, result, context):
+                self.count += 1
+                return result
+
+        enricher = CountingEnricher()
+        pipeline = EnrichmentPipeline(enrichers=[enricher])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+        strategy = NoOpStrategy()
+        records = [_make_record("sg-1"), _make_record("sg-2")]
+        context = _make_context()
+
+        processor.process(records, context, strategy)
+
+        assert enricher.count == 2
+
+    def test_custom_enrichment_pipeline_used(self):
+        """A custom pipeline replaces the default one."""
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        class TagEnricher(Enricher):
+            def enrich(self, result, context):
+                for item in result.data:
+                    item["_tagged"] = True
+                return result
+
+        pipeline = EnrichmentPipeline(enrichers=[TagEnricher()])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+        strategy = NoOpStrategy()
+        records = [_make_record("sg-1")]
+        context = _make_context()
+
+        output, _stats = processor.process(records, context, strategy)
+
+        assert output[0].get("_tagged") is True
+
+
+# ---------------------------------------------------------------------------
+# UnifiedProcessor — result collection
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedProcessorCollection:
+    """Tests for the result collection step."""
+
+    def test_stats_reflect_strategy_outcomes(self):
+        """Stats accurately count success/failed/exhausted from strategy."""
+
+        class MixedStrategy:
+            def invoke(self, records, context):
+                return [
+                    ProcessingResult.success(data=[records[0]], source_guid="sg-1"),
+                    ProcessingResult.failed(error="boom", source_guid="sg-2"),
+                ]
+
+        processor = UnifiedProcessor()
+        records = [_make_record("sg-1"), _make_record("sg-2")]
+        context = _make_context()
+
+        _output, stats = processor.process(records, context, MixedStrategy())
+
+        assert stats.success == 1
+        assert stats.failed == 1
+
+    def test_exhausted_results_counted(self):
+        """Exhausted results are tracked in stats."""
+
+        class ExhaustedStrategy:
+            def invoke(self, records, context):
+                return [
+                    ProcessingResult.exhausted(
+                        error="retries exceeded",
+                        data=[{"content": {"test_action": None}, "_unprocessed": True}],
+                        source_guid="sg-1",
+                    )
+                ]
+
+        processor = UnifiedProcessor()
+        records = [_make_record("sg-1")]
+        context = _make_context()
+
+        _output, stats = processor.process(records, context, ExhaustedStrategy())
+
+        assert stats.exhausted == 1
+
+
+# ---------------------------------------------------------------------------
+# UnifiedProcessor — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedProcessorEdgeCases:
+    """Edge cases and error scenarios."""
+
+    def test_strategy_returning_empty_results(self):
+        """Strategy may return fewer results than input records."""
+
+        class DroppingStrategy:
+            def invoke(self, records, context):
+                return []
+
+        processor = UnifiedProcessor()
+        records = [_make_record("sg-1")]
+        context = _make_context()
+
+        output, stats = processor.process(records, context, DroppingStrategy())
+
+        assert output == []
+        assert stats.success == 0
+
+    def test_strategy_returning_multiple_results_per_record(self):
+        """Strategy may produce N:M output (e.g., FILE tool fan-out)."""
+
+        class FanOutStrategy:
+            def invoke(self, records, context):
+                return [
+                    ProcessingResult.success(
+                        data=[
+                            {"content": {"test_action": {"i": 1}}},
+                            {"content": {"test_action": {"i": 2}}},
+                        ],
+                        source_guid="sg-1",
+                    )
+                ]
+
+        processor = UnifiedProcessor()
+        records = [_make_record("sg-1")]
+        context = _make_context()
+
+        output, stats = processor.process(records, context, FanOutStrategy())
+
+        assert stats.success == 1
+        assert len(output) == 2
+
+    def test_large_batch(self):
+        """Processor handles reasonable batch sizes without error."""
+        processor = UnifiedProcessor()
+        strategy = NoOpStrategy()
+        records = [_make_record(f"sg-{i}") for i in range(100)]
+        context = _make_context()
+
+        output, stats = processor.process(records, context, strategy)
+
+        assert stats.success == 100
+        assert len(output) == 100
+
+
+# ---------------------------------------------------------------------------
+# ProcessingStrategy protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestProcessingStrategyProtocol:
+    """Verify protocol structural typing works correctly."""
+
+    def test_class_with_correct_signature_satisfies_protocol(self):
+        class ValidStrategy:
+            def invoke(
+                self, records: list[dict], context: ProcessingContext
+            ) -> list[ProcessingResult]:
+                return []
+
+        assert isinstance(ValidStrategy(), ProcessingStrategy)
+
+    def test_lambda_does_not_satisfy_protocol(self):
+        # A plain function object does not satisfy a Protocol with invoke method
+        assert not isinstance(lambda r, c: [], ProcessingStrategy)


### PR DESCRIPTION
## Summary
- Adds `processing/unified.py` with `UnifiedProcessor` class and `ProcessingStrategy` protocol
- The skeleton implements the shared pipeline: guard → invoke → enrich → collect
- Includes `NoOpStrategy` for testing the skeleton in isolation
- 22 comprehensive tests covering all steps, edge cases, and protocol compliance

## Verification
- `pytest` — 6100 passed (22 new, 0 regressions)
- `ruff check` / `ruff format --check` — clean