### PR TITLE
fix: reject nested dict values in inline schema shorthand

### DIFF
--- a/.changes/unreleased/Bug Fix-20260510-133000.yaml
+++ b/.changes/unreleased/Bug Fix-20260510-133000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Reject nested dict values in inline schema shorthand with actionable error instead of silent acceptance followed by runtime AttributeError crash"
+time: 2026-05-10T13:30:00.000000Z

--- a/agent_actions/output/response/loader.py
+++ b/agent_actions/output/response/loader.py
@@ -155,6 +155,14 @@ class SchemaLoader:
 
         fields = []
         for field_name, field_type in schema_dict.items():
+            if not isinstance(field_type, str):
+                raise SchemaValidationError(
+                    f"Inline schema field '{field_name}' has a non-string type "
+                    f"({type(field_type).__name__}). Inline shorthand only supports "
+                    f"string type descriptors (e.g., 'string', 'integer', 'array[string]').",
+                    validation_type="structure",
+                    hint="Use a schema file for complex nested definitions.",
+                )
             is_required = field_type.endswith("!")
             if is_required:
                 field_type = field_type[:-1]
@@ -210,6 +218,14 @@ class SchemaLoader:
             schema_properties = {}
             required_fields = []
             for prop_name, prop_type in properties_dict.items():
+                if not isinstance(prop_type, str):
+                    raise SchemaValidationError(
+                        f"Object property '{prop_name}' has a non-string type "
+                        f"({type(prop_type).__name__}). Property types must be "
+                        f"string descriptors (e.g., 'string', 'number!').",
+                        validation_type="structure",
+                        hint="Use a schema file for deeply nested object definitions.",
+                    )
                 is_required = prop_type.endswith("!")
                 if is_required:
                     prop_type = prop_type[:-1]

--- a/agent_actions/output/response/loader.py
+++ b/agent_actions/output/response/loader.py
@@ -224,7 +224,7 @@ class SchemaLoader:
                         f"({type(prop_type).__name__}). Property types must be "
                         f"string descriptors (e.g., 'string', 'number!').",
                         validation_type="structure",
-                        hint="Use a schema file for deeply nested object definitions.",
+                        hint="Use a schema file for complex nested definitions.",
                     )
                 is_required = prop_type.endswith("!")
                 if is_required:

--- a/agent_actions/prompt/render_workflow.py
+++ b/agent_actions/prompt/render_workflow.py
@@ -15,6 +15,7 @@ from agent_actions.errors import ConfigurationError, TemplateRenderingError
 from agent_actions.output.response.loader import SchemaLoader
 from agent_actions.prompt.handler import PromptLoader
 from agent_actions.utils.safe_format import safe_format_error
+from agent_actions.utils.schema_utils import is_compiled_schema
 
 logger = logging.getLogger(__name__)
 
