### PR TITLE
refactor: migrate pipeline dispatch to UnifiedProcessor

### DIFF
--- a/.changes/unreleased/Under the Hood-20260429-309000.yaml
+++ b/.changes/unreleased/Under the Hood-20260429-309000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Migrate pipeline dispatch to UnifiedProcessor — collapse 3-way FILE/HITL/RECORD dispatch into strategy selection + single process() call"
+time: 2026-04-29T30:90:00.000000Z

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.processing.helpers import run_dynamic_agent
@@ -20,9 +20,6 @@ from agent_actions.workflow.pipeline_file_mode import (
     reconcile_outputs,
 )
 
-if TYPE_CHECKING:
-    from agent_actions.processing.enrichment import EnrichmentPipeline
-
 logger = logging.getLogger(__name__)
 
 
@@ -34,22 +31,28 @@ class FileToolStrategy:
     framework reconciles output to input via ``TrackedItem._source_index``
     (for N->N list returns) or ``FileUDFResult.source_index`` (for N->M
     transforms).  Plain dicts in list returns are an error.
-    """
 
-    def __init__(self, enrichment_pipeline: EnrichmentPipeline) -> None:
-        self.enrichment_pipeline = enrichment_pipeline
+    Conforms to the ``ProcessingStrategy`` protocol so it can be used
+    with ``UnifiedProcessor.process()``.  Enrichment is handled by the
+    processor, not by this strategy.
+    """
 
     def invoke(
         self,
-        data: list[dict],
-        original_data: list[dict],
+        records: list[dict[str, Any]],
         context: ProcessingContext,
     ) -> list[ProcessingResult]:
-        """Invoke a FILE-mode tool and reconcile outputs."""
+        """Invoke a FILE-mode tool and reconcile outputs.
+
+        ``context.source_data`` must contain the pre-context-scope records
+        that passed the guard filter (set by UnifiedProcessor before
+        invoking the strategy).  These are used for output reconciliation.
+        """
+        original_data = context.source_data
         try:
             context_scope = context.agent_config.get("context_scope") or {}
             clean_input: list[TrackedItem] = []
-            for i, record in enumerate(data):
+            for i, record in enumerate(records):
                 business = extract_tool_input(record, context_scope)
                 clean_input.append(TrackedItem(business, source_index=i))
 
@@ -62,12 +65,12 @@ class FileToolStrategy:
                 skip_guard_eval=True,
             )
 
-            if is_empty_response(raw_response) and data:
+            if is_empty_response(raw_response) and records:
                 return [
                     ProcessingResult.failed(
                         error=(
                             f"Tool '{context.agent_name}' returned empty result "
-                            f"from {len(data)} input record(s)"
+                            f"from {len(records)} input record(s)"
                         ),
                     )
                 ]
@@ -88,8 +91,6 @@ class FileToolStrategy:
                 source_mapping=source_mapping,
             )
 
-            result = self.enrichment_pipeline.enrich(result, context)
-
             return [result]
 
         except AgentActionsError:
@@ -100,7 +101,7 @@ class FileToolStrategy:
                 f"FILE mode tool '{context.agent_name}' failed: {e}",
                 context={
                     "agent_name": context.agent_name,
-                    "record_count": len(data),
+                    "record_count": len(records),
                     "operation": "file_mode_tool",
                 },
                 cause=e,

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from hashlib import sha256
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.processing.helpers import run_dynamic_agent
@@ -17,9 +17,6 @@ from agent_actions.processing.types import (
 )
 from agent_actions.record.envelope import RecordEnvelope
 
-if TYPE_CHECKING:
-    from agent_actions.processing.enrichment import EnrichmentPipeline
-
 logger = logging.getLogger(__name__)
 
 
@@ -29,18 +26,24 @@ class HITLStrategy:
     Invokes HITL once with the full array and applies the single file-level
     decision payload to every record so downstream stages retain full dataset
     cardinality.
-    """
 
-    def __init__(self, enrichment_pipeline: EnrichmentPipeline) -> None:
-        self.enrichment_pipeline = enrichment_pipeline
+    Conforms to the ``ProcessingStrategy`` protocol so it can be used
+    with ``UnifiedProcessor.process()``.  Enrichment is handled by the
+    processor, not by this strategy.
+    """
 
     def invoke(
         self,
-        data: list[dict],
-        original_data: list[dict],
+        records: list[dict[str, Any]],
         context: ProcessingContext,
     ) -> list[ProcessingResult]:
-        """Invoke a FILE-mode HITL action and broadcast the decision."""
+        """Invoke a FILE-mode HITL action and broadcast the decision.
+
+        ``context.source_data`` must contain the pre-context-scope records
+        that passed the guard filter (set by UnifiedProcessor before
+        invoking the strategy).  These are used to build structured output.
+        """
+        original_data = context.source_data
         try:
             # Inject HITL state persistence metadata into agent config
             hitl_agent_config = dict(context.agent_config)
@@ -59,7 +62,7 @@ class HITLStrategy:
             raw_response, executed = run_dynamic_agent(
                 agent_config=hitl_agent_config,
                 agent_name=context.agent_name,
-                context=data,
+                context=records,
                 formatted_prompt="",
                 tools_path=cast(str | None, hitl_agent_config.get("tools_path")),
                 skip_guard_eval=True,
@@ -89,11 +92,11 @@ class HITLStrategy:
                     1 for r in (decision_payload.get("record_reviews") or []) if r is not None
                 )
                 raise AgentActionsError(
-                    f"HITL review timed out ({reviewed}/{len(data)} records reviewed). "
+                    f"HITL review timed out ({reviewed}/{len(records)} records reviewed). "
                     "Partial reviews saved. Re-run workflow to resume.",
                     context={
                         "agent_name": context.agent_name,
-                        "record_count": len(data),
+                        "record_count": len(records),
                     },
                 )
 
@@ -136,7 +139,6 @@ class HITLStrategy:
                 source_mapping={i: i for i in range(len(structured_data))},
             )
 
-            result = self.enrichment_pipeline.enrich(result, context)
             return [result]
         except AgentActionsError:
             raise

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -13,6 +13,7 @@ from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import CollectionStats, ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,8 @@ class UnifiedProcessor:
         records: list[dict[str, Any]],
         context: ProcessingContext,
         strategy: ProcessingStrategy,
+        *,
+        raw_records: list[dict[str, Any]] | None = None,
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Run records through the full processing pipeline.
 
@@ -70,14 +73,38 @@ class UnifiedProcessor:
             3. Enrich — add lineage, metadata, version IDs, passthrough fields
             4. Collect — flatten results into output records with dispositions
 
