### PR TITLE
fix: null-safe observe/passthrough for guard-skipped/filtered namespaces

### DIFF
--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -25,6 +25,45 @@ logger = logging.getLogger(__name__)
 # Sentinel distinguishing "field not found" from a field whose value is falsy (0, "", False, None).
 _MISSING = object()
 
+
+def _resolve_missing_field(
+    prompt_context: dict,
+    ns_name: str,
+    field_ref: str,
+    action_name: str,
+    directive: str,
+) -> None:
+    """Return if namespace is null (guard-skipped/filtered), else raise.
+
+    When a dependency's guard triggers skip/filter, the namespace is stored
+    as None in field_context.  This matches guard evaluation semantics where
+    missing fields resolve to None rather than raising.
+    """
+    if ns_name in prompt_context and prompt_context[ns_name] is None:
+        logger.debug(
+            "[%s NULL-SAFE] '%s' on action '%s': namespace '%s' is "
+            "null (guard-skipped/filtered), resolving field as None",
+            directive.upper(),
+            field_ref,
+            action_name,
+            ns_name,
+        )
+        return None
+
+    field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref
+    raise ConfigurationError(
+        f"context_scope.{directive} field '{field_ref}' not found at runtime",
+        context={
+            "action": action_name,
+            "field_ref": field_ref,
+            "directive": directive,
+            "operation": "apply_context_scope",
+            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
+            f"Check the output schema of '{ns_name}'.",
+        },
+    )
+
+
 # Framework-injected namespaces that are always available for template rendering
 # regardless of context_scope.observe/passthrough. These are not user data —
 # they are iteration context, static reference data, and workflow metadata.
