### PR TITLE
Phase F: derive_disposition, status mutation fix, error policy, crash coherence

### DIFF
--- a/.changes/unreleased/Enhancement-20260502-050000.yaml
+++ b/.changes/unreleased/Enhancement-20260502-050000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Phase F: derive_disposition() centralizes RecordState→Disposition mapping, fix parse-error status mutation (CR-9), error policy upgrades disposition write failures to ERROR, crash coherence documented"
+time: 2026-05-02T05:00:00.000000Z

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -272,6 +272,7 @@ class ResultCollector:
                 # Reprompt has already had its chance to repair (it runs
                 # during invocation, before result collection).
                 if data and _data_has_parse_error(data):
+                    result.status = ProcessingStatus.FAILED
                     for d in data:
                         d["_unprocessed"] = True
                         _stamp(d, RecordState.FAILED, agent_name, PARSE_ERROR)

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -110,14 +110,7 @@ def _safe_set_disposition(
     disposition: str,
     **kwargs: Any,
 ) -> None:
-    """Write a disposition record — log ERROR on failure, do not crash pipeline.
-
-    Error policy (P5-053): disposition writes are must-not-lose metadata but
-    must not abort the batch. On failure: log ERROR with full context so
-    operators can detect disposition/state divergence. The record's _state in
-    target JSON remains the authoritative source; dispositions can be
-    re-derived from _state on the next run.
-    """
+    """Write a disposition record — log ERROR on failure, do not crash pipeline."""
     try:
         backend.set_disposition(action_name, record_id, disposition, **kwargs)
     except Exception:

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -110,19 +110,23 @@ def _safe_set_disposition(
     disposition: str,
     **kwargs: Any,
 ) -> None:
-    """Write a disposition record, logging and swallowing errors.
+    """Write a disposition record — log ERROR on failure, do not crash pipeline.
 
-    Disposition writes are telemetry — they must not crash the data pipeline.
+    Error policy (P5-053): disposition writes are must-not-lose metadata but
+    must not abort the batch. On failure: log ERROR with full context so
+    operators can detect disposition/state divergence. The record's _state in
+    target JSON remains the authoritative source; dispositions can be
+    re-derived from _state on the next run.
     """
     try:
         backend.set_disposition(action_name, record_id, disposition, **kwargs)
     except Exception:
-        logger.warning(
-            "Failed to write disposition action=%s record=%s disp=%s",
+        logger.exception(
+            "Failed to write disposition action=%s record=%s disp=%s — "
+            "disposition may diverge from _state until next run",
             action_name,
             record_id,
             disposition,
-            exc_info=True,
         )
 
 

--- a/agent_actions/record/disposition.py
+++ b/agent_actions/record/disposition.py
@@ -1,12 +1,4 @@
-"""Derive storage disposition from record lifecycle state.
-
-Single mapping from final RecordState to SQLite disposition. All
-record-level disposition writes should flow through derive_disposition().
-
-Node-level dispositions (NODE_LEVEL_RECORD_ID / __node__) are set
-explicitly by the executor based on aggregate action outcomes — they
-do not use this function.
-"""
+"""Derive storage disposition from record lifecycle state."""
 
 from __future__ import annotations
 
@@ -28,11 +20,6 @@ _STATE_TO_DISPOSITION: dict[RecordState, Disposition] = {
 
 
 def derive_disposition(record: dict[str, Any]) -> str:
-    """Map a record's _state to its storage disposition value.
-
-    Raises KeyError if _state is missing or not a valid RecordState.
-    This should never happen after P5-023 validation — if it does,
-    the pipeline has a bug.
-    """
+    """Map a record's ``_state`` to its storage disposition value."""
     state = RecordState(record["_state"])
     return _STATE_TO_DISPOSITION[state].value