+        Args:
+            records: Input records.  For FILE mode these are context-scope-
+                filtered; for RECORD mode they are the raw input.
+            context: Shared processing context.
+            strategy: Strategy that handles the invocation step.
+            raw_records: Pre-context-scope records (FILE mode only).  When
+                provided, the guard filter uses these as ``original_data``
+                so that skipped/passing records reference pre-observe fields.
+                RECORD mode callers should omit this parameter.
+
         Returns:
             Tuple of (output_records, stats).
         """
-        passing, guard_results = self._guard_filter(records, context)
+        if raw_records is not None:
+            # FILE mode: guard needs original_data for pre-observe alignment
+            passing, guard_results, original_passing = self._guard_filter_file_mode(
+                records, context, raw_records
+            )
+            context.source_data = original_passing
+        else:
+            passing, guard_results = self._guard_filter(records, context)
 
         invocation_results = strategy.invoke(passing, context) if passing else []
 
-        enriched = self._enrich(guard_results + invocation_results, context)
+        # FILE mode: invocation first, then guard skips (preserves historical order).
+        # RECORD mode: guard skips first, then invocation results.
+        if raw_records is not None:
+            all_results = invocation_results + guard_results
+        else:
+            all_results = guard_results + invocation_results
+
+        enriched = self._enrich(all_results, context)
 
         return self._collect(enriched, context)
 
@@ -121,6 +148,61 @@ class UnifiedProcessor:
             guard_results.append(ProcessingResult.filtered(source_guid=None))
 
         return passing, guard_results
+
+    def _guard_filter_file_mode(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+        raw_records: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], list[ProcessingResult], list[dict[str, Any]]]:
+        """FILE-mode guard filter with original_data alignment.
+
+        Differs from ``_guard_filter`` in three ways:
+
+        1. Passes ``original_data`` to ``prefilter_by_guard`` so that
+           skipped/passing records reference pre-context-scope fields.
+        2. Skipped records produce ``ProcessingResult.unprocessed()`` with
+           ``RecordEnvelope.build_skipped()`` (adds a null namespace marker)
+           rather than ``ProcessingResult.skipped()`` with a tombstone.
+        3. Returns ``original_passing`` so the caller can set
+           ``context.source_data`` for the enricher.
+
+        Returns:
+            (passing, guard_results, original_passing)
+        """
+        config = cast(dict[str, Any], context.agent_config)
+        passing, skipped, original_passing = prefilter_by_guard(
+            records,
+            config,
+            context.agent_name,
+            original_data=raw_records,
+        )
+
+        guard_results: list[ProcessingResult] = []
+        action_name = context.action_name
+
+        for item in skipped:
+            if action_name and isinstance(item, dict):
+                content = item.get("content")
+                if isinstance(content, dict) and action_name not in content:
+                    skipped_record = RecordEnvelope.build_skipped(action_name, item)
+                    for key in item:
+                        if key not in skipped_record:
+                            skipped_record[key] = item[key]
+                    item = skipped_record
+            guard_results.append(
+                ProcessingResult.unprocessed(
+                    data=[item],
+                    reason="guard_prefilter_skip",
+                    source_guid=item.get("source_guid") if isinstance(item, dict) else None,
+                )
+            )
+
+        filtered_count = len(records) - len(passing) - len(skipped)
+        for _i in range(filtered_count):
+            guard_results.append(ProcessingResult.filtered(source_guid=None))
+
+        return passing, guard_results, original_passing
 
     def _enrich(
         self,

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -16,18 +16,16 @@ from agent_actions.llm.batch.service import create_registry_manager_factory
 from agent_actions.llm.batch.services.submission import BatchSubmissionService
 from agent_actions.llm.realtime.output import OutputHandler
 from agent_actions.output.writer import FileWriter
-from agent_actions.processing.result_collector import ResultCollector, write_node_level_disposition
+from agent_actions.processing.result_collector import write_node_level_disposition
 from agent_actions.processing.strategies import FileToolStrategy, HITLStrategy
 from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
-from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.processing.types import ProcessingContext
 from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
-from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 from agent_actions.utils.safe_format import safe_format_error
-from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -152,20 +150,12 @@ class ProcessingPipeline:
                 },
             )
 
-        # Shared enrichment pipeline (FILE mode paths use directly,
-        # RECORD mode passes to UnifiedProcessor to avoid double allocation)
-        from agent_actions.processing.enrichment import EnrichmentPipeline
-
-        self.enrichment_pipeline = EnrichmentPipeline()
-
         # RECORD mode processor — created once, reused per file
         self._online_strategy = OnlineLLMStrategy(
             agent_config=cast(dict[str, Any], config.action_config),
             agent_name=config.action_name,
         )
-        self._unified_processor = UnifiedProcessor(
-            enrichment_pipeline=self.enrichment_pipeline,
-        )
+        self._unified_processor = UnifiedProcessor()
 
         # Initialize OutputHandler with optional storage backend
         self.output_handler = OutputHandler(
@@ -546,14 +536,14 @@ class ProcessingPipeline:
             storage_backend=self.config.storage_backend,
         )
 
-        # Process via RecordProcessor
-        # NOTE: Do NOT filter _unprocessed records here. Guard-skipped records
-        # (on_false: skip) produce _unprocessed tombstones that are valid pipeline
-        # data. task_preparer._is_upstream_unprocessed() handles them per-record.
+        # Select processing strategy based on granularity and action kind.
+        strategy = self._select_strategy()
+
         if self.granularity == "file" and (self.is_tool_action or self.is_hitl_action):
-            # For FILE mode, use the input data as source for parent lookup
-            # (not source_data which points to original source folder)
-            context.source_data = data
+            # FILE mode: apply context scope, then delegate guard + invoke +
+            # enrich + collect to UnifiedProcessor with raw_records for
+            # pre-observe alignment.  UnifiedProcessor sets context.source_data
+            # to original_passing after the guard filter runs.
             filtered = apply_context_scope_for_records(
                 records=data,
                 context_scope=cast(dict[str, Any], self.config.action_config).get(
@@ -562,42 +552,12 @@ class ProcessingPipeline:
                 action_name=self.config.action_name,
                 source_data=source_data,
             )
-
-            # Guards must run before FILE-mode processing because FILE mode
-            # sends the entire array in one batch and cannot filter per-record.
-            # Pass raw `data` so original_passing preserves pre-observe fields.
-            passing, skipped, original_passing = prefilter_by_guard(
-                filtered,
-                cast(dict[str, Any], self.config.action_config),
-                self.config.action_name,
-                original_data=data,
-            )
-
-            # Align context.source_data with the guard-passing subset so the
-            # enricher's source_mapping indices resolve to the correct parents.
-            context.source_data = original_passing
-
-            if not passing:
-                results = _build_skipped_results(skipped, self.config.action_name)
-            else:
-                if self.is_tool_action:
-                    results = self._process_file_mode_tool(passing, original_passing, context)
-                else:
-                    results = self._process_file_mode_hitl(passing, original_passing, context)
-
-                results.extend(_build_skipped_results(skipped, self.config.action_name))
-
-            # Collect FILE-mode results
-            output, stats = ResultCollector.collect_results(
-                results,
-                cast(dict[str, Any], self.config.action_config),
-                self.config.action_name,
-                is_first_stage=False,
-                storage_backend=self.config.storage_backend,
+            output, stats = self._unified_processor.process(
+                filtered, context, strategy, raw_records=data
             )
         else:
             # RECORD mode — UnifiedProcessor handles guard + invoke + enrich + collect
-            output, stats = self._unified_processor.process(data, context, self._online_strategy)
+            output, stats = self._unified_processor.process(data, context, strategy)
 
         # Signal node-level SKIP only when output is truly empty and the
         # only outcomes were guard-skip / guard-filter.  Guard-skipped
@@ -623,48 +583,14 @@ class ProcessingPipeline:
 
         self.output_handler.save_main_output(output, file_path, base_directory, output_directory)
 
-    def _process_file_mode_tool(
-        self, data: list[dict], original_data: list[dict], context: ProcessingContext
-    ) -> list:
-        """Delegate to FileToolStrategy for FILE-mode tool invocation."""
-        strategy = FileToolStrategy(self.enrichment_pipeline)
-        return strategy.invoke(data, original_data, context)
-
-    def _process_file_mode_hitl(
-        self, data: list[dict], original_data: list[dict], context: ProcessingContext
-    ) -> list:
-        """Delegate to HITLStrategy for FILE-mode HITL invocation."""
-        strategy = HITLStrategy(self.enrichment_pipeline)
-        return strategy.invoke(data, original_data, context)
-
-
-def _build_skipped_results(
-    skipped: list[dict], action_name: str | None = None
-) -> list[ProcessingResult]:
-    """Convert guard-skipped items into UNPROCESSED ProcessingResults.
-
-    When action_name is provided, adds a null namespace to the record's
-    content so downstream UI and processing see an explicit skip marker
-    rather than a missing namespace.
-    """
-    results = []
-    for item in skipped:
-        if action_name and isinstance(item, dict):
-            content = item.get("content")
-            if isinstance(content, dict) and action_name not in content:
-                skipped_record = RecordEnvelope.build_skipped(action_name, item)
-                for key in item:
-                    if key not in skipped_record:
-                        skipped_record[key] = item[key]
-                item = skipped_record
-        results.append(
-            ProcessingResult.unprocessed(
-                data=[item],
-                reason="guard_prefilter_skip",
-                source_guid=item.get("source_guid"),
-            )
-        )
-    return results
+    def _select_strategy(self):
+        """Select the processing strategy based on granularity and action kind."""
+        if self.granularity == "file":
+            if self.is_tool_action:
+                return FileToolStrategy()
+            if self.is_hitl_action:
+                return HITLStrategy()
+        return self._online_strategy
 
 
 def create_processing_pipeline(

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -20,7 +20,7 @@ from agent_actions.processing.result_collector import write_node_level_dispositi
 from agent_actions.processing.strategies import FileToolStrategy, HITLStrategy
 from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
 from agent_actions.processing.types import ProcessingContext
-from agent_actions.processing.unified import UnifiedProcessor
+from agent_actions.processing.unified import ProcessingStrategy, UnifiedProcessor
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
 from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
 from agent_actions.utils.atomic_write import atomic_json_write
@@ -583,7 +583,7 @@ class ProcessingPipeline:
 
         self.output_handler.save_main_output(output, file_path, base_directory, output_directory)
 
-    def _select_strategy(self):
+    def _select_strategy(self) -> ProcessingStrategy:
         """Select the processing strategy based on granularity and action kind."""
         if self.granularity == "file":
             if self.is_tool_action:

--- a/tests/unit/workflow/test_batch_pipeline_tombstone.py
+++ b/tests/unit/workflow/test_batch_pipeline_tombstone.py
@@ -6,10 +6,11 @@ import pytest
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.llm.batch.core.batch_models import SubmissionResult
+from agent_actions.processing.strategies.hitl import HITLStrategy
 from agent_actions.processing.types import ProcessingContext
 from agent_actions.workflow.config_pipeline import discover_workflow_udfs
 from agent_actions.workflow.models import WorkflowPaths, WorkflowRuntimeConfig
-from agent_actions.workflow.pipeline import BatchPipelineParams, PipelineConfig, ProcessingPipeline
+from agent_actions.workflow.pipeline import BatchPipelineParams, ProcessingPipeline
 
 # ---------------------------------------------------------------------------
 # C-1  ·  _handle_batch_generation — tombstone passthrough path exercises
@@ -98,26 +99,16 @@ class TestHandleBatchGenerationTombstone:
 # ---------------------------------------------------------------------------
 
 
-def _make_pipeline():
-    return ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-
-
 class TestHITLFileModePropagatesExceptions:
     """C-3 — non-AgentActionsError propagates bare (not swallowed or wrapped)."""
 
     def test_runtime_error_propagates_bare(self):
-        pipeline = _make_pipeline()
+        data = [{"source_guid": "sg-1", "content": {}}]
         context = ProcessingContext(
             agent_config={"kind": "hitl", "granularity": "file"},
             agent_name="review",
         )
+        context.source_data = data
         with (
             patch(
                 "agent_actions.processing.strategies.hitl.run_dynamic_agent",
@@ -125,14 +116,15 @@ class TestHITLFileModePropagatesExceptions:
             ),
             pytest.raises(RuntimeError, match="infra failure"),
         ):
-            pipeline._process_file_mode_hitl([{"source_guid": "sg-1", "content": {}}], [], context)
+            HITLStrategy().invoke(data, context)
 
     def test_non_agent_error_propagates_as_original_type(self):
-        pipeline = _make_pipeline()
+        data = [{"source_guid": "sg-1", "content": {}}]
         context = ProcessingContext(
             agent_config={"kind": "hitl", "granularity": "file"},
             agent_name="review",
         )
+        context.source_data = data
         original = ValueError("bad value")
         with (
             patch(
@@ -141,17 +133,18 @@ class TestHITLFileModePropagatesExceptions:
             ),
             pytest.raises(ValueError) as exc_info,
         ):
-            pipeline._process_file_mode_hitl([{"source_guid": "sg-1", "content": {}}], [], context)
+            HITLStrategy().invoke(data, context)
 
         assert exc_info.value is original
 
     def test_agent_actions_error_passes_through_unchanged(self):
         """AgentActionsError is NOT re-wrapped — it re-raises directly."""
-        pipeline = _make_pipeline()
+        data = [{"source_guid": "sg-1", "content": {}}]
         context = ProcessingContext(
             agent_config={"kind": "hitl", "granularity": "file"},
             agent_name="review",
         )
+        context.source_data = data
         original = AgentActionsError("original app error")
         with (
             patch(
@@ -160,7 +153,7 @@ class TestHITLFileModePropagatesExceptions:
             ),
             pytest.raises(AgentActionsError) as exc_info,
         ):
-            pipeline._process_file_mode_hitl([{"source_guid": "sg-1", "content": {}}], [], context)
+            HITLStrategy().invoke(data, context)
 
         assert exc_info.value is original
 

--- a/tests/unit/workflow/test_file_mode_guard_prefilter.py
+++ b/tests/unit/workflow/test_file_mode_guard_prefilter.py
@@ -3,8 +3,8 @@
 from unittest.mock import MagicMock, patch
 
 from agent_actions.input.preprocessing.filtering.evaluator import GuardResult
-from agent_actions.processing.types import ProcessingStatus
-from agent_actions.workflow.pipeline import _build_skipped_results
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 
@@ -277,51 +277,94 @@ class TestPrefilterByGuard:
         assert len(passing) == 0
 
 
-class TestBuildSkippedResults:
-    """Tests for _build_skipped_results()."""
+class TestGuardFilterFileMode:
+    """Tests for UnifiedProcessor._guard_filter_file_mode() skip-wrapping behavior.
 
