### PR TITLE
fix: batch guard-skip writes passthrough records with full bus content

### DIFF
--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from agent_actions.errors import ConfigurationError, ConfigValidationError, ExternalServiceError
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.core.batch_models import BatchJobEntry, SubmissionResult
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
     BatchClientResolver,
@@ -223,11 +224,20 @@ class BatchSubmissionService:
         Returns:
             SubmissionResult with passthrough dict
         """
+        has_guard_skipped = any(
+            BatchContextMetadata.is_skipped(row) for row in context_map.values()
+        )
+        if has_guard_skipped:
+            passthrough = BatchPassthroughBuilder(output_directory).from_context(
+                context_map, reason="guard_skip"
+            )
+            return SubmissionResult(passthrough=passthrough)
+
         where_config = agent_config.get("where_clause") or {}
         behavior = where_config.get("behavior", "filter")
 
         if behavior == "filter":
-            passthrough: dict[str, Any] = {
+            passthrough = {
                 "type": "tombstone",
                 "data": [],
                 "output_directory": output_directory,


### PR DESCRIPTION
## Summary

**Root cause:** When ALL records are guard-skipped in batch mode, `_handle_empty_tasks` checks `where_clause.behavior` (defaults to `"filter"`) and writes `data: []` — an empty list. Online mode doesn't have this gap because records stay in memory.

**Fix:** Before checking where_clause, detect guard-skipped records in context_map and use `BatchPassthroughBuilder.from_context()` to write passthrough records carrying the full accumulated bus content.

**Result:** Batch and online now produce identical output for guard-skipped actions: records in target with all upstream namespaces, `_state=GUARD_SKIPPED`, downstream resets to ACTIVE and processes normally.

## Evidence

| | Online | Batch (before) | Batch (after) |
|---|---|---|---|
| `rewrite_failed_question` target_data | 3 rows, "guard skipped" | 0 rows, "No data" | 3 rows, guard-skipped with content |
| Downstream (`validate_final_question`) | Processes normally | Fails — zero records | Processes normally |

## Verification
- 6,337 tests pass
- ruff clean