### PR TITLE
fix: update reprompt error messages to mention schema-based validation

### DIFF
--- a/.changes/unreleased/Bug Fix-20260509-403000.yaml
+++ b/.changes/unreleased/Bug Fix-20260509-403000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix reprompt error messages to mention schema-based validation alongside UDF-based"
+time: 2026-05-09T04:03:00.000000Z

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -296,7 +296,9 @@ class ActionConfig(BaseModel):
             return None
         if v is True:
             raise ValueError(
-                "reprompt: true is not valid; use reprompt: {validation: fn_name} or omit"
+                "reprompt: true is not valid. Use one of:\n"
+                "  reprompt: {on_schema_mismatch: reprompt}  # schema validates (no UDF needed)\n"
+                "  reprompt: {validation: fn_name}            # custom UDF validates"
             )
         return v
 
@@ -402,7 +404,9 @@ class DefaultsConfig(BaseModel):
             return None
         if v is True:
             raise ValueError(
-                "reprompt: true is not valid; use reprompt: {validation: fn_name} or omit"
+                "reprompt: true is not valid. Use one of:\n"
+                "  reprompt: {on_schema_mismatch: reprompt}  # schema validates (no UDF needed)\n"
+                "  reprompt: {validation: fn_name}            # custom UDF validates"
             )
         return v
 

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -384,8 +384,9 @@ def create_reprompt_service_from_config(
             )
         if reprompt_config:
             raise ValueError(
-                "Reprompt configuration missing required 'validation' field. "
-                "Example: {'validation': 'check_no_forbidden_words', 'max_attempts': 2}"
+                "Reprompt requires a validator. Add one of:\n"
+                "  validation: check_fn_name            # custom UDF\n"
+                "  on_schema_mismatch: reprompt         # use the action's schema"
             )
         return None
 

--- a/tests/integration/test_retry_reprompt_audit.py
+++ b/tests/integration/test_retry_reprompt_audit.py
@@ -571,7 +571,7 @@ class TestRepromptServiceFactory:
         assert svc is not None
 
     def test_config_missing_validation_no_validator_raises(self):
-        with pytest.raises(ValueError, match="missing required 'validation'"):
+        with pytest.raises(ValueError, match="Reprompt requires a validator"):
             create_reprompt_service_from_config({"max_attempts": 2})
 
     def test_config_with_validation_name(self):

--- a/tests/unit/config/test_reprompt_error_messages.py
+++ b/tests/unit/config/test_reprompt_error_messages.py
@@ -1,0 +1,33 @@
+"""tests/unit/config/test_reprompt_error_messages.py"""
+
+import pytest
+from pydantic import ValidationError
+
+from agent_actions.config.schema import ActionConfig, DefaultsConfig
+from agent_actions.processing.recovery.reprompt import create_reprompt_service_from_config
+
+
+class TestRepromptTrueRejection:
+    """reprompt: true must mention both schema-based and UDF-based options."""
+
+    def test_action_config_mentions_schema_option(self):
+        with pytest.raises(ValidationError, match="on_schema_mismatch"):
+            ActionConfig(
+                name="test_action",
+                intent="test",
+                reprompt=True,  # type: ignore[arg-type]
+            )
+
+    def test_defaults_config_mentions_schema_option(self):
+        with pytest.raises(ValidationError, match="on_schema_mismatch"):
+            DefaultsConfig(reprompt=True)  # type: ignore[arg-type]
+
+
+class TestRepromptMissingValidator:
+    """reprompt with no validator must mention on_schema_mismatch as an option."""
+
+    def test_missing_validator_mentions_schema_option(self):
+        with pytest.raises(ValueError, match="on_schema_mismatch"):
+            create_reprompt_service_from_config(
+                {"max_attempts": 3},  # no validation key, no external validator
+            )

--- a/tests/unit/core/test_reprompt_service.py
+++ b/tests/unit/core/test_reprompt_service.py
@@ -590,7 +590,7 @@ class TestParameterValidation:
         """Should raise ValueError when 'validation' key is missing from config."""
         config = {"max_attempts": 3}  # Missing "validation" key
 
-        with pytest.raises(ValueError, match="missing required 'validation' field"):
+        with pytest.raises(ValueError, match="Reprompt requires a validator"):
             create_reprompt_service_from_config(config)
 
     def test_valid_on_exhausted_values_accepted(self):

--- a/tests/unit/core/test_schema_mismatch_reprompt.py
+++ b/tests/unit/core/test_schema_mismatch_reprompt.py
@@ -302,7 +302,7 @@ class TestCreateRepromptServiceWithValidator:
     def test_no_validator_no_validation_key_raises(self):
         """No validator and no 'validation' key → ValueError."""
         reprompt_config = {"max_attempts": 3}
-        with pytest.raises(ValueError, match="missing required 'validation' field"):
+        with pytest.raises(ValueError, match="Reprompt requires a validator"):
             create_reprompt_service_from_config(reprompt_config)
 
 


### PR DESCRIPTION
## Summary
- Three error messages in reprompt configuration only suggested UDF-based reprompt (`validation: fn_name`).
  Updated to also show schema-based reprompt (`on_schema_mismatch: reprompt`) as a valid option.
- Affected locations:
  - `schema.py` ActionConfig `validate_reprompt` 
  - `schema.py` DefaultsConfig `validate_reprompt`
  - `reprompt.py` `create_reprompt_service_from_config`

## Verification
- Red→green test added (`test_reprompt_error_messages.py`) — 3 failures before fix, 3 passes after
- 3 existing test assertions updated to match new strings
- `ruff check` / `ruff format --check` clean
- `pytest` — 6468 passed, 2 skipped