### PR TITLE
fix: tombstones preserve _state_history via RECORD_LIFECYCLE_FIELDS

### DIFF
--- a/.changes/unreleased/Bug Fix-20260503-486000.yaml
+++ b/.changes/unreleased/Bug Fix-20260503-486000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix _state_history lost on tombstone records — add RECORD_LIFECYCLE_FIELDS so RecordEnvelope.build*() carries cumulative lifecycle fields automatically"
+time: 2026-05-03T14:48:06.000000Z

--- a/agent_actions/processing/exhausted_builder.py
+++ b/agent_actions/processing/exhausted_builder.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from agent_actions.processing.types import RecoveryMetadata
 from agent_actions.record.envelope import RecordEnvelope
-from agent_actions.utils.content import get_existing_content
 from agent_actions.utils.id_generation import IDGenerator
 from agent_actions.utils.lineage.builder import LineageBuilder
 
@@ -41,20 +40,23 @@ class ExhaustedRecordBuilder:
         agent_config: dict[str, Any],
         action_name: str,
     ) -> dict[str, Any]:
-        """Build an exhausted retry record with empty content and recovery metadata."""
+        """Build an exhausted retry record with empty content and recovery metadata.
+
+        Routes through :meth:`RecordEnvelope.build` so lifecycle fields
+        (``_state_history``, ``_state_schema_version``) are carried automatically.
+        """
         resolved_source_guid = LineageBuilder.resolve_source_guid(source_guid, original_row)
-
         empty_content = ExhaustedRecordBuilder.build_empty_content(agent_config)
-        existing = get_existing_content(original_row) if isinstance(original_row, dict) else {}
 
+        exhausted_item = RecordEnvelope.build(
+            action_name, empty_content, original_row if isinstance(original_row, dict) else None
+        )
+
+        exhausted_item["source_guid"] = resolved_source_guid
         node_id = IDGenerator.generate_node_id(action_name)
-        exhausted_item: dict[str, Any] = {
-            "source_guid": resolved_source_guid,
-            "content": RecordEnvelope.build_content(action_name, empty_content, existing),
-            "node_id": node_id,
-            "metadata": {"retry_exhausted": True, "agent_type": "tombstone"},
-            "_recovery": recovery_metadata.to_dict(),
-        }
+        exhausted_item["node_id"] = node_id
+        exhausted_item["metadata"] = {"retry_exhausted": True, "agent_type": "tombstone"}
+        exhausted_item["_recovery"] = recovery_metadata.to_dict()
 
         if isinstance(original_row, dict):
             if "target_id" in original_row and original_row["target_id"]:

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -16,11 +16,12 @@ from agent_actions.utils.content import get_existing_content, is_version_merge
 # Framework fields carried from input to output when the envelope builder
 # does not manage them automatically.
 # _state is intentionally absent — it resets per-action at the executor boundary.
+# _state_history: carried by RecordEnvelope.build*() via RECORD_LIFECYCLE_FIELDS
+# to preserve cumulative state transitions on tombstone records.
 CARRY_FORWARD_FIELDS: tuple[str, ...] = (
     "target_id",
     "_recovery",
     "metadata",
-    "_state_history",
 )
 
 
