### PR TITLE
P3-060: Delete apply_exhausted_reprompt_metadata from reprompt_ops

### DIFF
--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -577,25 +577,3 @@ def process_reprompt_results(
         result_map[reprompt_result.custom_id] = reprompt_result
 
     return list(result_map.values())
-
-
-def apply_exhausted_reprompt_metadata(
-    results: list[BatchResult],
-    failed_ids: set[str],
-    validation_name: str,
-    attempt: int,
-    on_exhausted: str,
-) -> list[BatchResult]:
-    """Apply reprompt exhaustion metadata to failed records.
-
-    Delegates to the consolidated exhaustion module.
-    """
-    from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
-
-    return apply_exhausted_reprompt(
-        results=results,
-        failed_ids=failed_ids,
-        validation_name=validation_name,
-        attempt=attempt,
-        on_exhausted=on_exhausted,
-    )

--- a/agent_actions/llm/batch/services/retry.py
+++ b/agent_actions/llm/batch/services/retry.py
@@ -315,7 +315,9 @@ class BatchRetryService:
         on_exhausted: str,
     ) -> list[BatchResult]:
         """Apply reprompt exhaustion metadata to failed records."""
-        return _reprompt.apply_exhausted_reprompt_metadata(
+        from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
+
+        return apply_exhausted_reprompt(
             results=results,
             failed_ids=failed_ids,
             validation_name=validation_name,

--- a/tests/manual/doc_audit/test_retry_reprompt.py
+++ b/tests/manual/doc_audit/test_retry_reprompt.py
@@ -30,7 +30,6 @@ if __name__ == "__main__":
 # --- project imports ---
 from agent_actions.errors import NetworkError, RateLimitError, VendorAPIError
 from agent_actions.llm.batch.services.reprompt_ops import (
-    apply_exhausted_reprompt_metadata,
     process_reprompt_results,
     validate_results,
 )
@@ -43,6 +42,9 @@ from agent_actions.llm.batch.services.retry_serialization import (
     serialize_results,
 )
 from agent_actions.llm.providers.error_wrapper import VendorErrorMapping, wrap_vendor_error
+from agent_actions.processing.evaluation.exhaustion import (
+    apply_exhausted_reprompt as apply_exhausted_reprompt_metadata,
+)
 from agent_actions.processing.recovery.reprompt import (
     RepromptService,
 )

--- a/tests/unit/llm/batch/test_composed_recovery.py
+++ b/tests/unit/llm/batch/test_composed_recovery.py
@@ -208,13 +208,11 @@ class TestComposedRecoveryPaths:
         loop.split.return_value = ([], [failing_result])
         mock_build_loop.return_value = (loop, strategy, None)
 
-        # Wire the real apply_exhausted_reprompt_metadata to get the raise
-        from agent_actions.llm.batch.services.reprompt_ops import (
-            apply_exhausted_reprompt_metadata,
-        )
+        # Wire the real exhaustion function to get the raise
+        from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
 
         service._retry_service.apply_exhausted_reprompt_metadata.side_effect = (
-            lambda **kwargs: apply_exhausted_reprompt_metadata(**kwargs)
+            lambda **kwargs: apply_exhausted_reprompt(**kwargs)
         )
 
         with pytest.raises(RuntimeError, match="Reprompt validation exhausted"):


### PR DESCRIPTION
## Summary
- Deletes `apply_exhausted_reprompt_metadata` function from `reprompt_ops.py` entirely
- No shim, no re-export — callers updated to import from `exhaustion.py` directly
- Facade (`retry.py`) now routes to consolidated module without passing through reprompt_ops
- Doc-audit test and composed recovery test updated

## Single pathway verification
```
processing_recovery.py → service._retry_service.apply_exhausted_reprompt_metadata
  → retry.py facade method
    → exhaustion.apply_exhausted_reprompt (consolidated)
```

No alternative path through reprompt_ops exists anymore.

## Verification
- 786 recovery-scoped tests pass (matches P3-025 baseline)
- `grep apply_exhausted_reprompt_metadata agent_actions/llm/batch/services/reprompt_ops.py` → zero hits
- ruff clean
- LLM critique conditional unchanged (line 209: `attempt + 1 >= critique_after`)