-    def test_empty_list(self):
-        """Empty skipped list -> empty results."""
-        results = _build_skipped_results([])
-        assert results == []
+    These tests verify that FILE-mode guard-skipped records are correctly
+    converted to UNPROCESSED ProcessingResults with null namespace markers.
+    """
 
-    def test_creates_unprocessed_results(self):
-        """Each skipped item becomes an UNPROCESSED result."""
-        skipped = [
+    @staticmethod
+    def _make_context(action_name="my_action"):
+        return ProcessingContext(
+            agent_config={"guard": {"clause": "score >= 80", "behavior": "skip"}},
+            agent_name=action_name,
+        )
+
+    @staticmethod
+    def _run_filter(records, raw_records, context):
+        processor = UnifiedProcessor()
+        return processor._guard_filter_file_mode(records, context, raw_records)
+
+    def test_no_guard_returns_all(self):
+        """No guard -> all records pass, no guard results."""
+        data = [{"content": {"x": 1}}, {"content": {"x": 2}}]
+        context = ProcessingContext(agent_config={}, agent_name="test")
+        passing, guard_results, original_passing = self._run_filter(data, data, context)
+        assert passing == data
+        assert guard_results == []
+        assert original_passing == data
+
+    def test_skipped_items_become_unprocessed(self):
+        """Each guard-skipped item produces an UNPROCESSED result."""
+        data = [
             {"content": {"score": 40}, "source_guid": "sg-1"},
             {"content": {"score": 20}, "source_guid": "sg-2"},
         ]
-        results = _build_skipped_results(skipped)
+        context = self._make_context()
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
 
-        assert len(results) == 2
-        for i, result in enumerate(results):
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            passing, guard_results, original_passing = self._run_filter(data, data, context)
+
+        assert passing == []
+        assert len(guard_results) == 2
+        for i, result in enumerate(guard_results):
             assert result.status == ProcessingStatus.UNPROCESSED
-            assert result.data == [skipped[i]]
-            assert result.source_guid == skipped[i]["source_guid"]
+            assert result.source_guid == data[i]["source_guid"]
+            # Null namespace marker added by RecordEnvelope.build_skipped
+            assert result.data[0]["content"]["my_action"] is None
 
     def test_missing_source_guid(self):
-        """Items without source_guid get None."""
-        skipped = [{"content": {"score": 40}}]
-        results = _build_skipped_results(skipped)
+        """Items without source_guid get None on the result."""
+        data = [{"content": {"score": 40}}]
+        context = self._make_context()
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
 
-        assert len(results) == 1
-        assert results[0].source_guid is None
-        assert results[0].status == ProcessingStatus.UNPROCESSED
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            _, guard_results, _ = self._run_filter(data, data, context)
 
-    def test_action_name_adds_null_namespace(self):
-        """With action_name, adds null namespace via RecordEnvelope."""
-        skipped = [{"content": {"prev_action": {"key": "val"}}, "source_guid": "sg-1"}]
-        results = _build_skipped_results(skipped, action_name="my_action")
+        assert len(guard_results) == 1
+        assert guard_results[0].source_guid is None
+        assert guard_results[0].status == ProcessingStatus.UNPROCESSED
 
-        assert len(results) == 1
-        item = results[0].data[0]
+    def test_adds_null_namespace(self):
+        """Skipped items get a null namespace marker via RecordEnvelope."""
+        data = [{"content": {"prev_action": {"key": "val"}}, "source_guid": "sg-1"}]
+        context = self._make_context()
+        evaluator = _make_evaluator(lambda item: False)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            _, guard_results, _ = self._run_filter(data, data, context)
+
+        assert len(guard_results) == 1
+        item = guard_results[0].data[0]
         assert item["content"]["my_action"] is None
         assert item["content"]["prev_action"] == {"key": "val"}
         assert item["source_guid"] == "sg-1"
 
-    def test_action_name_preserves_framework_fields(self):
-        """Framework fields (target_id, _unprocessed, metadata, batch_id) survive the envelope merge."""
-        skipped = [
+    def test_preserves_framework_fields(self):
+        """Framework fields survive the envelope merge for skipped records."""
+        data = [
             {
                 "content": {"prev": {}},
                 "source_guid": "sg-1",
@@ -331,51 +374,103 @@ class TestBuildSkippedResults:
                 "batch_id": "b-1",
             }
         ]
-        results = _build_skipped_results(skipped, action_name="act")
+        context = self._make_context(action_name="act")
+        evaluator = _make_evaluator(lambda item: False)
 
-        item = results[0].data[0]
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            _, guard_results, _ = self._run_filter(data, data, context)
+
+        item = guard_results[0].data[0]
         assert item["content"]["act"] is None
         assert item["target_id"] == "t-1"
         assert item["_unprocessed"] is True
         assert item["metadata"] == {"key": "val"}
         assert item["batch_id"] == "b-1"
 
-    def test_action_name_skips_when_already_present(self):
-        """If action_name already in content, no mutation occurs."""
-        skipped = [{"content": {"my_action": {"existing": True}}, "source_guid": "sg-1"}]
-        results = _build_skipped_results(skipped, action_name="my_action")
+    def test_skips_when_namespace_already_present(self):
+        """If action_name already in content, no null namespace added."""
+        data = [{"content": {"my_action": {"existing": True}}, "source_guid": "sg-1"}]
+        context = self._make_context()
+        evaluator = _make_evaluator(lambda item: False)
 
-        item = results[0].data[0]
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            _, guard_results, _ = self._run_filter(data, data, context)
+
+        item = guard_results[0].data[0]
         assert item["content"]["my_action"] == {"existing": True}
 
-    def test_no_action_name_no_mutation(self):
-        """Without action_name, items pass through unmodified."""
-        original = {"content": {"score": 40}, "source_guid": "sg-1"}
-        results = _build_skipped_results([original])
-
-        assert results[0].data[0] is original
-
-    def test_mixed_pass_skip_skipped_records_get_null_namespace(self):
-        """When some records pass and some are skipped, skipped get null namespace.
-
-        This exercises the pipeline path at line 568 where _build_skipped_results
-        is called with action_name for records skipped alongside passing records.
-        """
-        skipped = [
-            {"content": {"prev_action": {"key": "other"}}, "source_guid": "sg-2"},
-            {"content": {"prev_action": {"key": "third"}}, "source_guid": "sg-3"},
+    def test_filtered_items_become_filtered_results(self):
+        """Guard-filtered items produce FILTERED results."""
+        data = [
+            {"content": {"score": 40}, "source_guid": "sg-1"},
         ]
+        context = ProcessingContext(
+            agent_config={"guard": {"clause": "score >= 80", "behavior": "filter"}},
+            agent_name="test",
+        )
+        evaluator = _make_evaluator(lambda item: False)
 
-        # Simulate the pipeline call at line 568: _build_skipped_results(skipped, action_name)
-        results = _build_skipped_results(skipped, action_name="review_action")
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            passing, guard_results, original_passing = self._run_filter(data, data, context)
 
-        assert len(results) == 2
-        for i, result in enumerate(results):
+        assert passing == []
+        assert original_passing == []
+        assert len(guard_results) == 1
+        assert guard_results[0].status == ProcessingStatus.FILTERED
+
+    def test_mixed_pass_skip_produces_correct_results(self):
+        """Mixed pass/skip: passing records returned, skipped get null namespace."""
+        data = [
+            {"content": {"score": 90, "prev_action": {"key": "first"}}, "source_guid": "sg-1"},
+            {"content": {"score": 40, "prev_action": {"key": "other"}}, "source_guid": "sg-2"},
+            {"content": {"score": 30, "prev_action": {"key": "third"}}, "source_guid": "sg-3"},
+        ]
+        context = self._make_context(action_name="review_action")
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            passing, guard_results, original_passing = self._run_filter(data, data, context)
+
+        assert len(passing) == 1
+        assert len(guard_results) == 2
+        for result in guard_results:
             assert result.status == ProcessingStatus.UNPROCESSED
             item = result.data[0]
-            # Null namespace marker present
             assert "review_action" in item["content"]
             assert item["content"]["review_action"] is None
-            # Previous content preserved
-            assert item["content"]["prev_action"] == skipped[i]["content"]["prev_action"]
-            assert item["source_guid"] == skipped[i]["source_guid"]
+
+    def test_returns_original_passing(self):
+        """original_passing returns items from raw_records, not from records."""
+        filtered = [
+            {"content": {"score": 90}},
+            {"content": {"score": 40}},
+        ]
+        raw = [
+            {"content": {"score": 90, "name": "Alice"}, "source_guid": "sg-1"},
+            {"content": {"score": 40, "name": "Bob"}, "source_guid": "sg-2"},
+        ]
+        context = self._make_context()
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            passing, guard_results, original_passing = self._run_filter(filtered, raw, context)
+
+        assert len(passing) == 1
+        assert len(original_passing) == 1
+        assert original_passing[0]["content"]["name"] == "Alice"
+        assert original_passing[0]["source_guid"] == "sg-1"

--- a/tests/unit/workflow/test_file_mode_guard_prefilter.py
+++ b/tests/unit/workflow/test_file_mode_guard_prefilter.py
@@ -474,3 +474,59 @@ class TestGuardFilterFileMode:
         assert len(original_passing) == 1
         assert original_passing[0]["content"]["name"] == "Alice"
         assert original_passing[0]["source_guid"] == "sg-1"
+
+
+class TestUnifiedProcessorFileModePath:
+    """Integration test: UnifiedProcessor.process() with raw_records wires
+    context.source_data correctly before invoking the strategy."""
+
+    def test_process_sets_source_data_before_strategy_invoke(self):
+        """Strategy receives context.source_data = original_passing (not raw input)."""
+        from agent_actions.processing.unified import UnifiedProcessor
+
+        # Records after context scope (what guard evaluates on)
+        filtered = [
+            {"content": {"score": 90}},
+            {"content": {"score": 40}},
+        ]
+        # Raw pre-scope records (what original_passing should come from)
+        raw = [
+            {"content": {"score": 90, "name": "Alice"}, "source_guid": "sg-1"},
+            {"content": {"score": 40, "name": "Bob"}, "source_guid": "sg-2"},
+        ]
+        context = ProcessingContext(
+            agent_config={"guard": {"clause": "score >= 80", "behavior": "skip"}},
+            agent_name="my_tool",
+        )
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        captured_source_data = {}
+
+        class SpyStrategy:
+            def invoke(self, records, ctx):
+                captured_source_data["value"] = ctx.source_data
+                from agent_actions.processing.types import ProcessingResult
+
+                return [
+                    ProcessingResult.success(
+                        data=[{"content": {"my_tool": {"out": 1}}}],
+                        source_guid="sg-1",
+                    )
+                ]
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            output, stats = UnifiedProcessor().process(
+                filtered, context, SpyStrategy(), raw_records=raw
+            )
+
+        # Strategy must have seen original_passing (only the passing raw record)
+        assert len(captured_source_data["value"]) == 1
+        assert captured_source_data["value"][0]["content"]["name"] == "Alice"
+        assert captured_source_data["value"][0]["source_guid"] == "sg-1"
+
+        # Guard-skipped record should appear in output as UNPROCESSED
+        assert stats.unprocessed == 1
+        assert stats.success == 1

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -6,27 +6,19 @@ import pytest
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.llm.providers.tools.client import ToolClient
+from agent_actions.processing.strategies.file_tool import FileToolStrategy
+from agent_actions.processing.strategies.hitl import HITLStrategy
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.udf_management.registry import FileUDFResult
-from agent_actions.workflow.pipeline import PipelineConfig, ProcessingPipeline
 
 
-def _make_pipeline_and_context():
-    """Create a minimal pipeline and context for FILE-mode tool tests."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "tool", "granularity": "file"},
-            action_name="my_file_tool",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
+def _make_context(agent_name="my_file_tool"):
+    """Create a minimal context for FILE-mode tool tests."""
+    return ProcessingContext(
         agent_config={"kind": "tool", "granularity": "file"},
-        agent_name="my_file_tool",
+        agent_name=agent_name,
     )
