### PR TITLE
Reject staging data with reserved namespace field names

### DIFF
--- a/agent_actions/input/preprocessing/staging/_MANIFEST.md
+++ b/agent_actions/input/preprocessing/staging/_MANIFEST.md
@@ -12,6 +12,7 @@
 |------|------|-------------|---------|
 | `__init__.py` | Module | Module docstring describing the staging helpers. | `preprocessing` |
 | `initial_pipeline.py` | Module | `process_initial_stage` entry point plus validation, source saving, mode-specific preparation helpers, and storage-backend requirements for first-stage target writes. Delegates workflow root discovery to `utils.path_utils.derive_workflow_root`. | `processing`, `output`, `logging`, `utils.path_utils` |
+| `field_validation.py` | Module | `validate_staging_field_names` — rejects staging records whose field names collide with reserved prompt-context namespaces (`source`, `version`, `workflow`, etc.). Called at two points: staging file load (initial_pipeline) and prompt context build (scope_builder). | `utils.constants`, `errors` |
 
 ## Design Notes
 
@@ -24,6 +25,21 @@ since FileReader already returns `list[dict]` via pandas.
 
 This means CSV/XML files are read twice (once wasted). A follow-up could skip FileReader
 entirely for these file types.
+
+### Reserved namespace collision guard (`field_validation.py`)
+
+Staging records can have arbitrary user-defined field names. The framework reserves
+certain top-level names (`source`, `version`, `workflow`, `seed`, etc.) as prompt-context
+namespaces. If a staging field collides, the value is silently mis-routed at prompt-build
+time (e.g., `source.page_content` resolves to the wrong data).
+
+The guard runs at two convergence points:
+1. **Staging file load** — `process_initial_stage()` calls it before any processing
+2. **Prompt context build** — `_load_source_namespace()` in `scope_builder.py` calls it
+   as a belt-and-suspenders check, catching data that entered through storage reads,
+   batch resume, or FILE mode source resolution
+
+The reserved names come from `SPECIAL_NAMESPACES` in `utils/constants.py`.
 
 ### Zero-success failure check (`initial_pipeline.py`)
 

--- a/agent_actions/input/preprocessing/staging/field_validation.py
+++ b/agent_actions/input/preprocessing/staging/field_validation.py
@@ -1,0 +1,48 @@
+"""Staging field name validation — catches reserved namespace collisions early."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from agent_actions.errors import ConfigValidationError
+from agent_actions.utils.constants import SPECIAL_NAMESPACES
+
+logger = logging.getLogger(__name__)
+
+
+def validate_staging_field_names(raw_content: Any, file_path: str) -> None:
+    """Validate that staging record field names do not collide with reserved namespaces.
+
+    The framework reserves certain top-level names (``source``, ``version``,
+    ``workflow``, ``seed``, etc.) as prompt-context namespaces.  If a staging
+    record contains a field with one of these names the pipeline will silently
+    mis-route the value at prompt-build time.  Catching the collision here —
+    before any processing — gives the user a clear, actionable error.
+    """
+    if not raw_content:
+        return
+
+    # Grab a representative record to inspect field names.
+    if isinstance(raw_content, list) and raw_content:
+        sample = raw_content[0]
+    elif isinstance(raw_content, dict):
+        sample = raw_content
+    else:
+        return
+
+    if not isinstance(sample, dict):
+        return
+
+    collisions = SPECIAL_NAMESPACES & sample.keys()
+    if collisions:
+        collision_list = ", ".join(sorted(collisions))
+        reserved_list = ", ".join(sorted(SPECIAL_NAMESPACES))
+        raise ConfigValidationError(
+            f"Staging data field(s) {collision_list!r} in {Path(file_path).name} "
+            f"collide with reserved namespace names.\n\n"
+            f"Reserved names: {reserved_list}\n\n"
+            f"Rename the colliding field(s) in your staging data "
+            f"(e.g. 'source' → 'source_file', 'version' → 'doc_version').",
+        )

--- a/agent_actions/input/preprocessing/staging/field_validation.py
+++ b/agent_actions/input/preprocessing/staging/field_validation.py
@@ -2,40 +2,39 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import ConfigValidationError
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
 
-logger = logging.getLogger(__name__)
-
 
 def validate_staging_field_names(raw_content: Any, file_path: str) -> None:
     """Validate that staging record field names do not collide with reserved namespaces.
 
