### PR TITLE
fix(vscode-extension): scope preview data lookup by workflow name

### DIFF
--- a/vscode-extension/src/commands/index.ts
+++ b/vscode-extension/src/commands/index.ts
@@ -237,11 +237,10 @@ async function previewData(
         return;
     }
 
-    // Find the workflow this action belongs to
+    // Find the workflow this action belongs to (match by workflowName to avoid
+    // collisions when multiple workflows have actions with the same name)
     const workflows = model.getWorkflows();
-    const workflow = workflows.find((w) =>
-        w.actions.some((a) => a.name === action.name)
-    );
+    const workflow = workflows.find((w) => w.name === action.workflowName);
 
     if (!workflow) {
         vscode.window.showErrorMessage(`Could not find workflow for action ${action.name}`);

--- a/vscode-extension/src/model/types.ts
+++ b/vscode-extension/src/model/types.ts
@@ -35,6 +35,8 @@ export type ActionType =
 export interface ActionInfo {
     /** Action name from config */
     name: string;
+    /** Name of the workflow this action belongs to */
+    workflowName: string;
     /** 1-based execution order index */
     index: number;
     /** Execution level (0-based, actions at same level can run in parallel) */

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -474,6 +474,7 @@ export class WorkflowModel implements vscode.Disposable {
 
             return {
                 name: actionConfig.name,
+                workflowName: manifest?.workflow_name ?? parsedConfig.name,
                 index: actionIndex,
                 level,
                 status,


### PR DESCRIPTION
## Summary
- **Bug:** When two workflows have actions with the same name (e.g. `extract_raw_qa`), clicking "Preview Data" on one workflow's action shows data from the other workflow
- **Root cause:** `previewData()` resolved the parent workflow by finding the first workflow containing an action with a matching name — always returning the first match regardless of which tree node was clicked
- **Fix:** Added `workflowName` to `ActionInfo` so each action carries its parent workflow identity, then match on `w.name === action.workflowName` instead of scanning action name lists

## Changed files
- `vscode-extension/src/model/types.ts` — added `workflowName` field to `ActionInfo`
- `vscode-extension/src/model/workflowModel.ts` — set `workflowName` when constructing `ActionInfo`
- `vscode-extension/src/commands/index.ts` — lookup by workflow name instead of action name

## Verification
- TypeScript compiles cleanly (`npx tsc --noEmit`)
- Confirmed docs tooling already handles this correctly (per-workflow DB files, composite keys in catalog) — this fix aligns the extension with that pattern