### PR TITLE
Executor boundary reset — state-based downstream gating

### DIFF
--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -42,14 +42,12 @@ logger = logging.getLogger(__name__)
 
 
 def _stamp(record: dict[str, Any], state: RecordState, action_name: str, reason: str) -> None:
-    """Reset per-action _state and stamp the new lifecycle state.
+    """Stamp lifecycle state on a record entering output.
 
-    Records arriving from upstream carry a prior action's _state. Clear it
-    so transition() treats this as a fresh entry for this action. History
-    is preserved — the transition appends an entry with from=None.
+    Records arrive ACTIVE (after downstream reset) or CASCADE_BLOCKING.
+    ACTIVE → any settled is legal. CASCADE_BLOCKING → CASCADE_SKIPPED
+    is legal (cascade propagation). Same → same is a no-op.
     """
-    record.pop("_state", None)
-    record.pop("_state_schema_version", None)
     RecordEnvelope.transition(record, state, action_name, reason)
 
 

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -12,6 +12,7 @@ import datetime
 from typing import Any
 
 from agent_actions.record.state import (
+    CASCADE_BLOCKING_STATES,
     PROCESSABLE_STATES,
     RESETTABLE_DOWNSTREAM_STATES,
     RecordState,
@@ -188,6 +189,8 @@ def _validate_transition(from_state: RecordState | None, to_state: RecordState) 
     if from_state in PROCESSABLE_STATES:
         return
     if from_state in RESETTABLE_DOWNSTREAM_STATES and to_state in PROCESSABLE_STATES:
+        return
+    if from_state in CASCADE_BLOCKING_STATES and to_state == RecordState.CASCADE_SKIPPED:
         return
     raise RecordEnvelopeError(
         f"Illegal state transition: {from_state.value!r} → {to_state.value!r}"

--- a/agent_actions/record/lifecycle_read.py
+++ b/agent_actions/record/lifecycle_read.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 from typing import Any
 
 from agent_actions.errors.configuration import ConfigurationError
-from agent_actions.record.state import RecordState
+from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.state import RESETTABLE_DOWNSTREAM_STATES, RecordState
 
 _SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
 _VALID_STATES: frozenset[str] = frozenset(s.value for s in RecordState)
@@ -78,3 +79,24 @@ def validate_lifecycle_batch(
                 f"got {type(record).__name__}. Delete agent_io/target/ and re-run."
             )
         validate_lifecycle(record, action_name=action_name)
+
+
+_RESETTABLE_VALUES: frozenset[str] = frozenset(s.value for s in RESETTABLE_DOWNSTREAM_STATES)
+
+
+def reset_for_downstream(
+    records: list[dict[str, Any]],
+    *,
+    action_name: str,
+) -> None:
+    """Reset resettable records to ACTIVE for downstream processing.
+
+    Records in RESETTABLE_DOWNSTREAM_STATES (PROCESSED, COMMITTED,
+    GUARD_SKIPPED, GUARD_DEFERRED) are reset to ACTIVE via transition().
+    Records in CASCADE_BLOCKING_STATES stay as-is for cascade logic.
+    ACTIVE records pass through unchanged.
+    """
+    for record in records:
+        raw_state = record.get("_state")
+        if raw_state in _RESETTABLE_VALUES:
+            RecordEnvelope.transition(record, RecordState.ACTIVE, action_name, "downstream_reset")

--- a/agent_actions/storage/_MANIFEST.md
+++ b/agent_actions/storage/_MANIFEST.md
@@ -21,7 +21,7 @@ backends (S3, DuckDB, etc.). One database per workflow stored at
 | `get_storage_backend` | Function | Factory that creates storage backend instances by type (default: sqlite). | `workflow` |
 | `BACKENDS` | Dict | Registry mapping backend type names to their implementation classes. | `config` |
 | `backend.py` | Module | Abstract `StorageBackend` interface defining the contract for all backends. | `abc`, `typing` |
-| `StorageBackend` | ABC | Abstract base class with methods: `initialize`, `write_target`, `read_target`, `write_source`, `read_source`, `list_target_files`, `list_source_files`, `set_disposition`, `get_disposition`, `has_disposition`, `clear_disposition`, `close`. | `abc` |
+| `StorageBackend` | ABC | Abstract base class. `read_target()` is a template method: calls `_read_target_raw()` (abstract), then validates lifecycle and resets for downstream. Subclasses implement `_read_target_raw()` only. | `abc` |
 
 ## Integration Points
 

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -5,6 +5,8 @@ from enum import Enum
 from types import TracebackType
 from typing import Any
 
+from agent_actions.record.lifecycle_read import reset_for_downstream, validate_lifecycle_batch
+
 NODE_LEVEL_RECORD_ID = "__node__"
 """Sentinel record_id for node-level disposition signals."""
 DISPOSITION_PASSTHROUGH = "passthrough"
@@ -61,13 +63,24 @@ class StorageBackend(ABC):
         """Write target data for a specific node."""
         ...
 
-    @abstractmethod
     def read_target(self, action_name: str, relative_path: str) -> list[dict[str, Any]]:
-        """Read target data for a specific node.
+        """Read target data, validate lifecycle fields, and reset for downstream.
+
+        Subclasses implement _read_target_raw(). This method adds lifecycle
+        validation and executor boundary reset so every backend gets them
+        automatically.
 
         Raises:
             FileNotFoundError: If the target data doesn't exist.
         """
