### PR TITLE
refactor: extract OnlineLLMStrategy from RecordProcessor

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-307000.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-307000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Extract OnlineLLMStrategy from RecordProcessor — plugs into UnifiedProcessor for RECORD mode processing"
+time: 2026-04-28T03:07:00.000000Z

--- a/agent_actions/processing/record_processor.py
+++ b/agent_actions/processing/record_processor.py
@@ -1,10 +1,15 @@
-"""Record-level processor: single-item processing pipeline."""
+"""Record-level processor: thin wrapper around OnlineLLMStrategy.
 
-import json
+Delegates per-record logic to OnlineLLMStrategy.process_record() and adds
+enrichment + completion events on top.  Other callers (initial_pipeline,
+data_generator) still use this class.  Will be removed once all callers
+migrate to UnifiedProcessor.
+"""
+
 import logging
 from dataclasses import replace
 from datetime import UTC, datetime
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 from agent_actions.config.types import RunMode
 from agent_actions.errors import ConfigurationError, SchemaValidationError
@@ -15,22 +20,16 @@ from agent_actions.logging.events.data_pipeline_events import (
     BatchDataProcessingCompleteEvent,
     BatchProcessingProgressEvent,
     BatchProcessingStartedEvent,
-    RecordEmptyOutputEvent,
-    RecordFilteredEvent,
     RecordProcessingCompleteEvent,
-    RecordProcessingStartedEvent,
-    RecordTransformedEvent,
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
 from agent_actions.output.response.config_fields import get_default
 from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
 
 from .enrichment import EnrichmentPipeline
-from .exhausted_builder import ExhaustedRecordBuilder
 from .invocation import BatchProvider, InvocationStrategy, InvocationStrategyFactory
-from .prepared_task import GuardStatus, PreparationContext
-from .record_helpers import build_exhausted_tombstone, build_tombstone, extract_existing_content
-from .task_preparer import TaskPreparer, get_task_preparer
+from .strategies.online_llm import OnlineLLMStrategy
+from .task_preparer import TaskPreparer
 from .types import (
     ProcessingContext,
     ProcessingResult,
@@ -40,17 +39,8 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
-def _is_empty_output(response: Any) -> bool:
-    """Check if a tool/LLM response is effectively empty."""
-    if response is None:
-        return True
-    if isinstance(response, dict | list) and len(response) == 0:
-        return True
-    return False
-
-
 class RecordProcessor:
-    """Unified processor for first-stage and subsequent-stage record processing."""
+    """Thin wrapper: delegates per-record logic to OnlineLLMStrategy, adds enrichment."""
 
     @classmethod
     def create(
@@ -114,235 +104,24 @@ class RecordProcessor:
 
         self.enrichment_pipeline = EnrichmentPipeline()
 
-        self._strategy = strategy or InvocationStrategyFactory.create(
+        invocation_strategy = strategy or InvocationStrategyFactory.create(
             mode=mode,
             agent_config=agent_config,
             provider=provider,
         )
+        self._online_strategy = OnlineLLMStrategy(
+            agent_config=agent_config,
+            agent_name=agent_name,
+            invocation_strategy=invocation_strategy,
+        )
 
     def process(self, item: Any, context: ProcessingContext) -> ProcessingResult:
         """Process a single record through the full pipeline (prepare, invoke, transform, enrich)."""
-        prep_context = PreparationContext.from_processing_context(context)
-        prep_context.current_item = item if isinstance(item, dict) else None
-
-        task_preparer = get_task_preparer()
-        prepared = task_preparer.prepare(item, prep_context)
-
-        input_record = item if isinstance(item, dict) else None
-        source_guid = prepared.source_guid
-        source_snapshot = prepared.source_snapshot
-        content = prepared.original_content
-
-        fire_event(
-            RecordProcessingStartedEvent(
-                action_name=context.agent_name,
-                record_index=context.record_index,
-                source_guid=source_guid or "",
-            )
-        )
-
-        if prepared.guard_status == GuardStatus.UPSTREAM_UNPROCESSED:
-            preserved_item = dict(item) if isinstance(item, dict) else {"content": item}
-            preserved_item["_unprocessed"] = True
-            if not isinstance(preserved_item.get("metadata"), dict):
-                preserved_item["metadata"] = {}
-            if "agent_type" not in preserved_item["metadata"]:
-                preserved_item["metadata"]["agent_type"] = "tombstone"
-            result = ProcessingResult.unprocessed(
-                data=[preserved_item],
-                reason="upstream_unprocessed",
-                source_guid=source_guid,
-                source_snapshot=source_snapshot,
-                input_record=input_record,
-            )
-            return self._finalize_result(result, context, source_guid)
-
-        if prepared.guard_status == GuardStatus.FILTERED:
-            fire_event(
-                RecordFilteredEvent(
-                    action_name=context.agent_name,
-                    record_index=context.record_index,
-                    source_guid=source_guid or "",
-                    filter_reason="guard_filter",
-                )
-            )
-            return ProcessingResult.filtered(
-                source_guid=source_guid,
-                source_snapshot=source_snapshot,
-                input_record=input_record,
-            )
-
-        if prepared.guard_status == GuardStatus.SKIPPED:
-            fire_event(
-                RecordFilteredEvent(
-                    action_name=context.agent_name,
-                    record_index=context.record_index,
-                    source_guid=source_guid or "",
-                    filter_reason=f"guard_{prepared.guard_behavior}",
-                )
-            )
-            tombstone = build_tombstone(
-                context.action_name,
-                input_record,
-                f"guard_{prepared.guard_behavior}",
-                source_guid=source_guid,
-            )
-            result = ProcessingResult.skipped(
-                passthrough_data=tombstone,
-                reason=f"guard_{prepared.guard_behavior}",
-                source_guid=source_guid,
-            )
-            return self._finalize_result(result, context, source_guid)
-
-        invocation_result = self._strategy.invoke(prepared, context)
-
-        response = invocation_result.response
-        executed = invocation_result.executed
-        passthrough_fields = invocation_result.passthrough_fields
-        recovery_metadata = invocation_result.recovery_metadata
-
-        if (
-            context.storage_backend is not None
-            and executed
-            and response is not None
-            and source_guid is not None
-        ):
-            context.storage_backend.update_prompt_trace_response(
-                action_name=context.agent_name,
-                record_id=source_guid,
-                response_text=json.dumps(response, ensure_ascii=False, default=str),
-            )
-
-        if invocation_result.deferred:
-            return ProcessingResult.deferred(
-                task_id=invocation_result.task_id or "",
-                source_guid=source_guid,
-                passthrough_fields=passthrough_fields,
-                source_snapshot=source_snapshot,
-                input_record=input_record,
-            )
-
-        if not executed:
-            if response is None:
-                if recovery_metadata and recovery_metadata.retry:
-                    empty_content = ExhaustedRecordBuilder.build_empty_content(
-                        cast(dict[str, Any], context.agent_config)
-                    )
-                    tombstone = build_exhausted_tombstone(
-                        context.action_name,
-                        input_record,
-                        empty_content,
-                        source_guid=source_guid,
-                    )
-                    result = ProcessingResult.exhausted(
-                        error=f"Retry exhausted after {recovery_metadata.retry.attempts} attempts",
-                        data=[tombstone],
-                        source_guid=source_guid,
-                        recovery_metadata=recovery_metadata,
-                        source_snapshot=source_snapshot,
-                        input_record=input_record,
-                    )
-                    return self._finalize_result(result, context, source_guid)
-                fire_event(
-                    RecordFilteredEvent(
-                        action_name=context.agent_name,
-                        record_index=context.record_index,
-                        source_guid=source_guid or "",
-                        filter_reason="llm_layer_guard_filter",
-                    )
-                )
-                return ProcessingResult.filtered(
-                    source_guid=source_guid,
-                    source_snapshot=source_snapshot,
-                    input_record=input_record,
-                )
-            else:
-                fire_event(
-                    RecordFilteredEvent(
-                        action_name=context.agent_name,
-                        record_index=context.record_index,
-                        source_guid=source_guid or "",
-                        filter_reason="llm_layer_guard_skip",
-                    )
-                )
-                tombstone = build_tombstone(
-                    context.action_name,
-                    input_record,
-                    "guard_skip",
-                    source_guid=source_guid,
-                )
-                result = ProcessingResult.unprocessed(
-                    data=[tombstone],
-                    reason="guard_skip",
-                    source_guid=source_guid,
-                    source_snapshot=source_snapshot,
-                    input_record=input_record,
-                )
-                return self._finalize_result(result, context, source_guid)
-
-        if _is_empty_output(response):
-            on_empty = context.agent_config.get("on_empty", "warn")
-            input_field_count = len(content) if isinstance(content, dict) else 0
-
-            fire_event(
-                RecordEmptyOutputEvent(
-                    action_name=context.agent_name,
-                    record_index=context.record_index,
-                    source_guid=source_guid or "",
-                    input_field_count=input_field_count,
-                    output=response,
-                    on_empty=on_empty,
-                )
-            )
-
-            if on_empty == "error":
-                raise EmptyOutputError(
-                    f"Action '{context.agent_name}' produced empty output for record "
-                    f"'{source_guid}' (on_empty=error)",
-                    context={
-                        "agent_name": context.agent_name,
-                        "source_guid": source_guid,
-                        "output": str(response),
-                    },
-                )
-
-        item_existing_content = (
-            extract_existing_content(item, is_first_stage=context.is_first_stage)
-            if isinstance(item, dict)
-            else None
-        )
-        transformed = self._transform_response(
-            response,
-            content,
-            source_guid or "",
-            passthrough_fields,
-            context,
-            existing_content=item_existing_content,
-        )
-
-        input_size = 1 if not isinstance(response, list) else len(response)
-        output_size = len(transformed) if isinstance(transformed, list) else 1
-        fire_event(
-            RecordTransformedEvent(
-                action_name=context.agent_name,
-                record_index=context.record_index,
-                source_guid=source_guid or "",
-                input_size=input_size,
-                output_size=output_size,
-            )
-        )
-
-        result = ProcessingResult.success(
-            data=transformed,
-            source_guid=source_guid,
-            passthrough_fields=passthrough_fields,
-            source_snapshot=source_snapshot,
-            raw_response=response,
-            recovery_metadata=recovery_metadata,
-            input_record=input_record,
-        )
-
-        return self._finalize_result(result, context, source_guid)
+        result = self._online_strategy.process_record(item, context, skip_guard=False)
+        # DEFERRED and FILTERED results skip enrichment (matching old behavior)
+        if result.status in (ProcessingStatus.DEFERRED, ProcessingStatus.FILTERED):
+            return result
+        return self._finalize_result(result, context, result.source_guid)
 
     def process_batch(self, items: list[Any], context: ProcessingContext) -> list[ProcessingResult]:
         """Process multiple records, capturing per-item failures without aborting the batch."""
@@ -450,30 +229,6 @@ class RecordProcessor:
             )
         )
         return enriched_result
-
-    def _transform_response(
-        self,
-        response: Any,
-        content: Any,
-        source_guid: str,
-        passthrough_fields: dict[str, Any],
-        context: ProcessingContext,
-        existing_content: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
-        """Transform LLM response to output format."""
-        from agent_actions.processing.helpers import (
-            transform_with_passthrough,
-        )
-
-        return transform_with_passthrough(
-            response,
-            content,
-            source_guid,
-            cast(dict[str, Any], context.agent_config),
-            action_name=context.action_name,
-            passthrough_fields=passthrough_fields,
-            existing_content=existing_content,
-        )
 
     @staticmethod
     def _create_item_context(

--- a/agent_actions/processing/record_processor.py
+++ b/agent_actions/processing/record_processor.py
@@ -7,7 +7,6 @@ migrate to UnifiedProcessor.
 """
 
 import logging
-from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any, Optional
 
@@ -28,7 +27,7 @@ from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
 
 from .enrichment import EnrichmentPipeline
 from .invocation import BatchProvider, InvocationStrategy, InvocationStrategyFactory
-from .strategies.online_llm import OnlineLLMStrategy
+from .strategies.online_llm import OnlineLLMStrategy, _create_item_context
 from .task_preparer import TaskPreparer
 from .types import (
     ProcessingContext,
@@ -235,8 +234,4 @@ class RecordProcessor:
         base_context: ProcessingContext, index: int, item: Any
     ) -> ProcessingContext:
         """Create per-item context with updated record_index."""
-        return replace(
-            base_context,
-            record_index=index,
-            current_item=item if isinstance(item, dict) else None,
-        )
+        return _create_item_context(base_context, index, item)

--- a/agent_actions/processing/strategies/__init__.py
+++ b/agent_actions/processing/strategies/__init__.py
@@ -1,4 +1,4 @@
-"""Pipeline-level processing strategies for FILE-granularity modes."""
+"""Processing strategies for UnifiedProcessor and FILE-granularity modes."""
 
 from .file_tool import FileToolStrategy
 from .hitl import HITLStrategy

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -1,0 +1,443 @@
+"""Online LLM processing strategy for UnifiedProcessor.
+
+Handles per-record processing: prepare task, invoke LLM, handle response,
+transform output. Extracted from RecordProcessor.process().
+"""
+
+import json
+import logging
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from agent_actions.config.types import RunMode
+from agent_actions.errors import ConfigurationError, SchemaValidationError
+from agent_actions.errors.operations import TemplateVariableError
+from agent_actions.errors.processing import EmptyOutputError
+from agent_actions.logging.core.manager import fire_event
+from agent_actions.logging.events.data_pipeline_events import (
+    BatchDataProcessingCompleteEvent,
+    BatchProcessingProgressEvent,
+    BatchProcessingStartedEvent,
+    RecordEmptyOutputEvent,
+    RecordFilteredEvent,
+    RecordProcessingStartedEvent,
+    RecordTransformedEvent,
+)
+from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
+from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
+from agent_actions.processing.invocation import InvocationStrategy, InvocationStrategyFactory
+from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
+from agent_actions.processing.record_helpers import (
+    build_exhausted_tombstone,
+    build_tombstone,
+    extract_existing_content,
+)
+from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _is_empty_output(response: Any) -> bool:
+    """Check if a tool/LLM response is effectively empty."""
+    if response is None:
+        return True
+    if isinstance(response, dict | list) and len(response) == 0:
+        return True
+    return False
+
+
+def _create_item_context(
+    base_context: ProcessingContext, index: int, item: Any
+) -> ProcessingContext:
+    """Create per-item context with updated record_index."""
+    return replace(
+        base_context,
+        record_index=index,
+        current_item=item if isinstance(item, dict) else None,
+    )
+
+
+class OnlineLLMStrategy:
+    """Online LLM processing strategy for UnifiedProcessor.
+
+    Handles per-record: prepare task -> invoke LLM -> handle response -> transform.
+    Does NOT perform enrichment (handled by UnifiedProcessor).
+    """
+
+    def __init__(
+        self,
+        agent_config: dict[str, Any],
+        agent_name: str,
+        invocation_strategy: InvocationStrategy | None = None,
+    ) -> None:
+        self._agent_config = agent_config
+        self._agent_name = agent_name
+        self._invocation_strategy = invocation_strategy or InvocationStrategyFactory.create(
+            mode=RunMode.ONLINE,
+            agent_config=agent_config,
+        )
+
+    def invoke(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+    ) -> list[ProcessingResult]:
+        """Process records through the online LLM pipeline.
+
+        Iterates records, calling process_record() for each. Handles
+        per-item exceptions: re-raises critical errors (ConfigurationError,
+        EmptyOutputError, TemplateVariableError, SchemaValidationError),
+        wraps others as ProcessingResult.failed().
+        """
+        start_time = datetime.now(UTC)
+
+        fire_event(
+            BatchProcessingStartedEvent(
+                action_name=context.agent_name,
+                batch_size=len(records),
+            )
+        )
+
+        results: list[ProcessingResult] = []
+        successes = 0
+        failures = 0
+
+        for idx, item in enumerate(records):
+            try:
+                item_context = _create_item_context(context, idx, item)
+                result = self.process_record(item, item_context)
+                results.append(result)
+
+                if result.status == ProcessingStatus.SUCCESS:
+                    successes += 1
+                elif result.status == ProcessingStatus.FAILED:
+                    failures += 1
+
+                if (idx + 1) % 10 == 0 or (idx + 1) == len(records):
+                    fire_event(
+                        BatchProcessingProgressEvent(
+                            action_name=context.agent_name,
+                            processed=idx + 1,
+                            total=len(records),
+                            successes=successes,
+                            failures=failures,
+                        )
+                    )
+
+            except ConfigurationError:
+                raise
+            except EmptyOutputError:
+                raise
+            except TemplateVariableError as e:
+                fire_event(
+                    TemplateRenderingFailedEvent(
+                        action_name=context.agent_name,
+                        missing_variables=e.missing_variables,
+                        error_message=str(e),
+                    )
+                )
+                raise
+            except SchemaValidationError:
+                raise
+            except Exception as e:
+                logger.exception(
+                    "[%s] Error processing item %d: %s",
+                    context.agent_name,
+                    idx,
+                    str(e),
+                )
+                input_record = item if isinstance(item, dict) else None
+                source_snapshot = None
+                source_guid = None
+                if context.is_first_stage:
+                    from agent_actions.utils.id_generation import IDGenerator
+
+                    source_guid = IDGenerator.generate_deterministic_source_guid(item)
+                    source_snapshot = TaskPreparer._prepare_source_snapshot(item)
+                else:
+                    source_guid = item.get("source_guid") if isinstance(item, dict) else None
+                failed_result = ProcessingResult.failed(
+                    error=f"Error processing item {idx}: {str(e)}",
+                    source_guid=source_guid,
+                    source_snapshot=source_snapshot,
+                    input_record=input_record,
+                )
+                results.append(failed_result)
+                failures += 1
+
+        elapsed_time = (datetime.now(UTC) - start_time).total_seconds()
+        fire_event(
+            BatchDataProcessingCompleteEvent(
+                action_name=context.agent_name,
+                total_records=len(records),
+                elapsed_time=elapsed_time,
+            )
+        )
+
+        return results
+
+    def process_record(
+        self, item: Any, context: ProcessingContext, *, skip_guard: bool = True
+    ) -> ProcessingResult:
+        """Process a single record: prepare, invoke LLM, handle response, transform.
+
+        Args:
+            skip_guard: When True (default), guard evaluation is skipped because
+                UnifiedProcessor already filtered records at the batch level.
+                RecordProcessor passes False for backward compat with callers
+                that rely on per-record guard evaluation.
+
+        Does NOT enrich the result — enrichment is handled by UnifiedProcessor
+        or by RecordProcessor._finalize_result() for backward compat callers.
+        """
+        prep_context = PreparationContext.from_processing_context(context)
+        prep_context.current_item = item if isinstance(item, dict) else None
+
+        task_preparer = get_task_preparer()
+        prepared = task_preparer.prepare(item, prep_context, skip_guard=skip_guard)
+
+        input_record = item if isinstance(item, dict) else None
+        source_guid = prepared.source_guid
+        source_snapshot = prepared.source_snapshot
+        content = prepared.original_content
+
+        fire_event(
+            RecordProcessingStartedEvent(
+                action_name=context.agent_name,
+                record_index=context.record_index,
+                source_guid=source_guid or "",
+            )
+        )
+
+        # Upstream unprocessed — passthrough as tombstone
+        if prepared.guard_status == GuardStatus.UPSTREAM_UNPROCESSED:
+            preserved_item = dict(item) if isinstance(item, dict) else {"content": item}
+            preserved_item["_unprocessed"] = True
+            if not isinstance(preserved_item.get("metadata"), dict):
+                preserved_item["metadata"] = {}
+            if "agent_type" not in preserved_item["metadata"]:
+                preserved_item["metadata"]["agent_type"] = "tombstone"
+            return ProcessingResult.unprocessed(
+                data=[preserved_item],
+                reason="upstream_unprocessed",
+                source_guid=source_guid,
+                source_snapshot=source_snapshot,
+                input_record=input_record,
+            )
+
+        # Per-record guard outcomes (only when skip_guard=False)
+        if prepared.guard_status == GuardStatus.FILTERED:
+            fire_event(
+                RecordFilteredEvent(
+                    action_name=context.agent_name,
+                    record_index=context.record_index,
+                    source_guid=source_guid or "",
+                    filter_reason="guard_filter",
+                )
+            )
+            return ProcessingResult.filtered(
+                source_guid=source_guid,
+                source_snapshot=source_snapshot,
+                input_record=input_record,
+            )
+
+        if prepared.guard_status == GuardStatus.SKIPPED:
+            fire_event(
+                RecordFilteredEvent(
+                    action_name=context.agent_name,
+                    record_index=context.record_index,
+                    source_guid=source_guid or "",
+                    filter_reason=f"guard_{prepared.guard_behavior}",
+                )
+            )
+            tombstone = build_tombstone(
+                context.action_name,
+                input_record,
+                f"guard_{prepared.guard_behavior}",
+                source_guid=source_guid,
+            )
+            return ProcessingResult.skipped(
+                passthrough_data=tombstone,
+                reason=f"guard_{prepared.guard_behavior}",
+                source_guid=source_guid,
+            )
+
+        # Invoke the LLM strategy
+        invocation_result = self._invocation_strategy.invoke(prepared, context)
+
+        response = invocation_result.response
+        executed = invocation_result.executed
+        passthrough_fields = invocation_result.passthrough_fields
+        recovery_metadata = invocation_result.recovery_metadata
+
+        # Update prompt trace in storage
+        if (
+            context.storage_backend is not None
+            and executed
+            and response is not None
+            and source_guid is not None
+        ):
+            context.storage_backend.update_prompt_trace_response(
+                action_name=context.agent_name,
+                record_id=source_guid,
+                response_text=json.dumps(response, ensure_ascii=False, default=str),
+            )
+
+        # Deferred (batch mode)
+        if invocation_result.deferred:
+            return ProcessingResult.deferred(
+                task_id=invocation_result.task_id or "",
+                source_guid=source_guid,
+                passthrough_fields=passthrough_fields,
+                source_snapshot=source_snapshot,
+                input_record=input_record,
+            )
+
+        # Not executed — exhausted, filtered, or guard skip
+        if not executed:
+            if response is None:
+                if recovery_metadata and recovery_metadata.retry:
+                    empty_content = ExhaustedRecordBuilder.build_empty_content(
+                        cast(dict[str, Any], context.agent_config)
+                    )
+                    tombstone = build_exhausted_tombstone(
+                        context.action_name,
+                        input_record,
+                        empty_content,
+                        source_guid=source_guid,
+                    )
+                    return ProcessingResult.exhausted(
+                        error=f"Retry exhausted after {recovery_metadata.retry.attempts} attempts",
+                        data=[tombstone],
+                        source_guid=source_guid,
+                        recovery_metadata=recovery_metadata,
+                        source_snapshot=source_snapshot,
+                        input_record=input_record,
+                    )
+                fire_event(
+                    RecordFilteredEvent(
+                        action_name=context.agent_name,
+                        record_index=context.record_index,
+                        source_guid=source_guid or "",
+                        filter_reason="llm_layer_guard_filter",
+                    )
+                )
+                return ProcessingResult.filtered(
+                    source_guid=source_guid,
+                    source_snapshot=source_snapshot,
+                    input_record=input_record,
+                )
+            else:
+                fire_event(
+                    RecordFilteredEvent(
+                        action_name=context.agent_name,
+                        record_index=context.record_index,
+                        source_guid=source_guid or "",
+                        filter_reason="llm_layer_guard_skip",
+                    )
+                )
+                tombstone = build_tombstone(
+                    context.action_name,
+                    input_record,
+                    "guard_skip",
+                    source_guid=source_guid,
+                )
+                return ProcessingResult.unprocessed(
+                    data=[tombstone],
+                    reason="guard_skip",
+                    source_guid=source_guid,
+                    source_snapshot=source_snapshot,
+                    input_record=input_record,
+                )
+
+        # Empty output handling
+        if _is_empty_output(response):
+            on_empty = context.agent_config.get("on_empty", "warn")
+            input_field_count = len(content) if isinstance(content, dict) else 0
+
+            fire_event(
+                RecordEmptyOutputEvent(
+                    action_name=context.agent_name,
+                    record_index=context.record_index,
+                    source_guid=source_guid or "",
+                    input_field_count=input_field_count,
+                    output=response,
+                    on_empty=on_empty,
+                )
+            )
+
+            if on_empty == "error":
+                raise EmptyOutputError(
+                    f"Action '{context.agent_name}' produced empty output for record "
+                    f"'{source_guid}' (on_empty=error)",
+                    context={
+                        "agent_name": context.agent_name,
+                        "source_guid": source_guid,
+                        "output": str(response),
+                    },
+                )
+
+        # Transform response
+        item_existing_content = (
+            extract_existing_content(item, is_first_stage=context.is_first_stage)
+            if isinstance(item, dict)
+            else None
+        )
+        transformed = self._transform_response(
+            response,
+            content,
+            source_guid or "",
+            passthrough_fields,
+            context,
+            existing_content=item_existing_content,
+        )
+
+        input_size = 1 if not isinstance(response, list) else len(response)
+        output_size = len(transformed) if isinstance(transformed, list) else 1
+        fire_event(
+            RecordTransformedEvent(
+                action_name=context.agent_name,
+                record_index=context.record_index,
+                source_guid=source_guid or "",
+                input_size=input_size,
+                output_size=output_size,
+            )
+        )
+
+        return ProcessingResult.success(
+            data=transformed,
+            source_guid=source_guid,
+            passthrough_fields=passthrough_fields,
+            source_snapshot=source_snapshot,
+            raw_response=response,
+            recovery_metadata=recovery_metadata,
+            input_record=input_record,
+        )
+
+    def _transform_response(
+        self,
+        response: Any,
+        content: Any,
+        source_guid: str,
+        passthrough_fields: dict[str, Any],
+        context: ProcessingContext,
+        existing_content: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Transform LLM response to output format."""
+        from agent_actions.processing.helpers import transform_with_passthrough
+
+        return transform_with_passthrough(
+            response,
+            content,
+            source_guid,
+            cast(dict[str, Any], context.agent_config),
+            action_name=context.action_name,
+            passthrough_fields=passthrough_fields,
+            existing_content=existing_content,
+        )

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -16,10 +16,11 @@ from agent_actions.llm.batch.service import create_registry_manager_factory
 from agent_actions.llm.batch.services.submission import BatchSubmissionService
 from agent_actions.llm.realtime.output import OutputHandler
 from agent_actions.output.writer import FileWriter
-from agent_actions.processing.record_processor import RecordProcessor
 from agent_actions.processing.result_collector import ResultCollector, write_node_level_disposition
 from agent_actions.processing.strategies import FileToolStrategy, HITLStrategy
+from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
 from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
@@ -127,6 +128,20 @@ class ProcessingPipeline:
         # batch-mode bypass works regardless of which field the user sets.
         self.is_tool_action = self.action_kind == "tool" or self.model_vendor == "tool"
         self.is_hitl_action = self.action_kind == "hitl" or self.model_vendor == "hitl"
+
+        # HITL actions require FILE granularity
+        if self.is_hitl_action and self.granularity != "file":
+            from agent_actions.utils.constants import HITL_FILE_GRANULARITY_ERROR
+
+            raise ConfigurationError(
+                HITL_FILE_GRANULARITY_ERROR,
+                context={
+                    "action_name": config.action_name,
+                    "granularity": self.granularity,
+                    "kind": self.action_kind,
+                },
+            )
+
         if processor_factory is None:
             raise DependencyError(
                 "ProcessingPipeline requires processor_factory",
@@ -137,10 +152,11 @@ class ProcessingPipeline:
                 },
             )
 
-        self.record_processor = RecordProcessor.create(
-            agent_config=cast(dict[str, Any], config.action_config),
-            agent_name=config.action_name,
-        )
+        # Enrichment pipeline shared by FILE mode paths
+        from agent_actions.processing.enrichment import EnrichmentPipeline
+
+        self.enrichment_pipeline = EnrichmentPipeline()
+
         # Initialize OutputHandler with optional storage backend
         self.output_handler = OutputHandler(
             storage_backend=config.storage_backend,
@@ -560,17 +576,23 @@ class ProcessingPipeline:
                     results = self._process_file_mode_hitl(passing, original_passing, context)
 
                 results.extend(_build_skipped_results(skipped, self.config.action_name))
-        else:
-            results = self.record_processor.process_batch(data, context)
 
-        # Collect success results
-        output, stats = ResultCollector.collect_results(
-            results,
-            cast(dict[str, Any], self.config.action_config),
-            self.config.action_name,
-            is_first_stage=False,
-            storage_backend=self.config.storage_backend,
-        )
+            # Collect FILE-mode results
+            output, stats = ResultCollector.collect_results(
+                results,
+                cast(dict[str, Any], self.config.action_config),
+                self.config.action_name,
+                is_first_stage=False,
+                storage_backend=self.config.storage_backend,
+            )
+        else:
+            # RECORD mode — UnifiedProcessor handles guard + invoke + enrich + collect
+            strategy = OnlineLLMStrategy(
+                agent_config=cast(dict[str, Any], self.config.action_config),
+                agent_name=self.config.action_name,
+            )
+            unified = UnifiedProcessor()
+            output, stats = unified.process(data, context, strategy)
 
         # Signal node-level SKIP only when output is truly empty and the
         # only outcomes were guard-skip / guard-filter.  Guard-skipped
@@ -600,14 +622,14 @@ class ProcessingPipeline:
         self, data: list[dict], original_data: list[dict], context: ProcessingContext
     ) -> list:
         """Delegate to FileToolStrategy for FILE-mode tool invocation."""
-        strategy = FileToolStrategy(self.record_processor.enrichment_pipeline)
+        strategy = FileToolStrategy(self.enrichment_pipeline)
         return strategy.invoke(data, original_data, context)
 
     def _process_file_mode_hitl(
         self, data: list[dict], original_data: list[dict], context: ProcessingContext
     ) -> list:
         """Delegate to HITLStrategy for FILE-mode HITL invocation."""
-        strategy = HITLStrategy(self.record_processor.enrichment_pipeline)
+        strategy = HITLStrategy(self.enrichment_pipeline)
         return strategy.invoke(data, original_data, context)
 
 

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -152,10 +152,20 @@ class ProcessingPipeline:
                 },
             )
 
-        # Enrichment pipeline shared by FILE mode paths
+        # Shared enrichment pipeline (FILE mode paths use directly,
+        # RECORD mode passes to UnifiedProcessor to avoid double allocation)
         from agent_actions.processing.enrichment import EnrichmentPipeline
 
         self.enrichment_pipeline = EnrichmentPipeline()
+
+        # RECORD mode processor — created once, reused per file
+        self._online_strategy = OnlineLLMStrategy(
+            agent_config=cast(dict[str, Any], config.action_config),
+            agent_name=config.action_name,
+        )
+        self._unified_processor = UnifiedProcessor(
+            enrichment_pipeline=self.enrichment_pipeline,
+        )
 
         # Initialize OutputHandler with optional storage backend
         self.output_handler = OutputHandler(
@@ -587,12 +597,7 @@ class ProcessingPipeline:
             )
         else:
             # RECORD mode — UnifiedProcessor handles guard + invoke + enrich + collect
-            strategy = OnlineLLMStrategy(
-                agent_config=cast(dict[str, Any], self.config.action_config),
-                agent_name=self.config.action_name,
-            )
-            unified = UnifiedProcessor()
-            output, stats = unified.process(data, context, strategy)
+            output, stats = self._unified_processor.process(data, context, self._online_strategy)
 
         # Signal node-level SKIP only when output is truly empty and the
         # only outcomes were guard-skip / guard-filter.  Guard-skipped

--- a/tests/core/test_invocation_strategy.py
+++ b/tests/core/test_invocation_strategy.py
@@ -397,8 +397,8 @@ class TestRecordProcessorModeWiring:
 class TestDeferredResultInProcessor:
     """Regression test: batch invocations must surface as DEFERRED, not FILTERED."""
 
-    @patch("agent_actions.processing.record_processor.get_task_preparer")
-    @patch("agent_actions.processing.record_processor.fire_event")
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
     def test_batch_invocation_returns_deferred_not_filtered(
         self, mock_fire_event, mock_get_preparer
     ):

--- a/tests/processing/test_empty_output_detection.py
+++ b/tests/processing/test_empty_output_detection.py
@@ -8,7 +8,7 @@ from agent_actions.config.schema import ActionConfig
 from agent_actions.errors import EmptyOutputError
 from agent_actions.logging.events.data_pipeline_events import RecordEmptyOutputEvent
 from agent_actions.logging.events.handlers.run_results import ActionResult, RunResultsCollector
-from agent_actions.processing.record_processor import _is_empty_output
+from agent_actions.processing.strategies.online_llm import _is_empty_output
 
 # =============================================================================
 # _is_empty_output helper tests
@@ -140,7 +140,7 @@ class TestEmptyOutputDetection:
         fired_events = []
 
         with patch(
-            "agent_actions.processing.record_processor.fire_event",
+            "agent_actions.processing.strategies.online_llm.fire_event",
             side_effect=lambda e: fired_events.append(e),
         ):
             from agent_actions.processing.record_processor import RecordProcessor
@@ -167,7 +167,7 @@ class TestEmptyOutputDetection:
             processor = RecordProcessor(agent_config, "test_agent", strategy=mock_strategy)
 
             # Mock _transform_response to return a minimal valid result
-            processor._transform_response = MagicMock(
+            processor._online_strategy._transform_response = MagicMock(
                 return_value=[{"content": {}, "source_guid": "sg-1"}]
             )
 
@@ -178,7 +178,9 @@ class TestEmptyOutputDetection:
             )
 
             # Mock task_preparer
-            with patch("agent_actions.processing.record_processor.get_task_preparer") as mock_tp:
+            with patch(
+                "agent_actions.processing.strategies.online_llm.get_task_preparer"
+            ) as mock_tp:
                 mock_prepared = MagicMock()
                 mock_prepared.source_guid = "sg-1"
                 mock_prepared.source_snapshot = None
@@ -196,7 +198,7 @@ class TestEmptyOutputDetection:
     def test_empty_output_error_raises(self):
         """When on_empty=error, AgentActionsError is raised on empty output."""
         with patch(
-            "agent_actions.processing.record_processor.fire_event",
+            "agent_actions.processing.strategies.online_llm.fire_event",
         ):
             from agent_actions.processing.record_processor import RecordProcessor
             from agent_actions.processing.types import ProcessingContext
@@ -218,7 +220,7 @@ class TestEmptyOutputDetection:
             mock_strategy.invoke.return_value = mock_result
 
             processor = RecordProcessor(agent_config, "test_agent", strategy=mock_strategy)
-            processor._transform_response = MagicMock(
+            processor._online_strategy._transform_response = MagicMock(
                 return_value=[{"content": {}, "source_guid": "sg-1"}]
             )
 
@@ -228,7 +230,9 @@ class TestEmptyOutputDetection:
                 record_index=0,
             )
 
-            with patch("agent_actions.processing.record_processor.get_task_preparer") as mock_tp:
+            with patch(
+                "agent_actions.processing.strategies.online_llm.get_task_preparer"
+            ) as mock_tp:
                 mock_prepared = MagicMock()
                 mock_prepared.source_guid = "sg-1"
                 mock_prepared.source_snapshot = None
@@ -246,7 +250,7 @@ class TestEmptyOutputDetection:
         fired_events = []
 
         with patch(
-            "agent_actions.processing.record_processor.fire_event",
+            "agent_actions.processing.strategies.online_llm.fire_event",
             side_effect=lambda e: fired_events.append(e),
         ):
             from agent_actions.processing.record_processor import RecordProcessor
@@ -269,7 +273,7 @@ class TestEmptyOutputDetection:
             mock_strategy.invoke.return_value = mock_result
 
             processor = RecordProcessor(agent_config, "test_agent", strategy=mock_strategy)
-            processor._transform_response = MagicMock(
+            processor._online_strategy._transform_response = MagicMock(
                 return_value=[{"content": {}, "source_guid": "sg-1"}]
             )
 
@@ -279,7 +283,9 @@ class TestEmptyOutputDetection:
                 record_index=0,
             )
 
-            with patch("agent_actions.processing.record_processor.get_task_preparer") as mock_tp:
+            with patch(
+                "agent_actions.processing.strategies.online_llm.get_task_preparer"
+            ) as mock_tp:
                 mock_prepared = MagicMock()
                 mock_prepared.source_guid = "sg-1"
                 mock_prepared.source_snapshot = None
@@ -296,7 +302,7 @@ class TestEmptyOutputDetection:
     def test_empty_output_error_propagates_through_process_batch(self):
         """EmptyOutputError must propagate through process_batch (not be swallowed)."""
         with patch(
-            "agent_actions.processing.record_processor.fire_event",
+            "agent_actions.processing.strategies.online_llm.fire_event",
         ):
             from agent_actions.processing.record_processor import RecordProcessor
             from agent_actions.processing.types import ProcessingContext
@@ -318,7 +324,7 @@ class TestEmptyOutputDetection:
             mock_strategy.invoke.return_value = mock_result
 
             processor = RecordProcessor(agent_config, "test_agent", strategy=mock_strategy)
-            processor._transform_response = MagicMock(
+            processor._online_strategy._transform_response = MagicMock(
                 return_value=[{"content": {}, "source_guid": "sg-1"}]
             )
 
@@ -328,7 +334,9 @@ class TestEmptyOutputDetection:
                 record_index=0,
             )
 
-            with patch("agent_actions.processing.record_processor.get_task_preparer") as mock_tp:
+            with patch(
+                "agent_actions.processing.strategies.online_llm.get_task_preparer"
+            ) as mock_tp:
                 mock_prepared = MagicMock()
                 mock_prepared.source_guid = "sg-1"
                 mock_prepared.source_snapshot = None

--- a/tests/processing/test_guard_skip_disposition.py
+++ b/tests/processing/test_guard_skip_disposition.py
@@ -59,7 +59,7 @@ def guard_skip_result(record_processor, guard_skip_prepared, processing_context)
     mock_preparer.prepare.return_value = guard_skip_prepared
 
     with patch(
-        "agent_actions.processing.record_processor.get_task_preparer",
+        "agent_actions.processing.strategies.online_llm.get_task_preparer",
         return_value=mock_preparer,
     ):
         return record_processor.process(

--- a/tests/processing/test_source_guid_none_coercion.py
+++ b/tests/processing/test_source_guid_none_coercion.py
@@ -30,7 +30,9 @@ def _make_processor_and_context(agent_config=None):
     mock_strategy.invoke.return_value = mock_result
 
     processor = RecordProcessor(agent_config, "test_agent", strategy=mock_strategy)
-    processor._transform_response = MagicMock(return_value=[{"content": {"field": "value"}}])
+    processor._online_strategy._transform_response = MagicMock(
+        return_value=[{"content": {"field": "value"}}]
+    )
 
     context = ProcessingContext(
         agent_config=agent_config,
@@ -46,14 +48,23 @@ class TestSourceGuidNoneCoercion:
     def test_events_receive_empty_string_when_source_guid_is_none(self):
         """All events emitted during process() get source_guid='' when prepared.source_guid is None."""
         fired_events = []
+        collector = lambda e: fired_events.append(e)  # noqa: E731
 
-        with patch(
-            "agent_actions.processing.record_processor.fire_event",
-            side_effect=lambda e: fired_events.append(e),
+        with (
+            patch(
+                "agent_actions.processing.strategies.online_llm.fire_event",
+                side_effect=collector,
+            ),
+            patch(
+                "agent_actions.processing.record_processor.fire_event",
+                side_effect=collector,
+            ),
         ):
             processor, context = _make_processor_and_context()
 
-            with patch("agent_actions.processing.record_processor.get_task_preparer") as mock_tp:
+            with patch(
+                "agent_actions.processing.strategies.online_llm.get_task_preparer"
+            ) as mock_tp:
                 mock_prepared = MagicMock()
                 mock_prepared.source_guid = None  # The key scenario
                 mock_prepared.source_snapshot = None
@@ -81,10 +92,15 @@ class TestSourceGuidNoneCoercion:
 
     def test_transform_response_receives_empty_string(self):
         """_transform_response is called with source_guid='' when prepared.source_guid is None."""
-        with patch("agent_actions.processing.record_processor.fire_event"):
+        with (
+            patch("agent_actions.processing.strategies.online_llm.fire_event"),
+            patch("agent_actions.processing.record_processor.fire_event"),
+        ):
             processor, context = _make_processor_and_context()
 
-            with patch("agent_actions.processing.record_processor.get_task_preparer") as mock_tp:
+            with patch(
+                "agent_actions.processing.strategies.online_llm.get_task_preparer"
+            ) as mock_tp:
                 mock_prepared = MagicMock()
                 mock_prepared.source_guid = None
                 mock_prepared.source_snapshot = None
@@ -95,15 +111,20 @@ class TestSourceGuidNoneCoercion:
                 processor.process({"content": {"field": "value"}}, context)
 
         # _transform_response should have been called with "" as source_guid
-        call_args = processor._transform_response.call_args
+        call_args = processor._online_strategy._transform_response.call_args
         assert call_args[0][2] == ""  # 3rd positional arg is source_guid
 
     def test_processing_result_preserves_none_source_guid(self):
         """ProcessingResult.source_guid stays None — not coerced to ''."""
-        with patch("agent_actions.processing.record_processor.fire_event"):
+        with (
+            patch("agent_actions.processing.strategies.online_llm.fire_event"),
+            patch("agent_actions.processing.record_processor.fire_event"),
+        ):
             processor, context = _make_processor_and_context()
 
-            with patch("agent_actions.processing.record_processor.get_task_preparer") as mock_tp:
+            with patch(
+                "agent_actions.processing.strategies.online_llm.get_task_preparer"
+            ) as mock_tp:
                 mock_prepared = MagicMock()
                 mock_prepared.source_guid = None
                 mock_prepared.source_snapshot = None

--- a/tests/unit/processing/test_online_llm_strategy.py
+++ b/tests/unit/processing/test_online_llm_strategy.py
@@ -1,0 +1,478 @@
+"""Tests for OnlineLLMStrategy — the online LLM processing strategy."""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.processing.invocation.result import InvocationResult
+from agent_actions.processing.prepared_task import GuardStatus, PreparedTask
+from agent_actions.processing.strategies.online_llm import (
+    OnlineLLMStrategy,
+    _create_item_context,
+    _is_empty_output,
+)
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingStatus,
+    RecoveryMetadata,
+    RetryMetadata,
+)
+from agent_actions.processing.unified import ProcessingStrategy
+
+
+def _make_context(
+    agent_name: str = "test_action",
+    **kwargs: Any,
+) -> ProcessingContext:
+    """Create a minimal ProcessingContext."""
+    config: dict[str, Any] = {
+        "agent_type": agent_name,
+        "name": agent_name,
+    }
+    return ProcessingContext(
+        agent_config=config,
+        agent_name=agent_name,
+        **kwargs,
+    )
+
+
+def _make_prepared(
+    source_guid: str = "sg-1",
+    guard_status: GuardStatus = GuardStatus.PASSED,
+    **kwargs: Any,
+) -> PreparedTask:
+    """Create a minimal PreparedTask."""
+    return PreparedTask(
+        target_id="tid-1",
+        source_guid=source_guid,
+        formatted_prompt="test prompt",
+        llm_context={"content": "test"},
+        original_content={"field": "value"},
+        source_snapshot={"field": "value"},
+        guard_status=guard_status,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolCompliance:
+    """OnlineLLMStrategy must satisfy ProcessingStrategy protocol."""
+
+    def test_satisfies_processing_strategy_protocol(self):
+        mock_invocation = MagicMock()
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+        assert isinstance(strategy, ProcessingStrategy)
+
+
+# ---------------------------------------------------------------------------
+# process_record — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestProcessRecordSuccess:
+    """Tests for successful record processing."""
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_success_returns_correct_status(self, mock_fire, mock_get_preparer):
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response={"output": "result"},
+            executed=True,
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+        strategy._transform_response = MagicMock(
+            return_value=[{"content": {"test": {"output": "result"}}}]
+        )
+
+        context = _make_context()
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.SUCCESS
+        assert result.source_guid == "sg-1"
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_skip_guard_defaults_to_true(self, mock_fire, mock_get_preparer):
+        """process_record defaults to skip_guard=True for UnifiedProcessor path."""
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response={"out": "val"}, executed=True
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+        strategy._transform_response = MagicMock(return_value=[{"content": {}}])
+
+        context = _make_context()
+        strategy.process_record({"field": "value"}, context)
+
+        # TaskPreparer.prepare() should receive skip_guard=True
+        call_kwargs = mock_get_preparer.return_value.prepare.call_args
+        assert call_kwargs[1]["skip_guard"] is True
+
+
+# ---------------------------------------------------------------------------
+# process_record — guard statuses
+# ---------------------------------------------------------------------------
+
+
+class TestProcessRecordGuardStatuses:
+    """Tests for guard status handling in process_record."""
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_upstream_unprocessed_returns_unprocessed(self, mock_fire, mock_get_preparer):
+        prepared = _make_prepared(guard_status=GuardStatus.UPSTREAM_UNPROCESSED)
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        item = {"content": {"field": "value"}, "_unprocessed": True, "metadata": {}}
+        context = _make_context()
+        result = strategy.process_record(item, context)
+
+        assert result.status == ProcessingStatus.UNPROCESSED
+        assert result.skip_reason == "upstream_unprocessed"
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_filtered_guard_returns_filtered(self, mock_fire, mock_get_preparer):
+        """When skip_guard=False and guard filters, returns FILTERED."""
+        prepared = _make_prepared(guard_status=GuardStatus.FILTERED)
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        context = _make_context()
+        result = strategy.process_record({"field": "value"}, context, skip_guard=False)
+
+        assert result.status == ProcessingStatus.FILTERED
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_skipped_guard_returns_skipped(self, mock_fire, mock_get_preparer):
+        """When skip_guard=False and guard skips, returns SKIPPED."""
+        prepared = _make_prepared(
+            guard_status=GuardStatus.SKIPPED,
+            guard_behavior="skip",
+        )
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        context = _make_context()
+        result = strategy.process_record({"field": "value"}, context, skip_guard=False)
+
+        assert result.status == ProcessingStatus.SKIPPED
+        assert result.skip_reason == "guard_skip"
+
+
+# ---------------------------------------------------------------------------
+# process_record — LLM response handling
+# ---------------------------------------------------------------------------
+
+
+class TestProcessRecordResponseHandling:
+    """Tests for LLM response handling in process_record."""
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_deferred_returns_deferred(self, mock_fire, mock_get_preparer):
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.queued(
+            task_id="batch-123",
+            passthrough_fields={"k": "v"},
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = _make_context()
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.DEFERRED
+        assert result.task_id == "batch-123"
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_not_executed_none_response_returns_filtered(self, mock_fire, mock_get_preparer):
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response=None, executed=False
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = _make_context()
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.FILTERED
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_retry_exhausted_returns_exhausted(self, mock_fire, mock_get_preparer):
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        recovery = RecoveryMetadata(
+            retry=RetryMetadata(attempts=3, failures=3, succeeded=False, reason="timeout")
+        )
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response=None,
+            executed=False,
+            recovery=recovery,
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = _make_context()
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.EXHAUSTED
+        assert "3 attempts" in result.error
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_not_executed_with_response_returns_unprocessed(self, mock_fire, mock_get_preparer):
+        """executed=False with non-None response → guard_skip → UNPROCESSED."""
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response={"skipped": True}, executed=False
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = _make_context()
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.UNPROCESSED
+        assert result.skip_reason == "guard_skip"
+
+
+# ---------------------------------------------------------------------------
+# process_record — empty output
+# ---------------------------------------------------------------------------
+
+
+class TestProcessRecordEmptyOutput:
+    """Tests for empty output handling."""
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_empty_output_error_raises(self, mock_fire, mock_get_preparer):
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(response={}, executed=True)
+
+        from agent_actions.errors.processing import EmptyOutputError
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test", "on_empty": "error"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = _make_context()
+        context = ProcessingContext(
+            agent_config={"agent_type": "test", "on_empty": "error"},
+            agent_name="test",
+        )
+
+        with pytest.raises(EmptyOutputError, match="on_empty=error"):
+            strategy.process_record({"field": "value"}, context)
+
+
+# ---------------------------------------------------------------------------
+# invoke — batch loop
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeBatchLoop:
+    """Tests for the batch iteration in invoke()."""
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_processes_all_records(self, mock_fire, mock_get_preparer):
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response={"out": "val"}, executed=True
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+        strategy._transform_response = MagicMock(return_value=[{"content": {}}])
+
+        records = [{"f": "1"}, {"f": "2"}, {"f": "3"}]
+        context = _make_context()
+        results = strategy.invoke(records, context)
+
+        assert len(results) == 3
+        assert all(r.status == ProcessingStatus.SUCCESS for r in results)
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_wraps_generic_exception_as_failed(self, mock_fire, mock_get_preparer):
+        """Non-critical exceptions are wrapped as FAILED results."""
+        mock_get_preparer.return_value.prepare.side_effect = ValueError("boom")
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        context = _make_context()
+        results = strategy.invoke([{"f": "1"}], context)
+
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.FAILED
+        assert "boom" in results[0].error
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_reraises_configuration_error(self, mock_fire, mock_get_preparer):
+        from agent_actions.errors import ConfigurationError
+
+        mock_get_preparer.return_value.prepare.side_effect = ConfigurationError("bad config")
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        context = _make_context()
+        with pytest.raises(ConfigurationError, match="bad config"):
+            strategy.invoke([{"f": "1"}], context)
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_empty_records_returns_empty(self, mock_fire, mock_get_preparer):
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        context = _make_context()
+        results = strategy.invoke([], context)
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _is_empty_output helper
+# ---------------------------------------------------------------------------
+
+
+class TestIsEmptyOutput:
+    """Tests for the _is_empty_output helper."""
+
+    def test_none_is_empty(self):
+        assert _is_empty_output(None) is True
+
+    def test_empty_dict_is_empty(self):
+        assert _is_empty_output({}) is True
+
+    def test_empty_list_is_empty(self):
+        assert _is_empty_output([]) is True
+
+    def test_non_empty_dict_not_empty(self):
+        assert _is_empty_output({"key": "val"}) is False
+
+    def test_string_not_empty(self):
+        assert _is_empty_output("text") is False
+
+
+# ---------------------------------------------------------------------------
+# _create_item_context helper
+# ---------------------------------------------------------------------------
+
+
+class TestCreateItemContext:
+    """Tests for _create_item_context helper."""
+
+    def test_updates_record_index(self):
+        base = _make_context()
+        ctx = _create_item_context(base, 5, {"data": "val"})
+        assert ctx.record_index == 5
+
+    def test_sets_current_item_for_dict(self):
+        base = _make_context()
+        item = {"data": "val"}
+        ctx = _create_item_context(base, 0, item)
+        assert ctx.current_item is item
+
+    def test_sets_current_item_none_for_non_dict(self):
+        base = _make_context()
+        ctx = _create_item_context(base, 0, "string_item")
+        assert ctx.current_item is None

--- a/tests/unit/processing/test_online_llm_strategy.py
+++ b/tests/unit/processing/test_online_llm_strategy.py
@@ -10,7 +10,6 @@ from agent_actions.processing.prepared_task import GuardStatus, PreparedTask
 from agent_actions.processing.strategies.online_llm import (
     OnlineLLMStrategy,
     _create_item_context,
-    _is_empty_output,
 )
 from agent_actions.processing.types import (
     ProcessingContext,
@@ -427,30 +426,6 @@ class TestInvokeBatchLoop:
         results = strategy.invoke([], context)
 
         assert results == []
-
-
-# ---------------------------------------------------------------------------
-# _is_empty_output helper
-# ---------------------------------------------------------------------------
-
-
-class TestIsEmptyOutput:
-    """Tests for the _is_empty_output helper."""
-
-    def test_none_is_empty(self):
-        assert _is_empty_output(None) is True
-
-    def test_empty_dict_is_empty(self):
-        assert _is_empty_output({}) is True
-
-    def test_empty_list_is_empty(self):
-        assert _is_empty_output([]) is True
-
-    def test_non_empty_dict_not_empty(self):
-        assert _is_empty_output({"key": "val"}) is False
-
-    def test_string_not_empty(self):
-        assert _is_empty_output("text") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
+++ b/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agent_actions.processing.result_collector import CollectionStats
+from agent_actions.processing.result_collector import CollectionStats, ResultCollector
 from agent_actions.storage.backend import DISPOSITION_SKIPPED, NODE_LEVEL_RECORD_ID
 
 
@@ -34,7 +34,6 @@ def pipeline_and_mocks(tmp_path):
 
     pipeline = ProcessingPipeline.__new__(ProcessingPipeline)
     pipeline.config = config
-    pipeline.record_processor = MagicMock()
     pipeline.output_handler = MagicMock()
     pipeline.granularity = "record"
     pipeline.is_tool_action = False
@@ -49,25 +48,22 @@ class TestGuardSkipDisposition:
     def _run_with_stats(
         self, pipeline, config, stats, file_path, base_dir, output_dir, data=None, output=None
     ):
-        """Call process() with mocked collect_results stats.
+        """Call process() with mocked UnifiedProcessor stats.
 
         Args:
-            output: The output list returned by collect_results. Defaults to
-                ``data`` (simulating passthrough). Pass ``[]`` to simulate
-                filtered records that produce no output.
+            output: The output list returned by UnifiedProcessor.process().
+                Defaults to ``data`` (simulating passthrough). Pass ``[]``
+                to simulate filtered records that produce no output.
         """
         if data is None:
             data = [{"id": "1"}, {"id": "2"}]
         if output is None:
             output = data
 
-        pipeline.record_processor.process_batch.return_value = []
-
-        with patch(
-            "agent_actions.workflow.pipeline.ResultCollector.collect_results",
-            return_value=(output, stats),
-        ):
-            pipeline.process(file_path, base_dir, output_dir, data=data)
+        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
+            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
+                MockProcessor.return_value.process.return_value = (output, stats)
+                pipeline.process(file_path, base_dir, output_dir, data=data)
 
     def test_no_disposition_when_all_guard_skipped_with_output(self, pipeline_and_mocks):
         """Guard-skipped records ARE in output — no node-level skip, downstream proceeds."""
@@ -209,13 +205,11 @@ class TestToolActionEmptyOutputUsesGenericPath:
         pipeline.is_tool_action = True
         stats = CollectionStats(failed=1)
 
-        pipeline.record_processor.process_batch.return_value = []
-        with patch(
-            "agent_actions.workflow.pipeline.ResultCollector.collect_results",
-            return_value=([], stats),
-        ):
-            with pytest.raises(RuntimeError, match="produced 0 successful records"):
-                pipeline.process(fp, base, out, data=[{"id": "1"}])
+        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
+            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
+                MockProcessor.return_value.process.return_value = ([], stats)
+                with pytest.raises(RuntimeError, match="produced 0 successful records"):
+                    pipeline.process(fp, base, out, data=[{"id": "1"}])
 
 
 class TestZeroSuccessFailure:
@@ -228,19 +222,16 @@ class TestZeroSuccessFailure:
     """
 
     def _run_with_stats(self, pipeline, config, stats, fp, base, out, data=None, output=None):
-        """Call process() with mocked collect_results."""
+        """Call process() with mocked UnifiedProcessor."""
         if data is None:
             data = [{"id": "1"}, {"id": "2"}, {"id": "3"}]
         if output is None:
             output = data  # default: mock returns input as output
 
-        pipeline.record_processor.process_batch.return_value = []
-
-        with patch(
-            "agent_actions.workflow.pipeline.ResultCollector.collect_results",
-            return_value=(output, stats),
-        ):
-            pipeline.process(fp, base, out, data=data)
+        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
+            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
+                MockProcessor.return_value.process.return_value = (output, stats)
+                pipeline.process(fp, base, out, data=data)
 
     def test_all_failed_raises(self, pipeline_and_mocks):
         """All records FAILED with zero output → RuntimeError."""
@@ -322,11 +313,23 @@ class TestZeroSuccessFailure:
 class TestZeroSuccessWithRealResults:
     """Integration tests using real ProcessingResult objects through ResultCollector.
 
-    These tests do NOT mock collect_results — they send real ProcessingResult
-    objects through the actual collection pipeline to verify the full chain:
-    process_batch returns results → collect_results produces stats → pipeline
-    check raises RuntimeError.
+    These tests send real ProcessingResult objects through the actual
+    ResultCollector to compute stats, then verify the pipeline reacts
+    correctly to those stats.
     """
+
+    def _run_with_real_results(self, pipeline, config, results, fp, base, out, data):
+        """Compute stats from real results, then run pipeline with those stats."""
+        output, stats = ResultCollector.collect_results(
+            results,
+            config.action_config,
+            config.action_name,
+            is_first_stage=False,
+        )
+        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
+            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
+                MockProcessor.return_value.process.return_value = (output, stats)
+                pipeline.process(fp, base, out, data=data)
 
     def test_all_exhausted_real_results_raises(self, pipeline_and_mocks):
         """Real EXHAUSTED ProcessingResults through actual collect_results → RuntimeError."""
@@ -344,10 +347,16 @@ class TestZeroSuccessWithRealResults:
             for i in range(3)
         ]
 
-        pipeline.record_processor.process_batch.return_value = exhausted_results
-
         with pytest.raises(RuntimeError, match="produced 0 successful records"):
-            pipeline.process(fp, base, out, data=[{"id": "1"}, {"id": "2"}, {"id": "3"}])
+            self._run_with_real_results(
+                pipeline,
+                config,
+                exhausted_results,
+                fp,
+                base,
+                out,
+                data=[{"id": "1"}, {"id": "2"}, {"id": "3"}],
+            )
 
     def test_all_failed_real_results_raises(self, pipeline_and_mocks):
         """Real FAILED ProcessingResults through actual collect_results → RuntimeError."""
@@ -364,10 +373,16 @@ class TestZeroSuccessWithRealResults:
             for i in range(3)
         ]
 
-        pipeline.record_processor.process_batch.return_value = failed_results
-
         with pytest.raises(RuntimeError, match="produced 0 successful records"):
-            pipeline.process(fp, base, out, data=[{"id": "1"}, {"id": "2"}, {"id": "3"}])
+            self._run_with_real_results(
+                pipeline,
+                config,
+                failed_results,
+                fp,
+                base,
+                out,
+                data=[{"id": "1"}, {"id": "2"}, {"id": "3"}],
+            )
 
     def test_mixed_real_results_raises(self, pipeline_and_mocks):
         """Mixed FAILED + EXHAUSTED real results → RuntimeError."""
@@ -386,10 +401,16 @@ class TestZeroSuccessWithRealResults:
             ),
         ]
 
-        pipeline.record_processor.process_batch.return_value = results
-
         with pytest.raises(RuntimeError, match=r"2 failed, 1 exhausted"):
-            pipeline.process(fp, base, out, data=[{"id": "1"}, {"id": "2"}, {"id": "3"}])
+            self._run_with_real_results(
+                pipeline,
+                config,
+                results,
+                fp,
+                base,
+                out,
+                data=[{"id": "1"}, {"id": "2"}, {"id": "3"}],
+            )
 
     def test_partial_success_real_results_no_raise(self, pipeline_and_mocks):
         """Mix of SUCCESS + FAILED real results → no raise (partial success)."""
@@ -408,7 +429,8 @@ class TestZeroSuccessWithRealResults:
             ProcessingResult.failed("401 Unauthorized", source_guid="guid_1"),
         ]
 
-        pipeline.record_processor.process_batch.return_value = results
-        pipeline.process(fp, base, out, data=[{"id": "1"}, {"id": "2"}])
+        self._run_with_real_results(
+            pipeline, config, results, fp, base, out, data=[{"id": "1"}, {"id": "2"}]
+        )
 
         pipeline.output_handler.save_main_output.assert_called_once()

--- a/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
+++ b/tests/unit/workflow/test_pipeline_guard_skip_disposition.py
@@ -5,7 +5,7 @@ no exhausted retries), the pipeline writes DISPOSITION_SKIPPED at node
 level so the executor can mark the action as skipped in the tally.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -38,6 +38,8 @@ def pipeline_and_mocks(tmp_path):
     pipeline.granularity = "record"
     pipeline.is_tool_action = False
     pipeline.is_hitl_action = False
