### PR TITLE
refactor: consolidate on_schema_mismatch into reprompt config

### DIFF
--- a/.changes/unreleased/Breaking Change-20260504-493000.yaml
+++ b/.changes/unreleased/Breaking Change-20260504-493000.yaml
@@ -1,0 +1,3 @@
+kind: Breaking Change
+body: "Remove top-level on_schema_mismatch and strict_schema config keys. Schema conformance is now declared inside reprompt: {on_schema_mismatch: reject/reprompt}."
+time: 2026-05-04T04:93:00.000000Z

--- a/.changes/unreleased/Breaking Change-20260504-493000.yaml
+++ b/.changes/unreleased/Breaking Change-20260504-493000.yaml
@@ -1,3 +1,3 @@
 kind: Breaking Change
 body: "Remove top-level on_schema_mismatch and strict_schema config keys. Schema conformance is now declared inside reprompt: {on_schema_mismatch: reject/reprompt}."
-time: 2026-05-04T04:93:00.000000Z
+time: 2026-05-04T14:33:00.000000Z

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -93,6 +93,8 @@ class RepromptConfig(BaseModel):
     itself serves as the validator.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     validation: str | None = Field(default=None, description="Name of validation UDF function")
     on_schema_mismatch: Literal["reject", "reprompt"] | None = Field(
         default=None,

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -89,11 +89,15 @@ class RetryConfig(BaseModel):
 class RepromptConfig(BaseModel):
     """Configuration for reprompt behavior on validation failures.
 
-    ``validation`` is optional when an external validator is provided
-    (e.g. via ``on_schema_mismatch: reprompt``).
+    ``validation`` is optional when ``on_schema_mismatch`` is set — the schema
+    itself serves as the validator.
     """
 
     validation: str | None = Field(default=None, description="Name of validation UDF function")
+    on_schema_mismatch: Literal["reject", "reprompt"] | None = Field(
+        default=None,
+        description="Schema conformance check: reject (hard fail) or reprompt (retry on mismatch)",
+    )
     max_attempts: int = Field(
         default=2,
         ge=1,
@@ -186,12 +190,6 @@ class ActionConfig(BaseModel):
     )
     reprompt: RepromptConfig | None = Field(
         default=None, description="Reprompt configuration for validation failures"
-    )
-    strict_schema: bool | None = Field(
-        default=None, description="Enable strict schema validation (reject on mismatch)"
-    )
-    on_schema_mismatch: Literal["warn", "reprompt", "reject"] | None = Field(
-        default=None, description="Schema mismatch mode: warn, reprompt, or reject"
     )
     idempotency_key: str | None = Field(default=None, description="Idempotency key template")
     prompt: str | None = Field(default=None, description="Prompt template or reference")
@@ -361,10 +359,6 @@ class DefaultsConfig(BaseModel):
     )
     constraints: Any | None = Field(default=None, description="Default constraints")
     retry: RetryConfig | None = Field(default=None, description="Default retry configuration")
-    strict_schema: bool | None = Field(default=None, description="Default strict schema flag")
-    on_schema_mismatch: Literal["warn", "reprompt", "reject"] | None = Field(
-        default=None, description="Default schema mismatch mode"
-    )
 
     # --- Expander-consumed keys ---
     context_scope: dict[str, Any] | None = Field(default=None, description="Default ctx scope")

