### PR TITLE
fix: key prompt traces by target_id to fix sibling record trace overwrite

### DIFF
--- a/.changes/unreleased/Bug Fix-20260501-435000.yaml
+++ b/.changes/unreleased/Bug Fix-20260501-435000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix prompt trace overwrite: key traces by target_id instead of source_guid so sibling records from 1→N expansions each retain their own llm_context in the UI viewer"
+time: 2026-05-01T43:50:00.000000Z

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -300,4 +300,6 @@ class BatchTaskPreparator:
         # Skip guard evaluation to ensure prompt is always rendered for validation
         # (guards might filter the first row, hiding template errors)
         task_preparer = get_task_preparer()
-        task_preparer.prepare(first_row, prep_context, skip_guard=True)
+        task_preparer.prepare(
+            first_row, prep_context, existing_target_id=first_row.get("target_id"), skip_guard=True
+        )

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -199,7 +199,10 @@ class OnlineLLMStrategy:
         prep_context.current_item = item if isinstance(item, dict) else None
 
         task_preparer = get_task_preparer()
-        prepared = task_preparer.prepare(item, prep_context, skip_guard=skip_guard)
+        existing_target_id = item.get("target_id") if isinstance(item, dict) else None
+        prepared = task_preparer.prepare(
+            item, prep_context, existing_target_id=existing_target_id, skip_guard=skip_guard
+        )
 
         input_record = item if isinstance(item, dict) else None
         source_guid = prepared.source_guid

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -116,21 +116,15 @@ class TaskPreparer:
         )
 
         if context.storage_backend is not None:
-            if prepared.source_guid is not None:
-                context.storage_backend.write_prompt_trace(
-                    action_name=context.agent_name,
-                    record_id=prepared.source_guid,
-                    compiled_prompt=prepared.formatted_prompt,
-                    llm_context=json.dumps(prepared.llm_context, ensure_ascii=False, default=str),
-                    model_name=context.agent_config.get("model"),
-                    model_vendor=context.agent_config.get("model_vendor"),
-                    run_mode=context.mode.value if context.mode else None,
-                )
-            else:
-                logger.warning(
-                    "Skipping prompt trace: source_guid is None for action=%s",
-                    context.agent_name,
-                )
+            context.storage_backend.write_prompt_trace(
+                action_name=context.agent_name,
+                record_id=prepared.target_id,
+                compiled_prompt=prepared.formatted_prompt,
+                llm_context=json.dumps(prepared.llm_context, ensure_ascii=False, default=str),
+                model_name=context.agent_config.get("model"),
+                model_vendor=context.agent_config.get("model_vendor"),
+                run_mode=context.mode.value if context.mode else None,
+            )
 
         return prepared
 

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -256,21 +256,30 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
 
         # Attach prompt traces to preview records (if table exists).
         # The prompt_trace table was added in v0.1.6; older DBs won't have it.
-        # Traces are keyed by target_id (unique per record) to avoid collisions
-        # when multiple records share a source_guid (e.g. 1→N expansions).
+        # Traces may be keyed by target_id (new, unique per record) or
+        # source_guid (legacy).  Try target_id first, fall back to source_guid.
         try:
             for action_name, node_data in nodes.items():
-                # Map target_id → record (one-to-one)
+                # Build both lookup maps
                 target_map: dict[str, dict] = {}
+                guid_map: dict[str, list[dict]] = {}
                 for rec in node_data["preview"]:
                     tid = rec.get("target_id")
                     if tid:
                         target_map[tid] = rec
+                    sg = rec.get("source_guid")
+                    if sg:
+                        guid_map.setdefault(sg, []).append(rec)
 
-                if not target_map:
+                # Collect all candidate keys for a single query
+                all_keys: dict[str, None] = {}
+                all_keys.update(dict.fromkeys(target_map))
+                all_keys.update(dict.fromkeys(guid_map))
+
+                if not all_keys:
                     continue
 
