### PR TITLE
refactor: remove duplicate EnrichmentPipeline from BatchResultStrategy

### DIFF
--- a/.changes/unreleased/Under the Hood-20260429-312000.yaml
+++ b/.changes/unreleased/Under the Hood-20260429-312000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove duplicate EnrichmentPipeline from BatchResultStrategy; batch result enrichment now runs through BatchProcessingService using the shared pipeline class"
+time: 2026-04-29T03:12:00.000000Z

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -15,7 +15,6 @@ from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.response.config_fields import get_default
 from agent_actions.processing.batch_context_adapter import BatchContextAdapter
-from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 from agent_actions.processing.record_helpers import (
     apply_version_merge,
@@ -61,10 +60,12 @@ class BatchResultStrategy:
     this processes already-returned batch results.  The ``process()`` method
     returns ``list[ProcessingResult]`` so the caller can flatten, collect,
     and write dispositions through the shared pipeline.
-    """
 
-    def __init__(self) -> None:
-        self._enrichment_pipeline = EnrichmentPipeline()
+    Each returned result carries a ``processing_context`` field that the
+    caller (``BatchProcessingService``) uses to run enrichment through the
+    shared enrichment pipeline.  Error results have ``processing_context``
+    set to ``None`` and are intentionally not enriched.
+    """
 
     def process(
         self,
@@ -74,11 +75,16 @@ class BatchResultStrategy:
         agent_config: dict[str, Any] | None = None,
         exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
     ) -> list[ProcessingResult]:
-        """Convert batch results into enriched ProcessingResult objects.
+        """Convert batch results into unenriched ProcessingResult objects.
 
         Returns one ProcessingResult per input record (successful, failed,
-        exhausted, or unprocessed).  The caller is responsible for flattening
-        ``result.data`` into output records and writing dispositions.
+        exhausted, or unprocessed).  Successful, exhausted, and unprocessed
+        results carry a ``processing_context`` field; the caller uses it to
+        run enrichment through the shared enrichment pipeline.  Error
+        results have ``processing_context=None`` and are not enriched.
+
+        The caller is responsible for enriching, flattening ``result.data``
+        into output records, and writing dispositions.
         """
         ctx = self._init_context(
             batch_results,
@@ -227,7 +233,7 @@ class BatchResultStrategy:
         batch_result: BatchResult,
         custom_id: str,
     ) -> ProcessingResult:
-        """Parse a successful batch result into an enriched ProcessingResult."""
+        """Parse a successful batch result into a ProcessingResult."""
         if ctx.reconciler is None:
             raise RuntimeError(
                 "BatchProcessingContext.reconciler is None; "
@@ -282,7 +288,8 @@ class BatchResultStrategy:
             recovery_metadata=batch_result.recovery_metadata,
         )
 
-        return self._enrichment_pipeline.enrich(processing_result, processing_context)
+        processing_result.processing_context = processing_context
+        return processing_result
 
     def _apply_context_passthrough(
         self,
@@ -404,7 +411,7 @@ class BatchResultStrategy:
         source_guid: str,
         record_index: int,
     ) -> ProcessingResult:
-        """Build an enriched EXHAUSTED result for a retry-exhausted record."""
+        """Build an EXHAUSTED result for a retry-exhausted record."""
         if ctx.exhausted_recovery is None:
             raise RuntimeError(
                 "BatchProcessingContext.exhausted_recovery is None "
@@ -448,7 +455,8 @@ class BatchResultStrategy:
             source_guid=source_guid,
             recovery_metadata=recovery_meta,
         )
-        return self._enrichment_pipeline.enrich(processing_result, processing_context)
+        processing_result.processing_context = processing_context
+        return processing_result
 
     def _build_unprocessed_passthrough(
         self,
@@ -458,7 +466,7 @@ class BatchResultStrategy:
         source_guid: str,
         record_index: int,
     ) -> ProcessingResult:
-        """Build an enriched UNPROCESSED result for a passthrough record."""
+        """Build an UNPROCESSED result for a passthrough record."""
         # Determine actual skip reason from context metadata
         filter_phase = original_row.get(ContextMetaKeys.FILTER_PHASE, "")
         if filter_phase == "upstream_unprocessed":
@@ -486,4 +494,5 @@ class BatchResultStrategy:
             reason=reason,
             source_guid=source_guid,
         )
-        return self._enrichment_pipeline.enrich(processing_result, processing_context)
+        processing_result.processing_context = processing_context
+        return processing_result

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -43,6 +43,7 @@ from agent_actions.llm.batch.services.retry import BatchRetryService
 from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.writer import FileWriter
+from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.result_collector import (
     write_record_dispositions as _write_record_dispositions_impl,
 )
@@ -98,6 +99,7 @@ class BatchProcessingService:
             dependency_configs=self._dependency_configs,
             storage_backend=self._storage_backend,
         )
+        self._enrichment_pipeline = EnrichmentPipeline()
 
     def process_batch_results(
         self,
@@ -679,8 +681,15 @@ class BatchProcessingService:
             agent_config=agent_config,
             exhausted_recovery=exhausted_recovery,
         )
-        # Flatten ProcessingResult objects to workflow-format dicts.
-        return [item for result in results for item in (result.data or [])]
+        # Enrich results that carry a processing_context, then flatten to
+        # workflow-format dicts.  Error results (processing_context=None) are
+        # intentionally skipped — matching the original pipeline behaviour.
+        enriched: list = []
+        for result in results:
+            if result.processing_context is not None:
+                result = self._enrichment_pipeline.enrich(result, result.processing_context)
+            enriched.append(result)
+        return [item for result in enriched for item in (result.data or [])]
 
     @staticmethod
     def _apply_workflow_session_id(

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -684,12 +684,12 @@ class BatchProcessingService:
         # Enrich results that carry a processing_context, then flatten to
         # workflow-format dicts.  Error results (processing_context=None) are
         # intentionally skipped — matching the original pipeline behaviour.
-        enriched: list = []
+        output: list[dict[str, Any]] = []
         for result in results:
             if result.processing_context is not None:
                 result = self._enrichment_pipeline.enrich(result, result.processing_context)
-            enriched.append(result)
-        return [item for result in enriched for item in (result.data or [])]
+            output.extend(result.data or [])
+        return output
 
     @staticmethod
     def _apply_workflow_session_id(

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -130,6 +130,7 @@ class ProcessingResult:
     raw_response: Any | None = None
     pre_extracted_metadata: dict[str, Any] | None = None
     source_mapping: dict[int, int | list[int] | None] | None = None
+    processing_context: Optional["ProcessingContext"] = None
 
     @classmethod
     def success(

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -366,19 +366,11 @@ class TestBatchPathReasonDetection:
         ctx = self._make_ctx(passthrough_records=[("cid_4", row)])
         processor = BatchResultStrategy()
 
-        # Patch enrich to capture the ProcessingResult type
-        captured_results = []
-        original_enrich = processor._enrichment_pipeline.enrich
+        results = processor._reconcile_passthroughs(ctx)
 
-        def capturing_enrich(result, context):
-            captured_results.append(result)
-            return original_enrich(result, context)
-
-        processor._enrichment_pipeline.enrich = capturing_enrich
-        processor._reconcile_passthroughs(ctx)
-
-        assert len(captured_results) == 1
-        assert captured_results[0].status == ProcessingStatus.UNPROCESSED
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].processing_context is not None
 
     def test_batch_not_returned_uses_unprocessed_status(self):
         """batch_not_returned records should use ProcessingResult.unprocessed(), not .skipped()."""
@@ -390,15 +382,8 @@ class TestBatchPathReasonDetection:
         ctx = self._make_ctx(passthrough_records=[("cid_5", row)])
         processor = BatchResultStrategy()
 
-        captured_results = []
-        original_enrich = processor._enrichment_pipeline.enrich
+        results = processor._reconcile_passthroughs(ctx)
 
-        def capturing_enrich(result, context):
-            captured_results.append(result)
-            return original_enrich(result, context)
-
-        processor._enrichment_pipeline.enrich = capturing_enrich
-        processor._reconcile_passthroughs(ctx)
-
-        assert len(captured_results) == 1
-        assert captured_results[0].status == ProcessingStatus.UNPROCESSED
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].processing_context is not None

--- a/tests/unit/llm/batch/test_result_processor_version_merge.py
+++ b/tests/unit/llm/batch/test_result_processor_version_merge.py
@@ -9,7 +9,6 @@ the content namespace structure.
 """
 
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -39,11 +38,8 @@ def _make_ctx(
 
 @pytest.fixture
 def processor():
-    """BatchResultStrategy with enrichment pipeline stubbed to pass through."""
-    p = BatchResultStrategy()
-    p._enrichment_pipeline = MagicMock()
-    p._enrichment_pipeline.enrich.side_effect = lambda result, context: result
-    return p
+    """BatchResultStrategy for version_merge testing."""
+    return BatchResultStrategy()
 
 
 class TestLLMVersionMergeWrapsUnderActionName:
@@ -192,8 +188,6 @@ class TestProcessReturnsFlattenableResults:
         )
 
         strategy = BatchResultStrategy()
-        strategy._enrichment_pipeline = MagicMock()
-        strategy._enrichment_pipeline.enrich.side_effect = lambda result, ctx: result
 
         results = strategy.process(
             batch_results=[batch_result],


### PR DESCRIPTION
## Summary
- `BatchResultStrategy` owned a private `EnrichmentPipeline` and called `enrich()` at 3 inline points (success, exhausted, unprocessed). This duplicated the enrichment path used by `UnifiedProcessor` for online/FILE modes.
- Added optional `processing_context` field to `ProcessingResult` — the strategy attaches the per-record `ProcessingContext` it builds, then returns without enriching.
- `BatchProcessingService` now owns an `EnrichmentPipeline` and runs the enrichment loop in `_convert_batch_results_to_workflow_format()`, enriching results that carry a context and skipping error results (same behaviour as before).
- `grep "EnrichmentPipeline" agent_actions/llm/batch/processing/batch_result_strategy.py` → zero matches.

## Verification
- 6135 tests pass
- `ruff format --check` + `ruff check` clean (1 pre-existing F811 in unrelated test file)
- Error results (FAILED) remain unenriched — `processing_context=None`
- Success/exhausted/unprocessed results enriched through shared pipeline