+        result = self._read_target_raw(action_name, relative_path)
+        validate_lifecycle_batch(result, action_name=action_name)
+        reset_for_downstream(result, action_name=action_name)
+        return result
+
+    @abstractmethod
+    def _read_target_raw(self, action_name: str, relative_path: str) -> list[dict[str, Any]]:
+        """Read raw target data from storage. Subclasses implement this."""
         ...
 
     @abstractmethod

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from agent_actions.config.defaults import StorageDefaults
 from agent_actions.errors.configuration import ConfigValidationError
-from agent_actions.record.lifecycle_read import validate_lifecycle_batch
+from agent_actions.record.lifecycle_read import reset_for_downstream, validate_lifecycle_batch
 from agent_actions.storage.backend import VALID_DISPOSITIONS, Disposition, StorageBackend
 
 logger = logging.getLogger(__name__)
@@ -293,6 +293,7 @@ class SQLiteBackend(StorageBackend):
 
         result: list[dict[str, Any]] = json.loads(row["data"])
         validate_lifecycle_batch(result, action_name=action_name)
+        reset_for_downstream(result, action_name=action_name)
         return result
 
     def write_source(

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from agent_actions.config.defaults import StorageDefaults
 from agent_actions.errors.configuration import ConfigValidationError
-from agent_actions.record.lifecycle_read import reset_for_downstream, validate_lifecycle_batch
 from agent_actions.storage.backend import VALID_DISPOSITIONS, Disposition, StorageBackend
 
 logger = logging.getLogger(__name__)
@@ -272,8 +271,8 @@ class SQLiteBackend(StorageBackend):
                 )
                 raise
 
-    def read_target(self, action_name: str, relative_path: str) -> list[dict[str, Any]]:
-        """Read target data for a specific node.
+    def _read_target_raw(self, action_name: str, relative_path: str) -> list[dict[str, Any]]:
+        """Read raw target data from SQLite.
 
         Raises:
             FileNotFoundError: If no data exists for the given path.
@@ -291,10 +290,7 @@ class SQLiteBackend(StorageBackend):
         if row is None:
             raise FileNotFoundError(f"No target data found for {action_name}/{relative_path}")
 