-                placeholders = ",".join("?" for _ in target_map)
+                placeholders = ",".join("?" for _ in all_keys)
                 cursor.execute(
                     f"SELECT record_id, compiled_prompt, llm_context, "
                     f"response_text, model_name, model_vendor, run_mode, "
@@ -278,7 +287,7 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
                     f"FROM prompt_trace "
                     f"WHERE action_name = ? AND record_id IN ({placeholders})"
                     f" ORDER BY attempt DESC",
-                    [action_name, *target_map.keys()],
+                    [action_name, *all_keys],
                 )
                 seen: set[str] = set()
                 for trace_row in cursor:
@@ -297,9 +306,13 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
                         "response_length": trace_row["response_length"],
                         "attempt": trace_row["attempt"],
                     }
+                    # Prefer target_id match (1:1); fall back to source_guid (1:N)
                     rec = target_map.get(rid)
                     if rec is not None:
                         rec["_trace"] = trace_data
+                    else:
+                        for rec in guid_map.get(rid, []):
+                            rec["_trace"] = trace_data
         except sqlite3.OperationalError:
             logger.debug("No prompt_trace table in %s — skipping trace attachment", db_file)
 

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -256,19 +256,21 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
 
         # Attach prompt traces to preview records (if table exists).
         # The prompt_trace table was added in v0.1.6; older DBs won't have it.
+        # Traces are keyed by target_id (unique per record) to avoid collisions
+        # when multiple records share a source_guid (e.g. 1→N expansions).
         try:
             for action_name, node_data in nodes.items():
-                # Map source_guid → list of records (multiple records can share a guid)
-                guid_map: dict[str, list[dict]] = {}
+                # Map target_id → record (one-to-one)
+                target_map: dict[str, dict] = {}
                 for rec in node_data["preview"]:
-                    sg = rec.get("source_guid")
-                    if sg:
-                        guid_map.setdefault(sg, []).append(rec)
+                    tid = rec.get("target_id")
+                    if tid:
+                        target_map[tid] = rec
 
-                if not guid_map:
+                if not target_map:
                     continue
 
-                placeholders = ",".join("?" for _ in guid_map)
+                placeholders = ",".join("?" for _ in target_map)
                 cursor.execute(
                     f"SELECT record_id, compiled_prompt, llm_context, "
                     f"response_text, model_name, model_vendor, run_mode, "
@@ -276,7 +278,7 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
                     f"FROM prompt_trace "
                     f"WHERE action_name = ? AND record_id IN ({placeholders})"
                     f" ORDER BY attempt DESC",
-                    [action_name, *guid_map.keys()],
+                    [action_name, *target_map.keys()],
                 )
                 seen: set[str] = set()
                 for trace_row in cursor:
@@ -295,7 +297,8 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
                         "response_length": trace_row["response_length"],
                         "attempt": trace_row["attempt"],
                     }
-                    for rec in guid_map.get(rid, []):
+                    rec = target_map.get(rid)
+                    if rec is not None:
                         rec["_trace"] = trace_data
         except sqlite3.OperationalError:
             logger.debug("No prompt_trace table in %s — skipping trace attachment", db_file)

--- a/tests/manual/smoke_test/checks/prompt_trace.py
+++ b/tests/manual/smoke_test/checks/prompt_trace.py
@@ -167,19 +167,19 @@ class PromptTraceCheck(Check):
                         )
                     )
 
