### PR TITLE
Add RecordState enum and lifecycle helpers

### DIFF
--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -8,7 +8,8 @@ Single authority for record content assembly. Every action type, granularity, an
 |------|------|---------|---------|
 | `envelope.py` | Module | `RecordEnvelope`, `RecordEnvelopeError` | - |
 | `tracking.py` | Module | `TrackedItem` | - |
-| `__init__.py` | Re-export | `RecordEnvelope`, `RecordEnvelopeError`, `TrackedItem` | - |
+| `state.py` | Module | `RecordState`, `PROCESSABLE_STATES`, `SETTLED_STATES`, `RESETTABLE_DOWNSTREAM_STATES`, `CASCADE_BLOCKING_STATES`, `RETRIABLE_STATES`, `is_processable`, `is_settled`, `is_retriable` | - |
+| `__init__.py` | Re-export | `RecordEnvelope`, `RecordEnvelopeError`, `RecordState`, `TrackedItem` | - |
 
 ## Project Surface
 

--- a/agent_actions/record/__init__.py
+++ b/agent_actions/record/__init__.py
@@ -5,6 +5,13 @@ from agent_actions.record.envelope import (
     RecordEnvelope,
     RecordEnvelopeError,
 )
+from agent_actions.record.state import RecordState
 from agent_actions.record.tracking import TrackedItem
 
-__all__ = ["RECORD_FRAMEWORK_FIELDS", "RecordEnvelope", "RecordEnvelopeError", "TrackedItem"]
+__all__ = [
+    "RECORD_FRAMEWORK_FIELDS",
+    "RecordEnvelope",
+    "RecordEnvelopeError",
+    "RecordState",
+    "TrackedItem",
+]

--- a/agent_actions/record/state.py
+++ b/agent_actions/record/state.py
@@ -23,21 +23,9 @@ class RecordState(str, Enum):
     EXHAUSTED = "exhausted"
 
 
-# -- State categories --------------------------------------------------------
-
 PROCESSABLE_STATES: frozenset[RecordState] = frozenset({RecordState.ACTIVE})
 
