### PR TITLE
refactor: unify error context enrichment into shared helper

### DIFF
--- a/.changes/unreleased/Under the Hood-20260510-131000.yaml
+++ b/.changes/unreleased/Under the Hood-20260510-131000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Extract duplicated exception context-patching into enrich_exception_context() helper; add debug logging to 2 silent fallback blocks"
+time: 2026-05-10T13:10:00.000000Z

--- a/agent_actions/errors/_MANIFEST.md
+++ b/agent_actions/errors/_MANIFEST.md
@@ -7,6 +7,7 @@
 | `base.py` | Module | Base exception classes for agent-actions. `AgentActionsError.__init__` defensively copies `context` (`dict(context) if context else {}`), preventing mutation by callers — inherited by all subclasses. | `utilities` |
 | `AgentActionsError` | Class | Base exception for all agent-actions errors. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `detailed_str` | Method | Return message with full context dict — use at debug/event boundaries. | - |
+| `enrich_exception_context` | Function | Attach key-value context to any exception. For `AgentActionsError`, updates `.context` directly. For other exceptions, creates `.context` if missing or non-dict. | - |
 | `get_error_detail` | Function | Return `detailed_str()` for `AgentActionsError`, else `str()`. Use instead of `str(error)` at structured-logging boundaries. | - |
 | `common.py` | Module | Common errors used across multiple domains. | `errors` |
 | `InvalidParameterError` | Class | Raised when invalid or missing parameters are provided. | - |

--- a/agent_actions/errors/__init__.py
+++ b/agent_actions/errors/__init__.py
@@ -1,7 +1,11 @@
 """Centralized error exports for agent-actions."""
 
 # Base error
-from agent_actions.errors.base import AgentActionsError, get_error_detail
+from agent_actions.errors.base import (
+    AgentActionsError,
+    enrich_exception_context,
+    get_error_detail,
+)
 
 # Common errors
 from agent_actions.errors.common import InvalidParameterError
