### PR TITLE
Address review findings: docs, constants, error handling, tests

### DIFF
--- a/agent_actions/input/preprocessing/staging/field_validation.py
+++ b/agent_actions/input/preprocessing/staging/field_validation.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import ConfigValidationError
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
+
+logger = logging.getLogger(__name__)
 
 
 def validate_staging_field_names(raw_content: Any, file_path: str) -> None:
@@ -27,9 +30,16 @@ def validate_staging_field_names(raw_content: Any, file_path: str) -> None:
     if isinstance(raw_content, dict):
         _check_dict(raw_content, file_path)
     elif isinstance(raw_content, list):
-        for item in raw_content:
+        for idx, item in enumerate(raw_content):
             if isinstance(item, dict):
                 _check_dict(item, file_path)
+            else:
+                logger.debug(
+                    "Skipping non-dict element at index %d in %s (type: %s)",
+                    idx,
+                    Path(file_path).name,
+                    type(item).__name__,
+                )
 
 
 def _check_dict(record: dict[str, Any], file_path: str) -> None:

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -22,6 +22,7 @@ from agent_actions.record.reasons import (
     GUARD_SKIP,
     PARSE_ERROR,
     RETRY_EXHAUSTED,
+    SUCCESS,
     UNPROCESSED,
 )
 from agent_actions.record.state import RecordState
@@ -301,7 +302,7 @@ class ResultCollector:
 
                 if data:
                     for d in data:
-                        _stamp(d, RecordState.PROCESSED, agent_name, "success")
+                        _stamp(d, RecordState.PROCESSED, agent_name, SUCCESS)
                     output.extend(data)
                 logger.debug(
                     "Collected SUCCESS result source_guid=%s count=%d",

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -20,6 +20,8 @@ from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 logger = logging.getLogger(__name__)
 
+_LIFECYCLE_KEYS: frozenset[str] = frozenset({"_state", "_state_history", "_state_schema_version"})
+
 
 @runtime_checkable
 class ProcessingStrategy(Protocol):
@@ -189,7 +191,7 @@ class UnifiedProcessor:
                 if isinstance(content, dict) and action_name not in content:
                     skipped_record = RecordEnvelope.build_skipped(action_name, item)
                     for key in item:
-                        if key not in skipped_record:
+                        if key not in skipped_record and key not in _LIFECYCLE_KEYS:
                             skipped_record[key] = item[key]
                     item = skipped_record
             guard_results.append(

--- a/agent_actions/record/disposition.py
+++ b/agent_actions/record/disposition.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from agent_actions.record.envelope import RecordEnvelopeError
 from agent_actions.record.state import RecordState
 from agent_actions.storage.backend import Disposition
 
@@ -21,5 +22,18 @@ _STATE_TO_DISPOSITION: dict[RecordState, Disposition] = {
 
 def derive_disposition(record: dict[str, Any]) -> str:
     """Map a record's ``_state`` to its storage disposition value."""
-    state = RecordState(record["_state"])
-    return _STATE_TO_DISPOSITION[state].value
+    raw = record.get("_state")
+    if raw is None:
+        raise RecordEnvelopeError("Cannot derive disposition: record has no '_state' field")
+    try:
+        state = RecordState(raw)
+    except ValueError:
+        raise RecordEnvelopeError(
+            f"Cannot derive disposition: unknown _state value {raw!r}"
+        ) from None
+    disposition = _STATE_TO_DISPOSITION.get(state)
+    if disposition is None:
+        raise RecordEnvelopeError(
+            f"Cannot derive disposition: no mapping for state {state.value!r}"
+        )
+    return disposition.value

--- a/agent_actions/record/disposition.py
+++ b/agent_actions/record/disposition.py
@@ -22,18 +22,14 @@ _STATE_TO_DISPOSITION: dict[RecordState, Disposition] = {
 
 def derive_disposition(record: dict[str, Any]) -> str:
     """Map a record's ``_state`` to its storage disposition value."""
-    raw = record.get("_state")
-    if raw is None:
-        raise RecordEnvelopeError("Cannot derive disposition: record has no '_state' field")
     try:
-        state = RecordState(raw)
-    except ValueError:
+        state = RecordState(record["_state"])
+    except KeyError:
         raise RecordEnvelopeError(
-            f"Cannot derive disposition: unknown _state value {raw!r}"
+            "Cannot derive disposition: record has no '_state' field"
         ) from None
-    disposition = _STATE_TO_DISPOSITION.get(state)
-    if disposition is None:
+    except ValueError as e:
         raise RecordEnvelopeError(
-            f"Cannot derive disposition: no mapping for state {state.value!r}"
-        )
-    return disposition.value
+            f"Cannot derive disposition: unknown _state value {record['_state']!r}"
+        ) from e
+    return _STATE_TO_DISPOSITION[state].value

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -6,6 +6,9 @@ defined here.  Production code imports from this module instead of using bare
 string literals.
 """
 
+# -- Success -----------------------------------------------------------------
+SUCCESS = "success"
+
 # -- Guard outcomes ----------------------------------------------------------
 GUARD_SKIP = "guard_skip"
 GUARD_PREFILTER_SKIP = "guard_prefilter_skip"

--- a/agent_actions/utils/passthrough_builder.py
+++ b/agent_actions/utils/passthrough_builder.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.state import RecordState
 from agent_actions.utils.field_management.manager import FieldManager
 from agent_actions.utils.id_generation.generator import IDGenerator
 from agent_actions.utils.lineage.builder import LineageBuilder
@@ -70,6 +71,8 @@ class PassthroughItemBuilder:
             processed_item["metadata"][flag_name] = True
 
         processed_item["metadata"]["agent_type"] = "tombstone"
+
+        RecordEnvelope.transition(processed_item, RecordState.GUARD_SKIPPED, action_name, reason)
 
         return processed_item
 

--- a/docs/internal/phase5-invariant-table.md
+++ b/docs/internal/phase5-invariant-table.md
@@ -16,7 +16,7 @@ This table is **normative**. If code disagrees with this table, the code is wron
 | 8 | Retry exhausted (return_last) | EXHAUSTED | EXHAUSTED | false | No | `online_llm.py:311` |
 | 9 | Retry exhausted (raise) | — (exception) | EXHAUSTED | false | No | `result_collector.py:526` |
 | 10 | Guard deferred (HITL / batch queue) | — (not in output) | DEFERRED | false | No | `online_llm.py:299` |
-| 11 | FILE guard prefilter skip | CASCADE_SKIPPED | UNPROCESSED | false | No | `unified.py:186` |
+| 11 | FILE guard prefilter skip | GUARD_SKIPPED | UNPROCESSED | false | No | `unified.py:186` |
 | 12 | FILE tool success | PROCESSED | SUCCESS | true | Yes | `file_tool.py:85` |
 | 13 | FILE tool error | — (not in output) | FAILED | false | No | `file_tool.py:68` |
 | 14 | Batch success | PROCESSED | SUCCESS | true | Yes | `batch_result_strategy.py:287` |
@@ -41,14 +41,14 @@ This table is **normative**. If code disagrees with this table, the code is wron
 | SUCCESS | PROCESSED | Action completed, output produced |
 | SKIPPED | GUARD_SKIPPED | Guard clause rejected, tombstone written |
 | FILTERED | — (no output) | Guard rejected, record dropped entirely |
-| UNPROCESSED | CASCADE_SKIPPED | Upstream dependency missing or guard-prefilter |
+| UNPROCESSED | GUARD_SKIPPED or CASCADE_SKIPPED | Guard prefilter → GUARD_SKIPPED; cascade → CASCADE_SKIPPED |
 | EXHAUSTED | EXHAUSTED | Retries consumed, last attempt output preserved |
 | FAILED | FAILED | Error during processing (stamped only if data written) |
 | DEFERRED | — (no output) | Queued for batch/HITL, disposition tracked |
 
 ## Resolved Mismatches (P5-031)
 
-1. **FILE guard prefilter uses UNPROCESSED — intentional (FM13).** `unified.py:186` returns `ProcessingResult.unprocessed()` for FILE guard skips. This preserves `guard_results + invocation_results` merge ordering. Changing to `skipped()` would collapse the two list sources and risk FM13 regression. FILE prefilter skips remain CASCADE_SKIPPED by design.
+1. **FILE guard prefilter uses UNPROCESSED — intentional (FM13).** `unified.py:186` returns `ProcessingResult.unprocessed()` for FILE guard skips. This preserves `guard_results + invocation_results` merge ordering. Changing to `skipped()` would collapse the two list sources and risk FM13 regression. However, `ResultCollector` stamps these as **GUARD_SKIPPED** (resettable at boundary) because `skip_reason=GUARD_PREFILTER_SKIP` identifies them as guard decisions, not cascade failures.
 
 2. **Online post-invoke guard skip — FIXED.** `online_llm.py:343` now returns `ProcessingResult.skipped()` instead of `unprocessed()`. This is a guard decision (not a cascade), so GUARD_SKIPPED is correct. Aligns with pre-invoke guard skip behavior.
 

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -903,3 +903,83 @@ class TestParseErrorDisposition:
         )
 
         assert stats.failed == 1
+
+
+class TestCollectorStateStamping:
+    """Verify ResultCollector stamps correct _state based on skip_reason."""
+
+    def test_guard_prefilter_skip_stamps_guard_skipped(self):
+        """FILE prefilter skip_reason=guard_prefilter_skip → GUARD_SKIPPED (resettable)."""
+        record = {"content": {}, "_state": "active"}
+        result = ProcessingResult(
+            status=ProcessingStatus.UNPROCESSED,
+            source_guid="src-gp",
+            data=[record],
+            skip_reason="guard_prefilter_skip",
+        )
+
+        output, stats = ResultCollector.collect_results(
+            [result],
+            {},
+            "test_action",
+            is_first_stage=False,
+            storage_backend=None,
+        )
+
+        assert len(output) == 1
+        assert output[0]["_state"] == "guard_skipped"
+
+    def test_guard_skip_stamps_guard_skipped(self):
+        """skip_reason=guard_skip → GUARD_SKIPPED."""
+        record = {"content": {}, "_state": "active"}
+        result = ProcessingResult(
+            status=ProcessingStatus.UNPROCESSED,
+            source_guid="src-gs",
+            data=[record],
+            skip_reason="guard_skip",
+        )
+
+        output, _ = ResultCollector.collect_results(
+            [result],
+            {},
+            "test_action",
+            is_first_stage=False,
+            storage_backend=None,
+        )
+
+        assert output[0]["_state"] == "guard_skipped"
+
+    def test_cascade_reason_stamps_cascade_skipped(self):
+        """Non-guard skip_reason (e.g. 'upstream_unprocessed') → CASCADE_SKIPPED."""
+        record = {"content": {}, "_state": "active"}
+        result = ProcessingResult(
+            status=ProcessingStatus.UNPROCESSED,
+            source_guid="src-cs",
+            data=[record],
+            skip_reason="upstream_unprocessed",
+        )
+
+        output, _ = ResultCollector.collect_results(
+            [result],
+            {},
+            "test_action",
+            is_first_stage=False,
+            storage_backend=None,
+        )
+
+        assert output[0]["_state"] == "cascade_skipped"
+
+    def test_success_stamps_processed(self):
+        """SUCCESS results stamp PROCESSED."""
+        record = {"content": {"v": 1}, "_state": "active"}
+        result = ProcessingResult.success(data=[record], source_guid="src-s")
+
+        output, _ = ResultCollector.collect_results(
+            [result],
+            {},
+            "test_action",
+            is_first_stage=False,
+            storage_backend=None,
+        )
+
+        assert output[0]["_state"] == "processed"

--- a/tests/unit/record/test_derive_disposition.py
+++ b/tests/unit/record/test_derive_disposition.py
@@ -3,6 +3,7 @@
 import pytest
 
 from agent_actions.record.disposition import derive_disposition
+from agent_actions.record.envelope import RecordEnvelopeError
 from agent_actions.record.state import RecordState
 from agent_actions.storage.backend import Disposition
 
@@ -35,15 +36,15 @@ class TestDeriveDisposition:
         assert derive_disposition({"_state": "active"}) == Disposition.PASSTHROUGH.value
 
     def test_all_states_covered(self):
-        """Every RecordState has a mapping — no KeyError."""
+        """Every RecordState has a mapping."""
         for state in RecordState:
             result = derive_disposition({"_state": state.value})
             assert isinstance(result, str)
 
-    def test_missing_state_raises(self):
-        with pytest.raises(KeyError):
+    def test_missing_state_raises_envelope_error(self):
+        with pytest.raises(RecordEnvelopeError, match="no '_state' field"):
             derive_disposition({"content": "no state"})
 
-    def test_invalid_state_raises(self):
-        with pytest.raises(ValueError):
+    def test_invalid_state_raises_envelope_error(self):
+        with pytest.raises(RecordEnvelopeError, match="unknown _state value.*bogus"):
             derive_disposition({"_state": "bogus"})

--- a/tests/unit/record/test_transition.py
+++ b/tests/unit/record/test_transition.py
@@ -97,6 +97,20 @@ class TestTransitionLegalEdges:
         assert rec["_state"] == "active"
         assert len(rec["_state_history"]) == 1
 
+    @pytest.mark.parametrize(
+        "from_state",
+        [
+            RecordState.CASCADE_SKIPPED,
+            RecordState.FAILED,
+            RecordState.EXHAUSTED,
+        ],
+    )
+    def test_cascade_blocking_to_cascade_skipped(self, from_state):
+        """CASCADE_BLOCKING states can transition to CASCADE_SKIPPED (cascade propagation)."""
+        rec = _record(from_state)
+        RecordEnvelope.transition(rec, RecordState.CASCADE_SKIPPED, "downstream", "cascade")
+        assert rec["_state"] == "cascade_skipped"
+
 
 class TestTransitionIllegalEdges:
     @pytest.mark.parametrize(

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -1663,7 +1663,7 @@ def test_file_hitl_per_record_review_in_namespace():
 
 
 def test_file_hitl_carries_framework_fields():
-    """Framework fields (source_guid, target_id, _unprocessed) are preserved from input."""
+    """Framework fields (source_guid, target_id, _recovery) are preserved from input."""
     context = _make_hitl_context()
 
     input_data = [

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -152,7 +152,7 @@ def test_file_mode_hitl_empty_input_returns_empty_output():
 
 
 def test_file_mode_hitl_preserves_unprocessed_tombstone_markers():
-    """Tombstone markers (_unprocessed, metadata) must survive HITL merge."""
+    """Tombstone markers (_recovery, metadata) must survive HITL merge."""
     input_data = [
         {
             "source_guid": "sg-1",


### PR DESCRIPTION
## Summary
- Fix invariant table doc drift (FILE prefilter → GUARD_SKIPPED, not CASCADE_SKIPPED)
- Add `SUCCESS` constant to `record/reasons.py`, replace literal `"success"` in result_collector
- Add debug logging for non-dict list elements in staging field_validation
- Wrap `derive_disposition` KeyError/ValueError into `RecordEnvelopeError` (uniform domain error)
- Add CASCADE_BLOCKING → CASCADE_SKIPPED transition test (legal edge coverage)
- Add `TestCollectorStateStamping` class: verify `_state` stamps for guard prefilter, guard skip, cascade, and success paths
- Fix stale `_unprocessed` references in test docstrings

## Verification
- All 6288 tests pass
- ruff format + ruff check clean