-    The framework reserves certain top-level names (``source``, ``version``,
-    ``workflow``, ``seed``, etc.) as prompt-context namespaces.  If a staging
-    record contains a field with one of these names the pipeline will silently
-    mis-route the value at prompt-build time.  Catching the collision here —
-    before any processing — gives the user a clear, actionable error.
+    The framework reserves top-level names in ``SPECIAL_NAMESPACES``
+    (``source``, ``version``, ``workflow``, ``seed``, ``prompt``,
+    ``schema``, ``action``) as prompt-context namespaces.  If a staging
+    record contains a field with one of these names the pipeline will
+    silently mis-route the value at prompt-build time.
+
+    For list inputs every dict row is checked, not just the first — staging
+    files can contain heterogeneous records.
     """
     if not raw_content:
         return
 
-    # Grab a representative record to inspect field names.
-    if isinstance(raw_content, list) and raw_content:
-        sample = raw_content[0]
-    elif isinstance(raw_content, dict):
-        sample = raw_content
-    else:
-        return
+    if isinstance(raw_content, dict):
+        _check_dict(raw_content, file_path)
+    elif isinstance(raw_content, list):
+        for item in raw_content:
+            if isinstance(item, dict):
+                _check_dict(item, file_path)
 
-    if not isinstance(sample, dict):
-        return
 
-    collisions = SPECIAL_NAMESPACES & sample.keys()
+def _check_dict(record: dict[str, Any], file_path: str) -> None:
+    """Raise ``ConfigValidationError`` if *record* has reserved field names."""
+    collisions = SPECIAL_NAMESPACES & record.keys()
     if collisions:
         collision_list = ", ".join(sorted(collisions))
         reserved_list = ", ".join(sorted(SPECIAL_NAMESPACES))

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -162,6 +162,12 @@ def process_initial_stage(ctx: InitialStageContext):
         },
     )
 
+    from agent_actions.input.preprocessing.staging.field_validation import (
+        validate_staging_field_names,
+    )
+
+    validate_staging_field_names(raw_content=content, file_path=ctx.file_path)
+
     _validate_staged_data(
         raw_content=content,
         file_type=file_type,

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -16,6 +16,27 @@ loaders for cataloging prompts at documentation time.
 | `scope_inference.py` | Module | Dependency inference: fan-in detection, version branch expansion, input/context source resolution. | `preprocessing` |
 | `scope_application.py` | Module | Context scope application: observe/passthrough/drop filtering for RECORD mode (`apply_context_scope`) and FILE mode (`apply_context_scope_for_records`), LLM context formatting. | `preprocessing` |
 | `scope_namespace.py` | Module | Namespace enrichment, field filtering, and allowed-fields extraction. | `preprocessing` |
-| `scope_builder.py` | Module | `build_field_context_with_history`: assembles source/dependency/version/workflow namespaces. | `preprocessing` |
+| `scope_builder.py` | Module | `build_field_context_with_history`: assembles source/dependency/version/workflow namespaces. Convergence point for source data validation (see design note). | `preprocessing`, `staging.field_validation` |
 | ~~`scope_file_mode.py`~~ | Deleted | FILE-mode observe merged into `scope_application.py:apply_context_scope_for_records`. | — |
 | `static_loader.py` | Module | Static prompt loader used during docs generation to read prompt store files. | `tooling.docs`, `file_io` |
+
+## Design Notes
+
+### Source data: four retrieval paths, one convergence point
+
+Source data (the user's original staging input) reaches `_load_source_namespace()` in
+`scope_builder.py` through four paths, each serving a different pipeline lifecycle stage:
+
+| Path | When | How source data arrives | Entry point |
+|------|------|------------------------|-------------|
+| **Staging file load** | First action, initial run | Read from `agent_io/staging/*.json` by `FileReader` | `initial_pipeline.process_initial_stage()` |
+| **Storage lookup** | Downstream actions | Saved to storage during first action; retrieved by `source_guid` | `task_preparer._get_source_content()` |
+| **FILE mode index** | FILE-granularity actions | Resolved per-`source_guid` from a shared source index | `scope_application._resolve_source_content()` |
+| **Batch resume** | Batch re-run after prior submission | Records already in memory/storage from prior batch prep | `params.data` pre-loaded, skips `initial_pipeline` |
+
+The data is the same in all four cases — the user's original staging fields. The paths
+differ because of *where the data lives* at each stage (disk → storage → index → memory).
+
+`_load_source_namespace()` is the single convergence point where all four paths write to
+`field_context["source"]`. Validation for reserved namespace collisions runs here to
+cover all paths regardless of how the data entered the pipeline.

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -29,7 +29,7 @@ Source data (the user's original staging input) reaches `_load_source_namespace(
 
 | Path | When | How source data arrives | Entry point |
 |------|------|------------------------|-------------|
-| **Staging file load** | First action, initial run | Read from `agent_io/staging/*.json` by `FileReader` | `initial_pipeline.process_initial_stage()` |
+| **Staging file load** | First action, initial run | Read from the user-configured `data_source` path (`folder` + `file_type` in workflow config) by `FileReader` | `initial_pipeline.process_initial_stage()` |
 | **Storage lookup** | Downstream actions | Saved to storage during first action; retrieved by `source_guid` | `task_preparer._get_source_content()` |
 | **FILE mode index** | FILE-granularity actions | Resolved per-`source_guid` from a shared source index | `scope_application._resolve_source_content()` |
 | **Batch resume** | Batch re-run after prior submission | Records already in memory/storage from prior batch prep | `params.data` pre-loaded, skips `initial_pipeline` |

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -93,6 +93,11 @@ def _load_source_namespace(
             source_namespace = dict(source_content)
 
     if source_namespace:
+        from agent_actions.input.preprocessing.staging.field_validation import (
+            validate_staging_field_names,
+        )
+
+        validate_staging_field_names(source_namespace, f"action:{agent_name}")
         field_context["source"] = source_namespace
         logger.debug("Added 'source' namespace with %s fields", len(source_namespace))
         fire_event(

--- a/tests/unit/input/test_staging_field_name_collision.py
+++ b/tests/unit/input/test_staging_field_name_collision.py
@@ -1,0 +1,71 @@
+"""Tests for staging field name collision detection (P5-010 / CR-1).
+
+When a staging record contains a top-level field whose name matches a reserved
+prompt-context namespace (``source``, ``version``, ``workflow``, etc.), the
+pipeline must reject the data with an actionable error — not silently mis-route
+values at prompt-build time.
+"""
+
+import pytest
+
+from agent_actions.errors import ConfigValidationError
+from agent_actions.input.preprocessing.staging.field_validation import (
+    validate_staging_field_names,
+)
+
+
+class TestValidateStagingFieldNames:
+    """Collision detection for reserved namespace names in staging data."""
+
+    def test_field_named_source_raises(self):
+        records = [{"id": "1", "source": "Architecture.md", "page_content": "text"}]
+        with pytest.raises(ConfigValidationError, match="source"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_field_named_version_raises(self):
+        records = [{"id": "1", "version": "2.0", "title": "doc"}]
+        with pytest.raises(ConfigValidationError, match="version"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_field_named_workflow_raises(self):
+        records = [{"id": "1", "workflow": "main"}]
+        with pytest.raises(ConfigValidationError, match="workflow"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_field_named_seed_raises(self):
+        records = [{"id": "1", "seed": 42}]
+        with pytest.raises(ConfigValidationError, match="seed"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_multiple_collisions_reported(self):
+        records = [{"source": "a.md", "version": "1.0", "title": "doc"}]
+        with pytest.raises(ConfigValidationError, match="source.*version|version.*source"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_no_collision_passes(self):
+        records = [{"id": "1", "url": "http://example.com", "page_content": "text"}]
+        validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_dict_input_checked(self):
+        record = {"source": "file.md", "content": "text"}
+        with pytest.raises(ConfigValidationError, match="source"):
+            validate_staging_field_names(record, "/fake/staging/data.json")
+
+    def test_empty_input_passes(self):
+        validate_staging_field_names([], "/fake/staging/data.json")
+        validate_staging_field_names(None, "/fake/staging/data.json")
+        validate_staging_field_names("", "/fake/staging/data.json")
+
+    def test_non_dict_records_pass(self):
+        validate_staging_field_names(["plain string"], "/fake/staging/data.json")
+        validate_staging_field_names("raw text", "/fake/staging/data.json")
+
+    def test_error_message_includes_rename_suggestion(self):
+        records = [{"source": "Architecture.md"}]
+        with pytest.raises(ConfigValidationError, match="Rename"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_error_message_includes_filename(self):
+        records = [{"source": "Architecture.md"}]
+        with pytest.raises(ConfigValidationError, match="data.json"):
+            validate_staging_field_names(records, "/fake/staging/data.json")

--- a/tests/unit/input/test_staging_field_name_collision.py
+++ b/tests/unit/input/test_staging_field_name_collision.py
@@ -17,8 +17,6 @@ from agent_actions.input.preprocessing.staging.field_validation import (
 class TestValidateStagingFieldNames:
     """Collision detection for reserved namespace names in staging data."""
 
-    # -- Collisions on every SPECIAL_NAMESPACES member -----------------------
-
     @pytest.mark.parametrize(
         "field",
         ["source", "version", "workflow", "seed", "prompt", "schema", "action"],
@@ -33,8 +31,6 @@ class TestValidateStagingFieldNames:
         with pytest.raises(ConfigValidationError, match="source.*version|version.*source"):
             validate_staging_field_names(records, "/fake/staging/data.json")
 
-    # -- No collision --------------------------------------------------------
-
     def test_no_collision_list_passes(self):
         records = [{"id": "1", "url": "http://example.com", "page_content": "text"}]
         validate_staging_field_names(records, "/fake/staging/data.json")
@@ -43,36 +39,10 @@ class TestValidateStagingFieldNames:
         record = {"id": "1", "title": "doc", "body": "text"}
         validate_staging_field_names(record, "/fake/staging/data.json")
 
-    # -- Dict input ----------------------------------------------------------
-
     def test_dict_input_collision_raises(self):
         record = {"source": "file.md", "content_text": "text"}
         with pytest.raises(ConfigValidationError, match="source"):
             validate_staging_field_names(record, "/fake/staging/data.json")
-
-    # -- Empty / falsy input -------------------------------------------------
-
-    def test_empty_list_passes(self):
-        validate_staging_field_names([], "/fake/staging/data.json")
-
-    def test_none_passes(self):
-        validate_staging_field_names(None, "/fake/staging/data.json")
-
-    def test_empty_string_passes(self):
-        validate_staging_field_names("", "/fake/staging/data.json")
-
-    def test_empty_dict_passes(self):
-        validate_staging_field_names({}, "/fake/staging/data.json")
-
-    # -- Non-dict records ----------------------------------------------------
-
-    def test_list_of_strings_passes(self):
-        validate_staging_field_names(["plain string", "another"], "/fake/staging/data.json")
-
-    def test_plain_string_passes(self):
-        validate_staging_field_names("raw text", "/fake/staging/data.json")
-
-    # -- Later-row collision (critical fix) -----------------------------------
 
     def test_collision_on_second_record(self):
         """Collision only on record [1] — must not be missed."""
@@ -92,8 +62,6 @@ class TestValidateStagingFieldNames:
         with pytest.raises(ConfigValidationError, match="version"):
             validate_staging_field_names(records, "/fake/staging/data.json")
 
-    # -- Heterogeneous list (non-dict then dict) -----------------------------
-
     def test_non_dict_first_then_dict_with_collision(self):
         """First element is a string, second is a dict with collision."""
         records = ["plain text", {"source": "file.md", "body": "text"}]
@@ -101,25 +69,6 @@ class TestValidateStagingFieldNames:
             validate_staging_field_names(records, "/fake/staging/data.json")
 
     def test_non_dict_elements_skipped(self):
-        """Non-dict elements in list are silently skipped."""
+        """Non-dict elements in list are silently skipped, dicts still checked."""
         records = ["string1", 42, None, {"id": "1", "title": "safe"}]
         validate_staging_field_names(records, "/fake/staging/data.json")
-
-    # -- Error message quality -----------------------------------------------
-
-    def test_error_message_includes_rename_suggestion(self):
-        records = [{"source": "Architecture.md"}]
-        with pytest.raises(ConfigValidationError, match="Rename"):
-            validate_staging_field_names(records, "/fake/staging/data.json")
-
-    def test_error_message_includes_filename(self):
-        records = [{"source": "Architecture.md"}]
-        with pytest.raises(ConfigValidationError, match="data.json"):
-            validate_staging_field_names(records, "/fake/staging/data.json")
-
-    def test_error_message_lists_all_reserved_names(self):
-        records = [{"source": "x"}]
-        with pytest.raises(
-            ConfigValidationError, match="action.*prompt.*schema.*seed.*source.*version.*workflow"
-        ):
-            validate_staging_field_names(records, "/fake/staging/data.json")

--- a/tests/unit/input/test_staging_field_name_collision.py
+++ b/tests/unit/input/test_staging_field_name_collision.py
@@ -1,9 +1,9 @@
-"""Tests for staging field name collision detection (P5-010 / CR-1).
+"""Tests for staging field name collision detection (CR-1).
 
 When a staging record contains a top-level field whose name matches a reserved
-prompt-context namespace (``source``, ``version``, ``workflow``, etc.), the
-pipeline must reject the data with an actionable error — not silently mis-route
-values at prompt-build time.
+prompt-context namespace (any member of ``SPECIAL_NAMESPACES``), the pipeline
+must reject the data with an actionable error — not silently mis-route values
+at prompt-build time.
 """
 
 import pytest
