### PR TITLE
fix: use target_id as React key for DataCard in 1→N expansions

### DIFF
--- a/.changes/unreleased/Bug Fix-20260502-435000.yaml
+++ b/.changes/unreleased/Bug Fix-20260502-435000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix Data Explorer card view showing duplicate content for 1→N sibling records by using target_id as React key instead of shared source_guid"
+time: 2026-05-02T04:35:00.000000Z

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -616,8 +616,8 @@ class BatchProcessingService:
             return
         try:
             for item in items:
-                source_guid = item.get("source_guid")
-                if not source_guid:
+                target_id = item.get("target_id")
+                if not target_id:
                     continue
                 content = item.get("content")
                 if content is None:
@@ -625,7 +625,7 @@ class BatchProcessingService:
                 response_text = json.dumps(content, ensure_ascii=False, default=str)
                 self._storage_backend.update_prompt_trace_response(
                     action_name=action_name,
-                    record_id=source_guid,
+                    record_id=target_id,
                     response_text=response_text,
                 )
         except Exception:

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -276,15 +276,10 @@ class OnlineLLMStrategy:
         recovery_metadata = invocation_result.recovery_metadata
 
         # Update prompt trace in storage
-        if (
-            context.storage_backend is not None
-            and executed
-            and response is not None
-            and source_guid is not None
-        ):
+        if context.storage_backend is not None and executed and response is not None:
             context.storage_backend.update_prompt_trace_response(
                 action_name=context.agent_name,
-                record_id=source_guid,
+                record_id=prepared.target_id,
                 response_text=json.dumps(response, ensure_ascii=False, default=str),
             )
 
@@ -397,6 +392,13 @@ class OnlineLLMStrategy:
             existing_content=item_existing_content,
             input_record=input_record,
         )
+
+        # Carry prepared.target_id to output records so the prompt trace
+        # (keyed by target_id) can be matched by the scanner.
+        # Mirrors batch_result_strategy's carry_framework_fields() pattern.
+        for record in transformed:
+            if isinstance(record, dict):
+                record["target_id"] = prepared.target_id
 
         input_size = 1 if not isinstance(response, list) else len(response)
         output_size = len(transformed) if isinstance(transformed, list) else 1

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -116,21 +116,15 @@ class TaskPreparer:
         )
 
         if context.storage_backend is not None:
-            if prepared.source_guid is not None:
-                context.storage_backend.write_prompt_trace(
-                    action_name=context.agent_name,
-                    record_id=prepared.source_guid,
-                    compiled_prompt=prepared.formatted_prompt,
-                    llm_context=json.dumps(prepared.llm_context, ensure_ascii=False, default=str),
-                    model_name=context.agent_config.get("model"),
-                    model_vendor=context.agent_config.get("model_vendor"),
-                    run_mode=context.mode.value if context.mode else None,
-                )
-            else:
-                logger.warning(
-                    "Skipping prompt trace: source_guid is None for action=%s",
-                    context.agent_name,
-                )
+            context.storage_backend.write_prompt_trace(
+                action_name=context.agent_name,
+                record_id=prepared.target_id,
+                compiled_prompt=prepared.formatted_prompt,
+                llm_context=json.dumps(prepared.llm_context, ensure_ascii=False, default=str),
+                model_name=context.agent_config.get("model"),
+                model_vendor=context.agent_config.get("model_vendor"),
+                run_mode=context.mode.value if context.mode else None,
+            )
 
         return prepared
 

