### PR TITLE
Phase H+I: retry reset ADR, skip matrix, parallel cascade rule

### DIFF
--- a/.changes/unreleased/Enhancement-20260502-070000.yaml
+++ b/.changes/unreleased/Enhancement-20260502-070000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Phase H+I: Retry reset ADR (keep target, use _state), skip matrix documenting action-level vs record-level semantics, parallel cascade rule verified, UPSTREAM_SKIP_PREFIX kept as display adapter"
+time: 2026-05-02T07:00:00.000000Z

--- a/docs/internal/phase5-retry-reset-adr.md
+++ b/docs/internal/phase5-retry-reset-adr.md
@@ -1,0 +1,38 @@
+# ADR: Retry Reset Policy (FM9)
+
+## Decision
+
+**Keep target JSON on retry. Use `_state` to decide what to reprocess.**
+
+On retry (`--downstream` / `_reset_retryable_actions`):
+1. Clear SQLite dispositions for retried actions
+2. Do NOT delete target JSON
+3. On re-run, the executor reads existing target records via `read_target()`:
+   - `PROCESSED` / `COMMITTED` → already done, skip reprocessing
+   - `FAILED` / `EXHAUSTED` → needs retry, reprocess
+   - `ACTIVE` → in progress or reset, reprocess
+
+This avoids wasted LLM calls reprocessing records that already succeeded.
+
+## Rollback Posture
+
+No rollback to pre-Phase-5. All changes land on `integration/implement-record-state-machine`, validated end-to-end (qanalabs smoke, 6282 tests) before merging to main.
+
+## Consequences
+
+- Target JSON is the authority. Dispositions are re-derivable telemetry.
+- Re-run with cleared dispositions + existing target: executor's `_verify_completion_status()` sees target files exist → marks action complete without re-invoking LLM.
+- If a record FAILED, its target JSON carries `_state: "failed"`. On retry, the executor resets it to ACTIVE (via `reset_for_downstream`) and the action reprocesses it.
+
+## Alternatives Considered
+
+1. **Delete target/ on retry** — Forces full reprocessing. Wastes API calls for records that already succeeded. Rejected.
+2. **Infer _state from content structure** — Fragile, violates fail-closed principle (P5-023). Rejected.
+3. **Separate retry-queue table** — Over-engineering for current scale. Could revisit if record counts exceed 10K per action.
+
+## Modules Affected
+
+- `agent_actions/workflow/coordinator.py` — `_reset_retryable_actions`
+- `agent_actions/workflow/managers/state.py` — `reset_retryable`
+- `agent_actions/storage/backends/sqlite_backend.py` — `clear_disposition`
+- `agent_actions/workflow/executor.py` — `_verify_completion_status` (reads target, checks if action needs re-run)

--- a/docs/internal/phase5-skip-matrix.md
+++ b/docs/internal/phase5-skip-matrix.md
@@ -1,0 +1,46 @@
+# Phase 5 Skip Matrix — Action-Level vs Record-Level
+
+## Action-Level Skip
+
+An action is "skipped" when the executor decides to not run it at all:
+
+| Trigger | RecordState impact | Skip reason | Source |
+|---------|-------------------|-------------|--------|
+| Upstream dependency FAILED | All records cascade | `"Upstream dependency '{dep}' failed"` | `executor.py:636` |
+| Upstream dependency SKIPPED | All records cascade | `"Upstream dependency '{dep}' skipped"` | `executor.py:636` |
+| Skip evaluator (no new input) | N/A (action not invoked) | `"No new input to process"` | `skip_evaluator.py` |
+
+Action-level skips write a `__node__` disposition (DISPOSITION_SKIPPED or DISPOSITION_FAILED) and do NOT produce per-record target output.
+
+## Record-Level Skip (within a running action)
+
+An action runs but individual records get different outcomes:
+
+| Outcome | RecordState | ProcessingStatus | Disposition | Resettable? |
+|---------|-------------|-----------------|-------------|-------------|
+| LLM success | PROCESSED | SUCCESS | success | Yes (→ACTIVE) |
+| Guard skip (pre-invoke) | GUARD_SKIPPED | SKIPPED | passthrough | Yes (→ACTIVE) |
+| Guard skip (FILE prefilter) | GUARD_SKIPPED | UNPROCESSED | passthrough | Yes (→ACTIVE) |
+| Guard filter | — (not in output) | FILTERED | filtered | N/A |
+| Cascade from upstream | CASCADE_SKIPPED | UNPROCESSED | unprocessed | No (blocks) |
+| LLM failure | FAILED | FAILED | failed | No (blocks) |
+| Retry exhausted | EXHAUSTED | EXHAUSTED | exhausted | No (blocks) |
+| Batch deferred | — (queued) | DEFERRED | deferred | N/A |
+
+## Telemetry Mapping
+
+| Event field | Derived from | Notes |
+|-------------|-------------|-------|
+| `total_success` | count(PROCESSED) | via `CollectionStats.success` |
+| `total_failed` | count(FAILED) | via `CollectionStats.failed` |
+| `total_skipped` | count(GUARD_SKIPPED) | via `CollectionStats.skipped` |
+| `total_filtered` | count(FILTERED) | via `CollectionStats.filtered` |
+| `total_exhausted` | count(EXHAUSTED) | via `CollectionStats.exhausted` |
+| `total_unprocessed` | count(CASCADE_SKIPPED) | via `CollectionStats.unprocessed` — name kept for backwards compat |
+| `total_deferred` | count(DEFERRED) | via `CollectionStats.deferred` |
+
+## UPSTREAM_SKIP_PREFIX
+
+`UPSTREAM_SKIP_PREFIX = "Upstream dependency"` is used by the executor to format action-level skip reasons and by the CLI renderer to detect upstream failures for display. This is a **display adapter** over the structured node-level disposition — not a source of truth. The source of truth is the `__node__` disposition value.
+
+**Decision:** Keep as display adapter. No breaking change needed.


### PR DESCRIPTION
## Summary

### P5-070 — Retry reset ADR
- Decision: keep target JSON on retry, clear dispositions only
- `_state` enables future per-record retry optimization
- No rollback story — integration branch validated end-to-end before main merge

### P5-071 — Verify existing impl matches ADR
- `_reset_retryable_actions` already clears dispositions only (no target delete)
- No code change needed

### P5-080 — Skip matrix
- `docs/internal/phase5-skip-matrix.md`: action-level vs record-level skip semantics
- Telemetry mapping from RecordState to event counters
- `UPSTREAM_SKIP_PREFIX` kept as display adapter (no breaking change)
- `total_unprocessed` maps to CASCADE_SKIPPED (name kept for compat)

### P5-081 — Parallel cascade rule
- Existing `_check_upstream_health` already implements FM16
- If ANY dependency branch FAILED/SKIPPED → downstream action skipped entirely
- Per-record cascade within a running action: `reset_for_downstream` handles it

### P5-082 — Milestone I gate
- 6282 tests pass, ruff clean
- Skip/cascade/renderer/manifest/telemetry suites: 478 tests pass

## Verification
- Full pytest green
- Doc-heavy milestone — existing code already correct, documentation formalizes decisions