-    return pipeline, context
 
 
 # --- TrackedItem list return ---
@@ -34,12 +26,14 @@ def _make_pipeline_and_context():
 
 def test_tracked_item_list_works():
     """FILE tool returning TrackedItem list wraps output under action namespace."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
         {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
@@ -51,7 +45,7 @@ def test_tracked_item_list_works():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -63,22 +57,24 @@ def test_tracked_item_list_works():
 
 def test_tracked_item_source_mapping():
     """TrackedItem list return derives source_mapping from _source_index."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([TrackedItem({"score": 0.9}, source_index=0)], True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert results[0].source_mapping == {0: 0}
 
 
 def test_tracked_item_preserves_upstream_namespaces():
     """TrackedItem output preserves upstream namespaces from input record."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {
@@ -90,11 +86,13 @@ def test_tracked_item_preserves_upstream_namespaces():
         },
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([TrackedItem({"score": 0.95}, source_index=0)], True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     content = results[0].data[0]["content"]
     # Upstream namespaces preserved
@@ -109,7 +107,7 @@ def test_tracked_item_preserves_upstream_namespaces():
 
 def test_file_udf_result_reconciled():
     """FILE tool returning FileUDFResult reconciles via source_index."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     udf_result = FileUDFResult(
         outputs=[
@@ -123,11 +121,13 @@ def test_file_udf_result_reconciled():
         {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -139,7 +139,7 @@ def test_file_udf_result_reconciled():
 
 def test_file_udf_result_source_mapping():
     """FileUDFResult source_mapping derived from source_index declarations."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     udf_result = FileUDFResult(
         outputs=[
@@ -153,18 +153,20 @@ def test_file_udf_result_source_mapping():
         {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert results[0].source_mapping == {0: 0, 1: 1}
 
 
 def test_file_udf_result_list_source_index():
     """FileUDFResult with list source_index (many-to-one merge)."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     udf_result = FileUDFResult(
         outputs=[
@@ -177,11 +179,13 @@ def test_file_udf_result_list_source_index():
         {"source_guid": "sg-2", "content": {"prev": {"q": "B"}}},
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert results[0].source_mapping == {0: [0, 1]}
     assert results[0].data[0]["content"]["my_file_tool"]["merged"] is True
@@ -192,7 +196,7 @@ def test_file_udf_result_list_source_index():
 
 def test_synthetic_record_carries_forward_namespaces():
     """FileUDFResult with source_index=None gets namespaces from first input."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     udf_result = FileUDFResult(
         outputs=[
@@ -211,11 +215,13 @@ def test_synthetic_record_carries_forward_namespaces():
         },
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -235,7 +241,7 @@ def test_synthetic_record_carries_forward_namespaces():
 
 def test_synthetic_record_empty_original_data():
     """FileUDFResult with source_index=None and empty original_data does not crash."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     udf_result = FileUDFResult(
         outputs=[
@@ -243,11 +249,13 @@ def test_synthetic_record_empty_original_data():
         ],
     )
 
+    context.source_data = []
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool([], [], context)
+        results = FileToolStrategy().invoke([], context)
 
     assert len(results) == 1
     result = results[0]
@@ -259,7 +267,7 @@ def test_synthetic_record_empty_original_data():
 
 def test_synthetic_mixed_with_sourced_records():
     """FileUDFResult with both sourced and synthetic records in same batch."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     udf_result = FileUDFResult(
         outputs=[
@@ -280,11 +288,13 @@ def test_synthetic_mixed_with_sourced_records():
         },
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     result = results[0]
     assert len(result.data) == 3
@@ -319,44 +329,50 @@ def test_file_udf_result_accepts_none_source_index():
 
 def test_file_tool_plain_dict_rejected():
     """FILE tool returning plain dicts (not TrackedItem) raises ValueError."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([{"score": 0.9}], True),
     ):
         with pytest.raises(AgentActionsError, match="plain dict"):
-            pipeline._process_file_mode_tool(input_data, input_data, context)
+            FileToolStrategy().invoke(input_data, context)
 
 
 def test_file_tool_non_dict_rejected():
     """FILE tool returning non-dict items raises ValueError."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(["just a string"], True),
     ):
         with pytest.raises(AgentActionsError, match="expected TrackedItem"):
-            pipeline._process_file_mode_tool(input_data, input_data, context)
+            FileToolStrategy().invoke(input_data, context)
 
 
 def test_file_tool_non_list_non_fileudfresult_rejected():
     """FILE tool returning non-list, non-FileUDFResult raises ValueError."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=({"single": "dict"}, True),
     ):
         with pytest.raises(AgentActionsError, match="must return list or FileUDFResult"):
