### PR TITLE
fix: stamp _state on batch results and remove placeholder after completion

### DIFF
--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -10,9 +10,11 @@ Entry points:
     cleanup_recovery() — remove registry entries after finalization
 """
 
+import json
 import logging
 import time
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
@@ -31,6 +33,7 @@ from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import BatchCompleteEvent
 from agent_actions.processing.result_collector import write_record_dispositions
 from agent_actions.processing.types import RecoveryMetadata
+from agent_actions.record.envelope import RecordEnvelope
 
 if TYPE_CHECKING:
     from agent_actions.llm.batch.services.processing import BatchProcessingService
@@ -454,12 +457,24 @@ def finalize_batch_output(
     )
 
     effective_action_name = action_name if action_name is not None else service._action_name
+
+    # Stamp _state on batch records before writing — batch results bypass the
+    # online ResultCollector._stamp() path and arrive without lifecycle fields.
+    _stamp_batch_records(processed_data, effective_action_name or file_name)
+
     if service._storage_backend and effective_action_name:
         write_record_dispositions(service._storage_backend, processed_data, effective_action_name)
         service._update_prompt_trace_responses(processed_data, effective_action_name)
 
     output_file = service._determine_output_path(output_directory, file_name, batch_id)
     service._write_batch_output(output_file, processed_data, output_directory, action_name)
+
+    # Remove batch placeholder file if storage backend wrote to SQLite instead.
+    # The placeholder (written at batch submission) persists on disk when
+    # write_target goes to the backend, causing downstream reads to hit it.
+    output_path = Path(output_file) if not isinstance(output_file, Path) else output_file
+    if service._storage_backend and output_path.exists():
+        _remove_batch_placeholder(output_path)
 
     elapsed_time = time.time() - start_time
     total_count = len(batch_results)
@@ -550,3 +565,48 @@ def _register_recovery_batch(
         recovery_attempt=attempt,
     )
     manager.save_batch_job(recovery_file_name, recovery_entry)
+
+
+def _remove_batch_placeholder(output_file: Path) -> None:
+    """Remove a batch placeholder file from disk after results are in the backend.
+
+    Only removes if the file matches the placeholder shape (batch_job_id + status=submitted).
+    """
+    try:
+        with open(output_file, encoding="utf-8") as f:
+            data = json.load(f)
+    except OSError:
+        return  # File already gone
+    except json.JSONDecodeError:
+        logger.warning("Malformed JSON at %s during placeholder cleanup", output_file)
+        return
+
+    if isinstance(data, dict) and "batch_job_id" in data and data.get("status") == "submitted":
+        try:
+            output_file.unlink()
+            logger.debug("Removed batch placeholder: %s", output_file)
+        except OSError:
+            pass  # Already removed by concurrent worker
+
+
+def _stamp_batch_records(records: list[dict[str, Any]], action_name: str) -> None:
+    """Stamp _state on batch output records that lack lifecycle fields.
+
+    Batch results bypass the online ResultCollector._stamp() path. This ensures
+    every record written to target has a valid _state for Phase 5 fail-closed reads.
+    """
+    from agent_actions.record.state import RecordState
+
+    for record in records:
+        if "_state" in record:
+            continue
+        # Determine state from record content
+        content = record.get("content")
+        metadata = record.get("metadata", {})
+        if metadata.get("retry_exhausted") or metadata.get("reason") == "exhausted":
+            state = RecordState.EXHAUSTED
+        elif content is None and metadata.get("reason"):
+            state = RecordState.FAILED
+        else:
+            state = RecordState.PROCESSED
+        RecordEnvelope.transition(record, state, action_name, "batch_completion")

--- a/agent_actions/skills/agac-agent-skills/references/action-anatomy.md
+++ b/agent_actions/skills/agac-agent-skills/references/action-anatomy.md
@@ -46,7 +46,15 @@ UDFs have no `schema` -- output defined by return value.
 ## Key Fields
 
 ### dependencies
-Controls execution order. All dependencies must also appear in `context_scope.observe`.
+Controls execution order AND determines which records your action processes. The executor walks your dependency's output to find input records — your action runs once per record found. If a dependency was guard-skipped (produced no output), there are zero records and your action completes immediately as passthrough.
+
+**If your action should run regardless of whether an upstream was skipped**, list a dependency that always produces output. For example, if `rewrite` is conditional but `write_question` always runs, depend on both:
+
+```yaml
+dependencies: [write_question, rewrite]   # write_question guarantees input exists
+```
+
+All dependencies must also appear in `context_scope.observe`.
 
 ```yaml
 dependencies: [parent_action]                    # Single

--- a/agent_actions/skills/agac-agent-skills/references/action-anatomy.md
+++ b/agent_actions/skills/agac-agent-skills/references/action-anatomy.md
@@ -56,6 +56,8 @@ dependencies: [write_question, rewrite]   # write_question guarantees input exis
 
 All dependencies must also appear in `context_scope.observe`.
 
+**Bus snapshot rule:** Each record carries the bus state from when it was written. If you observe `review.issues` but depend on `write_question` (which ran before `review`), that field won't exist on the record. Your observe fields must exist on the bus at the point your dependency's output was written — list the latest action in the chain as your dependency.
+
 ```yaml
 dependencies: [parent_action]                    # Single
 dependencies: [action_a, action_b, action_c]     # Merge pattern

--- a/agent_actions/skills/agac-agent-skills/references/workflow-patterns.md
+++ b/agent_actions/skills/agac-agent-skills/references/workflow-patterns.md
@@ -44,7 +44,7 @@ source -->|                            |--> assign_response_team
       - assess_system_impact.*
 ```
 
-No merge operator needed. The bus has both namespaces. `dependencies` controls when, `observe` controls what.
+No merge operator needed. The bus has both namespaces. `dependencies` controls when (and provides input records to iterate), `observe` controls what data the LLM sees. If a dependency is guard-skipped, your action gets zero records — list a guaranteed-output dependency if you need the action to always run.
 
 ---
 

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -11,6 +11,7 @@ Mock boundaries: provider calls, disk I/O (RecoveryStateManager), event bus.
 Do NOT mock internal functions — only external boundaries.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
@@ -73,7 +74,7 @@ def _mock_service():
     service._action_name = "test_action"
     service._apply_workflow_session_id = MagicMock(return_value={"kind": "llm"})
     service._convert_batch_results_to_workflow_format = MagicMock(return_value=[])
-    service._determine_output_path = MagicMock(return_value="/tmp/output.json")
+    service._determine_output_path = MagicMock(return_value=Path("/tmp/output.json"))
     service._write_batch_output = MagicMock()
     service._cleanup_recovery_entries = MagicMock()
     service._update_prompt_trace_responses = MagicMock()
@@ -754,3 +755,149 @@ class TestApplyExhaustedReprompt:
         assert r1.recovery_metadata.reprompt.passed is False
         assert r1.recovery_metadata.retry.attempts == 3
         assert r1.recovery_metadata.retry.succeeded is False
+
+
+# ---------------------------------------------------------------------------
+# TestStampBatchRecords (direct unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestStampBatchRecords:
+    """Direct tests for _stamp_batch_records."""
+
+    def test_stamps_processed_on_record_with_content(self):
+        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
+
+        record = {"content": {"action": {"field": "value"}}, "source_guid": "g1"}
+        _stamp_batch_records([record], "test_action")
+
+        assert record["_state"] == "processed"
+        assert "_state_history" in record
+
+    def test_stamps_exhausted_on_retry_exhausted(self):
+        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
+
+        record = {"content": {"a": {}}, "metadata": {"retry_exhausted": True}, "source_guid": "g1"}
+        _stamp_batch_records([record], "test_action")
+
+        assert record["_state"] == "exhausted"
+
+    def test_stamps_exhausted_on_reason_exhausted(self):
+        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
+
+        record = {"content": {"a": {}}, "metadata": {"reason": "exhausted"}, "source_guid": "g1"}
+        _stamp_batch_records([record], "test_action")
+
+        assert record["_state"] == "exhausted"
+
+    def test_stamps_failed_on_none_content_with_reason(self):
+        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
+
+        record = {"content": None, "metadata": {"reason": "api_error"}, "source_guid": "g1"}
+        _stamp_batch_records([record], "test_action")
+
+        assert record["_state"] == "failed"
+
+    def test_empty_dict_content_is_processed_not_failed(self):
+        """Empty dict {} is valid content — must NOT be classified as FAILED."""
+        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
+
+        record = {"content": {}, "metadata": {"reason": "something"}, "source_guid": "g1"}
+        _stamp_batch_records([record], "test_action")
+
+        assert record["_state"] == "processed"
+
+    def test_skips_record_with_existing_state(self):
+        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
+
+        record = {"_state": "committed", "content": {"a": {}}, "source_guid": "g1"}
+        _stamp_batch_records([record], "test_action")
+
+        assert record["_state"] == "committed"  # unchanged
+
+    def test_stamps_multiple_records(self):
+        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
+
+        records = [
+            {"content": {"a": {}}, "source_guid": "g1"},
+            {"content": None, "metadata": {"reason": "timeout"}, "source_guid": "g2"},
+        ]
+        _stamp_batch_records(records, "test_action")
+
+        assert records[0]["_state"] == "processed"
+        assert records[1]["_state"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# TestRemoveBatchPlaceholder (direct unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveBatchPlaceholder:
+    """Direct tests for _remove_batch_placeholder."""
+
+    def test_removes_valid_placeholder(self, tmp_path):
+        import json
+
+        from agent_actions.llm.batch.services.processing_recovery import (
+            _remove_batch_placeholder,
+        )
+
+        placeholder = tmp_path / "output.json"
+        placeholder.write_text(
+            json.dumps({"batch_job_id": "batch_123", "status": "submitted", "agent": "test"})
+        )
+
+        _remove_batch_placeholder(placeholder)
+
+        assert not placeholder.exists()
+
+    def test_leaves_non_placeholder_json(self, tmp_path):
+        import json
+
+        from agent_actions.llm.batch.services.processing_recovery import (
+            _remove_batch_placeholder,
+        )
+
+        real_output = tmp_path / "output.json"
+        real_output.write_text(json.dumps([{"content": {"data": "real"}}]))
+
+        _remove_batch_placeholder(real_output)
+
+        assert real_output.exists()  # NOT deleted
+
+    def test_leaves_completed_batch_file(self, tmp_path):
+        import json
+
+        from agent_actions.llm.batch.services.processing_recovery import (
+            _remove_batch_placeholder,
+        )
+
+        completed = tmp_path / "output.json"
+        completed.write_text(
+            json.dumps({"batch_job_id": "batch_123", "status": "completed", "agent": "test"})
+        )
+
+        _remove_batch_placeholder(completed)
+
+        assert completed.exists()  # status != submitted, not removed
+
+    def test_handles_missing_file(self, tmp_path):
+        from agent_actions.llm.batch.services.processing_recovery import (
+            _remove_batch_placeholder,
+        )
+
+        missing = tmp_path / "nonexistent.json"
+        _remove_batch_placeholder(missing)  # no error
+
+    def test_handles_malformed_json(self, tmp_path):
+        from agent_actions.llm.batch.services.processing_recovery import (
+            _remove_batch_placeholder,
+        )
+
+        bad_file = tmp_path / "corrupt.json"
+        bad_file.write_text("not json{{{")
+
+        _remove_batch_placeholder(bad_file)
+
+        assert bad_file.exists()  # not deleted, just warned


### PR DESCRIPTION
## Summary

Two bugs causing batch workflow failure on qanalabs-quiz-maker:

**Bug 1: Batch results missing `_state`**
- Batch results bypass the online `ResultCollector._stamp()` path
- Records written to target_data without lifecycle fields
- Phase 5 fail-closed reader rejects them: "Record is missing '_state'"
- Fix: `_stamp_batch_records()` stamps PROCESSED/FAILED/EXHAUSTED before write

**Bug 2: Batch placeholder persists on disk**
- At submission, a placeholder JSON is written to `target/{action}/{file}.json`
- When batch completes, results go to SQLite via `write_target` (storage backend)
- Placeholder file on disk is never removed
- Downstream filesystem reads hit placeholder: "Cannot process batch placeholder file"
- Fix: `_remove_batch_placeholder()` deletes it after successful backend write

## Verification
- 6,325 tests pass
- ruff clean
- Tested against qanalabs-quiz-maker batch workflow

## Test plan
- [ ] Run qanalabs-quiz-maker with clean target/
- [ ] Verify summarize_page_content records have `_state` in SQLite
- [ ] Verify placeholder file removed after batch completion
- [ ] Downstream actions read successfully from backend