### PR TITLE
Fix: FILE guard prefilter stamps GUARD_SKIPPED not CASCADE_SKIPPED

### DIFF
--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -18,6 +18,7 @@ from agent_actions.processing.types import ProcessingResult, ProcessingStatus
 from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.record.reasons import (
     GUARD_FILTER,
+    GUARD_PREFILTER_SKIP,
     GUARD_SKIP,
     PARSE_ERROR,
     RETRY_EXHAUSTED,
@@ -445,13 +446,15 @@ class ResultCollector:
             elif status == ProcessingStatus.UNPROCESSED:
                 data = result.data or []
                 if data:
+                    reason = result.skip_reason or UNPROCESSED
+                    # FILE prefilter uses UNPROCESSED for ordering (FM13) but is a guard decision
+                    state = (
+                        RecordState.GUARD_SKIPPED
+                        if reason in (GUARD_PREFILTER_SKIP, GUARD_SKIP, GUARD_FILTER)
+                        else RecordState.CASCADE_SKIPPED
+                    )
                     for d in data:
-                        _stamp(
-                            d,
-                            RecordState.CASCADE_SKIPPED,
-                            agent_name,
-                            result.skip_reason or UNPROCESSED,
-                        )
+                        _stamp(d, state, agent_name, reason)
                     output.extend(data)  # Preserve in output for lineage
                 logger.debug(
                     "Collected UNPROCESSED result source_guid=%s count=%d",


### PR DESCRIPTION
## Summary
- FILE prefilter uses ProcessingResult.unprocessed() for FM13 ordering
- Previously ALL unprocessed stamped as CASCADE_SKIPPED — made guard-skipped records block downstream
- Now checks skip_reason: guard reasons → GUARD_SKIPPED (resettable), cascade reasons → CASCADE_SKIPPED (blocking)
- Restores pre-Phase-5 behavior where guard-skipped tombstones pass through downstream

## Verification
- 6282 tests pass
- qanalabs-quiz-maker full 42-action pipeline completes (was failing before this fix)
- 116 records: 111 processed, 5 guard_skipped, 0 cascade_skipped errors