--- a/agent_actions/record/disposition.py
+++ b/agent_actions/record/disposition.py
@@ -1,0 +1,38 @@
+"""Derive storage disposition from record lifecycle state.
+
+Single mapping from final RecordState to SQLite disposition. All
+record-level disposition writes should flow through derive_disposition().
+
+Node-level dispositions (NODE_LEVEL_RECORD_ID / __node__) are set
+explicitly by the executor based on aggregate action outcomes — they
+do not use this function.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_actions.record.state import RecordState
+from agent_actions.storage.backend import Disposition
+
+_STATE_TO_DISPOSITION: dict[RecordState, Disposition] = {
+    RecordState.PROCESSED: Disposition.SUCCESS,
+    RecordState.COMMITTED: Disposition.SUCCESS,
+    RecordState.GUARD_SKIPPED: Disposition.PASSTHROUGH,
+    RecordState.CASCADE_SKIPPED: Disposition.UNPROCESSED,
+    RecordState.GUARD_DEFERRED: Disposition.DEFERRED,
+    RecordState.FAILED: Disposition.FAILED,
+    RecordState.EXHAUSTED: Disposition.EXHAUSTED,
+    RecordState.ACTIVE: Disposition.PASSTHROUGH,
+}
+
+
+def derive_disposition(record: dict[str, Any]) -> str:
+    """Map a record's _state to its storage disposition value.
+
+    Raises KeyError if _state is missing or not a valid RecordState.
+    This should never happen after P5-023 validation — if it does,
+    the pipeline has a bug.
+    """
+    state = RecordState(record["_state"])
+    return _STATE_TO_DISPOSITION[state].value

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -805,8 +805,8 @@ class ActionExecutor:
             try:
                 submitted_dt = datetime.fromisoformat(submitted_at)
                 return (datetime.now() - submitted_dt).total_seconds()
-            except (ValueError, TypeError):
-                pass
+            except (ValueError, TypeError) as e:
+                logger.debug("Could not parse submitted_at %r: %s", submitted_at, e)
         return fallback
 
     def _handle_batch_check(

--- a/docs/internal/phase5-crash-coherence.md
+++ b/docs/internal/phase5-crash-coherence.md
@@ -1,0 +1,58 @@
+# Phase 5 Crash Coherence — Write Ordering and Recovery
+
+## Happy Path Write Order
+
+For each record batch in an action:
+
+1. **Target JSON** — `write_target()` persists records with `_state` to SQLite `target_data` table
+2. **Disposition** — `_safe_set_disposition()` writes the derived disposition to `record_disposition` table
+3. **Node disposition** — executor writes `__node__` disposition after all records complete
+
+## Crash Scenarios
+
+### Crash after target write, before disposition write
+
+**State:** Target JSON has correct `_state`. Disposition table is stale/missing.
+
+**Recovery:** On next run, the executor's `_verify_completion_status()` detects missing output and re-runs the action. Re-run calls `write_target()` (overwrites) + `set_disposition()` (writes fresh). Dispositions are derived from `_state` via `derive_disposition()` — so re-running produces correct dispositions automatically.
+
+**Manual cleanup:** None needed. Re-run self-heals.
+
+### Crash after disposition write, before node disposition
+
+**State:** Individual record dispositions are correct. Node-level `__node__` disposition is missing.
+
+**Recovery:** On next run, executor sees no node disposition → treats action as incomplete → re-runs. Since target data already exists, `_verify_completion_status()` detects existing output and may skip (depending on freshness check). If it re-runs, the idempotent write path overwrites safely.
+
+**Manual cleanup:** None needed.
+
+### Crash mid-batch (some records written, others not)
+
+**State:** Partial target data in SQLite. Some records have `_state`, others are missing entirely (not in target_data).
+
+**Recovery:** On re-run, `write_target()` overwrites the entire batch file atomically (one row per `action_name + relative_path`). So partial writes are replaced with a complete batch on the next run.
+
+**Manual cleanup:** None needed. The atomic write-per-file granularity prevents partial corruption.
+
+## Key Invariants
+
+1. **`_state` in target JSON is the authority.** Dispositions can always be re-derived from `_state` via `derive_disposition()`. If they diverge, `_state` wins.
+
+2. **`write_target()` is atomic per file.** A single `INSERT OR REPLACE` covers the entire batch for a given `action_name/relative_path`. No partial row states.
+
+3. **Re-run is always safe.** The framework is designed for idempotent re-runs. Stale data is overwritten, not appended.
+
+4. **Dispositions are telemetry, not authority.** They exist for skip-evaluator lookups and operator dashboards. If lost, the pipeline still produces correct output on re-run.
+
+## Logging Grep Hints
+
+```bash
+# Disposition write failures (elevated to ERROR in P5-053)
+grep "Failed to write disposition" logs/
+
+# Missing _state on read (fail-closed from P5-023)
+grep "Record is missing '_state'" logs/
+
+# Downstream reset events
+grep "downstream_reset" logs/
+```

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -794,6 +794,23 @@ class TestParseErrorDisposition:
         assert stats.failed == 1
         assert stats.success == 0
 
+    def test_parse_error_mutates_result_status(self):
+        """result.status is mutated to FAILED — not just the local counter (CR-9)."""
+        result = ProcessingResult.success(
+            data=[{"content": {"action": {"_parse_error": "bad", "raw_response": "x"}}}],
+            source_guid="guid-pe",
+        )
+        assert result.status == ProcessingStatus.SUCCESS
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "action",
+            is_first_stage=False,
+        )
+
+        assert result.status == ProcessingStatus.FAILED
+
     def test_normal_success_not_affected(self):
         """Normal SUCCESS records are not reclassified by parse error detection."""
         backend = _make_backend()

--- a/tests/unit/record/test_derive_disposition.py
+++ b/tests/unit/record/test_derive_disposition.py
@@ -1,0 +1,49 @@
+"""Tests for derive_disposition — RecordState to storage disposition mapping."""
+
+import pytest
+
+from agent_actions.record.disposition import derive_disposition
+from agent_actions.record.state import RecordState
+from agent_actions.storage.backend import Disposition
+
+
+class TestDeriveDisposition:
+    """Every RecordState maps to exactly one Disposition."""
+
+    def test_processed_maps_to_success(self):
+        assert derive_disposition({"_state": "processed"}) == Disposition.SUCCESS.value
+
+    def test_committed_maps_to_success(self):
+        assert derive_disposition({"_state": "committed"}) == Disposition.SUCCESS.value
+
+    def test_guard_skipped_maps_to_passthrough(self):
+        assert derive_disposition({"_state": "guard_skipped"}) == Disposition.PASSTHROUGH.value
+
+    def test_cascade_skipped_maps_to_unprocessed(self):
+        assert derive_disposition({"_state": "cascade_skipped"}) == Disposition.UNPROCESSED.value
+
+    def test_guard_deferred_maps_to_deferred(self):
+        assert derive_disposition({"_state": "guard_deferred"}) == Disposition.DEFERRED.value
+
+    def test_failed_maps_to_failed(self):
+        assert derive_disposition({"_state": "failed"}) == Disposition.FAILED.value
+
+    def test_exhausted_maps_to_exhausted(self):
+        assert derive_disposition({"_state": "exhausted"}) == Disposition.EXHAUSTED.value
+
+    def test_active_maps_to_passthrough(self):
+        assert derive_disposition({"_state": "active"}) == Disposition.PASSTHROUGH.value
+
+    def test_all_states_covered(self):
+        """Every RecordState has a mapping — no KeyError."""
+        for state in RecordState:
+            result = derive_disposition({"_state": state.value})
+            assert isinstance(result, str)
+
+    def test_missing_state_raises(self):
+        with pytest.raises(KeyError):
+            derive_disposition({"content": "no state"})
+
+    def test_invalid_state_raises(self):
+        with pytest.raises(ValueError):
+            derive_disposition({"_state": "bogus"})


### PR DESCRIPTION
## Summary

### P5-050 — derive_disposition
- `record/disposition.py`: single mapping from RecordState → Disposition value
- Covers all 8 states. 11 tests.

### P5-051 — fix parse-error status mutation (CR-9)
- `result.status` now mutated to FAILED when parse error detected
- Previously only the local counter was updated, leaving the object lying about its status

### P5-052 — set_disposition audit
- Audit confirms only `result_collector` (record-level) and `executor` (node-level) write dispositions
- No stray callers found

### P5-053 — error handling policy (CR-4)
- `_safe_set_disposition` failure logging elevated from WARNING to ERROR
- Policy documented: must-not-lose but must-not-crash; _state is authority
- `executor.py:808` silent `except pass` → `logger.debug`

### P5-054 — crash coherence doc
- `docs/internal/phase5-crash-coherence.md`: write ordering, crash scenarios, recovery steps, grep hints

## Verification
- 6280 tests pass, ruff clean
- All Phase F acceptance criteria met