@@ -281,6 +282,12 @@ def _compile_action_schemas(
     if schema_value and _is_inline_schema_dict(schema_value):
         action["schema"] = _expand_inline_schema(schema_value)
         logger.debug("Expanded inline schema for action '%s'", action_name)
+    elif schema_value and isinstance(schema_value, dict) and not is_compiled_schema(schema_value):
+        logger.warning(
+            "Action '%s' has an inline schema that is not in shorthand or compiled "
+            "format — it may contain nested dict values. Consider using a schema file.",
+            action_name,
+        )
 
     return action
 

--- a/agent_actions/utils/schema_utils.py
+++ b/agent_actions/utils/schema_utils.py
@@ -38,6 +38,8 @@ def is_inline_schema_shorthand(schema_value: Any) -> bool:
     valid_types = {"string", "number", "integer", "boolean", "array", "object"}
     for value in schema_value.values():
         if not isinstance(value, str):
+            # Dict values (nested JSON Schema fragments) are intentionally
+            # rejected — inline shorthand only supports string type descriptors.
             return False
         check_type = value.rstrip("!")
         if check_type.startswith("array[") and check_type.endswith("]"):

--- a/agent_actions/utils/schema_utils.py
+++ b/agent_actions/utils/schema_utils.py
@@ -38,8 +38,8 @@ def is_inline_schema_shorthand(schema_value: Any) -> bool:
     valid_types = {"string", "number", "integer", "boolean", "array", "object"}
     for value in schema_value.values():
         if not isinstance(value, str):
-            # Dict values (nested JSON Schema fragments) are intentionally
-            # rejected — inline shorthand only supports string type descriptors.
+            # Non-string values cause AttributeError in downstream .endswith("!")
+            # calls. Reject here so callers get False, not a crash.
             return False
         check_type = value.rstrip("!")
         if check_type.startswith("array[") and check_type.endswith("]"):

--- a/agent_actions/validation/action_validators/inline_schema_validator.py
+++ b/agent_actions/validation/action_validators/inline_schema_validator.py
@@ -65,12 +65,18 @@ class InlineSchemaValidator(BaseActionEntryValidator):
 
             if not isinstance(field_type, str):
                 if isinstance(field_type, dict):
-                    # Dict values are valid nested JSON Schema property
-                    # definitions (e.g. {type: array, items: {type: string}}).
+                    errors.append(
+                        f"{desc} inline schema field '{field_name}' uses a nested "
+                        f"definition, which is not supported in shorthand format. "
+                        f"For simple nested objects, use the string shorthand: "
+                        f"\"array[object:{{'prop': 'type'}}]\". "
+                        f"For complex structures, use a schema file: "
+                        f"'schema: <schema_name>' referencing a file in schema/."
+                    )
                     continue
                 errors.append(
                     f"{desc} 'schema' value for field '{field_name}' must be "
-                    f"a string or dict type, found {type(field_type).__name__}."
+                    f"a string type, found {type(field_type).__name__}."
                 )
                 continue
 

--- a/agent_actions/validation/static_analyzer/schema_structure_validator.py
+++ b/agent_actions/validation/static_analyzer/schema_structure_validator.py
@@ -358,18 +358,35 @@ class SchemaStructureValidator:
         for field_name, field_type in schema.items():
             if not isinstance(field_type, str):
                 if isinstance(field_type, dict):
-                    # Dict values are valid nested JSON Schema property
-                    # definitions (e.g. {type: array, items: {type: string}}).
+                    errors.append(
+                        StaticTypeError(
+                            message=(
+                                f"Inline schema field '{field_name}' uses a nested definition, "
+                                f"which is not supported in shorthand format"
+                            ),
+                            location=FieldLocation(
+                                agent_name=action_name,
+                                config_field=f"{config_field}.{field_name}",
+                            ),
+                            referenced_agent=action_name,
+                            referenced_field=field_name,
+                            hint=(
+                                "For simple nested objects, use: "
+                                "\"array[object:{'prop': 'type'}]\". "
+                                "For complex structures, use a schema file."
+                            ),
+                        )
+                    )
                     continue
                 errors.append(
                     StaticTypeError(
-                        message=f"Inline schema field '{field_name}' type must be a string or dict",
+                        message=f"Inline schema field '{field_name}' type must be a string",
                         location=FieldLocation(
                             agent_name=action_name, config_field=f"{config_field}.{field_name}"
                         ),
                         referenced_agent=action_name,
                         referenced_field=field_name,
-                        hint="Example: {name: 'string!', age: 'number'} or {tags: {type: 'array', items: {type: 'string'}}}",
+                        hint="Example: {name: 'string!', age: 'number'}",
                     )
                 )
                 continue

--- a/tests/core/parser/test_schema_compilation.py
+++ b/tests/core/parser/test_schema_compilation.py
@@ -7,6 +7,7 @@ These tests verify that:
 3. Strict mode raises errors on schema load failures
 """
 
+import logging
 import unittest.mock
 
 import pytest
@@ -331,10 +332,8 @@ class TestCompileActionSchemasWarning:
             },
         }
 
-        import logging
-
-        logger = logging.getLogger("agent_actions.prompt.render_workflow")
-        with unittest.mock.patch.object(logger, "warning") as mock_warn:
+        render_logger = logging.getLogger("agent_actions.prompt.render_workflow")
+        with unittest.mock.patch.object(render_logger, "warning") as mock_warn:
             _compile_action_schemas(action, project_root=tmp_path)
 
         mock_warn.assert_called_once()
@@ -349,10 +348,8 @@ class TestCompileActionSchemasWarning:
             "schema": {"name": "string", "age": "integer"},
         }
 
-        import logging
-
-        logger = logging.getLogger("agent_actions.prompt.render_workflow")
-        with unittest.mock.patch.object(logger, "warning") as mock_warn:
+        render_logger = logging.getLogger("agent_actions.prompt.render_workflow")
+        with unittest.mock.patch.object(render_logger, "warning") as mock_warn:
             _compile_action_schemas(action, project_root=tmp_path)
 
         # No warning should fire — valid shorthand gets expanded

--- a/tests/core/parser/test_schema_compilation.py
+++ b/tests/core/parser/test_schema_compilation.py
@@ -7,6 +7,8 @@ These tests verify that:
 3. Strict mode raises errors on schema load failures
 """
 
+import unittest.mock
+
 import pytest
 import yaml
 
@@ -143,6 +145,7 @@ class TestIsInlineSchemaDict:
             ),
             pytest.param({}, False, id="empty_dict"),
             pytest.param({"field1": ["string", "null"]}, False, id="non_string_values"),
