### PR TITLE
Phase G: schema enforcement + disposition DDL

### DIFF
--- a/.changes/unreleased/Enhancement-20260502-060000.yaml
+++ b/.changes/unreleased/Enhancement-20260502-060000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Phase G: SQLite schema enforcement via PRAGMA check + DROP/CREATE on mismatch. Disposition DDL adds detail column. Removes brittle ALTER TABLE migration hacks."
+time: 2026-05-02T06:00:00.000000Z

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -48,6 +48,7 @@ class SQLiteBackend(StorageBackend):
             record_id TEXT NOT NULL,
             disposition TEXT NOT NULL,
             reason TEXT,
+            detail TEXT,
             relative_path TEXT,
             input_snapshot TEXT,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -95,6 +96,21 @@ class SQLiteBackend(StorageBackend):
     """
 
     _MAX_TRACE_FIELD_SIZE = 1_048_576  # 1MB
+
+    # Required columns per table — schema enforcement drops tables missing any.
+    _REQUIRED_COLUMNS: dict[str, set[str]] = {
+        "source_data": {"relative_path", "source_guid", "data", "created_at"},
+        "target_data": {"action_name", "relative_path", "data", "record_count", "created_at"},
+        "record_disposition": {
+            "action_name", "record_id", "disposition", "reason",
+            "relative_path", "input_snapshot", "detail", "created_at",
+        },
+        "prompt_trace": {
+            "action_name", "record_id", "attempt", "compiled_prompt",
+            "llm_context", "response_text", "model_name", "model_vendor",
+            "run_mode", "prompt_length", "context_length", "response_length", "created_at",
+        },
+    }
 
     _INSERT_SOURCE_IGNORE_SQL = """
         INSERT OR IGNORE INTO source_data
@@ -182,11 +198,12 @@ class SQLiteBackend(StorageBackend):
             return self._connection
 
     def initialize(self) -> None:
-        """Create connection, tables, and indexes."""
+        """Create connection, enforce schema, create tables and indexes."""
         with self._lock:
             self._open_connection()
             cursor = self.connection.cursor()
             try:
+                self._enforce_schema(cursor)
                 cursor.execute(self.SOURCE_TABLE_SQL)
                 cursor.execute(self.TARGET_TABLE_SQL)
                 cursor.execute(self.DISPOSITION_TABLE_SQL)
@@ -197,24 +214,6 @@ class SQLiteBackend(StorageBackend):
                 cursor.execute(self.PROMPT_TRACE_TABLE_SQL)
                 cursor.execute(self.TRACE_INDEX_ACTION_SQL)
                 cursor.execute(self.TRACE_INDEX_ACTION_RECORD_SQL)
-                # Migration: add input_snapshot column for existing databases
-                try:
-                    cursor.execute("ALTER TABLE record_disposition ADD COLUMN input_snapshot TEXT")
-                    logger.debug("Added input_snapshot column to record_disposition")
-                except sqlite3.OperationalError:
-                    logger.debug("input_snapshot column already exists in record_disposition")
-                # Migration: add detail column for error messages and context
-                try:
-                    cursor.execute("ALTER TABLE record_disposition ADD COLUMN detail TEXT")
-                    logger.debug("Added detail column to record_disposition")
-                except sqlite3.OperationalError:
-                    logger.debug("detail column already exists in record_disposition")
-                # Migration: add run_mode column for existing prompt_trace tables
-                try:
-                    cursor.execute("ALTER TABLE prompt_trace ADD COLUMN run_mode TEXT")
-                    logger.debug("Added run_mode column to prompt_trace")
-                except sqlite3.OperationalError:
-                    logger.debug("run_mode column already exists in prompt_trace")
                 self.connection.commit()
                 logger.info(
                     "Initialized SQLite storage backend: %s",
@@ -229,6 +228,23 @@ class SQLiteBackend(StorageBackend):
                     extra={"db_path": str(self.db_path), "workflow_name": self.workflow_name},
                 )
                 raise