@@ -66,17 +67,16 @@ def build_exhausted_tombstone(
     the existing content (upstream namespaces) merged with an empty
     action output so downstream can see what was accumulated before
     exhaustion.
+
+    Routes through :meth:`RecordEnvelope.build` so lifecycle fields
+    (``_state_history``, ``_state_schema_version``) are carried automatically.
     """
-    existing = get_existing_content(input_record) if input_record else {}
-    content = RecordEnvelope.build_content(action_name, empty_content, existing)
-    item: dict[str, Any] = {
-        "content": content,
-        "source_guid": source_guid,
-        "metadata": {
-            "reason": RETRY_EXHAUSTED,
-            "retry_exhausted": True,
-            "agent_type": "tombstone",
-        },
+    item = RecordEnvelope.build(action_name, empty_content, input_record)
+    item["source_guid"] = source_guid
+    item["metadata"] = {
+        "reason": RETRY_EXHAUSTED,
+        "retry_exhausted": True,
+        "agent_type": "tombstone",
     }
     if extra_metadata:
         item["metadata"].update(extra_metadata)
@@ -102,7 +102,12 @@ def carry_framework_fields(
         return target
     for field in fields:
         if field in source:
-            target[field] = source[field]
+            value = source[field]
+            # Shallow-copy lists to prevent aliasing (transition()
+            # appends in-place to _state_history).
+            if isinstance(value, list):
+                value = list(value)
+            target[field] = value
     return target
 
 

--- a/agent_actions/record/__init__.py
+++ b/agent_actions/record/__init__.py
@@ -2,6 +2,7 @@
 
 from agent_actions.record.envelope import (
     RECORD_FRAMEWORK_FIELDS,
+    RECORD_LIFECYCLE_FIELDS,
     RecordEnvelope,
     RecordEnvelopeError,
 )
@@ -10,6 +11,7 @@ from agent_actions.record.tracking import TrackedItem
 
 __all__ = [
     "RECORD_FRAMEWORK_FIELDS",
+    "RECORD_LIFECYCLE_FIELDS",
     "RecordEnvelope",
     "RecordEnvelopeError",
     "RecordState",

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -30,6 +30,16 @@ RECORD_TRACKING_FIELDS: frozenset[str] = frozenset(
     }
 )
 
+# Lifecycle fields: cumulative across stages — carried forward AND appended to.
+# _state_history grows via transition(); _state_schema_version tags the format.
+# Carried by _carry_persistent_fields() so tombstone builders get them automatically.
+RECORD_LIFECYCLE_FIELDS: frozenset[str] = frozenset(
+    {
+        "_state_history",
+        "_state_schema_version",
+    }
+)
+
 # Per-stage fields: rebuilt by enrichers at each stage. NOT carried forward.
 # parent_target_id and root_target_id are set by LineageEnricher from the
 # parent's target_id — they're derived per-stage, not stable identity.
@@ -46,14 +56,16 @@ RECORD_STAGE_FIELDS: frozenset[str] = frozenset(
         "root_target_id",
         "chunk_info",
         "_state",
-        "_state_history",
-        "_state_schema_version",
     }
 )
 
+# Persistent fields: carried from input → output by RecordEnvelope.build*().
+# Tracking (stable identity) + lifecycle (cumulative).
+_PERSISTENT_FIELDS: frozenset[str] = RECORD_TRACKING_FIELDS | RECORD_LIFECYCLE_FIELDS
+
 # Union of all framework fields. Used by record_processor (first-stage source wrapping),
 # pipeline_file_mode (tool input stripping), and scope_namespace (metadata exclusion).
-RECORD_FRAMEWORK_FIELDS: frozenset[str] = RECORD_TRACKING_FIELDS | RECORD_STAGE_FIELDS
+RECORD_FRAMEWORK_FIELDS: frozenset[str] = _PERSISTENT_FIELDS | RECORD_STAGE_FIELDS
 
 
 class RecordEnvelopeError(Exception):
@@ -90,7 +102,7 @@ class RecordEnvelope:
 
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, action_name: action_output}}
-        return _carry_tracking_fields(result, input_record)
+        return _carry_persistent_fields(result, input_record)
 
     @staticmethod
     def build_content(
@@ -121,7 +133,7 @@ class RecordEnvelope:
             raise RecordEnvelopeError("action_name is required")
         existing = _extract_existing(input_record)
         result: dict[str, Any] = {"content": {**existing, action_name: None}}
-        return _carry_tracking_fields(result, input_record)
+        return _carry_persistent_fields(result, input_record)
 
     @staticmethod
     def transition(
@@ -197,21 +209,33 @@ def _validate_transition(from_state: RecordState | None, to_state: RecordState) 
     )
 
 
-def _carry_tracking_fields(
+def _carry_persistent_fields(
     result: dict[str, Any], input_record: dict[str, Any] | None
 ) -> dict[str, Any]:
-    """Copy tracking fields from *input_record* into *result*.
+    """Copy persistent fields from *input_record* into *result*.
 
-    Tracking fields (``source_guid``, ``version_correlation_id``) are the
-    record's stable identity — set once at creation and preserved through all
-    downstream 1:1 stages. Per-stage fields (metadata, lineage, etc.) are not
-    carried; enrichers rebuild those each stage.
+    Persistent fields fall into two categories:
+
+    1. **Tracking fields** (``source_guid``, ``version_correlation_id``) —
+       the record's stable identity, set once at creation.
+    2. **Lifecycle fields** (``_state_history``, ``_state_schema_version``) —
+       metadata tied to the record's state machine; ``_state_history`` grows
+       across stages, ``_state_schema_version`` tags the history format.
+
+    Per-stage fields (metadata, lineage, etc.) are not carried; enrichers
+    rebuild those each stage.
     """
     if input_record is None:
         return result
-    for field in RECORD_TRACKING_FIELDS:
+    for field in _PERSISTENT_FIELDS:
         if field in input_record:
-            result[field] = input_record[field]
+            value = input_record[field]
+            # Deep-copy mutable lifecycle fields to prevent aliasing —
+            # transition() appends in-place, so shared references between
+            # input and output records would corrupt the audit trail.
+            if isinstance(value, list):
+                value = list(value)
+            result[field] = value
     return result
 
 

--- a/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
+++ b/tests/unit/llm_invocation/test_batch_provider_edge_cases.py
@@ -64,6 +64,35 @@ class TestExhaustedRecordBuilderActionName:
                 action_name="",
             )
 