-SETTLED_STATES: frozenset[RecordState] = frozenset(
-    {
-        RecordState.PROCESSED,
-        RecordState.COMMITTED,
-        RecordState.GUARD_SKIPPED,
-        RecordState.GUARD_DEFERRED,
-        RecordState.CASCADE_SKIPPED,
-        RecordState.FAILED,
-        RecordState.EXHAUSTED,
-    }
-)
+SETTLED_STATES: frozenset[RecordState] = frozenset(RecordState) - PROCESSABLE_STATES
 
 RESETTABLE_DOWNSTREAM_STATES: frozenset[RecordState] = frozenset(
     {
@@ -62,9 +50,6 @@ RETRIABLE_STATES: frozenset[RecordState] = frozenset(
         RecordState.EXHAUSTED,
     }
 )
-
-
-# -- Helpers -----------------------------------------------------------------
 
 
 def is_processable(state: RecordState) -> bool:

--- a/agent_actions/record/state.py
+++ b/agent_actions/record/state.py
@@ -63,5 +63,5 @@ def is_settled(state: RecordState) -> bool:
 
 
 def is_retriable(state: RecordState) -> bool:
-    """True if the record failed and could be retried."""
+    """True if the record is in a retriable terminal state (FAILED or EXHAUSTED)."""
     return state in RETRIABLE_STATES

--- a/agent_actions/record/state.py
+++ b/agent_actions/record/state.py
@@ -1,0 +1,82 @@
+"""Record lifecycle state machine.
+
+``RecordState`` is the single source of truth for where a record sits in the
+pipeline lifecycle.  Every record carries a ``_state`` field whose value is
+one of these enum members.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RecordState(str, Enum):
+    """Lifecycle state of a pipeline record."""
+
+    ACTIVE = "active"
+    PROCESSED = "processed"
+    COMMITTED = "committed"
+    GUARD_SKIPPED = "guard_skipped"
+    GUARD_DEFERRED = "guard_deferred"
+    CASCADE_SKIPPED = "cascade_skipped"
+    FAILED = "failed"
+    EXHAUSTED = "exhausted"
+
+
+# -- State categories --------------------------------------------------------
+
+PROCESSABLE_STATES: frozenset[RecordState] = frozenset({RecordState.ACTIVE})
+
+SETTLED_STATES: frozenset[RecordState] = frozenset(
+    {
+        RecordState.PROCESSED,
+        RecordState.COMMITTED,
+        RecordState.GUARD_SKIPPED,
+        RecordState.GUARD_DEFERRED,
+        RecordState.CASCADE_SKIPPED,
+        RecordState.FAILED,
+        RecordState.EXHAUSTED,
+    }
+)
+
+RESETTABLE_DOWNSTREAM_STATES: frozenset[RecordState] = frozenset(
+    {
+        RecordState.PROCESSED,
+        RecordState.COMMITTED,
+        RecordState.GUARD_SKIPPED,
+        RecordState.GUARD_DEFERRED,
+    }
+)
+
+CASCADE_BLOCKING_STATES: frozenset[RecordState] = frozenset(
+    {
+        RecordState.CASCADE_SKIPPED,
+        RecordState.FAILED,
+        RecordState.EXHAUSTED,
+    }
+)
+
+RETRIABLE_STATES: frozenset[RecordState] = frozenset(
+    {
+        RecordState.FAILED,
+        RecordState.EXHAUSTED,
+    }
+)
+
+
+# -- Helpers -----------------------------------------------------------------
+
+
+def is_processable(state: RecordState) -> bool:
+    """True if the record can be sent to an LLM/tool for processing."""
+    return state in PROCESSABLE_STATES
+
+
+def is_settled(state: RecordState) -> bool:
+    """True if the record has reached a terminal state for this action."""
+    return state in SETTLED_STATES
+
+
+def is_retriable(state: RecordState) -> bool:
+    """True if the record failed and could be retried."""
+    return state in RETRIABLE_STATES

--- a/tests/unit/record/test_record_state.py
+++ b/tests/unit/record/test_record_state.py
@@ -15,6 +15,13 @@ from agent_actions.record.state import (
 )
 
 
+class TestPublicPackageContract:
+    def test_record_state_importable_from_package(self):
+        from agent_actions.record import RecordState as RS
+
+        assert RS.ACTIVE == "active"
+
+
 class TestRecordStateEnum:
     def test_is_str_enum(self):
         assert isinstance(RecordState.ACTIVE, str)

--- a/tests/unit/record/test_record_state.py
+++ b/tests/unit/record/test_record_state.py
@@ -1,0 +1,78 @@
+"""Tests for RecordState enum and lifecycle helpers."""
+
+import pytest
+
+from agent_actions.record.state import (
+    CASCADE_BLOCKING_STATES,
+    PROCESSABLE_STATES,
+    RESETTABLE_DOWNSTREAM_STATES,
+    RETRIABLE_STATES,
+    SETTLED_STATES,
+    RecordState,
+    is_processable,
+    is_retriable,
+    is_settled,
+)
+
+
+class TestRecordStateEnum:
+    def test_is_str_enum(self):
+        assert isinstance(RecordState.ACTIVE, str)
+        assert RecordState.ACTIVE == "active"
+
+    def test_all_members_have_unique_values(self):
+        values = [s.value for s in RecordState]
+        assert len(values) == len(set(values))
+
+    def test_member_count(self):
+        assert len(RecordState) == 8
+
+
+class TestStateCategories:
+    def test_only_active_is_processable(self):
+        assert PROCESSABLE_STATES == {RecordState.ACTIVE}
+
+    def test_active_is_not_settled(self):
+        assert RecordState.ACTIVE not in SETTLED_STATES
+
+    def test_every_non_active_state_is_settled(self):
+        for state in RecordState:
+            if state != RecordState.ACTIVE:
+                assert state in SETTLED_STATES, f"{state} should be settled"
+
+    def test_resettable_does_not_overlap_blocking(self):
+        assert RESETTABLE_DOWNSTREAM_STATES & CASCADE_BLOCKING_STATES == set()
+
+    def test_resettable_plus_blocking_covers_all_settled(self):
+        assert RESETTABLE_DOWNSTREAM_STATES | CASCADE_BLOCKING_STATES == SETTLED_STATES
+
+    def test_retriable_is_subset_of_blocking(self):
+        assert RETRIABLE_STATES <= CASCADE_BLOCKING_STATES
+
+    def test_guard_skipped_is_resettable(self):
+        assert RecordState.GUARD_SKIPPED in RESETTABLE_DOWNSTREAM_STATES
+
+    def test_cascade_skipped_blocks(self):
+        assert RecordState.CASCADE_SKIPPED in CASCADE_BLOCKING_STATES
+
+    def test_failed_blocks_and_is_retriable(self):
+        assert RecordState.FAILED in CASCADE_BLOCKING_STATES
+        assert RecordState.FAILED in RETRIABLE_STATES
+
+    def test_exhausted_blocks_and_is_retriable(self):
+        assert RecordState.EXHAUSTED in CASCADE_BLOCKING_STATES
+        assert RecordState.EXHAUSTED in RETRIABLE_STATES
+
+
+class TestHelperFunctions:
+    @pytest.mark.parametrize("state", list(RecordState))
+    def test_is_processable_matches_set(self, state):
+        assert is_processable(state) == (state in PROCESSABLE_STATES)
+
+    @pytest.mark.parametrize("state", list(RecordState))
+    def test_is_settled_matches_set(self, state):
+        assert is_settled(state) == (state in SETTLED_STATES)
+
+    @pytest.mark.parametrize("state", list(RecordState))
+    def test_is_retriable_matches_set(self, state):
+        assert is_retriable(state) == (state in RETRIABLE_STATES)


### PR DESCRIPTION
## Summary
- New `agent_actions/record/state.py` — `RecordState(str, Enum)` with 8 members
- State category sets: `RESETTABLE_DOWNSTREAM_STATES`, `CASCADE_BLOCKING_STATES`, `RETRIABLE_STATES`, `PROCESSABLE_STATES`, `SETTLED_STATES`
- Helper functions: `is_processable()`, `is_settled()`, `is_retriable()`
- Exported from `record/__init__.py`

## What this enables
Subsequent tickets wire this into the pipeline:
- P5-022: `RecordEnvelope.transition()` uses these states
- P5-040: executor boundary reset uses `RESETTABLE_DOWNSTREAM_STATES`
- P5-041: cascade rules use `CASCADE_BLOCKING_STATES`

## Verification
- 37 new tests: enum properties, category invariants (no overlap, full coverage), helper parity
- Full suite: 6210 passed, 2 skipped
- `ruff check` + `ruff format`: clean