+    pipeline._unified_processor = MagicMock()
+    pipeline._online_strategy = MagicMock()
 
     return pipeline, config, str(input_file), str(tmp_path), str(output_dir)
 
@@ -60,10 +62,8 @@ class TestGuardSkipDisposition:
         if output is None:
             output = data
 
-        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
-            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
-                MockProcessor.return_value.process.return_value = (output, stats)
-                pipeline.process(file_path, base_dir, output_dir, data=data)
+        pipeline._unified_processor.process.return_value = (output, stats)
+        pipeline.process(file_path, base_dir, output_dir, data=data)
 
     def test_no_disposition_when_all_guard_skipped_with_output(self, pipeline_and_mocks):
         """Guard-skipped records ARE in output — no node-level skip, downstream proceeds."""
@@ -205,11 +205,9 @@ class TestToolActionEmptyOutputUsesGenericPath:
         pipeline.is_tool_action = True
         stats = CollectionStats(failed=1)
 
-        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
-            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
-                MockProcessor.return_value.process.return_value = ([], stats)
-                with pytest.raises(RuntimeError, match="produced 0 successful records"):
-                    pipeline.process(fp, base, out, data=[{"id": "1"}])
+        pipeline._unified_processor.process.return_value = ([], stats)
+        with pytest.raises(RuntimeError, match="produced 0 successful records"):
+            pipeline.process(fp, base, out, data=[{"id": "1"}])
 
 
 class TestZeroSuccessFailure:
@@ -228,10 +226,8 @@ class TestZeroSuccessFailure:
         if output is None:
             output = data  # default: mock returns input as output
 
-        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
-            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
-                MockProcessor.return_value.process.return_value = (output, stats)
-                pipeline.process(fp, base, out, data=data)
+        pipeline._unified_processor.process.return_value = (output, stats)
+        pipeline.process(fp, base, out, data=data)
 
     def test_all_failed_raises(self, pipeline_and_mocks):
         """All records FAILED with zero output → RuntimeError."""
@@ -326,10 +322,8 @@ class TestZeroSuccessWithRealResults:
             config.action_name,
             is_first_stage=False,
         )
-        with patch("agent_actions.workflow.pipeline.OnlineLLMStrategy"):
-            with patch("agent_actions.workflow.pipeline.UnifiedProcessor") as MockProcessor:
-                MockProcessor.return_value.process.return_value = (output, stats)
-                pipeline.process(fp, base, out, data=data)
+        pipeline._unified_processor.process.return_value = (output, stats)
+        pipeline.process(fp, base, out, data=data)
 
     def test_all_exhausted_real_results_raises(self, pipeline_and_mocks):
         """Real EXHAUSTED ProcessingResults through actual collect_results → RuntimeError."""


### PR DESCRIPTION
## Summary
- Extract per-record online LLM processing logic from `RecordProcessor.process()` into `OnlineLLMStrategy` implementing the `ProcessingStrategy` protocol
- Pipeline RECORD mode now uses `UnifiedProcessor.process()` with `OnlineLLMStrategy`: guard → invoke → enrich → collect
- `RecordProcessor` becomes a thin wrapper delegating to `OnlineLLMStrategy` + enrichment for backward-compat callers (`initial_pipeline`, `data_generator`)
- HITL validation moved from `RecordProcessor` constructor to `ProcessingPipeline` constructor
- `pipeline_file_mode.py` uses `pipeline.enrichment_pipeline` directly

## Verification
- 23 new tests for `OnlineLLMStrategy` (protocol compliance, guard statuses, response handling, batch loop, edge cases)
- 6135 tests pass, ruff clean
- Updated 5 test files to target new module paths for mock patches