### PR TITLE
Fix tool module resolution from subdirectories

### DIFF
--- a/.changes/unreleased/Bug Fix-20260508-128000.yaml
+++ b/.changes/unreleased/Bug Fix-20260508-128000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Resolve tool module paths relative to project root so custom tool imports work when running agac from a subdirectory"
+time: 2026-05-08T12:80:00.000000Z

--- a/agent_actions/processing/invocation/online.py
+++ b/agent_actions/processing/invocation/online.py
@@ -87,9 +87,10 @@ class OnlineStrategy(InvocationStrategy):
     ) -> tuple[Any, bool]:
         """Execute a single LLM call, returning (response, executed)."""
         from agent_actions.processing.helpers import run_dynamic_agent
+        from agent_actions.utils.tools_resolver import resolve_tools_path
 
         agent_config = cast(dict[str, Any], context.agent_config)
-        tools_path = agent_config.get("tools", {}).get("path")
+        tools_path = resolve_tools_path(agent_config)
         return run_dynamic_agent(
             agent_config,
             context.agent_name,

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -14,6 +14,7 @@ from agent_actions.processing.types import (
 )
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
+from agent_actions.utils.tools_resolver import resolve_tools_path
 from agent_actions.workflow.pipeline_file_mode import (
     extract_tool_input,
     is_empty_response,
@@ -56,12 +57,13 @@ class FileToolStrategy:
                 business = extract_tool_input(record, context_scope)
                 clean_input.append(TrackedItem(business, source_index=i))
 
+            agent_config = cast(dict[str, Any], context.agent_config)
             raw_response, executed = run_dynamic_agent(
-                agent_config=cast(dict[str, Any], context.agent_config),
+                agent_config=agent_config,
                 agent_name=context.agent_name,
                 context=clean_input,
                 formatted_prompt="",
-                tools_path=context.agent_config.get("tools_path"),
+                tools_path=resolve_tools_path(agent_config),
                 skip_guard_eval=True,
             )
 

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.processing.helpers import run_dynamic_agent
@@ -16,6 +16,7 @@ from agent_actions.processing.types import (
     ProcessingStatus,
 )
 from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.utils.tools_resolver import resolve_tools_path
 from agent_actions.workflow.pipeline_file_mode import extract_tool_input
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,7 @@ class HITLStrategy:
                 agent_name=context.agent_name,
                 context=filtered_records,
                 formatted_prompt="",
-                tools_path=cast(str | None, hitl_agent_config.get("tools_path")),
+                tools_path=resolve_tools_path(hitl_agent_config),
                 skip_guard_eval=True,
             )
 

--- a/agent_actions/utils/tools_resolver.py
+++ b/agent_actions/utils/tools_resolver.py
@@ -7,9 +7,18 @@ from typing import Any, cast
 import yaml
 
 from agent_actions.errors import ConfigValidationError
+from agent_actions.utils.path_utils import resolve_relative_to
 from agent_actions.utils.project_root import find_project_root
 
 logger = logging.getLogger(__name__)
+
+
+def _anchor_to_project_root(path: str) -> str:
+    """Anchor a relative path to the project root, or return as-is if absolute."""
+    root = find_project_root()
+    if root:
+        return str(resolve_relative_to(path, root))
+    return path
 
 
 def resolve_tools_path(agent_config: dict[str, Any]) -> str | None:
@@ -17,22 +26,26 @@ def resolve_tools_path(agent_config: dict[str, Any]) -> str | None:
 
     Supports legacy ``tool_path`` (str/list), simple ``tools.path``,
     and OpenAI function-calling ``tools[].function.file`` formats.
+    Relative paths are resolved against the detected project root so
+    that tool imports work from any working directory.
     """
     tool_path = agent_config.get("tool_path")
     if tool_path:
         if isinstance(tool_path, list) and len(tool_path) > 0:
             logger.debug("Resolved tools_path from tool_path list: %s", tool_path[0])
-            return cast(str, tool_path[0])
+            return _anchor_to_project_root(cast(str, tool_path[0]))
         if isinstance(tool_path, str):
             logger.debug("Resolved tools_path from tool_path string: %s", tool_path)
-            return tool_path
+            return _anchor_to_project_root(tool_path)
 
     tools = agent_config.get("tools", [])
 
     if isinstance(tools, dict) and "path" in tools:
         path = tools.get("path")
-        logger.debug("Resolved tools_path from tools.path: %s", path)
-        return path
+        if isinstance(path, str) and path:
+            logger.debug("Resolved tools_path from tools.path: %s", path)
+            return _anchor_to_project_root(path)
+        return None
 
     if isinstance(tools, list):
         for tool in tools:
@@ -57,6 +70,8 @@ def resolve_tools_path(agent_config: dict[str, Any]) -> str | None:
                                 logger.debug(
                                     "Resolved tools_path from OpenAI tool config: %s", module_path
                                 )
+                                # module_path is a Python module name (e.g. "my.module"),
+                                # not a filesystem path — skip _anchor_to_project_root.
                                 return cast(str, module_path)
                     except (
                         yaml.YAMLError,

--- a/tests/utilities/test_tools_resolver.py
+++ b/tests/utilities/test_tools_resolver.py
@@ -1,5 +1,6 @@
 """Tests for shared tools_resolver utility."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -72,3 +73,68 @@ class TestToolsResolver:
 
         resolved = resolve_tools_path(agent_config)
         assert resolved is None, f"Expected None for empty list, got {resolved}"
+
+
+class TestToolsResolverAbsoluteResolution:
+    """Test that relative tools paths are resolved against the project root."""
+
+    def test_relative_tool_path_resolved_against_project_root(self, tmp_path):
+        """A relative tool_path string is anchored to the project root."""
+        agent_config = {"tool_path": "tools/my_workflow"}
+
+        with patch(
+            "agent_actions.utils.tools_resolver.find_project_root",
+            return_value=tmp_path,
+        ):
+            resolved = resolve_tools_path(agent_config)
+
+        assert resolved == str(tmp_path / "tools" / "my_workflow")
+
+    def test_relative_tools_dict_path_resolved(self, tmp_path):
+        """A relative tools.path value is anchored to the project root."""
+        agent_config = {"tools": {"path": "tools/actions"}}
+
+        with patch(
+            "agent_actions.utils.tools_resolver.find_project_root",
+            return_value=tmp_path,
+        ):
+            resolved = resolve_tools_path(agent_config)
+
+        assert resolved == str(tmp_path / "tools" / "actions")
+
+    def test_relative_tool_path_list_resolved(self, tmp_path):
+        """A relative path in a tool_path list is anchored to the project root."""
+        agent_config = {"tool_path": ["tools/custom"]}
+
+        with patch(
+            "agent_actions.utils.tools_resolver.find_project_root",
+            return_value=tmp_path,
+        ):
+            resolved = resolve_tools_path(agent_config)
+
+        assert resolved == str(tmp_path / "tools" / "custom")
+
+    def test_absolute_path_unchanged(self, tmp_path):
+        """An absolute tools path passes through without modification."""
+        abs_path = str(tmp_path / "tools" / "my_workflow")
+        agent_config = {"tool_path": abs_path}
+
+        with patch(
+            "agent_actions.utils.tools_resolver.find_project_root",
+            return_value=Path("/some/other/root"),
+        ):
+            resolved = resolve_tools_path(agent_config)
+
+        assert resolved == abs_path
+
+    def test_relative_path_no_project_root_returns_as_is(self):
+        """When no project root is found, relative path is returned unchanged."""
+        agent_config = {"tool_path": "tools/fallback"}
+
+        with patch(
+            "agent_actions.utils.tools_resolver.find_project_root",
+            return_value=None,
+        ):
+            resolved = resolve_tools_path(agent_config)
+
+        assert resolved == "tools/fallback"


### PR DESCRIPTION
## Summary
- `resolve_tools_path()` now anchors relative paths against the detected project root via `_ensure_absolute()`, so tool imports work regardless of shell CWD
- Replaced 3 call sites that bypassed `resolve_tools_path()` with direct config reads (`online.py`, `file_tool.py`, `hitl.py`) — all tool path resolution now flows through a single codepath
- OpenAI format `module_path` (Python module names) excluded from path normalization since they aren't filesystem paths

## Verification
- `ruff format --check` and `ruff check` pass
- 6465 tests pass, 0 failures
- 5 new tests cover: relative path resolution (tool_path string, tool_path list, tools.path dict), absolute path passthrough, and graceful fallback when no project root is found