-            pipeline._process_file_mode_tool(input_data, input_data, context)
+            FileToolStrategy().invoke(input_data, context)
 
 
 # --- Empty tool output detection ---
@@ -364,18 +380,20 @@ def test_file_tool_non_list_non_fileudfresult_rejected():
 
 def test_file_tool_empty_response_with_input_returns_failed():
     """Tool returning [] with non-empty input returns ProcessingResult.failed()."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
         {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([], True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     assert results[0].status == ProcessingStatus.FAILED
@@ -385,13 +403,15 @@ def test_file_tool_empty_response_with_input_returns_failed():
 
 def test_file_tool_empty_response_with_empty_input_ok():
     """Tool returning [] with empty input should NOT be marked failed."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
+
+    context.source_data = []
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([], True),
     ):
-        results = pipeline._process_file_mode_tool([], [], context)
+        results = FileToolStrategy().invoke([], context)
 
     assert len(results) == 1
     assert results[0].status == ProcessingStatus.SUCCESS
@@ -402,17 +422,19 @@ def test_file_tool_empty_response_feeds_existing_failure_check():
     """Empty tool result -> stats.failed=1 -> existing zero-success check fires."""
     from agent_actions.processing.result_collector import ResultCollector
 
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
     input_data = [
         {"content": {"prev": {"a": 1}}},
         {"content": {"prev": {"b": 2}}},
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([], True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     output, stats = ResultCollector.collect_results(
         results,
@@ -428,15 +450,17 @@ def test_file_tool_empty_response_feeds_existing_failure_check():
 
 def test_file_udf_result_empty_with_input_returns_failed():
     """FileUDFResult with empty outputs and non-empty input returns FAILED."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(FileUDFResult(outputs=[]), True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert results[0].status == ProcessingStatus.FAILED
     assert "returned empty result" in results[0].error
@@ -447,33 +471,37 @@ def test_file_udf_result_empty_with_input_returns_failed():
 
 def test_file_mode_error_surfaces():
     """FILE tool raising exception should propagate, not produce empty output."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         side_effect=RuntimeError("connection refused"),
     ):
         with pytest.raises(AgentActionsError, match="connection refused"):
-            pipeline._process_file_mode_tool(input_data, input_data, context)
+            FileToolStrategy().invoke(input_data, context)
 
 
 def test_file_mode_error_includes_context():
     """The surfaced error should include agent_name and record_count."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"content": {"prev": {"a": 1}}},
         {"content": {"prev": {"b": 2}}},
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         side_effect=ValueError("bad data"),
     ):
         with pytest.raises(AgentActionsError) as exc_info:
-            pipeline._process_file_mode_tool(input_data, input_data, context)
+            FileToolStrategy().invoke(input_data, context)
 
     assert exc_info.value.context["agent_name"] == "my_file_tool"
     assert exc_info.value.context["record_count"] == 2
@@ -819,12 +847,14 @@ def test_result_collector_does_not_raise_when_all_filtered():
 
 def test_tracked_item_preserves_source_guid():
     """TrackedItem output gets source_guid from input via source_index mapping."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
         {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
     ]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
@@ -836,7 +866,7 @@ def test_tracked_item_preserves_source_guid():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     result = results[0]
     assert result.data[0]["source_guid"] == "sg-1"
@@ -845,13 +875,15 @@ def test_tracked_item_preserves_source_guid():
 
 def test_tracked_item_filter_fewer_outputs():
     """When tool filters N→fewer, TrackedItem._source_index resolves correct source_guid."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
         {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
         {"source_guid": "sg-3", "content": {"prev": {"id": 3}}},
     ]
+
+    context.source_data = input_data
 
     # Tool filters 3→2, keeping items 0 and 2
     with patch(
@@ -864,7 +896,7 @@ def test_tracked_item_filter_fewer_outputs():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     result = results[0]
     assert result.data[0]["source_guid"] == "sg-1"
@@ -874,7 +906,7 @@ def test_tracked_item_filter_fewer_outputs():
 
 def test_file_udf_result_preserves_source_guid():
     """FileUDFResult outputs get source_guid from input via source_index."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"prev": {"q": "A"}}},
@@ -888,11 +920,13 @@ def test_file_udf_result_preserves_source_guid():
         ],
     )
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     result = results[0]
     # Reordered outputs map to correct source_guid
