### PR TITLE
Fail-closed lifecycle validation on target record reads

### DIFF
--- a/.changes/unreleased/Enhancement-20260501-023000.yaml
+++ b/.changes/unreleased/Enhancement-20260501-023000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add fail-closed lifecycle validation: records loaded from target storage must carry _state or raise ConfigurationError with actionable delete-and-rerun message"
+time: 2026-05-01T02:30:00.000000Z

--- a/agent_actions/record/lifecycle_read.py
+++ b/agent_actions/record/lifecycle_read.py
@@ -1,0 +1,76 @@
+"""Fail-closed lifecycle validation for records loaded from target storage.
+
+Any record loaded from a frozen target directory as upstream input for a
+downstream action must carry ``_state``.  Missing ``_state`` means the
+record pre-dates the lifecycle machine or was written outside
+``RecordEnvelope.transition()`` — both are unrecoverable without a re-run.
+
+There is no migration path: delete ``agent_io/target/`` and re-run from
+the beginning.  See ``record/_MANIFEST.md`` for the transition rules.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_actions.errors.configuration import ConfigurationError
+from agent_actions.record.state import RecordState
+
+_SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
+
+
+def validate_lifecycle(
+    record: dict[str, Any],
+    *,
+    action_name: str,
+) -> None:
+    """Raise ``ConfigurationError`` if *record* is missing a valid lifecycle state.
+
+    Call this immediately after loading a record from target storage as
+    upstream input.  Never call it on staging/source records — those do not
+    carry ``_state``.
+
+    Raises ``ConfigurationError`` with an actionable message that names the
+    offending action and record id so the operator knows exactly what to
+    delete and re-run.
+    """
+    source_guid = record.get("source_guid", "?")
+
+    if "_state" not in record:
+        raise ConfigurationError(
+            f"Record is missing '_state'. Delete agent_io/target/ and re-run. "
+            f"(action='{action_name}', source_guid='{source_guid}')"
+        )
+
+    raw_state = record["_state"]
+    try:
+        RecordState(raw_state)
+    except ValueError:
+        raise ConfigurationError(
+            f"Record has unrecognised '_state' value {raw_state!r}. "
+            f"Delete agent_io/target/ and re-run. "
+            f"(action='{action_name}', source_guid='{source_guid}')"
+        ) from None
+
+    schema_version = record.get("_state_schema_version")
+    if schema_version is not None and schema_version not in _SUPPORTED_SCHEMA_VERSIONS:
+        raise ConfigurationError(
+            f"Record has unsupported '_state_schema_version' {schema_version!r}. "
+            f"Supported: {sorted(_SUPPORTED_SCHEMA_VERSIONS)}. "
+            f"Delete agent_io/target/ and re-run. "
+            f"(action='{action_name}', source_guid='{source_guid}')"
+        )
+
+
+def validate_lifecycle_batch(
+    records: list[dict[str, Any]],
+    *,
+    action_name: str,
+) -> None:
+    """Validate lifecycle state for every record in *records*.
+
+    Fails on the first invalid record.  Use this after loading a full
+    target file from storage.
+    """
+    for record in records:
+        validate_lifecycle(record, action_name=action_name)

--- a/agent_actions/record/lifecycle_read.py
+++ b/agent_actions/record/lifecycle_read.py
@@ -17,6 +17,7 @@ from agent_actions.errors.configuration import ConfigurationError
 from agent_actions.record.state import RecordState
 
 _SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
+_VALID_STATES: frozenset[str] = frozenset(s.value for s in RecordState)
 
 
 def validate_lifecycle(
@@ -43,14 +44,12 @@ def validate_lifecycle(
         )
 
     raw_state = record["_state"]
-    try:
-        RecordState(raw_state)
-    except ValueError:
+    if raw_state not in _VALID_STATES:
         raise ConfigurationError(
             f"Record has unrecognised '_state' value {raw_state!r}. "
             f"Delete agent_io/target/ and re-run. "
             f"(action='{action_name}', source_guid='{source_guid}')"
-        ) from None
+        )
 
     schema_version = record.get("_state_schema_version")
     if schema_version is not None and schema_version not in _SUPPORTED_SCHEMA_VERSIONS:
@@ -72,5 +71,10 @@ def validate_lifecycle_batch(
     Fails on the first invalid record.  Use this after loading a full
     target file from storage.
     """
