### PR TITLE
refactor: split scope_builder into composable namespace builders

### DIFF
--- a/.changes/unreleased/Under the Hood-20260509-121000.yaml
+++ b/.changes/unreleased/Under the Hood-20260509-121000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Refactor scope_builder.py into composable namespace builders (Source, Dependency, Version, Workflow) for independent testability"
+time: 2026-05-09T12:10:00.000000Z

--- a/agent_actions/input/preprocessing/staging/_MANIFEST.md
+++ b/agent_actions/input/preprocessing/staging/_MANIFEST.md
@@ -35,7 +35,7 @@ time (e.g., `source.page_content` resolves to the wrong data).
 
 The guard runs at two convergence points:
 1. **Staging file load** — `process_initial_stage()` calls it before any processing
-2. **Prompt context build** — `_load_source_namespace()` in `scope_builder.py` calls it
+2. **Prompt context build** — `SourceNamespaceBuilder.build()` in `scope_builder.py` calls it
    as a belt-and-suspenders check, catching data that entered through storage reads,
    batch resume, or FILE mode source resolution
 

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -16,7 +16,7 @@ loaders for cataloging prompts at documentation time.
 | `scope_inference.py` | Module | Dependency inference: fan-in detection, version branch expansion, input/context source resolution. | `preprocessing` |
 | `scope_application.py` | Module | Context scope application: observe/passthrough/drop filtering for RECORD mode (`apply_context_scope`) and FILE mode (`apply_context_scope_for_records`), LLM context formatting. | `preprocessing` |
 | `scope_namespace.py` | Module | Namespace enrichment, field filtering, and allowed-fields extraction. | `preprocessing` |
-| `scope_builder.py` | Module | `build_field_context_with_history`: assembles source/dependency/version/workflow namespaces. Convergence point for source data validation (see design note). | `preprocessing`, `staging.field_validation` |
+| `scope_builder.py` | Module | `build_field_context_with_history`: assembles source/dependency/version/workflow namespaces via composable builder classes (`SourceNamespaceBuilder`, `DependencyNamespaceBuilder`, `VersionNamespaceBuilder`, `WorkflowMetadataBuilder`). Convergence point for source data validation (see design note). | `preprocessing`, `staging.field_validation` |
 | ~~`scope_file_mode.py`~~ | Deleted | FILE-mode observe merged into `scope_application.py:apply_context_scope_for_records`. | — |
 | `static_loader.py` | Module | Static prompt loader used during docs generation to read prompt store files. | `tooling.docs`, `file_io` |
 
@@ -24,7 +24,7 @@ loaders for cataloging prompts at documentation time.
 
 ### Source data: four retrieval paths, one convergence point
 