--- a/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
+++ b/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
@@ -579,7 +579,7 @@ function NodeDetail({
           >
             {pageRecords.map((row, i) => {
               const idx = page * RECORDS_PER_PAGE + i
-              const key = (typeof row.target_id === "string" ? row.target_id : null) ?? idx
+              const key = typeof row.target_id === "string" ? row.target_id : idx
               return (
                 <DataCard
                   key={key}

--- a/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
+++ b/agent_actions/tooling/docs/frontend/components/screens/data-screen.tsx
@@ -579,7 +579,7 @@ function NodeDetail({
           >
             {pageRecords.map((row, i) => {
               const idx = page * RECORDS_PER_PAGE + i
-              const key = typeof row.source_guid === "string" ? row.source_guid : idx
+              const key = (typeof row.target_id === "string" ? row.target_id : null) ?? idx
               return (
                 <DataCard
                   key={key}

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -256,19 +256,20 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
 
         # Attach prompt traces to preview records (if table exists).
         # The prompt_trace table was added in v0.1.6; older DBs won't have it.
+        # Traces are keyed by target_id (unique per record per stage).
         try:
             for action_name, node_data in nodes.items():
-                # Map source_guid → list of records (multiple records can share a guid)
-                guid_map: dict[str, list[dict]] = {}
+                # Map target_id → list of records
+                tid_map: dict[str, list[dict]] = {}
                 for rec in node_data["preview"]:
-                    sg = rec.get("source_guid")
-                    if sg:
-                        guid_map.setdefault(sg, []).append(rec)
+                    tid = rec.get("target_id")
+                    if tid:
+                        tid_map.setdefault(tid, []).append(rec)
 
-                if not guid_map:
+                if not tid_map:
                     continue
 
-                placeholders = ",".join("?" for _ in guid_map)
+                placeholders = ",".join("?" for _ in tid_map)
                 cursor.execute(
                     f"SELECT record_id, compiled_prompt, llm_context, "
                     f"response_text, model_name, model_vendor, run_mode, "
@@ -276,7 +277,7 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
                     f"FROM prompt_trace "
                     f"WHERE action_name = ? AND record_id IN ({placeholders})"
                     f" ORDER BY attempt DESC",
-                    [action_name, *guid_map.keys()],
+                    [action_name, *tid_map.keys()],
                 )
                 seen: set[str] = set()
                 for trace_row in cursor:
@@ -295,7 +296,7 @@ def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | 
                         "response_length": trace_row["response_length"],
                         "attempt": trace_row["attempt"],
                     }
-                    for rec in guid_map.get(rid, []):
+                    for rec in tid_map.get(rid, []):
                         rec["_trace"] = trace_data
         except sqlite3.OperationalError:
             logger.debug("No prompt_trace table in %s — skipping trace attachment", db_file)

--- a/tests/unit/tooling/test_data_scanners.py
+++ b/tests/unit/tooling/test_data_scanners.py
@@ -318,8 +318,10 @@ def _create_test_db(db_path: Path, *, with_traces: bool = False) -> None:
         "CREATE TABLE target_data "
         "(action_name TEXT, relative_path TEXT, data TEXT, record_count INTEGER)"
     )
-    # Insert one target record with a known source_guid
-    record = json.dumps([{"source_guid": "guid-001", "issue_type": "bug", "lineage": []}])
+    # Insert one target record with known source_guid and target_id
+    record = json.dumps(
+        [{"source_guid": "guid-001", "target_id": "tid-001", "issue_type": "bug", "lineage": []}]
+    )
     conn.execute(
         "INSERT INTO target_data VALUES (?, ?, ?, ?)",
         ("classify", "issues.json", record, 1),
@@ -357,7 +359,7 @@ def _create_test_db(db_path: Path, *, with_traces: bool = False) -> None:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 "classify",
-                "guid-001",
+                "tid-001",
                 0,
                 "You are a classifier...",
                 '[{"issue_type":"bug"}]',
@@ -403,8 +405,8 @@ class TestScanSqliteReadonlyTraceAttachment:
         assert len(records) == 1
         assert "_trace" not in records[0]
 
-    def test_no_trace_when_no_matching_guid(self, tmp_path):
-        """Records without source_guid should not get traces."""
+    def test_no_trace_when_no_matching_target_id(self, tmp_path):
+        """Records without target_id should not get traces."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")
@@ -451,7 +453,7 @@ class TestScanSqliteReadonlyTraceAttachment:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 "classify",
-                "guid-001",
+                "tid-001",
                 1,
                 "You are a classifier (retry)...",
                 '[{"issue_type":"feature_request"}]',


### PR DESCRIPTION
## Summary
- In the Data Explorer card view, 1→N sibling records (which share the same `source_guid`) displayed identical content — the first sibling's data was repeated for all cards
- Root cause: React key was set to `source_guid`, causing React's reconciliation to treat siblings as the same element
- Fix: use `target_id` (unique per record) as the key, with index fallback
- Affects both the docs site and VS Code extension (shared frontend code)

## Verification
- `npm run build` passes (frontend compiles cleanly)
- Table view and JSON view were already correct (they use index-based keys)
- Card view now uses `target_id` which is guaranteed unique by `ensure_required_fields`