@@ -902,17 +936,19 @@ def test_file_udf_result_preserves_source_guid():
 
 def test_file_tool_source_guid_never_empty_string():
     """No output item should ever have source_guid='' after FILE-mode processing."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([TrackedItem({"result": "ok"}, source_index=0)], True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     for item in results[0].data:
         assert item.get("source_guid") != "", "source_guid must not be empty string"
@@ -924,13 +960,15 @@ def test_file_tool_source_guid_never_empty_string():
 
 def test_file_tool_empty_input_empty_output():
     """Empty input + empty output → no crash, no source_guid issues."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
+
+    context.source_data = []
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=([], True),
     ):
-        results = pipeline._process_file_mode_tool([], [], context)
+        results = FileToolStrategy().invoke([], context)
 
     assert results[0].status == ProcessingStatus.SUCCESS
     assert results[0].data == []
@@ -938,12 +976,14 @@ def test_file_tool_empty_input_empty_output():
 
 def test_file_tool_input_without_source_guid():
     """Input records missing source_guid — no crash, outputs have absent source_guid."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"content": {"prev": {"id": 1}}},
         {"content": {"prev": {"id": 2}}},
     ]
+
+    context.source_data = input_data
 
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
@@ -955,7 +995,7 @@ def test_file_tool_input_without_source_guid():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert results[0].status == ProcessingStatus.SUCCESS
     assert len(results[0].data) == 2
@@ -963,13 +1003,15 @@ def test_file_tool_input_without_source_guid():
 
 def test_file_udf_result_merge_reduces_to_fewer():
     """N→fewer merge via FileUDFResult: each output maps to its declared source."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"prev": {"q": "A"}}},
         {"source_guid": "sg-2", "content": {"prev": {"q": "B"}}},
         {"source_guid": "sg-3", "content": {"prev": {"q": "C"}}},
     ]
