### PR TITLE
Normalize cascade exemption for all guard-skip variants

### DIFF
--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -12,11 +12,23 @@ from agent_actions.processing.prepared_task import (
     PreparationContext,
     PreparedTask,
 )
-from agent_actions.record.reasons import GUARD_SKIP
+from agent_actions.record.reasons import GUARD_FILTER, GUARD_PREFILTER_SKIP, GUARD_SKIP
 from agent_actions.utils.content import get_existing_content
 from agent_actions.utils.id_generation import IDGenerator
 
 logger = logging.getLogger(__name__)
+
+# Guard outcomes that should NOT cascade as upstream failures.
+# A guard-skipped record is valid pipeline data — the action was intentionally
+# skipped but downstream should still process.  All guard-skip variants must
+# be listed here regardless of which mode (online/batch/FILE) produced them.
+GUARD_EXEMPT_REASONS: frozenset[str] = frozenset(
+    {
+        GUARD_SKIP,
+        GUARD_PREFILTER_SKIP,
+        GUARD_FILTER,
+    }
+)
 
 
 class TaskPreparer:
@@ -301,16 +313,20 @@ class TaskPreparer:
     def _is_upstream_unprocessed(item: Any) -> bool:
         """Return True only for cascade-failure tombstones, not guard-skip tombstones.
 
-        Guard-skipped records (reason=guard_skip) are valid pipeline data — the
-        action was intentionally skipped but downstream should still process.
-        Only upstream_unprocessed cascades should propagate as unprocessed.
+        Guard-skipped records are valid pipeline data — the action was
+        intentionally skipped but downstream should still process.  All guard
+        outcome variants (online ``guard_skip``, FILE ``guard_prefilter_skip``,
+        ``guard_filter``) are exempt from cascade propagation.
+
+        Only true upstream failures (``upstream_unprocessed``, ``batch_not_returned``,
+        etc.) should propagate as unprocessed.
         """
         if not isinstance(item, dict):
             return False
         if item.get("_unprocessed") is not True:
             return False
         metadata = item.get("metadata")
-        if isinstance(metadata, dict) and metadata.get("reason") == GUARD_SKIP:
+        if isinstance(metadata, dict) and metadata.get("reason") in GUARD_EXEMPT_REASONS:
             return False
         return True
 

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -18,10 +18,6 @@ from agent_actions.utils.id_generation import IDGenerator
 
 logger = logging.getLogger(__name__)
 
