### PR TITLE
refactor: extract BatchResultStrategy from result_processor.py

### DIFF
--- a/.changes/unreleased/Under the Hood-20260429-031000.yaml
+++ b/.changes/unreleased/Under the Hood-20260429-031000.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
 body: "Extract BatchResultStrategy from result_processor.py — batch result processing now returns typed ProcessingResult objects instead of raw dicts"
-time: 2026-04-29T31:00:00.000000Z
+time: 2026-04-29T03:10:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260429-310000.yaml
+++ b/.changes/unreleased/Under the Hood-20260429-310000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Extract BatchResultStrategy from result_processor.py — batch result processing now returns typed ProcessingResult objects instead of raw dicts"
+time: 2026-04-29T31:00:00.000000Z

--- a/agent_actions/llm/batch/processing/_MANIFEST.md
+++ b/agent_actions/llm/batch/processing/_MANIFEST.md
@@ -12,4 +12,4 @@ before persisted results are written.
 | `batch_passthrough_builder.py` | Module | Constructs passthrough records for batch guard filtering. | `preprocessing`, `lineage` |
 | `preparator.py` | Module | Prepares batch workloads (chunking, formatting, batching). | `preprocessing`, `input` |
 | `reconciler.py` | Module | Reconciles batch outputs with context; uses string-normalized custom_id for JSON compatibility. | `formatting`, `output` |
-| `result_processor.py` | Module | Processes batch results into workflow format; normalizes custom_id to string for context lookups. | `processing`, `output` |
+| `batch_result_strategy.py` | Module | Batch result processing strategy; converts raw BatchResult objects into enriched ProcessingResult records. | `processing`, `output` |

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -123,8 +123,8 @@ class BatchResultStrategy:
         json_mode = get_default("json_mode")
         output_field = get_default("output_field")
         if agent_config:
-            json_mode = agent_config.get("json_mode", get_default("json_mode"))
-            output_field = agent_config.get("output_field", get_default("output_field"))
+            json_mode = agent_config.get("json_mode", json_mode)
+            output_field = agent_config.get("output_field", output_field)
 
         ctx = BatchProcessingContext(
             batch_results=batch_results,
@@ -345,29 +345,6 @@ class BatchResultStrategy:
             recovery_metadata=recovery_metadata,
         )
 
-    def _create_exhausted_item(
-        self,
-        ctx: BatchProcessingContext,
-        custom_id: str,
-        original_row: dict[str, Any],
-        recovery_metadata: RecoveryMetadata,
-    ) -> dict[str, Any]:
-        """Create an exhausted retry item via ExhaustedRecordBuilder."""
-        if ctx.reconciler is None:
-            raise RuntimeError(
-                "BatchProcessingContext.reconciler is None; "
-                "reconciler must be initialized before creating exhausted items"
-            )
-        source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "NOT_SET")
-
-        return ExhaustedRecordBuilder.build_exhausted_item(
-            source_guid=source_guid,
-            original_row=original_row,
-            recovery_metadata=recovery_metadata,
-            agent_config=ctx.agent_config or {},
-            action_name=(ctx.agent_config.get("action_name", "") if ctx.agent_config else ""),
-        )
-
     # -- Passthrough reconciliation --------------------------------------------
 
     def _reconcile_passthroughs(self, ctx: BatchProcessingContext) -> list[ProcessingResult]:
@@ -439,23 +416,17 @@ class BatchResultStrategy:
             retry_config = ctx.agent_config.get("retry", {})
             on_exhausted = retry_config.get("on_exhausted", "return_last")
 
