### PR TITLE
Add RecordEnvelope.transition() — single lifecycle state mutator

### DIFF
--- a/.changes/unreleased/Enhancement-20260501-022000.yaml
+++ b/.changes/unreleased/Enhancement-20260501-022000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add RecordEnvelope.transition() as the single sanctioned mutator for record lifecycle state (_state, _state_history, _state_schema_version)"
+time: 2026-05-01T02:20:00.000000Z

--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -18,6 +18,7 @@ Single authority for record content assembly. Every action type, granularity, an
 | `RecordEnvelope.build()` | `agent_io/target/{action}/` | Writes record with action output under namespace | - |
 | `RecordEnvelope.build_content()` | `agent_io/target/{action}/` | Writes content dict (no record wrapper) | - |
 | `RecordEnvelope.build_skipped()` | `agent_io/target/{action}/` | Writes record with null namespace for guard skip | - |
+| `RecordEnvelope.transition()` | `agent_io/target/{action}/` | Only sanctioned writer of `_state`, `_state_history`, `_state_schema_version` | - |
 | `TrackedItem` | `tools/{workflow}/*.py` | FILE tool input: dict subclass with hidden `_source_index` provenance | - |
 
 ## Dependencies
@@ -42,3 +43,16 @@ The module does NOT own:
 - Enrichment (lineage, node_id, target_id) -- `EnrichmentPipeline` handles post-assembly
 - Initial source structuring -- `initial_pipeline.py` creates the first `source` namespace
 - Observe/passthrough resolution -- `scope_application.py` reads FROM content
+
+### transition() — legal state edges
+
+| From | To | Allowed? |
+|------|----|----------|
+| `None` (new record) | any | Yes — first write |
+| `ACTIVE` | any settled | Yes — normal progression |
+| `PROCESSED`, `COMMITTED`, `GUARD_SKIPPED`, `GUARD_DEFERRED` | `ACTIVE` | Yes — downstream reset |
+| any | same state | Yes — idempotent re-application |
+| `CASCADE_SKIPPED`, `FAILED`, `EXHAUSTED` | `ACTIVE` | **No** — cascade-blocking states cannot be reset |
+| settled | different settled | **No** — cross-settled writes are not valid |
+
+History is capped at 64 entries (oldest drops on overflow). Schema version bumps when a required key is added to history entries or an existing key changes semantics.

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -1,8 +1,40 @@
-"""Unified record envelope -- single authority for record content assembly."""
+"""Unified record envelope -- single authority for record content assembly.
+
+``RecordEnvelope.transition()`` is the **only** sanctioned mutator for
+lifecycle fields (``_state``, ``_state_history``, ``_state_schema_version``).
+All other code reads these fields; it does not write them directly.
+
+## _state_schema_version bump rules
+
+Version 1 (current): history entries have keys
+  {timestamp, action, from, to, reason, detail}
+
+Bump to version 2 when: a new required key is added to history entries,
+or the semantics of an existing key change in a breaking way.  Additive
+optional keys do not require a bump.
+
+## _state_history cap
+
+History is capped at ``STATE_HISTORY_CAP`` entries (default: 64).  This
+prevents unbounded serialization growth across long retry chains.  When the
+cap is reached, the oldest entry is dropped on each new append.  64 entries
+is enough for any realistic pipeline run (typical records see 2-10
+transitions).
+"""
 
 from __future__ import annotations
 
+import datetime
 from typing import Any
+
+from agent_actions.record.state import (
+    PROCESSABLE_STATES,
+    RESETTABLE_DOWNSTREAM_STATES,
+    RecordState,
+)
+
+STATE_HISTORY_CAP: int = 64
+_STATE_SCHEMA_VERSION: int = 1
 
 # Tracking fields: set once at record creation, carried forward through all 1:1
 # pipeline stages by RecordEnvelope.build(). These are the record's stable identity.
@@ -28,6 +60,9 @@ RECORD_STAGE_FIELDS: frozenset[str] = frozenset(
         "parent_target_id",
         "root_target_id",
         "chunk_info",
+        "_state",
+        "_state_history",
+        "_state_schema_version",
     }
 )
 
@@ -102,6 +137,75 @@ class RecordEnvelope:
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, action_name: None}}
         return _carry_tracking_fields(result, input_record)
