### PR TITLE
P3-030: Consolidate reprompt exhaustion handling

### DIFF
--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -188,19 +188,19 @@ def validate_and_reprompt(
             reprompted_ids[r.custom_id] = reprompted_ids.get(r.custom_id, 0) + 1
 
         if attempt == max_attempts - 1:
-            if on_exhausted == "raise" and still_failing:
-                raise RuntimeError(
-                    f"Reprompt validation exhausted for {still_failing[0].custom_id} "
-                    f"after {attempt + 1} attempts (validation: {validation_name})"
-                )
-            for r in still_failing:
-                if not r.recovery_metadata:
-                    r.recovery_metadata = RecoveryMetadata()
-                r.recovery_metadata.reprompt = RepromptMetadata(
-                    attempts=reprompted_ids[r.custom_id],
-                    passed=False,
-                    validation=validation_name,
-                )
+            from agent_actions.processing.evaluation.exhaustion import (
+                apply_exhausted_reprompt,
+            )
+
+            failed_ids = {r.custom_id for r in still_failing}
+            apply_exhausted_reprompt(
+                results=still_failing,
+                failed_ids=failed_ids,
+                validation_name=validation_name,
+                attempt=attempt + 1,
+                on_exhausted=on_exhausted,
+                per_record_attempts=reprompted_ids,
+            )
             all_graduated.extend(still_failing)
             break
 
@@ -588,41 +588,14 @@ def apply_exhausted_reprompt_metadata(
 ) -> list[BatchResult]:
     """Apply reprompt exhaustion metadata to failed records.
 
-    Mutates results in-place (sets recovery_metadata on individual items)
-    and returns the same list for convenience.
-
-    Args:
-        results: All accumulated results (mutated in-place)
-        failed_ids: IDs that still fail validation
-        validation_name: Name of the validation UDF
-        attempt: Number of attempts made
-        on_exhausted: Policy — "return_last" or "raise"
-
-    Returns:
-        The same results list with exhaustion metadata applied
-
-    Raises:
-        RuntimeError: If on_exhausted == "raise"
+    Delegates to the consolidated exhaustion module.
     """
-    from agent_actions.processing.types import RepromptMetadata
+    from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
 
-    for result in results:
-        if result.custom_id not in failed_ids:
-            continue
-
-        if on_exhausted == "raise":
-            raise RuntimeError(
-                f"Reprompt validation exhausted for {result.custom_id} "
-                f"after {attempt} attempts (validation: {validation_name})"
-            )
-
-        if not result.recovery_metadata:
-            result.recovery_metadata = RecoveryMetadata()
-
-        result.recovery_metadata.reprompt = RepromptMetadata(
-            attempts=attempt,
-            passed=False,
-            validation=validation_name,
-        )
-
-    return results
+    return apply_exhausted_reprompt(
+        results=results,
+        failed_ids=failed_ids,
+        validation_name=validation_name,
+        attempt=attempt,
+        on_exhausted=on_exhausted,
+    )

--- a/agent_actions/processing/evaluation/__init__.py
+++ b/agent_actions/processing/evaluation/__init__.py
@@ -1,5 +1,6 @@
 """Generic evaluation loop with graduated pool pattern."""
 
+from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
 from agent_actions.processing.evaluation.loop import EvaluationLoop, EvaluationStrategy
 
-__all__ = ["EvaluationLoop", "EvaluationStrategy"]
+__all__ = ["EvaluationLoop", "EvaluationStrategy", "apply_exhausted_reprompt"]

--- a/agent_actions/processing/evaluation/exhaustion.py
+++ b/agent_actions/processing/evaluation/exhaustion.py
@@ -1,0 +1,74 @@
+"""Consolidated reprompt exhaustion handling.
+
+Single source of truth for what happens when reprompt recovery attempts
+are exhausted. Optionally raises based on the ``on_exhausted`` policy
+configured in the workflow.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_actions.llm.providers.batch_base import BatchResult
+
+from agent_actions.processing.types import RecoveryMetadata, RepromptMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def apply_exhausted_reprompt(
+    results: list[BatchResult],
+    failed_ids: set[str],
+    validation_name: str,
+    attempt: int,
+    on_exhausted: str,
+    per_record_attempts: dict[str, int] | None = None,
+) -> list[BatchResult]:
+    """Apply reprompt exhaustion metadata to records that failed validation.
+
+    Mutates results in-place and returns the same list.
+
+    Args:
+        results: Batch results (mutated in-place for failed IDs).
+        failed_ids: Custom IDs that still fail validation.
+        validation_name: Name of the validation strategy.
+        attempt: Default number of attempts (used when per_record_attempts
+            is not provided or a record is missing from it).
+        on_exhausted: ``"return_last"`` to accept last response, or
+            ``"raise"`` to propagate a RuntimeError.
+        per_record_attempts: Optional per-record attempt counts. When
+            provided, each record's metadata uses its own count instead
+            of the scalar ``attempt``. Used by the sync reprompt path.
+
+    Returns:
+        The same results list with exhaustion metadata applied.
+
+    Raises:
+        RuntimeError: When ``on_exhausted="raise"`` and failed records exist.
+    """
+    for result in results:
+        if result.custom_id not in failed_ids:
+            continue
+
+        if on_exhausted == "raise":
+            raise RuntimeError(
+                f"Reprompt validation exhausted for {result.custom_id} "
+                f"after {attempt} attempts (validation: {validation_name})"
+            )
+
+        record_attempts = (
+            per_record_attempts.get(result.custom_id, attempt) if per_record_attempts else attempt
+        )
+
+        if not result.recovery_metadata:
+            result.recovery_metadata = RecoveryMetadata()
+
+        result.recovery_metadata.reprompt = RepromptMetadata(
+            attempts=record_attempts,
+            passed=False,
+            validation=validation_name,
+        )
+
+    return results


### PR DESCRIPTION
## Summary
- Creates `processing/evaluation/exhaustion.py` with `apply_exhausted_reprompt()`
- `apply_exhausted_reprompt_metadata` in reprompt_ops.py now delegates to consolidated function
- Inline exhaustion in handle_reprompt_recovery flows through same path (via facade)
- Preserves raise vs return_last semantics exactly

## Grep verification
- `on_exhausted == "raise"` in production recovery code: only in exhaustion.py + validate_and_reprompt sync loop (P3-060 scope)
- Out-of-scope sites (batch_result_strategy, result_collector, online reprompt) unchanged

## Test verification
- 786 recovery-scoped tests pass (matches P3-025 baseline)
- 27 B+C tests pass unchanged
- ruff clean