### PR TITLE
Centralize reason string literals in record/reasons.py

### DIFF
--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -27,6 +27,7 @@ from agent_actions.processing.types import (
     ProcessingStatus,
     RecoveryMetadata,
 )
+from agent_actions.record.reasons import BATCH_NOT_RETURNED, GUARD_SKIP, UPSTREAM_UNPROCESSED
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
@@ -471,12 +472,12 @@ class BatchResultStrategy:
         """Build an UNPROCESSED result for a passthrough record."""
         # Determine actual skip reason from context metadata
         filter_phase = original_row.get(ContextMetaKeys.FILTER_PHASE, "")
-        if filter_phase == "upstream_unprocessed":
-            reason = "upstream_unprocessed"
+        if filter_phase == UPSTREAM_UNPROCESSED:
+            reason = UPSTREAM_UNPROCESSED
         elif BatchContextMetadata.get_filter_status(original_row) == FilterStatus.SKIPPED:
-            reason = "guard_skip"
+            reason = GUARD_SKIP
         else:
-            reason = "batch_not_returned"
+            reason = BATCH_NOT_RETURNED
 
         passthrough_item = build_tombstone(
             action_name,

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -14,6 +14,7 @@ from agent_actions.llm.batch.core.batch_models import (
 )
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
 from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
+from agent_actions.record.reasons import FILTER_PHASE_UNIFIED, FILTER_PHASE_UPSTREAM
 from agent_actions.utils.constants import JSON_MODE_KEY
 from agent_actions.utils.id_generation import IDGenerator
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -174,7 +175,7 @@ class BatchTaskPreparator:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.SKIPPED
             )
-            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = "upstream_unprocessed"
+            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = FILTER_PHASE_UPSTREAM
             stats.skipped_items += 1
             logger.debug("Upstream unprocessed item %s", custom_id)
             return None
@@ -183,7 +184,7 @@ class BatchTaskPreparator:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.FILTERED
             )
-            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = "unified"
+            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = FILTER_PHASE_UNIFIED
             stats.filtered_items += 1
             logger.debug("Guard filtered item %s (phase=unified)", custom_id)
             return None
@@ -192,7 +193,7 @@ class BatchTaskPreparator:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.SKIPPED
             )
-            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = "unified"
+            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = FILTER_PHASE_UNIFIED
             stats.skipped_items += 1
             logger.debug("Guard skipped item %s (phase=unified)", custom_id)
             return None

--- a/agent_actions/processing/prepared_task.py
+++ b/agent_actions/processing/prepared_task.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from agent_actions.config.types import RunMode
+from agent_actions.record import reasons
 
 if TYPE_CHECKING:
     from agent_actions.processing.types import ProcessingContext
@@ -17,7 +18,7 @@ class GuardStatus(Enum):
     PASSED = "passed"  # Guard passed, task should be executed
     SKIPPED = "skipped"  # Guard triggered skip behavior (passthrough)
     FILTERED = "filtered"  # Guard triggered filter behavior (excluded)
-    UPSTREAM_UNPROCESSED = "upstream_unprocessed"  # Upstream failed/skipped this record
+    UPSTREAM_UNPROCESSED = reasons.UPSTREAM_UNPROCESSED
 
 
 @dataclass

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS, RecordEnvelope
+from agent_actions.record.reasons import RETRY_EXHAUSTED
 from agent_actions.utils.content import get_existing_content, is_version_merge
 
 # Framework fields that should be carried from an input record to an output
