### PR TITLE
fix: return error dict on JSON parse failure instead of raising

### DIFF
--- a/.changes/unreleased/Bug Fix-20260504-491000.yaml
+++ b/.changes/unreleased/Bug Fix-20260504-491000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Return error dict instead of raising VendorAPIError on JSON parse failure in ollama cloud and openai online clients, enabling reprompt loop to retry with JSON-specific feedback"
+time: 2026-05-04T14:49:10.000000Z

--- a/agent_actions/llm/providers/ollama/client.py
+++ b/agent_actions/llm/providers/ollama/client.py
@@ -21,7 +21,7 @@ import httpx
 from ollama import Client, ResponseError
 
 from agent_actions.config.defaults import OllamaCloudDefaults
-from agent_actions.errors import ConfigurationError, VendorAPIError
+from agent_actions.errors import ConfigurationError
 from agent_actions.llm.providers.client_base import BaseClient
 from agent_actions.llm.providers.error_wrapper import VendorErrorMapping, wrap_vendor_error
 from agent_actions.llm.providers.generation_params import extract_generation_params
@@ -170,13 +170,14 @@ def _call_ollama_json(
             parsed = json.loads(content)
             return [parsed] if isinstance(parsed, dict) else [{"response": parsed}]
         except json.JSONDecodeError as e:
-            logger.debug("JSON parse failed: %s, request_id=%s", e, request_id)
+            logger.warning(
+                "%s/%s returned invalid JSON: %s",
+                vendor_slug,
+                model,
+                e,
+            )
             fire_event(LLMJSONParseErrorEvent(provider=vendor_slug, model=model, error=str(e)))
-            raise VendorAPIError(
-                f"Ollama returned invalid JSON: {e}",
-                context={"vendor": vendor_slug, "request_id": request_id},
-                cause=e,
-            ) from e
+            return [{"raw_response": content or "", "_parse_error": str(e)}]
     if isinstance(content, dict):
         return [content]
     return [{"response": content}]

--- a/agent_actions/llm/providers/openai/client.py
+++ b/agent_actions/llm/providers/openai/client.py
@@ -127,14 +127,11 @@ class OpenAIClient(BaseClient):
                     request_id=request_id,
                 )
             )
-            raise VendorAPIError(
-                "Empty response content from OpenAI API",
-                context={
-                    "model_name": model_name,
-                    "vendor": "openai",
-                    "api_operation": "chat.completions.create",
-                },
+            logger.warning(
+                "Empty response content from OpenAI API, model=%s",
+                model_name,
             )
+            return [{"raw_response": "", "_parse_error": "Empty response from API"}]
         try:
             response_data: dict[str, Any] | list[dict[str, Any]] = json.loads(response_content)
         except json.JSONDecodeError as e:
@@ -152,15 +149,7 @@ class OpenAIClient(BaseClient):
                     request_id=request_id,
                 )
             )
-            raise VendorAPIError(
-                f"Failed to parse JSON response from OpenAI: {e}",
-                context={
-                    "model_name": model_name,
-                    "vendor": "openai",
-                    "api_operation": "chat.completions.create",
-                    "raw_response_snippet": response_content[:200],
-                },
-            ) from e
+            return [{"raw_response": response_content, "_parse_error": str(e)}]
         response_list: list[dict[str, Any]] = (
             response_data if isinstance(response_data, list) else [response_data]
         )