-    for record in records:
+    for i, record in enumerate(records):
+        if not isinstance(record, dict):
+            raise ConfigurationError(
+                f"Expected a dict at index {i} in target data for action '{action_name}', "
+                f"got {type(record).__name__}. Delete agent_io/target/ and re-run."
+            )
         validate_lifecycle(record, action_name=action_name)

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from agent_actions.config.defaults import StorageDefaults
 from agent_actions.errors.configuration import ConfigValidationError
+from agent_actions.record.lifecycle_read import validate_lifecycle_batch
 from agent_actions.storage.backend import VALID_DISPOSITIONS, Disposition, StorageBackend
 
 logger = logging.getLogger(__name__)
@@ -291,6 +292,7 @@ class SQLiteBackend(StorageBackend):
             raise FileNotFoundError(f"No target data found for {action_name}/{relative_path}")
 
         result: list[dict[str, Any]] = json.loads(row["data"])
+        validate_lifecycle_batch(result, action_name=action_name)
         return result
 
     def write_source(

--- a/tests/integration/test_storage_backend_integration.py
+++ b/tests/integration/test_storage_backend_integration.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 import pytest
 
+
+def _tr(*extra_fields, **kwargs) -> dict:
+    """Minimal valid target record with lifecycle fields."""
+    return {"_state": "processed", "_state_schema_version": 1, **kwargs}
+
 from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
@@ -79,8 +84,8 @@ class TestTargetDataOperations:
     def test_write_and_read_target_data(self, backend):
         """Can write and read target data for a node."""
         test_data = [
-            {"content": {"text": "record 1"}, "source_guid": "guid-1"},
-            {"content": {"text": "record 2"}, "source_guid": "guid-2"},
+            {"_state": "processed", "_state_schema_version": 1, "content": {"text": "record 1"}, "source_guid": "guid-1"},
+            {"_state": "processed", "_state_schema_version": 1, "content": {"text": "record 2"}, "source_guid": "guid-2"},
         ]
 
         # Write
@@ -96,10 +101,10 @@ class TestTargetDataOperations:
     def test_write_target_overwrites_existing(self, backend):
         """Writing to same path overwrites existing data."""
         # Write initial data
-        backend.write_target("node1", "file.json", [{"id": 1}])
+        backend.write_target("node1", "file.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}])
 
         # Write new data to same path
-        backend.write_target("node1", "file.json", [{"id": 2}, {"id": 3}])
+        backend.write_target("node1", "file.json", [{"_state": "processed", "_state_schema_version": 1, "id": 2}, {"_state": "processed", "_state_schema_version": 1, "id": 3}])
 
         # Should have new data
         retrieved = backend.read_target("node1", "file.json")
@@ -115,9 +120,9 @@ class TestTargetDataOperations:
 
     def test_list_target_files(self, backend):
         """Can list all target files for a node."""
-        backend.write_target("node1", "batch_001.json", [{"id": 1}])
-        backend.write_target("node1", "batch_002.json", [{"id": 2}])
-        backend.write_target("node2", "batch_001.json", [{"id": 3}])
+        backend.write_target("node1", "batch_001.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}])
+        backend.write_target("node1", "batch_002.json", [{"_state": "processed", "_state_schema_version": 1, "id": 2}])
+        backend.write_target("node2", "batch_001.json", [{"_state": "processed", "_state_schema_version": 1, "id": 3}])
 
         node1_files = backend.list_target_files("node1")
         assert len(node1_files) == 2
@@ -232,17 +237,17 @@ class TestPreviewAndStats:
             backend.write_target(
                 "extract",
                 "batch_001.json",
-                [{"id": i, "text": f"record {i}"} for i in range(15)],
+                [{"_state": "processed", "_state_schema_version": 1, "id": i, "text": f"record {i}"} for i in range(15)],
             )
             backend.write_target(
                 "extract",
                 "batch_002.json",
-                [{"id": i, "text": f"record {i}"} for i in range(15, 25)],
+                [{"_state": "processed", "_state_schema_version": 1, "id": i, "text": f"record {i}"} for i in range(15, 25)],
             )
             backend.write_target(
                 "transform",
                 "batch_001.json",
-                [{"id": i, "result": f"transformed {i}"} for i in range(5)],
+                [{"_state": "processed", "_state_schema_version": 1, "id": i, "result": f"transformed {i}"} for i in range(5)],
             )
 
             # Add sample source data
@@ -373,7 +378,7 @@ class TestConcurrencyAndResilience:
                     backend.write_target(
                         "node1",
                         f"batch_{i:03d}.json",
-                        [{"batch": i, "id": j} for j in range(5)],
+                        [{"_state": "processed", "_state_schema_version": 1, "batch": i, "id": j} for j in range(5)],
                     )
 
                 files = backend.list_target_files("node1")
@@ -388,9 +393,9 @@ class TestConcurrencyAndResilience:
                 backend.initialize()
 
                 test_data = [
-                    {"text": "Hello 世界 🌍"},
-                    {"text": "Ελληνικά"},
-                    {"text": "العربية"},
+                    {"_state": "processed", "_state_schema_version": 1, "text": "Hello 世界 🌍"},
+                    {"_state": "processed", "_state_schema_version": 1, "text": "Ελληνικά"},
+                    {"_state": "processed", "_state_schema_version": 1, "text": "العربية"},
                 ]
 
                 backend.write_target("node1", "unicode.json", test_data)
@@ -410,7 +415,7 @@ class TestConcurrencyAndResilience:
 
                 # Create a large record (~1MB of text)
                 large_text = "x" * (1024 * 1024)
-                test_data = [{"large_field": large_text}]
+                test_data = [{"_state": "processed", "_state_schema_version": 1, "large_field": large_text}]
 
                 backend.write_target("node1", "large.json", test_data)
                 retrieved = backend.read_target("node1", "large.json")
@@ -446,7 +451,7 @@ class TestConcurrencyAndResilience:
                         backend.write_target(
                             f"node_{thread_id}",
                             f"batch_{i}.json",
-                            [{"id": i, "thread": thread_id}],
+                            [{"_state": "processed", "_state_schema_version": 1, "id": i, "thread": thread_id}],
                         )
                     results.append(f"target-{thread_id}")
                 except Exception as e:
@@ -496,8 +501,8 @@ class TestWorkflowIntegration:
 
                 # Action 1: Extract - writes target data
                 extract_output = [
-                    {"source_guid": "g1", "content": {"raw": "doc1"}},
-                    {"source_guid": "g2", "content": {"raw": "doc2"}},
+                    {"_state": "processed", "_state_schema_version": 1, "source_guid": "g1", "content": {"raw": "doc1"}},
+                    {"_state": "processed", "_state_schema_version": 1, "source_guid": "g2", "content": {"raw": "doc2"}},
                 ]
                 backend.write_target("extract", "batch.json", extract_output)
 
@@ -525,9 +530,9 @@ class TestWorkflowIntegration:
                 backend.initialize()
 
                 # Simulate parallel writes from different actions
-                backend.write_target("action_a", "batch.json", [{"from": "a"}])
-                backend.write_target("action_b", "batch.json", [{"from": "b"}])
-                backend.write_target("action_c", "batch.json", [{"from": "c"}])
+                backend.write_target("action_a", "batch.json", [{"_state": "processed", "_state_schema_version": 1, "from": "a"}])
+                backend.write_target("action_b", "batch.json", [{"_state": "processed", "_state_schema_version": 1, "from": "b"}])
+                backend.write_target("action_c", "batch.json", [{"_state": "processed", "_state_schema_version": 1, "from": "c"}])
 
                 # Each action's data is separate
                 data_a = backend.read_target("action_a", "batch.json")
@@ -547,8 +552,8 @@ class TestWorkflowIntegration:
                 backend.initialize()
 
                 # Two parallel upstream actions
-                backend.write_target("extract_a", "batch.json", [{"id": 1, "src": "a"}])
-                backend.write_target("extract_b", "batch.json", [{"id": 2, "src": "b"}])
+                backend.write_target("extract_a", "batch.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1, "src": "a"}])
+                backend.write_target("extract_b", "batch.json", [{"_state": "processed", "_state_schema_version": 1, "id": 2, "src": "b"}])
 
                 # Merge action reads from both
                 data_a = backend.read_target("extract_a", "batch.json")
@@ -665,7 +670,7 @@ class TestDispositionLifecycle:
                 backend.initialize()
 
                 # Write some target data and dispositions
-                backend.write_target("node1", "batch.json", [{"id": 1}])
+                backend.write_target("node1", "batch.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}])
                 backend.set_disposition("node1", NODE_LEVEL_RECORD_ID, "passthrough")
                 backend.set_disposition("node1", "rec_1", "filtered")
 

--- a/tests/integration/test_storage_backend_integration.py
+++ b/tests/integration/test_storage_backend_integration.py
@@ -13,11 +13,6 @@ from pathlib import Path
 
 import pytest
 
-
-def _tr(*extra_fields, **kwargs) -> dict:
-    """Minimal valid target record with lifecycle fields."""
-    return {"_state": "processed", "_state_schema_version": 1, **kwargs}
-
 from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 

--- a/tests/unit/record/test_lifecycle_read.py
+++ b/tests/unit/record/test_lifecycle_read.py
@@ -1,0 +1,71 @@
+"""Tests for lifecycle_read validation helper."""
+
+import pytest
+
+from agent_actions.errors.configuration import ConfigurationError
+from agent_actions.record.lifecycle_read import validate_lifecycle, validate_lifecycle_batch
+from agent_actions.record.state import RecordState
+
+
+def _record(state: str = "active", **kwargs) -> dict:
+    return {"_state": state, "_state_schema_version": 1, "source_guid": "sg-1", **kwargs}
+
+
+class TestValidateLifecycle:
+    def test_valid_record_passes(self):
+        validate_lifecycle(_record(), action_name="my_action")
+
+    def test_all_valid_states_pass(self):
+        for state in RecordState:
+            validate_lifecycle(_record(state.value), action_name="act")
+
+    def test_missing_state_raises(self):
+        record = {"source_guid": "sg-1", "content": {}}
+        with pytest.raises(ConfigurationError, match="_state") as exc:
+            validate_lifecycle(record, action_name="my_action")
+        assert "my_action" in str(exc.value)
+        assert "sg-1" in str(exc.value)
+        assert "re-run" in str(exc.value)
+
+    def test_unknown_state_value_raises(self):
+        record = {"_state": "bogus", "source_guid": "sg-2"}
+        with pytest.raises(ConfigurationError, match="unrecognised.*bogus"):
+            validate_lifecycle(record, action_name="act")
+
+    def test_unsupported_schema_version_raises(self):
+        record = {"_state": "active", "_state_schema_version": 99, "source_guid": "sg-3"}
+        with pytest.raises(ConfigurationError, match="unsupported.*99"):
+            validate_lifecycle(record, action_name="act")
+
+    def test_missing_schema_version_passes(self):
+        record = {"_state": "active", "source_guid": "sg-4"}
+        validate_lifecycle(record, action_name="act")
+
+    def test_missing_source_guid_shows_question_mark(self):
+        record = {"_state": "bogus"}
+        with pytest.raises(ConfigurationError, match="source_guid='\\?'"):
+            validate_lifecycle(record, action_name="act")
+
+    def test_action_name_in_error_message(self):
+        record = {"content": {}}
+        with pytest.raises(ConfigurationError, match="action='specific_action'"):
+            validate_lifecycle(record, action_name="specific_action")
+
+
+class TestValidateLifecycleBatch:
+    def test_all_valid_passes(self):
+        records = [_record("active"), _record("processed"), _record("committed")]
+        validate_lifecycle_batch(records, action_name="act")
+
+    def test_empty_list_passes(self):
+        validate_lifecycle_batch([], action_name="act")
+
+    def test_first_invalid_raises(self):
+        records = [_record(), {"source_guid": "bad"}, _record()]
+        with pytest.raises(ConfigurationError, match="_state"):
+            validate_lifecycle_batch(records, action_name="act")
+
+    def test_last_invalid_raises(self):
+        records = [_record(), _record(), {"source_guid": "bad-last"}]
+        with pytest.raises(ConfigurationError, match="_state"):
+            validate_lifecycle_batch(records, action_name="act")

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from agent_actions.errors.configuration import ConfigurationError
 from agent_actions.storage import BACKENDS, get_storage_backend
 from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
@@ -85,8 +86,6 @@ class TestSQLiteBackend:
 
     def test_read_target_raises_when_state_missing(self, backend):
         """read_target raises ConfigurationError when persisted records omit _state."""
-        from agent_actions.errors.configuration import ConfigurationError
-
         data = [{"source_guid": "sg-1", "content": {"x": 1}}]
         backend.write_target("node_1", "batch.json", data)
         with pytest.raises(ConfigurationError, match="_state"):

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -83,6 +83,15 @@ class TestSQLiteBackend:
         with pytest.raises(FileNotFoundError):
             backend.read_target("node_1", "nonexistent.json")
 
+    def test_read_target_raises_when_state_missing(self, backend):
+        """read_target raises ConfigurationError when persisted records omit _state."""
+        from agent_actions.errors.configuration import ConfigurationError
+
+        data = [{"source_guid": "sg-1", "content": {"x": 1}}]
+        backend.write_target("node_1", "batch.json", data)
+        with pytest.raises(ConfigurationError, match="_state"):
+            backend.read_target("node_1", "batch.json")
+
     def test_write_and_read_source(self, backend):
         """Test writing and reading source data."""
         data = [

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -66,8 +66,8 @@ class TestSQLiteBackend:
     def test_write_and_read_target(self, backend):
         """Test writing and reading target data."""
         data = [
-            {"target_id": "t1", "content": {"field1": "value1"}},
-            {"target_id": "t2", "content": {"field2": "value2"}},
+            {"_state": "processed", "_state_schema_version": 1, "target_id": "t1", "content": {"field1": "value1"}},
+            {"_state": "processed", "_state_schema_version": 1, "target_id": "t2", "content": {"field2": "value2"}},
         ]
 
         # Write target data
@@ -173,11 +173,11 @@ class TestSQLiteBackend:
 
     def test_target_update_replaces_data(self, backend):
         """Test that writing to same target path replaces data."""
-        backend.write_target("node_1", "file.json", [{"v": "original"}])
-        backend.write_target("node_1", "file.json", [{"v": "updated"}])
+        backend.write_target("node_1", "file.json", [{"_state": "active", "v": "original"}])
+        backend.write_target("node_1", "file.json", [{"_state": "active", "v": "updated"}])
 
         data = backend.read_target("node_1", "file.json")
-        assert data == [{"v": "updated"}]
+        assert data == [{"_state": "active", "v": "updated"}]
 
 
 class TestDispositionMethods:
@@ -349,13 +349,13 @@ class TestValidation:
 
     def test_path_with_dots_but_no_traversal_allowed(self, backend):
         """Test that paths with dots (but not ..) are still valid."""
-        backend.write_target("node_1", "file.v2.json", [{"id": 1}])
-        assert backend.read_target("node_1", "file.v2.json") == [{"id": 1}]
+        backend.write_target("node_1", "file.v2.json", [{"_state": "active", "id": 1}])
+        assert backend.read_target("node_1", "file.v2.json") == [{"_state": "active", "id": 1}]
 
     def test_relative_path_with_spaces_allowed(self, backend):
         """Test that filenames with spaces are accepted."""
-        backend.write_target("node_1", "my file.json", [{"id": 1}])
-        assert backend.read_target("node_1", "my file.json") == [{"id": 1}]
+        backend.write_target("node_1", "my file.json", [{"_state": "active", "id": 1}])
+        assert backend.read_target("node_1", "my file.json") == [{"_state": "active", "id": 1}]
 
     def test_whitespace_only_path_rejected(self, backend):
         """Test that whitespace-only relative_path is rejected."""
@@ -369,13 +369,13 @@ class TestValidation:
 
     def test_leading_trailing_spaces_in_path_allowed(self, backend):
         """Test that leading/trailing spaces in paths are accepted."""
-        backend.write_target("node_1", " file.json ", [{"id": 1}])
-        assert backend.read_target("node_1", " file.json ") == [{"id": 1}]
+        backend.write_target("node_1", " file.json ", [{"_state": "active", "id": 1}])
+        assert backend.read_target("node_1", " file.json ") == [{"_state": "active", "id": 1}]
 
     def test_space_in_action_name_allowed(self, backend):
         """Test that spaces in action_name are accepted."""
-        backend.write_target("node 1", "file.json", [{"id": 1}])
-        assert backend.read_target("node 1", "file.json") == [{"id": 1}]
+        backend.write_target("node 1", "file.json", [{"_state": "active", "id": 1}])
+        assert backend.read_target("node 1", "file.json") == [{"_state": "active", "id": 1}]
 
     def test_invalid_character_rejected(self, backend):
         """Test that characters outside the allowlist are rejected."""

--- a/tests/workflow/test_stale_completion_verification.py
+++ b/tests/workflow/test_stale_completion_verification.py
@@ -222,7 +222,7 @@ class TestSQLiteBackendThreadSafeReads:
 
         backend = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
         backend.initialize()
-        backend.write_target("action_a", "out.json", [{"id": 1}])
+        backend.write_target("action_a", "out.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}])
 
         acquired = []
         original_lock = backend._lock
@@ -245,7 +245,7 @@ class TestSQLiteBackendThreadSafeReads:
 
         backend = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
         backend.initialize()
-        backend.write_target("action_a", "out.json", [{"id": 1}])
+        backend.write_target("action_a", "out.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}])
 
         acquired = []
         original_lock = backend._lock
@@ -271,7 +271,7 @@ class TestSQLiteBackendThreadSafeReads:
 
         backend = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
         backend.initialize()
-        backend.write_target("upstream", "data.json", [{"val": i} for i in range(50)])
+        backend.write_target("upstream", "data.json", [{"_state": "processed", "_state_schema_version": 1, "val": i} for i in range(50)])
 
         results: list[list[str]] = []
         errors: list[Exception] = []
@@ -364,7 +364,7 @@ class TestSQLiteBackendRemainingReadLocks:
 
     def test_preview_target_acquires_lock(self, tmp_path):
         backend = self._setup_backend(tmp_path)
-        backend.write_target("action_a", "out.json", [{"id": 1}])
+        backend.write_target("action_a", "out.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}])
 
         tracking_lock, acquired = _make_tracking_lock(backend)
         with patch.object(backend, "_lock", tracking_lock):
@@ -374,7 +374,7 @@ class TestSQLiteBackendRemainingReadLocks:
 
     def test_get_storage_stats_acquires_lock(self, tmp_path):
         backend = self._setup_backend(tmp_path)
-        backend.write_target("action_a", "out.json", [{"id": 1}])
+        backend.write_target("action_a", "out.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}])
 
         tracking_lock, acquired = _make_tracking_lock(backend)
         with patch.object(backend, "_lock", tracking_lock):


### PR DESCRIPTION
## Summary
- New `record/lifecycle_read.py`: `validate_lifecycle(record, action_name=)` and `validate_lifecycle_batch(records, action_name=)`
- Wired into `sqlite_backend.read_target()` — the single canonical path where frozen target records are loaded as upstream input
- Missing `_state` → `ConfigurationError` with action name, source_guid, and "delete target/ and re-run" instruction
- Unknown state value → `ConfigurationError` (not bare `ValueError`)
- Unsupported `_state_schema_version` → `ConfigurationError`
- No silent repair, no inference from `_unprocessed`, no migration tooling

## Why narrow scope
Previous attempt (PR #444, closed) wired validation across 41 files and updated 700+ test lines. That breadth was the trust issue. This PR validates only at `read_target()` — the boundary where the lifecycle contract actually matters — and fixes only the test fixtures that directly call that boundary.

## Verification
- 12 new unit tests in `test_lifecycle_read.py`
- 6256 tests passing, 2 skipped, ruff clean