### PR TITLE
fix: guard empty namespace + feat: concurrent Ollama batch

### DIFF
--- a/agent_actions/config/defaults.py
+++ b/agent_actions/config/defaults.py
@@ -18,12 +18,14 @@ class OllamaDefaults:
     """Defaults for Ollama local LLM provider."""
 
     BASE_URL: str = "http://localhost:11434"
+    BATCH_MAX_WORKERS: int = 1
 
 
 class OllamaCloudDefaults:
     """Defaults for Ollama Cloud provider (ollama.com)."""
 
     BASE_URL: str = "https://ollama.com"
+    BATCH_MAX_WORKERS: int = 1
 
 
 class ApiDefaults:

--- a/agent_actions/input/preprocessing/parsing/ast_nodes.py
+++ b/agent_actions/input/preprocessing/parsing/ast_nodes.py
@@ -182,6 +182,16 @@ def evaluate_node(
     if isinstance(node, FieldNode):
         value = get_nested_value(data, node.field_path)
         if value is None and not _field_exists(data, node.field_path):
+            # For dotted paths (ns.field), check if the top-level namespace exists
+            # but is None (guard-skipped/filtered) or empty dict (upstream failed).
+            # Return None instead of raising — the field is "expected absent."
+            if "." in node.field_path and isinstance(data, dict):
+                top_key = node.field_path.split(".", 1)[0]
+                if top_key in data:
+                    ns_value = data[top_key]
+                    if ns_value is None or (isinstance(ns_value, dict) and not ns_value):
+                        return None
+
             available = (
                 ", ".join(sorted(data.keys())) if isinstance(data, dict) else "(non-dict data)"
             )

--- a/agent_actions/llm/providers/batch_client_factory.py
+++ b/agent_actions/llm/providers/batch_client_factory.py
@@ -90,7 +90,10 @@ def _create_ollama_local(config: dict[str, Any]) -> BaseBatchClient:
     from .ollama.batch_client import OllamaBatchClient
 
     base_url = config.get("base_url") or os.getenv("OLLAMA_HOST", OllamaDefaults.BASE_URL)
-    return OllamaBatchClient(base_url=base_url, vendor_slug="ollama_local", cloud=False)
+    max_workers = config.get("batch_max_workers")
+    return OllamaBatchClient(
+        base_url=base_url, vendor_slug="ollama_local", cloud=False, max_workers=max_workers
+    )
 
 
 def _create_ollama_cloud(config: dict[str, Any]) -> BaseBatchClient:
@@ -103,8 +106,13 @@ def _create_ollama_cloud(config: dict[str, Any]) -> BaseBatchClient:
     base_url = config.get("base_url") or os.getenv(
         "OLLAMA_CLOUD_HOST", OllamaCloudDefaults.BASE_URL
     )
+    max_workers = config.get("batch_max_workers")
     return OllamaBatchClient(
-        base_url=base_url, api_key=api_key, vendor_slug="ollama_cloud", cloud=True
+        base_url=base_url,
+        api_key=api_key,
+        vendor_slug="ollama_cloud",
+        cloud=True,
+        max_workers=max_workers,
     )
 
 

--- a/agent_actions/llm/providers/ollama/batch_client.py
+++ b/agent_actions/llm/providers/ollama/batch_client.py
@@ -1,9 +1,13 @@
 """
-Ollama Batch Client — synchronous batch simulation for local and cloud.
+Ollama Batch Client — batch simulation for local and cloud.
 
-Both vendors use the same fake synchronous loop (no real batch API exists
-for either). The ``cloud`` flag controls client construction (Bearer auth)
+Both vendors use the same in-process loop (no real batch API exists for
+either). The ``cloud`` flag controls client construction (Bearer auth)
 and whether the ``format`` param is passed to ``client.chat()``.
+
+Records are processed concurrently via ``ThreadPoolExecutor``.  Concurrency
+is controlled by ``OLLAMA_BATCH_MAX_WORKERS`` (env var) or the constructor
+``max_workers`` parameter.  Default is 1 (sequential, matching prior behavior).
 
 When Ollama ships a real cloud batch API, add a
 ``_submit_to_cloud_batch_api`` branch inside ``_submit_to_provider_api``.
@@ -14,6 +18,7 @@ import logging
 import os
 import time
 import uuid
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -48,9 +53,11 @@ class OllamaBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
         *,
         vendor_slug: str = "ollama_local",
         cloud: bool = False,
+        max_workers: int | None = None,
     ):
         self.vendor_slug = vendor_slug
         self.cloud = cloud
+        self._max_workers = max_workers
 
         if cloud:
             self.base_url = base_url or os.getenv("OLLAMA_CLOUD_HOST", OllamaCloudDefaults.BASE_URL)
@@ -114,83 +121,134 @@ class OllamaBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
     ) -> Path:
         return self._write_jsonl_file(tasks, batch_dir, batch_name, self.vendor_slug)
 
+    _MAX_WORKERS_LIMIT: int = 32
+
+    def _get_max_workers(self) -> int:
+        """Resolve batch concurrency: constructor param > env var > class default."""
+        default = (
+            OllamaCloudDefaults.BATCH_MAX_WORKERS
+            if self.cloud
+            else OllamaDefaults.BATCH_MAX_WORKERS
+        )
+
+        if self._max_workers is not None:
+            val = self._max_workers
+        else:
+            env_val = os.getenv("OLLAMA_BATCH_MAX_WORKERS")
+            if env_val:
+                try:
+                    val = int(env_val)
+                except ValueError:
+                    logger.warning(
+                        "OLLAMA_BATCH_MAX_WORKERS=%s is not an integer, using default", env_val
+                    )
+                    return default
+            else:
+                return default
+
+        if val < 1:
+            logger.warning("batch_max_workers=%s invalid (must be >= 1), using default", val)
+            return default
+        if val > self._MAX_WORKERS_LIMIT:
+            logger.warning(
+                "batch_max_workers=%s exceeds limit of %s, clamping",
+                val,
+                self._MAX_WORKERS_LIMIT,
+            )
+            return self._MAX_WORKERS_LIMIT
+        return val
+
+    def _process_single_task(
+        self, task: dict[str, Any], idx: int, total: int
+    ) -> dict[str, Any] | None:
+        """Process one batch task. Returns result dict, or None if injection-dropped."""
+        custom_id = task["custom_id"]
+        logger.info("Processing request %d/%d: %s", idx + 1, total, custom_id)
+
+        try:
+            body = task["body"]
+            messages = body["messages"]
+            model = body.get("model", "llama2")
+
+            temperature = body.get("temperature")
+            options: dict[str, Any] = {
+                "temperature": temperature if temperature is not None else 1.0
+            }
+            max_tokens = body.get("max_tokens")
+            if max_tokens is not None:
+                options["num_predict"] = max_tokens
+
+            # Handle JSON mode with structured outputs.
+            # Cloud: format param not supported (ollama/ollama#12362).
+            format_param: str | dict[str, Any] | None = None
+            if not self.cloud:
+                response_format = body.get("response_format")
+                if response_format and isinstance(response_format, dict):
+                    if response_format.get("type") == "json_schema":
+                        json_schema = response_format.get("json_schema", {})
+                        format_param = _extract_ollama_schema(json_schema)
+                        if not format_param:
+                            format_param = "json"
+
+            ollama_response = self.client.chat(
+                model=model,
+                messages=messages,
+                options=options,
+                format=format_param,  # type: ignore[arg-type]
+            )
+
+            if should_fail_batch_record(custom_id, idx):
+                logger.debug("[INJECTION] Simulating missing result for %s", custom_id)
+                return None
+
+            return self._transform_ollama_response(
+                ollama_response,
+                custom_id,
+                model,  # type: ignore[arg-type]
+            )
+
+        except Exception as e:
+            logger.error("Error processing %s: %s", custom_id, e)
+            return {
+                "custom_id": custom_id,
+                "response": None,
+                "error": {
+                    "message": str(e),
+                    "type": f"{self.vendor_slug}_error",
+                    "code": "inference_error",
+                },
+            }
+
     def _submit_to_provider_api(self, input_file: Path, batch_name: str) -> tuple[str, str]:
-        """Process batch synchronously (no actual API submission)."""
+        """Process batch with concurrent workers (default: 1 = sequential)."""
         batch_id = f"batch_{uuid.uuid4().hex}"
 
-        tasks = []
+        tasks: list[dict[str, Any]] = []
         with open(input_file, encoding="utf-8") as f:
             for line in f:
                 if line.strip():
                     tasks.append(json.loads(line))
 
-        results = []
-        completed = 0
-        failed = 0
+        total = len(tasks)
+        max_workers = self._get_max_workers()
+        results: list[dict[str, Any]] = []
 
-        for idx, task in enumerate(tasks):
-            custom_id = task["custom_id"]
-            logger.info("Processing request %d/%d: %s", idx + 1, len(tasks), custom_id)
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ollama_batch") as pool:
+            futures: dict[Future[dict[str, Any] | None], str] = {
+                pool.submit(self._process_single_task, task, idx, total): task["custom_id"]
+                for idx, task in enumerate(tasks)
+            }
+            for future in as_completed(futures):
+                custom_id = futures[future]
+                try:
+                    result = future.result()
+                    if result is not None:
+                        results.append(result)
+                except Exception as e:
+                    logger.error("Unexpected error processing %s: %s", custom_id, e)
 
-            try:
-                body = task["body"]
-                messages = body["messages"]
-                model = body.get("model", "llama2")
-
-                options: dict[str, Any] = {
-                    "temperature": (
-                        body.get("temperature") if body.get("temperature") is not None else 1.0
-                    )
-                }
-                max_tokens = body.get("max_tokens")
-                if max_tokens is not None:
-                    options["num_predict"] = max_tokens
-
-                # Handle JSON mode with structured outputs.
-                # Cloud: format param not supported (ollama/ollama#12362).
-                format_param: str | dict[str, Any] | None = None
-                if not self.cloud:
-                    response_format = body.get("response_format")
-                    if response_format and isinstance(response_format, dict):
-                        if response_format.get("type") == "json_schema":
-                            json_schema = response_format.get("json_schema", {})
-                            format_param = _extract_ollama_schema(json_schema)
-                            if not format_param:
-                                format_param = "json"
-
-                ollama_response = self.client.chat(
-                    model=model,
-                    messages=messages,
-                    options=options,
-                    format=format_param,  # type: ignore[arg-type]
-                )
-
-                if should_fail_batch_record(custom_id, idx):
-                    logger.debug("[INJECTION] Simulating missing result for %s", custom_id)
-                    failed += 1
-                    continue
-
-                openai_response = self._transform_ollama_response(
-                    ollama_response,
-                    custom_id,
-                    model,  # type: ignore[arg-type]
-                )
-                results.append(openai_response)
-                completed += 1
-
-            except Exception as e:
-                logger.error("Error processing %s: %s", custom_id, e)
-                error_response = {
-                    "custom_id": custom_id,
-                    "response": None,
-                    "error": {
-                        "message": str(e),
-                        "type": f"{self.vendor_slug}_error",
-                        "code": "inference_error",
-                    },
-                }
-                results.append(error_response)
-                failed += 1
+        completed = sum(1 for r in results if r.get("error") is None)
+        failed = total - completed
 
         batch_dir = input_file.parent
         output_file_path = batch_dir / f"{batch_id}_results.jsonl"

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -25,6 +25,45 @@ logger = logging.getLogger(__name__)
 # Sentinel distinguishing "field not found" from a field whose value is falsy (0, "", False, None).
 _MISSING = object()
 
+
+def _resolve_missing_field(
+    prompt_context: dict,
+    ns_name: str,
+    field_ref: str,
+    action_name: str,
+    directive: str,
+) -> None:
+    """Return if namespace is null (guard-skipped/filtered), else raise.
+
+    When a dependency's guard triggers skip/filter, the namespace is stored
+    as None in field_context.  This matches guard evaluation semantics where
+    missing fields resolve to None rather than raising.
+    """
+    if ns_name in prompt_context and prompt_context[ns_name] is None:
+        logger.debug(
+            "[%s NULL-SAFE] '%s' on action '%s': namespace '%s' is "
+            "null (guard-skipped/filtered), resolving field as None",
+            directive.upper(),
+            field_ref,
+            action_name,
+            ns_name,
+        )
+        return None
+
+    field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref
+    raise ConfigurationError(
+        f"context_scope.{directive} field '{field_ref}' not found at runtime",
+        context={
+            "action": action_name,
+            "field_ref": field_ref,
+            "directive": directive,
+            "operation": "apply_context_scope",
+            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
+            f"Check the output schema of '{ns_name}'.",
+        },
+    )
+
+
 # Framework-injected namespaces that are always available for template rendering
 # regardless of context_scope.observe/passthrough. These are not user data —
 # they are iteration context, static reference data, and workflow metadata.
@@ -104,17 +143,10 @@ def apply_context_scope(
                 value = extract_field_value(prompt_context, ns_name, field_name, default=_MISSING)
 
                 if value is _MISSING:
-                    raise ConfigurationError(
-                        f"context_scope.passthrough field '{field_ref}' not found at runtime",
-                        context={
-                            "action": action_name,
-                            "field_ref": field_ref,
-                            "directive": "passthrough",
-                            "operation": "apply_context_scope",
-                            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
-                            f"Check the output schema of '{ns_name}'.",
-                        },
+                    _resolve_missing_field(
+                        prompt_context, ns_name, field_ref, action_name, "passthrough"
                     )
+                    value = None
 
                 passthrough_fields.setdefault(ns_name, {})[field_name] = value
 
@@ -217,17 +249,10 @@ def apply_context_scope(
                 value = extract_field_value(prompt_context, ns_name, field_name, default=_MISSING)
 
                 if value is _MISSING:
-                    raise ConfigurationError(
-                        f"context_scope.observe field '{field_ref}' not found at runtime",
-                        context={
-                            "action": action_name,
-                            "field_ref": field_ref,
-                            "directive": "observe",
-                            "operation": "apply_context_scope",
-                            "hint": f"Field '{field_name}' does not exist in '{ns_name}' output. "
-                            f"Check the output schema of '{ns_name}'.",
-                        },
+                    _resolve_missing_field(
+                        prompt_context, ns_name, field_ref, action_name, "observe"
                     )
+                    value = None
 
                 llm_context.setdefault(ns_name, {})[field_name] = value
 

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -166,11 +166,17 @@ def _load_dependency_namespaces(
 
                 dep_data = namespaced_content.get(dep_name)
                 if dep_data is None:
+                    # Namespace is null (guard-skipped) or absent (guard-filtered /
+                    # arrived via a different branch).  Store None so downstream
+                    # observe/passthrough can distinguish "declared but absent" from
+                    # "undeclared" and yield None instead of crashing.
                     logger.debug(
-                        "[RECORD NAMESPACE] '%s' not found on record for action '%s'",
+                        "[RECORD NAMESPACE] '%s' null/absent on record for action '%s' "
+                        "(likely guard-skipped or guard-filtered)",
                         dep_name,
                         agent_name,
                     )
+                    field_context[dep_name] = None
                     continue
 
                 if not isinstance(dep_data, dict):

--- a/tests/integrations/providers/ollama/test_ollama_batch_client.py
+++ b/tests/integrations/providers/ollama/test_ollama_batch_client.py
@@ -2,13 +2,11 @@
 Tests for OllamaBatchClient.
 
 This test suite inherits all 11 contract tests from BaseBatchClientTests
-and adds Ollama-specific edge cases.
-
-Total tests for Ollama:
-- 11 inherited contract tests
-- 2 Ollama-specific tests
-= 13 total tests
+and adds Ollama-specific edge cases and concurrency tests.
 """
+
+import json
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -101,3 +99,191 @@ class TestOllamaBatchClient(BaseBatchClientTests):
         assert result["response"]["body"]["usage"]["completion_tokens"] == 8
         assert result["response"]["body"]["usage"]["total_tokens"] == 23
         assert result["error"] is None
+
+
+# ── Concurrency tests ───────────────────────────────────────────────
+
+
+def _make_ollama_response(content: str = "ok") -> dict:
+    """Build a minimal Ollama chat response dict."""
+    return {
+        "model": "llama2",
+        "message": {"role": "assistant", "content": content},
+        "done": True,
+        "prompt_eval_count": 5,
+        "eval_count": 3,
+    }
+
+
+def _make_task(custom_id: str) -> dict:
+    """Build a minimal JSONL task dict."""
+    return {
+        "custom_id": custom_id,
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": "llama2",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    }
+
+
+class TestOllamaBatchConcurrency:
+    """Tests for concurrent batch processing and max_workers config."""
+
+    def test_default_max_workers_is_one(self):
+        """No behavior change without opt-in."""
+        client = OllamaBatchClient(base_url="http://localhost:11434")
+        assert client._get_max_workers() == 1
+
+    def test_max_workers_from_constructor(self):
+        """Constructor param is used directly."""
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=4)
+        assert client._get_max_workers() == 4
+
+    def test_max_workers_from_env_var(self, monkeypatch):
+        """Env var OLLAMA_BATCH_MAX_WORKERS is respected."""
+        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "6")
+        client = OllamaBatchClient(base_url="http://localhost:11434")
+        assert client._get_max_workers() == 6
+
+    def test_max_workers_constructor_overrides_env(self, monkeypatch):
+        """Constructor param takes precedence over env var."""
+        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "8")
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=2)
+        assert client._get_max_workers() == 2
+
+    def test_max_workers_env_invalid_uses_default(self, monkeypatch):
+        """Non-integer env var falls back to default."""
+        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "not_a_number")
+        client = OllamaBatchClient(base_url="http://localhost:11434")
+        assert client._get_max_workers() == 1
+
+    def test_max_workers_env_zero_uses_default(self, monkeypatch):
+        """Zero env var falls back to default (must be >= 1)."""
+        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "0")
+        client = OllamaBatchClient(base_url="http://localhost:11434")
+        assert client._get_max_workers() == 1
+
+    def test_max_workers_constructor_negative_uses_default(self):
+        """Negative constructor value falls back to default."""
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=-1)
+        assert client._get_max_workers() == 1
+
+    def test_max_workers_constructor_zero_uses_default(self):
+        """Zero constructor value falls back to default."""
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=0)
+        assert client._get_max_workers() == 1
+
+    def test_max_workers_clamped_at_limit(self):
+        """Values above limit are clamped to 32."""
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=500)
+        assert client._get_max_workers() == 32
+
+    def test_max_workers_at_limit_is_allowed(self):
+        """Exactly at the limit is fine."""
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=32)
+        assert client._get_max_workers() == 32
+
+    def test_cloud_default_max_workers(self):
+        """Cloud client also defaults to 1."""
+        client = OllamaBatchClient(
+            base_url="https://ollama.com",
+            api_key="test-key-1234567890",
+            cloud=True,
+            vendor_slug="ollama_cloud",
+        )
+        assert client._get_max_workers() == 1
+
+    def test_concurrent_processes_all_records(self, tmp_path):
+        """All custom_ids present in results with max_workers=4."""
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=4)
+        client.client = MagicMock()
+        client.client.chat = MagicMock(return_value=_make_ollama_response())
+
+        tasks = [_make_task(f"rec-{i}") for i in range(10)]
+        input_file = tmp_path / "batch" / "input.jsonl"
+        input_file.parent.mkdir(parents=True)
+        with open(input_file, "w") as f:
+            for task in tasks:
+                f.write(json.dumps(task) + "\n")
+
+        batch_id, status = client._submit_to_provider_api(input_file, "test_batch")
+
+        assert status == "submitted"
+        output_file = input_file.parent / f"{batch_id}_results.jsonl"
+        assert output_file.exists()
+
+        results = []
+        with open(output_file) as f:
+            for line in f:
+                results.append(json.loads(line))
+
+        result_ids = {r["custom_id"] for r in results}
+        expected_ids = {f"rec-{i}" for i in range(10)}
+        assert result_ids == expected_ids
+
+    def test_concurrent_error_isolation(self, tmp_path):
+        """One task error doesn't kill others."""
+        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=3)
+        client.client = MagicMock()
+
+        def side_effect(model, messages, options, format):
+            # Fail for rec-2 only
+            if messages == [{"role": "user", "content": "fail"}]:
+                raise RuntimeError("simulated error")
+            return _make_ollama_response()
+
+        client.client.chat = MagicMock(side_effect=side_effect)
+
+        tasks = [_make_task(f"rec-{i}") for i in range(5)]
+        # Make rec-2 trigger the error
+        tasks[2]["body"]["messages"] = [{"role": "user", "content": "fail"}]
+
+        input_file = tmp_path / "batch" / "input.jsonl"
+        input_file.parent.mkdir(parents=True)
+        with open(input_file, "w") as f:
+            for task in tasks:
+                f.write(json.dumps(task) + "\n")
+
+        batch_id, _ = client._submit_to_provider_api(input_file, "test_batch")
+        output_file = input_file.parent / f"{batch_id}_results.jsonl"
+
+        results = []
+        with open(output_file) as f:
+            for line in f:
+                results.append(json.loads(line))
+
+        assert len(results) == 5
+        error_results = [r for r in results if r.get("error") is not None]
+        success_results = [r for r in results if r.get("error") is None]
+        assert len(error_results) == 1
+        assert error_results[0]["custom_id"] == "rec-2"
+        assert len(success_results) == 4
+
+    def test_sequential_preserved_with_default(self, tmp_path):
+        """max_workers=1 (default) produces correct results."""
+        client = OllamaBatchClient(base_url="http://localhost:11434")
+        client.client = MagicMock()
+        client.client.chat = MagicMock(return_value=_make_ollama_response("sequential"))
+
+        tasks = [_make_task(f"seq-{i}") for i in range(3)]
+        input_file = tmp_path / "batch" / "input.jsonl"
+        input_file.parent.mkdir(parents=True)
+        with open(input_file, "w") as f:
+            for task in tasks:
+                f.write(json.dumps(task) + "\n")
+
+        batch_id, _ = client._submit_to_provider_api(input_file, "test_batch")
+        output_file = input_file.parent / f"{batch_id}_results.jsonl"
+
+        results = []
+        with open(output_file) as f:
+            for line in f:
+                results.append(json.loads(line))
+
+        result_ids = {r["custom_id"] for r in results}
+        assert result_ids == {"seq-0", "seq-1", "seq-2"}
+        for r in results:
+            assert r["error"] is None
+            assert r["response"]["body"]["choices"][0]["message"]["content"] == "sequential"