-        if on_exhausted == "raise":
-            recovery_meta = ctx.exhausted_recovery[custom_id]
-            if recovery_meta.retry is None:
-                raise RuntimeError(
-                    "RecoveryMetadata.retry is None for exhausted record "
-                    f"custom_id={custom_id}; expected retry metadata"
-                )
-            raise RuntimeError(
-                f"Retry exhausted for record {custom_id} after "
-                f"{recovery_meta.retry.attempts} attempts (on_exhausted=raise)"
-            )
-
         recovery_meta = ctx.exhausted_recovery[custom_id]
         if recovery_meta.retry is None:
             raise RuntimeError(
                 "RecoveryMetadata.retry is None for exhausted record "
                 f"custom_id={custom_id}; expected retry metadata with attempt count"
+            )
+
+        if on_exhausted == "raise":
+            raise RuntimeError(
+                f"Retry exhausted for record {custom_id} after "
+                f"{recovery_meta.retry.attempts} attempts (on_exhausted=raise)"
             )
         empty_content = ExhaustedRecordBuilder.build_empty_content(ctx.agent_config or {})
         exhausted_item = build_exhausted_tombstone(

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -1,9 +1,11 @@
-"""
-Batch Result Processor.
+"""Batch result processing strategy.
+
+Converts raw BatchResult objects into enriched ProcessingResult records
+that can flow through the shared enrich/collect pipeline.
 """
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
@@ -21,7 +23,11 @@ from agent_actions.processing.record_helpers import (
     build_tombstone,
     carry_framework_fields,
 )
-from agent_actions.processing.types import ProcessingResult, RecoveryMetadata
+from agent_actions.processing.types import (
+    ProcessingResult,
+    ProcessingStatus,
+    RecoveryMetadata,
+)
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
@@ -29,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class BatchProcessingContext:
-    """Context passed through the batch result processing pipeline."""
+    """Internal context for batch result parsing."""
 
     # Input data
     batch_results: list[BatchResult]
@@ -47,19 +53,17 @@ class BatchProcessingContext:
     # Per-record recovery metadata for exhausted records (custom_id -> RecoveryMetadata)
     exhausted_recovery: dict[str, RecoveryMetadata] | None = None
 
-    # Accumulated output
-    processed_data: list[dict[str, Any]] = field(default_factory=list)
 
-    # Statistics
-    success_count: int = 0
-    error_count: int = 0
-    passthrough_count: int = 0
+class BatchResultStrategy:
+    """Converts batch provider results into ProcessingResult objects.
 
+    Unlike InvocationStrategy implementations that invoke LLM/tool/HITL,
+    this processes already-returned batch results.  The ``process()`` method
+    returns ``list[ProcessingResult]`` so the caller can flatten, collect,
+    and write dispositions through the shared pipeline.
+    """
 
-class BatchResultProcessor:
-    """Converts batch provider results into workflow format via pipeline stages."""
-
-    def __init__(self):
+    def __init__(self) -> None:
         self._enrichment_pipeline = EnrichmentPipeline()
 
     def process(
@@ -69,32 +73,43 @@ class BatchResultProcessor:
         output_directory: str | None = None,
         agent_config: dict[str, Any] | None = None,
         exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
-    ) -> list[dict[str, Any]]:
-        """Process batch results through the pipeline into workflow format."""
-        ctx = self._stage_1_initialize_context(
+    ) -> list[ProcessingResult]:
+        """Convert batch results into enriched ProcessingResult objects.
+
+        Returns one ProcessingResult per input record (successful, failed,
+        exhausted, or unprocessed).  The caller is responsible for flattening
+        ``result.data`` into output records and writing dispositions.
+        """
+        ctx = self._init_context(
             batch_results,
             context_map,
             output_directory,
             agent_config,
             exhausted_recovery,
         )
+        ctx.reconciler = BatchResultReconciler(ctx.context_map)
 
-        ctx = self._stage_2_reconcile(ctx)
+        results = self._process_batch_results(ctx)
+        results.extend(self._reconcile_passthroughs(ctx))
 
-        ctx = self._stage_3_4_process_results(ctx)
-
-        ctx = self._stage_6_merge_passthroughs(ctx)
+        success_count = sum(1 for r in results if r.status == ProcessingStatus.SUCCESS)
+        error_count = sum(
+            1 for r in results if r.status in (ProcessingStatus.FAILED, ProcessingStatus.EXHAUSTED)
+        )
+        passthrough_count = sum(1 for r in results if r.status == ProcessingStatus.UNPROCESSED)
 
         logger.debug(
             "Batch result processing complete: %d success, %d errors, %d passthrough",
-            ctx.success_count,
-            ctx.error_count,
-            ctx.passthrough_count,
+            success_count,
+            error_count,
+            passthrough_count,
         )
 
-        return ctx.processed_data
+        return results
 
-    def _stage_1_initialize_context(
+    # -- Initialisation --------------------------------------------------------
+
+    def _init_context(
         self,
         batch_results: list[BatchResult],
         context_map: dict[str, Any] | None,
@@ -102,7 +117,7 @@ class BatchResultProcessor:
         agent_config: dict[str, Any] | None,
         exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
     ) -> BatchProcessingContext:
-        """Initialize processing context with configuration values."""
+        """Build the internal parsing context from caller parameters."""
         context_map = context_map or {}
 
         json_mode = get_default("json_mode")
@@ -129,26 +144,24 @@ class BatchResultProcessor:
 
         return ctx
 
-    def _stage_2_reconcile(self, ctx: BatchProcessingContext) -> BatchProcessingContext:
-        """Set up BatchResultReconciler for tracking processed vs missing records."""
-        ctx.reconciler = BatchResultReconciler(ctx.context_map)
-        return ctx
+    # -- Batch result processing -----------------------------------------------
 
-    def _stage_3_4_process_results(self, ctx: BatchProcessingContext) -> BatchProcessingContext:
-        """Process all batch results, handling both successes and errors."""
+    def _process_batch_results(self, ctx: BatchProcessingContext) -> list[ProcessingResult]:
+        """Process all batch results, returning one ProcessingResult per result."""
         if ctx.reconciler is None:
             raise RuntimeError(
                 "BatchProcessingContext.reconciler is None; "
-                "_stage_2_reconcile() must run before _stage_3_4_process_results()"
+                "reconciler must be initialized before processing results"
             )
+        results: list[ProcessingResult] = []
+
         for batch_result in ctx.batch_results:
             custom_id = str(batch_result.custom_id)
 
             if batch_result.success and batch_result.content is not None:
                 try:
-                    items = self._process_successful_result(ctx, batch_result, custom_id)
-                    ctx.processed_data.extend(items)
-                    ctx.success_count += len(items)
+                    result = self._process_successful_result(ctx, batch_result, custom_id)
+                    results.append(result)
                     ctx.reconciler.mark_processed(custom_id)
 
                     logger.debug(
@@ -156,22 +169,22 @@ class BatchResultProcessor:
                         extra={
                             "operation": "process_batch_item",
                             "custom_id": custom_id,
-                            "items_generated": len(items),
+                            "items_generated": len(result.data),
                             "success": True,
                         },
                     )
 
                 except Exception as e:
-                    error_item = self._create_error_item(
-                        ctx,
-                        custom_id,
-                        f"Processing error: {str(e)}",
-                        batch_result.metadata,
-                        batch_result.content,
-                        recovery_metadata=batch_result.recovery_metadata,
+                    results.append(
+                        self._build_error_result(
+                            ctx,
+                            custom_id,
+                            f"Processing error: {str(e)}",
+                            batch_result.metadata,
+                            batch_result.content,
+                            recovery_metadata=batch_result.recovery_metadata,
+                        )
                     )
-                    ctx.processed_data.append(error_item)
-                    ctx.error_count += 1
                     ctx.reconciler.mark_processed(custom_id)
 
                     logger.error(
@@ -185,15 +198,15 @@ class BatchResultProcessor:
                     )
 
             else:
-                error_item = self._create_error_item(
-                    ctx,
-                    custom_id,
-                    batch_result.error or "Batch processing failed",
-                    batch_result.metadata,
-                    recovery_metadata=batch_result.recovery_metadata,
+                results.append(
+                    self._build_error_result(
+                        ctx,
+                        custom_id,
+                        batch_result.error or "Batch processing failed",
+                        batch_result.metadata,
+                        recovery_metadata=batch_result.recovery_metadata,
+                    )
                 )
-                ctx.processed_data.append(error_item)
-                ctx.error_count += 1
                 ctx.reconciler.mark_processed(custom_id)
 
                 logger.error(
@@ -206,12 +219,15 @@ class BatchResultProcessor:
                     },
                 )
 
-        return ctx
+        return results
 
     def _process_successful_result(
-        self, ctx: BatchProcessingContext, batch_result: BatchResult, custom_id: str
-    ) -> list[dict[str, Any]]:
-        """Build agent output from successful batch result, delegating enrichment to EnrichmentPipeline."""
+        self,
+        ctx: BatchProcessingContext,
+        batch_result: BatchResult,
+        custom_id: str,
+    ) -> ProcessingResult:
+        """Parse a successful batch result into an enriched ProcessingResult."""
         if ctx.reconciler is None:
             raise RuntimeError(
                 "BatchProcessingContext.reconciler is None; "
@@ -230,7 +246,6 @@ class BatchResultProcessor:
             if custom_id in ctx.context_map:
                 generated_list = self._apply_context_passthrough(ctx, custom_id, generated_list)
             elif ctx.agent_config.get("context_scope", {}).get("passthrough"):
-                # Passthrough configured but custom_id missing from context_map
                 logger.warning(
                     "custom_id '%s' not found in context_map, skipping passthrough",
                     custom_id,
@@ -267,9 +282,7 @@ class BatchResultProcessor:
             recovery_metadata=batch_result.recovery_metadata,
         )
 
-        enriched = self._enrichment_pipeline.enrich(processing_result, processing_context)
-
-        return enriched.data
+        return self._enrichment_pipeline.enrich(processing_result, processing_context)
 
     def _apply_context_passthrough(
         self,
@@ -288,7 +301,9 @@ class BatchResultProcessor:
 
         return generated_list
 
-    def _create_error_item(
+    # -- Error / exhausted / unprocessed builders ------------------------------
+
+    def _build_error_result(
         self,
         ctx: BatchProcessingContext,
         custom_id: str,
@@ -296,8 +311,13 @@ class BatchResultProcessor:
         metadata: dict[str, Any] | None = None,
         raw_content: Any = None,
         recovery_metadata: RecoveryMetadata | None = None,
-    ) -> dict[str, Any]:
-        """Create an error item for failed batch results."""
+    ) -> ProcessingResult:
+        """Build a FAILED ProcessingResult for a batch error.
+
+        Error results carry the error dict in ``data`` so that downstream
+        ``write_record_dispositions()`` can still find and disposition them.
+        Error results are NOT enriched (matching the original pipeline behaviour).
+        """
         if ctx.reconciler is None:
             raise RuntimeError(
                 "BatchProcessingContext.reconciler is None; "
@@ -317,7 +337,13 @@ class BatchResultProcessor:
         if recovery_metadata:
             error_item["_recovery"] = recovery_metadata.to_dict()
 
-        return error_item
+        return ProcessingResult(
+            status=ProcessingStatus.FAILED,
+            data=[error_item],
+            source_guid=source_guid,
+            error=error_message,
+            recovery_metadata=recovery_metadata,
+        )
 
     def _create_exhausted_item(
         self,
@@ -332,8 +358,6 @@ class BatchResultProcessor:
                 "BatchProcessingContext.reconciler is None; "
                 "reconciler must be initialized before creating exhausted items"
             )
-        from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
-
         source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "NOT_SET")
 
         return ExhaustedRecordBuilder.build_exhausted_item(
@@ -341,19 +365,16 @@ class BatchResultProcessor:
             original_row=original_row,
             recovery_metadata=recovery_metadata,
             agent_config=ctx.agent_config or {},
-            action_name=ctx.agent_config.get("action_name", "") if ctx.agent_config else "",
+            action_name=(ctx.agent_config.get("action_name", "") if ctx.agent_config else ""),
         )
 
-    def _stage_6_merge_passthroughs(self, ctx: BatchProcessingContext) -> BatchProcessingContext:
-        """
-        Stage 6: Merge passthrough records for missing/skipped items.
+    # -- Passthrough reconciliation --------------------------------------------
 
-        Routes all passthrough/exhausted records through the EnrichmentPipeline
-        for consistent lineage, metadata, and version_correlation_id enrichment.
+    def _reconcile_passthroughs(self, ctx: BatchProcessingContext) -> list[ProcessingResult]:
+        """Reconcile missing/skipped records into ProcessingResult objects.
 
-        IMPORTANT: Exhausted retry records are treated differently from skipped records:
-        - Skipped records (guard/conditional): Passthrough with original content
-        - Exhausted retry records: Empty schema content + _recovery metadata
+        Routes exhausted-retry and passthrough records through enrichment
+        for consistent lineage, metadata, and version_correlation_id.
         """
         if ctx.reconciler is None:
             raise RuntimeError(
@@ -361,113 +382,137 @@ class BatchResultProcessor:
                 "reconciler must be initialized before merging passthroughs"
             )
         reconciliation = ctx.reconciler.reconcile()
+        results: list[ProcessingResult] = []
 
-        if reconciliation.passthrough_records:
-            for custom_id, original_row in reconciliation.passthrough_records:
-                is_exhausted = ctx.exhausted_recovery and custom_id in ctx.exhausted_recovery
+        if not reconciliation.passthrough_records:
+            return results
 
-                record_index = ctx.reconciler.get_record_index(custom_id)
-                source_guid = ctx.reconciler.get_source_guid(
-                    custom_id, fallback=custom_id or "NOT_SET"
+        for custom_id, original_row in reconciliation.passthrough_records:
+            is_exhausted = ctx.exhausted_recovery and custom_id in ctx.exhausted_recovery
+
+            record_index = ctx.reconciler.get_record_index(custom_id)
+            source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "NOT_SET")
+
+            if not ctx.agent_config or "action_name" not in ctx.agent_config:
+                raise ValueError("agent_config must contain 'action_name' for content namespacing")
+            action_name = ctx.agent_config["action_name"]
+
+            if is_exhausted:
+                result = self._build_exhausted_passthrough(
+                    ctx,
+                    custom_id,
+                    original_row,
+                    action_name,
+                    source_guid,
+                    record_index,
                 )
+            else:
+                result = self._build_unprocessed_passthrough(
+                    ctx,
+                    original_row,
+                    action_name,
+                    source_guid,
+                    record_index,
+                )
+            results.append(result)
 
-                if not ctx.agent_config or "action_name" not in ctx.agent_config:
-                    raise ValueError(
-                        "agent_config must contain 'action_name' for content namespacing"
-                    )
-                stage6_action_name = ctx.agent_config["action_name"]
+        return results
 
-                if is_exhausted:
-                    if ctx.exhausted_recovery is None:
-                        raise RuntimeError(
-                            "BatchProcessingContext.exhausted_recovery is None "
-                            "but record was identified as exhausted; "
-                            f"expected exhausted_recovery dict for custom_id={custom_id}"
-                        )
-                    on_exhausted = "return_last"  # default
-                    if ctx.agent_config:
-                        retry_config = ctx.agent_config.get("retry", {})
-                        on_exhausted = retry_config.get("on_exhausted", "return_last")
+    def _build_exhausted_passthrough(
+        self,
+        ctx: BatchProcessingContext,
+        custom_id: str,
+        original_row: dict[str, Any],
+        action_name: str,
+        source_guid: str,
+        record_index: int,
+    ) -> ProcessingResult:
+        """Build an enriched EXHAUSTED result for a retry-exhausted record."""
+        if ctx.exhausted_recovery is None:
+            raise RuntimeError(
+                "BatchProcessingContext.exhausted_recovery is None "
+                "but record was identified as exhausted; "
+                f"expected exhausted_recovery dict for custom_id={custom_id}"
+            )
+        on_exhausted = "return_last"  # default
+        if ctx.agent_config:
+            retry_config = ctx.agent_config.get("retry", {})
+            on_exhausted = retry_config.get("on_exhausted", "return_last")
 
-                    if on_exhausted == "raise":
-                        recovery_meta = ctx.exhausted_recovery[custom_id]
-                        if recovery_meta.retry is None:
-                            raise RuntimeError(
-                                "RecoveryMetadata.retry is None for exhausted record "
-                                f"custom_id={custom_id}; expected retry metadata"
-                            )
-                        raise RuntimeError(
-                            f"Retry exhausted for record {custom_id} after "
-                            f"{recovery_meta.retry.attempts} attempts (on_exhausted=raise)"
-                        )
+        if on_exhausted == "raise":
+            recovery_meta = ctx.exhausted_recovery[custom_id]
+            if recovery_meta.retry is None:
+                raise RuntimeError(
+                    "RecoveryMetadata.retry is None for exhausted record "
+                    f"custom_id={custom_id}; expected retry metadata"
+                )
+            raise RuntimeError(
+                f"Retry exhausted for record {custom_id} after "
+                f"{recovery_meta.retry.attempts} attempts (on_exhausted=raise)"
+            )
 
-                    recovery_meta = ctx.exhausted_recovery[custom_id]
-                    if recovery_meta.retry is None:
-                        raise RuntimeError(
-                            "RecoveryMetadata.retry is None for exhausted record "
-                            f"custom_id={custom_id}; expected retry metadata with attempt count"
-                        )
-                    empty_content = ExhaustedRecordBuilder.build_empty_content(
-                        ctx.agent_config or {}
-                    )
-                    exhausted_item = build_exhausted_tombstone(
-                        stage6_action_name,
-                        original_row,
-                        empty_content,
-                        source_guid=source_guid,
-                    )
+        recovery_meta = ctx.exhausted_recovery[custom_id]
+        if recovery_meta.retry is None:
+            raise RuntimeError(
+                "RecoveryMetadata.retry is None for exhausted record "
+                f"custom_id={custom_id}; expected retry metadata with attempt count"
+            )
+        empty_content = ExhaustedRecordBuilder.build_empty_content(ctx.agent_config or {})
+        exhausted_item = build_exhausted_tombstone(
+            action_name,
+            original_row,
+            empty_content,
+            source_guid=source_guid,
+        )
 
-                    processing_context = BatchContextAdapter.to_processing_context(
-                        agent_config=ctx.agent_config or {},
-                        original_row=original_row,
-                        record_index=record_index,
-                        output_directory=ctx.output_directory,
-                    )
-                    processing_result = ProcessingResult.exhausted(
-                        error=f"Retry exhausted after {recovery_meta.retry.attempts} attempts",
-                        data=[exhausted_item],
-                        source_guid=source_guid,
-                        recovery_metadata=recovery_meta,
-                    )
-                    enriched = self._enrichment_pipeline.enrich(
-                        processing_result, processing_context
-                    )
-                    ctx.processed_data.extend(enriched.data)
-                    ctx.error_count += 1
-                else:
-                    # Determine actual skip reason from context metadata
-                    filter_phase = original_row.get(ContextMetaKeys.FILTER_PHASE, "")
-                    if filter_phase == "upstream_unprocessed":
-                        reason = "upstream_unprocessed"
-                    elif (
-                        BatchContextMetadata.get_filter_status(original_row) == FilterStatus.SKIPPED
-                    ):
-                        reason = "guard_skipped"
-                    else:
-                        reason = "batch_not_returned"
+        processing_context = BatchContextAdapter.to_processing_context(
+            agent_config=ctx.agent_config or {},
+            original_row=original_row,
+            record_index=record_index,
+            output_directory=ctx.output_directory,
+        )
+        processing_result = ProcessingResult.exhausted(
+            error=f"Retry exhausted after {recovery_meta.retry.attempts} attempts",
+            data=[exhausted_item],
+            source_guid=source_guid,
+            recovery_metadata=recovery_meta,
+        )
+        return self._enrichment_pipeline.enrich(processing_result, processing_context)
 
-                    passthrough_item = build_tombstone(
-                        stage6_action_name,
-                        original_row,
-                        reason,
-                        source_guid=source_guid,
-                    )
+    def _build_unprocessed_passthrough(
+        self,
+        ctx: BatchProcessingContext,
+        original_row: dict[str, Any],
+        action_name: str,
+        source_guid: str,
+        record_index: int,
+    ) -> ProcessingResult:
+        """Build an enriched UNPROCESSED result for a passthrough record."""
+        # Determine actual skip reason from context metadata
+        filter_phase = original_row.get(ContextMetaKeys.FILTER_PHASE, "")
+        if filter_phase == "upstream_unprocessed":
+            reason = "upstream_unprocessed"
+        elif BatchContextMetadata.get_filter_status(original_row) == FilterStatus.SKIPPED:
+            reason = "guard_skipped"
+        else:
+            reason = "batch_not_returned"
 
-                    processing_context = BatchContextAdapter.to_processing_context(
-                        agent_config=ctx.agent_config or {},
-                        original_row=original_row,
-                        record_index=record_index,
-                        output_directory=ctx.output_directory,
-                    )
-                    processing_result = ProcessingResult.unprocessed(
-                        data=[passthrough_item],
-                        reason=reason,
-                        source_guid=source_guid,
-                    )
-                    enriched = self._enrichment_pipeline.enrich(
-                        processing_result, processing_context
-                    )
-                    ctx.processed_data.extend(enriched.data)
-                    ctx.passthrough_count += 1
+        passthrough_item = build_tombstone(
+            action_name,
+            original_row,
+            reason,
+            source_guid=source_guid,
+        )
 
-        return ctx
+        processing_context = BatchContextAdapter.to_processing_context(
+            agent_config=ctx.agent_config or {},
+            original_row=original_row,
+            record_index=record_index,
+            output_directory=ctx.output_directory,
+        )
+        processing_result = ProcessingResult.unprocessed(
+            data=[passthrough_item],
+            reason=reason,
+            source_guid=source_guid,
+        )
+        return self._enrichment_pipeline.enrich(processing_result, processing_context)

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -26,10 +26,10 @@ from agent_actions.llm.batch.infrastructure.recovery_state import (
 from agent_actions.llm.batch.infrastructure.registry import (
     BatchRegistryManager,
 )
-from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
-from agent_actions.llm.batch.processing.result_processor import (
-    BatchResultProcessor,
+from agent_actions.llm.batch.processing.batch_result_strategy import (
+    BatchResultStrategy,
 )
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.batch.services.processing_recovery import (
     check_and_submit_reprompt as _check_and_submit_reprompt_impl,
 )
@@ -63,7 +63,7 @@ class BatchProcessingService:
         self,
         client_resolver: BatchClientResolver,
         context_manager: BatchContextManager,
-        result_processor: BatchResultProcessor,
+        result_processor: BatchResultStrategy,
         registry_manager_factory: Callable[[str], BatchRegistryManager],
         source_handler: Any | None = None,
         action_indices: dict[str, int] | None = None,
@@ -672,13 +672,15 @@ class BatchProcessingService:
         Returns:
             Processed results in workflow format
         """
-        return self._result_processor.process(
+        results = self._result_processor.process(
             batch_results=batch_results,
             context_map=context_map,
             output_directory=output_directory,
             agent_config=agent_config,
             exhausted_recovery=exhausted_recovery,
         )
+        # Flatten ProcessingResult objects to workflow-format dicts.
+        return [item for result in results for item in (result.data or [])]
 
     @staticmethod
     def _apply_workflow_session_id(

--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -29,7 +29,7 @@ Single authority for record content assembly. Every action type, granularity, an
 | **Depended on by** | `llm/providers/tools/client.py` | TrackedItem preservation in `_strip_internal_fields` |
 | **Depended on by** | `processing/record_processor.py` | (Phase 2) tombstone builder |
 | **Depended on by** | `processing/exhausted_builder.py` | (Phase 2) exhausted record builder |
-| **Depended on by** | `llm/batch/processing/result_processor.py` | (Phase 2) batch result assembly |
+| **Depended on by** | `llm/batch/processing/batch_result_strategy.py` | (Phase 2) batch result assembly |
 | **Depended on by** | `workflow/managers/loop.py` | (Phase 2) version correlator |
 
 ## Notes

--- a/agent_actions/workflow/service_init.py
+++ b/agent_actions/workflow/service_init.py
@@ -106,11 +106,11 @@ def initialize_services(
     )
     from agent_actions.llm.batch.infrastructure.context import BatchContextManager
     from agent_actions.llm.batch.infrastructure.job_manager import BatchJobManager
-    from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
+    from agent_actions.llm.batch.processing.batch_result_strategy import BatchResultStrategy
     from agent_actions.llm.batch.service import create_registry_manager_factory
     from agent_actions.llm.batch.services.processing import BatchProcessingService
 
-    result_processor = BatchResultProcessor()
+    result_processor = BatchResultStrategy()
     context_manager = BatchContextManager()
     client_resolver = BatchClientResolver(client_cache={}, default_client=None)
     source_handler = BatchSourceHandler()

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -263,11 +263,13 @@ class TestEnrichmentUnprocessed:
 
 
 class TestBatchPathReasonDetection:
-    """Tests for three-way reason branching in BatchResultProcessor._stage_6_merge_passthroughs."""
+    """Tests for three-way reason branching in BatchResultStrategy._reconcile_passthroughs."""
 
     def _make_ctx(self, passthrough_records):
         """Build a minimal BatchProcessingContext with mocked reconciler."""
-        from agent_actions.llm.batch.processing.result_processor import BatchProcessingContext
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchProcessingContext,
+        )
 
         reconciliation = MagicMock()
         reconciliation.passthrough_records = passthrough_records
@@ -289,7 +291,9 @@ class TestBatchPathReasonDetection:
     def test_upstream_unprocessed_reason(self):
         """Records with FILTER_PHASE=upstream_unprocessed get reason=upstream_unprocessed."""
         from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys
-        from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchResultStrategy,
+        )
 
         row = {
             "content": {"upstream_action": {"field": "value"}},
@@ -297,11 +301,11 @@ class TestBatchPathReasonDetection:
             ContextMetaKeys.FILTER_PHASE: "upstream_unprocessed",
         }
         ctx = self._make_ctx(passthrough_records=[("cid_1", row)])
-        processor = BatchResultProcessor()
-        result_ctx = processor._stage_6_merge_passthroughs(ctx)
+        processor = BatchResultStrategy()
+        results = processor._reconcile_passthroughs(ctx)
 
-        assert len(result_ctx.processed_data) >= 1
-        item = result_ctx.processed_data[0]
+        assert len(results) >= 1
+        item = results[0].data[0]
         assert item["metadata"]["reason"] == "upstream_unprocessed"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
@@ -312,16 +316,18 @@ class TestBatchPathReasonDetection:
         """Records with SKIPPED filter status get reason=guard_skipped."""
         from agent_actions.llm.batch.core.batch_constants import FilterStatus
         from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
-        from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchResultStrategy,
+        )
 
         row = {"content": {"prev": {"x": 1}}, "source_guid": "sg_batch_2"}
         BatchContextMetadata.set_filter_status(row, FilterStatus.SKIPPED)
         ctx = self._make_ctx(passthrough_records=[("cid_2", row)])
-        processor = BatchResultProcessor()
-        result_ctx = processor._stage_6_merge_passthroughs(ctx)
+        processor = BatchResultStrategy()
+        results = processor._reconcile_passthroughs(ctx)
 
-        assert len(result_ctx.processed_data) >= 1
-        item = result_ctx.processed_data[0]
+        assert len(results) >= 1
+        item = results[0].data[0]
         assert item["metadata"]["reason"] == "guard_skipped"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
@@ -329,15 +335,17 @@ class TestBatchPathReasonDetection:
 
     def test_batch_not_returned_reason(self):
         """Records without filter metadata get reason=batch_not_returned."""
-        from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchResultStrategy,
+        )
 
         row = {"content": {"prev": {"x": 1}}, "source_guid": "sg_batch_3"}
         ctx = self._make_ctx(passthrough_records=[("cid_3", row)])
-        processor = BatchResultProcessor()
-        result_ctx = processor._stage_6_merge_passthroughs(ctx)
+        processor = BatchResultStrategy()
+        results = processor._reconcile_passthroughs(ctx)
 
-        assert len(result_ctx.processed_data) >= 1
-        item = result_ctx.processed_data[0]
+        assert len(results) >= 1
+        item = results[0].data[0]
         assert item["metadata"]["reason"] == "batch_not_returned"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
@@ -346,7 +354,9 @@ class TestBatchPathReasonDetection:
     def test_upstream_unprocessed_uses_unprocessed_status(self):
         """upstream_unprocessed records should use ProcessingResult.unprocessed(), not .skipped()."""
         from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys
-        from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchResultStrategy,
+        )
 
         row = {
             "content": {"upstream": {"data": "stale"}},
@@ -354,7 +364,7 @@ class TestBatchPathReasonDetection:
             ContextMetaKeys.FILTER_PHASE: "upstream_unprocessed",
         }
         ctx = self._make_ctx(passthrough_records=[("cid_4", row)])
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         # Patch enrich to capture the ProcessingResult type
         captured_results = []
@@ -365,18 +375,20 @@ class TestBatchPathReasonDetection:
             return original_enrich(result, context)
 
         processor._enrichment_pipeline.enrich = capturing_enrich
-        processor._stage_6_merge_passthroughs(ctx)
+        processor._reconcile_passthroughs(ctx)
 
         assert len(captured_results) == 1
         assert captured_results[0].status == ProcessingStatus.UNPROCESSED
 
     def test_batch_not_returned_uses_unprocessed_status(self):
         """batch_not_returned records should use ProcessingResult.unprocessed(), not .skipped()."""
-        from agent_actions.llm.batch.processing.result_processor import BatchResultProcessor
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchResultStrategy,
+        )
 
         row = {"content": {"prev": {"x": 1}}, "source_guid": "sg_batch_5"}
         ctx = self._make_ctx(passthrough_records=[("cid_5", row)])
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         captured_results = []
         original_enrich = processor._enrichment_pipeline.enrich
@@ -386,7 +398,7 @@ class TestBatchPathReasonDetection:
             return original_enrich(result, context)
 
         processor._enrichment_pipeline.enrich = capturing_enrich
-        processor._stage_6_merge_passthroughs(ctx)
+        processor._reconcile_passthroughs(ctx)
 
         assert len(captured_results) == 1
         assert captured_results[0].status == ProcessingStatus.UNPROCESSED

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -304,7 +304,7 @@ class TestBatchPathReasonDetection:
         processor = BatchResultStrategy()
         results = processor._reconcile_passthroughs(ctx)
 
-        assert len(results) >= 1
+        assert len(results) == 1
         item = results[0].data[0]
         assert item["metadata"]["reason"] == "upstream_unprocessed"
         assert item["metadata"]["agent_type"] == "tombstone"
@@ -326,7 +326,7 @@ class TestBatchPathReasonDetection:
         processor = BatchResultStrategy()
         results = processor._reconcile_passthroughs(ctx)
 
-        assert len(results) >= 1
+        assert len(results) == 1
         item = results[0].data[0]
         assert item["metadata"]["reason"] == "guard_skipped"
         assert item["metadata"]["agent_type"] == "tombstone"
@@ -344,7 +344,7 @@ class TestBatchPathReasonDetection:
         processor = BatchResultStrategy()
         results = processor._reconcile_passthroughs(ctx)
 
-        assert len(results) >= 1
+        assert len(results) == 1
         item = results[0].data[0]
         assert item["metadata"]["reason"] == "batch_not_returned"
         assert item["metadata"]["agent_type"] == "tombstone"

--- a/tests/unit/llm/batch/test_batch_passthrough_stored.py
+++ b/tests/unit/llm/batch/test_batch_passthrough_stored.py
@@ -8,9 +8,9 @@ generated items.
 from typing import Any
 
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
-from agent_actions.llm.batch.processing.result_processor import (
+from agent_actions.llm.batch.processing.batch_result_strategy import (
     BatchProcessingContext,
-    BatchResultProcessor,
+    BatchResultStrategy,
 )
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -49,7 +49,7 @@ class TestStoredPassthroughMerge:
         entry = _make_context_map_entry()
         BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "AI overview"}])
 
@@ -67,7 +67,7 @@ class TestStoredPassthroughMerge:
             },
         )
         ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
 
@@ -79,7 +79,7 @@ class TestStoredPassthroughMerge:
         entry = _make_context_map_entry()
         BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(
             ctx, "rec_001", [{"item": 1}, {"item": 2}, {"item": 3}]
@@ -101,7 +101,7 @@ class TestStoredPassthroughEdgeCases:
         entry = _make_context_map_entry()
         BatchContextMetadata.set_passthrough_fields(entry, {})
         ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
 
@@ -111,7 +111,7 @@ class TestStoredPassthroughEdgeCases:
         """When no passthrough was stored at all, generated items are unchanged."""
         entry = _make_context_map_entry()
         ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
 
@@ -122,7 +122,7 @@ class TestStoredPassthroughEdgeCases:
         entry = _make_context_map_entry()
         BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(
             ctx, "rec_001", [{"summary": "test"}, "raw_string", 42]
@@ -137,7 +137,7 @@ class TestStoredPassthroughEdgeCases:
         entry = _make_context_map_entry()
         BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
         ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(ctx, "rec_001", [])
 
@@ -151,7 +151,7 @@ class TestStoredPassthroughEdgeCases:
             context_map={"rec_001": entry},
             agent_config={"action_name": "test"},
         )
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         result = processor._apply_context_passthrough(ctx, "rec_001", [{"output": "val"}])
 

--- a/tests/unit/llm/batch/test_result_processor_version_merge.py
+++ b/tests/unit/llm/batch/test_result_processor_version_merge.py
@@ -1,9 +1,9 @@
-"""Tests for version_merge branching in batch result processor.
+"""Tests for version_merge branching in batch result strategy.
 
 kind:llm with version_consumption must wrap output under action_name namespace.
 kind:tool with version_consumption flat-spreads into existing content.
 
-The guard at result_processor.py:244-245 ensures only TOOL actions get flat spread.
+The guard at record_helpers.py ensures only TOOL actions get flat spread.
 If someone removes the `and is_tool` guard, LLM actions would silently corrupt
 the content namespace structure.
 """
@@ -13,11 +13,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
-from agent_actions.llm.batch.processing.result_processor import (
+from agent_actions.llm.batch.processing.batch_result_strategy import (
     BatchProcessingContext,
-    BatchResultProcessor,
+    BatchResultStrategy,
 )
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.providers.batch_base import BatchResult
 
 
@@ -39,8 +39,8 @@ def _make_ctx(
 
 @pytest.fixture
 def processor():
-    """BatchResultProcessor with enrichment pipeline stubbed to pass through."""
-    p = BatchResultProcessor()
+    """BatchResultStrategy with enrichment pipeline stubbed to pass through."""
+    p = BatchResultStrategy()
     p._enrichment_pipeline = MagicMock()
     p._enrichment_pipeline.enrich.side_effect = lambda result, context: result
     return p
@@ -73,8 +73,8 @@ class TestLLMVersionMergeWrapsUnderActionName:
 
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 
-        assert len(result) == 1
-        content = result[0]["content"]
+        assert len(result.data) == 1
+        content = result.data[0]["content"]
         assert content["aggregate"] == {"decision": "keep", "reason": "majority vote"}
         assert content["source"] == {"url": "http://example.com"}
         assert content["voter_1"] == {"vote": "keep"}
@@ -110,8 +110,8 @@ class TestToolVersionMergeFlatSpreads:
 
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 
-        assert len(result) == 1
-        content = result[0]["content"]
+        assert len(result.data) == 1
+        content = result.data[0]["content"]
         assert content["final_decision"] == "keep"
         assert content["confidence"] == 0.8
         assert content["source"] == {"url": "http://example.com"}
@@ -142,7 +142,7 @@ class TestNoVersionMergeWrapsNormally:
 
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 
-        content = result[0]["content"]
+        content = result.data[0]["content"]
         assert content["classify"] == {"category": "tech"}
         assert content["source"] == {"url": "http://example.com"}
         assert "category" not in content
@@ -167,6 +167,6 @@ class TestNoVersionMergeWrapsNormally:
 
         result = processor._process_successful_result(ctx, batch_result, custom_id)
 
-        content = result[0]["content"]
+        content = result.data[0]["content"]
         assert content["extract"] == {"entities": ["AI", "ML"]}
         assert "entities" not in content

--- a/tests/unit/llm/batch/test_result_processor_version_merge.py
+++ b/tests/unit/llm/batch/test_result_processor_version_merge.py
@@ -170,3 +170,72 @@ class TestNoVersionMergeWrapsNormally:
         content = result.data[0]["content"]
         assert content["extract"] == {"entities": ["AI", "ML"]}
         assert "entities" not in content
+
+
+class TestProcessReturnsFlattenableResults:
+    """BatchResultStrategy.process() returns list[ProcessingResult] that flatten correctly."""
+
+    def test_process_returns_processing_results(self):
+        """process() returns ProcessingResult objects, not raw dicts."""
+        from agent_actions.processing.types import ProcessingStatus
+
+        custom_id = "rec_001"
+        original_row = {
+            "source_guid": "src_001",
+            "content": {"source": {"url": "http://example.com"}},
+        }
+        agent_config = {"action_name": "classify", "kind": "llm"}
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content={"category": "tech"},
+            success=True,
+        )
+
+        strategy = BatchResultStrategy()
+        strategy._enrichment_pipeline = MagicMock()
+        strategy._enrichment_pipeline.enrich.side_effect = lambda result, ctx: result
+
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map={custom_id: original_row},
+            agent_config=agent_config,
+        )
+
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS
+        assert len(results[0].data) == 1
+        assert results[0].data[0]["content"]["classify"] == {"category": "tech"}
+
+        # Verify flatten produces the same dicts the caller extracts
+        flat = [item for r in results for item in (r.data or [])]
+        assert len(flat) == 1
+        assert flat[0]["content"]["classify"] == {"category": "tech"}
+        assert flat[0]["source_guid"] == "src_001"
+
+    def test_process_error_result_flattens_with_error_key(self):
+        """Failed batch results produce ProcessingResult with error dict in data."""
+        from agent_actions.processing.types import ProcessingStatus
+
+        custom_id = "rec_err"
+        original_row = {"source_guid": "src_err", "content": {}}
+        agent_config = {"action_name": "classify", "kind": "llm"}
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content=None,
+            success=False,
+            error="API timeout",
+        )
+
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map={custom_id: original_row},
+            agent_config=agent_config,
+        )
+
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.FAILED
+        flat = [item for r in results for item in (r.data or [])]
+        assert len(flat) == 1
+        assert flat[0]["error"] == "API timeout"
+        assert flat[0]["source_guid"] == "src_err"

--- a/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
+++ b/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
@@ -28,9 +28,9 @@ class TestCreateExhaustedItemActionName:
 
     def test_action_name_propagated_from_agent_config(self):
         """action_name from agent_config flows into the exhausted item's node_id."""
-        from agent_actions.llm.batch.processing.result_processor import (
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchProcessingContext,
-            BatchResultProcessor,
+            BatchResultStrategy,
         )
 
         ctx = BatchProcessingContext(
@@ -45,7 +45,7 @@ class TestCreateExhaustedItemActionName:
         recovery = RecoveryMetadata(
             retry=RetryMetadata(attempts=3, failures=3, succeeded=False, reason="api_error")
         )
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         item = processor._create_exhausted_item(ctx, "custom-1", {"text": "hello"}, recovery)
 
@@ -57,9 +57,9 @@ class TestCreateExhaustedItemActionName:
 
     def test_action_name_missing_raises(self):
         """When agent_config has no action_name, RecordEnvelopeError is raised (empty names are banned)."""
-        from agent_actions.llm.batch.processing.result_processor import (
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchProcessingContext,
-            BatchResultProcessor,
+            BatchResultStrategy,
         )
         from agent_actions.record.envelope import RecordEnvelopeError
 
@@ -75,16 +75,16 @@ class TestCreateExhaustedItemActionName:
         recovery = RecoveryMetadata(
             retry=RetryMetadata(attempts=2, failures=2, succeeded=False, reason="timeout")
         )
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         with pytest.raises(RecordEnvelopeError, match="action_name is required"):
             processor._create_exhausted_item(ctx, "custom-2", {"text": "world"}, recovery)
 
     def test_action_name_missing_when_agent_config_is_none_raises(self):
         """When agent_config is None, RecordEnvelopeError is raised (empty names are banned)."""
-        from agent_actions.llm.batch.processing.result_processor import (
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchProcessingContext,
-            BatchResultProcessor,
+            BatchResultStrategy,
         )
         from agent_actions.record.envelope import RecordEnvelopeError
 
@@ -100,7 +100,7 @@ class TestCreateExhaustedItemActionName:
         recovery = RecoveryMetadata(
             retry=RetryMetadata(attempts=1, failures=1, succeeded=False, reason="network_error")
         )
-        processor = BatchResultProcessor()
+        processor = BatchResultStrategy()
 
         with pytest.raises(RecordEnvelopeError, match="action_name is required"):
             processor._create_exhausted_item(ctx, "custom-3", {"text": "data"}, recovery)

--- a/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
+++ b/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
@@ -23,87 +23,65 @@ _RB = "agent_actions.output.response.response_builder"
 # =============================================================================
 
 
-class TestCreateExhaustedItemActionName:
-    """_create_exhausted_item must pass action_name to ExhaustedRecordBuilder."""
+class TestExhaustedRecordBuilderActionName:
+    """ExhaustedRecordBuilder.build_exhausted_item validates action_name propagation."""
 
     def test_action_name_propagated_from_agent_config(self):
         """action_name from agent_config flows into the exhausted item's node_id."""
-        from agent_actions.llm.batch.processing.batch_result_strategy import (
-            BatchProcessingContext,
-            BatchResultStrategy,
-        )
-
-        ctx = BatchProcessingContext(
-            batch_results=[],
-            context_map={},
-            output_directory=None,
-            agent_config={"action_name": "classify_sentiment"},
-        )
-        ctx.reconciler = MagicMock()
-        ctx.reconciler.get_source_guid.return_value = "sg-123"
+        from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 
         recovery = RecoveryMetadata(
             retry=RetryMetadata(attempts=3, failures=3, succeeded=False, reason="api_error")
         )
-        processor = BatchResultStrategy()
 
-        item = processor._create_exhausted_item(ctx, "custom-1", {"text": "hello"}, recovery)
+        item = ExhaustedRecordBuilder.build_exhausted_item(
+            source_guid="sg-123",
+            original_row={"text": "hello"},
+            recovery_metadata=recovery,
+            agent_config={"action_name": "classify_sentiment"},
+            action_name="classify_sentiment",
+        )
 
-        # node_id is generated from action_name — verify it contains the action name
         assert item["node_id"].startswith("classify_sentiment_")
         assert item["source_guid"] == "sg-123"
         assert item["metadata"]["retry_exhausted"] is True
         assert item["_unprocessed"] is True
 
     def test_action_name_missing_raises(self):
-        """When agent_config has no action_name, RecordEnvelopeError is raised (empty names are banned)."""
-        from agent_actions.llm.batch.processing.batch_result_strategy import (
-            BatchProcessingContext,
-            BatchResultStrategy,
-        )
+        """When action_name is empty, RecordEnvelopeError is raised."""
+        from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
         from agent_actions.record.envelope import RecordEnvelopeError
-
-        ctx = BatchProcessingContext(
-            batch_results=[],
-            context_map={},
-            output_directory=None,
-            agent_config={"model_vendor": "openai"},  # no action_name
-        )
-        ctx.reconciler = MagicMock()
-        ctx.reconciler.get_source_guid.return_value = "sg-456"
 
         recovery = RecoveryMetadata(
             retry=RetryMetadata(attempts=2, failures=2, succeeded=False, reason="timeout")
         )
-        processor = BatchResultStrategy()
 
         with pytest.raises(RecordEnvelopeError, match="action_name is required"):
-            processor._create_exhausted_item(ctx, "custom-2", {"text": "world"}, recovery)
+            ExhaustedRecordBuilder.build_exhausted_item(
+                source_guid="sg-456",
+                original_row={"text": "world"},
+                recovery_metadata=recovery,
+                agent_config={"model_vendor": "openai"},
+                action_name="",
+            )
 
-    def test_action_name_missing_when_agent_config_is_none_raises(self):
-        """When agent_config is None, RecordEnvelopeError is raised (empty names are banned)."""
-        from agent_actions.llm.batch.processing.batch_result_strategy import (
-            BatchProcessingContext,
-            BatchResultStrategy,
-        )
+    def test_action_name_empty_when_agent_config_is_none_raises(self):
+        """When action_name is empty (derived from None config), RecordEnvelopeError is raised."""
+        from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
         from agent_actions.record.envelope import RecordEnvelopeError
-
-        ctx = BatchProcessingContext(
-            batch_results=[],
-            context_map={},
-            output_directory=None,
-            agent_config=None,
-        )
-        ctx.reconciler = MagicMock()
-        ctx.reconciler.get_source_guid.return_value = "sg-789"
 
         recovery = RecoveryMetadata(
             retry=RetryMetadata(attempts=1, failures=1, succeeded=False, reason="network_error")
         )
-        processor = BatchResultStrategy()
 
         with pytest.raises(RecordEnvelopeError, match="action_name is required"):
-            processor._create_exhausted_item(ctx, "custom-3", {"text": "data"}, recovery)
+            ExhaustedRecordBuilder.build_exhausted_item(
+                source_guid="sg-789",
+                original_row={"text": "data"},
+                recovery_metadata=recovery,
+                agent_config={},
+                action_name="",
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Extract batch result processing from `BatchResultProcessor` (6-stage mutable pipeline) into `BatchResultStrategy` that returns typed `list[ProcessingResult]`
- Delete `result_processor.py` entirely — all logic moved to `batch_result_strategy.py`
- Caller in `processing.py` flattens `ProcessingResult` objects to dicts for backward compatibility with `write_record_dispositions()`
- Migrate 4 test files to new imports and return-type assertions

## Verification
- 6078 tests pass, 2 skipped
- ruff format clean, ruff check clean
- `result_processor.py` deleted (0 lines)
- Disposition writing unchanged — `write_record_dispositions()` still operates on flattened dicts