@@ -104,17 +143,10 @@ def apply_context_scope(
                 value = extract_field_value(prompt_context, ns_name, field_name, default=_MISSING)
 
                 if value is _MISSING:
-                    raise ConfigurationError(
-                        f"context_scope.passthrough field '{field_ref}' not found at runtime",
-                        context={
-                            "action": action_name,
-                            "field_ref": field_ref,
-                            "directive": "passthrough",
-                            "operation": "apply_context_scope",
-                            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
-                            f"Check the output schema of '{ns_name}'.",
-                        },
+                    _resolve_missing_field(
+                        prompt_context, ns_name, field_ref, action_name, "passthrough"
                     )
+                    value = None
 
                 passthrough_fields.setdefault(ns_name, {})[field_name] = value
 
@@ -217,17 +249,10 @@ def apply_context_scope(
                 value = extract_field_value(prompt_context, ns_name, field_name, default=_MISSING)
 
                 if value is _MISSING:
-                    raise ConfigurationError(
-                        f"context_scope.observe field '{field_ref}' not found at runtime",
-                        context={
-                            "action": action_name,
-                            "field_ref": field_ref,
-                            "directive": "observe",
-                            "operation": "apply_context_scope",
-                            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
-                            f"Check the output schema of '{ns_name}'.",
-                        },
+                    _resolve_missing_field(
+                        prompt_context, ns_name, field_ref, action_name, "observe"
                     )
+                    value = None
 
                 llm_context.setdefault(ns_name, {})[field_name] = value
 

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -166,11 +166,17 @@ def _load_dependency_namespaces(
 
                 dep_data = namespaced_content.get(dep_name)
                 if dep_data is None:
+                    # Namespace is null (guard-skipped) or absent (guard-filtered /
+                    # arrived via a different branch).  Store None so downstream
+                    # observe/passthrough can distinguish "declared but absent" from
+                    # "undeclared" and yield None instead of crashing.
                     logger.debug(
-                        "[RECORD NAMESPACE] '%s' not found on record for action '%s'",
+                        "[RECORD NAMESPACE] '%s' null/absent on record for action '%s' "
+                        "(likely guard-skipped or guard-filtered)",
                         dep_name,
                         agent_name,
                     )
+                    field_context[dep_name] = None
                     continue
 
                 if not isinstance(dep_data, dict):

--- a/tests/unit/prompt/context/test_null_safe_observe.py
+++ b/tests/unit/prompt/context/test_null_safe_observe.py
@@ -1,0 +1,254 @@
+"""Tests for null-safe observe/passthrough resolution (specs 401 + 402).
+
+When a guard skips or filters an upstream action, its namespace is null
+on the record.  Downstream observe/passthrough must yield None for its
+fields instead of raising ConfigurationError.
+"""
+
+import pytest
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.prompt.context.scope_application import apply_context_scope
+
+
+def _make_field_context(**namespaces):
+    """Build a field_context dict from namespace kwargs.
+
+    Example: _make_field_context(dep={"f": 1}, skipped=None)
+    """
+    return dict(namespaces)
+
+
+# ── Observe: null namespace (guard-skipped) ──────────────────────────
+
+
+class TestObserveNullNamespace:
+    """Spec 401: observe from guard-skipped namespace yields None."""
+
+    def test_specific_field_yields_none(self):
+        """observe: ['skipped.field'] where skipped is None → field is None, no crash."""
+        fc = _make_field_context(skipped=None)
+        prompt_ctx, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"]["field"] is None
+
+    def test_multiple_fields_all_yield_none(self):
+        """Multiple fields from a null namespace all resolve to None."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.a", "skipped.b", "skipped.c"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"] == {"a": None, "b": None, "c": None}
+
+    def test_wildcard_on_null_namespace_is_empty(self):
+        """observe: ['skipped.*'] where skipped is None → no fields extracted (already safe)."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.*"]},
+            action_name="downstream",
+        )
+        assert "skipped" not in llm_ctx
+
+    def test_mixed_null_and_present_namespaces(self):
+        """Normal namespace works; null namespace yields None."""
+        fc = _make_field_context(
+            present={"score": 95},
+            skipped=None,
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["present.score", "skipped.status"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["present"]["score"] == 95
+        assert llm_ctx["skipped"]["status"] is None
+
+    def test_null_namespace_in_prompt_context(self):
+        """Null namespace appears in prompt_context as None (for template rendering)."""
+        fc = _make_field_context(skipped=None)
+        prompt_ctx, _, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert prompt_ctx["skipped"] is None
+
+
+# ── Observe: strict mode preserved ───────────────────────────────────
+
+
+class TestObserveStrictPreserved:
+    """Normal observe behavior is unchanged: missing field from present namespace still crashes."""
+
+    def test_missing_field_from_present_namespace_raises(self):
+        """observe: ['dep.nonexistent'] where dep is a real dict → ConfigurationError."""
+        fc = _make_field_context(dep={"actual_field": "value"})
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["dep.nonexistent"]},
+                action_name="downstream",
+            )
+
+    def test_undeclared_namespace_raises(self):
+        """observe: ['ghost.field'] where ghost is not in field_context → ConfigurationError."""
+        fc = _make_field_context(dep={"f": 1})
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["ghost.field"]},
+                action_name="downstream",
+            )
+
+
+# ── Passthrough: null namespace ──────────────────────────────────────
+
+
+class TestPassthroughNullNamespace:
+    """Spec 401/402: passthrough from guard-skipped namespace yields None."""
+
+    def test_specific_field_yields_none(self):
+        """passthrough: ['skipped.field'] where skipped is None → field is None."""
+        fc = _make_field_context(skipped=None)
+        _, _, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"passthrough": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert pt["skipped"]["field"] is None
+
+    def test_wildcard_on_null_namespace_is_empty(self):
+        """passthrough: ['skipped.*'] where skipped is None → no fields extracted."""
+        fc = _make_field_context(skipped=None)
+        _, _, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"passthrough": ["skipped.*"]},
+            action_name="downstream",
+        )
+        assert "skipped" not in pt
+
+    def test_passthrough_strict_preserved(self):
+        """passthrough: ['dep.nonexistent'] from present namespace → ConfigurationError."""
+        fc = _make_field_context(dep={"actual": "value"})
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"passthrough": ["dep.nonexistent"]},
+                action_name="downstream",
+            )
+
+
+# ── Drop: null namespace ─────────────────────────────────────────────
+
+
+class TestDropNullNamespace:
+    """Drop on null namespace should not crash (already safe via isinstance check)."""
+
+    def test_drop_on_null_namespace_no_crash(self):
+        """drop: ['skipped.field'] where skipped is None → no crash, valid return."""
+        fc = _make_field_context(skipped=None)
+        prompt_ctx, llm_ctx, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"drop": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert isinstance(prompt_ctx, dict)
+        assert isinstance(llm_ctx, dict)
+        assert isinstance(pt, dict)
+
+
+# ── Gating: null namespace ───────────────────────────────────────────
+
+
+class TestGatingNullNamespace:
+    """The gating phase (prompt_context filtering) handles None correctly."""
+
+    def test_null_namespace_passes_through_gate(self):
+        """Null namespace in allowed set passes gating as None."""
+        fc = _make_field_context(skipped=None, present={"f": 1})
+        prompt_ctx, _, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.status", "present.f"]},
+            action_name="downstream",
+        )
+        assert prompt_ctx["skipped"] is None
+        assert prompt_ctx["present"]["f"] == 1
+
+
+# ── Fan-in: filter scenario (spec 402) ──────────────────────────────
+
+
+class TestFanInFilterScenario:
+    """Spec 402: fan-in where one branch was guard-filtered."""
+
+    def test_observe_from_filtered_branch(self):
+        """Action D depends on B and C; C was guard-filtered.
+
+        D's merged record has B's namespace but C is None.
+        Observe from C.field should yield None.
+        """
+        fc = _make_field_context(
+            action_b={"output": "processed"},
+            action_c=None,  # guard-filtered: arrived via different branch
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["action_b.output", "action_c.reason"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["action_b"]["output"] == "processed"
+        assert llm_ctx["action_c"]["reason"] is None
+
+    def test_passthrough_from_filtered_branch(self):
+        """Passthrough from filtered branch yields None."""
+        fc = _make_field_context(
+            action_b={"id": "abc"},
+            action_c=None,
+        )
+        _, _, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"passthrough": ["action_b.id", "action_c.trace_id"]},
+            action_name="downstream",
+        )
+        assert pt["action_b"]["id"] == "abc"
+        assert pt["action_c"]["trace_id"] is None
+
+
+# ── Combined: observe + passthrough + drop on null ───────────────────
+
+
+class TestCombinedDirectivesNullNamespace:
+    """Interaction of multiple directives when one namespace is null."""
+
+    def test_observe_and_passthrough_both_null_safe(self):
+        """Both observe and passthrough on the same null namespace yield None."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={
+                "observe": ["skipped.status"],
+                "passthrough": ["skipped.trace_id"],
+            },
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"]["status"] is None
+        assert pt["skipped"]["trace_id"] is None
+
+    def test_drop_then_observe_on_null_no_crash(self):
+        """Drop + observe on null namespace: drop is no-op, observe yields None."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={
+                "drop": ["skipped.secret"],
+                "observe": ["skipped.status"],
+            },
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"]["status"] is None