--- a/tests/unit/input/test_guard_empty_namespace.py
+++ b/tests/unit/input/test_guard_empty_namespace.py
@@ -1,0 +1,261 @@
+"""Tests for guard evaluation on empty/null upstream namespaces (spec 126).
+
+When an upstream action fails (e.g., prompt too long), its namespace is an
+empty dict {}. When an upstream action is guard-skipped, its namespace is
+None.  In both cases, guard conditions referencing fields in that namespace
+should evaluate to None (falsy) instead of raising MissingFieldError.
+"""
+
+import pytest
+
+from agent_actions.input.preprocessing.parsing.ast_nodes import (
+    ComparisonNode,
+    ComparisonOperator,
+    FieldNode,
+    LiteralNode,
+    LogicalNode,
+    LogicalOperator,
+    MissingFieldError,
+    evaluate_node,
+)
+
+# ── Empty namespace (upstream failed) ────────────────────────────────
+
+
+class TestEmptyNamespace:
+    """Guard references field in empty namespace (upstream ran but failed)."""
+
+    def test_dotted_field_returns_none(self):
+        """ns.field where ns={} returns None, no MissingFieldError."""
+        node = FieldNode("upstream.exam_density")
+        data = {"upstream": {}, "source": {"text": "hello"}}
+        assert evaluate_node(node, data) is None
+
+    def test_eq_comparison_returns_false(self):
+        """ns.field == 'value' where ns={} evaluates to False."""
+        node = ComparisonNode(
+            FieldNode("upstream.exam_density"),
+            ComparisonOperator.EQ,
+            LiteralNode("high"),
+        )
+        data = {"upstream": {}, "source": {"text": "hello"}}
+        assert evaluate_node(node, data) is False
+
+    def test_is_null_returns_true(self):
+        """ns.field IS NULL where ns={} returns True."""
+        node = ComparisonNode(
+            FieldNode("upstream.exam_density"),
+            ComparisonOperator.IS_NULL,
+        )
+        data = {"upstream": {}}
+        assert evaluate_node(node, data) is True
+
+    def test_is_not_null_returns_false(self):
+        """ns.field IS NOT NULL where ns={} returns False."""
+        node = ComparisonNode(
+            FieldNode("upstream.exam_density"),
+            ComparisonOperator.IS_NOT_NULL,
+        )
+        data = {"upstream": {}}
+        assert evaluate_node(node, data) is False
+
+    def test_or_with_two_empty_fields_returns_false(self):
+        """ns.a == 'x' OR ns.b == 'y' where ns={} evaluates to False."""
+        node = LogicalNode(
+            LogicalOperator.OR,
+            ComparisonNode(
+                FieldNode("upstream.a"),
+                ComparisonOperator.EQ,
+                LiteralNode("x"),
+            ),
+            ComparisonNode(
+                FieldNode("upstream.b"),
+                ComparisonOperator.EQ,
+                LiteralNode("y"),
+            ),
+        )
+        data = {"upstream": {}}
+        assert evaluate_node(node, data) is False
+
+    def test_multiple_fields_all_return_none(self):
+        """Multiple field accesses on empty namespace all return None."""
+        data = {"upstream": {}}
+        assert evaluate_node(FieldNode("upstream.a"), data) is None
+        assert evaluate_node(FieldNode("upstream.b"), data) is None
+        assert evaluate_node(FieldNode("upstream.c"), data) is None
+
+
+# ── Null namespace (guard-skipped/filtered) ──────────────────────────
+
+
+class TestNullNamespace:
+    """Guard references field in null namespace (guard-skipped upstream)."""
+
+    def test_dotted_field_returns_none(self):
+        """ns.field where ns=None returns None, no MissingFieldError."""
+        node = FieldNode("skipped.status")
+        data = {"skipped": None, "source": {"text": "hello"}}
+        assert evaluate_node(node, data) is None
+
+    def test_eq_comparison_returns_false(self):
+        """ns.field == 'value' where ns=None evaluates to False."""
+        node = ComparisonNode(
+            FieldNode("skipped.status"),
+            ComparisonOperator.EQ,
+            LiteralNode("active"),
+        )
+        data = {"skipped": None}
+        assert evaluate_node(node, data) is False
+
+    def test_is_null_returns_true(self):
+        """ns.field IS NULL where ns=None returns True."""
+        node = ComparisonNode(
+            FieldNode("skipped.status"),
+            ComparisonOperator.IS_NULL,
+        )
+        data = {"skipped": None}
+        assert evaluate_node(node, data) is True
+
+
+# ── Strict behavior preserved ────────────────────────────────────────
+
+
+class TestStrictBehaviorPreserved:
+    """MissingFieldError still raised for actual config errors."""
+
+    def test_non_empty_namespace_missing_field_raises(self):
+        """ns.nonexistent where ns has data → MissingFieldError (likely typo)."""
+        node = FieldNode("upstream.nonexistent")
+        data = {"upstream": {"actual_field": "value"}}
+        with pytest.raises(MissingFieldError, match="does not exist"):
+            evaluate_node(node, data)
+
+    def test_absent_namespace_raises(self):
+        """ghost.field where ghost is not in data → MissingFieldError."""
+        node = FieldNode("ghost.field")
+        data = {"source": {"text": "hello"}}
+        with pytest.raises(MissingFieldError, match="does not exist"):
+            evaluate_node(node, data)
+
+    def test_non_dotted_missing_field_raises(self):
+        """Plain field (no dot) missing → MissingFieldError (existing behavior)."""
+        node = FieldNode("nonexistent")
+        data = {"name": "Alice"}
+        with pytest.raises(MissingFieldError, match="does not exist"):
+            evaluate_node(node, data)
+
+    def test_non_empty_namespace_preserves_suggestions(self):
+        """Flat field that exists as sub-field still gets 'Did you mean' suggestion."""
+        node = FieldNode("severity")
+        data = {"assess_severity": {"severity": "high"}}
+        with pytest.raises(MissingFieldError, match="Did you mean"):
+            evaluate_node(node, data)
+
+
+# ── Mixed namespaces ─────────────────────────────────────────────────
+
+
+class TestMixedNamespaces:
+    """One namespace is empty/null, another has data."""
+
+    def test_present_namespace_works_empty_returns_none(self):
+        """Normal namespace resolves; empty namespace returns None."""
+        data = {
+            "present": {"score": 95},
+            "failed": {},
+        }
+        assert evaluate_node(FieldNode("present.score"), data) == 95
+        assert evaluate_node(FieldNode("failed.score"), data) is None
+
+    def test_guard_or_mixed_namespaces(self):
+        """present.score > 50 OR failed.status == 'ok' — left is True, right is None."""
+        node = LogicalNode(
+            LogicalOperator.OR,
+            ComparisonNode(
+                FieldNode("present.score"),
+                ComparisonOperator.GT,
+                LiteralNode(50),
+            ),
+            ComparisonNode(
+                FieldNode("failed.status"),
+                ComparisonOperator.EQ,
+                LiteralNode("ok"),
+            ),
+        )
+        data = {"present": {"score": 95}, "failed": {}}
+        assert evaluate_node(node, data) is True
+
+    def test_guard_and_with_empty_right_returns_false(self):
+        """present.score > 50 AND failed.status == 'ok' — left True, right False."""
+        node = LogicalNode(
+            LogicalOperator.AND,
+            ComparisonNode(
+                FieldNode("present.score"),
+                ComparisonOperator.GT,
+                LiteralNode(50),
+            ),
+            ComparisonNode(
+                FieldNode("failed.status"),
+                ComparisonOperator.EQ,
+                LiteralNode("ok"),
+            ),
+        )
+        data = {"present": {"score": 95}, "failed": {}}
+        assert evaluate_node(node, data) is False
+
+
+# ── Reproduction case from spec 126 ─────────────────────────────────
+
+
+class TestSpec126Reproduction:
+    """Exact reproduction of the production scenario from spec 126.
+
+    Guard condition: summarize_page_content.exam_density == "high" or
+                     summarize_page_content.exam_density == "medium"
+    Upstream: summarize_page_content failed → empty namespace {}
+    Expected: condition evaluates to False → on_false: filter applies
+    """
+
+    def test_production_guard_condition_on_empty_namespace(self):
+        node = LogicalNode(
+            LogicalOperator.OR,
+            ComparisonNode(
+                FieldNode("summarize_page_content.exam_density"),
+                ComparisonOperator.EQ,
+                LiteralNode("high"),
+            ),
+            ComparisonNode(
+                FieldNode("summarize_page_content.exam_density"),
+                ComparisonOperator.EQ,
+                LiteralNode("medium"),
+            ),
+        )
+        data = {
+            "summarize_page_content": {},
+            "source": {"page_content": "some text"},
+            "version": {"iteration": 1},
+            "i": 1,
+            "idx": 0,
+        }
+        assert evaluate_node(node, data) is False
+
+    def test_production_guard_condition_on_present_namespace(self):
+        """Same condition with present data evaluates correctly."""
+        node = LogicalNode(
+            LogicalOperator.OR,
+            ComparisonNode(
+                FieldNode("summarize_page_content.exam_density"),
+                ComparisonOperator.EQ,
+                LiteralNode("high"),
+            ),
+            ComparisonNode(
+                FieldNode("summarize_page_content.exam_density"),
+                ComparisonOperator.EQ,
+                LiteralNode("medium"),
+            ),
+        )
+        data = {
+            "summarize_page_content": {"exam_density": "high", "summary": "..."},
+            "source": {"page_content": "some text"},
+        }
+        assert evaluate_node(node, data) is True