+
+    context.source_data = input_data
 
     # Tool merges 3→2
     udf_result = FileUDFResult(
@@ -983,7 +1025,7 @@ def test_file_udf_result_merge_reduces_to_fewer():
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     result = results[0]
     assert result.source_mapping == {0: [0, 1], 1: 2}
@@ -992,11 +1034,13 @@ def test_file_udf_result_merge_reduces_to_fewer():
 
 def test_file_udf_result_expansion():
     """1→N expansion via FileUDFResult: each output traces to source."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-only", "content": {"prev": {"nested": [1, 2, 3, 4, 5]}}},
     ]
+
+    context.source_data = input_data
 
     udf_result = FileUDFResult(
         outputs=[{"source_index": 0, "data": {"val": i}} for i in range(5)],
@@ -1006,7 +1050,7 @@ def test_file_udf_result_expansion():
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(udf_result, True),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     assert len(results[0].data) == 5
     for i, item in enumerate(results[0].data):
@@ -1352,7 +1396,7 @@ class TestExtractToolInput:
 
 def test_file_tool_content_preserved_via_tracked_item():
     """FILE tool content is correctly preserved when using TrackedItem reconciliation."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {
@@ -1369,6 +1413,8 @@ def test_file_tool_content_preserved_via_tracked_item():
         },
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(
@@ -1383,7 +1429,7 @@ def test_file_tool_content_preserved_via_tracked_item():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
@@ -1400,11 +1446,13 @@ def test_file_tool_content_preserved_via_tracked_item():
 
 def test_file_tool_shared_source_guid_each_output_gets_correct_mapping():
     """When inputs share source_guid, TrackedItem._source_index resolves each correctly."""
-    pipeline, context = _make_pipeline_and_context()
+    context = _make_context()
 
     input_data = [
         {"source_guid": "sg-shared", "content": {"prev": {"q": f"Q{i}"}}} for i in range(5)
     ]
+
+    context.source_data = input_data
 
     # Tool deduplicates 5→4, returns TrackedItems skipping index 2
     with patch(
@@ -1419,7 +1467,7 @@ def test_file_tool_shared_source_guid_each_output_gets_correct_mapping():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     result = results[0]
     assert result.source_mapping == {0: 0, 1: 1, 2: 3, 3: 4}
@@ -1433,7 +1481,9 @@ def test_file_tool_shared_source_guid_each_output_gets_correct_mapping():
 
 def test_file_tool_tracked_item_extends_lineage():
     """TrackedItem-based reconciliation extends parent lineage correctly."""
-    pipeline, context = _make_pipeline_and_context()
+    from agent_actions.processing.enrichment import EnrichmentPipeline
+
+    context = _make_context()
 
     input_data = [
         {
@@ -1462,20 +1512,28 @@ def test_file_tool_tracked_item_extends_lineage():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
+    # Manually enrich to get lineage extension (enrichment is now done by UnifiedProcessor)
     result = results[0]
-    assert result.status == ProcessingStatus.SUCCESS
-    assert result.source_mapping == {0: 0, 1: 1}
+    enriched_results = EnrichmentPipeline().enrich(result, context)
 
-    assert result.data[0]["content"]["my_file_tool"]["transformed"] == "new value from original"
-    assert result.data[1]["content"]["my_file_tool"]["transformed"] == "new value from other"
+    assert enriched_results.status == ProcessingStatus.SUCCESS
+    assert enriched_results.source_mapping == {0: 0, 1: 1}
 
-    assert result.data[0]["source_guid"] == "sg-1"
-    assert result.data[1]["source_guid"] == "sg-2"
+    assert (
+        enriched_results.data[0]["content"]["my_file_tool"]["transformed"]
+        == "new value from original"
+    )
+    assert (
+        enriched_results.data[1]["content"]["my_file_tool"]["transformed"] == "new value from other"
+    )
+
+    assert enriched_results.data[0]["source_guid"] == "sg-1"
+    assert enriched_results.data[1]["source_guid"] == "sg-2"
 
     # Lineage must be extended from parent, not truncated to just [self]
-    for i, item in enumerate(result.data):
+    for i, item in enumerate(enriched_results.data):
         lineage = item.get("lineage", [])
         assert len(lineage) >= 3, f"item[{i}] lineage not extended from parent: {lineage}"
 
@@ -1483,26 +1541,17 @@ def test_file_tool_tracked_item_extends_lineage():
 # --- FILE HITL RecordEnvelope tests ---
 
 
-def _make_hitl_pipeline_and_context():
-    """Create a minimal pipeline and context for FILE-mode HITL tests."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_answers",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
+def _make_hitl_context(agent_name="review_answers"):
+    """Create a minimal context for FILE-mode HITL tests."""
+    return ProcessingContext(
         agent_config={"kind": "hitl", "granularity": "file"},
-        agent_name="review_answers",
+        agent_name=agent_name,
     )
-    return pipeline, context
 
 
 def test_file_hitl_namespaces_output_under_action():
     """FILE HITL wraps output under action namespace, not flat into content."""
-    pipeline, context = _make_hitl_pipeline_and_context()
+    context = _make_hitl_context()
 
     input_data = [
         {
@@ -1514,13 +1563,15 @@ def test_file_hitl_namespaces_output_under_action():
         },
     ]
 
+    context.source_data = input_data
+
     decision = {"hitl_status": "approved", "user_comment": "Looks good", "timestamp": "2026-01-01"}
 
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=([decision], True),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     result = results[0]
     assert result.status == ProcessingStatus.SUCCESS
@@ -1539,7 +1590,7 @@ def test_file_hitl_namespaces_output_under_action():
 
 def test_file_hitl_preserves_upstream_namespaces():
     """FILE HITL preserves all upstream namespaces from input records."""
-    pipeline, context = _make_hitl_pipeline_and_context()
+    context = _make_hitl_context()
 
     input_data = [
         {
@@ -1552,13 +1603,15 @@ def test_file_hitl_preserves_upstream_namespaces():
         },
     ]
 
+    context.source_data = input_data
+
     decision = {"hitl_status": "approved"}
 
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=([decision], True),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     content = results[0].data[0]["content"]
     assert "source" in content
@@ -1571,12 +1624,14 @@ def test_file_hitl_preserves_upstream_namespaces():
 
 def test_file_hitl_per_record_review_in_namespace():
     """Per-record review fields go under the action namespace, not flat."""
-    pipeline, context = _make_hitl_pipeline_and_context()
+    context = _make_hitl_context()
 
     input_data = [
         {"source_guid": "sg-1", "content": {"source": {"a": 1}}},
         {"source_guid": "sg-2", "content": {"source": {"a": 2}}},
     ]
+
+    context.source_data = input_data
 
     decision = {
         "hitl_status": "approved",
@@ -1590,7 +1645,7 @@ def test_file_hitl_per_record_review_in_namespace():
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=([decision], True),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     result = results[0]
     # Per-record review overrides file-level decision within the namespace
@@ -1605,7 +1660,7 @@ def test_file_hitl_per_record_review_in_namespace():
 
 def test_file_hitl_carries_framework_fields():
     """Framework fields (source_guid, target_id, _unprocessed) are preserved from input."""
-    pipeline, context = _make_hitl_pipeline_and_context()
+    context = _make_hitl_context()
 
     input_data = [
         {
@@ -1617,13 +1672,15 @@ def test_file_hitl_carries_framework_fields():
         },
     ]
 
+    context.source_data = input_data
+
     decision = {"hitl_status": "approved"}
 
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=([decision], True),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     item = results[0].data[0]
     assert item["source_guid"] == "sg-1"
@@ -1634,20 +1691,13 @@ def test_file_hitl_carries_framework_fields():
 
 def test_file_tool_version_merge_spreads_not_wraps():
     """Version merge tool output is spread flat, not wrapped under action name."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={
-                "kind": "tool",
-                "granularity": "file",
-                "version_consumption_config": {"source": "extract", "pattern": "merge"},
-            },
-            action_name="aggregate",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
+    agent_config = {
+        "kind": "tool",
+        "granularity": "file",
+        "version_consumption_config": {"source": "extract", "pattern": "merge"},
+    }
     context = ProcessingContext(
-        agent_config=pipeline.config.action_config,
+        agent_config=agent_config,
         agent_name="aggregate",
     )
 
@@ -1661,6 +1711,8 @@ def test_file_tool_version_merge_spreads_not_wraps():
         }
     ]
 
+    context.source_data = input_data
+
     with patch(
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(
@@ -1668,7 +1720,7 @@ def test_file_tool_version_merge_spreads_not_wraps():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_tool(input_data, input_data, context)
+        results = FileToolStrategy().invoke(input_data, context)
 
     content = results[0].data[0]["content"]
     # Flat spread, NOT wrapped under action name

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import patch
 
+import pytest
+
+from agent_actions.errors import AgentActionsError
 from agent_actions.processing.strategies.hitl import HITLStrategy
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
@@ -253,6 +256,35 @@ def test_file_mode_hitl_sets_identity_source_mapping():
     result = results[0]
     # source_mapping must be an identity map: output[i] came from input[i]
     assert result.source_mapping == {0: 0, 1: 1, 2: 2}
+
+
+def test_file_mode_hitl_timeout_raises_with_record_count():
+    """HITL timeout raises AgentActionsError with correct record count."""
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+        {"source_guid": "sg-3", "content": {"id": 3}},
+    ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
+    with (
+        patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=(
+                {
+                    "hitl_status": "timeout",
+                    "record_reviews": [{"hitl_status": "approved"}, None, None],
+                },
+                True,
+            ),
+        ),
+        pytest.raises(AgentActionsError, match="1/3 records reviewed"),
+    ):
+        HITLStrategy().invoke(input_data, context)
 
 
 def test_file_mode_hitl_observe_filters_and_orders_fields():

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -2,30 +2,23 @@
 
 from unittest.mock import patch
 
+from agent_actions.processing.strategies.hitl import HITLStrategy
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
-from agent_actions.workflow.pipeline import PipelineConfig, ProcessingPipeline
 
 
 def test_file_mode_hitl_applies_file_decision_to_each_input_record():
     """FILE-mode HITL should preserve all records and attach shared decision payload."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
-        agent_config={"kind": "hitl", "granularity": "file"},
-        agent_name="review_data",
-    )
-
     input_data = [
         {"source_guid": "sg-1", "content": {"id": 1, "question": "Q1"}},
         {"source_guid": "sg-2", "content": {"id": 2, "question": "Q2"}},
     ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=(
@@ -37,7 +30,7 @@ def test_file_mode_hitl_applies_file_decision_to_each_input_record():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -57,23 +50,16 @@ def test_file_mode_hitl_applies_file_decision_to_each_input_record():
 
 def test_file_mode_hitl_applies_per_record_decisions_when_provided():
     """Per-record review payload should override shared status for each record."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
-        agent_config={"kind": "hitl", "granularity": "file"},
-        agent_name="review_data",
-    )
-
     input_data = [
         {"source_guid": "sg-1", "content": {"id": 1}},
         {"source_guid": "sg-2", "content": {"id": 2}},
     ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=(
@@ -88,7 +74,7 @@ def test_file_mode_hitl_applies_per_record_decisions_when_provided():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -103,20 +89,13 @@ def test_file_mode_hitl_applies_per_record_decisions_when_provided():
 
 def test_file_mode_hitl_preserves_existing_status_field():
     """HITL decision metadata should not overwrite content.status."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
+    input_data = [{"source_guid": "sg-1", "content": {"id": 1, "status": "pending"}}]
     context = ProcessingContext(
         agent_config={"kind": "hitl", "granularity": "file"},
         agent_name="review_data",
+        source_data=input_data,
     )
 
-    input_data = [{"source_guid": "sg-1", "content": {"id": 1, "status": "pending"}}]
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=(
@@ -131,7 +110,7 @@ def test_file_mode_hitl_preserves_existing_status_field():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -144,17 +123,10 @@ def test_file_mode_hitl_preserves_existing_status_field():
 
 def test_file_mode_hitl_empty_input_returns_empty_output():
     """Empty data input should produce zero output records, not a synthetic one."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
     context = ProcessingContext(
         agent_config={"kind": "hitl", "granularity": "file"},
         agent_name="review_data",
+        source_data=[],
     )
 
     with patch(
@@ -168,7 +140,7 @@ def test_file_mode_hitl_empty_input_returns_empty_output():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_hitl([], [], context)
+        results = HITLStrategy().invoke([], context)
 
     assert len(results) == 1
     result = results[0]
@@ -178,19 +150,6 @@ def test_file_mode_hitl_empty_input_returns_empty_output():
 
 def test_file_mode_hitl_preserves_unprocessed_tombstone_markers():
     """Tombstone markers (_unprocessed, metadata) must survive HITL merge."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
-        agent_config={"kind": "hitl", "granularity": "file"},
-        agent_name="review_data",
-    )
-
     input_data = [
         {
             "source_guid": "sg-1",
@@ -200,6 +159,12 @@ def test_file_mode_hitl_preserves_unprocessed_tombstone_markers():
             "metadata": {"agent_type": "tombstone"},
         },
     ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=(
@@ -211,7 +176,7 @@ def test_file_mode_hitl_preserves_unprocessed_tombstone_markers():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -228,19 +193,6 @@ def test_file_mode_hitl_preserves_unprocessed_tombstone_markers():
 
 def test_file_mode_hitl_preserves_target_id():
     """Input target_id should be preserved through HITL merge."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
-        agent_config={"kind": "hitl", "granularity": "file"},
-        agent_name="review_data",
-    )
-
     input_data = [
         {
             "source_guid": "sg-1",
@@ -248,6 +200,12 @@ def test_file_mode_hitl_preserves_target_id():
             "content": {"id": 1},
         },
     ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=(
@@ -259,7 +217,7 @@ def test_file_mode_hitl_preserves_target_id():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -271,24 +229,17 @@ def test_file_mode_hitl_preserves_target_id():
 
 def test_file_mode_hitl_sets_identity_source_mapping():
     """HITL result must include identity source_mapping for lineage resolution."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "hitl", "granularity": "file"},
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
-        agent_config={"kind": "hitl", "granularity": "file"},
-        agent_name="review_data",
-    )
-
     input_data = [
         {"source_guid": "sg-1", "content": {"id": 1}},
         {"source_guid": "sg-2", "content": {"id": 2}},
         {"source_guid": "sg-3", "content": {"id": 3}},
     ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
     with patch(
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         return_value=(
@@ -296,7 +247,7 @@ def test_file_mode_hitl_sets_identity_source_mapping():
             True,
         ),
     ):
-        results = pipeline._process_file_mode_hitl(input_data, input_data, context)
+        results = HITLStrategy().invoke(input_data, context)
 
     assert len(results) == 1
     result = results[0]
@@ -306,27 +257,16 @@ def test_file_mode_hitl_sets_identity_source_mapping():
 
 def test_file_mode_hitl_observe_filters_and_orders_fields():
     """context_scope.observe should filter fields shown to HITL and preserve order."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={
-                "kind": "hitl",
-                "granularity": "file",
-                "context_scope": {
-                    "observe": [
-                        "upstream.question",
-                        "upstream.answer",
-                    ],
-                },
-            },
-            action_name="review_data",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
-    context = ProcessingContext(
-        agent_config=pipeline.config.action_config,
-        agent_name="review_data",
-    )
+    action_config = {
+        "kind": "hitl",
+        "granularity": "file",
+        "context_scope": {
+            "observe": [
+                "upstream.question",
+                "upstream.answer",
+            ],
+        },
+    }
 
     # Upstream data with namespaced content (additive model)
     original_data = [
@@ -355,7 +295,7 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
     ]
 
     # Apply the filter using unified context_scope
-    context_scope = pipeline.config.action_config.get("context_scope", {})
+    context_scope = action_config.get("context_scope", {})
     filtered = apply_context_scope_for_records(
         records=original_data,
         context_scope=context_scope,
@@ -369,6 +309,12 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
     assert filtered[0]["content"]["upstream"]["selectedAnswerer"] == "Alice"
     assert filtered[0]["source_guid"] == "sg-1"
     assert filtered[1]["content"]["answer"] == "Z is W"
+
+    context = ProcessingContext(
+        agent_config=action_config,
+        agent_name="review_data",
+        source_data=original_data,
+    )
 
     # Verify HITL receives filtered data but merge uses original_data
     captured_context = {}
@@ -384,7 +330,7 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
         "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         side_effect=mock_run_dynamic_agent,
     ):
-        results = pipeline._process_file_mode_hitl(filtered, original_data, context)
+        results = HITLStrategy().invoke(filtered, context)
 
     # HITL UI receives full enriched records
     assert captured_context["context"][0]["content"]["question"] == "What is X?"

--- a/tests/unit/workflow/test_version_merge_content.py
+++ b/tests/unit/workflow/test_version_merge_content.py
@@ -13,17 +13,17 @@ import pytest
 from agent_actions.input.preprocessing.transformation.transformer import (
     DataTransformer,
 )
+from agent_actions.processing.strategies.file_tool import FileToolStrategy
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
 from agent_actions.record.tracking import TrackedItem
-from agent_actions.workflow.pipeline import PipelineConfig, ProcessingPipeline
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_version_merge_pipeline_and_context():
-    """Create pipeline and context for a version consumption FILE-mode tool."""
+def _make_version_merge_context():
+    """Create context for a version consumption FILE-mode tool."""
     config = {
         "kind": "tool",
         "granularity": "file",
@@ -32,33 +32,17 @@ def _make_version_merge_pipeline_and_context():
             "pattern": "merge",
         },
     }
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config=config,
-            action_name="aggregate_votes",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
     context = ProcessingContext(agent_config=config, agent_name="aggregate_votes")
-    return pipeline, context
+    return context
 
 
-def _make_normal_pipeline_and_context():
-    """Create pipeline and context for a normal (non-version-merge) FILE-mode tool."""
-    pipeline = ProcessingPipeline(
-        config=PipelineConfig(
-            action_config={"kind": "tool", "granularity": "file"},
-            action_name="summarize",
-            idx=0,
-        ),
-        processor_factory=object(),
-    )
+def _make_normal_context():
+    """Create context for a normal (non-version-merge) FILE-mode tool."""
     context = ProcessingContext(
         agent_config={"kind": "tool", "granularity": "file"},
         agent_name="summarize",
     )
-    return pipeline, context
+    return context
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +55,7 @@ class TestFileModePipelineVersionMerge:
 
     def test_version_merge_spreads_tool_output(self):
         """Version merge action: tool output spread at top level, not wrapped."""
-        pipeline, context = _make_version_merge_pipeline_and_context()
+        context = _make_version_merge_context()
 
         # Version-correlated input record (what the version correlator produces)
         input_data = [
@@ -84,6 +68,7 @@ class TestFileModePipelineVersionMerge:
                 },
             }
         ]
+        context.source_data = input_data
 
         # Tool returns aggregated output via TrackedItem
         with patch(
@@ -93,7 +78,7 @@ class TestFileModePipelineVersionMerge:
                 True,
             ),
         ):