+            pytest.param({"field1": {"type": "string"}}, False, id="dict_values_nested_schema"),
             pytest.param({"field1": "invalid_type"}, False, id="invalid_types"),
             pytest.param({"tags": "array[string]", "count": "integer"}, True, id="array_types"),
         ],
@@ -304,6 +307,7 @@ class TestSchemaUtilsShared:
             pytest.param({"tags": "array[string]"}, True, id="array_type"),
             pytest.param({"name": "foo", "fields": []}, False, id="compiled_format"),
             pytest.param("schema_name", False, id="non_dict"),
+            pytest.param({"field1": {"type": "string"}}, False, id="dict_values_nested_schema"),
         ],
     )
     def test_is_inline_schema_shorthand(self, schema, expected):
@@ -311,3 +315,46 @@ class TestSchemaUtilsShared:
         from agent_actions.utils.schema_utils import is_inline_schema_shorthand
 
         assert is_inline_schema_shorthand(schema) is expected
+
+
+class TestCompileActionSchemasWarning:
+    """Compile-time warning for unrecognized dict schemas."""
+
+    def test_unrecognized_dict_schema_logs_warning(self, tmp_path):
+        """A dict schema that is neither shorthand nor compiled logs a warning."""
+        _setup_project(tmp_path)
+
+        action = {
+            "name": "test_action",
+            "schema": {
+                "questions": {"type": "array", "items": {"type": "string"}},
+            },
+        }
+
+        import logging
+
+        logger = logging.getLogger("agent_actions.prompt.render_workflow")
+        with unittest.mock.patch.object(logger, "warning") as mock_warn:
+            _compile_action_schemas(action, project_root=tmp_path)
+
+        mock_warn.assert_called_once()
+        assert "not in shorthand or compiled format" in mock_warn.call_args[0][0]
+
+    def test_valid_shorthand_no_warning(self, tmp_path):
+        """A valid shorthand dict schema does not trigger the warning."""
+        _setup_project(tmp_path)
+
+        action = {
+            "name": "test_action",
+            "schema": {"name": "string", "age": "integer"},
+        }
+
+        import logging
+
+        logger = logging.getLogger("agent_actions.prompt.render_workflow")
+        with unittest.mock.patch.object(logger, "warning") as mock_warn:
+            _compile_action_schemas(action, project_root=tmp_path)
+
+        # No warning should fire — valid shorthand gets expanded
+        for call in mock_warn.call_args_list:
+            assert "not in shorthand or compiled format" not in call[0][0]

--- a/tests/unit/output/test_loader.py
+++ b/tests/unit/output/test_loader.py
@@ -3,6 +3,7 @@
 import pytest
 import yaml
 
+from agent_actions.errors import SchemaValidationError
 from agent_actions.output.response.loader import SchemaLoader
 
 
@@ -95,3 +96,26 @@ class TestSchemaLoaderConstructSchemaFromDict:
         result = SchemaLoader.construct_schema_from_dict({})
         assert result["name"] == "InlineSchema"
         assert result["fields"] == []
+
+    def test_dict_value_raises_schema_validation_error(self):
+        """Dict values raise SchemaValidationError, not AttributeError."""
+        with pytest.raises(SchemaValidationError, match="non-string type"):
+            SchemaLoader.construct_schema_from_dict(
+                {"tags": {"type": "array", "items": {"type": "string"}}}
+            )
+
+    def test_mixed_string_and_dict_raises_on_first_dict(self):
+        """Mixed schemas raise on the dict field, not crash on .endswith()."""
+        with pytest.raises(SchemaValidationError, match="'questions'"):
+            SchemaLoader.construct_schema_from_dict(
+                {"name": "string", "questions": {"type": "array"}}
+            )
+
+
+class TestParseObjectPropertiesGuard:
+    """_parse_object_properties rejects non-string property types."""
+
+    def test_non_string_property_type_raises(self):
+        """Nested dict inside object properties raises SchemaValidationError."""
+        with pytest.raises(SchemaValidationError, match="non-string type"):
+            SchemaLoader._parse_object_properties("{'sub': {'type': 'string'}}")