+    def test_carries_state_history_from_original_row(self):
+        """Exhausted items must preserve the cumulative state audit trail."""
+        from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
+
+        history = [
+            {
+                "timestamp": "t",
+                "action": "a",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        recovery = RecoveryMetadata(
+            retry=RetryMetadata(attempts=3, failures=3, succeeded=False, reason="api_error")
+        )
+        item = ExhaustedRecordBuilder.build_exhausted_item(
+            source_guid="sg-hist",
+            original_row={"text": "hello", "target_id": "tid-1", "_state_history": history},
+            recovery_metadata=recovery,
+            agent_config={"action_name": "act"},
+            action_name="act",
+        )
+        assert item["_state_history"] == history
+        # Verify isolation — mutating output must not corrupt input
+        item["_state_history"].append({"extra": True})
+        assert len(history) == 1
+
     def test_action_name_empty_when_agent_config_is_none_raises(self):
         """When action_name is empty (derived from None config), RecordEnvelopeError is raised."""
         from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder

--- a/tests/unit/processing/test_record_helpers.py
+++ b/tests/unit/processing/test_record_helpers.py
@@ -63,6 +63,37 @@ class TestBuildTombstone:
         assert result["content"]["ns_b"] == {"y": 2}
         assert result["content"]["ns_c"] is None
 
+    def test_carries_state_history_from_input(self):
+        history = [
+            {
+                "timestamp": "t",
+                "action": "prior",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        input_record = {"content": {}, "target_id": "tid-1", "_state_history": history}
+        result = build_tombstone("act", input_record, "guard_skip")
+        assert result["_state_history"] == history
+
+    def test_carried_history_isolated_from_input(self):
+        history = [
+            {
+                "timestamp": "t",
+                "action": "a",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        input_record = {"content": {}, "_state_history": history}
+        result = build_tombstone("act", input_record, "guard_skip")
+        result["_state_history"].append({"extra": True})
+        assert len(input_record["_state_history"]) == 1
+
 
 # ---------------------------------------------------------------------------
 # build_exhausted_tombstone
@@ -104,6 +135,37 @@ class TestBuildExhaustedTombstone:
         result = build_exhausted_tombstone("act", None, {"f": None})
         assert result["content"] == {"act": {"f": None}}
 
+    def test_carries_state_history_from_input(self):
+        history = [
+            {
+                "timestamp": "t",
+                "action": "prior",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        input_record = {"content": {}, "target_id": "tid-1", "_state_history": history}
+        result = build_exhausted_tombstone("act", input_record, {})
+        assert result["_state_history"] == history
+
+    def test_carried_history_isolated_from_input(self):
+        history = [
+            {
+                "timestamp": "t",
+                "action": "a",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        input_record = {"content": {}, "_state_history": history}
+        result = build_exhausted_tombstone("act", input_record, {})
+        result["_state_history"].append({"extra": True})
+        assert len(input_record["_state_history"]) == 1
+
 
 # ---------------------------------------------------------------------------
 # carry_framework_fields
@@ -124,14 +186,12 @@ class TestCarryFrameworkFields:
             "target_id": "tid",
             "_recovery": {"attempt": 1},
             "metadata": {"reason": "test"},
-            "_state_history": [{"action": "a"}],
         }
         target: dict = {}
         carry_framework_fields(source, target)
         assert target["target_id"] == "tid"
         assert target["_recovery"] == {"attempt": 1}
         assert target["metadata"]["reason"] == "test"
-        assert target["_state_history"] == [{"action": "a"}]
 
     def test_skips_missing_fields(self):
         source = {"content": {"x": 1}}
@@ -166,27 +226,14 @@ class TestCarryFrameworkFields:
             "target_id",
             "_recovery",
             "metadata",
-            "_state_history",
         )
 
-    def test_state_history_is_carried(self):
-        history = [
-            {
-                "timestamp": "t",
-                "action": "a",
-                "from": None,
-                "to": "active",
-                "reason": "r",
-                "detail": None,
-            }
-        ]
-        source = {"_state": "processed", "_state_history": history}
-        target: dict = {}
-        carry_framework_fields(source, target)
-        assert target["_state_history"] == history
+    def test_state_history_not_in_carry_forward(self):
+        """_state_history is now carried by RecordEnvelope.build*() via RECORD_LIFECYCLE_FIELDS."""
+        assert "_state_history" not in CARRY_FORWARD_FIELDS
 
     def test_state_is_not_carried(self):
-        source = {"_state": "processed", "_state_history": []}
+        source = {"_state": "processed"}
         target: dict = {}
         carry_framework_fields(source, target)
         assert "_state" not in target

--- a/tests/unit/record/test_tracking_field_propagation.py
+++ b/tests/unit/record/test_tracking_field_propagation.py
@@ -2,6 +2,7 @@
 
 from agent_actions.record.envelope import (
     RECORD_FRAMEWORK_FIELDS,
+    RECORD_LIFECYCLE_FIELDS,
     RECORD_STAGE_FIELDS,
     RECORD_TRACKING_FIELDS,
     RecordEnvelope,
@@ -12,14 +13,25 @@ class TestFieldSets:
     def test_tracking_fields_are_subset_of_framework(self):
         assert RECORD_TRACKING_FIELDS < RECORD_FRAMEWORK_FIELDS
 
+    def test_lifecycle_fields_are_subset_of_framework(self):
+        assert RECORD_LIFECYCLE_FIELDS < RECORD_FRAMEWORK_FIELDS
+
     def test_stage_fields_are_subset_of_framework(self):
         assert RECORD_STAGE_FIELDS < RECORD_FRAMEWORK_FIELDS
 
     def test_framework_is_union(self):
-        assert RECORD_FRAMEWORK_FIELDS == RECORD_TRACKING_FIELDS | RECORD_STAGE_FIELDS
+        assert RECORD_FRAMEWORK_FIELDS == (
+            RECORD_TRACKING_FIELDS | RECORD_LIFECYCLE_FIELDS | RECORD_STAGE_FIELDS
+        )
 
-    def test_sets_are_disjoint(self):
+    def test_tracking_and_lifecycle_are_disjoint(self):
+        assert RECORD_TRACKING_FIELDS.isdisjoint(RECORD_LIFECYCLE_FIELDS)
+
+    def test_tracking_and_stage_are_disjoint(self):
         assert RECORD_TRACKING_FIELDS.isdisjoint(RECORD_STAGE_FIELDS)
+
+    def test_lifecycle_and_stage_are_disjoint(self):
+        assert RECORD_LIFECYCLE_FIELDS.isdisjoint(RECORD_STAGE_FIELDS)
 
     def test_tracking_contains_source_guid(self):
         assert "source_guid" in RECORD_TRACKING_FIELDS
@@ -82,6 +94,106 @@ class TestEnvelopeBuildCarriesTrackingFields:
 
         assert r3["version_correlation_id"] == "vcid-xyz"
         assert r3["source_guid"] == "g1"
+
+
+class TestEnvelopeBuildCarriesLifecycleFields:
+    def test_carries_state_history(self):
+        history = [
+            {
+                "timestamp": "t",
+                "action": "a",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        inp = {"source_guid": "g1", "_state_history": history, "content": {}}
+        result = RecordEnvelope.build("act", {"x": 1}, inp)
+        assert result["_state_history"] == history
+
+    def test_carries_state_schema_version(self):
+        inp = {"source_guid": "g1", "_state_schema_version": 1, "content": {}}
+        result = RecordEnvelope.build("act", {"x": 1}, inp)
+        assert result["_state_schema_version"] == 1
+
+    def test_build_skipped_carries_state_history(self):
+        history = [
+            {
+                "timestamp": "t",
+                "action": "a",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        inp = {"source_guid": "g1", "_state_history": history, "content": {"prior": {"x": 1}}}
+        result = RecordEnvelope.build_skipped("skipped_action", inp)
+        assert result["_state_history"] == history
+
+    def test_does_not_carry_state(self):
+        """_state is a per-stage field — must not be carried by build()."""
+        inp = {"source_guid": "g1", "_state": "processed", "content": {}}
+        result = RecordEnvelope.build("act", {"x": 1}, inp)
+        assert "_state" not in result
+
+    def test_carried_history_is_isolated_copy(self):
+        """Mutating output history must not corrupt input record."""
+        history = [
+            {
+                "timestamp": "t",
+                "action": "a",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        inp = {"source_guid": "g1", "_state_history": history, "content": {}}
+        result = RecordEnvelope.build("act", {"x": 1}, inp)
+        result["_state_history"].append({"extra": True})
+        assert len(inp["_state_history"]) == 1  # input unchanged
+
+    def test_build_skipped_history_is_isolated_copy(self):
+        """Mutating skipped output history must not corrupt input record."""
+        history = [
+            {
+                "timestamp": "t",
+                "action": "a",
+                "from": None,
+                "to": "active",
+                "reason": "r",
+                "detail": None,
+            }
+        ]
+        inp = {"source_guid": "g1", "_state_history": history, "content": {"prior": {"x": 1}}}
+        result = RecordEnvelope.build_skipped("skipped_action", inp)
+        result["_state_history"].append({"extra": True})
+        assert len(inp["_state_history"]) == 1
+
+    def test_cumulative_growth_across_build_transition_build(self):
+        """History must grow across build → transition → build chain."""
+        from agent_actions.record.state import RecordState
+
+        r1 = RecordEnvelope.build("stage1", {"a": 1}, {"source_guid": "g1", "content": {}})
+        RecordEnvelope.transition(r1, RecordState.PROCESSED, "stage1", "done")
+        assert len(r1["_state_history"]) == 1
+
+        RecordEnvelope.transition(r1, RecordState.ACTIVE, "reset", "downstream_reset")
+        r2 = RecordEnvelope.build("stage2", {"b": 2}, r1)
+        RecordEnvelope.transition(r2, RecordState.PROCESSED, "stage2", "done")
+        assert len(r2["_state_history"]) == 3  # stage1 + reset + stage2
+
+    def test_build_skipped_carries_state_schema_version(self):
+        inp = {"source_guid": "g1", "_state_schema_version": 1, "content": {"prior": {"x": 1}}}
+        result = RecordEnvelope.build_skipped("skipped_action", inp)
+        assert result["_state_schema_version"] == 1
+
+    def test_empty_history_list_carried(self):
+        inp = {"source_guid": "g1", "_state_history": [], "content": {}}
+        result = RecordEnvelope.build("act", {"x": 1}, inp)
+        assert result["_state_history"] == []
 
 
 class TestBuildSkippedCarriesTrackingFields:

--- a/tests/unit/record/test_transition.py
+++ b/tests/unit/record/test_transition.py
@@ -4,6 +4,7 @@ import pytest
 
 from agent_actions.record.envelope import (
     RECORD_FRAMEWORK_FIELDS,
+    RECORD_LIFECYCLE_FIELDS,
     RECORD_STAGE_FIELDS,
     STATE_HISTORY_CAP,
     RecordEnvelope,
@@ -183,12 +184,16 @@ class TestTransitionHistoryCap:
 
 
 class TestFrameworkFields:
-    def test_state_fields_in_record_stage_fields(self):
+    def test_state_in_stage_fields(self):
         assert "_state" in RECORD_STAGE_FIELDS
-        assert "_state_history" in RECORD_STAGE_FIELDS
-        assert "_state_schema_version" in RECORD_STAGE_FIELDS
 
-    def test_state_fields_in_framework_fields(self):
+    def test_lifecycle_fields_in_lifecycle_not_stage(self):
+        assert "_state_history" in RECORD_LIFECYCLE_FIELDS
+        assert "_state_schema_version" in RECORD_LIFECYCLE_FIELDS
+        assert "_state_history" not in RECORD_STAGE_FIELDS
+        assert "_state_schema_version" not in RECORD_STAGE_FIELDS
+
+    def test_all_state_fields_in_framework_fields(self):
         assert "_state" in RECORD_FRAMEWORK_FIELDS
         assert "_state_history" in RECORD_FRAMEWORK_FIELDS
         assert "_state_schema_version" in RECORD_FRAMEWORK_FIELDS


### PR DESCRIPTION
## Summary
- `_state_history` was misclassified in `RECORD_STAGE_FIELDS` (rebuilt per stage) but is actually cumulative — it grows across stages
- Tombstone builders (`build_tombstone`, `build_exhausted_tombstone`) called `build_skipped()` then `carry_framework_fields(fields=("target_id",))`, dropping history entirely
- Introduces `RECORD_LIFECYCLE_FIELDS` as a third field category for cumulative fields carried forward AND appended to
- `RecordEnvelope.build*()` now carries both tracking and lifecycle fields via renamed `_carry_persistent_fields()`
- All record assembly paths (including tombstones) automatically preserve the audit trail
- `RECORD_FRAMEWORK_FIELDS` = TRACKING | LIFECYCLE | STAGE — no content leak

## Verification
- 6372 tests passed, 0 failures
- `ruff check` and `ruff format --check` clean
- Targeted tests confirm: `build()` and `build_skipped()` carry `_state_history`, `_state` is NOT carried, lifecycle fields are disjoint from both tracking and stage