-            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+            results = FileToolStrategy().invoke(input_data, context)
 
         assert results[0].status == ProcessingStatus.SUCCESS
         content = results[0].data[0]["content"]
@@ -111,7 +96,7 @@ class TestFileModePipelineVersionMerge:
 
     def test_version_merge_preserves_version_namespaces(self):
         """Version namespaces from input are preserved in the output content."""
-        pipeline, context = _make_version_merge_pipeline_and_context()
+        context = _make_version_merge_context()
 
         input_data = [
             {
@@ -124,6 +109,7 @@ class TestFileModePipelineVersionMerge:
                 },
             }
         ]
+        context.source_data = input_data
 
         with patch(
             "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
@@ -132,7 +118,7 @@ class TestFileModePipelineVersionMerge:
                 True,
             ),
         ):
-            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+            results = FileToolStrategy().invoke(input_data, context)
 
         content = results[0].data[0]["content"]
         assert len([k for k in content if k.startswith("filter_learning_quality")]) == 3
@@ -140,7 +126,7 @@ class TestFileModePipelineVersionMerge:
 
     def test_normal_action_still_wraps_under_action_name(self):
         """Non-version-merge action: tool output wrapped under action name."""
-        pipeline, context = _make_normal_pipeline_and_context()
+        context = _make_normal_context()
 
         input_data = [
             {
@@ -149,6 +135,7 @@ class TestFileModePipelineVersionMerge:
                 "content": {"upstream_action": {"text": "hello"}},
             }
         ]
+        context.source_data = input_data
 
         with patch(
             "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
@@ -157,7 +144,7 @@ class TestFileModePipelineVersionMerge:
                 True,
             ),
         ):
-            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+            results = FileToolStrategy().invoke(input_data, context)
 
         content = results[0].data[0]["content"]
         # Normal action wraps under action name
@@ -168,7 +155,7 @@ class TestFileModePipelineVersionMerge:
 
     def test_version_merge_tool_returns_content_key(self):
         """Version merge tool returning {"content": {...}} is handled correctly."""
-        pipeline, context = _make_version_merge_pipeline_and_context()
+        context = _make_version_merge_context()
 
         input_data = [
             {
@@ -180,6 +167,7 @@ class TestFileModePipelineVersionMerge:
                 },
             }
         ]
+        context.source_data = input_data
 
         # Tool returns output via TrackedItem
         with patch(
@@ -189,7 +177,7 @@ class TestFileModePipelineVersionMerge:
                 True,
             ),
         ):
-            results = pipeline._process_file_mode_tool(input_data, input_data, context)
+            results = FileToolStrategy().invoke(input_data, context)
 
         content = results[0].data[0]["content"]
         assert "aggregate_votes" not in content


### PR DESCRIPTION
## Summary
- Collapse the 3-way FILE tool / FILE HITL / RECORD online dispatch in `_process_by_strategy()` into strategy selection (`_select_strategy()`) + single `UnifiedProcessor.process()` call
- Adapt `FileToolStrategy` and `HITLStrategy` to the `ProcessingStrategy` protocol — `invoke(records, context)` instead of `invoke(data, original_data, context)`
- Move enrichment out of FILE strategies into `UnifiedProcessor` (eliminates potential double-enrichment)
- Add `_guard_filter_file_mode()` to `UnifiedProcessor` for FILE-mode guard handling with `original_data` alignment and `UNPROCESSED` result type preservation
- Delete dead code: `_process_file_mode_tool()`, `_process_file_mode_hitl()`, `_build_skipped_results()`, `enrichment_pipeline` field
- Net: +550 −462 lines across 10 files (guard logic consolidated, tests retargeted)

## Verification
- 6133 tests pass, 2 skipped (pre-existing)
- `ruff check` and `ruff format --check` clean on all changed files
- Pre-existing ruff F811 in `test_api_key_secret.py` (not touched by this PR)
- FILE-mode guard skip behavior preserved: `ProcessingResult.unprocessed()` with `RecordEnvelope.build_skipped` (not RECORD-mode tombstone format)
- Result ordering preserved: FILE mode = invocation + guard skips; RECORD mode = guard skips + invocation