### PR TITLE
feat: validate seed field references during preflight

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260509-408000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260509-408000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add preflight validation for seed field references in prompt templates — catches typos and missing fields before pipeline execution instead of mid-flight at Jinja2 render time"
+time: 2026-05-09T04:08:00.000000Z

--- a/agent_actions/validation/preflight/resolution_service.py
+++ b/agent_actions/validation/preflight/resolution_service.py
@@ -2,14 +2,16 @@
 
 Performs a single comprehensive resolution pass across all actions:
 - API key environment variable presence
-- Seed file ($file:) reference existence
+- Seed file ($file:) reference existence and field validation
 - Provider capability / run_mode compatibility
 
 Uses the same resolution utilities that runtime uses, ensuring no divergence.
 """
 
+import json
 import logging
 import os
+from difflib import get_close_matches
 from pathlib import Path
 from typing import Any
 
@@ -83,6 +85,18 @@ def _get_api_key_env_name(vendor: str) -> str | None:
     return str(default) if default is not None else None
 
 
+def _nested_key_exists(data: Any, path: str) -> bool:
+    """Walk nested dict keys along *path*.  Stop at array boundaries."""
+    current = data
+    for part in path.split("."):
+        if isinstance(current, list):
+            return True  # Can't validate past array boundary
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True
+
+
 class WorkflowResolutionService:
     """Performs unified pre-flight resolution checks."""
 
@@ -113,8 +127,11 @@ class WorkflowResolutionService:
             if self.verify_keys and vendor_keys and not result.errors:
                 self._verify_api_keys(vendor_keys, result)
 
-        for error in self._check_seed_file_references():
+        seed_errors, seed_warnings = self._check_seed_file_references()
+        for error in seed_errors:
             result.add_error(error)
+        for warning in seed_warnings:
+            result.add_warning(warning)
 
         for error in self._check_vendor_run_mode_compatibility():
             result.add_error(error)
@@ -224,13 +241,28 @@ class WorkflowResolutionService:
 
     # ── Seed file checks ───────────────────────────────────────────────
 
-    def _check_seed_file_references(self) -> list[StaticTypeError]:
-        """Check that all $file: references resolve to existing files."""
+    def _check_seed_file_references(
+        self,
+    ) -> tuple[list[StaticTypeError], list[StaticTypeWarning]]:
+        """Check $file: references and validate seed field references.
+
+        Phase 1: Validate file existence, path security, and load JSON content.
+        Phase 2: Extract seed references from templates/directives and validate
+        that referenced fields exist in the loaded seed data.
+
+        Returns (errors, warnings).  Namespace mismatches are errors (blocking).
+        Nested field mismatches are warnings (non-blocking).
+        """
         errors: list[StaticTypeError] = []
+        warnings: list[StaticTypeWarning] = []
 
         seed_data_dir = self._resolve_seed_data_dir()
         if seed_data_dir is None:
-            return errors
+            return errors, warnings
+
+        # Phase 1: validate file existence and load seed data
+        action_seed_data: dict[str, dict[str, Any]] = {}
+        action_seed_keys: dict[str, set[str]] = {}
 
         for action_name, config in self.action_configs.items():
             context_scope = config.get("context_scope", {})
@@ -239,6 +271,9 @@ class WorkflowResolutionService:
             seed_path_config = context_scope.get("seed_path", {})
             if not seed_path_config or not isinstance(seed_path_config, dict):
                 continue
+
+            action_seed_keys[action_name] = set(seed_path_config.keys())
+            action_seed_data[action_name] = {}
 
             for field_name, file_spec in seed_path_config.items():
                 if not isinstance(file_spec, str):
@@ -285,8 +320,148 @@ class WorkflowResolutionService:
                             ),
                         )
                     )
+                    continue
 
-        return errors
+                # Load JSON content for field validation
+                try:
+                    content = json.loads(resolved.read_text(encoding="utf-8"))
+                    action_seed_data[action_name][field_name] = content
+                except (OSError, json.JSONDecodeError) as e:
+                    errors.append(
+                        StaticTypeError(
+                            message=f"Seed file '{file_spec}' failed to parse: {e}",
+                            location=FieldLocation(
+                                agent_name=action_name,
+                                config_field=f"context_scope.seed_path.{field_name}",
+                                raw_reference=file_spec,
+                            ),
+                            referenced_agent=action_name,
+                            referenced_field=field_name,
+                            hint="Ensure the seed file contains valid JSON.",
+                        )
+                    )
+
+        # Phase 2: validate seed field references against loaded data
+        self._validate_seed_field_references(action_seed_data, action_seed_keys, errors, warnings)
+
+        return errors, warnings
+
+    def _validate_seed_field_references(
+        self,
+        action_seed_data: dict[str, dict[str, Any]],
+        action_seed_keys: dict[str, set[str]],
+        errors: list[StaticTypeError],
+        warnings: list[StaticTypeWarning],
+    ) -> None:
+        """Validate that seed field references in templates match loaded seed data."""
+        from agent_actions.validation.static_analyzer.reference_extractor import (
+            ReferenceExtractor,
+        )
+
+        ref_extractor = ReferenceExtractor()
+
+        for action_name, config in self.action_configs.items():
+            effective_config = self._resolve_prompt_for_extraction(config)
+            requirements = ref_extractor.extract_from_agent(effective_config)
+            seed_refs = [r for r in requirements if r.source_agent == "seed"]
+            if not seed_refs:
+                continue
+
+            declared_keys = action_seed_keys.get(action_name, set())
+            loaded_data = action_seed_data.get(action_name, {})
+
+            seen_refs: set[str] = set()
+            for req in seed_refs:
+                ref_key = f"{action_name}:{req.field_path}"
+                if ref_key in seen_refs:
+                    continue
+                seen_refs.add(ref_key)
+
+                parts = req.field_path.split(".", 1)
+                seed_key = parts[0]
+                nested_path = parts[1] if len(parts) > 1 else None
+
+                # Namespace validation (ERROR — high confidence)
+                if seed_key not in declared_keys:
+                    hint = (
+                        f"Declared seed keys: {', '.join(sorted(declared_keys))}"
+                        if declared_keys
+                        else f"No seed_path entries declared for action '{action_name}'."
+                    )
+                    errors.append(
+                        StaticTypeError(
+                            message=(
+                                f"Action '{action_name}' references seed.{seed_key} "
+                                f"but '{seed_key}' is not declared in "
+                                f"context_scope.seed_path"
+                            ),
+                            location=FieldLocation(
+                                agent_name=action_name,
+                                config_field=req.location,
+                                raw_reference=req.raw_reference,
+                            ),
+                            referenced_agent=action_name,
+                            referenced_field=f"seed.{seed_key}",
+                            available_fields=declared_keys,
+                            hint=hint,
+                        )
+                    )
+                    continue
+
+                # Nested field validation (WARNING — could be conditional/dynamic)
+                if not nested_path or seed_key not in loaded_data:
+                    continue
+                # Skip wildcard paths — can't validate statically
+                if "*" in nested_path:
+                    continue
+
+                content = loaded_data[seed_key]
+                if not _nested_key_exists(content, nested_path):
+                    available = sorted(content.keys()) if isinstance(content, dict) else []
+                    top_field = nested_path.split(".")[0]
+                    suggestions = get_close_matches(top_field, available, n=1, cutoff=0.6)
+                    warnings.append(
+                        StaticTypeWarning(
+                            message=(
+                                f"Seed field '{seed_key}.{nested_path}' referenced "
+                                f"in action '{action_name}' does not exist in "
+                                f"seed data"
+                            ),
+                            location=FieldLocation(
+                                agent_name=action_name,
+                                config_field=req.location,
+                                raw_reference=req.raw_reference,
+                            ),
+                            referenced_agent=action_name,
+                            referenced_field=f"seed.{seed_key}.{nested_path}",
+                            available_fields=set(available),
+                            hint=(
+                                f"Did you mean: {suggestions[0]}?"
+                                if suggestions
+                                else f"Available fields: {', '.join(available)}"
+                            ),
+                        )
+                    )
+
+    @staticmethod
+    def _resolve_prompt_for_extraction(config: dict[str, Any]) -> dict[str, Any]:
+        """Resolve $file: prompt references for seed field extraction.
+
+        Returns the config with the prompt resolved to actual template text.
+        Falls back to the original config if resolution fails (e.g. prompt
+        file not found — that error is caught by other validators).
+        """
+        prompt = config.get("prompt", "")
+        if not isinstance(prompt, str) or not prompt.startswith("$"):
+            return config
+
+        try:
+            from agent_actions.prompt.formatter import PromptFormatter
+
+            resolved = PromptFormatter.get_raw_prompt(config)
+            return {**config, "prompt": resolved}
+        except Exception:
+            return config
 
     # ── Vendor run-mode compatibility ──────────────────────────────────
 

--- a/agent_actions/validation/preflight/resolution_service.py
+++ b/agent_actions/validation/preflight/resolution_service.py
@@ -461,6 +461,11 @@ class WorkflowResolutionService:
             resolved = PromptFormatter.get_raw_prompt(config)
             return {**config, "prompt": resolved}
         except Exception:
+            logger.debug(
+                "Cannot resolve prompt for seed field extraction in action '%s', "
+                "skipping template-level seed validation",
+                config.get("name", "unknown"),
+            )
             return config
 
     # ── Vendor run-mode compatibility ──────────────────────────────────

--- a/tests/unit/validation/test_seed_field_validation.py
+++ b/tests/unit/validation/test_seed_field_validation.py
@@ -1,0 +1,568 @@
+"""Tests for seed field reference validation in preflight checks.
+
+Covers:
+- Namespace mismatches (error): seed.X where X is not in seed_path
+- Nested field mismatches (warning): seed.rubric.typo where typo doesn't exist
+- Deeply nested field walks
+- Array boundary handling
+- JSON parse failures
+- Did-you-mean suggestions
+- Multiple actions sharing seed keys
+- Wildcard path handling
+- Existing file-level checks are unchanged
+"""
+
+import json
+
+from agent_actions.validation.preflight.resolution_service import (
+    WorkflowResolutionService,
+    _nested_key_exists,
+)
+
+
+def _make_project(tmp_path, seed_files=None):
+    """Create project directory structure with seed files.
+
+    Returns the workflow_config_path string.
+    """
+    project = tmp_path / "project"
+    agent_config = project / "agent_config"
+    agent_config.mkdir(parents=True)
+    seed_data = project / "seed_data"
+    seed_data.mkdir()
+
+    for name, content in (seed_files or {}).items():
+        (seed_data / name).write_text(
+            json.dumps(content) if isinstance(content, (dict, list)) else content
+        )
+
+    return str(agent_config / "workflow.yml")
+
+
+# ---------------------------------------------------------------------------
+# _nested_key_exists helper
+# ---------------------------------------------------------------------------
+
+
+class TestNestedKeyExists:
+    def test_top_level_key(self):
+        assert _nested_key_exists({"a": 1}, "a") is True
+
+    def test_top_level_missing(self):
+        assert _nested_key_exists({"a": 1}, "b") is False
+
+    def test_nested_key(self):
+        assert _nested_key_exists({"a": {"b": {"c": 1}}}, "a.b.c") is True
+
+    def test_nested_missing(self):
+        assert _nested_key_exists({"a": {"b": 1}}, "a.c") is False
+
+    def test_array_boundary_stops(self):
+        assert _nested_key_exists({"items": [1, 2, 3]}, "items.0.name") is True
+
+    def test_non_dict_returns_false(self):
+        assert _nested_key_exists({"a": 42}, "a.b") is False
+
+    def test_empty_dict(self):
+        assert _nested_key_exists({}, "a") is False
+
+
+# ---------------------------------------------------------------------------
+# Namespace mismatch — ERROR (blocks execution)
+# ---------------------------------------------------------------------------
+
+
+class TestSeedNamespaceValidation:
+    """Referencing seed.X when X is not in seed_path produces a blocking error."""
+
+    def test_undeclared_namespace_from_observe(self, tmp_path):
+        """observe: [seed.missing.field] with no seed_path entry for 'missing'."""
+        wf_path = _make_project(tmp_path, {"rubric.json": {"scoring": 1}})
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.missing.field"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        ns_errors = [e for e in result.errors if "seed.missing" in e.message]
+        assert len(ns_errors) == 1
+        assert "not declared in context_scope.seed_path" in ns_errors[0].message
+        assert "rubric" in ns_errors[0].hint  # suggests declared key
+
+    def test_undeclared_namespace_no_seed_path_at_all(self, tmp_path):
+        """Action references seed.X but has no seed_path config."""
+        wf_path = _make_project(tmp_path)
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "observe": ["seed.rubric.field"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        ns_errors = [e for e in result.errors if "seed.rubric" in e.message]
+        assert len(ns_errors) == 1
+        assert "not declared" in ns_errors[0].message
+
+    def test_declared_namespace_passes(self, tmp_path):
+        """Referencing a declared seed key produces no namespace errors."""
+        wf_path = _make_project(tmp_path, {"rubric.json": {"scoring": 1}})
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        ns_errors = [e for e in result.errors if "not declared" in e.message]
+        assert len(ns_errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# Nested field mismatch — WARNING (non-blocking)
+# ---------------------------------------------------------------------------
+
+
+class TestSeedFieldValidation:
+    """Referencing seed.rubric.typo where typo doesn't exist produces a warning."""
+
+    def test_missing_nested_field_warning(self, tmp_path):
+        """Typo in nested field reference produces a warning, not error."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"scoring_criteria": {"weight": 0.5}, "tone": "formal"}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric.scoring_critera"],  # typo
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        # No blocking errors from this
+        ns_errors = [e for e in result.errors if "seed" in e.message.lower()]
+        assert len(ns_errors) == 0
+
+        # Warning with did-you-mean
+        assert len(result.warnings) == 1
+        w = result.warnings[0]
+        assert "scoring_critera" in w.message
+        assert "Does not exist" in w.message or "does not exist" in w.message
+        assert "scoring_criteria" in w.hint  # did-you-mean suggestion
+
+    def test_valid_nested_field_no_warning(self, tmp_path):
+        """Valid nested field reference produces no warnings."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"scoring_criteria": {"weight": 0.5}}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric.scoring_criteria"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 0
+
+    def test_deeply_nested_field_walk(self, tmp_path):
+        """Validates path walk through multiple nesting levels."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"scoring": {"helpfulness": {"weight": 0.35, "description": "help"}}}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": [
+                            "seed.rubric.scoring.helpfulness.weight",  # valid
+                            "seed.rubric.scoring.helpfulness.typo",  # invalid
+                        ],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 1
+        assert "scoring.helpfulness.typo" in result.warnings[0].message
+
+    def test_array_boundary_accepted(self, tmp_path):
+        """Array boundary stops validation — accepts the reference."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"items": [{"name": "a"}, {"name": "b"}]}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric.items"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 0
+
+    def test_did_you_mean_suggestion(self, tmp_path):
+        """Close misspelling triggers did-you-mean hint."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rules.json": {"marketplace_rules": 1, "brand_voice": 2}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rules": "$file:rules.json"},
+                        "observe": ["seed.rules.marketplace_ruls"],  # close typo
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 1
+        assert "marketplace_rules" in result.warnings[0].hint
+
+    def test_no_suggestion_for_distant_name(self, tmp_path):
+        """Completely different name gets no did-you-mean, just available fields."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"scoring_criteria": 1, "tone": 2}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric.zzz_completely_wrong"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 1
+        assert "Available fields:" in result.warnings[0].hint
+
+    def test_wildcard_path_skipped(self, tmp_path):
+        """Wildcard paths (passthrough: seed.rubric.*) are not validated."""
+        wf_path = _make_project(tmp_path, {"rubric.json": {"a": 1}})
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "passthrough": ["seed.rubric.*"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# JSON parse failures — ERROR
+# ---------------------------------------------------------------------------
+
+
+class TestSeedJsonParseFailure:
+    def test_malformed_json_error(self, tmp_path):
+        """Malformed JSON in seed file produces a blocking error."""
+        wf_path = _make_project(tmp_path, {"bad.json": "not valid json {"})
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "loader": {
+                    "context_scope": {
+                        "seed_path": {"data": "$file:bad.json"},
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        parse_errors = [e for e in result.errors if "failed to parse" in e.message]
+        assert len(parse_errors) == 1
+        assert "valid JSON" in parse_errors[0].hint
+
+
+# ---------------------------------------------------------------------------
+# Multiple actions
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleActions:
+    def test_two_actions_same_seed_key(self, tmp_path):
+        """Two actions referencing same seed key — both validated independently."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"scoring_criteria": 1, "tone": 2}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "action_a": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric.scoring_criteria"],  # valid
+                    },
+                },
+                "action_b": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric.typo_field"],  # invalid
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        # Only action_b should have a warning
+        assert len(result.warnings) == 1
+        assert "action_b" in result.warnings[0].message
+
+    def test_action_without_seed_path_referencing_seed(self, tmp_path):
+        """Action A has seed_path, action B doesn't but references seed."""
+        wf_path = _make_project(tmp_path, {"rubric.json": {"a": 1}})
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "action_a": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric"],
+                    },
+                },
+                "action_b": {
+                    "context_scope": {
+                        "observe": ["seed.rubric.field"],  # no seed_path!
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        # action_b should have a namespace error
+        ns_errors = [
+            e for e in result.errors if "action_b" in e.message and "not declared" in e.message
+        ]
+        assert len(ns_errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# Inline prompt extraction
+# ---------------------------------------------------------------------------
+
+
+class TestInlinePromptExtraction:
+    """Seed references in inline prompts are validated."""
+
+    def test_inline_prompt_seed_ref_validated(self, tmp_path):
+        """Seed reference in inline Jinja2 prompt is caught."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"scoring_criteria": 1}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "name": "processor",
+                    "prompt": "Score using {{ seed.rubric.scoring_critera }}",
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 1
+        assert "scoring_critera" in result.warnings[0].message
+
+    def test_inline_prompt_undeclared_namespace(self, tmp_path):
+        """Seed reference to undeclared namespace from inline prompt is an error."""
+        wf_path = _make_project(tmp_path, {"rubric.json": {"a": 1}})
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "name": "processor",
+                    "prompt": "Use {{ seed.missing_data.field }}",
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        ns_errors = [e for e in result.errors if "seed.missing_data" in e.message]
+        assert len(ns_errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# Existing file-level checks unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestExistingChecksUnchanged:
+    """Verify that file existence and path security checks still work."""
+
+    def test_missing_file_still_detected(self, tmp_path):
+        """Missing seed file is still caught (existing behavior)."""
+        wf_path = _make_project(tmp_path)
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "loader": {
+                    "context_scope": {
+                        "seed_path": {"field1": "$file:missing.json"},
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        seed_errors = [e for e in result.errors if "Seed file not found" in e.message]
+        assert len(seed_errors) == 1
+
+    def test_path_traversal_still_caught(self, tmp_path):
+        """Path traversal is still caught (existing behavior)."""
+        wf_path = _make_project(tmp_path)
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "loader": {
+                    "context_scope": {
+                        "seed_path": {"field1": "$file:../../etc/passwd"},
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        seed_errors = [e for e in result.errors if "escapes base directory" in e.message]
+        assert len(seed_errors) == 1
+
+    def test_no_seed_path_no_errors(self):
+        """No seed_path in config produces no errors (existing behavior)."""
+        svc = WorkflowResolutionService(
+            action_configs={"loader": {"context_scope": {}}},
+        )
+        result = svc.resolve_all()
+
+        seed_errors = [e for e in result.errors if "seed" in e.message.lower()]
+        assert len(seed_errors) == 0
+
+    def test_seed_data_dir_missing_graceful_skip(self, tmp_path):
+        """No seed_data directory → graceful skip (existing behavior)."""
+        project = tmp_path / "project"
+        agent_config = project / "agent_config"
+        agent_config.mkdir(parents=True)
+        # No seed_data dir
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "loader": {
+                    "context_scope": {
+                        "seed_path": {"field1": "$file:data.json"},
+                    },
+                },
+            },
+            workflow_config_path=str(agent_config / "workflow.yml"),
+        )
+        result = svc.resolve_all()
+
+        assert len(result.errors) == 0
+        assert len(result.warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    def test_same_ref_from_multiple_directives_deduplicated(self, tmp_path):
+        """Same seed ref in observe and passthrough produces one finding, not two."""
+        wf_path = _make_project(
+            tmp_path,
+            {"rubric.json": {"scoring_criteria": 1}},
+        )
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "processor": {
+                    "context_scope": {
+                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "observe": ["seed.rubric.typo_field"],
+                        "passthrough": ["seed.rubric.typo_field"],
+                    },
+                },
+            },
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        assert len(result.warnings) == 1


### PR DESCRIPTION
## Summary
- Extend preflight seed check to load seed JSON files and validate that fields
  referenced in prompt templates actually exist in the seed data
- Namespace mismatches (seed key not in seed_path) are errors that block execution
- Nested field mismatches (typo in field name) are warnings that log but don't block
  (strict mode escalates to errors via existing `StaticValidationResult` infrastructure)
- Uses `ReferenceExtractor` to parse template references — no custom template parsing
- Includes did-you-mean suggestions via `difflib.get_close_matches`
- Stops validation at array boundaries and skips wildcard paths

## Verification
- 27 new preflight tests for seed field validation (all passing)
- All 16 existing resolution service tests unchanged and passing
- 6400+ tests pass, 5 pre-existing ollama-related failures unrelated to this change
- `ruff format --check` and `ruff check` clean