-        result: list[dict[str, Any]] = json.loads(row["data"])
-        validate_lifecycle_batch(result, action_name=action_name)
-        reset_for_downstream(result, action_name=action_name)
-        return result
+        return json.loads(row["data"])
 
     def write_source(
         self,

--- a/tests/unit/record/test_executor_reset.py
+++ b/tests/unit/record/test_executor_reset.py
@@ -1,0 +1,85 @@
+"""Tests for executor boundary reset (P5-040)."""
+
+from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.lifecycle_read import reset_for_downstream
+from agent_actions.record.state import RecordState
+
+
+def _record(state: str) -> dict:
+    """Create a record with a given _state via transition."""
+    rec: dict = {}
+    RecordEnvelope.transition(rec, RecordState(state), "upstream_action", "test")
+    return rec
+
+
+class TestResetForDownstream:
+    """Tests for reset_for_downstream() — executor boundary reset."""
+
+    def test_processed_resets_to_active(self):
+        records = [_record("processed")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "active"
+
+    def test_committed_resets_to_active(self):
+        records = [_record("committed")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "active"
+
+    def test_guard_skipped_resets_to_active(self):
+        records = [_record("guard_skipped")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "active"
+
+    def test_guard_deferred_resets_to_active(self):
+        records = [_record("guard_deferred")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "active"
+
+    def test_cascade_skipped_stays(self):
+        records = [_record("cascade_skipped")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "cascade_skipped"
+
+    def test_failed_stays(self):
+        records = [_record("failed")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "failed"
+
+    def test_exhausted_stays(self):
+        records = [_record("exhausted")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "exhausted"
+
+    def test_active_stays(self):
+        records = [_record("active")]
+        reset_for_downstream(records, action_name="downstream")
+        assert records[0]["_state"] == "active"
+
+    def test_reset_appends_history(self):
+        records = [_record("processed")]
+        reset_for_downstream(records, action_name="downstream")
+        history = records[0]["_state_history"]
+        last_entry = history[-1]
+        assert last_entry["from"] == "processed"
+        assert last_entry["to"] == "active"
+        assert last_entry["action"] == "downstream"
+        assert last_entry["reason"] == "downstream_reset"
+
+    def test_cascade_blocking_no_history_added(self):
+        records = [_record("failed")]
+        history_len_before = len(records[0]["_state_history"])
+        reset_for_downstream(records, action_name="downstream")
+        assert len(records[0]["_state_history"]) == history_len_before
+
+    def test_mixed_batch(self):
+        records = [
+            _record("processed"),
+            _record("cascade_skipped"),
+            _record("guard_skipped"),
+            _record("failed"),
+        ]
+        reset_for_downstream(records, action_name="next_action")
+        assert records[0]["_state"] == "active"
+        assert records[1]["_state"] == "cascade_skipped"
+        assert records[2]["_state"] == "active"
+        assert records[3]["_state"] == "failed"

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -65,7 +65,7 @@ class TestSQLiteBackend:
         backend.close()
 
     def test_write_and_read_target(self, backend):
-        """Test writing and reading target data."""
+        """Test writing and reading target data — read resets resettable states to ACTIVE."""
         data = [
             {"_state": "processed", "_state_schema_version": 1, "target_id": "t1", "content": {"field1": "value1"}},
             {"_state": "processed", "_state_schema_version": 1, "target_id": "t2", "content": {"field2": "value2"}},
@@ -75,9 +75,12 @@ class TestSQLiteBackend:
         result = backend.write_target("node_1", "batch_001.json", data)
         assert result == "node_1:batch_001.json"
 
-        # Read target data
+        # Read target data — resettable states become ACTIVE
         read_data = backend.read_target("node_1", "batch_001.json")
-        assert read_data == data
+        assert read_data[0]["_state"] == "active"
+        assert read_data[0]["target_id"] == "t1"
+        assert read_data[1]["_state"] == "active"
+        assert read_data[1]["target_id"] == "t2"
 
     def test_read_target_not_found_raises(self, backend):
         """Test that reading non-existent target raises FileNotFoundError."""

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -674,7 +674,7 @@ class TestGetFailedItems:
             def write_target(self, *a, **kw):
                 pass
 
-            def read_target(self, *a, **kw):
+            def _read_target_raw(self, *a, **kw):
                 return []
 
             def write_source(self, *a, **kw):


### PR DESCRIPTION
## Summary
- `reset_for_downstream()` resets RESETTABLE states (PROCESSED, COMMITTED, GUARD_SKIPPED, GUARD_DEFERRED) to ACTIVE at the read boundary
- CASCADE_BLOCKING states (CASCADE_SKIPPED, FAILED, EXHAUSTED) stay as-is for cascade logic
- Wired into `sqlite_backend.read_target()` after lifecycle validation
- New transition rule: CASCADE_BLOCKING → CASCADE_SKIPPED (cascade propagation)
- Removed `_state` pop from `ResultCollector._stamp()` — no longer needed since records arrive in legal states

## Verification
- 11 new tests in `test_executor_reset.py` covering all state classes
- 6272 tests pass, ruff clean
- History entries correctly show `from: "processed", to: "active", reason: "downstream_reset"`