--- a/tests/unit/prompt/context/test_null_safe_observe.py
+++ b/tests/unit/prompt/context/test_null_safe_observe.py
@@ -1,0 +1,254 @@
+"""Tests for null-safe observe/passthrough resolution (specs 401 + 402).
+
+When a guard skips or filters an upstream action, its namespace is null
+on the record.  Downstream observe/passthrough must yield None for its
+fields instead of raising ConfigurationError.
+"""
+
+import pytest
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.prompt.context.scope_application import apply_context_scope
+
+
+def _make_field_context(**namespaces):
+    """Build a field_context dict from namespace kwargs.
+
+    Example: _make_field_context(dep={"f": 1}, skipped=None)
+    """
+    return dict(namespaces)
+
+
+# ── Observe: null namespace (guard-skipped) ──────────────────────────
+
+
+class TestObserveNullNamespace:
+    """Spec 401: observe from guard-skipped namespace yields None."""
+
+    def test_specific_field_yields_none(self):
+        """observe: ['skipped.field'] where skipped is None → field is None, no crash."""
+        fc = _make_field_context(skipped=None)
+        prompt_ctx, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"]["field"] is None
+
+    def test_multiple_fields_all_yield_none(self):
+        """Multiple fields from a null namespace all resolve to None."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.a", "skipped.b", "skipped.c"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"] == {"a": None, "b": None, "c": None}
+
+    def test_wildcard_on_null_namespace_is_empty(self):
+        """observe: ['skipped.*'] where skipped is None → no fields extracted (already safe)."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.*"]},
+            action_name="downstream",
+        )
+        assert "skipped" not in llm_ctx
+
+    def test_mixed_null_and_present_namespaces(self):
+        """Normal namespace works; null namespace yields None."""
+        fc = _make_field_context(
+            present={"score": 95},
+            skipped=None,
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["present.score", "skipped.status"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["present"]["score"] == 95
+        assert llm_ctx["skipped"]["status"] is None
+
+    def test_null_namespace_in_prompt_context(self):
+        """Null namespace appears in prompt_context as None (for template rendering)."""
+        fc = _make_field_context(skipped=None)
+        prompt_ctx, _, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert prompt_ctx["skipped"] is None
+
+
+# ── Observe: strict mode preserved ───────────────────────────────────
+
+
+class TestObserveStrictPreserved:
+    """Normal observe behavior is unchanged: missing field from present namespace still crashes."""
+
+    def test_missing_field_from_present_namespace_raises(self):
+        """observe: ['dep.nonexistent'] where dep is a real dict → ConfigurationError."""
+        fc = _make_field_context(dep={"actual_field": "value"})
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["dep.nonexistent"]},
+                action_name="downstream",
+            )
+
+    def test_undeclared_namespace_raises(self):
+        """observe: ['ghost.field'] where ghost is not in field_context → ConfigurationError."""
+        fc = _make_field_context(dep={"f": 1})
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["ghost.field"]},
+                action_name="downstream",
+            )
+
+
+# ── Passthrough: null namespace ──────────────────────────────────────
+
+
+class TestPassthroughNullNamespace:
+    """Spec 401/402: passthrough from guard-skipped namespace yields None."""
+
+    def test_specific_field_yields_none(self):
+        """passthrough: ['skipped.field'] where skipped is None → field is None."""
+        fc = _make_field_context(skipped=None)
+        _, _, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"passthrough": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert pt["skipped"]["field"] is None
+
+    def test_wildcard_on_null_namespace_is_empty(self):
+        """passthrough: ['skipped.*'] where skipped is None → no fields extracted."""
+        fc = _make_field_context(skipped=None)
+        _, _, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"passthrough": ["skipped.*"]},
+            action_name="downstream",
+        )
+        assert "skipped" not in pt
+
+    def test_passthrough_strict_preserved(self):
+        """passthrough: ['dep.nonexistent'] from present namespace → ConfigurationError."""
+        fc = _make_field_context(dep={"actual": "value"})
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"passthrough": ["dep.nonexistent"]},
+                action_name="downstream",
+            )
+
+
+# ── Drop: null namespace ─────────────────────────────────────────────
+
+
+class TestDropNullNamespace:
+    """Drop on null namespace should not crash (already safe via isinstance check)."""
+
+    def test_drop_on_null_namespace_no_crash(self):
+        """drop: ['skipped.field'] where skipped is None → no crash, valid return."""
+        fc = _make_field_context(skipped=None)
+        prompt_ctx, llm_ctx, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"drop": ["skipped.field"]},
+            action_name="downstream",
+        )
+        assert isinstance(prompt_ctx, dict)
+        assert isinstance(llm_ctx, dict)
+        assert isinstance(pt, dict)
+
+
+# ── Gating: null namespace ───────────────────────────────────────────
+
+
+class TestGatingNullNamespace:
+    """The gating phase (prompt_context filtering) handles None correctly."""
+
+    def test_null_namespace_passes_through_gate(self):
+        """Null namespace in allowed set passes gating as None."""
+        fc = _make_field_context(skipped=None, present={"f": 1})
+        prompt_ctx, _, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped.status", "present.f"]},
+            action_name="downstream",
+        )
+        assert prompt_ctx["skipped"] is None
+        assert prompt_ctx["present"]["f"] == 1
+
+
+# ── Fan-in: filter scenario (spec 402) ──────────────────────────────
+
+
+class TestFanInFilterScenario:
+    """Spec 402: fan-in where one branch was guard-filtered."""
+
+    def test_observe_from_filtered_branch(self):
+        """Action D depends on B and C; C was guard-filtered.
+
+        D's merged record has B's namespace but C is None.
+        Observe from C.field should yield None.
+        """
+        fc = _make_field_context(
+            action_b={"output": "processed"},
+            action_c=None,  # guard-filtered: arrived via different branch
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["action_b.output", "action_c.reason"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["action_b"]["output"] == "processed"
+        assert llm_ctx["action_c"]["reason"] is None
+
+    def test_passthrough_from_filtered_branch(self):
+        """Passthrough from filtered branch yields None."""
+        fc = _make_field_context(
+            action_b={"id": "abc"},
+            action_c=None,
+        )
+        _, _, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"passthrough": ["action_b.id", "action_c.trace_id"]},
+            action_name="downstream",
+        )
+        assert pt["action_b"]["id"] == "abc"
+        assert pt["action_c"]["trace_id"] is None
+
+
+# ── Combined: observe + passthrough + drop on null ───────────────────
+
+
+class TestCombinedDirectivesNullNamespace:
+    """Interaction of multiple directives when one namespace is null."""
+
+    def test_observe_and_passthrough_both_null_safe(self):
+        """Both observe and passthrough on the same null namespace yield None."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={
+                "observe": ["skipped.status"],
+                "passthrough": ["skipped.trace_id"],
+            },
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"]["status"] is None
+        assert pt["skipped"]["trace_id"] is None
+
+    def test_drop_then_observe_on_null_no_crash(self):
+        """Drop + observe on null namespace: drop is no-op, observe yields None."""
+        fc = _make_field_context(skipped=None)
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={
+                "drop": ["skipped.secret"],
+                "observe": ["skipped.status"],
+            },
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped"]["status"] is None

--- a/tests/unit/prompt/context/test_scope_application_file_mode.py
+++ b/tests/unit/prompt/context/test_scope_application_file_mode.py
@@ -250,12 +250,13 @@ class TestNoneNamespace:
         assert content["field"] == "value"
         assert "skipped" in content  # None namespace preserved for guards
 
-    def test_explicit_ref_on_none_namespace_skips_record(self):
-        """Explicit field ref on guard-skipped namespace skips enrichment."""
+    def test_explicit_ref_on_none_namespace_enriches_with_null_safe(self):
+        """Explicit field ref on guard-skipped namespace resolves as None (null-safe)."""
         record = {"content": {"skipped": None}}
         scope = {"observe": ["skipped.field"]}
         result = apply_context_scope_for_records([record], scope, action_name="test")
-        assert result[0] is record
+        # Record is enriched (not skipped) — null namespace preserved in content
+        assert result[0]["content"]["skipped"] is None
 
 
 # ── Drop + passthrough interaction ────────────────────────────────────

--- a/tests/unit/prompt/test_scope_builder_warning.py
+++ b/tests/unit/prompt/test_scope_builder_warning.py
@@ -58,12 +58,13 @@ class TestMissingNamespaceLogging:
         assert "extract" in result
         assert result["extract"]["text"] == "hello"
 
-        # classify namespace absent — not in result, no error
-        assert "classify" not in result
+        # classify namespace marked as None (guard-skipped/filtered)
+        assert "classify" in result
+        assert result["classify"] is None
 
         # Should log at DEBUG, not WARNING or ERROR
         debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
-        assert any("classify" in msg and "not found" in msg for msg in debug_messages)
+        assert any("classify" in msg and "null/absent" in msg for msg in debug_messages)
 
     def test_all_namespaces_present(self, caplog):
         """When all namespaces are present, no missing-namespace log is emitted."""


### PR DESCRIPTION
## Summary
- **Guard null-safety (spec 126):** Guard conditions referencing fields in empty (`{}`) or null (`None`) upstream namespaces now return `None` instead of crashing with `MissingFieldError`. When an upstream action fails for a specific record, downstream guards evaluate to falsy and `on_false: filter` applies correctly.
- **Null-safe observe/passthrough:** Observe and passthrough field resolution handles guard-skipped and guard-filtered namespaces without errors.
- **Concurrent Ollama batch processing:** Records are now processed via `ThreadPoolExecutor` instead of sequentially. Configurable per-action (`batch_max_workers` in YAML), via env var (`OLLAMA_BATCH_MAX_WORKERS`), or constructor param. Default is 1 (no behavior change). Capped at 32.

## Configuration
```yaml
- name: summarize
  model_vendor: ollama_local
  batch_max_workers: 4  # process 4 records concurrently
```

Or via env var: `OLLAMA_BATCH_MAX_WORKERS=4`

## Verification
- 26 Ollama batch tests pass (14 new: concurrency, config resolution, error isolation, validation)
- 18 guard empty namespace tests pass (new)
- Full suite: 6460 passed, 2 skipped
- Linting clean (`ruff check` + `ruff format`)