### PR TITLE
Fix extension trace lookup: use target_id instead of source_guid

### DIFF
--- a/.changes/unreleased/Bug Fix-20260506-496000.yaml
+++ b/.changes/unreleased/Bug Fix-20260506-496000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Extension data preview now shows Prompt Trace, Input Data, and Raw Response sections (trace lookup was using wrong key)"
+time: 2026-05-06T496000.000000Z

--- a/vscode-extension/src/commands/index.ts
+++ b/vscode-extension/src/commands/index.ts
@@ -193,10 +193,7 @@ async function navigatePreviewPage(
     panel.showResults(result, actionName, workflowPath, workflowName, limit, newOffset);
 }
 
-/**
- * Attach prompt traces to preview records by source_guid.
- * Fetches traces from the storage backend and merges them in-place.
- */
+/** Attach prompt traces to preview records by target_id. */
 async function attachTracesToRecords(
     reader: StorageReader,
     actionName: string,
@@ -208,9 +205,9 @@ async function attachTracesToRecords(
 
         for (const record of result.records) {
             const rec = record as Record<string, unknown>;
-            const guid = rec.source_guid;
-            if (typeof guid === 'string' && traceMap.has(guid)) {
-                rec._trace = traceMap.get(guid);
+            const tid = rec.target_id;
+            if (typeof tid === 'string' && traceMap.has(tid)) {
+                rec._trace = traceMap.get(tid);
             }
         }
     } catch {


### PR DESCRIPTION
## Summary
- `attachTracesToRecords` was looking up traces by `source_guid`, but the `prompt_trace` table keys by `target_id`. This meant Prompt Trace, Input Data, and Raw Response sections never appeared in the data preview.
- The docs scanner already uses `target_id` for the same lookup (`data_scanners.py` line 265).

## Verification
- `npm run package` passes
- Trace sections now appear in Cards view when prompt trace data exists