### PR TITLE
Fix extension preview: unwrap namespaces, truncate table cells

### DIFF
--- a/vscode-extension/src/utils/storageReader.ts
+++ b/vscode-extension/src/utils/storageReader.ts
@@ -298,11 +298,32 @@ try:
         print(result)
 
     elif command == 'preview':
+        action_name_arg = args['action_name']
         result = backend.preview_target(
-            action_name=args['action_name'],
+            action_name=action_name_arg,
             limit=args.get('limit', 50),
             offset=args.get('offset', 0),
         )
+        # Unwrap namespaced content — match docs scanner's _unwrap_record_content.
+        # Replaces record["content"] with only the action's namespace fields,
+        # stripping sibling namespaces (e.g. source.page_content) from display.
+        def _unwrap(rec):
+            if not isinstance(rec, dict):
+                return rec
+            content = rec.get('content')
+            if not isinstance(content, dict):
+                return rec
+            if action_name_arg in content:
+                ns = content[action_name_arg]
+                if ns is None:
+                    return {**rec, 'content': {}}
+                if isinstance(ns, dict):
+                    return {**rec, 'content': ns}
+                return {**rec, 'content': {action_name_arg: ns}}
+            if any(isinstance(v, (dict, type(None))) for v in content.values()):
+                return {**rec, 'content': {}}
+            return rec
+        result['records'] = [_unwrap(r) for r in result.get('records', [])]
         result['storagePath'] = str(backend.db_path) if hasattr(backend, 'db_path') else workflow_path
         result['backendType'] = backend.backend_type
         print(json.dumps(result, ensure_ascii=False, default=str))

--- a/vscode-extension/src/views/queryResultsPanel.ts
+++ b/vscode-extension/src/views/queryResultsPanel.ts
@@ -338,8 +338,12 @@ export class QueryResultsPanel implements vscode.Disposable {
                         dr[actionName] = actionNs;
                         nsExtracted = true;
                     }
+                } else if (Object.keys(content).length > 0) {
+                    // Content already unwrapped by backend — use directly (matches docs getDisplayFields)
+                    dr = content;
+                    nsExtracted = true;
                 } else if (actionName) {
-                    // Action namespace not in content — record passed through without this action producing output
+                    // Empty content = guard skipped
                     dr = {};
                     guardSkipped = true;
                 } else {
@@ -549,7 +553,8 @@ function formatCell(value: unknown): string {
         const str = JSON.stringify(value);
         return str.length > 80 ? str.slice(0, 80) + '\u2026' : str;
     }
-    return String(value);
+    const str = String(value).replace(/\n/g, ' ').replace(/\t/g, ' ');
+    return str.length > 80 ? str.slice(0, 80) + '\u2026' : str;
 }
 
 /** Compute common pagination display variables. */


### PR DESCRIPTION
## Summary
- **Namespace unwrapping**: Extension preview now strips sibling namespaces from records before sending to the webview, matching the docs scanner's `_unwrap_record_content`. Prevents `source.page_content` (multi-KB scraped text with `\n` sequences) from rendering as a wall of text in Cards/Table views.
- **Table cell truncation**: `formatCell()` now truncates string values at 80 chars with whitespace normalization, matching the existing object truncation behavior.
- **Card script**: `buildCard` handles already-unwrapped content (non-empty `content` dict without action namespace key) by using it directly, matching docs' `getDisplayFields`.

## Verification
- `npm run package` passes (typecheck + build + vsix)
- Cards view shows only action output fields (summary, exam_density, density_reason) — no more source.page_content wall of text
- Table view truncates long string cells at 80 chars
- JSON view unchanged (raw data)