### PR TITLE
P3-040: Extract recovery cleanup from finalize_batch_output

### DIFF
--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -34,6 +34,9 @@ from agent_actions.llm.batch.services.processing_recovery import (
     check_and_submit_reprompt as _check_and_submit_reprompt_impl,
 )
 from agent_actions.llm.batch.services.processing_recovery import (
+    cleanup_recovery as _cleanup_recovery_impl,
+)
+from agent_actions.llm.batch.services.processing_recovery import (
     finalize_batch_output as _finalize_batch_output_impl,
 )
 from agent_actions.llm.batch.services.processing_recovery import (
@@ -585,11 +588,11 @@ class BatchProcessingService:
         action_name: str | None,
         start_time: float,
     ) -> str:
-        """Finalize batch processing: convert, write output, fire events.
+        """Finalize batch processing: convert, write output, fire events, cleanup.
 
-        Delegates to processing_recovery.finalize_batch_output.
+        Delegates to processing_recovery.finalize_batch_output then cleanup_recovery.
         """
-        return _finalize_batch_output_impl(
+        output_path = _finalize_batch_output_impl(
             self,
             batch_results=batch_results,
             exhausted_recovery=exhausted_recovery,
@@ -602,6 +605,8 @@ class BatchProcessingService:
             action_name=action_name,
             start_time=start_time,
         )
+        _cleanup_recovery_impl(self, manager, output_directory, file_name)
+        return output_path
 
     def _write_record_dispositions(self, items: list[dict[str, Any]], action_name: str) -> None:
         """Write dispositions for non-success records in batch output.

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -207,7 +207,7 @@ def handle_retry_recovery(
         return None  # Reprompt submitted, processing paused
 
     RecoveryStateManager.delete(output_directory, parent_file_name)
-    return finalize_batch_output(
+    output_path = finalize_batch_output(
         service,
         batch_results=merged,
         exhausted_recovery=exhausted_recovery,
@@ -220,6 +220,8 @@ def handle_retry_recovery(
         action_name=action_name,
         start_time=start_time,
     )
+    cleanup_recovery(service, manager, output_directory, parent_file_name)
+    return output_path
 
 
 # ---------------------------------------------------------------------------
@@ -256,7 +258,8 @@ def handle_reprompt_recovery(
         on_exhausted=state.on_exhausted,
     )
     if setup is None:
-        return finalize_batch_output(
+        RecoveryStateManager.delete(output_directory, parent_file_name)
+        output_path = finalize_batch_output(
             service,
             batch_results=recovery_results,
             exhausted_recovery=None,
@@ -269,6 +272,8 @@ def handle_reprompt_recovery(
             action_name=action_name,
             start_time=start_time,
         )
+        cleanup_recovery(service, manager, output_directory, parent_file_name)
+        return output_path
 
     loop, strategy, _ = setup
 
@@ -340,7 +345,7 @@ def handle_reprompt_recovery(
         )
 
     RecoveryStateManager.delete(output_directory, parent_file_name)
-    return finalize_batch_output(
+    output_path = finalize_batch_output(
         service,
         batch_results=final_results,
         exhausted_recovery=exhausted_recovery,
@@ -353,6 +358,8 @@ def handle_reprompt_recovery(
         action_name=action_name,
         start_time=start_time,
     )
+    cleanup_recovery(service, manager, output_directory, parent_file_name)
+    return output_path
 
 
 # ---------------------------------------------------------------------------
@@ -524,9 +531,28 @@ def finalize_batch_output(
     )
 
     manager.update_status(batch_id, BatchStatus.COMPLETED)
-    service._cleanup_recovery_entries(manager, file_name)
 
     return str(output_file)
+
+
+# ---------------------------------------------------------------------------
+# Recovery cleanup
+# ---------------------------------------------------------------------------
+
+
+def cleanup_recovery(
+    service: "BatchProcessingService",
+    manager: BatchRegistryManager,
+    output_directory: str,
+    parent_file_name: str,
+) -> None:
+    """Clean up recovery state after finalization.
+
+    Removes recovery batch entries from the registry for this parent file.
+    Recovery state file deletion is handled by callers before finalize
+    (RecoveryStateManager.delete).
+    """
+    service._cleanup_recovery_entries(manager, parent_file_name)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -580,9 +580,10 @@ class TestFinalizeBatchOutput:
         _, manager, _, _ = self._run_finalize(batch_id="batch-789")
         manager.update_status.assert_called_once_with("batch-789", BatchStatus.COMPLETED)
 
-    def test_recovery_entries_cleaned_up(self):
-        service, manager, _, _ = self._run_finalize()
-        service._cleanup_recovery_entries.assert_called_once_with(manager, "test_file")
+    def test_finalize_does_not_handle_recovery_cleanup(self):
+        """Cleanup is the caller's responsibility — finalize only does processing."""
+        service, _, _, _ = self._run_finalize()
+        service._cleanup_recovery_entries.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `finalize_batch_output` no longer handles recovery cleanup — only processing concerns
- New `cleanup_recovery()` function handles registry entry removal
- Each finalization site explicitly calls cleanup after finalize returns
- Clear boundary: finalize owns processing outcomes, callers own recovery bookkeeping

## Boundary after this PR
```
output_path = finalize_batch_output(...)   # processing: convert, write, event, status
cleanup_recovery(...)                       # bookkeeping: remove registry entries
```

## Verification
- 786 recovery-scoped tests pass (matches P3-025 baseline)
- 27 B+C tests pass
- Test updated: `test_finalize_does_not_handle_recovery_cleanup` verifies separation
- ruff clean