### PR TITLE
Batch dispatch via RecordState instead of FILTER_PHASE

### DIFF
--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
-from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys, FilterStatus
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.providers.batch_base import BatchResult
@@ -28,9 +28,14 @@ from agent_actions.processing.types import (
     RecoveryMetadata,
 )
 from agent_actions.record.reasons import BATCH_NOT_RETURNED, GUARD_SKIP, UPSTREAM_UNPROCESSED
+from agent_actions.record.state import CASCADE_BLOCKING_STATES
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
+
+_CASCADE_BLOCKING_VALUES: frozenset[str] = frozenset(
+    s.value for s in CASCADE_BLOCKING_STATES
+)
 
 
 @dataclass
@@ -470,9 +475,8 @@ class BatchResultStrategy:
         record_index: int,
     ) -> ProcessingResult:
         """Build an UNPROCESSED result for a passthrough record."""
-        # Determine actual skip reason from context metadata
-        filter_phase = original_row.get(ContextMetaKeys.FILTER_PHASE, "")
-        if filter_phase == UPSTREAM_UNPROCESSED:
+        raw_state = original_row.get("_state")
+        if raw_state in _CASCADE_BLOCKING_VALUES:
             reason = UPSTREAM_UNPROCESSED
         elif BatchContextMetadata.get_filter_status(original_row) == FilterStatus.SKIPPED:
             reason = GUARD_SKIP

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from agent_actions.config.types import RunMode
 from agent_actions.errors import ConfigurationError
-from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys, FilterStatus
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.core.batch_models import (
     BatchTaskPreparationStats,
@@ -14,7 +14,6 @@ from agent_actions.llm.batch.core.batch_models import (
 )
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
 from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
-from agent_actions.record.reasons import FILTER_PHASE_UNIFIED, FILTER_PHASE_UPSTREAM
 from agent_actions.utils.constants import JSON_MODE_KEY
 from agent_actions.utils.id_generation import IDGenerator
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -175,7 +174,6 @@ class BatchTaskPreparator:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.SKIPPED
             )
-            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = FILTER_PHASE_UPSTREAM
             stats.skipped_items += 1
             logger.debug("Upstream unprocessed item %s", custom_id)
             return None
@@ -184,18 +182,16 @@ class BatchTaskPreparator:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.FILTERED
             )
-            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = FILTER_PHASE_UNIFIED
             stats.filtered_items += 1
-            logger.debug("Guard filtered item %s (phase=unified)", custom_id)
+            logger.debug("Guard filtered item %s", custom_id)
             return None
 
         if prepared.guard_status == GuardStatus.SKIPPED:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.SKIPPED
             )
-            context_map_builder[custom_id][ContextMetaKeys.FILTER_PHASE] = FILTER_PHASE_UNIFIED
             stats.skipped_items += 1
-            logger.debug("Guard skipped item %s (phase=unified)", custom_id)
+            logger.debug("Guard skipped item %s", custom_id)
             return None
 
         # 7. Create and return task

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -28,7 +28,3 @@ PARSE_ERROR = "parse_error"
 
 # -- Action-level skip reasons -----------------------------------------------
 GUARD_FILTERED_ALL = "All records guard-filtered — no output produced"
-
-# -- FILTER_PHASE values (batch preparator) -----------------------------------
-FILTER_PHASE_UPSTREAM = UPSTREAM_UNPROCESSED  # same value by design — batch dispatch relies on this
-FILTER_PHASE_UNIFIED = "unified"

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -302,8 +302,7 @@ class TestBatchPathReasonDetection:
         )
 
     def test_upstream_unprocessed_reason(self):
-        """Records with FILTER_PHASE=upstream_unprocessed get reason=upstream_unprocessed."""
-        from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys
+        """Records with cascade-blocking _state get reason=upstream_unprocessed."""
         from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchResultStrategy,
         )
@@ -311,7 +310,8 @@ class TestBatchPathReasonDetection:
         row = {
             "content": {"upstream_action": {"field": "value"}},
             "source_guid": "sg_batch_1",
-            ContextMetaKeys.FILTER_PHASE: "upstream_unprocessed",
+            "_state": "cascade_skipped",
+            "_state_schema_version": 1,
         }
         ctx = self._make_ctx(passthrough_records=[("cid_1", row)])
         processor = BatchResultStrategy()
@@ -365,8 +365,7 @@ class TestBatchPathReasonDetection:
         assert item["content"]["test_batch"] is None
 
     def test_upstream_unprocessed_uses_unprocessed_status(self):
-        """upstream_unprocessed records should use ProcessingResult.unprocessed(), not .skipped()."""
-        from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys
+        """cascade-blocking records should use ProcessingResult.unprocessed(), not .skipped()."""
         from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchResultStrategy,
         )
@@ -374,7 +373,8 @@ class TestBatchPathReasonDetection:
         row = {
             "content": {"upstream": {"data": "stale"}},
             "source_guid": "sg_batch_4",
-            ContextMetaKeys.FILTER_PHASE: "upstream_unprocessed",
+            "_state": "failed",
+            "_state_schema_version": 1,
         }
         ctx = self._make_ctx(passthrough_records=[("cid_4", row)])
         processor = BatchResultStrategy()


### PR DESCRIPTION
## Summary
- Replace FILTER_PHASE string dispatch in `_build_unprocessed_passthrough` with `_state in CASCADE_BLOCKING_VALUES`
- Remove FILTER_PHASE writes from `preparator.py` (no longer consumed)
- Delete dead `FILTER_PHASE_UPSTREAM` / `FILTER_PHASE_UNIFIED` constants from `reasons.py`
- Batch and online paths now use identical state-based cascade detection

## Verification
- 6268 tests pass, ruff clean
- Batch reason detection tests updated to use `_state` fixtures
- `test_upstream_unprocessed_reason` — uses `_state: "cascade_skipped"`
- `test_upstream_unprocessed_uses_unprocessed_status` — uses `_state: "failed"`