-Source data (the user's original staging input) reaches `_load_source_namespace()` in
+Source data (the user's original staging input) reaches `SourceNamespaceBuilder.build()` in
 `scope_builder.py` through four paths, each serving a different pipeline lifecycle stage:
 
 | Path | When | How source data arrives | Entry point |
@@ -37,6 +37,6 @@ Source data (the user's original staging input) reaches `_load_source_namespace(
 The data is the same in all four cases — the user's original staging fields. The paths
 differ because of *where the data lives* at each stage (disk → storage → index → memory).
 
-`_load_source_namespace()` is the single convergence point where all four paths write to
+`SourceNamespaceBuilder.build()` is the single convergence point where all four paths write to
 `field_context["source"]`. Validation for reserved namespace collisions runs here to
 cover all paths regardless of how the data entered the pipeline.

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -1,4 +1,11 @@
-"""Field context builder — reads from record's namespaced content."""
+"""Field context builder — reads from record's namespaced content.
+
+Assembles field_context from four composable namespace builders:
+- SourceNamespaceBuilder: user input data
+- DependencyNamespaceBuilder: upstream action outputs
+- VersionNamespaceBuilder: loop iteration info + promoted convenience vars
+- WorkflowMetadataBuilder: workflow-level metadata
+"""
 
 import logging
 from typing import Any
@@ -20,76 +27,41 @@ __all__ = [
 ]
 
 
-def build_field_context_with_history(
-    agent_name: str,
-    agent_config: dict | None,
-    agent_indices: dict[str, int] | None = None,
-    source_content: Any | None = None,
-    version_context: dict | None = None,
-    workflow_metadata: dict | None = None,
-    current_item: dict | None = None,
-    context_scope: dict | None = None,
-) -> dict:
-    """
-    Build field context with explicit namespace structure.
+# ---------------------------------------------------------------------------
+# Namespace builders
+# ---------------------------------------------------------------------------
 
-    Composes focused builders for each concern: source data, dependency
-    namespaces, version iteration info, and workflow metadata.
 
-    Architecture (per anatomy_action.md):
-    field_context = {
-        "source": {...},        # Original input data
-        "{dep_name}": {...},    # Dependency action outputs (FILTERED by context_scope)
-        "seed": {...},          # Static reference data (via static_data)
-        "version": {...},       # Version iteration info (i, idx, length, first, last)
-        "workflow": {...},      # Workflow metadata
-    }
+class SourceNamespaceBuilder:
+    """Build the 'source' namespace from input data."""
 
-    Args:
-        agent_name: Name of the current action
-        agent_config: Action configuration dict
-        agent_indices: REQUIRED if action has dependencies. Maps action names to positions.
-        source_content: Original input data for "source" namespace
-        version_context: Loop iteration info
-        workflow_metadata: Workflow metadata
-        current_item: Current record being processed (has lineage, content)
-        context_scope: Controls which fields to load (progressive data exposure)
+    @staticmethod
+    def build(source_content: Any | None, agent_name: str) -> dict | None:
+        """Return source namespace dict, or None if no source data.
 
-    Returns:
-        Dict with namespaces: source, {dep_names}, version, workflow.
-        May contain "_dependency_metadata" key with field-load diagnostics
-        (callers needing it should pop it before passing downstream).
+        Handles both wrapped (``{"content": {...}}``) and flat dict formats.
+        Fires ContextNamespaceLoadedEvent on success.
+        """
+        source_namespace: dict = {}
+        if source_content and isinstance(source_content, dict):
+            if "content" in source_content and isinstance(source_content["content"], dict):
+                source_namespace = source_content["content"]
+            else:
+                source_namespace = dict(source_content)
 
-    Raises:
-        ConfigurationError: If action has dependencies but agent_indices not provided
-    """
-    field_context: dict = {}
+        if not source_namespace:
+            return None
 
-    source_ns = SourceNamespaceBuilder.build(source_content, agent_name)
-    if source_ns:
-        field_context["source"] = source_ns
-
-    dep_namespaces, dep_metadata = DependencyNamespaceBuilder.build(
-        agent_name, agent_config, agent_indices, current_item, context_scope
-    )
-    field_context.update(dep_namespaces)
-    if dep_metadata:
-        field_context["_dependency_metadata"] = dep_metadata
-    version_result = VersionNamespaceBuilder.build(version_context, agent_name)
-    if version_result:
-        field_context.update(version_result)
-
-    workflow_ns = WorkflowMetadataBuilder.build(workflow_metadata, agent_name)
-    if workflow_ns:
-        field_context["workflow"] = workflow_ns
-
-    logger.debug(
-        "Built field_context for '%s' with namespaces: %s",
-        agent_name,
-        list(field_context.keys()),
-    )
-
-    return field_context
+        logger.debug("Added 'source' namespace with %s fields", len(source_namespace))
+        fire_event(
+            ContextNamespaceLoadedEvent(
+                action_name=agent_name,
+                namespace="source",
+                field_count=len(source_namespace),
+                fields=list(source_namespace.keys()),
+            )
+        )
+        return source_namespace
 
 
 class DependencyNamespaceBuilder:
@@ -260,38 +232,6 @@ class VersionNamespaceBuilder:
         return result
 
 
-class SourceNamespaceBuilder:
-    """Build the 'source' namespace from input data."""
-
-    @staticmethod
-    def build(source_content: Any | None, agent_name: str) -> dict | None:
-        """Return source namespace dict, or None if no source data.
-
-        Handles both wrapped (``{"content": {...}}``) and flat dict formats.
-        Fires ContextNamespaceLoadedEvent on success.
-        """
-        source_namespace: dict = {}
-        if source_content and isinstance(source_content, dict):
-            if "content" in source_content and isinstance(source_content["content"], dict):
-                source_namespace = source_content["content"]
-            else:
-                source_namespace = dict(source_content)
-
-        if not source_namespace:
-            return None
-
-        logger.debug("Added 'source' namespace with %s fields", len(source_namespace))
-        fire_event(
-            ContextNamespaceLoadedEvent(
-                action_name=agent_name,
-                namespace="source",
-                field_count=len(source_namespace),
-                fields=list(source_namespace.keys()),
-            )
-        )
-        return source_namespace
-
-
 class WorkflowMetadataBuilder:
     """Build the 'workflow' namespace from workflow metadata."""
 
@@ -314,3 +254,81 @@ class WorkflowMetadataBuilder:
             )
         )
         return workflow_metadata
+
+
+# ---------------------------------------------------------------------------
+# Assembler
+# ---------------------------------------------------------------------------
+
+
+def build_field_context_with_history(
+    agent_name: str,
+    agent_config: dict | None,
+    agent_indices: dict[str, int] | None = None,
+    source_content: Any | None = None,
+    version_context: dict | None = None,
+    workflow_metadata: dict | None = None,
+    current_item: dict | None = None,
+    context_scope: dict | None = None,
+) -> dict:
+    """
+    Build field context with explicit namespace structure.
+
+    Composes focused builders for each concern: source data, dependency
+    namespaces, version iteration info, and workflow metadata.
+
+    Architecture (per anatomy_action.md):
+    field_context = {
+        "source": {...},        # Original input data
+        "{dep_name}": {...},    # Dependency action outputs (FILTERED by context_scope)
+        "seed": {...},          # Static reference data (via static_data)
+        "version": {...},       # Version iteration info (i, idx, length, first, last)
+        "workflow": {...},      # Workflow metadata
+    }
+
+    Args:
+        agent_name: Name of the current action
+        agent_config: Action configuration dict
+        agent_indices: REQUIRED if action has dependencies. Maps action names to positions.
+        source_content: Original input data for "source" namespace
+        version_context: Loop iteration info
+        workflow_metadata: Workflow metadata
+        current_item: Current record being processed (has lineage, content)
+        context_scope: Controls which fields to load (progressive data exposure)
+
+    Returns:
+        Dict with namespaces: source, {dep_names}, version, workflow.
+        May contain "_dependency_metadata" key with field-load diagnostics
+        (callers needing it should pop it before passing downstream).
+
+    Raises:
+        ConfigurationError: If action has dependencies but agent_indices not provided
+    """
+    field_context: dict = {}
+
+    source_ns = SourceNamespaceBuilder.build(source_content, agent_name)
+    if source_ns:
+        field_context["source"] = source_ns
+
+    dep_namespaces, dep_metadata = DependencyNamespaceBuilder.build(
+        agent_name, agent_config, agent_indices, current_item, context_scope
+    )
+    field_context.update(dep_namespaces)
+    if dep_metadata:
+        field_context["_dependency_metadata"] = dep_metadata
+
+    version_result = VersionNamespaceBuilder.build(version_context, agent_name)
+    if version_result:
+        field_context.update(version_result)
+
+    workflow_ns = WorkflowMetadataBuilder.build(workflow_metadata, agent_name)
+    if workflow_ns:
+        field_context["workflow"] = workflow_ns
+
+    logger.debug(
+        "Built field_context for '%s' with namespaces: %s",
+        agent_name,
+        list(field_context.keys()),
+    )
+
+    return field_context

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -72,7 +72,9 @@ def build_field_context_with_history(
     _load_dependency_namespaces(
         field_context, agent_name, agent_config, agent_indices, current_item, context_scope
     )
-    _load_version_context(field_context, version_context, agent_name)
+    version_result = VersionNamespaceBuilder.build(version_context, agent_name)
+    if version_result:
+        field_context.update(version_result)
 
     workflow_ns = WorkflowMetadataBuilder.build(workflow_metadata, agent_name)
     if workflow_ns:
@@ -204,34 +206,47 @@ def _load_dependency_namespaces(
         )
 
 
-def _load_version_context(
-    field_context: dict, version_context: dict | None, agent_name: str
-) -> None:
-    """Load version iteration info and promote convenience variables to top level."""
-    if not version_context:
-        return
+class VersionNamespaceBuilder:
+    """Build the 'version' namespace and promote convenience variables."""
 
-    field_context["version"] = version_context
-    # Add common version variables at top level for convenience
-    # This enables {{ i }} instead of requiring {{ version.i }}
-    if "i" in version_context:
-        field_context["i"] = version_context["i"]
-    if "idx" in version_context:
-        field_context["idx"] = version_context["idx"]
-    # Add custom param names at top level (e.g., {{ classifier_id }})
-    reserved_keys = {"i", "idx", "length", "first", "last"}
-    for key, value in version_context.items():
-        if key not in reserved_keys:
-            field_context[key] = value
-    logger.debug("Added 'version' namespace with version context")
-    fire_event(
-        ContextNamespaceLoadedEvent(
-            action_name=agent_name,
-            namespace="version",
-            field_count=len(version_context),
-            fields=list(version_context.keys()),
+    _RESERVED_KEYS = frozenset({"i", "idx", "length", "first", "last"})
+
+    @staticmethod
+    def build(version_context: dict | None, agent_name: str) -> dict | None:
+        """Return dict with 'version' namespace and promoted top-level keys, or None.
+
+        Promotes ``i`` and ``idx`` to top level for Jinja2 convenience
+        (``{{ i }}`` instead of ``{{ version.i }}``). Custom params (non-reserved)
+        are also promoted to top level.
+
+        Fires ContextNamespaceLoadedEvent on success.
+        """
+        if not version_context:
+            return None
+
+        result: dict = {"version": version_context}
+
+        # Promote i/idx to top level for Jinja2 convenience
+        if "i" in version_context:
+            result["i"] = version_context["i"]
+        if "idx" in version_context:
+            result["idx"] = version_context["idx"]
+
+        # Promote custom param names (e.g., {{ classifier_id }})
+        for key, value in version_context.items():
+            if key not in VersionNamespaceBuilder._RESERVED_KEYS:
+                result[key] = value
+
+        logger.debug("Added 'version' namespace with version context")
+        fire_event(
+            ContextNamespaceLoadedEvent(
+                action_name=agent_name,
+                namespace="version",
+                field_count=len(version_context),
+                fields=list(version_context.keys()),
+            )
         )
-    )
+        return result
 
 
 class SourceNamespaceBuilder:

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -69,9 +69,12 @@ def build_field_context_with_history(
     if source_ns:
         field_context["source"] = source_ns
 
-    _load_dependency_namespaces(
-        field_context, agent_name, agent_config, agent_indices, current_item, context_scope
+    dep_namespaces, dep_metadata = DependencyNamespaceBuilder.build(
+        agent_name, agent_config, agent_indices, current_item, context_scope
     )
+    field_context.update(dep_namespaces)
+    if dep_metadata:
+        field_context["_dependency_metadata"] = dep_metadata
     version_result = VersionNamespaceBuilder.build(version_context, agent_name)
     if version_result:
         field_context.update(version_result)
@@ -89,121 +92,129 @@ def build_field_context_with_history(
     return field_context
 
 
-def _load_dependency_namespaces(
-    field_context: dict,
-    agent_name: str,
-    agent_config: dict | None,
-    agent_indices: dict[str, int] | None,
-    current_item: dict | None,
-    context_scope: dict | None,
-) -> None:
-    """Load dependency action outputs from record's namespaced content.
+class DependencyNamespaceBuilder:
+    """Build dependency namespaces from record's namespaced content."""
 
-    With the additive content model, every previous action's output is
-    stored under its namespace on the record: content = {"action_a": {...}, ...}.
+    @staticmethod
+    def build(
+        agent_name: str,
+        agent_config: dict | None,
+        agent_indices: dict[str, int] | None,
+        current_item: dict | None,
+        context_scope: dict | None,
+    ) -> tuple[dict[str, Any], dict]:
+        """Return (dep_namespaces, metadata).
 
-    Collects field-load metadata and stores it on field_context["_dependency_metadata"]
-    for downstream diagnostics.
-    """
-    from agent_actions.utils.constants import SPECIAL_NAMESPACES
+        dep_namespaces maps dep_name -> filtered data (or None for guard-skipped).
+        metadata maps dep_name -> {stored_fields, loaded_fields, stored_count, loaded_count}.
 
-    batch_mode_enabled = bool(agent_config and agent_indices and current_item)
-    logger.debug(
-        "[CONTEXT BUILD] Action '%s': batch_mode_enabled=%s",
-        agent_name,
-        batch_mode_enabled,
-    )
+        Raises:
+            ConfigurationError: If action has dependencies but agent_indices not provided.
+        """
+        from agent_actions.utils.constants import SPECIAL_NAMESPACES
 
-    if batch_mode_enabled:
-        # Narrowed by batch_mode_enabled — all are truthy
-        if agent_config is None or agent_indices is None or current_item is None:
-            raise ValueError(
-                f"batch_mode requires agent_config, agent_indices, and current_item "
-                f"(action: '{agent_name}')"
-            )
-
-        workflow_actions = list(agent_indices.keys())
-        input_sources, context_sources = infer_dependencies(
-            agent_config, workflow_actions, agent_name, validate=False
-        )
-
-        logger.debug(
-            "[AUTO-INFER] Action '%s': input_sources=%s, context_sources=%s",
-            agent_name,
-            input_sources,
-            context_sources,
-        )
-
-        namespaced_content = _extract_content_data(current_item)
-        all_deps = input_sources + context_sources
+        dep_namespaces: dict[str, Any] = {}
         metadata_collector: dict = {}
 
-        if all_deps:
-            allowed_fields_map = _extract_allowed_fields_per_dependency(
-                all_deps, context_scope, agent_name
-            )
+        batch_mode_enabled = bool(agent_config and agent_indices and current_item)
+        logger.debug(
+            "[CONTEXT BUILD] Action '%s': batch_mode_enabled=%s",
+            agent_name,
+            batch_mode_enabled,
+        )
 
-            for dep_name in all_deps:
-                if dep_name in SPECIAL_NAMESPACES:
-                    logger.debug("Skipping special namespace '%s' (handled separately)", dep_name)
-                    continue
-
-                dep_data = namespaced_content.get(dep_name)
-                if dep_data is None:
-                    # Namespace is null (guard-skipped) or absent (guard-filtered /
-                    # arrived via a different branch).  Store None so downstream
-                    # observe/passthrough can distinguish "declared but absent" from
-                    # "undeclared" and yield None instead of crashing.
-                    logger.debug(
-                        "[RECORD NAMESPACE] '%s' null/absent on record for action '%s' "
-                        "(likely guard-skipped or guard-filtered)",
-                        dep_name,
-                        agent_name,
-                    )
-                    field_context[dep_name] = None
-                    continue
-
-                if not isinstance(dep_data, dict):
-                    logger.warning(
-                        "[RECORD NAMESPACE] '%s' for action '%s' is %s, not dict — skipping",
-                        dep_name,
-                        agent_name,
-                        type(dep_data).__name__,
-                    )
-                    continue
-
-                allowed_fields = allowed_fields_map.get(dep_name)
-                _filter_and_store_fields(
-                    field_context,
-                    dep_name,
-                    dep_data,
-                    allowed_fields,
-                    source_type="RECORD NAMESPACE",
-                    fail_on_missing=True,
-                    metadata_collector=metadata_collector,
+        if batch_mode_enabled:
+            # Narrowed by batch_mode_enabled — all are truthy
+            if agent_config is None or agent_indices is None or current_item is None:
+                raise ValueError(
+                    f"batch_mode requires agent_config, agent_indices, and current_item "
+                    f"(action: '{agent_name}')"
                 )
 
-        if metadata_collector:
-            field_context["_dependency_metadata"] = metadata_collector
+            workflow_actions = list(agent_indices.keys())
+            input_sources, context_sources = infer_dependencies(
+                agent_config, workflow_actions, agent_name, validate=False
+            )
 
-    else:
-        logger.debug(
-            "[CONTEXT BUILD SKIP] Action '%s': Batch mode condition not met.",
-            agent_name,
-        )
+            logger.debug(
+                "[AUTO-INFER] Action '%s': input_sources=%s, context_sources=%s",
+                agent_name,
+                input_sources,
+                context_sources,
+            )
 
-    if agent_config and agent_config.get("dependencies") and not agent_indices:
-        dependencies = agent_config.get("dependencies", [])
-        raise ConfigurationError(
-            f"Action '{agent_name}' has dependencies {dependencies} but agent_indices was not provided. "
-            f"agent_indices is required for dependency resolution.\n\n"
-            f"Ensure the workflow orchestrator passes agent_indices to build_field_context_with_history().",
-            context={
-                "action": agent_name,
-                "dependencies": dependencies,
-                "hint": "agent_indices must be a dict mapping action names to their positions",
-            },
-        )
+            namespaced_content = _extract_content_data(current_item)
+            all_deps = input_sources + context_sources
+
+            if all_deps:
+                allowed_fields_map = _extract_allowed_fields_per_dependency(
+                    all_deps, context_scope, agent_name
+                )
+
+                for dep_name in all_deps:
+                    if dep_name in SPECIAL_NAMESPACES:
+                        logger.debug(
+                            "Skipping special namespace '%s' (handled separately)", dep_name
+                        )
+                        continue
+
+                    dep_data = namespaced_content.get(dep_name)
+                    if dep_data is None:
+                        # Namespace is null (guard-skipped) or absent (guard-filtered /
+                        # arrived via a different branch).  Store None so downstream
+                        # observe/passthrough can distinguish "declared but absent" from
+                        # "undeclared" and yield None instead of crashing.
+                        logger.debug(
+                            "[RECORD NAMESPACE] '%s' null/absent on record for action '%s' "
+                            "(likely guard-skipped or guard-filtered)",
+                            dep_name,
+                            agent_name,
+                        )
+                        dep_namespaces[dep_name] = None
+                        continue
+
+                    if not isinstance(dep_data, dict):
+                        logger.warning(
+                            "[RECORD NAMESPACE] '%s' for action '%s' is %s, not dict — skipping",
+                            dep_name,
+                            agent_name,
+                            type(dep_data).__name__,
+                        )
+                        continue
+
+                    allowed_fields = allowed_fields_map.get(dep_name)
+                    _filter_and_store_fields(
+                        dep_namespaces,
+                        dep_name,
+                        dep_data,
+                        allowed_fields,
+                        source_type="RECORD NAMESPACE",
+                        fail_on_missing=True,
+                        metadata_collector=metadata_collector,
+                    )
+
+        else:
+            logger.debug(
+                "[CONTEXT BUILD SKIP] Action '%s': Batch mode condition not met.",
+                agent_name,
+            )
+
+        # ConfigurationError: MUST remain after batch-mode branch.
+        # Fires when deps are declared but agent_indices is missing.
+        if agent_config and agent_config.get("dependencies") and not agent_indices:
+            dependencies = agent_config.get("dependencies", [])
+            raise ConfigurationError(
+                f"Action '{agent_name}' has dependencies {dependencies} but agent_indices was not provided. "
+                f"agent_indices is required for dependency resolution.\n\n"
+                f"Ensure the workflow orchestrator passes agent_indices to build_field_context_with_history().",
+                context={
+                    "action": agent_name,
+                    "dependencies": dependencies,
+                    "hint": "agent_indices must be a dict mapping action names to their positions",
+                },
+            )
+
+        return dep_namespaces, metadata_collector
 
 
 class VersionNamespaceBuilder:

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -65,12 +65,18 @@ def build_field_context_with_history(
     """
     field_context: dict = {}
 
-    _load_source_namespace(field_context, source_content, agent_name)
+    source_ns = SourceNamespaceBuilder.build(source_content, agent_name)
+    if source_ns:
+        field_context["source"] = source_ns
+
     _load_dependency_namespaces(
         field_context, agent_name, agent_config, agent_indices, current_item, context_scope
     )
     _load_version_context(field_context, version_context, agent_name)
-    _load_workflow_metadata(field_context, workflow_metadata, agent_name)
+
+    workflow_ns = WorkflowMetadataBuilder.build(workflow_metadata, agent_name)
+    if workflow_ns:
+        field_context["workflow"] = workflow_ns
 
     logger.debug(
         "Built field_context for '%s' with namespaces: %s",
@@ -79,30 +85,6 @@ def build_field_context_with_history(
     )
 
     return field_context
-
-
-def _load_source_namespace(
-    field_context: dict, source_content: Any | None, agent_name: str
-) -> None:
-    """Load original input data into the 'source' namespace."""
-    source_namespace: dict = {}
-    if source_content and isinstance(source_content, dict):
-        if "content" in source_content and isinstance(source_content["content"], dict):
-            source_namespace = source_content["content"]
-        else:
-            source_namespace = dict(source_content)
-
-    if source_namespace:
-        field_context["source"] = source_namespace
-        logger.debug("Added 'source' namespace with %s fields", len(source_namespace))
-        fire_event(
-            ContextNamespaceLoadedEvent(
-                action_name=agent_name,
-                namespace="source",
-                field_count=len(source_namespace),
-                fields=list(source_namespace.keys()),
-            )
-        )
 
 
 def _load_dependency_namespaces(
@@ -252,20 +234,57 @@ def _load_version_context(
     )
 
 
-def _load_workflow_metadata(
-    field_context: dict, workflow_metadata: dict | None, agent_name: str
-) -> None:
-    """Load workflow metadata into the 'workflow' namespace."""
-    if not workflow_metadata:
-        return
+class SourceNamespaceBuilder:
+    """Build the 'source' namespace from input data."""
 
-    field_context["workflow"] = workflow_metadata
-    logger.debug("Added 'workflow' namespace")
-    fire_event(
-        ContextNamespaceLoadedEvent(
-            action_name=agent_name,
-            namespace="workflow",
-            field_count=len(workflow_metadata),
-            fields=list(workflow_metadata.keys()),
+    @staticmethod
+    def build(source_content: Any | None, agent_name: str) -> dict | None:
+        """Return source namespace dict, or None if no source data.
+
+        Handles both wrapped (``{"content": {...}}``) and flat dict formats.
+        Fires ContextNamespaceLoadedEvent on success.
+        """
+        source_namespace: dict = {}
+        if source_content and isinstance(source_content, dict):
+            if "content" in source_content and isinstance(source_content["content"], dict):
+                source_namespace = source_content["content"]
+            else:
+                source_namespace = dict(source_content)
+
+        if not source_namespace:
+            return None
+
+        logger.debug("Added 'source' namespace with %s fields", len(source_namespace))
+        fire_event(
+            ContextNamespaceLoadedEvent(
+                action_name=agent_name,
+                namespace="source",
+                field_count=len(source_namespace),
+                fields=list(source_namespace.keys()),
+            )
         )
-    )
+        return source_namespace
+
+
+class WorkflowMetadataBuilder:
+    """Build the 'workflow' namespace from workflow metadata."""
+
+    @staticmethod
+    def build(workflow_metadata: dict | None, agent_name: str) -> dict | None:
+        """Return workflow namespace dict, or None if no metadata.
+
+        Fires ContextNamespaceLoadedEvent on success.
+        """
+        if not workflow_metadata:
+            return None
+
+        logger.debug("Added 'workflow' namespace")
+        fire_event(
+            ContextNamespaceLoadedEvent(
+                action_name=agent_name,
+                namespace="workflow",
+                field_count=len(workflow_metadata),
+                fields=list(workflow_metadata.keys()),
+            )
+        )
+        return workflow_metadata

--- a/tests/unit/prompt/test_scope_builder_builders.py
+++ b/tests/unit/prompt/test_scope_builder_builders.py
@@ -136,7 +136,7 @@ class TestDependencyNamespace:
             agent_config={"agent_type": "test"},
             agent_indices=None,
         )
-        assert isinstance(result, dict)
+        assert result == {}
 
     def test_absent_namespace_marked_none(self):
         """Absent dependency namespace stored as None (guard-skipped)."""

--- a/tests/unit/prompt/test_scope_builder_builders.py
+++ b/tests/unit/prompt/test_scope_builder_builders.py
@@ -1,0 +1,401 @@
+"""Safety-net tests for build_field_context_with_history builder concerns.
+
+Tests each namespace concern (source, dependency, version, workflow) and
+cross-cutting behaviors (event firing, assembler combinations) through the
+public API. These tests lock in current behavior before the builder-class
+refactor and must pass identically after.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.prompt.context.scope_builder import build_field_context_with_history
+
+_EVENT_PATH = "agent_actions.prompt.context.scope_builder.fire_event"
+
+
+# ---------------------------------------------------------------------------
+# Source namespace
+# ---------------------------------------------------------------------------
+class TestSourceNamespace:
+    """Source namespace: wrapped content, flat content, None, empty."""
+
+    def test_wrapped_content(self):
+        """Wrapped format: {'content': {'field': value}} unwraps to source."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            source_content={"content": {"text": "hello", "lang": "en"}},
+        )
+        assert result["source"] == {"text": "hello", "lang": "en"}
+
+    def test_flat_content(self):
+        """Flat dict goes directly into source namespace."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            source_content={"text": "hello"},
+        )
+        assert result["source"] == {"text": "hello"}
+
+    def test_none_input(self):
+        """None source_content produces no 'source' key."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            source_content=None,
+        )
+        assert "source" not in result
+
+    def test_empty_dict(self):
+        """Empty dict produces no 'source' key (falsy check)."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            source_content={},
+        )
+        assert "source" not in result
+
+    def test_non_dict_content_field(self):
+        """If 'content' key exists but is not a dict, treat as flat."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            source_content={"content": "just a string", "other": "val"},
+        )
+        assert result["source"] == {"content": "just a string", "other": "val"}
+
+
+# ---------------------------------------------------------------------------
+# Dependency namespace
+# ---------------------------------------------------------------------------
+class TestDependencyNamespace:
+    """Dependency loading: metadata structure, absent namespaces, config errors."""
+
+    def _make_current_item(self, content: dict) -> dict:
+        return {
+            "content": content,
+            "lineage": ["node-1"],
+            "source_guid": "sg-1",
+        }
+
+    def test_metadata_dict_structure(self):
+        """_dependency_metadata has per-dep keys with stored/loaded field info."""
+        current_item = self._make_current_item(
+            {
+                "extract": {"text": "hello", "lang": "en"},
+            }
+        )
+        agent_config = {
+            "dependencies": ["extract"],
+            "context_scope": {"observe": ["extract.text"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="summarize",
+            agent_config=agent_config,
+            agent_indices={"extract": 0, "summarize": 1},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        meta = result.get("_dependency_metadata")
+        assert meta is not None, "_dependency_metadata must be present when deps are loaded"
+        assert "extract" in meta
+        extract_meta = meta["extract"]
+        # context_scope observes only extract.text, so 1 field loaded out of 2 stored
+        assert sorted(extract_meta["stored_fields"]) == ["lang", "text"]
+        assert extract_meta["loaded_fields"] == ["text"]
+        assert extract_meta["stored_count"] == 2
+        assert extract_meta["loaded_count"] == 1
+
+    def test_metadata_absent_without_deps(self):
+        """No _dependency_metadata when no dependencies are loaded."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config={"agent_type": "test"},
+            source_content={"text": "hello"},
+        )
+        assert "_dependency_metadata" not in result
+
+    def test_configuration_error_deps_without_agent_indices(self):
+        """ConfigurationError raised when deps declared but agent_indices missing."""
+        with pytest.raises(ConfigurationError, match="agent_indices"):
+            build_field_context_with_history(
+                agent_name="summarize",
+                agent_config={"dependencies": ["extract"]},
+                agent_indices=None,
+            )
+
+    def test_no_error_without_deps_and_without_indices(self):
+        """No error when no dependencies and no agent_indices."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config={"agent_type": "test"},
+            agent_indices=None,
+        )
+        assert isinstance(result, dict)
+
+    def test_absent_namespace_marked_none(self):
+        """Absent dependency namespace stored as None (guard-skipped)."""
+        current_item = self._make_current_item(
+            {
+                "extract": {"text": "hello"},
+                # "classify" absent
+            }
+        )
+        agent_config = {
+            "dependencies": ["extract"],
+            "context_scope": {"observe": ["extract.text", "classify.topic"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="summarize",
+            agent_config=agent_config,
+            agent_indices={"extract": 0, "classify": 1, "summarize": 2},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        assert result["classify"] is None
+
+    def test_batch_mode_skipped_without_current_item(self):
+        """Without current_item, batch mode is skipped — no dep namespaces loaded."""
+        agent_config = {
+            "dependencies": ["extract"],
+            "context_scope": {"observe": ["extract.text"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="summarize",
+            agent_config=agent_config,
+            agent_indices={"extract": 0, "summarize": 1},
+            current_item=None,
+            context_scope=agent_config["context_scope"],
+        )
+
+        assert "extract" not in result
+        assert "_dependency_metadata" not in result
+
+
+# ---------------------------------------------------------------------------
+# Version namespace
+# ---------------------------------------------------------------------------
+class TestVersionNamespace:
+    """Version context: namespace structure, top-level promotion, reserved keys."""
+
+    def test_version_namespace_populated(self):
+        """Version context stored under 'version' key."""
+        vc = {"i": 2, "idx": 1, "length": 3, "first": False, "last": False}
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            version_context=vc,
+        )
+        assert result["version"] == vc
+
+    def test_top_level_i_idx_promotion(self):
+        """i and idx promoted to top level for Jinja2 convenience."""
+        vc = {"i": 2, "idx": 1, "length": 3, "first": False, "last": False}
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            version_context=vc,
+        )
+        assert result["i"] == 2
+        assert result["idx"] == 1
+
+    def test_custom_params_promoted(self):
+        """Custom version params (non-reserved) promoted to top level."""
+        vc = {
+            "i": 1,
+            "idx": 0,
+            "length": 2,
+            "first": True,
+            "last": False,
+            "classifier_id": 42,
+            "model_name": "gpt-4",
+        }
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            version_context=vc,
+        )
+        assert result["classifier_id"] == 42
+        assert result["model_name"] == "gpt-4"
+
+    def test_reserved_keys_not_double_promoted(self):
+        """Reserved keys (length, first, last) are NOT promoted to top level via custom path."""
+        vc = {"i": 1, "idx": 0, "length": 5, "first": True, "last": False}
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            version_context=vc,
+        )
+        # length, first, last live under version namespace only
+        # (i and idx are promoted separately via explicit checks)
+        assert result.get("length") is None
+        assert result.get("first") is None
+        assert result.get("last") is None
+
+    def test_none_version_context(self):
+        """No 'version' key when version_context is None."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            version_context=None,
+        )
+        assert "version" not in result
+
+
+# ---------------------------------------------------------------------------
+# Workflow namespace
+# ---------------------------------------------------------------------------
+class TestWorkflowNamespace:
+    """Workflow metadata namespace."""
+
+    def test_workflow_populated(self):
+        """Workflow metadata stored under 'workflow' key."""
+        wf = {"name": "my_workflow", "run_id": "abc123"}
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            workflow_metadata=wf,
+        )
+        assert result["workflow"] == wf
+
+    def test_none_workflow(self):
+        """No 'workflow' key when workflow_metadata is None."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            workflow_metadata=None,
+        )
+        assert "workflow" not in result
+
+
+# ---------------------------------------------------------------------------
+# Event firing
+# ---------------------------------------------------------------------------
+class TestEventFiring:
+    """ContextNamespaceLoadedEvent fires for source, version, workflow."""
+
+    @staticmethod
+    def _events_for_namespace(mock_fire, namespace: str) -> list:
+        return [
+            call.args[0]
+            for call in mock_fire.call_args_list
+            if hasattr(call.args[0], "namespace") and call.args[0].namespace == namespace
+        ]
+
+    @patch(_EVENT_PATH)
+    def test_source_event(self, mock_fire):
+        """Source namespace fires event with correct payload."""
+        build_field_context_with_history(
+            agent_name="test_action",
+            agent_config=None,
+            source_content={"text": "hello", "lang": "en"},
+        )
+
+        events = self._events_for_namespace(mock_fire, "source")
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.action_name == "test_action"
+        assert evt.field_count == 2
+        assert sorted(evt.fields) == ["lang", "text"]
+
+    @patch(_EVENT_PATH)
+    def test_version_event(self, mock_fire):
+        """Version namespace fires event with correct payload."""
+        vc = {"i": 1, "idx": 0, "length": 2, "first": True, "last": False}
+        build_field_context_with_history(
+            agent_name="test_action",
+            agent_config=None,
+            version_context=vc,
+        )
+
+        events = self._events_for_namespace(mock_fire, "version")
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.action_name == "test_action"
+        assert evt.field_count == 5
+        assert sorted(evt.fields) == ["first", "i", "idx", "last", "length"]
+
+    @patch(_EVENT_PATH)
+    def test_workflow_event(self, mock_fire):
+        """Workflow namespace fires event with correct payload."""
+        wf = {"name": "my_wf", "run_id": "r1"}
+        build_field_context_with_history(
+            agent_name="test_action",
+            agent_config=None,
+            workflow_metadata=wf,
+        )
+
+        events = self._events_for_namespace(mock_fire, "workflow")
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.action_name == "test_action"
+        assert evt.field_count == 2
+        assert sorted(evt.fields) == ["name", "run_id"]
+
+    @patch(_EVENT_PATH)
+    def test_no_events_for_empty_inputs(self, mock_fire):
+        """No events fire when all inputs are None/empty."""
+        build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+        )
+        assert mock_fire.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Assembler combinations
+# ---------------------------------------------------------------------------
+class TestAssemblerCombinations:
+    """Test that the assembler handles all combinations of None/populated args."""
+
+    def test_all_none_returns_empty(self):
+        """All None inputs produce empty dict."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+        )
+        assert result == {}
+
+    def test_source_only(self):
+        """Only source populated — only 'source' key present."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            source_content={"text": "hi"},
+        )
+        assert set(result.keys()) == {"source"}
+
+    def test_version_only(self):
+        """Only version populated — 'version' + promoted keys present."""
+        vc = {"i": 1, "idx": 0, "length": 1, "first": True, "last": True}
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            version_context=vc,
+        )
+        assert "version" in result
+        assert "i" in result
+        assert "idx" in result
+
+    def test_all_populated(self):
+        """All non-dependency inputs populated — all namespaces present."""
+        result = build_field_context_with_history(
+            agent_name="test",
+            agent_config=None,
+            source_content={"text": "hi"},
+            version_context={"i": 1, "idx": 0, "length": 1, "first": True, "last": True},
+            workflow_metadata={"name": "wf"},
+        )
+        assert "source" in result
+        assert "version" in result
+        assert "workflow" in result
+        assert result["source"] == {"text": "hi"}
+        assert result["workflow"] == {"name": "wf"}


### PR DESCRIPTION
## Summary

- Refactors `build_field_context_with_history()` in `scope_builder.py` from 4 mutating private functions into 4 composable builder classes (`SourceNamespaceBuilder`, `DependencyNamespaceBuilder`, `VersionNamespaceBuilder`, `WorkflowMetadataBuilder`)
- Each builder takes explicit inputs and returns its namespace dict — no shared mutable state between builders
- Public function signature, return shape, and `_dependency_metadata` pop pattern unchanged — zero caller modifications
- Adds 26 safety-net regression tests covering all 4 namespace concerns, event firing, and assembler combinations
- Updates `_MANIFEST.md` references from deleted private functions to new builder classes

## Motivation

The original 271-line file coupled 4 distinct concerns through shared state (`field_context` dict mutation) and ordering assumptions. Bugs in one namespace loader could silently affect others. The metadata side-channel (`_dependency_metadata`) required callers to pop a magic key — an implicit contract that was inconsistently handled across 3 callers.

This is Phase 1: extract builders internally. Phase 2 (separate spec) would return metadata as a separate value and eliminate the pop pattern.

## Commit strategy

| # | Risk | What |
|---|------|------|
| 1 | Zero | Add 26 safety-net tests through public API (works before AND after refactor) |
| 2 | Low | Extract `SourceNamespaceBuilder` + `WorkflowMetadataBuilder` |
| 3 | Low | Extract `VersionNamespaceBuilder` |
| 4 | Medium | Extract `DependencyNamespaceBuilder` (most complex — batch gating, metadata, ConfigurationError) |
| 5 | Zero | Reorganize file, update manifests, changie entry |

## Verification

- All 26 new builder tests pass
- All 5 existing test files pass unchanged:
  - `tests/unit/prompt/test_scope_builder_warning.py`
  - `tests/preprocessing/context/test_infer_dependencies.py`
  - `tests/core/parser/test_version_context_injection.py`
  - `tests/integration/test_context_scope_split_records.py`
  - `tests/integration/test_context_scope_integrity.py`
- Full suite: 6423 passed (all failures pre-existing ollama/vendor parity)
- `ruff check` and `ruff format --check` clean
- 3 production callers (`context_provider.py`, `task_preparer.py`, `prompt/service.py`) work without changes
- `_dependency_metadata` pop pattern preserved for all callers
- `ConfigurationError` fires at same logical position (after batch-mode branch)
- `ContextNamespaceLoadedEvent` payloads identical