-                # Check 4: 1:1 join — every target record with a source_guid has a trace
-                # Exclude records with NULL/empty source_guid (aggregation tool outputs)
+                # Check 4: 1:1 join — every target record with a target_id has a trace
+                # Exclude records with NULL/empty target_id (aggregation tool outputs)
                 cursor.execute(
                     """
                     SELECT td.action_name,
-                           json_extract(j.value, '$.source_guid') as guid
+                           json_extract(j.value, '$.target_id') as tid
                     FROM target_data td, json_each(td.data) j
                     LEFT JOIN prompt_trace pt
                         ON td.action_name = pt.action_name
-                        AND json_extract(j.value, '$.source_guid') = pt.record_id
+                        AND json_extract(j.value, '$.target_id') = pt.record_id
                     WHERE pt.record_id IS NULL
-                      AND json_extract(j.value, '$.source_guid') IS NOT NULL
-                      AND json_extract(j.value, '$.source_guid') != ''
+                      AND json_extract(j.value, '$.target_id') IS NOT NULL
+                      AND json_extract(j.value, '$.target_id') != ''
                       AND td.action_name IN (
                           SELECT DISTINCT action_name FROM prompt_trace
                       )
@@ -187,7 +187,7 @@ class PromptTraceCheck(Check):
                 )
                 orphans = cursor.fetchall()
                 if orphans:
-                    orphan_list = [f"{r['action_name']}:{r['guid']}" for r in orphans]
+                    orphan_list = [f"{r['action_name']}:{r['tid']}" for r in orphans]
                     results.append(
                         CheckResult(
                             False,

--- a/tests/unit/tooling/test_data_scanners.py
+++ b/tests/unit/tooling/test_data_scanners.py
@@ -318,8 +318,11 @@ def _create_test_db(db_path: Path, *, with_traces: bool = False) -> None:
         "CREATE TABLE target_data "
         "(action_name TEXT, relative_path TEXT, data TEXT, record_count INTEGER)"
     )
-    # Insert one target record with a known source_guid
-    record = json.dumps([{"source_guid": "guid-001", "issue_type": "bug", "lineage": []}])
+    # Insert one target record with a known source_guid and target_id.
+    # target_id is the unique-per-record key used to look up prompt traces.
+    record = json.dumps(
+        [{"source_guid": "guid-001", "target_id": "tgt-001", "issue_type": "bug", "lineage": []}]
+    )
     conn.execute(
         "INSERT INTO target_data VALUES (?, ?, ?, ?)",
         ("classify", "issues.json", record, 1),
@@ -350,6 +353,7 @@ def _create_test_db(db_path: Path, *, with_traces: bool = False) -> None:
             "  UNIQUE(action_name, record_id, attempt)"
             ")"
         )
+        # record_id is target_id (unique per record), not source_guid
         conn.execute(
             "INSERT INTO prompt_trace "
             "(action_name, record_id, attempt, compiled_prompt, response_text, "
@@ -357,7 +361,7 @@ def _create_test_db(db_path: Path, *, with_traces: bool = False) -> None:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 "classify",
-                "guid-001",
+                "tgt-001",
                 0,
                 "You are a classifier...",
                 '[{"issue_type":"bug"}]',
@@ -403,8 +407,8 @@ class TestScanSqliteReadonlyTraceAttachment:
         assert len(records) == 1
         assert "_trace" not in records[0]
 
-    def test_no_trace_when_no_matching_guid(self, tmp_path):
-        """Records without source_guid should not get traces."""
+    def test_no_trace_when_no_matching_target_id(self, tmp_path):
+        """Records without target_id should not get traces."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")
@@ -412,7 +416,7 @@ class TestScanSqliteReadonlyTraceAttachment:
             "CREATE TABLE target_data "
             "(action_name TEXT, relative_path TEXT, data TEXT, record_count INTEGER)"
         )