@@ -72,7 +73,7 @@ def build_exhausted_tombstone(
         "content": content,
         "source_guid": source_guid,
         "metadata": {
-            "reason": "retry_exhausted",
+            "reason": RETRY_EXHAUSTED,
             "retry_exhausted": True,
             "agent_type": "tombstone",
         },

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -15,6 +15,13 @@ from agent_actions.logging.events import (
     ResultCollectionStartedEvent,
 )
 from agent_actions.processing.types import ProcessingResult, ProcessingStatus
+from agent_actions.record.reasons import (
+    GUARD_FILTER,
+    GUARD_SKIP,
+    PARSE_ERROR,
+    RETRY_EXHAUSTED,
+    UNPROCESSED,
+)
 from agent_actions.storage.backend import (
     DISPOSITION_DEFERRED,
     DISPOSITION_EXHAUSTED,
@@ -182,10 +189,10 @@ def write_record_dispositions(
                 action_name,
                 source_guid,
                 DISPOSITION_EXHAUSTED,
-                reason="retry_exhausted",
+                reason=RETRY_EXHAUSTED,
             )
         elif item.get("_unprocessed"):
-            reason = metadata.get("reason", "unprocessed")
+            reason = metadata.get("reason", UNPROCESSED)
             if metadata.get("skipped_by_where_clause"):
                 disposition = DISPOSITION_FILTERED
             else:
@@ -277,7 +284,7 @@ class ResultCollector:
                             agent_name,
                             result.source_guid,
                             DISPOSITION_FAILED,
-                            reason="parse_error",
+                            reason=PARSE_ERROR,
                         )
                     continue
 
@@ -325,7 +332,7 @@ class ResultCollector:
                         agent_name,
                         result.source_guid,
                         DISPOSITION_PASSTHROUGH,
-                        reason=result.skip_reason or "guard_skip",
+                        reason=result.skip_reason or GUARD_SKIP,
                     )
 
             elif status == ProcessingStatus.EXHAUSTED:
@@ -410,7 +417,7 @@ class ResultCollector:
                         agent_name,
                         result.source_guid,
                         DISPOSITION_FILTERED,
-                        reason=result.skip_reason or "guard_filter",
+                        reason=result.skip_reason or GUARD_FILTER,
                     )
 
             elif status == ProcessingStatus.UNPROCESSED:
@@ -435,7 +442,7 @@ class ResultCollector:
                         agent_name,
                         result.source_guid,
                         DISPOSITION_UNPROCESSED,
-                        reason=result.skip_reason or "unprocessed",
+                        reason=result.skip_reason or UNPROCESSED,
                     )
 
             elif status == ProcessingStatus.DEFERRED:

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -39,6 +39,13 @@ from agent_actions.processing.types import (
     ProcessingResult,
     ProcessingStatus,
 )
