### PR TITLE
fix: normalize batch guard-skip reason string and fix UI detection

### DIFF
--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -464,7 +464,7 @@ class BatchResultStrategy:
         if filter_phase == "upstream_unprocessed":
             reason = "upstream_unprocessed"
         elif BatchContextMetadata.get_filter_status(original_row) == FilterStatus.SKIPPED:
-            reason = "guard_skipped"
+            reason = "guard_skip"
         else:
             reason = "batch_not_returned"
 

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -500,9 +500,12 @@ export function getDisplayFields(record: Record<string, unknown>): Record<string
 export function DataCard({ record, index, fontSize, defaultOpen = true, actionInfo }: DataCardProps) {
   const [recordOpen, setRecordOpen] = useState(defaultOpen)
   const displayRecord = getDisplayFields(record)
-  // After namespace unwrap, all displayRecord keys are user content — classifyField
-  // is not used here because a user field named "metadata" is content, not framework metadata.
-  const guardSkipped = Object.values(displayRecord).every(v => v === null)
+  const recordMetadata = record.metadata as Record<string, unknown> | undefined
+  const tombstoneReason = typeof recordMetadata === "object" && recordMetadata !== null
+    ? recordMetadata.reason as string | undefined
+    : undefined
+  const guardSkipped = tombstoneReason === "guard_skip"
+  const upstreamUnprocessed = tombstoneReason === "upstream_unprocessed"
   const { identity, metadata } = classifyRecord(record)
 
   const outputFields = Object.entries(displayRecord)
@@ -573,7 +576,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true, actionIn
         )}
         {!recordOpen && (
           <span className="text-[10px] text-foreground/50 ml-auto">
-            {guardSkipped ? "guard skipped" : `${trace ? "trace + " : ""}${plural(outputFields.length, "field")}`}
+            {guardSkipped ? "guard skipped" : upstreamUnprocessed ? "upstream unprocessed" : `${trace ? "trace + " : ""}${plural(outputFields.length, "field")}`}
           </span>
         )}
       </button>
@@ -687,19 +690,23 @@ export function DataCard({ record, index, fontSize, defaultOpen = true, actionIn
       )}
 
       {/* Section 3: Action Output */}
-      {(outputFields.length > 0 || guardSkipped) && (
+      {(outputFields.length > 0 || guardSkipped || upstreamUnprocessed) && (
         <CollapsibleSection
           label="Action Output"
 
-          hint={guardSkipped ? "guard skipped" : plural(outputFields.length, "field")}
+          hint={guardSkipped ? "guard skipped" : upstreamUnprocessed ? "upstream unprocessed" : plural(outputFields.length, "field")}
           open={sec.actionOutput}
           onToggle={() => toggle("actionOutput")}
-          copyText={guardSkipped ? undefined : outputJson}
+          copyText={guardSkipped || upstreamUnprocessed ? undefined : outputJson}
         >
           <div className="pb-2 pl-4">
             {guardSkipped ? (
               <div className="px-4 pb-3 text-xs text-muted-foreground italic">
                 Guard skipped — no output produced
+              </div>
+            ) : upstreamUnprocessed ? (
+              <div className="px-4 pb-3 text-xs text-muted-foreground italic">
+                Upstream failure — no output produced
               </div>
             ) : (
               outputFields.map((f) => {
@@ -730,7 +737,7 @@ export function DataCard({ record, index, fontSize, defaultOpen = true, actionIn
         </CollapsibleSection>
       )}
 
-      {outputFields.length === 0 && !guardSkipped && (
+      {outputFields.length === 0 && !guardSkipped && !upstreamUnprocessed && (
         <div className="px-4 pb-3 text-xs text-muted-foreground italic">No content fields</div>
       )}
 

--- a/tests/simulation/simulate_batch_resubmission.py
+++ b/tests/simulation/simulate_batch_resubmission.py
@@ -442,7 +442,7 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
             {
                 "content": {"text": f"Record {i} content", "category": f"cat-{i % 3}"},
                 "source_guid": f"sg-{i:03d}",
-                "metadata": {"reason": "guard_skipped", "agent_type": "tombstone"},
+                "metadata": {"reason": "guard_skip", "agent_type": "tombstone"},
                 "_unprocessed": True,
             }
         )
@@ -483,9 +483,9 @@ def run_reconciliation_scenarios() -> tuple[int, int]:
     for sg in expected_passthrough_guids:
         reason = storage._dispositions.get(("my_action", sg, DISPOSITION_PASSTHROUGH))
         check(
-            reason == "guard_skipped",
-            f"{sg} disposition reason is 'guard_skipped'",
-            f"{sg} reason is '{reason}', expected 'guard_skipped'",
+            reason == "guard_skip",
+            f"{sg} disposition reason is 'guard_skip'",
+            f"{sg} reason is '{reason}', expected 'guard_skip'",
         )
 
     # Verify: consolidated output has all 10 records

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -313,7 +313,7 @@ class TestBatchPathReasonDetection:
         assert item["content"]["upstream_action"] == {"field": "value"}
 
     def test_guard_skipped_reason(self):
-        """Records with SKIPPED filter status get reason=guard_skipped."""
+        """Records with SKIPPED filter status get reason=guard_skip."""
         from agent_actions.llm.batch.core.batch_constants import FilterStatus
         from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
         from agent_actions.llm.batch.processing.batch_result_strategy import (
@@ -328,7 +328,7 @@ class TestBatchPathReasonDetection:
 
         assert len(results) == 1
         item = results[0].data[0]
-        assert item["metadata"]["reason"] == "guard_skipped"
+        assert item["metadata"]["reason"] == "guard_skip"
         assert item["metadata"]["agent_type"] == "tombstone"
         assert item.get("_unprocessed") is True
         assert item["content"]["test_batch"] is None


### PR DESCRIPTION
## Summary
- Batch path used `"guard_skipped"` while online path uses `"guard_skip"`, causing guard-skipped records to cascade as `upstream_unprocessed` in batch mode — silently dropping valid records from the downstream chain
- UI detected guard skips via all-null heuristic (`Object.values(displayRecord).every(v => v === null)`) which incorrectly matched upstream_unprocessed tombstones too. Now uses `metadata.reason` for accurate detection
- UI now shows distinct messages: "Guard skipped — no output produced" vs "Upstream failure — no output produced"

## Changes
- `batch_result_strategy.py:467`: `"guard_skipped"` → `"guard_skip"` (matches online path and `_is_upstream_unprocessed` detector)
- `data-card.tsx`: Replace all-null heuristic with `record.metadata.reason` check; add `upstreamUnprocessed` state with separate UI message
- Updated test assertions in `test_upstream_unprocessed_filter.py` and `simulate_batch_resubmission.py`

## Verification
- `pytest` — 6132 passed, 2 skipped
- `ruff format --check` / `ruff check` — clean on changed files
- `npm run build` (frontend) — compiled successfully
- Pre-existing circular import in `test_upstream_unprocessed_filter.py` confirmed on clean main (not introduced by this PR)