--- a/tests/unit/prompt/context/test_scope_application_file_mode.py
+++ b/tests/unit/prompt/context/test_scope_application_file_mode.py
@@ -250,12 +250,13 @@ class TestNoneNamespace:
         assert content["field"] == "value"
         assert "skipped" in content  # None namespace preserved for guards
 
-    def test_explicit_ref_on_none_namespace_skips_record(self):
-        """Explicit field ref on guard-skipped namespace skips enrichment."""
+    def test_explicit_ref_on_none_namespace_enriches_with_null_safe(self):
+        """Explicit field ref on guard-skipped namespace resolves as None (null-safe)."""
         record = {"content": {"skipped": None}}
         scope = {"observe": ["skipped.field"]}
         result = apply_context_scope_for_records([record], scope, action_name="test")
-        assert result[0] is record
+        # Record is enriched (not skipped) — null namespace preserved in content
+        assert result[0]["content"]["skipped"] is None
 
 
 # ── Drop + passthrough interaction ────────────────────────────────────

--- a/tests/unit/prompt/test_scope_builder_warning.py
+++ b/tests/unit/prompt/test_scope_builder_warning.py
@@ -58,12 +58,13 @@ class TestMissingNamespaceLogging:
         assert "extract" in result
         assert result["extract"]["text"] == "hello"
 
-        # classify namespace absent — not in result, no error
-        assert "classify" not in result
+        # classify namespace marked as None (guard-skipped/filtered)
+        assert "classify" in result
+        assert result["classify"] is None
 
         # Should log at DEBUG, not WARNING or ERROR
         debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
-        assert any("classify" in msg and "not found" in msg for msg in debug_messages)
+        assert any("classify" in msg and "null/absent" in msg for msg in debug_messages)
 
     def test_all_namespaces_present(self, caplog):
         """When all namespaces are present, no missing-namespace log is emitted."""


### PR DESCRIPTION
## Summary

- When an upstream action is guard-skipped (`on_false: skip`) or guard-filtered (`on_false: filter`), downstream `context_scope.observe` and `passthrough` now resolve fields as `None` instead of raising `ConfigurationError`
- This unblocks conditional HITL overrides and optional LLM fallback patterns that were previously impossible to configure
- Strict mode preserved: missing fields from present namespaces and undeclared namespaces still error

## Changes

| File | What changed |
|---|---|
| `scope_builder.py:167` | Null/absent dependency namespace stored as `None` in field_context (was silently skipped) |
| `scope_application.py:219` | Observe yields `None` for null namespace fields (was `ConfigurationError`) |
| `scope_application.py:106` | Passthrough: same null-safe behavior |
| `test_null_safe_observe.py` | 16 new tests: observe, passthrough, drop, gating, fan-in, combined directives, strict preservation |
| 2 existing test files | Updated assertions to match new null-namespace behavior |

## How it works

**Change 1** (scope_builder): When `_load_dependency_namespaces()` encounters a declared dependency whose namespace is `None` (guard-skipped) or absent (guard-filtered, arrived via different branch), it stores `None` in `field_context` instead of skipping. This marks "declared but absent" vs "undeclared".

**Change 2** (scope_application): When observe/passthrough encounters `_MISSING` and the namespace is explicitly `None` in `prompt_context`, it yields `None` instead of crashing. If the namespace doesn't exist at all (undeclared), it still raises `ConfigurationError`.

## Test plan

- [x] 16 new unit tests covering all directive × null-namespace combinations
- [x] 2 existing tests updated (scope_builder warning, FILE mode enrichment)
- [x] Full test suite: 6428 passed, 0 failed
- [x] `ruff check` and `ruff format --check` clean

Closes specs 401 and 402.