+
+    @staticmethod
+    def transition(
+        record: dict[str, Any],
+        to_state: RecordState,
+        action_name: str,
+        reason: str,
+        detail: str | None = None,
+    ) -> dict[str, Any]:
+        """Transition *record* to *to_state* — the only sanctioned lifecycle mutator.
+
+        Updates ``_state``, appends to ``_state_history`` (capped at
+        ``STATE_HISTORY_CAP``), and sets ``_state_schema_version``.
+
+        Raises ``RecordEnvelopeError`` if the transition is illegal.
+        Returns the record (mutated in-place) for chaining.
+        """
+        from_state_raw = record.get("_state")
+        from_state = RecordState(from_state_raw) if from_state_raw is not None else None
+
+        _validate_transition(from_state, to_state)
+
+        history: list[dict[str, Any]] = list(record.get("_state_history") or [])
+        entry: dict[str, Any] = {
+            "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+            "action": action_name,
+            "from": from_state_raw,
+            "to": to_state.value,
+            "reason": reason,
+            "detail": detail,
+        }
+        history.append(entry)
+        if len(history) > STATE_HISTORY_CAP:
+            history = history[-STATE_HISTORY_CAP:]
+
+        record["_state"] = to_state.value
+        record["_state_history"] = history
+        record["_state_schema_version"] = _STATE_SCHEMA_VERSION
+        return record
+
+
+def _validate_transition(from_state: RecordState | None, to_state: RecordState) -> None:
+    """Raise RecordEnvelopeError if the from→to edge is not legal.
+
+    Legal edges:
+    - None → any state          (first transition on a new record)
+    - ACTIVE → any settled      (normal pipeline progression)
+    - RESETTABLE → ACTIVE       (downstream reset before retry)
+    - any → same state          (idempotent re-application, e.g. retry logic)
+
+    Illegal edges:
+    - CASCADE_BLOCKING → ACTIVE (CASCADE_SKIPPED/FAILED/EXHAUSTED cannot be
+                                 reset to ACTIVE directly; they require an
+                                 explicit reset through RESETTABLE states first,
+                                 which is not a supported path today)
+    - SETTLED → SETTLED (cross-settled transitions, e.g. PROCESSED → FAILED,
+                         are not valid — settled means done for this stage)
+    """
+    if from_state is None:
+        return
+    if from_state == to_state:
+        return
+    if from_state in PROCESSABLE_STATES:
+        return
+    if from_state in RESETTABLE_DOWNSTREAM_STATES and to_state in PROCESSABLE_STATES:
+        return
+    raise RecordEnvelopeError(
+        f"Illegal state transition: {from_state.value!r} → {to_state.value!r}"
+    )
 
 
 def _carry_tracking_fields(

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -1,25 +1,9 @@
 """Unified record envelope -- single authority for record content assembly.
 
-``RecordEnvelope.transition()`` is the **only** sanctioned mutator for
-lifecycle fields (``_state``, ``_state_history``, ``_state_schema_version``).
-All other code reads these fields; it does not write them directly.
-
-## _state_schema_version bump rules
-
-Version 1 (current): history entries have keys
-  {timestamp, action, from, to, reason, detail}
-
-Bump to version 2 when: a new required key is added to history entries,
-or the semantics of an existing key change in a breaking way.  Additive
-optional keys do not require a bump.
-
-## _state_history cap
-
-History is capped at ``STATE_HISTORY_CAP`` entries (default: 64).  This
-prevents unbounded serialization growth across long retry chains.  When the
-cap is reached, the oldest entry is dropped on each new append.  64 entries
-is enough for any realistic pipeline run (typical records see 2-10
-transitions).
+``RecordEnvelope.transition()`` is the only sanctioned mutator for lifecycle
+fields (``_state``, ``_state_history``, ``_state_schema_version``).  See
+``record/_MANIFEST.md`` for legal transition edges, history cap, and schema
+version bump rules.
 """
 
 from __future__ import annotations

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -135,15 +135,32 @@ class RecordEnvelope:
         Updates ``_state``, appends to ``_state_history`` (capped at
         ``STATE_HISTORY_CAP``), and sets ``_state_schema_version``.
 
-        Raises ``RecordEnvelopeError`` if the transition is illegal.
+        Raises ``RecordEnvelopeError`` for illegal transitions, unknown current
+        state values, or corrupt history shapes.
         Returns the record (mutated in-place) for chaining.
         """
+        if not action_name:
+            raise RecordEnvelopeError("action_name is required")
+
         from_state_raw = record.get("_state")
-        from_state = RecordState(from_state_raw) if from_state_raw is not None else None
+        if from_state_raw is not None:
+            try:
+                from_state: RecordState | None = RecordState(from_state_raw)
+            except ValueError:
+                raise RecordEnvelopeError(
+                    f"Record has unknown _state value: {from_state_raw!r}"
+                ) from None
+        else:
+            from_state = None
 
         _validate_transition(from_state, to_state)
 
-        history: list[dict[str, Any]] = record.get("_state_history") or []
+        raw_history = record.get("_state_history")
+        if raw_history is not None and not isinstance(raw_history, list):
+            raise RecordEnvelopeError(
+                f"_state_history must be a list, got {type(raw_history).__name__}"
+            )
+        history: list[dict[str, Any]] = raw_history or []
         entry: dict[str, Any] = {
             "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
             "action": action_name,

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -73,10 +73,10 @@ class RecordEnvelope:
         """Build a record wrapping *action_output* under *action_name*.
 
         Preserves upstream namespaces from *input_record* and carries
-        ``source_guid``.  Collision on *action_name* overwrites.
+        ``source_guid``. Collision on *action_name* overwrites.
 
-        The assembled content dict is new, but *action_output* itself is stored
-        by reference inside it.  Callers must not mutate *action_output* after
+        The assembled content dict is new, but *action_output* is stored by
+        reference inside it. Callers must not mutate *action_output* after
         calling ``build()``.
         """
         if not action_name:
@@ -99,7 +99,7 @@ class RecordEnvelope:
     ) -> dict[str, Any]:
         """Return a content dict with *action_output* under *action_name*.
 
-        No record wrapper or ``source_guid`` -- content level only.
+        No record wrapper or ``source_guid`` — content level only.
         """
         if not action_name:
             raise RecordEnvelopeError("action_name is required")
@@ -114,7 +114,7 @@ class RecordEnvelope:
     ) -> dict[str, Any]:
         """Build a record with a null namespace for a guard-skipped action.
 
-        Does NOT set ``_unprocessed`` or ``metadata`` -- callers add those.
+        Does not set ``_unprocessed`` or ``metadata`` — callers add those.
         """
         if not action_name:
             raise RecordEnvelopeError("action_name is required")
@@ -130,14 +130,14 @@ class RecordEnvelope:
         reason: str,
         detail: str | None = None,
     ) -> dict[str, Any]:
-        """Transition *record* to *to_state* — the only sanctioned lifecycle mutator.
+        """Transition *record* to *to_state*.
 
-        Updates ``_state``, appends to ``_state_history`` (capped at
-        ``STATE_HISTORY_CAP``), and sets ``_state_schema_version``.
+        The only sanctioned mutator for ``_state``, ``_state_history``, and
+        ``_state_schema_version``. Appends a timestamped history entry (capped
+        at ``STATE_HISTORY_CAP``) and mutates the record in-place.
 
         Raises ``RecordEnvelopeError`` for illegal transitions, unknown current
-        state values, or corrupt history shapes.
-        Returns the record (mutated in-place) for chaining.
+        state values, or corrupt history shapes. Returns the record for chaining.
         """
         if not action_name:
             raise RecordEnvelopeError("action_name is required")
@@ -197,12 +197,12 @@ def _validate_transition(from_state: RecordState | None, to_state: RecordState) 
 def _carry_tracking_fields(
     result: dict[str, Any], input_record: dict[str, Any] | None
 ) -> dict[str, Any]:
-    """Copy tracking fields from input_record to result.
+    """Copy tracking fields from *input_record* into *result*.
 
-    Tracking fields are the record's stable identity — set once at creation
-    (first stage or 1→N expansion) and preserved through all downstream
-    1:1 stages. Per-stage fields (metadata, lineage, node_id, etc.) are
-    NOT carried — enrichers rebuild those.
+    Tracking fields (``source_guid``, ``version_correlation_id``) are the
+    record's stable identity — set once at creation and preserved through all
+    downstream 1:1 stages. Per-stage fields (metadata, lineage, etc.) are not
+    carried; enrichers rebuild those each stage.
     """
     if input_record is None:
         return result

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -159,7 +159,7 @@ class RecordEnvelope:
 
         _validate_transition(from_state, to_state)
 
-        history: list[dict[str, Any]] = list(record.get("_state_history") or [])
+        history: list[dict[str, Any]] = record.get("_state_history") or []
         entry: dict[str, Any] = {
             "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
             "action": action_name,
@@ -179,22 +179,7 @@ class RecordEnvelope:
 
 
 def _validate_transition(from_state: RecordState | None, to_state: RecordState) -> None:
-    """Raise RecordEnvelopeError if the from→to edge is not legal.
-
-    Legal edges:
-    - None → any state          (first transition on a new record)
-    - ACTIVE → any settled      (normal pipeline progression)
-    - RESETTABLE → ACTIVE       (downstream reset before retry)
-    - any → same state          (idempotent re-application, e.g. retry logic)
-
-    Illegal edges:
-    - CASCADE_BLOCKING → ACTIVE (CASCADE_SKIPPED/FAILED/EXHAUSTED cannot be
-                                 reset to ACTIVE directly; they require an
-                                 explicit reset through RESETTABLE states first,
-                                 which is not a supported path today)
-    - SETTLED → SETTLED (cross-settled transitions, e.g. PROCESSED → FAILED,
-                         are not valid — settled means done for this stage)
-    """
+    """Raise RecordEnvelopeError if the from→to edge violates state machine rules."""
     if from_state is None:
         return
     if from_state == to_state:

--- a/tests/unit/record/test_transition.py
+++ b/tests/unit/record/test_transition.py
@@ -1,0 +1,167 @@
+"""Tests for RecordEnvelope.transition() — lifecycle state mutator."""
+
+import pytest
+
+from agent_actions.record.envelope import (
+    STATE_HISTORY_CAP,
+    RecordEnvelope,
+    RecordEnvelopeError,
+)
+from agent_actions.record.state import RecordState
+
+
+def _active_record() -> dict:
+    return {"_state": "active", "content": {}, "source_guid": "sg-1"}
+
+
+def _record(state: RecordState) -> dict:
+    return {"_state": state.value, "content": {}}
+
+
+class TestTransitionBasic:
+    def test_sets_state(self):
+        rec = _active_record()
+        RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", "done")
+        assert rec["_state"] == "processed"
+
+    def test_sets_schema_version(self):
+        rec = _active_record()
+        RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", "done")
+        assert rec["_state_schema_version"] == 1
+
+    def test_returns_record(self):
+        rec = _active_record()
+        result = RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", "done")
+        assert result is rec
+
+    def test_history_entry_shape(self):
+        rec = _active_record()
+        RecordEnvelope.transition(rec, RecordState.PROCESSED, "my_action", "completed", detail="ok")
+        entry = rec["_state_history"][0]
+        assert entry["from"] == "active"
+        assert entry["to"] == "processed"
+        assert entry["action"] == "my_action"
+        assert entry["reason"] == "completed"
+        assert entry["detail"] == "ok"
+        assert "timestamp" in entry
+
+    def test_detail_none_stored(self):
+        rec = _active_record()
+        RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", "done")
+        assert rec["_state_history"][0]["detail"] is None
+
+    def test_first_transition_from_none(self):
+        rec = {"content": {}}
+        RecordEnvelope.transition(rec, RecordState.ACTIVE, "init", "bootstrap")
+        assert rec["_state"] == "active"
+        assert rec["_state_history"][0]["from"] is None
+
+
+class TestTransitionLegalEdges:
+    @pytest.mark.parametrize(
+        "to_state",
+        [
+            RecordState.PROCESSED,
+            RecordState.COMMITTED,
+            RecordState.GUARD_SKIPPED,
+            RecordState.GUARD_DEFERRED,
+            RecordState.CASCADE_SKIPPED,
+            RecordState.FAILED,
+            RecordState.EXHAUSTED,
+        ],
+    )
+    def test_active_to_any_settled(self, to_state):
+        rec = _active_record()
+        RecordEnvelope.transition(rec, to_state, "act", "reason")
+        assert rec["_state"] == to_state.value
+
+    @pytest.mark.parametrize(
+        "from_state",
+        [
+            RecordState.PROCESSED,
+            RecordState.COMMITTED,
+            RecordState.GUARD_SKIPPED,
+            RecordState.GUARD_DEFERRED,
+        ],
+    )
+    def test_resettable_to_active(self, from_state):
+        rec = _record(from_state)
+        RecordEnvelope.transition(rec, RecordState.ACTIVE, "reset", "retry")
+        assert rec["_state"] == "active"
+
+    def test_idempotent_same_state(self):
+        rec = _active_record()
+        RecordEnvelope.transition(rec, RecordState.ACTIVE, "act", "noop")
+        assert rec["_state"] == "active"
+        assert len(rec["_state_history"]) == 1
+
+
+class TestTransitionIllegalEdges:
+    @pytest.mark.parametrize(
+        "from_state",
+        [
+            RecordState.CASCADE_SKIPPED,
+            RecordState.FAILED,
+            RecordState.EXHAUSTED,
+        ],
+    )
+    def test_cascade_blocking_cannot_reset_to_active(self, from_state):
+        rec = _record(from_state)
+        with pytest.raises(RecordEnvelopeError, match="Illegal state transition"):
+            RecordEnvelope.transition(rec, RecordState.ACTIVE, "act", "reset")
+
+    def test_processed_cannot_go_to_failed(self):
+        rec = _record(RecordState.PROCESSED)
+        with pytest.raises(RecordEnvelopeError, match="Illegal state transition"):
+            RecordEnvelope.transition(rec, RecordState.FAILED, "act", "oops")
+
+    def test_committed_cannot_go_to_guard_skipped(self):
+        rec = _record(RecordState.COMMITTED)
+        with pytest.raises(RecordEnvelopeError, match="Illegal state transition"):
+            RecordEnvelope.transition(rec, RecordState.GUARD_SKIPPED, "act", "reason")
+
+
+class TestTransitionHistoryCap:
+    def test_history_grows_to_cap(self):
+        rec = {"content": {}}
+        for i in range(STATE_HISTORY_CAP):
+            rec["_state"] = "active"
+            RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", f"step-{i}")
+            rec["_state"] = "processed"
+            RecordEnvelope.transition(rec, RecordState.ACTIVE, "reset", f"reset-{i}")
+        assert len(rec["_state_history"]) == STATE_HISTORY_CAP
+
+    def test_oldest_entry_dropped_at_cap(self):
+        rec = {"content": {}}
+        # Fill to cap
+        for i in range(STATE_HISTORY_CAP):
+            rec["_state"] = "active"
+            RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", f"step-{i}")
+            rec["_state"] = "processed"
+            if i < STATE_HISTORY_CAP - 1:
+                RecordEnvelope.transition(rec, RecordState.ACTIVE, "reset", f"reset-{i}")
+
+        first_reason_before_cap = rec["_state_history"][0]["reason"]
+
+        # One more transition pushes oldest off
+        rec["_state"] = "processed"
+        RecordEnvelope.transition(rec, RecordState.ACTIVE, "reset", "overflow")
+        assert len(rec["_state_history"]) == STATE_HISTORY_CAP
+        assert rec["_state_history"][0]["reason"] != first_reason_before_cap
+        assert rec["_state_history"][-1]["reason"] == "overflow"
+
+
+class TestFrameworkFields:
+    def test_state_fields_in_record_stage_fields(self):
+        from agent_actions.record.envelope import RECORD_STAGE_FIELDS
+
+        assert "_state" in RECORD_STAGE_FIELDS
+        assert "_state_history" in RECORD_STAGE_FIELDS
+        assert "_state_schema_version" in RECORD_STAGE_FIELDS
+
+    def test_state_fields_in_framework_fields(self):
+        from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS
+
+        assert "_state" in RECORD_FRAMEWORK_FIELDS
+        assert "_state_history" in RECORD_FRAMEWORK_FIELDS
+        assert "_state_schema_version" in RECORD_FRAMEWORK_FIELDS

--- a/tests/unit/record/test_transition.py
+++ b/tests/unit/record/test_transition.py
@@ -3,6 +3,8 @@
 import pytest
 
 from agent_actions.record.envelope import (
+    RECORD_FRAMEWORK_FIELDS,
+    RECORD_STAGE_FIELDS,
     STATE_HISTORY_CAP,
     RecordEnvelope,
     RecordEnvelopeError,
@@ -107,18 +109,33 @@ class TestTransitionIllegalEdges:
     )
     def test_cascade_blocking_cannot_reset_to_active(self, from_state):
         rec = _record(from_state)
-        with pytest.raises(RecordEnvelopeError, match="Illegal state transition"):
+        with pytest.raises(RecordEnvelopeError, match=f"{from_state.value!r}.*active"):
             RecordEnvelope.transition(rec, RecordState.ACTIVE, "act", "reset")
 
     def test_processed_cannot_go_to_failed(self):
         rec = _record(RecordState.PROCESSED)
-        with pytest.raises(RecordEnvelopeError, match="Illegal state transition"):
+        with pytest.raises(RecordEnvelopeError, match="'processed'.*'failed'"):
             RecordEnvelope.transition(rec, RecordState.FAILED, "act", "oops")
 
     def test_committed_cannot_go_to_guard_skipped(self):
         rec = _record(RecordState.COMMITTED)
-        with pytest.raises(RecordEnvelopeError, match="Illegal state transition"):
+        with pytest.raises(RecordEnvelopeError, match="'committed'.*'guard_skipped'"):
             RecordEnvelope.transition(rec, RecordState.GUARD_SKIPPED, "act", "reason")
+
+    def test_unknown_state_value_raises_envelope_error(self):
+        rec = {"_state": "bogus_state", "content": {}}
+        with pytest.raises(RecordEnvelopeError, match="unknown _state value.*bogus_state"):
+            RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", "reason")
+
+    def test_corrupt_history_type_raises_envelope_error(self):
+        rec = {"_state": "active", "_state_history": "not-a-list", "content": {}}
+        with pytest.raises(RecordEnvelopeError, match="_state_history must be a list"):
+            RecordEnvelope.transition(rec, RecordState.PROCESSED, "act", "reason")
+
+    def test_empty_action_name_raises(self):
+        rec = _active_record()
+        with pytest.raises(RecordEnvelopeError, match="action_name is required"):
+            RecordEnvelope.transition(rec, RecordState.PROCESSED, "", "reason")
 
 
 class TestTransitionHistoryCap:
@@ -153,15 +170,11 @@ class TestTransitionHistoryCap:
 
 class TestFrameworkFields:
     def test_state_fields_in_record_stage_fields(self):
-        from agent_actions.record.envelope import RECORD_STAGE_FIELDS
-
         assert "_state" in RECORD_STAGE_FIELDS
         assert "_state_history" in RECORD_STAGE_FIELDS
         assert "_state_schema_version" in RECORD_STAGE_FIELDS
 
     def test_state_fields_in_framework_fields(self):
-        from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS
-
         assert "_state" in RECORD_FRAMEWORK_FIELDS
         assert "_state_history" in RECORD_FRAMEWORK_FIELDS
         assert "_state_schema_version" in RECORD_FRAMEWORK_FIELDS


### PR DESCRIPTION
## Summary
- `RecordEnvelope.transition(record, to_state, action_name, reason, detail=None)` is now the **only** sanctioned mutator for `_state`, `_state_history`, `_state_schema_version`
- Validates legal transition edges: ACTIVE → any settled, RESETTABLE → ACTIVE, same → same; raises `RecordEnvelopeError` on illegal edges (CASCADE_BLOCKING → ACTIVE, settled cross-writes)
- History capped at 64 entries — oldest rolls off on overflow; cap rationale and schema version bump rules documented in module docstring
- `_state`, `_state_history`, `_state_schema_version` added to `RECORD_STAGE_FIELDS` (auto-included in `RECORD_FRAMEWORK_FIELDS`)

## Verification
- 27 new tests: valid transitions, illegal edges, history cap (oldest-drops behavior), framework field membership
- 128 record unit tests passing
- ruff clean