--- a/tests/unit/validation/test_inline_schema_validator_coverage.py
+++ b/tests/unit/validation/test_inline_schema_validator_coverage.py
@@ -190,13 +190,48 @@ class TestInvalidInlineSchemaTypes:
         ctx = _make_context({"schema": {"field1": 123}})
         result = validator.validate(ctx)
         assert len(result.errors) == 1
-        assert "must be a string or dict type" in result.errors[0]
+        assert "must be a string type" in result.errors[0]
 
-    def test_dict_field_type_value_accepted(self, validator):
-        """Dict values in inline schemas are valid (nested JSON Schema)."""
+    def test_dict_field_type_value_rejected(self, validator):
+        """Nested dict values in inline schemas produce an actionable error."""
         ctx = _make_context({"schema": {"tags": {"type": "array", "items": {"type": "string"}}}})
         result = validator.validate(ctx)
-        assert len(result.errors) == 0
+        assert len(result.errors) == 1
+        assert "nested" in result.errors[0].lower()
+        assert "schema file" in result.errors[0].lower() or "schema:" in result.errors[0]
+        assert "array[object:" in result.errors[0]
+
+    def test_dict_field_type_error_names_field(self, validator):
+        """Error message identifies the specific field with the nested dict."""
+        ctx = _make_context(
+            {"schema": {"questions": {"type": "object", "properties": {"q": {"type": "string"}}}}}
+        )
+        result = validator.validate(ctx)
+        assert len(result.errors) == 1
+        assert "'questions'" in result.errors[0]
+
+    def test_empty_nested_dict_rejected(self, validator):
+        """Even an empty dict value is rejected — not silently accepted."""
+        ctx = _make_context({"schema": {"metadata": {}}})
+        result = validator.validate(ctx)
+        assert len(result.errors) == 1
+        assert "'metadata'" in result.errors[0]
+
+    def test_mixed_flat_and_nested_reports_nested_field(self, validator):
+        """Mixed schemas with both string and dict values report only the nested field."""
+        ctx = _make_context(
+            {
+                "schema": {
+                    "name": "string",
+                    "questions": {"type": "array", "items": {"type": "string"}},
+                }
+            }
+        )
+        result = validator.validate(ctx)
+        assert len(result.errors) == 1
+        assert "'questions'" in result.errors[0]
+        # The string field "name" should not be flagged
+        assert "'name'" not in result.errors[0]
 
     def test_mixed_valid_and_invalid(self, validator):
         ctx = _make_context(

--- a/tests/validation/static_analyzer/test_schema_structure_validator.py
+++ b/tests/validation/static_analyzer/test_schema_structure_validator.py
@@ -184,7 +184,12 @@ class TestInlineShorthandFormat:
         [
             pytest.param({"name": "invalid_type"}, "invalid", id="invalid_type"),
             pytest.param({"items": "array[invalid]"}, "invalid", id="invalid_array_item_type"),
-            pytest.param({"name": 123}, "string or dict", id="non_string_type_value"),
+            pytest.param({"name": 123}, "must be a string", id="non_string_type_value"),
+            pytest.param(
+                {"tags": {"type": "array", "items": {"type": "string"}}},
+                "nested definition",
+                id="nested_dict_rejected",
+            ),
         ],
     )
     def test_inline_validation_errors(self, validator, schema, error_pattern):


### PR DESCRIPTION
## Summary
- Inline schemas with nested dict values (e.g., `{questions: {type: array, items: ...}}`) were silently accepted by validation but crashed at runtime with `AttributeError: 'dict' object has no attribute 'endswith'`
- Replace the silent `continue` in `InlineSchemaValidator` and `schema_structure_validator` with actionable errors that direct users to `array[object:{...}]` shorthand or schema files
- Add defense-in-depth `isinstance(str)` guards in `construct_schema_from_dict()` and `_parse_object_properties()` to raise `SchemaValidationError` instead of `AttributeError`
- Add compile-time warning in `_compile_action_schemas()` for unrecognized dict schemas that bypass validation

## Verification
- 111 targeted tests pass across 4 test files (39 validator, 32 compilation, 13 loader, 27 static analyzer)
- 6508 full suite pass, 0 regressions
- 12 pre-existing vendor parity failures unchanged
- ruff check + ruff format clean