### PR TITLE
fix: recover Ollama Cloud JSON wrapped in markdown fences

### DIFF
--- a/agent_actions/llm/providers/ollama/client.py
+++ b/agent_actions/llm/providers/ollama/client.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from typing import Any, ClassVar
 
 import httpx
+from json_repair import repair_json
 from ollama import Client, ResponseError
 
 from agent_actions.config.defaults import OllamaCloudDefaults
@@ -170,12 +171,34 @@ def _call_ollama_json(
             parsed = json.loads(content)
             return [parsed] if isinstance(parsed, dict) else [{"response": parsed}]
         except json.JSONDecodeError as e:
-            logger.debug(
-                "%s/%s returned invalid JSON: %s",
-                vendor_slug,
-                model,
-                e,
-            )
+            if not cloud:
+                logger.debug("%s/%s returned invalid JSON: %s", vendor_slug, model, e)
+                fire_event(LLMJSONParseErrorEvent(provider=vendor_slug, model=model, error=str(e)))
+                return [{"raw_response": content or "", "_parse_error": str(e)}]
+            # Cloud often wraps valid JSON in markdown fences or adds
+            # trailing commas. Use json_repair to recover the payload.
+            # Remove this branch when Ollama Cloud supports structured
+            # outputs (ollama/ollama#12362).
+            logger.debug("%s/%s: raw json.loads failed, attempting repair", vendor_slug, model)
+            repaired = repair_json(content, return_objects=True, skip_json_loads=True)
+            if isinstance(repaired, dict):
+                logger.info(
+                    "%s/%s: json_repair recovered valid dict from malformed response",
+                    vendor_slug,
+                    model,
+                )
+                return [repaired]
+            if isinstance(repaired, list):
+                logger.info(
+                    "%s/%s: json_repair recovered valid list from malformed response",
+                    vendor_slug,
+                    model,
+                )
+                return (
+                    repaired
+                    if all(isinstance(r, dict) for r in repaired)
+                    else [{"response": repaired}]
+                )
             fire_event(LLMJSONParseErrorEvent(provider=vendor_slug, model=model, error=str(e)))
             return [{"raw_response": content or "", "_parse_error": str(e)}]
     if isinstance(content, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "pyparsing>=3.1.1,<4",
     "sentence-transformers>=2.2.2,<6",
     "numpy>=1.26.4,<3",
+    "json-repair>=0.30.0,<1",
     "jsonschema>=4.23.0,<5",
     "pydantic>=2.8.0,<3",
     "pydantic-settings>=2.4.0,<3",

--- a/tests/unit/llm/providers/ollama/test_ollama_vendor_split.py
+++ b/tests/unit/llm/providers/ollama/test_ollama_vendor_split.py
@@ -297,6 +297,95 @@ class TestOllamaCloudClient:
         assert result[0]["_parse_error"]
         assert result[0]["raw_response"] == "not json at all"
 
+    @patch("agent_actions.llm.providers.ollama.client.ResponseBuilder")
+    @patch("agent_actions.llm.providers.ollama.client.fire_event")
+    @patch("agent_actions.llm.providers.ollama.client._build_ollama_client")
+    @patch("agent_actions.llm.providers.ollama.client.MessageBuilder")
+    def test_cloud_repair_recovers_fenced_json(self, mock_mb, mock_build, mock_fire, mock_rb):
+        """Cloud path recovers valid JSON wrapped in markdown fences."""
+        mock_envelope = MagicMock()
+        mock_envelope.to_dicts.return_value = [{"role": "user", "content": "hi"}]
+        mock_mb.build.return_value = mock_envelope
+
+        fenced = '```json\n{"label": "fruit"}\n```'
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _fake_chat_response(content=fenced)
+        mock_build.return_value = mock_client
+
+        config = _make_agent_config()
+        result = _call_ollama_json(
+            "key",
+            config,
+            PROMPT,
+            CONTEXT,
+            SCHEMA,
+            vendor_slug="ollama_cloud",
+            cloud=True,
+        )
+
+        assert len(result) == 1
+        assert result[0]["label"] == "fruit"
+        assert "_parse_error" not in result[0]
+
+    @patch("agent_actions.llm.providers.ollama.client.ResponseBuilder")
+    @patch("agent_actions.llm.providers.ollama.client.fire_event")
+    @patch("agent_actions.llm.providers.ollama.client._build_ollama_client")
+    @patch("agent_actions.llm.providers.ollama.client.MessageBuilder")
+    def test_cloud_repair_recovers_trailing_comma(self, mock_mb, mock_build, mock_fire, mock_rb):
+        """Cloud path recovers JSON with trailing commas."""
+        mock_envelope = MagicMock()
+        mock_envelope.to_dicts.return_value = [{"role": "user", "content": "hi"}]
+        mock_mb.build.return_value = mock_envelope
+
+        bad_json = '{"label": "fruit",}'
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _fake_chat_response(content=bad_json)
+        mock_build.return_value = mock_client
+
+        config = _make_agent_config()
+        result = _call_ollama_json(
+            "key",
+            config,
+            PROMPT,
+            CONTEXT,
+            SCHEMA,
+            vendor_slug="ollama_cloud",
+            cloud=True,
+        )
+
+        assert len(result) == 1
+        assert result[0]["label"] == "fruit"
+        assert "_parse_error" not in result[0]
+
+    @patch("agent_actions.llm.providers.ollama.client.ResponseBuilder")
+    @patch("agent_actions.llm.providers.ollama.client.fire_event")
+    @patch("agent_actions.llm.providers.ollama.client._build_ollama_client")
+    @patch("agent_actions.llm.providers.ollama.client.MessageBuilder")
+    def test_local_parse_failure_returns_error_dict(self, mock_mb, mock_build, mock_fire, mock_rb):
+        """Local path returns error dict without attempting repair."""
+        mock_envelope = MagicMock()
+        mock_envelope.to_dicts.return_value = [{"role": "user", "content": "hi"}]
+        mock_mb.build.return_value = mock_envelope
+
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _fake_chat_response(content="not json")
+        mock_build.return_value = mock_client
+
+        config = _make_agent_config()
+        result = _call_ollama_json(
+            None,
+            config,
+            PROMPT,
+            CONTEXT,
+            None,
+            vendor_slug="ollama_local",
+            cloud=False,
+        )
+
+        assert len(result) == 1
+        assert result[0]["_parse_error"]
+        assert result[0]["raw_response"] == "not json"
+
     def test_missing_api_key_raises_configuration_error(self):
         """_build_ollama_client(cloud=True) without api_key raises ConfigurationError."""
         config = _make_agent_config()


### PR DESCRIPTION
## Summary
- Ollama Cloud models return valid JSON wrapped in markdown fences (```json ... ```), trailing commas, or single quotes — `json.loads` rejects these, triggering an expensive reprompt LLM call for a formatting-only issue
- Added `json-repair` to recover the payload on the cloud path before falling back to the error dict
- Local path unchanged (API enforces `format` param)
- Tagged for removal when Ollama Cloud adds structured output support (ollama/ollama#12362)

## Verification
- `ruff format --check` and `ruff check` clean
- 78 Ollama tests pass, 2 skipped