### PR TITLE
fix: unify action_name injection for online and batch paths

### DIFF
--- a/.changes/unreleased/Bug Fix-20260503-315000.yaml
+++ b/.changes/unreleased/Bug Fix-20260503-315000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Unify action_name injection: coordinator sets it for all actions at init, eliminating online/batch divergence where non-versioned expansions could miss version_correlation_id assignment"
+time: 2026-05-03T03:15:00.000000Z

--- a/agent_actions/utils/correlation/version_id.py
+++ b/agent_actions/utils/correlation/version_id.py
@@ -107,9 +107,9 @@ class VersionIdGenerator:
         if not version_base_name:
             if not force:
                 return obj
-            # Expansion fallback: use action_name as the base name so each
+            # Expansion path: use action_name as the base name so each
             # expanding action produces a distinct ID namespace.
-            version_base_name = agent_config.get("action_name") or agent_config.get("name")
+            version_base_name = agent_config.get("action_name")
             if not version_base_name:
                 return obj
 

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -138,7 +138,7 @@ class AgentWorkflow:
 
         # Session
         self.workflow_session_id = self._generate_workflow_session_id()
-        self._inject_workflow_session_id()
+        self._prepare_action_configs()
 
         # Event logger (after services are ready)
         self.event_logger = WorkflowEventLogger(
@@ -340,13 +340,18 @@ class AgentWorkflow:
         config_hash = hashlib.sha256(config_content.encode()).hexdigest()[:16]
         return f"workflow_{config_hash}"
 
-    def _inject_workflow_session_id(self):
-        """Inject workflow session ID into all action configurations."""
+    def _prepare_action_configs(self):
+        """Inject workflow-level metadata into all action configurations.
+
+        Sets action_name and workflow_session_id on each config so both
+        online and batch paths resolve identity from the same source.
+        """
         from agent_actions.utils.correlation import VersionIdGenerator
 
         VersionIdGenerator.clear_version_correlation_registry()
 
-        for action_config in self.action_configs.values():
+        for action_name, action_config in self.action_configs.items():
+            action_config["action_name"] = action_name
             action_config["workflow_session_id"] = self.workflow_session_id
 
     def _initialize_event_context(self) -> None:

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -812,9 +812,6 @@ class ActionExecutor:
         """Handle batch job status checking (synchronous)."""
         self.deps.state_manager.update_status(action_name, ActionStatus.CHECKING_BATCH)
         output_directory = self._batch_output_directory(action_name)
-        # Config uses "agent_type" but additive model needs "action_name" for
-        # RecordEnvelope.build_content() namespace resolution.
-        action_config["action_name"] = action_name
 
         output_folder, batch_status = self.deps.batch_manager.handle_batch_agent(
             action_name, output_directory, action_config
@@ -835,9 +832,6 @@ class ActionExecutor:
         """Handle batch job status checking (asynchronous)."""
         self.deps.state_manager.update_status(action_name, ActionStatus.CHECKING_BATCH)
         output_directory = self._batch_output_directory(action_name)
-        # Config uses "agent_type" but additive model needs "action_name" for
-        # RecordEnvelope.build_content() namespace resolution.
-        action_config["action_name"] = action_name
 
         output_folder, batch_status = await asyncio.to_thread(
             self.deps.batch_manager.handle_batch_agent,

--- a/tests/unit/processing/test_version_id_enricher.py
+++ b/tests/unit/processing/test_version_id_enricher.py
@@ -137,6 +137,44 @@ class TestVersionIdEnricherPassthrough:
         # No version_correlation_id should be set — action is not versioned
         assert "version_correlation_id" not in enriched.data[0]
 
+    def test_name_key_alone_does_not_trigger_expansion_id(self):
+        """Regression: removed 'name' fallback — only 'action_name' is used.
+
+        If agent_config has 'name' but not 'action_name', force=True must
+        NOT assign a version_correlation_id (returns obj unchanged).
+        """
+        from agent_actions.utils.correlation import VersionIdGenerator
+
+        obj = {"source_guid": "g1"}
+        config = {
+            "name": "flatten_questions",
+            "workflow_session_id": "sess-123",
+        }
+
+        result = VersionIdGenerator.add_version_correlation_id(
+            obj, config, record_index=0, force=True
+        )
+
+        assert "version_correlation_id" not in result
+
+    def test_action_name_key_triggers_expansion_id(self):
+        """action_name is the canonical key for expansion ID assignment."""
+        from agent_actions.utils.correlation import VersionIdGenerator
+
+        VersionIdGenerator.clear()
+        obj = {"source_guid": "g1"}
+        config = {
+            "action_name": "flatten_questions",
+            "workflow_session_id": "sess-123",
+        }
+
+        result = VersionIdGenerator.add_version_correlation_id(
+            obj, config, record_index=0, force=True
+        )
+
+        assert "version_correlation_id" in result
+        assert result["version_correlation_id"] != ""
+
     def test_negative_record_index_skipped(self):
         data = [{"source_guid": "g1"}]
         result = _make_result(data)

--- a/tests/unit/workflow/test_executor_batch.py
+++ b/tests/unit/workflow/test_executor_batch.py
@@ -47,11 +47,41 @@ class TestBatchActionNamePresent:
     """action_name must be on action_config when handle_batch_agent is called.
 
     The coordinator injects action_name at workflow init. These tests verify
-    the executor correctly passes it through to handle_batch_agent.
+    the executor does NOT mutate action_name — it relies on the coordinator.
     """
 
-    def test_action_name_passed_to_handle_batch_agent_sync(self, executor, mock_deps):
-        """Sync batch-check passes action_name through to handle_batch_agent."""
+    def test_executor_does_not_inject_action_name_sync(self, executor, mock_deps):
+        """Sync batch-check does NOT mutate action_name — coordinator owns injection."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
+        mock_deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
+
+        config = {"kind": "llm"}
+
+        with patch("agent_actions.workflow.executor.fire_event"):
+            executor.execute_action_sync(
+                "my_extract", action_idx=0, action_config=config, is_last_action=False
+            )
+
+        # Executor must NOT inject action_name (that's coordinator's job)
+        assert "action_name" not in config
+
+    @pytest.mark.asyncio
+    async def test_executor_does_not_inject_action_name_async(self, executor, mock_deps):
+        """Async batch-check does NOT mutate action_name — coordinator owns injection."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
+        mock_deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
+
+        config = {"kind": "llm"}
+
+        with patch("agent_actions.workflow.executor.fire_event"):
+            await executor.execute_action_async(
+                "my_extract", action_idx=0, action_config=config, is_last_action=False
+            )
+
+        assert "action_name" not in config
+
+    def test_action_name_reaches_batch_manager_when_present(self, executor, mock_deps):
+        """When coordinator has set action_name, it flows through to handle_batch_agent."""
         mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
         captured_config = {}
 
@@ -61,7 +91,6 @@ class TestBatchActionNamePresent:
 
         mock_deps.batch_manager.handle_batch_agent.side_effect = capture_config
 
-        # action_name is pre-set by coordinator (not by executor)
         config = {"kind": "llm", "action_name": "my_extract"}
 
         with patch("agent_actions.workflow.executor.fire_event"):
@@ -70,21 +99,3 @@ class TestBatchActionNamePresent:
             )
 
         assert captured_config["action_name"] == "my_extract"
-
-    @pytest.mark.asyncio
-    async def test_action_name_passed_to_handle_batch_agent_async(self, executor, mock_deps):
-        """Async batch-check passes action_name through to handle_batch_agent."""
-        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
-        mock_deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
-
-        # action_name is pre-set by coordinator (not by executor)
-        config = {"kind": "llm", "action_name": "my_extract"}
-
-        with patch("agent_actions.workflow.executor.fire_event"):
-            await executor.execute_action_async(
-                "my_extract", action_idx=0, action_config=config, is_last_action=False
-            )
-
-        call_args = mock_deps.batch_manager.handle_batch_agent.call_args
-        passed_config = call_args[0][2]
-        assert passed_config["action_name"] == "my_extract"

--- a/tests/unit/workflow/test_executor_batch.py
+++ b/tests/unit/workflow/test_executor_batch.py
@@ -1,9 +1,9 @@
-"""Tests for batch action_name injection in executor batch-check paths.
+"""Tests for batch action_name availability in executor batch-check paths.
 
 The batch result processor needs action_name on action_config for
-RecordEnvelope.build_content() namespacing. executor.py:827 (sync)
-and :913 (async) inject it before calling handle_batch_agent.
-If these lines are removed, batch namespacing breaks silently.
+RecordEnvelope.build_content() namespacing. The coordinator injects
+action_name into all action_configs at workflow init time, so it is
+always present when the executor runs.
 """
 
 from unittest.mock import MagicMock, patch
@@ -43,63 +43,47 @@ def executor(mock_deps):
     return ActionExecutor(mock_deps)
 
 
-class TestBatchActionNameInjectionSync:
-    """action_name must be on action_config before handle_batch_agent is called (sync)."""
+class TestBatchActionNamePresent:
+    """action_name must be on action_config when handle_batch_agent is called.
 
-    def test_batch_check_injects_action_name_into_config(self, executor, mock_deps):
-        """Sync batch-check path injects action_name before calling handle_batch_agent."""
-        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
-        mock_deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
+    The coordinator injects action_name at workflow init. These tests verify
+    the executor correctly passes it through to handle_batch_agent.
+    """
 
-        config = {"kind": "llm"}
-
-        with patch("agent_actions.workflow.executor.fire_event"):
-            executor.execute_action_sync(
-                "my_extract", action_idx=0, action_config=config, is_last_action=False
-            )
-
-        assert config["action_name"] == "my_extract"
-
-    def test_action_name_present_before_handle_batch_agent_called(self, executor, mock_deps):
-        """action_name injection must happen BEFORE handle_batch_agent, not after."""
+    def test_action_name_passed_to_handle_batch_agent_sync(self, executor, mock_deps):
+        """Sync batch-check passes action_name through to handle_batch_agent."""
         mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
         captured_config = {}
 
         def capture_config(action_name, output_dir, agent_config):
-            # Snapshot the config at the moment handle_batch_agent is called
             captured_config.update(agent_config)
             return ("/output", "completed")
 
         mock_deps.batch_manager.handle_batch_agent.side_effect = capture_config
 
+        # action_name is pre-set by coordinator (not by executor)
+        config = {"kind": "llm", "action_name": "my_extract"}
+
         with patch("agent_actions.workflow.executor.fire_event"):
             executor.execute_action_sync(
-                "my_extract",
-                action_idx=0,
-                action_config={"kind": "llm"},
-                is_last_action=False,
+                "my_extract", action_idx=0, action_config=config, is_last_action=False
             )
 
         assert captured_config["action_name"] == "my_extract"
 
-
-class TestBatchActionNameInjectionAsync:
-    """action_name must be on action_config before handle_batch_agent is called (async)."""
-
     @pytest.mark.asyncio
-    async def test_batch_check_async_injects_action_name_into_config(self, executor, mock_deps):
-        """Async batch-check path injects action_name before calling handle_batch_agent."""
+    async def test_action_name_passed_to_handle_batch_agent_async(self, executor, mock_deps):
+        """Async batch-check passes action_name through to handle_batch_agent."""
         mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
         mock_deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
 
-        config = {"kind": "llm"}
+        # action_name is pre-set by coordinator (not by executor)
+        config = {"kind": "llm", "action_name": "my_extract"}
 
         with patch("agent_actions.workflow.executor.fire_event"):
             await executor.execute_action_async(
                 "my_extract", action_idx=0, action_config=config, is_last_action=False
             )
-
-        assert config["action_name"] == "my_extract"
 
         call_args = mock_deps.batch_manager.handle_batch_agent.call_args
         passed_config = call_args[0][2]

--- a/tests/unit/workflow/test_prepare_action_configs.py
+++ b/tests/unit/workflow/test_prepare_action_configs.py
@@ -1,0 +1,72 @@
+"""Tests for AgentWorkflow._prepare_action_configs — canonical injection point."""
+
+from unittest.mock import MagicMock
+
+from agent_actions.workflow.coordinator import AgentWorkflow
+from agent_actions.workflow.models import WorkflowRuntimeConfig
+
+
+def _build_workflow_for_prepare(action_configs):
+    """Build a minimal AgentWorkflow to test _prepare_action_configs."""
+    wf = object.__new__(AgentWorkflow)
+    metadata = MagicMock()
+    metadata.action_configs = action_configs
+    wf.metadata = metadata
+    wf.workflow_session_id = "workflow_abc123"
+    wf.config = MagicMock(spec=WorkflowRuntimeConfig)
+    return wf
+
+
+class TestPrepareActionConfigs:
+    """_prepare_action_configs injects action_name and workflow_session_id."""
+
+    def test_injects_action_name_for_all_actions(self):
+        configs = {
+            "extract_claims": {"kind": "llm"},
+            "flatten_questions": {"kind": "tool"},
+            "score_quality": {"kind": "llm"},
+        }
+        wf = _build_workflow_for_prepare(configs)
+
+        wf._prepare_action_configs()
+
+        assert configs["extract_claims"]["action_name"] == "extract_claims"
+        assert configs["flatten_questions"]["action_name"] == "flatten_questions"
+        assert configs["score_quality"]["action_name"] == "score_quality"
+
+    def test_injects_workflow_session_id_for_all_actions(self):
+        configs = {
+            "action_a": {"kind": "llm"},
+            "action_b": {"kind": "tool"},
+        }
+        wf = _build_workflow_for_prepare(configs)
+
+        wf._prepare_action_configs()
+
+        assert configs["action_a"]["workflow_session_id"] == "workflow_abc123"
+        assert configs["action_b"]["workflow_session_id"] == "workflow_abc123"
+
+    def test_action_name_matches_dict_key(self):
+        """action_name must equal the dict key, not any 'name' field in the config."""
+        configs = {
+            "my_action": {"kind": "llm", "name": "Some Display Name"},
+        }
+        wf = _build_workflow_for_prepare(configs)
+
+        wf._prepare_action_configs()
+
+        assert configs["my_action"]["action_name"] == "my_action"
+
+    def test_clears_version_correlation_registry(self):
+        """_prepare_action_configs must clear stale correlation IDs from prior runs."""
+        from agent_actions.utils.correlation import VersionIdGenerator
+
+        # Seed the registry with a stale entry
+        VersionIdGenerator._version_correlation_registry = {"stale": "value"}
+
+        configs = {"action_a": {"kind": "llm"}}
+        wf = _build_workflow_for_prepare(configs)
+
+        wf._prepare_action_configs()
+
+        assert VersionIdGenerator._version_correlation_registry == {}


### PR DESCRIPTION
## Summary
- Coordinator now injects `action_name` into all action_configs at workflow init (alongside `workflow_session_id`)
- Removes redundant executor mutations that only set `action_name` for batch paths
- Removes `or agent_config.get("name")` fallback in `VersionIdGenerator` — `action_name` is always present
- Renames `_inject_workflow_session_id` → `_prepare_action_configs` to reflect actual scope

## Root cause
Batch path had `action_config["action_name"]` injected by executor before calling `handle_batch_agent`. Online path never injected it — `VersionIdGenerator` fell back to `agent_config.get("name")` which could be `None` (optional field on post-expansion `AgentConfig`). This meant non-versioned 1→N expansions in online mode could silently fail to assign `version_correlation_id`.

## Verification
- All 6363 tests pass
- `ruff check` and `ruff format --check` clean
- Confirmed single injection point in coordinator serves both batch and online paths