### PR TITLE
fix: CLI preview detects tombstones via _state instead of dead _unprocessed field

### DIFF
--- a/agent_actions/cli/preview.py
+++ b/agent_actions/cli/preview.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 
 import click
 from rich.console import Console
@@ -12,7 +13,17 @@ from rich.table import Table
 
 from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
 from agent_actions.config.project_paths import ProjectPathsFactory
+from agent_actions.record.state import CASCADE_BLOCKING_STATES, RecordState
 from agent_actions.storage import get_storage_backend
+
+_TOMBSTONE_STATES: frozenset[str] = frozenset(
+    s.value for s in CASCADE_BLOCKING_STATES | {RecordState.GUARD_SKIPPED}
+)
+
+
+def _is_tombstone(record: dict[str, Any]) -> bool:
+    """Detect non-content records that should render as labeled placeholders."""
+    return record.get("_state") in _TOMBSTONE_STATES
 
 
 class PreviewCommand:
@@ -159,9 +170,9 @@ class PreviewCommand:
         {"action_a": {...}, "action_b": {...}, ...}. When previewing a
         specific action, unwrap so all formats show that action's fields.
 
-        Guard-skipped actions have ``content[action] = None`` and carry
-        ``_unprocessed: True`` with ``metadata.reason``.  Content is set
-        to ``{}`` so json/raw formats show the real record structure
+        Guard-skipped actions have ``content[action] = None`` and a
+        non-processable ``_state`` with ``metadata.reason``.  Content is
+        set to ``{}`` so json/raw formats show the real record structure
         (empty content + metadata) rather than an invented sentinel.
         """
         if not self.action:
@@ -190,7 +201,7 @@ class PreviewCommand:
 
         all_keys: set[str] = set()
         for record in records:
-            if isinstance(record, dict) and not record.get("_unprocessed"):
+            if isinstance(record, dict) and not _is_tombstone(record):
                 if "content" in record and isinstance(record["content"], dict):
                     all_keys.update(record["content"].keys())
                 else:
@@ -211,9 +222,8 @@ class PreviewCommand:
 
         for idx, record in enumerate(records, self.offset + 1):
             if isinstance(record, dict):
-                if record.get("_unprocessed"):
-                    reason = record.get("metadata", {}).get("reason", "skipped")
-                    label = f"[{reason.replace('_', '-')}]"
+                if _is_tombstone(record):
+                    label = f"[{record['_state'].replace('_', '-')}]"
                     values = [str(idx), rich_escape(label)]
                     values.extend("" for _ in display_keys[1:])
                     table.add_row(*values)

--- a/tests/unit/cli/test_preview_namespace.py
+++ b/tests/unit/cli/test_preview_namespace.py
@@ -7,7 +7,7 @@ guard-skipped actions (null namespace).
 
 import json
 
-from agent_actions.cli.preview import PreviewCommand
+from agent_actions.cli.preview import PreviewCommand, _is_tombstone
 
 NAMESPACED_RECORDS = [
     {
@@ -33,7 +33,7 @@ GUARD_SKIPPED_RECORDS = [
             "classify": {"genre": "fiction"},
             "review": None,
         },
-        "_unprocessed": True,
+        "_state": "guard_skipped",
         "metadata": {"reason": "guard_skip", "agent_type": "tombstone"},
     },
     {
@@ -42,8 +42,37 @@ GUARD_SKIPPED_RECORDS = [
             "classify": {"genre": "nonfiction"},
             "review": {"quality": "good"},
         },
+        "_state": "processed",
     },
 ]
+
+
+class TestIsTombstone:
+    """_is_tombstone detects non-content records via _state."""
+
+    def test_guard_skipped_state(self):
+        assert _is_tombstone({"_state": "guard_skipped"}) is True
+
+    def test_cascade_skipped_state(self):
+        assert _is_tombstone({"_state": "cascade_skipped"}) is True
+
+    def test_failed_state(self):
+        assert _is_tombstone({"_state": "failed"}) is True
+
+    def test_exhausted_state(self):
+        assert _is_tombstone({"_state": "exhausted"}) is True
+
+    def test_processed_state_is_not_tombstone(self):
+        assert _is_tombstone({"_state": "processed"}) is False
+
+    def test_committed_state_is_not_tombstone(self):
+        assert _is_tombstone({"_state": "committed"}) is False
+
+    def test_active_state_is_not_tombstone(self):
+        assert _is_tombstone({"_state": "active"}) is False
+
+    def test_missing_state_is_not_tombstone(self):
+        assert _is_tombstone({"content": {"field": "value"}}) is False
 
 
 class TestUnwrapRecords:
@@ -101,7 +130,7 @@ class TestUnwrapRecords:
         """Batch with both skipped and normal records."""
         result = self._cmd("review")._unwrap_records(GUARD_SKIPPED_RECORDS)
         assert result[0]["content"] == {}
-        assert result[0]["_unprocessed"] is True
+        assert result[0]["_state"] == "guard_skipped"
         assert result[1]["content"] == {"quality": "good"}
 
 
@@ -144,14 +173,14 @@ class TestShowTableNamespaceUnwrap:
 
 
 class TestGuardSkippedDisplay:
-    """Display methods render guard-skipped records using real metadata."""
+    """Display methods render guard-skipped records with _state as label."""
 
-    def test_table_shows_reason_from_metadata(self, capsys):
+    def test_table_shows_state_as_label(self, capsys):
         cmd = PreviewCommand(workflow="test_wf", action="review")
         records = cmd._unwrap_records(GUARD_SKIPPED_RECORDS)
         cmd._show_table(records)
         output = capsys.readouterr().out
-        assert "[guard-skip]" in output
+        assert "[guard-skipped]" in output
         assert "good" in output  # non-skipped record renders normally
 
     def test_table_skipped_row_does_not_pollute_columns(self, capsys):
@@ -161,15 +190,27 @@ class TestGuardSkippedDisplay:
         cmd._show_table(records)
         output = capsys.readouterr().out
         assert "quality" in output  # column from normal record
-        assert "_unprocessed" not in output
+        assert "_state" not in output
         assert "metadata" not in output
+
+    def test_cascade_skipped_renders_as_tombstone(self, capsys):
+        """cascade_skipped state renders with _state as label."""
+        records = [
+            {"content": {}, "_state": "cascade_skipped"},
+            {"content": {"name": "Alice"}, "_state": "processed"},
+        ]
+        cmd = PreviewCommand(workflow="test_wf", action=None)
+        cmd._show_table(records)
+        output = capsys.readouterr().out
+        assert "[cascade-skipped]" in output
+        assert "Alice" in output
 
     def test_json_shows_real_record_structure(self, capsys):
         cmd = PreviewCommand(workflow="test_wf", action="review")
         records = cmd._unwrap_records(GUARD_SKIPPED_RECORDS)
         cmd._show_json(records)
         output = capsys.readouterr().out
-        assert '"_unprocessed": true' in output
+        assert '"guard_skipped"' in output
         assert '"guard_skip"' in output
         assert "quality" in output
 
@@ -180,7 +221,7 @@ class TestGuardSkippedDisplay:
         output = capsys.readouterr().out
         parsed = json.loads(output)
         assert parsed[0]["content"] == {}
-        assert parsed[0]["_unprocessed"] is True
+        assert parsed[0]["_state"] == "guard_skipped"
         assert parsed[0]["metadata"]["reason"] == "guard_skip"
         assert parsed[1]["content"] == {"quality": "good"}
 


### PR DESCRIPTION
## Summary
- `preview.py` branched on `record.get("_unprocessed")` which is no longer written by any production code path — every tombstone rendered as a blank normal row
- Replaced with `_is_tombstone()` that reads `_state` (the sole lifecycle authority)
- Tombstone states derived compositionally from `CASCADE_BLOCKING_STATES | {GUARD_SKIPPED}` to avoid drift if new states are added

## Verification
- 26 preview tests pass (8 new for `_is_tombstone`, 1 new for cascade display)
- Full suite: 6400 passed
- `ruff check` + `ruff format --check` clean