+
+    def _enforce_schema(self, cursor: sqlite3.Cursor) -> None:
+        """Drop tables whose columns don't match _REQUIRED_COLUMNS."""
+        for table_name, required in self._REQUIRED_COLUMNS.items():
+            cursor.execute(f"PRAGMA table_info({table_name})")
+            rows = cursor.fetchall()
+            if not rows:
+                continue  # table doesn't exist yet — CREATE will handle it
+            existing = {row[1] for row in rows}
+            missing = required - existing
+            if missing:
+                logger.warning(
+                    "Table '%s' schema outdated (missing: %s) — dropping and recreating",
+                    table_name,
+                    sorted(missing),
+                )
+                cursor.execute(f"DROP TABLE {table_name}")
 
     def write_target(self, action_name: str, relative_path: str, data: list[dict[str, Any]]) -> str:
         """Write target data for a specific node."""

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -596,3 +596,62 @@ class TestServiceInitSqliteError:
         console.print.assert_called()
         error_output = console.print.call_args[0][0]
         assert "Storage backend failed" in error_output
+
+
+class TestSchemaEnforcement:
+    """Tests for _enforce_schema dropping stale tables."""
+
+    def test_old_schema_dropped_and_recreated(self, tmp_path):
+        """Table with missing columns is dropped and recreated on initialize()."""
+        import sqlite3
+
+        db_path = tmp_path / "test.db"
+        # Create a DB with old schema missing 'detail' column
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE record_disposition (
+                id INTEGER PRIMARY KEY,
+                action_name TEXT,
+                record_id TEXT,
+                disposition TEXT,
+                reason TEXT
+            )
+        """)
+        conn.execute(
+            "INSERT INTO record_disposition (action_name, record_id, disposition) VALUES ('a', 'r', 'd')"
+        )
+        conn.commit()
+        conn.close()
+
+        backend = SQLiteBackend(str(db_path), "test_workflow")
+        backend.initialize()
+
+        # Table should now have all required columns
+        cursor = backend.connection.cursor()
+        cursor.execute("PRAGMA table_info(record_disposition)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "detail" in columns
+        assert "input_snapshot" in columns
+
+        # Old data should be gone (table was dropped)
+        cursor.execute("SELECT COUNT(*) FROM record_disposition")
+        assert cursor.fetchone()[0] == 0
+        backend.close()
+
+    def test_correct_schema_not_dropped(self, tmp_path):
+        """Table with all columns is left intact on initialize()."""
+        db_path = tmp_path / "test.db"
+        backend = SQLiteBackend(str(db_path), "test_workflow")
+        backend.initialize()
+
+        # Write some data
+        backend.write_target("node1", "file.json", [{"_state": "active", "id": 1}])
+
+        # Re-initialize — data should survive
+        backend.close()
+        backend2 = SQLiteBackend(str(db_path), "test_workflow")
+        backend2.initialize()
+
+        data = backend2.read_target("node1", "file.json")
+        assert data[0]["id"] == 1
+        backend2.close()


### PR DESCRIPTION
## Summary

### P5-060 — Schema enforcement
- `_enforce_schema()` checks PRAGMA table_info against `_REQUIRED_COLUMNS`
- Missing columns → DROP TABLE + CREATE (not ALTER)
- Removes 3 brittle ALTER TABLE migration hacks (CR-8)

### P5-061 — Disposition DDL update
- `detail` column added to `record_disposition` CREATE TABLE
- Added to `_REQUIRED_COLUMNS` so old DBs get recreated

### P5-062 — Gate verification
- 6282 tests pass, ruff clean
- Schema upgrade test: old schema dropped and recreated
- Correct schema: data survives re-initialize

## Verification
- `test_old_schema_dropped_and_recreated` — creates DB with old schema, verifies enforce path
- `test_correct_schema_not_dropped` — verifies data survives when schema is current
- Full integration + storage suites green