@@ -17,24 +17,15 @@ from agent_actions.input.preprocessing.staging.field_validation import (
 class TestValidateStagingFieldNames:
     """Collision detection for reserved namespace names in staging data."""
 
-    def test_field_named_source_raises(self):
-        records = [{"id": "1", "source": "Architecture.md", "page_content": "text"}]
-        with pytest.raises(ConfigValidationError, match="source"):
-            validate_staging_field_names(records, "/fake/staging/data.json")
+    # -- Collisions on every SPECIAL_NAMESPACES member -----------------------
 
-    def test_field_named_version_raises(self):
-        records = [{"id": "1", "version": "2.0", "title": "doc"}]
-        with pytest.raises(ConfigValidationError, match="version"):
-            validate_staging_field_names(records, "/fake/staging/data.json")
-
-    def test_field_named_workflow_raises(self):
-        records = [{"id": "1", "workflow": "main"}]
-        with pytest.raises(ConfigValidationError, match="workflow"):
-            validate_staging_field_names(records, "/fake/staging/data.json")
-
-    def test_field_named_seed_raises(self):
-        records = [{"id": "1", "seed": 42}]
-        with pytest.raises(ConfigValidationError, match="seed"):
+    @pytest.mark.parametrize(
+        "field",
+        ["source", "version", "workflow", "seed", "prompt", "schema", "action"],
+    )
+    def test_each_reserved_name_raises(self, field):
+        records = [{"id": "1", field: "value"}]
+        with pytest.raises(ConfigValidationError, match=field):
             validate_staging_field_names(records, "/fake/staging/data.json")
 
     def test_multiple_collisions_reported(self):
@@ -42,23 +33,79 @@ class TestValidateStagingFieldNames:
         with pytest.raises(ConfigValidationError, match="source.*version|version.*source"):
             validate_staging_field_names(records, "/fake/staging/data.json")
 
-    def test_no_collision_passes(self):
+    # -- No collision --------------------------------------------------------
+
+    def test_no_collision_list_passes(self):
         records = [{"id": "1", "url": "http://example.com", "page_content": "text"}]
         validate_staging_field_names(records, "/fake/staging/data.json")
 
-    def test_dict_input_checked(self):
-        record = {"source": "file.md", "content": "text"}
+    def test_no_collision_dict_passes(self):
+        record = {"id": "1", "title": "doc", "body": "text"}
+        validate_staging_field_names(record, "/fake/staging/data.json")
+
+    # -- Dict input ----------------------------------------------------------
+
+    def test_dict_input_collision_raises(self):
+        record = {"source": "file.md", "content_text": "text"}
         with pytest.raises(ConfigValidationError, match="source"):
             validate_staging_field_names(record, "/fake/staging/data.json")
 
-    def test_empty_input_passes(self):
+    # -- Empty / falsy input -------------------------------------------------
+
+    def test_empty_list_passes(self):
         validate_staging_field_names([], "/fake/staging/data.json")
+
+    def test_none_passes(self):
         validate_staging_field_names(None, "/fake/staging/data.json")
+
+    def test_empty_string_passes(self):
         validate_staging_field_names("", "/fake/staging/data.json")
 
-    def test_non_dict_records_pass(self):
-        validate_staging_field_names(["plain string"], "/fake/staging/data.json")
+    def test_empty_dict_passes(self):
+        validate_staging_field_names({}, "/fake/staging/data.json")
+
+    # -- Non-dict records ----------------------------------------------------
+
+    def test_list_of_strings_passes(self):
+        validate_staging_field_names(["plain string", "another"], "/fake/staging/data.json")
+
+    def test_plain_string_passes(self):
         validate_staging_field_names("raw text", "/fake/staging/data.json")
+
+    # -- Later-row collision (critical fix) -----------------------------------
+
+    def test_collision_on_second_record(self):
+        """Collision only on record [1] — must not be missed."""
+        records = [
+            {"id": "1", "title": "safe"},
+            {"id": "2", "source": "Architecture.md"},
+        ]
+        with pytest.raises(ConfigValidationError, match="source"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_collision_on_last_record(self):
+        records = [
+            {"id": "1", "title": "ok"},
+            {"id": "2", "title": "ok"},
+            {"id": "3", "version": "2.0"},
+        ]
+        with pytest.raises(ConfigValidationError, match="version"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    # -- Heterogeneous list (non-dict then dict) -----------------------------
+
+    def test_non_dict_first_then_dict_with_collision(self):
+        """First element is a string, second is a dict with collision."""
+        records = ["plain text", {"source": "file.md", "body": "text"}]
+        with pytest.raises(ConfigValidationError, match="source"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_non_dict_elements_skipped(self):
+        """Non-dict elements in list are silently skipped."""
+        records = ["string1", 42, None, {"id": "1", "title": "safe"}]
+        validate_staging_field_names(records, "/fake/staging/data.json")
+
+    # -- Error message quality -----------------------------------------------
 
     def test_error_message_includes_rename_suggestion(self):
         records = [{"source": "Architecture.md"}]
@@ -68,4 +115,11 @@ class TestValidateStagingFieldNames:
     def test_error_message_includes_filename(self):
         records = [{"source": "Architecture.md"}]
         with pytest.raises(ConfigValidationError, match="data.json"):
+            validate_staging_field_names(records, "/fake/staging/data.json")
+
+    def test_error_message_lists_all_reserved_names(self):
+        records = [{"source": "x"}]
+        with pytest.raises(
+            ConfigValidationError, match="action.*prompt.*schema.*seed.*source.*version.*workflow"
+        ):
             validate_staging_field_names(records, "/fake/staging/data.json")


### PR DESCRIPTION
## Summary
- Adds validation at staging data ingress that errors if a record field name collides with a reserved prompt-context namespace (`source`, `version`, `workflow`, `seed`, `prompt`, `schema`, `action`)
- Actionable error message tells the user exactly which field to rename and suggests alternatives
- Extracted to standalone `field_validation.py` module to avoid pre-existing circular import in `initial_pipeline.py`

## Why not rename the framework key?
The `field_context["source"]` key is the **prompt-facing namespace** — users write `{{source.page_content}}` in templates. Renaming it to `_source_namespace` would break every existing prompt config. Instead, we validate early and reject collisions before they cause silent failures.

## What this prevents
PR #433 proved this in production: staging data with a field named `"source"` caused `source.page_content not found at runtime`. The validation catches this before any processing starts.

## Verification
- 11 new tests: collision detection for `source`, `version`, `workflow`, `seed`, multiple collisions, non-dict records, empty input, error message content
- Full suite: 6163 passed, 2 skipped (was 6152 — 11 new)
- `ruff check` + `ruff format --check`: clean