-# Guard outcomes that should NOT cascade as upstream failures.
-# A guard-skipped record is valid pipeline data — the action was intentionally
-# skipped but downstream should still process.  All guard-skip variants must
-# be listed here regardless of which mode (online/batch/FILE) produced them.
 GUARD_EXEMPT_REASONS: frozenset[str] = frozenset(
     {
         GUARD_SKIP,

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -65,15 +65,11 @@ class TestIsUpstreamUnprocessed:
         item = {"content": "data", "_unprocessed": False}
         assert TaskPreparer._is_upstream_unprocessed(item) is False
 
-    # -- Guard exemption: all variants must NOT cascade --------------------
-
     def test_guard_skip_exempt_from_cascade(self):
-        """Online guard-skip should not propagate as upstream failure."""
         item = {"content": "data", "_unprocessed": True, "metadata": {"reason": "guard_skip"}}
         assert TaskPreparer._is_upstream_unprocessed(item) is False
 
     def test_guard_prefilter_skip_exempt_from_cascade(self):
-        """FILE-mode guard-skip should not propagate as upstream failure."""
         item = {
             "content": "data",
             "_unprocessed": True,
@@ -82,14 +78,10 @@ class TestIsUpstreamUnprocessed:
         assert TaskPreparer._is_upstream_unprocessed(item) is False
 
     def test_guard_filter_exempt_from_cascade(self):
-        """Guard-filter should not propagate as upstream failure."""
         item = {"content": "data", "_unprocessed": True, "metadata": {"reason": "guard_filter"}}
         assert TaskPreparer._is_upstream_unprocessed(item) is False
 
-    # -- Non-guard reasons: MUST cascade -----------------------------------
-
     def test_upstream_unprocessed_cascades(self):
-        """True upstream failure must propagate."""
         item = {
             "content": "data",
             "_unprocessed": True,
@@ -98,7 +90,6 @@ class TestIsUpstreamUnprocessed:
         assert TaskPreparer._is_upstream_unprocessed(item) is True
 
     def test_batch_not_returned_cascades(self):
-        """Batch not-returned must propagate."""
         item = {
             "content": "data",
             "_unprocessed": True,
@@ -107,7 +98,6 @@ class TestIsUpstreamUnprocessed:
         assert TaskPreparer._is_upstream_unprocessed(item) is True
 
     def test_retry_exhausted_cascades(self):
-        """Retry-exhausted must propagate."""
         item = {
             "content": "data",
             "_unprocessed": True,

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -65,6 +65,56 @@ class TestIsUpstreamUnprocessed:
         item = {"content": "data", "_unprocessed": False}
         assert TaskPreparer._is_upstream_unprocessed(item) is False
 
+    # -- Guard exemption: all variants must NOT cascade --------------------
+
+    def test_guard_skip_exempt_from_cascade(self):
+        """Online guard-skip should not propagate as upstream failure."""
+        item = {"content": "data", "_unprocessed": True, "metadata": {"reason": "guard_skip"}}
+        assert TaskPreparer._is_upstream_unprocessed(item) is False
+
+    def test_guard_prefilter_skip_exempt_from_cascade(self):
+        """FILE-mode guard-skip should not propagate as upstream failure."""
+        item = {
+            "content": "data",
+            "_unprocessed": True,
+            "metadata": {"reason": "guard_prefilter_skip"},
+        }
+        assert TaskPreparer._is_upstream_unprocessed(item) is False
+
+    def test_guard_filter_exempt_from_cascade(self):
+        """Guard-filter should not propagate as upstream failure."""
+        item = {"content": "data", "_unprocessed": True, "metadata": {"reason": "guard_filter"}}
+        assert TaskPreparer._is_upstream_unprocessed(item) is False
+
+    # -- Non-guard reasons: MUST cascade -----------------------------------
+
+    def test_upstream_unprocessed_cascades(self):
+        """True upstream failure must propagate."""
+        item = {
+            "content": "data",
+            "_unprocessed": True,
+            "metadata": {"reason": "upstream_unprocessed"},
+        }
+        assert TaskPreparer._is_upstream_unprocessed(item) is True
+
+    def test_batch_not_returned_cascades(self):
+        """Batch not-returned must propagate."""
+        item = {
+            "content": "data",
+            "_unprocessed": True,
+            "metadata": {"reason": "batch_not_returned"},
+        }
+        assert TaskPreparer._is_upstream_unprocessed(item) is True
+
+    def test_retry_exhausted_cascades(self):
+        """Retry-exhausted must propagate."""
+        item = {
+            "content": "data",
+            "_unprocessed": True,
+            "metadata": {"reason": "retry_exhausted"},
+        }
+        assert TaskPreparer._is_upstream_unprocessed(item) is True
+
 
 # --- TaskPreparer.prepare() early exit ---
 


### PR DESCRIPTION
## Summary
- `_is_upstream_unprocessed` now compares against `GUARD_EXEMPT_REASONS` frozenset instead of only `"guard_skip"`
- FILE-mode `guard_prefilter_skip` and `guard_filter` are now exempted from cascade — previously they were treated as upstream failures

## What this fixes
Same concept (guard skipped this record) had different cascade behavior depending on the mode:
- Online: `guard_skip` → exempted, downstream processes normally
- FILE: `guard_prefilter_skip` → **not exempted**, downstream incorrectly treated as upstream failure
- Filter: `guard_filter` → **not exempted**, same problem

Now all three are exempted. True upstream failures (`upstream_unprocessed`, `batch_not_returned`, `retry_exhausted`) still cascade.

## Verification
- 6 new tests: 3 guard variants exempt, 3 non-guard reasons cascade
- Full suite: 6173 passed, 2 skipped
- `ruff check` + `ruff format`: clean