### PR TITLE
feat(vscode-extension): sync webview theme from native VS Code variables

### DIFF
--- a/vscode-extension/src/views/dagWebview.ts
+++ b/vscode-extension/src/views/dagWebview.ts
@@ -139,7 +139,9 @@ export class DagWebview implements vscode.Disposable {
         const direction = layout === 'horizontal' ? 'LR' : 'TD';
 
         const diagram = this.buildMermaidDiagram(workflow.actions, direction);
-        this.panel.webview.html = this.renderHtml(this.panel.webview, diagram, workflow.name);
+        const isDark = vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
+                       vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast;
+        this.panel.webview.html = this.renderHtml(this.panel.webview, diagram, workflow.name, isDark);
     }
 
     private buildMermaidDiagram(actions: ActionInfo[], direction: string): string {
@@ -202,7 +204,7 @@ export class DagWebview implements vscode.Disposable {
         return status;
     }
 
-    private renderHtml(webview: vscode.Webview, diagram: string, workflowName: string): string {
+    private renderHtml(webview: vscode.Webview, diagram: string, workflowName: string, isDark: boolean): string {
         const nonce = this.getNonce();
 
         // Use locally bundled Mermaid for security and offline support
@@ -292,7 +294,7 @@ ${diagram}
 
         mermaid.initialize({
             startOnLoad: true,
-            theme: 'dark',
+            theme: '${isDark ? 'dark' : 'default'}',
             flowchart: {
                 curve: 'basis',
                 htmlLabels: false,  // Disable HTML labels for security

--- a/vscode-extension/src/views/dagWebview.ts
+++ b/vscode-extension/src/views/dagWebview.ts
@@ -22,9 +22,14 @@ export class DagWebview implements vscode.Disposable {
         private readonly context: vscode.ExtensionContext,
         private readonly model: WorkflowModel
     ) {
-        // Auto-update when model changes
+        // Auto-update when model changes or theme switches
         this.disposables.push(
             this.model.onDidChange(() => {
+                if (this.panel) {
+                    this.update();
+                }
+            }),
+            vscode.window.onDidChangeActiveColorTheme(() => {
                 if (this.panel) {
                     this.update();
                 }

--- a/vscode-extension/src/views/queryResultsPanel.ts
+++ b/vscode-extension/src/views/queryResultsPanel.ts
@@ -29,15 +29,12 @@ interface PreviewPayload {
     workflowPath: string;
     limit: number;
     offset: number;
-    themeKind: ThemeKind;
     /** Set when the storage backend's totalCount disagrees with the actual
      * records length on this page. The backend's `record_count` column can
      * go stale relative to the JSON `data` array; we surface the lie so
      * the user can see when storage is misreporting. */
     countDrift?: { reported: number; actual: number };
 }
-
-type ThemeKind = 'light' | 'dark' | 'high-contrast' | 'high-contrast-light';
 
 export class QueryResultsPanel implements vscode.Disposable {
     private panel: vscode.WebviewPanel | undefined;
@@ -121,7 +118,6 @@ export class QueryResultsPanel implements vscode.Disposable {
             workflowPath,
             limit,
             offset,
-            themeKind: currentThemeKind(),
             countDrift: drift,
         };
     }
@@ -202,14 +198,6 @@ export class QueryResultsPanel implements vscode.Disposable {
             this.disposables
         );
 
-        // Reflect VS Code theme changes into the webview
-        const themeSub = vscode.window.onDidChangeActiveColorTheme(() => {
-            if (this.panel && this.webviewReady) {
-                this.panel.webview.postMessage({ type: 'theme:update', kind: currentThemeKind() });
-            }
-        });
-        this.disposables.push(themeSub);
-
         return this.panel;
     }
 }
@@ -233,10 +221,8 @@ function renderAppHtml(
     ].join('; ');
 
     const initialJson = JSON.stringify(payload).replace(/</g, '\\u003c');
-    const themeClass = payload.themeKind === 'light' || payload.themeKind === 'high-contrast-light' ? 'theme-light' : 'dark';
-
     return `<!DOCTYPE html>
-<html lang="en" class="${themeClass}">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="Content-Security-Policy" content="${csp}">
@@ -289,16 +275,3 @@ function escapeHtml(value: string): string {
         .replace(/"/g, '&quot;');
 }
 
-function currentThemeKind(): ThemeKind {
-    switch (vscode.window.activeColorTheme.kind) {
-        case vscode.ColorThemeKind.Light:
-            return 'light';
-        case vscode.ColorThemeKind.HighContrast:
-            return 'high-contrast';
-        case vscode.ColorThemeKind.HighContrastLight:
-            return 'high-contrast-light';
-        case vscode.ColorThemeKind.Dark:
-        default:
-            return 'dark';
-    }
-}

--- a/vscode-extension/src/webview/main.tsx
+++ b/vscode-extension/src/webview/main.tsx
@@ -17,19 +17,7 @@ declare global {
   }
 }
 
-type ThemeKind = "light" | "dark" | "high-contrast" | "high-contrast-light";
-
-const VALID_THEME_KINDS: ReadonlySet<string> = new Set([
-  "light",
-  "dark",
-  "high-contrast",
-  "high-contrast-light",
-]);
-
 interface PreviewPayload {
-  // Records are unknown shapes from the backend; the only contract is
-  // that DataCard accepts them. Match the host-side type to keep the
-  // host/webview pair in sync.
   records: unknown[];
   totalCount: number;
   nodeName: string;
@@ -41,7 +29,6 @@ interface PreviewPayload {
   limit: number;
   offset: number;
   actionInfo?: ActionInfo;
-  themeKind?: ThemeKind;
   /** Set when host detects records.length disagrees with backend-reported
    * totalCount (either direction). The masthead chip surfaces the lie so
    * we don't paper over stale storage counts. */
@@ -50,23 +37,10 @@ interface PreviewPayload {
 
 const vscode = window.acquireVsCodeApi();
 
-function applyTheme(kind: ThemeKind | undefined) {
-  // Guard against malformed theme:update payloads — unknown values fall
-  // through to dark rather than triggering a visible flip.
-  const safe: ThemeKind = kind && VALID_THEME_KINDS.has(kind) ? kind : "dark";
-  const isLight = safe === "light" || safe === "high-contrast-light";
-  document.documentElement.classList.toggle("theme-light", isLight);
-  document.documentElement.classList.toggle("dark", !isLight);
-}
-
 const Tick = () => <span className="toolbar-tick" aria-hidden>│</span>;
 
 function App({ initial }: { initial: PreviewPayload }) {
   const [data, setData] = useState<PreviewPayload>(initial);
-
-  useEffect(() => {
-    applyTheme(data.themeKind);
-  }, [data.themeKind]);
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
@@ -74,8 +48,6 @@ function App({ initial }: { initial: PreviewPayload }) {
       if (!msg || typeof msg !== "object") return;
       if (msg.type === "preview:update" && msg.payload) {
         setData(msg.payload as PreviewPayload);
-      } else if (msg.type === "theme:update") {
-        applyTheme(msg.kind);
       }
     };
     window.addEventListener("message", handler);
@@ -224,6 +196,104 @@ function App({ initial }: { initial: PreviewPayload }) {
     </div>
   );
 }
+
+/* ── VS Code theme sync ──────────────────────────────────────────────── */
+// Reads VS Code's native CSS variables (auto-updated on theme change) and
+// converts them to HSL component format so our variable-based CSS adapts
+// to any installed theme — light, dark, or high-contrast.
+
+function colorToHsl(raw: string): string | null {
+  let r: number, g: number, b: number;
+  const hex = raw.match(/^#([0-9a-f]{3,8})$/i);
+  if (hex) {
+    const h = hex[1];
+    if (h.length === 3) {
+      r = parseInt(h[0] + h[0], 16);
+      g = parseInt(h[1] + h[1], 16);
+      b = parseInt(h[2] + h[2], 16);
+    } else if (h.length >= 6) {
+      r = parseInt(h.slice(0, 2), 16);
+      g = parseInt(h.slice(2, 4), 16);
+      b = parseInt(h.slice(4, 6), 16);
+    } else return null;
+  } else {
+    const rgb = raw.match(/rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/);
+    if (rgb) {
+      r = parseInt(rgb[1]);
+      g = parseInt(rgb[2]);
+      b = parseInt(rgb[3]);
+    } else return null;
+  }
+  const rn = r / 255,
+    gn = g / 255,
+    bn = b / 255;
+  const max = Math.max(rn, gn, bn),
+    min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  let hue = 0,
+    sat = 0;
+  if (max !== min) {
+    const d = max - min;
+    sat = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === rn) hue = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6;
+    else if (max === gn) hue = ((bn - rn) / d + 2) / 6;
+    else hue = ((rn - gn) / d + 4) / 6;
+  }
+  return `${Math.round(hue * 360)} ${Math.round(sat * 100)}% ${Math.round(l * 100)}%`;
+}
+
+const VSCODE_THEME_MAP: [string, ...string[]][] = [
+  ["--background", "--vscode-editor-background"],
+  ["--foreground", "--vscode-editor-foreground"],
+  ["--card", "--vscode-editorWidget-background", "--vscode-sideBar-background", "--vscode-editor-background"],
+  ["--card-foreground", "--vscode-editor-foreground"],
+  ["--card-elevated", "--vscode-editorHoverWidget-background", "--vscode-tab-activeBackground", "--vscode-editorWidget-background"],
+  ["--popover", "--vscode-editorWidget-background"],
+  ["--popover-foreground", "--vscode-editor-foreground"],
+  ["--primary", "--vscode-textLink-foreground"],
+  ["--primary-foreground", "--vscode-button-foreground", "--vscode-editor-background"],
+  ["--secondary", "--vscode-input-background", "--vscode-editor-background"],
+  ["--secondary-foreground", "--vscode-input-foreground", "--vscode-editor-foreground"],
+  ["--muted", "--vscode-input-background", "--vscode-editor-background"],
+  ["--muted-foreground", "--vscode-descriptionForeground"],
+  ["--accent", "--vscode-list-hoverBackground", "--vscode-editor-background"],
+  ["--accent-foreground", "--vscode-editor-foreground"],
+  ["--destructive", "--vscode-errorForeground"],
+  ["--border", "--vscode-panel-border", "--vscode-editorWidget-border"],
+  ["--border-strong", "--vscode-contrastBorder", "--vscode-panel-border"],
+  ["--input", "--vscode-input-background"],
+  ["--ring", "--vscode-focusBorder"],
+  ["--success", "--vscode-testing-iconPassed", "--vscode-debugIcon-startForeground"],
+  ["--warning", "--vscode-editorWarning-foreground"],
+];
+
+function syncVscodeTheme() {
+  const cs = getComputedStyle(document.documentElement);
+  const el = document.documentElement;
+  for (const [target, ...sources] of VSCODE_THEME_MAP) {
+    for (const src of sources) {
+      const raw = cs.getPropertyValue(src).trim();
+      if (raw) {
+        const hsl = colorToHsl(raw);
+        if (hsl) {
+          el.style.setProperty(target, hsl);
+          break;
+        }
+      }
+    }
+  }
+  const isDark =
+    document.body.classList.contains("vscode-dark") ||
+    document.body.classList.contains("vscode-high-contrast");
+  el.style.setProperty("color-scheme", isDark ? "dark" : "light");
+}
+
+// Run immediately; re-sync when VS Code flips the body class on theme change.
+syncVscodeTheme();
+new MutationObserver(() => syncVscodeTheme()).observe(document.body, {
+  attributes: true,
+  attributeFilter: ["class"],
+});
 
 /* ── Bootstrap ───────────────────────────────────────────────────────── */
 

--- a/vscode-extension/src/webview/main.tsx
+++ b/vscode-extension/src/webview/main.tsx
@@ -204,7 +204,7 @@ function App({ initial }: { initial: PreviewPayload }) {
 
 function colorToHsl(raw: string): string | null {
   let r: number, g: number, b: number;
-  const hex = raw.match(/^#([0-9a-f]{3,8})$/i);
+  const hex = raw.match(/^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
   if (hex) {
     const h = hex[1];
     if (h.length === 3) {
@@ -219,9 +219,9 @@ function colorToHsl(raw: string): string | null {
   } else {
     const rgb = raw.match(/rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/);
     if (rgb) {
-      r = parseInt(rgb[1]);
-      g = parseInt(rgb[2]);
-      b = parseInt(rgb[3]);
+      r = parseInt(rgb[1], 10);
+      g = parseInt(rgb[2], 10);
+      b = parseInt(rgb[3], 10);
     } else return null;
   }
   const rn = r / 255,
@@ -290,7 +290,20 @@ function syncVscodeTheme() {
 
 // Run immediately; re-sync when VS Code flips the body class on theme change.
 syncVscodeTheme();
-new MutationObserver(() => syncVscodeTheme()).observe(document.body, {
+let lastBodyClass = document.body.className;
+let rafPending = false;
+new MutationObserver(() => {
+  const cls = document.body.className;
+  if (cls === lastBodyClass) return;
+  lastBodyClass = cls;
+  if (!rafPending) {
+    rafPending = true;
+    requestAnimationFrame(() => {
+      rafPending = false;
+      syncVscodeTheme();
+    });
+  }
+}).observe(document.body, {
   attributes: true,
   attributeFilter: ["class"],
 });

--- a/vscode-extension/src/webview/webview.css
+++ b/vscode-extension/src/webview/webview.css
@@ -60,8 +60,10 @@
     color-scheme: dark;
   }
 
-  /* ─── Light theme ─── */
-  .theme-light {
+  /* ─── Light theme fallback — VS Code body class provides instant defaults;
+     the JS theme sync refines these to match the exact installed theme. ─── */
+  body.vscode-light,
+  body.vscode-high-contrast-light {
     --background:           220 18% 96%;
     --foreground:           225 30%  9%;
     --card:                 0 0% 100%;
@@ -90,8 +92,6 @@
 
     --success:              152 50% 36%;
     --warning:              38 80% 44%;
-
-    color-scheme: light;
   }
 
   *,
@@ -127,7 +127,8 @@
     background-size: 22px 22px;
     background-attachment: fixed;
   }
-  .theme-light body {
+  body.vscode-light,
+  body.vscode-high-contrast-light {
     background-image:
       radial-gradient(
         circle at 1px 1px,
@@ -501,12 +502,12 @@
   .dc-json-bool   { color: hsl(264 72% 78%); font-style: italic; }
   .dc-json-null   { color: hsl(264 72% 78%); font-style: italic; opacity: 0.7; }
 
-  .theme-light .dc-json-key    { color: hsl(198 88% 36%); }
-  .theme-light .dc-json-string { color: hsl(28 75% 38%); }
-  .theme-light .dc-json-number { color: hsl(264 60% 42%); }
-  .theme-light .dc-json-brace  { color: hsl(150 50% 28%); }
-  .theme-light .dc-json-bool   { color: hsl(264 60% 42%); }
-  .theme-light .dc-json-null   { color: hsl(264 60% 42%); opacity: 0.6; }
+  body.vscode-light .dc-json-key    { color: hsl(198 88% 36%); }
+  body.vscode-light .dc-json-string { color: hsl(28 75% 38%); }
+  body.vscode-light .dc-json-number { color: hsl(264 60% 42%); }
+  body.vscode-light .dc-json-brace  { color: hsl(150 50% 28%); }
+  body.vscode-light .dc-json-bool   { color: hsl(264 60% 42%); }
+  body.vscode-light .dc-json-null   { color: hsl(264 60% 42%); opacity: 0.6; }
 }
 
 /* Source quote + long prose blocks */
@@ -593,9 +594,9 @@
   .data-card button:hover:not(.dc-section-header):not(.dc-copy-btn):not(.nav-btn) {
     background: hsl(var(--accent) / 0.45);
   }
-  .theme-light .data-card span[style*="#7dd3fc"],
-  .theme-light .data-card span[style*="#c084fc"],
-  .theme-light .data-card span[style*="#6ee7b7"] {
+  body.vscode-light .data-card span[style*="#7dd3fc"],
+  body.vscode-light .data-card span[style*="#c084fc"],
+  body.vscode-light .data-card span[style*="#6ee7b7"] {
     color: hsl(var(--foreground) / 0.85) !important;
   }
 }

--- a/vscode-extension/src/webview/webview.css
+++ b/vscode-extension/src/webview/webview.css
@@ -92,6 +92,8 @@
 
     --success:              152 50% 36%;
     --warning:              38 80% 44%;
+
+    color-scheme: light;
   }
 
   *,
@@ -502,12 +504,18 @@
   .dc-json-bool   { color: hsl(264 72% 78%); font-style: italic; }
   .dc-json-null   { color: hsl(264 72% 78%); font-style: italic; opacity: 0.7; }
 
-  body.vscode-light .dc-json-key    { color: hsl(198 88% 36%); }
-  body.vscode-light .dc-json-string { color: hsl(28 75% 38%); }
-  body.vscode-light .dc-json-number { color: hsl(264 60% 42%); }
-  body.vscode-light .dc-json-brace  { color: hsl(150 50% 28%); }
-  body.vscode-light .dc-json-bool   { color: hsl(264 60% 42%); }
-  body.vscode-light .dc-json-null   { color: hsl(264 60% 42%); opacity: 0.6; }
+  body.vscode-light .dc-json-key,
+  body.vscode-high-contrast-light .dc-json-key       { color: hsl(198 88% 36%); }
+  body.vscode-light .dc-json-string,
+  body.vscode-high-contrast-light .dc-json-string    { color: hsl(28 75% 38%); }
+  body.vscode-light .dc-json-number,
+  body.vscode-high-contrast-light .dc-json-number    { color: hsl(264 60% 42%); }
+  body.vscode-light .dc-json-brace,
+  body.vscode-high-contrast-light .dc-json-brace     { color: hsl(150 50% 28%); }
+  body.vscode-light .dc-json-bool,
+  body.vscode-high-contrast-light .dc-json-bool      { color: hsl(264 60% 42%); }
+  body.vscode-light .dc-json-null,
+  body.vscode-high-contrast-light .dc-json-null      { color: hsl(264 60% 42%); opacity: 0.6; }
 }
 
 /* Source quote + long prose blocks */


### PR DESCRIPTION
## Summary
- Webview now reads VS Code's native `--vscode-*` CSS variables, converts hex→HSL, and sets our custom properties so the panel matches whatever theme the user has installed (Monokai, Dracula, Solarized, GitHub Light, etc.)
- Replaced manual `.theme-light` class toggling with VS Code's native `body.vscode-light` body class — no host-side theme coordination needed
- Mermaid DAG diagram theme now switches dynamically between dark/default based on `activeColorTheme.kind`

## Verification
- `npm run build` passes
- Reviewed diff for all 4 changed files
- Theme sync maps 22 CSS custom properties with fallback chains to VS Code variables
- Light theme CSS fallback retained for instant rendering before JS sync runs