@@ -77,6 +81,7 @@ from agent_actions.errors.validation import (
 __all__ = [
     # Base
     "AgentActionsError",
+    "enrich_exception_context",
     "get_error_detail",
     # Common
     "InvalidParameterError",

--- a/agent_actions/errors/base.py
+++ b/agent_actions/errors/base.py
@@ -44,9 +44,8 @@ def enrich_exception_context(exc: Exception, **context: Any) -> None:
     updated directly.  For other exception types, a ``.context`` dict
     attribute is created if it doesn't exist or isn't a dict.
 
-    This centralises the defensive pattern used in coordinator and
-    config_pipeline so callers avoid repeated ``hasattr`` / ``isinstance``
-    / ``type: ignore`` boilerplate.
+    Centralises defensive context-patching so callers avoid repeated
+    ``hasattr`` / ``isinstance`` / ``type: ignore`` boilerplate.
     """
     if isinstance(exc, AgentActionsError):
         exc.context.update(context)

--- a/agent_actions/errors/base.py
+++ b/agent_actions/errors/base.py
@@ -37,6 +37,27 @@ class AgentActionsError(Exception):
             return super().__str__()
 
 
+def enrich_exception_context(exc: Exception, **context: Any) -> None:
+    """Attach key-value context to any exception.
+
+    If *exc* is an ``AgentActionsError``, its ``.context`` dict is
+    updated directly.  For other exception types, a ``.context`` dict
+    attribute is created if it doesn't exist or isn't a dict.
+
+    This centralises the defensive pattern used in coordinator and
+    config_pipeline so callers avoid repeated ``hasattr`` / ``isinstance``
+    / ``type: ignore`` boilerplate.
+    """
+    if isinstance(exc, AgentActionsError):
+        exc.context.update(context)
+    else:
+        existing = getattr(exc, "context", None)
+        if not isinstance(existing, dict):
+            exc.context = dict(context)  # type: ignore[attr-defined]
+        else:
+            exc.context.update(context)  # type: ignore[attr-defined]
+
+
 def get_error_detail(error: Exception) -> str:
     """Return detailed_str() for AgentActionsError, else str()."""
     if isinstance(error, AgentActionsError):

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -7,6 +7,7 @@ from typing import Any
 from rich.console import Console
 
 from agent_actions.config.manager import ConfigManager
+from agent_actions.errors import enrich_exception_context
 from agent_actions.input.loaders.udf import discover_udfs
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import (
@@ -31,14 +32,7 @@ def _run_config_stage(fn: Any, stage: str, manager: ConfigManager, *args: Any) -
     except Exception as e:
         agent = getattr(manager, "agent_name", "unknown")
         logger.debug("Config stage '%s' failed for agent '%s': %s", stage, agent, e)
-        if not hasattr(e, "context") or not isinstance(e.context, dict):  # type: ignore[attr-defined]
-            e.context = {}  # type: ignore[attr-defined]
-        e.context.update(  # type: ignore[attr-defined]
-            {
-                "agent": agent,
-                "pipeline_stage": stage,
-            }
-        )
+        enrich_exception_context(e, agent=agent, pipeline_stage=stage)
         raise
 
 

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from rich.console import Console
 
-from agent_actions.errors import ConfigurationError
+from agent_actions.errors import ConfigurationError, enrich_exception_context
 from agent_actions.errors.preflight import PreFlightValidationError
 from agent_actions.input.preprocessing.parsing.parser import WhereClauseParser
 
@@ -420,13 +420,10 @@ class AgentWorkflow:
                 self.state.failed = True
                 # Enrich BEFORE firing the error event so the formatter
                 # has full context when it renders the user-facing message.
-                if not hasattr(e, "context") or not isinstance(e.context, dict):  # type: ignore[attr-defined]
-                    e.context = {}  # type: ignore[attr-defined]
-                e.context.update(  # type: ignore[attr-defined]
-                    {
-                        "workflow": self.metadata.agent_name,
-                        "operation": "async_workflow_execution",
-                    }
+                enrich_exception_context(
+                    e,
+                    workflow=self.metadata.agent_name,
+                    operation="async_workflow_execution",
                 )
                 self.event_logger.handle_workflow_error(e, elapsed_time=duration)
                 raise
@@ -515,13 +512,10 @@ class AgentWorkflow:
                 self.state.failed = True
                 # Enrich BEFORE firing the error event so the formatter
                 # has full context when it renders the user-facing message.
-                if not hasattr(e, "context") or not isinstance(e.context, dict):  # type: ignore[attr-defined]
-                    e.context = {}  # type: ignore[attr-defined]
-                e.context.update(  # type: ignore[attr-defined]
-                    {
-                        "workflow": self.metadata.agent_name,
-                        "operation": "sequential_workflow_execution",
-                    }
+                enrich_exception_context(
+                    e,
+                    workflow=self.metadata.agent_name,
+                    operation="sequential_workflow_execution",
                 )
                 self.event_logger.handle_workflow_error(e, elapsed_time=duration)
                 raise

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -478,12 +478,16 @@ class ProcessingPipeline:
 
                 logger.debug("Loaded source data via SourceDataLoader for %s", file_path)
 
-            except (FileNotFoundError, ValueError):
+            except (FileNotFoundError, ValueError) as e:
                 # FileNotFoundError: no source data for this path (normal for
                 # cross-workflow workflows that have no staging data).
                 # ValueError: empty/invalid path from storage backend validation.
                 # In both cases, input data is the correct source context.
-                pass
+                logger.debug(
+                    "Source data not loaded for %s (using input data as source context): %s",
+                    file_path,
+                    e,
+                )
 
         # ── per-action record_limit ──────────────────────────────────────
         record_limit = self.config.action_config.get("record_limit")

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -247,7 +247,10 @@ class ActionRunner:
                 if dep_path.exists():
                     return dep_path
             except KeyError:
-                pass
+                logger.debug(
+                    "Manifest-based resolution failed for dependency '%s' — trying direct path",
+                    dep_name,
+                )
 
         # Direct path using simple name
         simple_path = target_dir / dep_name

--- a/tests/unit/errors/test_enrich_exception_context.py
+++ b/tests/unit/errors/test_enrich_exception_context.py
@@ -5,7 +5,6 @@ from agent_actions.errors.base import enrich_exception_context as base_enrich
 
 
 class TestEnrichAgentActionsError:
-
     def test_updates_empty_context(self):
         e = AgentActionsError("msg")
         enrich_exception_context(e, key="val")
@@ -28,7 +27,6 @@ class TestEnrichAgentActionsError:
 
 
 class TestEnrichBareException:
-
     def test_bare_exception_gets_context_created(self):
         e = RuntimeError("msg")
         enrich_exception_context(e, key="val")
@@ -63,6 +61,5 @@ class TestEnrichBareException:
 
 
 class TestReExport:
-
     def test_importable_from_package(self):
         assert enrich_exception_context is base_enrich

--- a/tests/unit/errors/test_enrich_exception_context.py
+++ b/tests/unit/errors/test_enrich_exception_context.py
@@ -1,0 +1,68 @@
+"""Tests for enrich_exception_context helper."""
+
+from agent_actions.errors import AgentActionsError, enrich_exception_context
+from agent_actions.errors.base import enrich_exception_context as base_enrich
+
+
+class TestEnrichAgentActionsError:
+
+    def test_updates_empty_context(self):
+        e = AgentActionsError("msg")
+        enrich_exception_context(e, key="val")
+        assert e.context["key"] == "val"
+
+    def test_preserves_existing_context(self):
+        e = AgentActionsError("msg", context={"existing": 1})
+        enrich_exception_context(e, new="2")
+        assert e.context == {"existing": 1, "new": "2"}
+
+    def test_overwrites_duplicate_key(self):
+        e = AgentActionsError("msg", context={"op": "old"})
+        enrich_exception_context(e, op="new")
+        assert e.context["op"] == "new"
+
+    def test_multiple_kwargs(self):
+        e = AgentActionsError("msg")
+        enrich_exception_context(e, workflow="wf", operation="async")
+        assert e.context == {"workflow": "wf", "operation": "async"}
+
+
+class TestEnrichBareException:
+
+    def test_bare_exception_gets_context_created(self):
+        e = RuntimeError("msg")
+        enrich_exception_context(e, key="val")
+        assert e.context["key"] == "val"  # type: ignore[attr-defined]
+
+    def test_string_context_gets_replaced(self):
+        e = RuntimeError("msg")
+        e.context = "I am a string"  # type: ignore[attr-defined]
+        enrich_exception_context(e, key="val")
+        assert isinstance(e.context, dict)  # type: ignore[attr-defined]
+        assert e.context["key"] == "val"  # type: ignore[attr-defined]
+
+    def test_existing_dict_context_gets_updated(self):
+        e = RuntimeError("msg")
+        e.context = {"old": 1}  # type: ignore[attr-defined]
+        enrich_exception_context(e, new=2)
+        assert e.context == {"old": 1, "new": 2}  # type: ignore[attr-defined]
+
+    def test_none_context_gets_replaced(self):
+        e = ValueError("msg")
+        e.context = None  # type: ignore[attr-defined]
+        enrich_exception_context(e, key="val")
+        assert isinstance(e.context, dict)  # type: ignore[attr-defined]
+        assert e.context["key"] == "val"  # type: ignore[attr-defined]
+
+    def test_list_context_gets_replaced(self):
+        e = KeyError("msg")
+        e.context = [1, 2, 3]  # type: ignore[attr-defined]
+        enrich_exception_context(e, key="val")
+        assert isinstance(e.context, dict)  # type: ignore[attr-defined]
+        assert e.context["key"] == "val"  # type: ignore[attr-defined]
+
+
+class TestReExport:
+
+    def test_importable_from_package(self):
+        assert enrich_exception_context is base_enrich

--- a/tests/unit/workflow/test_coordinator_error_enrichment.py
+++ b/tests/unit/workflow/test_coordinator_error_enrichment.py
@@ -7,7 +7,7 @@ Verifies that:
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -54,6 +54,37 @@ def _build_workflow(execution_order=None):
     wf.event_logger = MagicMock()
 
     return wf
+
+
+class TestAsyncErrorEnrichment:
+    """Verify enrichment ordering in async_run."""
+
+    @pytest.mark.asyncio
+    async def test_async_context_set_before_handle_workflow_error(self):
+        """The .context dict must be populated BEFORE the event logger fires (async path)."""
+        wf = _build_workflow()
+        error = RuntimeError("async kaboom")
+
+        orchestrator = wf.services.core.action_level_orchestrator
+        orchestrator.execute_level_async = AsyncMock(side_effect=error)
+
+        captured_context = {}
+
+        def capture_context(exc, **kwargs):
+            if hasattr(exc, "context") and isinstance(exc.context, dict):
+                captured_context.update(exc.context)
+
+        wf.event_logger.handle_workflow_error.side_effect = capture_context
+
+        with patch("agent_actions.workflow.coordinator.get_manager") as mock_gm:
+            mock_gm.return_value.context.return_value.__enter__ = MagicMock()
+            mock_gm.return_value.context.return_value.__exit__ = MagicMock(return_value=False)
+
+            with pytest.raises(RuntimeError):
+                await wf.async_run()
+
+        assert captured_context["workflow"] == "test_workflow"
+        assert captured_context["operation"] == "async_workflow_execution"
 
 
 class TestSequentialErrorEnrichment:


### PR DESCRIPTION
## Summary
- Extract duplicated 9-line defensive context-patching pattern from 3 call sites (coordinator.py x2, config_pipeline.py x1) into `enrich_exception_context()` helper in `errors/base.py`
- Remove 9 `# type: ignore[attr-defined]` comments from workflow code (consolidated to 2 in the helper)
- Add `logger.debug()` to 2 silent fallback blocks in pipeline.py (source data loading) and runner.py (manifest dependency resolution)
- Close async path enrichment test gap (pre-existing — only sequential path had coverage)

## Files changed
- `agent_actions/errors/base.py` — new `enrich_exception_context()` function
- `agent_actions/errors/__init__.py` — re-export + `__all__` entry
- `agent_actions/workflow/coordinator.py` — 2 inline blocks → helper calls
- `agent_actions/workflow/config_pipeline.py` — 1 inline block → helper call
- `agent_actions/workflow/pipeline.py` — debug logging for source data fallback
- `agent_actions/workflow/runner.py` — debug logging for manifest resolution fallback
- `agent_actions/errors/_MANIFEST.md` — new entry
- `tests/unit/errors/test_enrich_exception_context.py` — 10 unit tests
- `tests/unit/workflow/test_coordinator_error_enrichment.py` — 1 async enrichment test

## Verification
- `ruff check` and `ruff format --check`: clean
- `pytest`: 6498 passed (12 pre-existing vendor parity failures, 2 pre-existing Ollama collection errors)
- Zero `type: ignore[attr-defined]` remaining in coordinator.py and config_pipeline.py
- All 5 existing coordinator enrichment tests pass (4 sequential + 1 new async)
- Exception propagation chain verified: bare `raise` preserved at all 3 sites