--- a/agent_actions/llm/providers/ollama/client.py
+++ b/agent_actions/llm/providers/ollama/client.py
@@ -170,7 +170,7 @@ def _call_ollama_json(
             parsed = json.loads(content)
             return [parsed] if isinstance(parsed, dict) else [{"response": parsed}]
         except json.JSONDecodeError as e:
-            logger.warning(
+            logger.debug(
                 "%s/%s returned invalid JSON: %s",
                 vendor_slug,
                 model,

--- a/agent_actions/llm/providers/openai/client.py
+++ b/agent_actions/llm/providers/openai/client.py
@@ -127,7 +127,7 @@ class OpenAIClient(BaseClient):
                     request_id=request_id,
                 )
             )
-            logger.warning(
+            logger.debug(
                 "Empty response content from OpenAI API, model=%s",
                 model_name,
             )
@@ -135,7 +135,7 @@ class OpenAIClient(BaseClient):
         try:
             response_data: dict[str, Any] | list[dict[str, Any]] = json.loads(response_content)
         except json.JSONDecodeError as e:
-            logger.warning(
+            logger.debug(
                 "Failed to parse JSON from OpenAI response: %s (snippet: %.200s)",
                 e,
                 response_content,

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from agent_actions.errors import SchemaValidationError
-from agent_actions.utils.constants import ON_SCHEMA_MISMATCH_KEY, SCHEMA_KEY, STRICT_SCHEMA_KEY
+from agent_actions.utils.constants import SCHEMA_KEY
 from agent_actions.utils.transformation import PassthroughTransformer
 
 logger = logging.getLogger(__name__)
@@ -70,20 +70,14 @@ def run_dynamic_agent(
 
 
 def _resolve_schema_mismatch_mode(agent_config: dict[str, Any]) -> str:
-    """Resolve on_schema_mismatch to 'warn', 'reprompt', or 'reject'."""
-    explicit = agent_config.get(ON_SCHEMA_MISMATCH_KEY)
-    if explicit in ("warn", "reprompt", "reject"):
-        return str(explicit)
+    """Resolve schema mismatch mode from reprompt.on_schema_mismatch.
 
-    if explicit is not None:
-        logger.warning(
-            "Unrecognized on_schema_mismatch value '%s', defaulting to 'warn'",
-            explicit,
-        )
-
-    if agent_config.get(STRICT_SCHEMA_KEY, False):
-        return "reject"
-
+    Returns ``"reject"``, ``"reprompt"``, or ``"warn"`` (internal signal for
+    no enforcement).
+    """
+    reprompt = agent_config.get("reprompt")
+    if isinstance(reprompt, dict) and reprompt.get("on_schema_mismatch"):
+        return str(reprompt["on_schema_mismatch"])
     return "warn"
 
 
@@ -96,9 +90,9 @@ def _validate_llm_output_schema(
 ) -> Any:
     """Validate LLM output against expected schema if defined.
 
-    Returns the response unchanged. When ``on_schema_mismatch`` is "reprompt"
-    and ``skip_schema_validation`` is True, validation is deferred to the
-    outer reprompt loop.
+    Returns the response unchanged. When ``reprompt.on_schema_mismatch`` is
+    "reprompt" and ``skip_schema_validation`` is True, validation is deferred
+    to the outer reprompt loop.
 
     Raises:
         SchemaValidationError: If on_schema_mismatch="reject" and validation fails.
@@ -108,9 +102,8 @@ def _validate_llm_output_schema(
         mismatch_mode = _resolve_schema_mismatch_mode(agent_config)
         if mismatch_mode in ("reject", "reprompt"):
             logger.warning(
-                "Action '%s': on_schema_mismatch is '%s' but no schema is defined — "
-                "schema validation will be skipped. Define a schema or set "
-                "on_schema_mismatch to 'warn'.",
+                "Action '%s': reprompt.on_schema_mismatch is '%s' but no schema is "
+                "defined — schema validation will be skipped.",
                 agent_name,
                 mismatch_mode,
             )
@@ -141,8 +134,8 @@ def _validate_llm_output_schema(
         if not report.is_compliant:
             if strict_mode:
                 hint = (
-                    "Enable strict_schema: false to allow schema mismatches, "
-                    "or update the prompt to match expected schema"
+                    "Remove reprompt.on_schema_mismatch: reject to allow schema "
+                    "mismatches, or update the prompt to match expected schema"
                 )
                 if report.namespace_hint:
                     hint = f"{hint}. {report.namespace_hint}"

--- a/agent_actions/processing/invocation/factory.py
+++ b/agent_actions/processing/invocation/factory.py
@@ -77,7 +77,7 @@ class InvocationStrategyFactory:
             SchemaValidator,
             UdfValidator,
         )
-        from agent_actions.utils.constants import SCHEMA_KEY, STRICT_SCHEMA_KEY
+        from agent_actions.utils.constants import SCHEMA_KEY
 
         validators: list[ResponseValidator] = []
 
@@ -92,8 +92,7 @@ class InvocationStrategyFactory:
             mode = _resolve_schema_mismatch_mode(agent_config)
             if mode == "reprompt":
                 action_name = agent_config.get("name", "unknown")
-                strict = agent_config.get(STRICT_SCHEMA_KEY, False)
-                validators.append(SchemaValidator(schema, action_name, strict_mode=strict))
+                validators.append(SchemaValidator(schema, action_name))
 
         if not validators:
             return None

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -19,38 +19,46 @@ from .response_validator import (
 )
 from .retry import RetryExhaustedException
 
-_JSON_PARSE_FEEDBACK = (
-    "Your previous response was not valid JSON. "
-    "Return only a JSON object — no markdown, no explanation, no code fences."
-)
+
+def _extract_field_names(schema: dict) -> list[str]:
+    """Extract field names from any schema format."""
+    # fields-style (agent-actions format)
+    fields = schema.get("fields")
+    if isinstance(fields, list):
+        return [f.get("id") or f.get("name", "") for f in fields if isinstance(f, dict)]
+    # properties-style (JSON Schema format)
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        return list(props.keys())
+    # Inline schema: keys are field names directly
+    if all(isinstance(v, str) for v in schema.values()):
+        return list(schema.keys())
+    return []
 
 
 def _build_json_parse_feedback(validator: Any) -> str:
-    """Build JSON parse error feedback, including expected schema fields if available."""
-    base = _JSON_PARSE_FEEDBACK
-
-    # If the validator is a SchemaValidator, extract field names to guide the model
+    """Build forceful JSON parse error feedback with expected schema fields."""
     schema = getattr(validator, "_schema", None)
-    if not isinstance(schema, dict):
-        return base
+    field_names = _extract_field_names(schema) if isinstance(schema, dict) else []
 
-    # Try fields-style schema (agent-actions format)
-    fields = schema.get("fields")
-    if isinstance(fields, list):
-        names = [f.get("id") or f.get("name", "") for f in fields if isinstance(f, dict)]
-        if names:
-            return f"{base}\n\nExpected JSON fields: {', '.join(names)}"
+    if field_names:
+        fields_str = ", ".join(field_names)
+        return (
+            "CRITICAL: Your previous response was empty or not valid JSON. "
+            "This is a strict JSON pipeline — every response MUST be a single "
+            "JSON object. No markdown. No code fences. No explanation. No "
+            "preamble. Just the raw JSON object.\n\n"
+            f"You MUST return a JSON object with these fields: {fields_str}\n\n"
+            "Example structure:\n"
+            "{\n" + "".join(f'  "{name}": "...",\n' for name in field_names) + "}"
+        )
 
-    # Try properties-style schema (JSON Schema format)
-    props = schema.get("properties")
-    if isinstance(props, dict):
-        return f"{base}\n\nExpected JSON fields: {', '.join(props.keys())}"
-
-    # Inline schema: keys are field names directly
-    if all(isinstance(v, str) for v in schema.values()):
-        return f"{base}\n\nExpected JSON fields: {', '.join(schema.keys())}"
-
-    return base
+    return (
+        "CRITICAL: Your previous response was empty or not valid JSON. "
+        "This is a strict JSON pipeline — every response MUST be a single "
+        "JSON object. No markdown. No code fences. No explanation. No "
+        "preamble. Just the raw JSON object."
+    )
 
 
 def _get_parse_error(response: Any) -> str | None:

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -25,6 +25,34 @@ _JSON_PARSE_FEEDBACK = (
 )
 
 
+def _build_json_parse_feedback(validator: Any) -> str:
+    """Build JSON parse error feedback, including expected schema fields if available."""
+    base = _JSON_PARSE_FEEDBACK
+
+    # If the validator is a SchemaValidator, extract field names to guide the model
+    schema = getattr(validator, "_schema", None)
+    if not isinstance(schema, dict):
+        return base
+
+    # Try fields-style schema (agent-actions format)
+    fields = schema.get("fields")
+    if isinstance(fields, list):
+        names = [f.get("id") or f.get("name", "") for f in fields if isinstance(f, dict)]
+        if names:
+            return f"{base}\n\nExpected JSON fields: {', '.join(names)}"
+
+    # Try properties-style schema (JSON Schema format)
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        return f"{base}\n\nExpected JSON fields: {', '.join(props.keys())}"
+
+    # Inline schema: keys are field names directly
+    if all(isinstance(v, str) for v in schema.values()):
+        return f"{base}\n\nExpected JSON fields: {', '.join(schema.keys())}"
+
+    return base
+
+
 def _get_parse_error(response: Any) -> str | None:
     """Return ``_parse_error`` string if *response* signals a provider JSON parse failure."""
     if isinstance(response, list) and response and isinstance(response[0], dict):
@@ -251,7 +279,7 @@ class RepromptService:
             )
 
             if parse_error is not None:
-                feedback = _JSON_PARSE_FEEDBACK
+                feedback = _build_json_parse_feedback(self._validator)
             else:
                 feedback = build_validation_feedback(
                     response, self._validator.feedback_message, strategies=self._strategies

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -206,7 +206,7 @@ class RepromptService:
             if parse_error is not None:
                 is_valid = False
                 logger.warning(
-                    "[%s] Provider returned invalid JSON on attempt %d/%d: %s",
+                    "[%s] Invalid JSON on attempt %d/%d — %s",
                     context,
                     attempts,
                     self.max_attempts,
@@ -216,12 +216,13 @@ class RepromptService:
                 is_valid = safe_validate(self._validator.validate, response, context=context)
 
             if is_valid:
-                logger.info(
-                    "[%s] Validation passed on attempt %d/%d",
-                    context,
-                    attempts,
-                    self.max_attempts,
-                )
+                if attempts > 1:
+                    logger.info(
+                        "[%s] Reprompt passed on attempt %d/%d",
+                        context,
+                        attempts,
+                        self.max_attempts,
+                    )
                 return RepromptResult(
                     response=response,
                     executed=True,
@@ -231,15 +232,23 @@ class RepromptService:
                     exhausted=False,
                 )
 
-            logger.warning(
-                "[%s] Validation failed on attempt %d/%d",
-                context,
-                attempts,
-                self.max_attempts,
-            )
+            if parse_error is None:
+                logger.warning(
+                    "[%s] Schema validation failed on attempt %d/%d",
+                    context,
+                    attempts,
+                    self.max_attempts,
+                )
 
             if attempts >= self.max_attempts:
                 break
+
+            logger.info(
+                "[%s] Retrying with feedback (attempt %d/%d)",
+                context,
+                attempts + 1,
+                self.max_attempts,
+            )
 
             if parse_error is not None:
                 feedback = _JSON_PARSE_FEEDBACK

--- a/agent_actions/skills/agac-agent-skills/references/reprompt-patterns.md
+++ b/agent_actions/skills/agac-agent-skills/references/reprompt-patterns.md
@@ -28,9 +28,13 @@ How to configure automatic retry with feedback when LLM output fails validation.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `on_schema_mismatch` | string | None | `"reprompt"` (retry on schema fail) or `"reject"` (hard fail) |
 | `validation` | string | None | Name of `@reprompt_validation` function |
 | `max_attempts` | int | 2 | Total attempts including first try (1-10) |
 | `on_exhausted` | string | `"return_last"` | What to do when all attempts fail |
+| `use_self_reflection` | bool | false | Add self-analysis prompt before retry |
+| `use_llm_critique` | bool | false | Use a second LLM call to critique failures |
+| `critique_after_attempt` | int | 2 | Critique starts on this attempt number |
 
 **`on_exhausted` options:**
 - `"return_last"` — Accept the last response even though it failed validation. Downstream actions receive potentially invalid data.

--- a/agent_actions/skills/agac-agent-skills/references/reprompt-patterns.md
+++ b/agent_actions/skills/agac-agent-skills/references/reprompt-patterns.md
@@ -38,14 +38,14 @@ How to configure automatic retry with feedback when LLM output fails validation.
 
 ## Schema-Based Reprompt (No Custom UDF)
 
-For simple schema validation without writing Python, use `on_schema_mismatch`:
+For simple schema validation without writing Python, set `on_schema_mismatch` inside the `reprompt` block:
 
 ```yaml
 - name: classify_issue
   schema: issue_classification
   json_mode: true
-  on_schema_mismatch: reprompt         # "warn" | "reprompt" | "reject"
   reprompt:
+    on_schema_mismatch: reprompt       # "reprompt" | "reject"
     max_attempts: 3
 ```
 
@@ -101,13 +101,13 @@ tools/
 
 ## Composed Validators
 
-When both `validation` (custom UDF) and `on_schema_mismatch: reprompt` are configured, validators are composed — the schema check runs first, then the custom UDF. Fails on the first failure.
+When both `validation` (custom UDF) and `on_schema_mismatch: reprompt` are configured in the same `reprompt` block, validators are composed — the schema check runs first, then the custom UDF. Fails on the first failure.
 
 ```yaml
 - name: generate_catalog_entry
   schema: catalog_entry
-  on_schema_mismatch: reprompt         # Layer 1: schema check
   reprompt:
+    on_schema_mismatch: reprompt       # Layer 1: schema check
     validation: "check_valid_bisac"    # Layer 2: custom business logic
     max_attempts: 3
 ```
@@ -189,8 +189,8 @@ def check_genre_classification(response: dict) -> bool:
     entities: array[string]!           # Required array of strings
     confidence: number!                # Required number
   json_mode: true
-  on_schema_mismatch: reprompt
   reprompt:
+    on_schema_mismatch: reprompt
     max_attempts: 2
     on_exhausted: raise                # Fail if schema still violated
 ```

--- a/agent_actions/utils/constants.py
+++ b/agent_actions/utils/constants.py
@@ -12,8 +12,6 @@ API_KEY_KEY = "api_key"
 PROMPT_KEY = "prompt"
 SCHEMA_NAME_KEY = "schema_name"
 SCHEMA_KEY = "schema"
-STRICT_SCHEMA_KEY = "strict_schema"
-ON_SCHEMA_MISMATCH_KEY = "on_schema_mismatch"
 CHUNK_CONFIG_KEY = "chunk_config"
 
 # Reserved agent/action names that cannot be used in workflows.

--- a/agent_actions/validation/action_validators/granularity_output_field_validator.py
+++ b/agent_actions/validation/action_validators/granularity_output_field_validator.py
@@ -55,7 +55,8 @@ class GranularityAndOutputFieldValidator(BaseActionEntryValidator):
             if json_mode:
                 errors.append(f"{desc} 'output_field' can only be used when 'json_mode' is false.")
 
-        reprompt_cfg = normalized_entry.get("reprompt") or {}
+        reprompt_raw = normalized_entry.get("reprompt")
+        reprompt_cfg = reprompt_raw if isinstance(reprompt_raw, dict) else {}
         schema_mismatch_mode = reprompt_cfg.get("on_schema_mismatch")
         if schema_mismatch_mode in ("reprompt", "reject"):
             has_schema = bool(

--- a/agent_actions/validation/action_validators/granularity_output_field_validator.py
+++ b/agent_actions/validation/action_validators/granularity_output_field_validator.py
@@ -4,7 +4,6 @@ from agent_actions.output.response.config_fields import get_default
 from agent_actions.utils.constants import (
     HITL_FILE_GRANULARITY_ERROR,
     JSON_MODE_KEY,
-    ON_SCHEMA_MISMATCH_KEY,
     SCHEMA_KEY,
     SCHEMA_NAME_KEY,
 )
@@ -56,31 +55,17 @@ class GranularityAndOutputFieldValidator(BaseActionEntryValidator):
             if json_mode:
                 errors.append(f"{desc} 'output_field' can only be used when 'json_mode' is false.")
 
-        on_mismatch_raw = normalized_entry.get(ON_SCHEMA_MISMATCH_KEY)
-        if isinstance(on_mismatch_raw, str):
-            on_mismatch = on_mismatch_raw.lower()
-        else:
-            on_mismatch = None
-
-        if on_mismatch in ("reject", "reprompt"):
+        reprompt_cfg = normalized_entry.get("reprompt") or {}
+        schema_mismatch_mode = reprompt_cfg.get("on_schema_mismatch")
+        if schema_mismatch_mode in ("reprompt", "reject"):
             has_schema = bool(
                 normalized_entry.get(SCHEMA_KEY) or normalized_entry.get(SCHEMA_NAME_KEY)
             )
             if not has_schema:
                 errors.append(
-                    f"{desc} 'on_schema_mismatch: {on_mismatch}' requires a schema "
-                    "to validate against. Define 'schema' or 'schema_name', "
-                    "or change on_schema_mismatch to 'warn'."
+                    f"{desc} reprompt.on_schema_mismatch: {schema_mismatch_mode} requires "
+                    "a schema to validate against. Define 'schema' or 'schema_name'."
                 )
-
-            if on_mismatch == "reprompt":
-                reprompt = normalized_entry.get("reprompt")
-                if not reprompt:
-                    errors.append(
-                        f"{desc} 'on_schema_mismatch: reprompt' requires a 'reprompt' "
-                        "configuration block. Add reprompt: {{validation: your_udf_name}} "
-                        "or change on_schema_mismatch to 'warn' or 'reject'."
-                    )
 
         if errors:
             return ActionEntryValidationResult.with_errors(errors)

--- a/docs.agent-actions/docs/reference/validation/output-validation.md
+++ b/docs.agent-actions/docs/reference/validation/output-validation.md
@@ -155,21 +155,22 @@ The retry prompt includes:
 
 ### Schema Mismatch Behavior
 
-Control what happens when an LLM response doesn't match the expected schema using `on_schema_mismatch`:
+Control what happens when an LLM response doesn't match the expected schema using `on_schema_mismatch` inside the `reprompt` block:
 
 ```yaml
 - name: extract_entities
   schema: entity_schema
-  on_schema_mismatch: reprompt   # "warn" | "reprompt" | "reject"
   reprompt:
+    on_schema_mismatch: reprompt   # "reprompt" | "reject"
     max_attempts: 3
 ```
 
 | Value | Behavior |
 |-------|----------|
-| `warn` | Log a warning, accept the response anyway (default) |
 | `reprompt` | Trigger reprompt with schema errors as feedback |
 | `reject` | Reject the response, action fails |
+
+When not set, schema is not enforced — the output is accepted regardless of schema conformance.
 
 When set to `reprompt`, no custom validation UDF is needed — the schema errors are used directly as feedback to the LLM.
 

--- a/docs.agent-actions/docs/reference/validation/output-validation.md
+++ b/docs.agent-actions/docs/reference/validation/output-validation.md
@@ -36,12 +36,13 @@ Guards run last because they evaluate semantic conditions that require valid, sc
 
 ## Layer 1: JSON Validation
 
-Ensures the LLM returns valid JSON. If parsing fails, the LLM is reprompted with the error:
+Ensures the LLM returns valid JSON. If parsing fails and reprompt is configured, the LLM is retried with forceful JSON feedback including the expected field names:
 
 ```yaml
 - name: extract_data
   schema: my_schema
   reprompt:
+    on_schema_mismatch: reprompt    # enables JSON + schema reprompt
     max_attempts: 3
     on_exhausted: return_last
 ```
@@ -138,20 +139,21 @@ properties:
 
 ### Reprompt on Schema Failure
 
-When schema validation fails, reprompting retries with error context:
+When schema validation fails, reprompting retries with error context. Set `on_schema_mismatch: reprompt` inside the `reprompt` block to enable this:
 
 ```yaml
 - name: generate_analysis
   schema: analysis_schema
   reprompt:
+    on_schema_mismatch: reprompt
     max_attempts: 4
     on_exhausted: return_last
 ```
 
 The retry prompt includes:
 - Original response that failed
-- Specific validation errors
-- Field/constraint that failed
+- Specific validation errors (missing fields, wrong types)
+- Expected field names from the schema
 
 ### Schema Mismatch Behavior
 
@@ -244,6 +246,7 @@ actions:
     prompt: $prompts.extract_facts
     schema: candidate_facts_list  # Layer 2: type/structure
     reprompt:
+      on_schema_mismatch: reprompt
       max_attempts: 4
       on_exhausted: return_last
 
@@ -259,6 +262,7 @@ actions:
     dependencies: validate_facts  # Input source
     schema: quality_score  # Ensures score is 0-100
     reprompt:
+      on_schema_mismatch: reprompt
       max_attempts: 3
       on_exhausted: return_last
 
@@ -281,6 +285,7 @@ actions:
     prompt: $prompts.generate
     schema: content_schema
     reprompt:
+      on_schema_mismatch: reprompt
       max_attempts: 4
       on_exhausted: return_last
 
@@ -323,6 +328,7 @@ properties:
 - name: classify_content
   schema: classification
   reprompt:
+    on_schema_mismatch: reprompt
     max_attempts: 3
     on_exhausted: return_last
 
@@ -356,6 +362,7 @@ properties:
     Scores below 70 indicate low confidence.
   schema: score_schema
   reprompt:
+    on_schema_mismatch: reprompt
     max_attempts: 5
     on_exhausted: return_last
 
@@ -378,6 +385,7 @@ actions:
   - name: generate_content
     schema: content_schema
     reprompt:
+      on_schema_mismatch: reprompt
       max_attempts: 3
       on_exhausted: return_last
 
@@ -422,7 +430,7 @@ def validate_content(data: dict) -> dict:
 
 | Want to Reject | Use | Example |
 |----------------|-----|---------|
-| Invalid JSON | `reprompt: { max_attempts: 3 }` | Malformed response |
+| Invalid JSON | `reprompt: { on_schema_mismatch: reprompt }` | Malformed response |
 | Wrong type | Schema `type` | String instead of number |
 | Missing field | Schema `required` | No "title" field |
 | Wrong value | Schema `enum` | "maybe" not in ["yes", "no"] |
@@ -466,6 +474,7 @@ The limitation here: reprompting costs API tokens. Guards are free. If you're fi
 - name: extract
   schema: extraction_schema
   reprompt:
+    on_schema_mismatch: reprompt
     max_attempts: 4
     on_exhausted: return_last
 
@@ -504,11 +513,13 @@ properties:
 ```yaml
 # Simple schema: fewer attempts
 reprompt:
+  on_schema_mismatch: reprompt
   max_attempts: 3
   on_exhausted: return_last
 
 # Complex schema: more attempts, fail on exhaustion
 reprompt:
+  on_schema_mismatch: reprompt
   max_attempts: 5
   on_exhausted: raise
 ```

--- a/tests/integration/test_schema_dispatch_audit.py
+++ b/tests/integration/test_schema_dispatch_audit.py
@@ -3,7 +3,7 @@
 Tests the full schema pipeline:
 - Resolution: inline vs named vs tool-derived vs HITL auto-generated
 - Compilation: vendor-specific format per provider
-- Validation: on_schema_mismatch modes (warn, reprompt, reject)
+- Validation: reprompt.on_schema_mismatch modes (reprompt, reject)
 - Edge cases: json_mode interaction, schemaless actions, dispatch_task()
 """
 
@@ -406,10 +406,10 @@ class TestVendorCompilation:
 
 
 class TestSchemaMismatchModes:
-    """Tests for on_schema_mismatch: warn, reprompt, reject."""
+    """Tests for reprompt.on_schema_mismatch: reprompt, reject."""
 
-    def _config(self, **overrides) -> dict[str, Any]:
-        base = {
+    def _config(self, on_schema_mismatch=None) -> dict[str, Any]:
+        base: dict[str, Any] = {
             "schema": {
                 "fields": [
                     {"name": "title", "type": "string", "required": True},
@@ -417,30 +417,23 @@ class TestSchemaMismatchModes:
                 ]
             },
         }
-        base.update(overrides)
+        if on_schema_mismatch:
+            base["reprompt"] = {"on_schema_mismatch": on_schema_mismatch}
         return base
 
-    def test_default_is_warn(self):
+    def test_default_is_warn_when_no_reprompt(self):
         assert _resolve_schema_mismatch_mode({}) == "warn"
 
-    def test_explicit_warn(self):
-        assert _resolve_schema_mismatch_mode({"on_schema_mismatch": "warn"}) == "warn"
-
     def test_explicit_reprompt(self):
-        assert _resolve_schema_mismatch_mode({"on_schema_mismatch": "reprompt"}) == "reprompt"
+        config = {"reprompt": {"on_schema_mismatch": "reprompt"}}
+        assert _resolve_schema_mismatch_mode(config) == "reprompt"
 
     def test_explicit_reject(self):
-        assert _resolve_schema_mismatch_mode({"on_schema_mismatch": "reject"}) == "reject"
+        config = {"reprompt": {"on_schema_mismatch": "reject"}}
+        assert _resolve_schema_mismatch_mode(config) == "reject"
 
-    def test_strict_schema_maps_to_reject(self):
-        assert _resolve_schema_mismatch_mode({"strict_schema": True}) == "reject"
-
-    def test_explicit_overrides_strict_schema(self):
-        config = {"strict_schema": True, "on_schema_mismatch": "warn"}
-        assert _resolve_schema_mismatch_mode(config) == "warn"
-
-    def test_warn_logs_and_continues(self):
-        """Warn mode returns response unchanged (does not raise)."""
+    def test_no_mismatch_mode_returns_response(self):
+        """No on_schema_mismatch set returns response unchanged (no raise)."""
         config = self._config()
         response = {"wrong_field": "value"}
         result = _validate_llm_output_schema(response, config, "test")
@@ -473,13 +466,6 @@ class TestSchemaMismatchModes:
         response = {"wrong": "data"}
         result = _validate_llm_output_schema(response, config, "test")
         assert result == response
-
-    def test_invalid_mode_defaults_to_warn(self):
-        """Unrecognized on_schema_mismatch value defaults to warn."""
-        config = self._config(on_schema_mismatch="invalid_mode")
-        response = {"wrong": "data"}
-        result = _validate_llm_output_schema(response, config, "test")
-        assert result == response  # warn mode, no raise
 
 
 # ===================================================================
@@ -707,22 +693,15 @@ class TestSchemalessActions:
         assert result == response
 
     def test_schemaless_with_reject_not_enforced(self):
-        """Schemaless action + on_schema_mismatch=reject does NOT raise.
+        """Schemaless action + reprompt.on_schema_mismatch=reject does NOT raise.
 
         This is a known gap: when no schema is defined, _validate_llm_output_schema
         returns early before checking mismatch mode. The intent of 'reject' is
         violated silently.
         """
-        config = {"on_schema_mismatch": "reject"}  # no schema key
+        config = {"reprompt": {"on_schema_mismatch": "reject"}}  # no schema key
         response = {"any_field": "any_value"}
         # Does NOT raise — schema check is bypassed when schema is None
-        result = _validate_llm_output_schema(response, config, "test")
-        assert result == response
-
-    def test_schemaless_with_strict_not_enforced(self):
-        """Schemaless action + strict_schema=true does NOT raise."""
-        config = {"strict_schema": True}  # no schema key
-        response = {"any_field": "any_value"}
         result = _validate_llm_output_schema(response, config, "test")
         assert result == response
 

--- a/tests/unit/config/test_schema_extra_forbid.py
+++ b/tests/unit/config/test_schema_extra_forbid.py
@@ -38,9 +38,7 @@ class TestActionConfigForbidsUnknownKeys:
             "versions": None,
             "version_consumption": None,
             "retry": {"max_attempts": 3},
-            "reprompt": {"validation": "check_fn"},
-            "strict_schema": True,
-            "on_schema_mismatch": "reject",
+            "reprompt": {"validation": "check_fn", "on_schema_mismatch": "reject"},
             "idempotency_key": "key-{id}",
             "prompt": "Do something",
             "dependencies": ["dep_a"],
@@ -118,7 +116,7 @@ class TestActionConfigForbidsUnknownKeys:
         assert config.reprompt.validation == "check"
 
     def test_reprompt_without_validation_accepted(self):
-        """Reprompt without validation (used with on_schema_mismatch: reprompt)."""
+        """Reprompt without validation (used with reprompt.on_schema_mismatch: reprompt)."""
         data = {"name": "a", "intent": "i", "reprompt": {"max_attempts": 3}}
         config = ActionConfig.model_validate(data)
         assert config.reprompt.max_attempts == 3
@@ -152,13 +150,21 @@ class TestActionConfigForbidsUnknownKeys:
         with pytest.raises(ValidationError, match="max_tokens"):
             ActionConfig.model_validate(data)
 
-    def test_on_schema_mismatch_rejects_invalid_value(self):
-        data = {"name": "a", "intent": "i", "on_schema_mismatch": "ignore"}
+    def test_on_schema_mismatch_rejects_invalid_value_in_reprompt(self):
+        """Invalid on_schema_mismatch inside reprompt dict is rejected."""
+        data = {"name": "a", "intent": "i", "reprompt": {"on_schema_mismatch": "ignore"}}
         with pytest.raises(ValidationError, match="on_schema_mismatch"):
             ActionConfig.model_validate(data)
 
-    def test_strict_schema_rejects_non_bool(self):
-        data = {"name": "a", "intent": "i", "strict_schema": "banana"}
+    def test_top_level_on_schema_mismatch_rejected(self):
+        """Top-level on_schema_mismatch is no longer a valid key."""
+        data = {"name": "a", "intent": "i", "on_schema_mismatch": "reject"}
+        with pytest.raises(ValidationError, match="on_schema_mismatch"):
+            ActionConfig.model_validate(data)
+
+    def test_top_level_strict_schema_rejected(self):
+        """Top-level strict_schema is no longer a valid key."""
+        data = {"name": "a", "intent": "i", "strict_schema": True}
         with pytest.raises(ValidationError, match="strict_schema"):
             ActionConfig.model_validate(data)
 
@@ -215,16 +221,15 @@ class TestActionConfigForbidsUnknownKeys:
         config = ActionConfig.model_validate(data)
         assert config.kind.value == "llm"
 
-    def test_strict_schema_and_on_schema_mismatch_accepted(self):
+    def test_on_schema_mismatch_in_reprompt_accepted(self):
+        """on_schema_mismatch inside reprompt dict is accepted."""
         data = {
             "name": "a",
             "intent": "i",
-            "strict_schema": True,
-            "on_schema_mismatch": "reject",
+            "reprompt": {"on_schema_mismatch": "reject"},
         }
         config = ActionConfig.model_validate(data)
-        assert config.strict_schema is True
-        assert config.on_schema_mismatch == "reject"
+        assert config.reprompt.on_schema_mismatch == "reject"
 
     # --- Version config ---
 
@@ -313,11 +318,9 @@ class TestDefaultsConfigValidation:
             "max_tokens": 1000,
             "top_p": 0.9,
             "stop": ["\n"],
-            "reprompt": False,
+            "reprompt": {"on_schema_mismatch": "reject"},
             "constraints": [],
             "retry": None,
-            "strict_schema": False,
-            "on_schema_mismatch": "warn",
             # Expander-consumed
             "context_scope": {"input": "seed_data"},
             "chunk_config": {"size": 100},
@@ -345,9 +348,10 @@ class TestDefaultsConfigValidation:
         with pytest.raises(ValidationError, match="temperature"):
             DefaultsConfig.model_validate({"temperature": "warm"})
 
-    def test_on_schema_mismatch_rejects_invalid_value(self):
+    def test_on_schema_mismatch_rejects_invalid_value_in_reprompt(self):
+        """Invalid on_schema_mismatch inside reprompt dict is rejected in defaults."""
         with pytest.raises(ValidationError, match="on_schema_mismatch"):
-            DefaultsConfig.model_validate({"on_schema_mismatch": "ignore"})
+            DefaultsConfig.model_validate({"reprompt": {"on_schema_mismatch": "ignore"}})
 
     def test_retry_false_converts_to_none(self):
         config = DefaultsConfig.model_validate({"retry": False})

--- a/tests/unit/core/test_reprompt_service.py
+++ b/tests/unit/core/test_reprompt_service.py
@@ -823,10 +823,11 @@ class TestRepromptServiceParseError:
 
         service.execute(llm_operation=llm_operation, original_prompt="Test prompt", context="test")
 
-        # Second call should include JSON feedback in the prompt
+        # Second call should include forceful JSON feedback in the prompt
         second_call_prompt = llm_operation.call_args_list[1][0][0]
+        assert "CRITICAL" in second_call_prompt
         assert "not valid JSON" in second_call_prompt
-        assert "no markdown" in second_call_prompt
+        assert "No markdown" in second_call_prompt
 
     def test_parse_error_exhaustion_returns_empty(self):
         """On exhaustion with persistent parse errors, return [{}] not the error dict."""

--- a/tests/unit/core/test_schema_mismatch_reprompt.py
+++ b/tests/unit/core/test_schema_mismatch_reprompt.py
@@ -1,10 +1,9 @@
-"""Integration tests for on_schema_mismatch: reprompt.
+"""Integration tests for reprompt.on_schema_mismatch.
 
 Covers:
-- _resolve_schema_mismatch_mode returns correct mode
+- _resolve_schema_mismatch_mode returns correct mode from reprompt config
 - _validate_llm_output_schema skips when mode is "reprompt"
-- _validate_llm_output_schema still raises when strict_schema: true (reject)
-- _validate_llm_output_schema still warns when default (warn)
+- _validate_llm_output_schema still raises when mode is "reject"
 - _validate_llm_output_schema reprompt fallback logs warning
 - Factory builds SchemaValidator when mode is "reprompt"
 - Factory composes UDF + schema when both configured
@@ -42,35 +41,22 @@ from agent_actions.processing.recovery.validation import (
 
 
 class TestResolveSchemaMode:
-    """Tests for _resolve_schema_mismatch_mode."""
+    """Tests for _resolve_schema_mismatch_mode reading from reprompt config."""
 
-    def test_default_is_warn(self):
+    def test_default_is_warn_when_no_reprompt(self):
         assert _resolve_schema_mismatch_mode({}) == "warn"
 
     def test_explicit_reprompt(self):
-        assert _resolve_schema_mismatch_mode({"on_schema_mismatch": "reprompt"}) == "reprompt"
-
-    def test_explicit_reject(self):
-        assert _resolve_schema_mismatch_mode({"on_schema_mismatch": "reject"}) == "reject"
-
-    def test_explicit_warn(self):
-        assert _resolve_schema_mismatch_mode({"on_schema_mismatch": "warn"}) == "warn"
-
-    def test_strict_schema_true_becomes_reject(self):
-        assert _resolve_schema_mismatch_mode({"strict_schema": True}) == "reject"
-
-    def test_explicit_overrides_strict(self):
-        """on_schema_mismatch takes precedence over strict_schema."""
-        config = {"strict_schema": True, "on_schema_mismatch": "reprompt"}
+        config = {"reprompt": {"on_schema_mismatch": "reprompt"}}
         assert _resolve_schema_mismatch_mode(config) == "reprompt"
 
-    def test_invalid_explicit_falls_through_to_strict(self):
-        """Invalid on_schema_mismatch value falls through."""
-        config = {"strict_schema": True, "on_schema_mismatch": "invalid"}
+    def test_explicit_reject(self):
+        config = {"reprompt": {"on_schema_mismatch": "reject"}}
         assert _resolve_schema_mismatch_mode(config) == "reject"
 
-    def test_invalid_explicit_no_strict(self):
-        config = {"on_schema_mismatch": "invalid"}
+    def test_reprompt_dict_without_on_schema_mismatch_defaults_to_warn(self):
+        """Reprompt config without on_schema_mismatch falls through to warn."""
+        config = {"reprompt": {"validation": "check_fn"}}
         assert _resolve_schema_mismatch_mode(config) == "warn"
 
 
@@ -82,7 +68,7 @@ class TestResolveSchemaMode:
 class TestValidateSchemaSkip:
     """Tests for _validate_llm_output_schema skip/fallback behavior."""
 
-    def _make_config(self, **overrides):
+    def _make_config(self, on_schema_mismatch=None):
         config = {
             "schema": {
                 "fields": [
@@ -91,7 +77,8 @@ class TestValidateSchemaSkip:
                 ]
             },
         }
-        config.update(overrides)
+        if on_schema_mismatch:
+            config["reprompt"] = {"on_schema_mismatch": on_schema_mismatch}
         return config
 
     def test_reprompt_mode_skips_when_flag_set(self):
@@ -112,20 +99,13 @@ class TestValidateSchemaSkip:
         assert result == response  # warn mode returns response, no exception
 
     def test_reject_mode_raises(self):
-        """strict_schema / reject still raises."""
+        """on_schema_mismatch: reject still raises."""
         from agent_actions.errors import SchemaValidationError
 
-        config = self._make_config(strict_schema=True)
+        config = self._make_config(on_schema_mismatch="reject")
         response = {"wrong_field": "value"}
         with pytest.raises(SchemaValidationError):
             _validate_llm_output_schema(response, config, "test_action")
-
-    def test_warn_mode_returns_response(self):
-        """Default warn mode returns response (just logs warning)."""
-        config = self._make_config()  # default = warn
-        response = {"wrong_field": "value"}
-        result = _validate_llm_output_schema(response, config, "test_action")
-        assert result == response  # returned, no exception
 
     def test_no_schema_returns_immediately(self):
         """No schema configured -- skip entirely."""
@@ -161,15 +141,15 @@ class TestFactoryBuildValidator:
     def test_schema_reprompt_only(self):
         config = {
             "schema": {"fields": [{"name": "x", "type": "string", "required": True}]},
-            "on_schema_mismatch": "reprompt",
+            "reprompt": {"on_schema_mismatch": "reprompt"},
             "name": "my_action",
         }
         result = InvocationStrategyFactory._build_validator(config)
         assert isinstance(result, SchemaValidator)
         assert result.name == "schema:my_action"
 
-    def test_schema_warn_not_included(self):
-        """Schema with default warn mode should NOT produce a validator."""
+    def test_schema_without_reprompt_mismatch_not_included(self):
+        """Schema without on_schema_mismatch in reprompt should NOT produce a validator."""
         config = {
             "schema": {"fields": [{"name": "x", "type": "string", "required": True}]},
             "name": "my_action",
@@ -179,9 +159,11 @@ class TestFactoryBuildValidator:
 
     def test_both_udf_and_schema(self):
         config = {
-            "reprompt": {"validation": "check_positive"},
+            "reprompt": {
+                "validation": "check_positive",
+                "on_schema_mismatch": "reprompt",
+            },
             "schema": {"fields": [{"name": "x", "type": "string", "required": True}]},
-            "on_schema_mismatch": "reprompt",
             "name": "my_action",
         }
         result = InvocationStrategyFactory._build_validator(config)
@@ -325,7 +307,7 @@ class TestCreateRepromptServiceWithValidator:
 class TestRepromptFallbackWarning:
     """Test that reprompt mode without skip_schema_validation logs a warning."""
 
-    def _make_config(self, **overrides):
+    def _make_config(self, on_schema_mismatch=None):
         config = {
             "schema": {
                 "fields": [
@@ -334,7 +316,8 @@ class TestRepromptFallbackWarning:
                 ]
             },
         }
-        config.update(overrides)
+        if on_schema_mismatch:
+            config["reprompt"] = {"on_schema_mismatch": on_schema_mismatch}
         return config
 
     @patch("agent_actions.processing.helpers.logger")

--- a/tests/unit/core/test_schema_mismatch_reprompt.py
+++ b/tests/unit/core/test_schema_mismatch_reprompt.py
@@ -61,6 +61,26 @@ class TestResolveSchemaMode:
 
 
 # ---------------------------------------------------------------------------
+# Shared test helper
+# ---------------------------------------------------------------------------
+
+
+def _make_schema_config(on_schema_mismatch=None):
+    """Build a minimal config with a two-field schema and optional mismatch mode."""
+    config = {
+        "schema": {
+            "fields": [
+                {"name": "title", "type": "string", "required": True},
+                {"name": "score", "type": "number", "required": True},
+            ]
+        },
+    }
+    if on_schema_mismatch:
+        config["reprompt"] = {"on_schema_mismatch": on_schema_mismatch}
+    return config
+
+
+# ---------------------------------------------------------------------------
 # _validate_llm_output_schema skip behavior
 # ---------------------------------------------------------------------------
 
@@ -68,22 +88,9 @@ class TestResolveSchemaMode:
 class TestValidateSchemaSkip:
     """Tests for _validate_llm_output_schema skip/fallback behavior."""
 
-    def _make_config(self, on_schema_mismatch=None):
-        config = {
-            "schema": {
-                "fields": [
-                    {"name": "title", "type": "string", "required": True},
-                    {"name": "score", "type": "number", "required": True},
-                ]
-            },
-        }
-        if on_schema_mismatch:
-            config["reprompt"] = {"on_schema_mismatch": on_schema_mismatch}
-        return config
-
     def test_reprompt_mode_skips_when_flag_set(self):
         """With skip_schema_validation=True, returns response unchanged."""
-        config = self._make_config(on_schema_mismatch="reprompt")
+        config = _make_schema_config(on_schema_mismatch="reprompt")
         response = {"wrong_field": "value"}
         result = _validate_llm_output_schema(
             response, config, "test_action", skip_schema_validation=True
@@ -92,7 +99,7 @@ class TestValidateSchemaSkip:
 
     def test_reprompt_mode_falls_back_to_warn_without_flag(self):
         """Without skip_schema_validation, reprompt mode falls back to warn."""
-        config = self._make_config(on_schema_mismatch="reprompt")
+        config = _make_schema_config(on_schema_mismatch="reprompt")
         response = {"wrong_field": "value"}
         # Should NOT skip -- falls back to warn (returns response, logs warning)
         result = _validate_llm_output_schema(response, config, "test_action")
@@ -102,7 +109,7 @@ class TestValidateSchemaSkip:
         """on_schema_mismatch: reject still raises."""
         from agent_actions.errors import SchemaValidationError
 
-        config = self._make_config(on_schema_mismatch="reject")
+        config = _make_schema_config(on_schema_mismatch="reject")
         response = {"wrong_field": "value"}
         with pytest.raises(SchemaValidationError):
             _validate_llm_output_schema(response, config, "test_action")
@@ -307,23 +314,10 @@ class TestCreateRepromptServiceWithValidator:
 class TestRepromptFallbackWarning:
     """Test that reprompt mode without skip_schema_validation logs a warning."""
 
-    def _make_config(self, on_schema_mismatch=None):
-        config = {
-            "schema": {
-                "fields": [
-                    {"name": "title", "type": "string", "required": True},
-                    {"name": "score", "type": "number", "required": True},
-                ]
-            },
-        }
-        if on_schema_mismatch:
-            config["reprompt"] = {"on_schema_mismatch": on_schema_mismatch}
-        return config
-
     @patch("agent_actions.processing.helpers.logger")
     def test_reprompt_fallback_logs_warning(self, mock_logger):
         """Reprompt mode without flag falls back to warn and logs."""
-        config = self._make_config(on_schema_mismatch="reprompt")
+        config = _make_schema_config(on_schema_mismatch="reprompt")
         response = {"wrong_field": "value"}
 
         result = _validate_llm_output_schema(response, config, "test_action")

--- a/tests/unit/processing/test_schema_key_error_propagation.py
+++ b/tests/unit/processing/test_schema_key_error_propagation.py
@@ -22,7 +22,7 @@ class TestSchemaValidationKeyErrorPropagates:
         from agent_actions.processing.helpers import _validate_llm_output_schema
 
         response = {"result": "value"}
-        agent_config = {"schema": {"type": "object"}, "on_schema_mismatch": "warn"}
+        agent_config = {"schema": {"type": "object"}}
 
         mock_mod = self._make_mock_validator(KeyError("unexpected_key"))
 
@@ -37,12 +37,12 @@ class TestSchemaValidationKeyErrorPropagates:
             else:
                 sys.modules["agent_actions.validation.schema_output_validator"] = saved
 
-    def test_value_error_in_warn_mode_is_swallowed(self):
-        """ValueError in non-strict mode must be caught (not propagate)."""
+    def test_value_error_in_default_mode_is_swallowed(self):
+        """ValueError in default mode (no reprompt config) must be caught (not propagate)."""
         from agent_actions.processing.helpers import _validate_llm_output_schema
 
         response = {"result": "value"}
-        agent_config = {"schema": {"type": "object"}, "on_schema_mismatch": "warn"}
+        agent_config = {"schema": {"type": "object"}}
 
         mock_mod = self._make_mock_validator(ValueError("bad_value"))
 

--- a/tests/unit/validation/test_schemaless_reject.py
+++ b/tests/unit/validation/test_schemaless_reject.py
@@ -1,4 +1,4 @@
-"""Regression tests: on_schema_mismatch without schema must not silently pass.
+"""Regression tests: reprompt.on_schema_mismatch without schema must not silently pass.
 
 Covers preflight detection and runtime warning for configurations where the user
 requests strict schema validation (reject/reprompt) but provides no schema.
@@ -21,13 +21,22 @@ def _validate_entry(entry: dict) -> tuple[list, list]:
     return orch.get_validation_errors(), orch.get_validation_warnings()
 
 
-def _base_entry(**overrides) -> dict:
-    """Minimal LLM action entry with overrides."""
+def _base_entry(on_schema_mismatch=None, **overrides) -> dict:
+    """Minimal LLM action entry with overrides.
+
+    on_schema_mismatch is placed inside the reprompt dict.
+    """
     entry = {
         "name": "test_action",
         "agent_type": "llm",
         "model_name": "gpt-4",
     }
+    if on_schema_mismatch:
+        reprompt = entry.get("reprompt", {})
+        if isinstance(overrides.get("reprompt"), dict):
+            reprompt = overrides.pop("reprompt")
+        reprompt["on_schema_mismatch"] = on_schema_mismatch
+        entry["reprompt"] = reprompt
     entry.update(overrides)
     return entry
 
@@ -36,7 +45,7 @@ def _base_entry(**overrides) -> dict:
 
 
 class TestPreflightRejectWithoutSchema:
-    """on_schema_mismatch: reject + no schema → preflight error."""
+    """reprompt.on_schema_mismatch: reject + no schema → preflight error."""
 
     def test_reject_no_schema_produces_actionable_error(self):
         """Reject mode without schema is caught with an actionable message."""
@@ -44,7 +53,7 @@ class TestPreflightRejectWithoutSchema:
         mismatch_errors = [e for e in errors if "on_schema_mismatch" in e.lower()]
         assert len(mismatch_errors) > 0, f"Expected schema-related error, got: {errors}"
         assert any(
-            "schema" in e.lower() and ("warn" in e.lower() or "define" in e.lower())
+            "schema" in e.lower() and ("define" in e.lower() or "requires" in e.lower())
             for e in mismatch_errors
         )
 
@@ -80,10 +89,10 @@ class TestPreflightRejectWithoutSchema:
 
 
 class TestPreflightRepromptWithoutSchema:
-    """on_schema_mismatch: reprompt + no schema → preflight error."""
+    """reprompt.on_schema_mismatch: reprompt + no schema → preflight error."""
 
     def test_reprompt_no_schema_produces_error(self):
-        """Reprompt mode without schema is caught (in addition to missing reprompt block)."""
+        """Reprompt mode without schema is caught."""
         errors, _ = _validate_entry(_base_entry(on_schema_mismatch="reprompt"))
         assert any("requires a schema" in e.lower() for e in errors), (
             f"Expected schema-required error, got: {errors}"
@@ -91,31 +100,29 @@ class TestPreflightRepromptWithoutSchema:
 
     def test_reprompt_with_schema_and_config_passes(self):
         """Reprompt mode with schema + reprompt block has no schema-missing error."""
-        errors, _ = _validate_entry(
-            _base_entry(
-                on_schema_mismatch="reprompt",
-                schema={"summary": "string"},
-                reprompt={"validation": "my_validator"},
-            )
-        )
+        entry = {
+            "name": "test_action",
+            "agent_type": "llm",
+            "model_name": "gpt-4",
+            "reprompt": {
+                "on_schema_mismatch": "reprompt",
+                "validation": "my_validator",
+            },
+            "schema": {"summary": "string"},
+        }
+        errors, _ = _validate_entry(entry)
         schema_errors = [e for e in errors if "requires a schema" in e.lower()]
         assert len(schema_errors) == 0
 
 
-# ── Preflight: warn/default without schema (no false positives) ─────
+# ── Preflight: no false positives ─────────────────────────────────
 
 
 class TestPreflightNoFalsePositives:
-    """Warn and default modes must NOT error when schema is missing."""
-
-    def test_warn_no_schema_no_error(self):
-        """Explicit warn mode + no schema → no on_schema_mismatch error."""
-        errors, _ = _validate_entry(_base_entry(on_schema_mismatch="warn"))
-        mismatch_errors = [e for e in errors if "on_schema_mismatch" in e.lower()]
-        assert len(mismatch_errors) == 0
+    """Default (no reprompt config) must NOT error when schema is missing."""
 
     def test_default_no_schema_no_error(self):
-        """No on_schema_mismatch set + no schema → no error (common valid config)."""
+        """No reprompt config + no schema → no on_schema_mismatch error."""
         errors, _ = _validate_entry(_base_entry())
         mismatch_errors = [e for e in errors if "on_schema_mismatch" in e.lower()]
         assert len(mismatch_errors) == 0
@@ -130,7 +137,7 @@ class TestRuntimeWarning:
     @patch("agent_actions.processing.helpers.logger")
     def test_reject_no_schema_logs_warning(self, mock_logger):
         """Runtime path logs warning when reject is set but no schema."""
-        config = {"on_schema_mismatch": "reject"}
+        config = {"reprompt": {"on_schema_mismatch": "reject"}}
         response = {"any": "value"}
         result = _validate_llm_output_schema(response, config, "test_action")
         assert result == response  # passes through (no schema to validate)
@@ -141,7 +148,7 @@ class TestRuntimeWarning:
     @patch("agent_actions.processing.helpers.logger")
     def test_reprompt_no_schema_logs_warning(self, mock_logger):
         """Runtime path logs warning when reprompt is set but no schema."""
-        config = {"on_schema_mismatch": "reprompt"}
+        config = {"reprompt": {"on_schema_mismatch": "reprompt"}}
         response = {"any": "value"}
         result = _validate_llm_output_schema(response, config, "test_action")
         assert result == response
@@ -150,27 +157,9 @@ class TestRuntimeWarning:
         assert "no schema is defined" in msg
 
     @patch("agent_actions.processing.helpers.logger")
-    def test_warn_no_schema_no_warning(self, mock_logger):
-        """Runtime path does NOT warn for warn mode (expected behavior)."""
-        config = {"on_schema_mismatch": "warn"}
-        response = {"any": "value"}
-        _validate_llm_output_schema(response, config, "test_action")
-        mock_logger.warning.assert_not_called()
-
-    @patch("agent_actions.processing.helpers.logger")
     def test_no_config_no_warning(self, mock_logger):
         """Runtime path does NOT warn when no mismatch mode is set."""
         config = {}
         response = {"any": "value"}
         _validate_llm_output_schema(response, config, "test_action")
         mock_logger.warning.assert_not_called()
-
-    @patch("agent_actions.processing.helpers.logger")
-    def test_strict_schema_true_logs_warning(self, mock_logger):
-        """strict_schema: true (legacy) also triggers the warning."""
-        config = {"strict_schema": True}
-        response = {"any": "value"}
-        _validate_llm_output_schema(response, config, "test_action")
-        mock_logger.warning.assert_called_once()
-        msg = mock_logger.warning.call_args[0][0]
-        assert "no schema is defined" in msg

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -316,28 +316,30 @@ class TestRecoveryValidation:
         # The static analyzer should flag the missing UDF
         assert any("totally_nonexistent_validator_xyz" in e.message for e in result.errors)
 
-    def test_on_schema_mismatch_reprompt_requires_reprompt_config(self):
-        """on_schema_mismatch: reprompt without reprompt block is caught."""
+    def test_on_schema_mismatch_reprompt_requires_schema(self):
+        """reprompt.on_schema_mismatch: reprompt without schema is caught."""
         errors, _ = _validate_entry(
             {
                 "name": "test",
                 "agent_type": "llm",
                 "model_name": "gpt-4",
-                "on_schema_mismatch": "reprompt",
-                # no reprompt config
+                "reprompt": {"on_schema_mismatch": "reprompt"},
+                # no schema
             }
         )
-        assert any("reprompt" in e.lower() and "on_schema_mismatch" in e.lower() for e in errors)
+        assert any("on_schema_mismatch" in e.lower() for e in errors)
 
-    def test_on_schema_mismatch_reprompt_with_reprompt_config_passes(self):
-        """on_schema_mismatch: reprompt with reprompt block and schema passes validation."""
+    def test_on_schema_mismatch_reprompt_with_schema_passes(self):
+        """reprompt.on_schema_mismatch: reprompt with schema passes validation."""
         errors, _ = _validate_entry(
             {
                 "name": "test",
                 "agent_type": "llm",
                 "model_name": "gpt-4",
-                "on_schema_mismatch": "reprompt",
-                "reprompt": {"validation": "my_validator"},
+                "reprompt": {
+                    "on_schema_mismatch": "reprompt",
+                    "validation": "my_validator",
+                },
                 "schema": {"summary": "string"},
             }
         )
@@ -505,19 +507,16 @@ class TestActionableErrors:
         assert any("granularity: file" in e.lower() or "remove" in e.lower() for e in hitl_errors)
 
     def test_reprompt_mismatch_error_is_actionable(self):
-        """on_schema_mismatch error tells the user what to add."""
+        """reprompt.on_schema_mismatch error tells the user what to add."""
         errors, _ = _validate_entry(
             {
                 "name": "test",
                 "agent_type": "llm",
                 "model_name": "gpt-4",
-                "on_schema_mismatch": "reprompt",
+                "reprompt": {"on_schema_mismatch": "reprompt"},
             }
         )
         reprompt_errors = [e for e in errors if "on_schema_mismatch" in e.lower()]
         assert len(reprompt_errors) > 0
-        # Should suggest adding reprompt block or changing the mode
-        assert any(
-            "reprompt:" in e.lower() or "warn" in e.lower() or "reject" in e.lower()
-            for e in reprompt_errors
-        )
+        # Should suggest defining a schema
+        assert any("schema" in e.lower() or "define" in e.lower() for e in reprompt_errors)


### PR DESCRIPTION
## Summary
- Remove `on_schema_mismatch` and `strict_schema` as top-level action/defaults config keys
- Add `on_schema_mismatch: Literal["reject", "reprompt"]` to `RepromptConfig`
- Schema conformance is now declared entirely inside the `reprompt:` block
- No backward compat, no warn mode, no aliases

### Before
```yaml
on_schema_mismatch: reprompt
schema:
  genre: str
reprompt:
  max_attempts: 3
```

### After
```yaml
schema:
  genre: str
reprompt:
  on_schema_mismatch: reprompt
  max_attempts: 3
```

## Files changed (13)
- `config/schema.py` — field migration
- `processing/helpers.py` — `_resolve_schema_mismatch_mode` reads from reprompt dict
- `processing/invocation/factory.py` — remove `STRICT_SCHEMA_KEY` usage
- `validation/granularity_output_field_validator.py` — new schema-required check
- `utils/constants.py` — remove dead constants
- 6 test files — fixture migration + rejection tests
- 2 doc files — updated examples

## Verification
- `ruff check` + `ruff format --check` clean
- 6388 tests passed, 0 failures
- grep gates: zero stale references to `on_schema_mismatch`, `strict_schema`, `ON_SCHEMA_MISMATCH_KEY`, `STRICT_SCHEMA_KEY` in production code