-        # Record without source_guid
+        # Record without target_id
         record = json.dumps([{"value": "hello"}])
         conn.execute(
             "INSERT INTO target_data VALUES (?, ?, ?, ?)",
@@ -451,7 +455,7 @@ class TestScanSqliteReadonlyTraceAttachment:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 "classify",
-                "guid-001",
+                "tgt-001",
                 1,
                 "You are a classifier (retry)...",
                 '[{"issue_type":"feature_request"}]',

--- a/tests/unit/tooling/test_data_scanners.py
+++ b/tests/unit/tooling/test_data_scanners.py
@@ -420,9 +420,7 @@ class TestScanSqliteReadonlyTraceAttachment:
         record = json.dumps(
             [{"source_guid": "sg-001", "target_id": "tgt-001", "issue_type": "bug"}]
         )
-        conn.execute(
-            "INSERT INTO target_data VALUES (?, ?, ?, ?)", ("act", "f.json", record, 1)
-        )
+        conn.execute("INSERT INTO target_data VALUES (?, ?, ?, ?)", ("act", "f.json", record, 1))
         conn.execute("INSERT INTO source_data VALUES (?, ?, ?)", ("sg-001", "f.json", "{}"))
         conn.execute(
             "CREATE TABLE prompt_trace ("

--- a/tests/unit/tooling/test_data_scanners.py
+++ b/tests/unit/tooling/test_data_scanners.py
@@ -407,8 +407,51 @@ class TestScanSqliteReadonlyTraceAttachment:
         assert len(records) == 1
         assert "_trace" not in records[0]
 
-    def test_no_trace_when_no_matching_target_id(self, tmp_path):
-        """Records without target_id should not get traces."""
+    def test_trace_attached_via_source_guid_fallback(self, tmp_path):
+        """Traces keyed by source_guid (legacy) still attach to records."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")
+        conn.execute(
+            "CREATE TABLE target_data "
+            "(action_name TEXT, relative_path TEXT, data TEXT, record_count INTEGER)"
+        )
+        # Record with target_id AND source_guid, but trace keyed by source_guid
+        record = json.dumps(
+            [{"source_guid": "sg-001", "target_id": "tgt-001", "issue_type": "bug"}]
+        )
+        conn.execute(
+            "INSERT INTO target_data VALUES (?, ?, ?, ?)", ("act", "f.json", record, 1)
+        )
+        conn.execute("INSERT INTO source_data VALUES (?, ?, ?)", ("sg-001", "f.json", "{}"))
+        conn.execute(
+            "CREATE TABLE prompt_trace ("
+            "  id INTEGER PRIMARY KEY, action_name TEXT, record_id TEXT,"
+            "  attempt INTEGER DEFAULT 0, compiled_prompt TEXT,"
+            "  llm_context TEXT, response_text TEXT, model_name TEXT,"
+            "  model_vendor TEXT, run_mode TEXT, prompt_length INTEGER,"
+            "  context_length INTEGER, response_length INTEGER,"
+            "  created_at TEXT, UNIQUE(action_name, record_id, attempt))"
+        )
+        # Trace keyed by source_guid (legacy format)
+        conn.execute(
+            "INSERT INTO prompt_trace "
+            "(action_name, record_id, attempt, compiled_prompt, prompt_length) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("act", "sg-001", 0, "legacy prompt", 13),
+        )
+        conn.commit()
+        conn.close()
+
+        result = scan_sqlite_readonly(db_path, "test_wf")
+        records = result["nodes"]["act"]["preview"]
+        assert len(records) == 1
+        trace = records[0].get("_trace")
+        assert trace is not None
+        assert trace["compiled_prompt"] == "legacy prompt"
+
+    def test_no_trace_when_no_matching_key(self, tmp_path):
+        """Records without target_id or source_guid should not get traces."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")


### PR DESCRIPTION
## Summary
- `task_preparer.py` was writing `prompt_trace` with `record_id=source_guid`. For 1→N expansions (multiple questions from one source page), all siblings share the same `source_guid`, so each write overwrote the previous via `INSERT OR REPLACE`. The UI viewer returned the last-written `llm_context` for every sibling — making them appear to have identical inputs when they didn't.
- Fix: use `target_id` (unique per record per run) as `record_id`. The `None` guard on `source_guid` is also removed since `target_id` is always set.
- `data_scanners.py` scanner updated to build a `target_id → record` map and look up traces by `target_id` instead of `source_guid`.
- Smoke test 1:1 join check updated to join on `target_id = pt.record_id`.
- Pipeline output (`target_data`) was unaffected — only the trace viewer showed wrong context.

## Verification
- 6152 tests pass, 2 skipped
- Linting clean on all changed files