### PR TITLE
Lifecycle carry rules: _state_history carried, _state not

### DIFF
--- a/.changes/unreleased/Enhancement-20260502-024000.yaml
+++ b/.changes/unreleased/Enhancement-20260502-024000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Document and enforce lifecycle carry rules: _state_history carries forward across actions (audit trail), _state does not (per-action; executor resets it)"
+time: 2026-05-02T02:40:00.000000Z

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -13,15 +13,9 @@ from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS, RecordEnvelop
 from agent_actions.record.reasons import RETRY_EXHAUSTED
 from agent_actions.utils.content import get_existing_content, is_version_merge
 
-# Framework fields carried from an input record to an output record when the
-# envelope builder does not manage them automatically.
-#
-# Lifecycle carry rules (P5-024):
-#   _state_history  — CARRIED: cumulative audit trail across all actions.
-#   _state          — NOT CARRIED: per-action; executor resets it at each
-#                     action boundary (P5-040). Carrying a stale value from
-#                     a prior action (e.g. COMMITTED) would corrupt the
-#                     downstream lifecycle.
+# Framework fields carried from input to output when the envelope builder
+# does not manage them automatically.
+# _state is intentionally absent — it resets per-action at the executor boundary.
 CARRY_FORWARD_FIELDS: tuple[str, ...] = (
     "target_id",
     "_unprocessed",

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -13,13 +13,21 @@ from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS, RecordEnvelop
 from agent_actions.record.reasons import RETRY_EXHAUSTED
 from agent_actions.utils.content import get_existing_content, is_version_merge
 
-# Framework fields that should be carried from an input record to an output
-# record when the envelope builder does not manage them automatically.
+# Framework fields carried from an input record to an output record when the
+# envelope builder does not manage them automatically.
+#
+# Lifecycle carry rules (P5-024):
+#   _state_history  — CARRIED: cumulative audit trail across all actions.
+#   _state          — NOT CARRIED: per-action; executor resets it at each
+#                     action boundary (P5-040). Carrying a stale value from
+#                     a prior action (e.g. COMMITTED) would corrupt the
+#                     downstream lifecycle.
 CARRY_FORWARD_FIELDS: tuple[str, ...] = (
     "target_id",
     "_unprocessed",
     "_recovery",
     "metadata",
+    "_state_history",
 )
 
 

--- a/tests/unit/processing/test_record_helpers.py
+++ b/tests/unit/processing/test_record_helpers.py
@@ -171,7 +171,26 @@ class TestCarryFrameworkFields:
         assert result is target
 
     def test_default_fields_match_constant(self):
-        assert CARRY_FORWARD_FIELDS == ("target_id", "_unprocessed", "_recovery", "metadata")
+        assert CARRY_FORWARD_FIELDS == (
+            "target_id",
+            "_unprocessed",
+            "_recovery",
+            "metadata",
+            "_state_history",
+        )
+
+    def test_state_history_is_carried(self):
+        history = [{"timestamp": "t", "action": "a", "from": None, "to": "active", "reason": "r", "detail": None}]
+        source = {"_state": "processed", "_state_history": history}
+        target: dict = {}
+        carry_framework_fields(source, target)
+        assert target["_state_history"] == history
+
+    def test_state_is_not_carried(self):
+        source = {"_state": "processed", "_state_history": []}
+        target: dict = {}
+        carry_framework_fields(source, target)
+        assert "_state" not in target
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `_state_history` to `CARRY_FORWARD_FIELDS` in `record_helpers.py` — it is a cumulative audit trail that must persist across all pipeline stages
- Leave `_state` absent from carry — it is per-action; the executor resets it at each action boundary (P5-040). Carrying a stale value (e.g. `COMMITTED` from a prior action) would corrupt the downstream lifecycle view
- Document the rule in the constant comment so the next engineer understands why `_state` is intentionally excluded
- Confirm `_carry_tracking_fields()` in `envelope.py` already excludes `_state` (it iterates only `RECORD_TRACKING_FIELDS`)

## Verification
- `test_state_history_is_carried` — asserts `_state_history` propagates through `carry_framework_fields`
- `test_state_is_not_carried` — asserts `_state` is absent from the output
- `test_default_fields_match_constant` updated to match new tuple
- 6259 tests passed, ruff clean