+from agent_actions.record.reasons import (
+    GUARD_FILTER,
+    GUARD_SKIP,
+    LLM_LAYER_GUARD_FILTER,
+    LLM_LAYER_GUARD_SKIP,
+    UPSTREAM_UNPROCESSED,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +231,7 @@ class OnlineLLMStrategy:
                 preserved_item["metadata"]["agent_type"] = "tombstone"
             return ProcessingResult.unprocessed(
                 data=[preserved_item],
-                reason="upstream_unprocessed",
+                reason=UPSTREAM_UNPROCESSED,
                 source_guid=source_guid,
                 source_snapshot=source_snapshot,
                 input_record=input_record,
@@ -237,7 +244,7 @@ class OnlineLLMStrategy:
                     action_name=context.agent_name,
                     record_index=context.record_index,
                     source_guid=source_guid or "",
-                    filter_reason="guard_filter",
+                    filter_reason=GUARD_FILTER,
                 )
             )
             return ProcessingResult.filtered(
@@ -324,7 +331,7 @@ class OnlineLLMStrategy:
                         action_name=context.agent_name,
                         record_index=context.record_index,
                         source_guid=source_guid or "",
-                        filter_reason="llm_layer_guard_filter",
+                        filter_reason=LLM_LAYER_GUARD_FILTER,
                     )
                 )
                 return ProcessingResult.filtered(
@@ -338,18 +345,18 @@ class OnlineLLMStrategy:
                         action_name=context.agent_name,
                         record_index=context.record_index,
                         source_guid=source_guid or "",
-                        filter_reason="llm_layer_guard_skip",
+                        filter_reason=LLM_LAYER_GUARD_SKIP,
                     )
                 )
                 tombstone = build_tombstone(
                     context.action_name,
                     input_record,
-                    "guard_skip",
+                    GUARD_SKIP,
                     source_guid=source_guid,
                 )
                 return ProcessingResult.unprocessed(
                     data=[tombstone],
-                    reason="guard_skip",
+                    reason=GUARD_SKIP,
                     source_guid=source_guid,
                     source_snapshot=source_snapshot,
                     input_record=input_record,

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -12,6 +12,7 @@ from agent_actions.processing.prepared_task import (
     PreparationContext,
     PreparedTask,
 )
+from agent_actions.record.reasons import GUARD_SKIP
 from agent_actions.utils.content import get_existing_content
 from agent_actions.utils.id_generation import IDGenerator
 
@@ -309,7 +310,7 @@ class TaskPreparer:
         if item.get("_unprocessed") is not True:
             return False
         metadata = item.get("metadata")
-        if isinstance(metadata, dict) and metadata.get("reason") == "guard_skip":
+        if isinstance(metadata, dict) and metadata.get("reason") == GUARD_SKIP:
             return False
         return True
 

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
 
 from agent_actions.config.types import ActionConfigDict, RunMode
+from agent_actions.record import reasons
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -19,7 +20,7 @@ class ProcessingStatus(Enum):
     FAILED = "failed"  # Processing failed
     EXHAUSTED = "exhausted"  # Retry exhausted
     DEFERRED = "deferred"  # Deferred for batch execution
-    UNPROCESSED = "unprocessed"  # Upstream failed/skipped this record
+    UNPROCESSED = reasons.UNPROCESSED
 
 
 @dataclass

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -15,6 +15,7 @@ from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import CollectionStats, ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
 from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.reasons import GUARD_PREFILTER_SKIP, GUARD_SKIP
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 logger = logging.getLogger(__name__)
@@ -133,13 +134,13 @@ class UnifiedProcessor:
             tombstone = build_tombstone(
                 context.action_name,
                 item,
-                "guard_skip",
+                GUARD_SKIP,
                 source_guid=source_guid,
             )
             guard_results.append(
                 ProcessingResult.skipped(
                     passthrough_data=tombstone,
-                    reason="guard_skip",
+                    reason=GUARD_SKIP,
                     source_guid=source_guid,
                 )
             )
@@ -194,7 +195,7 @@ class UnifiedProcessor:
             guard_results.append(
                 ProcessingResult.unprocessed(
                     data=[item],
-                    reason="guard_prefilter_skip",
+                    reason=GUARD_PREFILTER_SKIP,
                     source_guid=item.get("source_guid") if isinstance(item, dict) else None,
                 )
             )

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -4,9 +4,6 @@ Every reason/skip/cascade/filter string that flows through disposition writes,
 tombstone metadata, ProcessingResult factories, or telemetry events must be
 defined here.  Production code imports from this module instead of using bare
 string literals.
-
-Test files may still use bare strings — that is intentional so tests break
-visibly if a constant value changes.
 """
 
 # -- Guard outcomes ----------------------------------------------------------
@@ -33,5 +30,5 @@ PARSE_ERROR = "parse_error"
 GUARD_FILTERED_ALL = "All records guard-filtered — no output produced"
 
 # -- FILTER_PHASE values (batch preparator) -----------------------------------
-FILTER_PHASE_UPSTREAM = "upstream_unprocessed"
+FILTER_PHASE_UPSTREAM = UPSTREAM_UNPROCESSED  # same value by design — batch dispatch relies on this
 FILTER_PHASE_UNIFIED = "unified"

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -1,0 +1,37 @@
+"""Canonical reason string constants for record lifecycle events.
+
+Every reason/skip/cascade/filter string that flows through disposition writes,
+tombstone metadata, ProcessingResult factories, or telemetry events must be
+defined here.  Production code imports from this module instead of using bare
+string literals.
+
+Test files may still use bare strings — that is intentional so tests break
+visibly if a constant value changes.
+"""
+
+# -- Guard outcomes ----------------------------------------------------------
+GUARD_SKIP = "guard_skip"
+GUARD_PREFILTER_SKIP = "guard_prefilter_skip"
+GUARD_FILTER = "guard_filter"
+LLM_LAYER_GUARD_SKIP = "llm_layer_guard_skip"
+LLM_LAYER_GUARD_FILTER = "llm_layer_guard_filter"
+
+# -- Cascade / upstream ------------------------------------------------------
+UPSTREAM_UNPROCESSED = "upstream_unprocessed"
+
+# -- Batch -------------------------------------------------------------------
+BATCH_NOT_RETURNED = "batch_not_returned"
+
+# -- Exhaustion --------------------------------------------------------------
+RETRY_EXHAUSTED = "retry_exhausted"
+
+# -- Disposition fallbacks ---------------------------------------------------
+UNPROCESSED = "unprocessed"
+PARSE_ERROR = "parse_error"
+
+# -- Action-level skip reasons -----------------------------------------------
+GUARD_FILTERED_ALL = "All records guard-filtered — no output produced"
+
+# -- FILTER_PHASE values (batch preparator) -----------------------------------
+FILTER_PHASE_UPSTREAM = "upstream_unprocessed"
+FILTER_PHASE_UNIFIED = "unified"

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -18,6 +18,7 @@ from agent_actions.logging.events import (
     BatchCompleteEvent,
     BatchSubmittedEvent,
 )
+from agent_actions.record.reasons import GUARD_FILTERED_ALL
 from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_SKIPPED,
@@ -369,7 +370,7 @@ class ActionExecutor:
                 params.action_name,
                 ActionStatus.SKIPPED,
                 execution_time=duration,
-                skip_reason="All records guard-filtered — no output produced",
+                skip_reason=GUARD_FILTERED_ALL,
             )
             total_actions = (
                 len(self.deps.action_runner.execution_order)
@@ -381,7 +382,7 @@ class ActionExecutor:
                     action_name=params.action_name,
                     action_index=params.action_idx,
                     total_actions=total_actions,
-                    skip_reason="All records guard-filtered — no output produced",
+                    skip_reason=GUARD_FILTERED_ALL,
                     mode=params.action_config.get("run_mode", ""),
                 )
             )
@@ -391,7 +392,7 @@ class ActionExecutor:
                     action_name=params.action_name,
                     status="skipped",
                     duration_seconds=duration,
-                    skip_reason="All records guard-filtered — no output produced",
+                    skip_reason=GUARD_FILTERED_ALL,
                 )
                 self.run_tracker.record_action_complete(config=config)
             return ActionExecutionResult(


### PR DESCRIPTION
## Summary
- New `agent_actions/record/reasons.py` with 13 canonical constants for all guard/skip/cascade/filter reason strings
- Replaced bare string literals across 9 production files with constant imports
- Pure mechanical refactor — no behavior change, no string value changes

## Files changed
| File | What changed |
|------|-------------|
| `record/reasons.py` | **New** — all constants defined here |
| `processing/unified.py` | `"guard_skip"` → `GUARD_SKIP`, `"guard_prefilter_skip"` → `GUARD_PREFILTER_SKIP` |
| `processing/strategies/online_llm.py` | `"upstream_unprocessed"` → `UPSTREAM_UNPROCESSED`, `"guard_filter"` → `GUARD_FILTER`, `"guard_skip"` → `GUARD_SKIP`, `"llm_layer_guard_*"` → constants |
| `processing/task_preparer.py` | `"guard_skip"` → `GUARD_SKIP` |
| `processing/record_helpers.py` | `"retry_exhausted"` → `RETRY_EXHAUSTED` |
| `processing/result_collector.py` | 6 bare strings → constants |
| `llm/batch/processing/batch_result_strategy.py` | `"upstream_unprocessed"`, `"guard_skip"`, `"batch_not_returned"` → constants |
| `llm/batch/processing/preparator.py` | FILTER_PHASE `"upstream_unprocessed"`, `"unified"` → `FILTER_PHASE_UPSTREAM`, `FILTER_PHASE_UNIFIED` |
| `workflow/executor.py` | `"All records guard-filtered..."` ×3 → `GUARD_FILTERED_ALL` |

## Verification
- `rg` for bare strings returns zero hits in production code (outside `reasons.py`)
- Remaining hits are: ThreadPoolExecutor thread name, static_loader error dict keys, metadata boolean flags — none are reason string values
- Full suite: 6167 passed, 2 skipped
- `ruff check` + `ruff format`: clean