--- a/agent_actions/llm/providers/openai/client.py
+++ b/agent_actions/llm/providers/openai/client.py
@@ -136,8 +136,9 @@ class OpenAIClient(BaseClient):
             response_data: dict[str, Any] | list[dict[str, Any]] = json.loads(response_content)
         except json.JSONDecodeError as e:
             logger.warning(
-                "Failed to parse JSON from OpenAI response: %s",
+                "Failed to parse JSON from OpenAI response: %s (snippet: %.200s)",
                 e,
+                response_content,
                 extra={"model": model_name, "operation": "call_json"},
             )
             fire_event(

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -19,6 +19,21 @@ from .response_validator import (
 )
 from .retry import RetryExhaustedException
 
+_JSON_PARSE_FEEDBACK = (
+    "Your previous response was not valid JSON. "
+    "Return only a JSON object — no markdown, no explanation, no code fences."
+)
+
+
+def _get_parse_error(response: Any) -> str | None:
+    """Return ``_parse_error`` string if *response* signals a provider JSON parse failure."""
+    if isinstance(response, list) and response and isinstance(response[0], dict):
+        return response[0].get("_parse_error") or None
+    if isinstance(response, dict):
+        return response.get("_parse_error") or None
+    return None
+
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -187,7 +202,18 @@ class RepromptService:
 
             last_response = response
 
-            is_valid = safe_validate(self._validator.validate, response, context=context)
+            parse_error = _get_parse_error(response)
+            if parse_error is not None:
+                is_valid = False
+                logger.warning(
+                    "[%s] Provider returned invalid JSON on attempt %d/%d: %s",
+                    context,
+                    attempts,
+                    self.max_attempts,
+                    parse_error,
+                )
+            else:
+                is_valid = safe_validate(self._validator.validate, response, context=context)
 
             if is_valid:
                 logger.info(
@@ -215,9 +241,12 @@ class RepromptService:
             if attempts >= self.max_attempts:
                 break
 
-            feedback = build_validation_feedback(
-                response, self._validator.feedback_message, strategies=self._strategies
-            )
+            if parse_error is not None:
+                feedback = _JSON_PARSE_FEEDBACK
+            else:
+                feedback = build_validation_feedback(
+                    response, self._validator.feedback_message, strategies=self._strategies
+                )
 
             if self._critique_fn is not None and attempts >= self._critique_after_attempt:
                 try:
@@ -256,6 +285,15 @@ class RepromptService:
                 f"Reprompt validation exhausted after {attempts} attempts "
                 f"(validation: {self.validation_name})"
             )
+
+        if _get_parse_error(last_response) is not None:
+            logger.warning(
+                "[%s] Exhausted after %d attempts with persistent parse errors "
+                "— returning empty fields so downstream actions are not blocked",
+                context,
+                attempts,
+            )
+            last_response = [{}]
 
         return RepromptResult(
             response=last_response,

--- a/tests/unit/core/test_reprompt_service.py
+++ b/tests/unit/core/test_reprompt_service.py
@@ -11,6 +11,7 @@ import pytest
 
 from agent_actions.processing.recovery.reprompt import (
     RepromptService,
+    _get_parse_error,
     create_reprompt_service_from_config,
     parse_reprompt_config,
 )
@@ -738,3 +739,152 @@ class TestRepromptServiceRetryExhaustion:
 
         assert "Retry exhausted" in str(exc_info.value)
         assert "429 throttled" in str(exc_info.value)
+
+
+class TestGetParseError:
+    """Tests for _get_parse_error helper."""
+
+    def test_list_with_parse_error(self):
+        assert _get_parse_error([{"_parse_error": "bad json"}]) == "bad json"
+
+    def test_bare_dict_with_parse_error(self):
+        assert _get_parse_error({"_parse_error": "bad json"}) == "bad json"
+
+    def test_list_without_parse_error(self):
+        assert _get_parse_error([{"value": 10}]) is None
+
+    def test_bare_dict_without_parse_error(self):
+        assert _get_parse_error({"value": 10}) is None
+
+    def test_empty_list(self):
+        assert _get_parse_error([]) is None
+
+    def test_empty_dict(self):
+        """[{}] is the exhaustion sentinel — must not re-trigger parse error detection."""
+        assert _get_parse_error([{}]) is None
+
+    def test_none(self):
+        assert _get_parse_error(None) is None
+
+    def test_empty_string_parse_error_returns_none(self):
+        """An empty _parse_error value should not be treated as a parse error."""
+        assert _get_parse_error([{"_parse_error": ""}]) is None
+        assert _get_parse_error({"_parse_error": ""}) is None
+
+    def test_nested_parse_error_not_detected(self):
+        """_parse_error inside nested content must not be detected."""
+        assert _get_parse_error([{"content": {"ns": {"_parse_error": "oops"}}}]) is None
+
+
+class TestRepromptServiceParseError:
+    """Tests for _parse_error detection and recovery in the reprompt loop."""
+
+    def setup_method(self):
+        _VALIDATION_REGISTRY.clear()
+
+        @reprompt_validation("Must be valid")
+        def always_pass(response: dict) -> bool:
+            return True
+
+    def test_parse_error_forces_retry(self):
+        """A _parse_error response should force retry even when validator always passes."""
+        service = RepromptService(
+            validation_name="always_pass", max_attempts=3, on_exhausted="return_last"
+        )
+
+        llm_operation = Mock(
+            side_effect=[
+                ([{"raw_response": "", "_parse_error": "Expecting value"}], True),
+                ({"value": 42}, True),  # valid on attempt 2
+            ]
+        )
+
+        result = service.execute(
+            llm_operation=llm_operation, original_prompt="Test prompt", context="test"
+        )
+
+        assert llm_operation.call_count == 2
+        assert result.response == {"value": 42}
+        assert result.passed is True
+        assert result.attempts == 2
+
+    def test_parse_error_uses_json_feedback(self):
+        """When parse error occurs, the reprompt prompt should contain JSON feedback."""
+        service = RepromptService(
+            validation_name="always_pass", max_attempts=2, on_exhausted="return_last"
+        )
+
+        llm_operation = Mock(
+            side_effect=[
+                ([{"raw_response": "", "_parse_error": "Expecting value"}], True),
+                ({"value": 42}, True),
+            ]
+        )
+
+        service.execute(llm_operation=llm_operation, original_prompt="Test prompt", context="test")
+
+        # Second call should include JSON feedback in the prompt
+        second_call_prompt = llm_operation.call_args_list[1][0][0]
+        assert "not valid JSON" in second_call_prompt
+        assert "no markdown" in second_call_prompt
+
+    def test_parse_error_exhaustion_returns_empty(self):
+        """On exhaustion with persistent parse errors, return [{}] not the error dict."""
+        service = RepromptService(
+            validation_name="always_pass", max_attempts=2, on_exhausted="return_last"
+        )
+
+        llm_operation = Mock(
+            side_effect=[
+                ([{"raw_response": "", "_parse_error": "Expecting value"}], True),
+                ([{"raw_response": "", "_parse_error": "Expecting value"}], True),
+            ]
+        )
+
+        result = service.execute(
+            llm_operation=llm_operation, original_prompt="Test prompt", context="test"
+        )
+
+        assert llm_operation.call_count == 2
+        assert result.response == [{}]
+        assert result.passed is False
+        assert result.exhausted is True
+
+    def test_parse_error_exhaustion_with_raise(self):
+        """on_exhausted='raise' should raise RuntimeError, not return [{}]."""
+        service = RepromptService(
+            validation_name="always_pass", max_attempts=2, on_exhausted="raise"
+        )
+
+        llm_operation = Mock(
+            side_effect=[
+                ([{"raw_response": "", "_parse_error": "Expecting value"}], True),
+                ([{"raw_response": "", "_parse_error": "Expecting value"}], True),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="exhausted"):
+            service.execute(
+                llm_operation=llm_operation, original_prompt="Test prompt", context="test"
+            )
+
+    def test_good_response_after_parse_error_not_corrupted(self):
+        """parse_error must not carry across iterations — good response on attempt 2 uses validator."""
+        service = RepromptService(
+            validation_name="always_pass", max_attempts=3, on_exhausted="return_last"
+        )
+
+        llm_operation = Mock(
+            side_effect=[
+                ([{"raw_response": "", "_parse_error": "bad"}], True),
+                ({"value": 10}, True),  # valid, no _parse_error
+            ]
+        )
+
+        result = service.execute(
+            llm_operation=llm_operation, original_prompt="Test prompt", context="test"
+        )
+
+        assert result.response == {"value": 10}
+        assert result.passed is True
+        assert result.attempts == 2

--- a/tests/unit/llm/providers/ollama/test_ollama_vendor_split.py
+++ b/tests/unit/llm/providers/ollama/test_ollama_vendor_split.py
@@ -266,6 +266,37 @@ class TestOllamaCloudClient:
             "Cloud JSON call must NOT pass 'format' to chat() (structured output not supported yet)"
         )
 
+    @patch("agent_actions.llm.providers.ollama.client.ResponseBuilder")
+    @patch("agent_actions.llm.providers.ollama.client.fire_event")
+    @patch("agent_actions.llm.providers.ollama.client._build_ollama_client")
+    @patch("agent_actions.llm.providers.ollama.client.MessageBuilder")
+    def test_call_json_returns_error_dict_on_invalid_json(
+        self, mock_mb, mock_build, mock_fire, mock_rb
+    ):
+        """Invalid JSON returns error dict instead of raising VendorAPIError."""
+        mock_envelope = MagicMock()
+        mock_envelope.to_dicts.return_value = [{"role": "user", "content": "hi"}]
+        mock_mb.build.return_value = mock_envelope
+
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _fake_chat_response(content="not json at all")
+        mock_build.return_value = mock_client
+
+        config = _make_agent_config()
+        result = _call_ollama_json(
+            "some-api-key",
+            config,
+            PROMPT,
+            CONTEXT,
+            SCHEMA,
+            vendor_slug="ollama_cloud",
+            cloud=True,
+        )
+
+        assert len(result) == 1
+        assert result[0]["_parse_error"]
+        assert result[0]["raw_response"] == "not json at all"
+
     def test_missing_api_key_raises_configuration_error(self):
         """_build_ollama_client(cloud=True) without api_key raises ConfigurationError."""
         config = _make_agent_config()

--- a/tests/unit/llm_invocation/providers/test_non_json_standardization.py
+++ b/tests/unit/llm_invocation/providers/test_non_json_standardization.py
@@ -833,6 +833,47 @@ class TestOpenAITopPStopForwarding:
         assert call_kwargs["presence_penalty"] == 0.3
 
 
+class TestOpenAICallJsonParseErrors:
+    """OpenAI call_json returns error dict instead of raising on bad JSON."""
+
+    @patch("agent_actions.llm.providers.openai.client.fire_event")
+    @patch("agent_actions.llm.providers.openai.client.OpenAI")
+    def test_empty_response_returns_error_dict(self, mock_openai_cls, mock_fire):
+        from agent_actions.llm.providers.openai.client import OpenAIClient
+
+        mock_response = _make_openai_style_mocks(None)
+        mock_response.choices[0].message.content = None
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_cls.return_value = mock_client
+
+        config = {"model_name": "gpt-4"}
+        schema = {"name": "test", "strict": True, "schema": {"type": "object", "properties": {}}}
+        result = OpenAIClient.call_json("key", config, "prompt", "data", schema)
+
+        assert len(result) == 1
+        assert result[0]["_parse_error"] == "Empty response from API"
+        assert result[0]["raw_response"] == ""
+
+    @patch("agent_actions.llm.providers.openai.client.fire_event")
+    @patch("agent_actions.llm.providers.openai.client.OpenAI")
+    def test_invalid_json_returns_error_dict(self, mock_openai_cls, mock_fire):
+        from agent_actions.llm.providers.openai.client import OpenAIClient
+
+        mock_response = _make_openai_style_mocks("not valid json {{{")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_cls.return_value = mock_client
+
+        config = {"model_name": "gpt-4"}
+        schema = {"name": "test", "strict": True, "schema": {"type": "object", "properties": {}}}
+        result = OpenAIClient.call_json("key", config, "prompt", "data", schema)
+
+        assert len(result) == 1
+        assert "Expecting value" in result[0]["_parse_error"]
+        assert result[0]["raw_response"] == "not valid json {{{"
+
+
 class TestAnthropicStopForwarding:
     """Anthropic maps stop → stop_sequences (as list)."""
 


### PR DESCRIPTION
## Summary
- **ollama cloud** and **openai online** clients raised `VendorAPIError` when the model returned empty or malformed JSON — the exception escaped the reprompt loop entirely, so `on_schema_mismatch: reprompt` / `max_attempts` / `on_exhausted: return_last` had no effect
- Both providers now return `{"raw_response": ..., "_parse_error": ...}` (aligned with the `JSONResponseMixin` pattern used by Groq, Gemini, Mistral, Cohere)
- The reprompt service detects `_parse_error` **before** user validators run, retries with JSON-specific feedback, and on exhaustion returns `[{}]` so downstream actions are not cascade-skipped
- When reprompt is **not** configured, `result_collector`'s existing `_parse_error` → FAILED backstop still applies (unchanged)

## Changes
| File | What |
|------|------|
| `ollama/client.py` | Return error dict instead of raise; `debug` → `warning`; removed unused `VendorAPIError` import |
| `openai/client.py` | Return error dict on both empty response and JSON parse failure |
| `reprompt.py` | `_get_parse_error()` helper, pre-filter before `safe_validate`, JSON feedback, `[{}]` on parse-error exhaustion |
| `test_reprompt_service.py` | 16 new tests: helper (8 cases), reprompt loop (5 cases incl. exhaustion, raise, feedback, no stale carry) |

## Verification
- `ruff check` + `ruff format --check` clean
- `pytest` — 6414 passed, 2 skipped, 0 failures