### PR TITLE
fix: handle Anthropic batch 'errored' result type correctly

### DIFF
--- a/.changes/unreleased/Bug Fix-20260510-044000.yaml
+++ b/.changes/unreleased/Bug Fix-20260510-044000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix Anthropic batch stuck in infinite recovery loop — result type 'errored' was not recognized, causing error info loss and repeated recovery submissions"
+time: 2026-05-10T04:40:00.000000Z

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -189,7 +189,12 @@ class BatchClientResolver:
                 if key:
                     return {"api_key": key}
             except Exception:
-                pass  # Fall through to vendor default
+                logger.debug(
+                    "Failed to resolve API key from agent_config for vendor '%s', "
+                    "falling back to vendor default env var",
+                    vendor,
+                    exc_info=True,
+                )
 
         # 2. Try vendor config class default
         from agent_actions.validation.preflight.resolution_service import (

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -154,7 +154,8 @@ class BatchClientResolver:
                     reason="client not cached",
                 )
             )
-            return BatchClientFactory.create_client(client_type)
+            config = self._resolve_api_key_for_vendor(client_type)
+            return BatchClientFactory.create_client(client_type, config)
 
         if self._default_client:
             return self._default_client
@@ -163,6 +164,28 @@ class BatchClientResolver:
             f"Cannot determine client for batch_id {batch_id}",
             context={"batch_id": batch_id, "output_directory": output_directory},
         )
+
+    @staticmethod
+    def _resolve_api_key_for_vendor(vendor: str) -> dict[str, Any]:
+        """Resolve API key from vendor config's env var name.
+
+        Uses the same env var name that the online path reads (e.g.
+        ``CLAUDE_API_KEY`` if the user configured ``api_key: ${CLAUDE_API_KEY}``
+        in their vendor config).  Falls back to an empty dict so the factory
+        can still try its own hardcoded env var lookup.
+        """
+        import os
+
+        from agent_actions.validation.preflight.resolution_service import (
+            _get_api_key_env_name,
+        )
+
+        env_name = _get_api_key_env_name(vendor)
+        if env_name:
+            key = os.environ.get(env_name)
+            if key:
+                return {"api_key": key}
+        return {}
 
     def _find_cached_client(self, client_type: str) -> BaseBatchClient | None:
         if client_type in self._client_cache:

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -119,7 +119,11 @@ class BatchClientResolver:
             ) from e
 
     def get_for_batch_id(
-        self, batch_id: str, registry_manager, output_directory: str | None = None
+        self,
+        batch_id: str,
+        registry_manager,
+        output_directory: str | None = None,
+        agent_config: dict[str, Any] | None = None,
     ) -> BaseBatchClient:
         """
         Get the client that was used for a specific batch ID.
@@ -132,6 +136,8 @@ class BatchClientResolver:
             registry_manager: BatchRegistryManager instance to lookup batch info
             output_directory: Output directory (used as fallback when
                 registry_manager is None)
+            agent_config: Optional agent config for API key resolution on
+                cache miss (avoids falling back to hardcoded env var names)
 
         Returns:
             BaseBatchClient instance
@@ -154,7 +160,7 @@ class BatchClientResolver:
                     reason="client not cached",
                 )
             )
-            config = self._resolve_api_key_for_vendor(client_type)
+            config = self._resolve_api_key_config(client_type, agent_config)
             return BatchClientFactory.create_client(client_type, config)
 
         if self._default_client:
@@ -166,16 +172,26 @@ class BatchClientResolver:
         )
 
     @staticmethod
-    def _resolve_api_key_for_vendor(vendor: str) -> dict[str, Any]:
-        """Resolve API key from vendor config's env var name.
+    def _resolve_api_key_config(vendor: str, agent_config: dict[str, Any] | None) -> dict[str, Any]:
+        """Build a config dict with the API key for creating a batch client.
 
-        Uses the same env var name that the online path reads (e.g.
-        ``CLAUDE_API_KEY`` if the user configured ``api_key: ${CLAUDE_API_KEY}``
-        in their vendor config).  Falls back to an empty dict so the factory
-        can still try its own hardcoded env var lookup.
+        Resolution order:
+        1. agent_config["api_key"] → resolve env var (same path online mode uses)
+        2. Vendor config class default env var name (e.g. ANTHROPIC_API_KEY)
+        3. Empty dict → factory tries its own hardcoded fallback
         """
         import os
 
+        # 1. Try agent_config (user's actual configured key name)
+        if agent_config and agent_config.get(API_KEY_KEY):
+            try:
+                key = BaseClient.get_api_key(agent_config)
+                if key:
+                    return {"api_key": key}
+            except Exception:
+                pass  # Fall through to vendor default
+
+        # 2. Try vendor config class default
         from agent_actions.validation.preflight.resolution_service import (
             _get_api_key_env_name,
         )
@@ -185,6 +201,7 @@ class BatchClientResolver:
             key = os.environ.get(env_name)
             if key:
                 return {"api_key": key}
+
         return {}
 
     def _find_cached_client(self, client_type: str) -> BaseBatchClient | None:

--- a/agent_actions/llm/batch/infrastructure/job_manager.py
+++ b/agent_actions/llm/batch/infrastructure/job_manager.py
@@ -33,10 +33,14 @@ class BatchJobManager:
         """Set the registry manager (for lazy initialization)."""
         self._registry_manager = registry_manager
 
-    def _check_status(self, batch_id: str, output_directory: str) -> str:
+    def _check_status(
+        self, batch_id: str, output_directory: str, agent_config: dict | None = None
+    ) -> str:
         """Check status of a batch job via client."""
         manager = self._registry_manager
-        client = self._client_resolver.get_for_batch_id(batch_id, manager, output_directory)
+        client = self._client_resolver.get_for_batch_id(
+            batch_id, manager, output_directory, agent_config=agent_config
+        )
         return client.check_status(batch_id)
 
     def _get_registry_manager(self, output_directory: str) -> BatchRegistryManager | None:
@@ -49,11 +53,14 @@ class BatchJobManager:
 
         return BatchRegistryManager(registry_path)
 
-    def are_all_jobs_completed(self, output_directory: str) -> bool:
+    def are_all_jobs_completed(
+        self, output_directory: str, agent_config: dict | None = None
+    ) -> bool:
         """Check if all batch jobs in the registry are completed.
 
         Args:
             output_directory: Directory containing the batch registry
+            agent_config: Optional agent config for API key resolution
 
         Returns:
             True if all jobs are completed, False otherwise
@@ -77,7 +84,7 @@ class BatchJobManager:
             return True
 
         def check_provider(batch_id: str) -> str:
-            return self._check_status(batch_id, output_directory)
+            return self._check_status(batch_id, output_directory, agent_config)
 
         return manager.are_all_jobs_completed(check_provider=check_provider)
 

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -244,8 +244,22 @@ class BatchResultStrategy:
                 "reconciler must be initialized before processing results"
             )
         generated_obj = batch_result.content
-        if not ctx.json_mode and isinstance(generated_obj, str):
-            generated_obj = {ctx.output_field: generated_obj}
+        if isinstance(generated_obj, str):
+            if ctx.json_mode:
+                # JSON mode but content is still a string — parsing failed.
+                # Wrap in _parse_error dict so batch reprompt can detect and
+                # retry, matching the online-path convention.
+                logger.warning(
+                    "Batch result for %s is unparsed string in json_mode; "
+                    "wrapping as _parse_error for reprompt",
+                    custom_id,
+                )
+                generated_obj = {
+                    "raw_response": generated_obj,
+                    "_parse_error": "Failed to parse JSON from LLM response",
+                }
+            else:
+                generated_obj = {ctx.output_field: generated_obj}
 
         generated_list = DataTransformer.ensure_list(generated_obj)
 

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -417,7 +417,9 @@ class BatchProcessingService:
             output_directory, file_name or "default"
         )
         agent_config = self._apply_workflow_session_id(agent_config, entry)
-        provider = self._client_resolver.get_for_batch_id(batch_id, manager, output_directory)
+        provider = self._client_resolver.get_for_batch_id(
+            batch_id, manager, output_directory, agent_config=agent_config
+        )
 
         batch_results = retrieve_and_reconcile(
             provider,

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -234,7 +234,7 @@ class BatchProcessingService:
             if entry.parent_file_name is not None:
                 continue
 
-            if not self._is_batch_ready_for_processing(batch_id, output_directory):
+            if not self._is_batch_ready_for_processing(batch_id, output_directory, agent_config):
                 continue
 
             try:
@@ -277,19 +277,27 @@ class BatchProcessingService:
             )
         return processed_files
 
-    def _is_batch_ready_for_processing(self, batch_id: str, output_directory: str) -> bool:
+    def _is_batch_ready_for_processing(
+        self,
+        batch_id: str,
+        output_directory: str,
+        agent_config: dict[str, Any] | None = None,
+    ) -> bool:
         """Check if batch is ready for processing (completed status).
 
         Args:
             batch_id: The batch job ID to check
             output_directory: Directory containing batch registry
+            agent_config: Optional agent config for API key resolution
 
         Returns:
             True if batch status is COMPLETED, False otherwise
         """
         try:
             manager = self._registry_manager_factory(output_directory)
-            provider = self._client_resolver.get_for_batch_id(batch_id, manager, output_directory)
+            provider = self._client_resolver.get_for_batch_id(
+                batch_id, manager, output_directory, agent_config=agent_config
+            )
             status = provider.check_status(batch_id)
             return status == BatchStatus.COMPLETED
         except Exception as e:

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -75,7 +75,9 @@ def process_recovery_batch(
         output_directory, parent_file_name
     )
     agent_config = service._apply_workflow_session_id(agent_config, entry)
-    provider = service._client_resolver.get_for_batch_id(batch_id, manager, output_directory)
+    provider = service._client_resolver.get_for_batch_id(
+        batch_id, manager, output_directory, agent_config=agent_config
+    )
 
     recovery_results = retrieve_and_reconcile(
         provider,

--- a/agent_actions/llm/providers/anthropic/batch_client.py
+++ b/agent_actions/llm/providers/anthropic/batch_client.py
@@ -134,13 +134,16 @@ class AnthropicBatchClient(BaseBatchClient):
             return "Invalid response format from Anthropic"
 
         result_type = self._get_attribute_or_key(result, "type")
-        if result_type == "failed":
-            error_info = self._get_attribute_or_key(result, "error", {})
-            return str(error_info) if error_info else "Batch processing failed"
         if result_type == "succeeded":
             return None
-        else:
-            return f"Unknown result type: {result_type}"
+        if result_type == "errored":
+            error_info = self._get_attribute_or_key(result, "error", {})
+            return str(error_info) if error_info else "Batch processing errored"
+        if result_type == "expired":
+            return "Batch result expired before processing"
+        if result_type == "canceled":
+            return "Batch result was canceled"
+        return f"Unknown result type: {result_type}"
 
     def _extract_content_from_response(self, raw_response: Any) -> Any:
         """Extract content from Anthropic response."""

--- a/agent_actions/llm/providers/anthropic/batch_client.py
+++ b/agent_actions/llm/providers/anthropic/batch_client.py
@@ -11,7 +11,7 @@ from agent_actions.llm.providers.anthropic import PROMPT_CACHING_BETA_HEADER
 from agent_actions.prompt.message_builder import MessageBuilder
 from agent_actions.utils.atomic_write import atomic_json_write
 
-from ..batch_base import BaseBatchClient, BatchResult, BatchTask
+from ..batch_base import BaseBatchClient, BatchTask
 
 logger = logging.getLogger(__name__)
 
@@ -336,70 +336,21 @@ class AnthropicBatchClient(BaseBatchClient):
         }
         return status_mapping.get(raw_status, raw_status)
 
-    def retrieve_results(
-        self, batch_id: str, output_directory: str | None = None
-    ) -> list[BatchResult]:
-        """
-        Retrieve and transform Anthropic batch results to our format.
-
-        NOTE: Anthropic overrides the base template method because it streams
-        result objects directly instead of returning JSONL bytes. This is a
-        provider-specific optimization that doesn't fit the base template.
-
-        Args:
-            batch_id: Anthropic batch job ID
-            output_directory: Optional directory for caching results
-
-        Returns:
-            List of BatchResult objects
-        """
-        try:
-            status = self.check_status(batch_id)
-            if status != "completed":
-                return []
-            results_stream = self.client.messages.batches.results(batch_id)
-            batch_results = []
-            raw_entries = []
-            for entry in results_stream:
-                batch_result = self.parse_provider_response(entry)
-                batch_results.append(batch_result)
-                if hasattr(entry, "model_dump"):
-                    raw_entries.append(entry.model_dump())
-                elif hasattr(entry, "__dict__"):
-                    raw_entries.append(entry.__dict__)
-                else:
-                    raw_entries.append(entry)  # type: ignore[arg-type]
-            if output_directory and raw_entries:
-                batch_dir = self._get_batch_directory(output_directory)
-                raw_results_file = batch_dir / f"{batch_id}_anthropic_raw_results.jsonl"
-                with open(raw_results_file, "w", encoding="utf-8") as f:
-                    for entry in raw_entries:  # type: ignore[assignment]
-                        f.write(json.dumps(entry) + "\n")
-            return batch_results
-        except self.anthropic.APIError as e:
-            from agent_actions.errors import AnthropicError
-
-            raise AnthropicError(
-                "Anthropic API error retrieving batch results",
-                context={"operation": "retrieve_results", "batch_id": batch_id},
-                cause=e,
-            ) from e
-        except Exception as e:
-            from agent_actions.errors import AnthropicError
-
-            raise AnthropicError(
-                "Failed to retrieve Anthropic batch results",
-                context={"operation": "retrieve_results", "batch_id": batch_id},
-                cause=e,
-            ) from e
-
     def _get_result_file_name(self, batch_id: str) -> str:
-        """Not used by Anthropic (streams results instead of file-based)."""
+        """Return the result file name for Anthropic batch results."""
         return f"{batch_id}_anthropic_raw_results.jsonl"
 
     def _fetch_raw_results(self, batch_id: str) -> bytes:
-        """Not used by Anthropic (overrides retrieve_results entirely)."""
-        raise NotImplementedError("Anthropic uses custom streaming-based retrieve_results()")
+        """Stream results from Anthropic API and return as JSONL bytes."""
+        lines = []
+        for entry in self.client.messages.batches.results(batch_id):
+            if hasattr(entry, "model_dump"):
+                lines.append(json.dumps(entry.model_dump()))
+            elif hasattr(entry, "__dict__"):
+                lines.append(json.dumps(entry.__dict__))
+            else:
+                lines.append(json.dumps(entry))
+        return ("\n".join(lines) + "\n").encode("utf-8")
 
     def _create_json_tool_from_schema(self, schema: dict[str, Any]) -> list[dict[str, Any]]:
         """

--- a/agent_actions/llm/providers/batch_base.py
+++ b/agent_actions/llm/providers/batch_base.py
@@ -331,24 +331,20 @@ class BaseBatchClient(ABC):
             target[key] = default
 
     def _parse_json_content(self, content_str: str) -> Any:
-        """
-        Parse JSON string, return as-is if parsing fails.
+        """Parse JSON string from an LLM response.
 
-        This helper eliminates duplicated JSON parsing logic across providers.
-
-        Args:
-            content_str: String to parse as JSON
-
-        Returns:
-            Parsed JSON object, or original string if parsing fails
+        Handles markdown code fences and common malformations (trailing
+        commas, unquoted keys) via the shared :func:`parse_llm_json`
+        utility.  Returns the original string when all strategies fail;
+        the caller decides how to handle it (e.g. wrapping in a
+        ``_parse_error`` dict when ``json_mode=True``).
         """
         if not isinstance(content_str, str):
             return content_str  # type: ignore[unreachable]
 
-        try:
-            return json.loads(content_str)
-        except json.JSONDecodeError:
-            return content_str
+        from agent_actions.utils.json_parsing import parse_llm_json
+
+        return parse_llm_json(content_str)
 
     def _get_attribute_or_key(self, obj: Any, key: str, default: Any = None) -> Any:
         """

--- a/agent_actions/llm/providers/mixins.py
+++ b/agent_actions/llm/providers/mixins.py
@@ -5,7 +5,6 @@ This module provides common functionality that multiple vendor handlers share,
 eliminating duplicate code across different provider implementations.
 """
 
-import json
 import logging
 from typing import Any
 
@@ -32,10 +31,11 @@ class JSONResponseMixin:
         model_name: str,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """
-        Parse JSON response with error dict pattern for repair support.
+        Parse JSON response with code-fence stripping and repair support.
 
-        On parse failure, returns `{"raw_response": ..., "_parse_error": ...}` dict
-        instead of raising, allowing RepromptEngine to attempt JSON repair.
+        Uses the shared :func:`parse_llm_json` utility (strips markdown
+        fences, tries ``json_repair``) before falling back to a
+        ``_parse_error`` dict that lets RepromptEngine retry.
 
         Args:
             response_content: Raw JSON string from API
@@ -54,8 +54,10 @@ class JSONResponseMixin:
             )
             return [{"raw_response": "", "_parse_error": "Empty response from API"}]
 
-        try:
-            response_data = json.loads(response_content)
+        from agent_actions.utils.json_parsing import parse_llm_json
+
+        result = parse_llm_json(response_content)
+        if not isinstance(result, str):
             logger.debug(
                 "%s JSON response parsed successfully",
                 vendor_name,
@@ -65,27 +67,31 @@ class JSONResponseMixin:
                     "response_length": len(response_content),
                 },
             )
-            return response_data  # type: ignore[no-any-return]
-        except json.JSONDecodeError as e:
-            logger.warning(
-                "%s returned invalid JSON, returning error dict for repair",
-                vendor_name,
-                extra={
-                    "operation": f"{vendor_name}_{operation}",
-                    "model": model_name,
-                    "response_text": response_content[:200],
-                    "error": str(e),
-                    "line": e.lineno if hasattr(e, "lineno") else None,
-                },
+            return result  # type: ignore[return-value]
+
+        # All parse strategies failed — return error dict for reprompt
+        logger.warning(
+            "%s returned unparseable JSON, returning error dict for repair",
+            vendor_name,
+            extra={
+                "operation": f"{vendor_name}_{operation}",
+                "model": model_name,
+                "response_text": response_content[:200],
+            },
+        )
+        fire_event(
+            LLMJSONParseErrorEvent(
+                provider=vendor_name.lower(),
+                model=model_name,
+                error="Failed to parse JSON after all strategies",
             )
-            fire_event(
-                LLMJSONParseErrorEvent(
-                    provider=vendor_name.lower(),
-                    model=model_name,
-                    error=str(e),
-                )
-            )
-            return [{"raw_response": response_content, "_parse_error": str(e)}]
+        )
+        return [
+            {
+                "raw_response": response_content,
+                "_parse_error": "Failed to parse JSON from LLM response",
+            }
+        ]
 
 
 class GenericErrorHandlerMixin:

--- a/agent_actions/llm/providers/ollama/client.py
+++ b/agent_actions/llm/providers/ollama/client.py
@@ -10,7 +10,6 @@ remove the ``if not cloud`` guard on the ``format`` kwarg and change cloud's
 ProviderMessageConfig from SchemaInjection.PROMPT to SchemaInjection.NONE.
 """
 
-import json
 import logging
 import os
 import uuid
@@ -18,7 +17,6 @@ from datetime import datetime
 from typing import Any, ClassVar
 
 import httpx
-from json_repair import repair_json
 from ollama import Client, ResponseError
 
 from agent_actions.config.defaults import OllamaCloudDefaults
@@ -167,40 +165,23 @@ def _call_ollama_json(
 
     content = response.message.content
     if isinstance(content, str):
-        try:
-            parsed = json.loads(content)
-            return [parsed] if isinstance(parsed, dict) else [{"response": parsed}]
-        except json.JSONDecodeError as e:
-            if not cloud:
-                logger.debug("%s/%s returned invalid JSON: %s", vendor_slug, model, e)
-                fire_event(LLMJSONParseErrorEvent(provider=vendor_slug, model=model, error=str(e)))
-                return [{"raw_response": content or "", "_parse_error": str(e)}]
-            # Cloud often wraps valid JSON in markdown fences or adds
-            # trailing commas. Use json_repair to recover the payload.
-            # Remove this branch when Ollama Cloud supports structured
-            # outputs (ollama/ollama#12362).
-            logger.debug("%s/%s: raw json.loads failed, attempting repair", vendor_slug, model)
-            repaired = repair_json(content, return_objects=True, skip_json_loads=True)
-            if isinstance(repaired, dict):
-                logger.info(
-                    "%s/%s: json_repair recovered valid dict from malformed response",
-                    vendor_slug,
-                    model,
-                )
-                return [repaired]
-            if isinstance(repaired, list):
-                logger.info(
-                    "%s/%s: json_repair recovered valid list from malformed response",
-                    vendor_slug,
-                    model,
-                )
-                return (
-                    repaired
-                    if all(isinstance(r, dict) for r in repaired)
-                    else [{"response": repaired}]
-                )
-            fire_event(LLMJSONParseErrorEvent(provider=vendor_slug, model=model, error=str(e)))
-            return [{"raw_response": content or "", "_parse_error": str(e)}]
+        from agent_actions.utils.json_parsing import parse_llm_json
+
+        result = parse_llm_json(content)
+        if isinstance(result, dict):
+            return [result]
+        if isinstance(result, list):
+            return result if all(isinstance(r, dict) for r in result) else [{"response": result}]
+        # All parse strategies failed
+        fire_event(
+            LLMJSONParseErrorEvent(provider=vendor_slug, model=model, error="Failed to parse JSON")
+        )
+        return [
+            {
+                "raw_response": content or "",
+                "_parse_error": "Failed to parse JSON from LLM response",
+            }
+        ]
     if isinstance(content, dict):
         return [content]
     return [{"response": content}]

--- a/agent_actions/llm/providers/openai/client.py
+++ b/agent_actions/llm/providers/openai/client.py
@@ -8,7 +8,6 @@ SDK errors are wrapped into unified agent-actions error types to enable
 consistent retry handling across all providers.
 """
 
-import json
 import logging
 import uuid
 from datetime import datetime
@@ -132,12 +131,12 @@ class OpenAIClient(BaseClient):
                 model_name,
             )
             return [{"raw_response": "", "_parse_error": "Empty response from API"}]
-        try:
-            response_data: dict[str, Any] | list[dict[str, Any]] = json.loads(response_content)
-        except json.JSONDecodeError as e:
+        from agent_actions.utils.json_parsing import parse_llm_json
+
+        response_data = parse_llm_json(response_content)
+        if isinstance(response_data, str):
             logger.debug(
-                "Failed to parse JSON from OpenAI response: %s (snippet: %.200s)",
-                e,
+                "Failed to parse JSON from OpenAI response (snippet: %.200s)",
                 response_content,
                 extra={"model": model_name, "operation": "call_json"},
             )
@@ -146,11 +145,16 @@ class OpenAIClient(BaseClient):
                     provider="openai",
                     model=model_name,
                     error_type="JSONDecodeError",
-                    error_message=f"Failed to parse JSON from response: {e}",
+                    error_message="Failed to parse JSON from response",
                     request_id=request_id,
                 )
             )
-            return [{"raw_response": response_content, "_parse_error": str(e)}]
+            return [
+                {
+                    "raw_response": response_content,
+                    "_parse_error": "Failed to parse JSON from LLM response",
+                }
+            ]
         response_list: list[dict[str, Any]] = (
             response_data if isinstance(response_data, list) else [response_data]
         )

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -50,6 +50,15 @@ class LineageEnricher(Enricher):
         for i, item in enumerate(result.data):
             node_id = f"{base_node_id}_{i}" if len(result.data) > 1 else base_node_id
 
+            # 1→N expansions: each child needs a unique target_id so that
+            # batch custom_ids are unique and context_map keys don't collide.
+            # The parent's target_id moves to parent_target_id for lineage.
+            if result.is_expansion:
+                old_target_id = item.get("target_id")
+                item["target_id"] = IDGenerator.generate_target_id()
+                if old_target_id:
+                    item["parent_target_id"] = old_target_id
+
             if (
                 result.source_mapping is not None
                 and context.source_data is not None

--- a/agent_actions/utils/json_parsing.py
+++ b/agent_actions/utils/json_parsing.py
@@ -1,0 +1,92 @@
+"""Shared LLM JSON response parsing.
+
+Every LLM provider — online and batch — must parse the model's text output
+into a Python dict/list.  Models frequently wrap valid JSON in markdown code
+fences or produce trailing-comma / unquoted-key variants.
+
+This module is the **single source of truth** for that conversion:
+
+    1. ``json.loads()``          — fast path for well-formed JSON
+    2. Strip markdown fences     — ````` ```json … ``` ````` → inner text, retry
+    3. ``json_repair``           — recover trailing commas, unquoted keys, etc.
+
+Callers should use :func:`parse_llm_json` and branch on the return type:
+
+* ``dict | list`` → parse succeeded
+* ``str``         → all attempts failed; string is the original content
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Matches ```json … ``` or ``` … ``` with optional language tag.
+# DOTALL so `.` matches newlines inside the fenced block.
+_CODE_FENCE_RE = re.compile(
+    r"^\s*```(?:\w+)?\s*\n(.*?)\n\s*```\s*$",
+    re.DOTALL,
+)
+
+
+def strip_code_fences(text: str) -> str:
+    """Remove a single markdown code fence wrapper if present.
+
+    Returns the inner content (stripped) when fences are found,
+    or the original *text* unchanged otherwise.
+    """
+    match = _CODE_FENCE_RE.match(text.strip())
+    return match.group(1).strip() if match else text
+
+
+def parse_llm_json(content: str) -> dict[str, Any] | list[Any] | str:
+    """Best-effort parse of an LLM text response into a Python object.
+
+    Returns
+    -------
+    dict | list
+        On success.
+    str
+        The original *content* when every strategy fails — the caller
+        decides how to handle (e.g. return a ``_parse_error`` dict).
+    """
+    if not isinstance(content, str) or not content.strip():
+        return content  # type: ignore[return-value]
+
+    # 1. Fast path — well-formed JSON
+    try:
+        return json.loads(content)  # type: ignore[no-any-return]
+    except json.JSONDecodeError:
+        pass
+
+    # 2. Strip markdown code fences and retry
+    stripped = strip_code_fences(content)
+    if stripped != content:
+        try:
+            return json.loads(stripped)  # type: ignore[no-any-return]
+        except json.JSONDecodeError:
+            pass
+
+    # 3. json_repair — handles trailing commas, unquoted keys, etc.
+    #    Guard: reject empty results ({}, []) — json_repair is aggressive and
+    #    "repairs" arbitrary prose into empty containers, which is worse than
+    #    signalling a parse failure.
+    try:
+        from json_repair import repair_json
+
+        repaired = repair_json(content, return_objects=True, skip_json_loads=True)
+        if isinstance(repaired, dict) and repaired:
+            logger.debug("json_repair recovered valid dict from malformed LLM response")
+            return repaired
+        if isinstance(repaired, list) and repaired:
+            logger.debug("json_repair recovered valid list from malformed LLM response")
+            return repaired
+    except Exception:
+        logger.debug("json_repair failed", exc_info=True)
+
+    # All strategies exhausted — return the original string.
+    return content

--- a/agent_actions/workflow/managers/batch.py
+++ b/agent_actions/workflow/managers/batch.py
@@ -78,7 +78,7 @@ class BatchLifecycleManager:
             return (output_directory, "completed")
 
         if registry_status in ["in_progress", "partial_failed"]:
-            if self.job_manager.are_all_jobs_completed(output_directory):
+            if self.job_manager.are_all_jobs_completed(output_directory, agent_config):
                 fire_event(BatchProcessingCompleteEvent(action_name=agent_name))
                 self._process_batch_results(output_directory, agent_config, agent_name)
                 # Re-check — processing may have submitted recovery batches

--- a/tests/integrations/providers/anthropic/test_anthropic_batch_client.py
+++ b/tests/integrations/providers/anthropic/test_anthropic_batch_client.py
@@ -165,6 +165,58 @@ class TestAnthropicBatchClient(BaseBatchClientTests):
         assert batch_id is not None
         assert "msgbatch" in batch_id
 
+    # -----------------------------------------------------------------
+    # Error extraction tests
+    # -----------------------------------------------------------------
+
+    def test_errored_result_extracts_error_info(self, provider, provider_error_response):
+        """Errored results return the actual error message, not 'Unknown result type'."""
+        error = provider._extract_error_from_response(provider_error_response)
+        assert error is not None
+        assert "invalid_request_error" in error
+        assert "Unknown result type" not in error
+
+    def test_succeeded_result_returns_none(self, provider, provider_success_response_json):
+        """Succeeded results return None (no error)."""
+        error = provider._extract_error_from_response(provider_success_response_json)
+        assert error is None
+
+    def test_expired_result_returns_clear_error(self, provider):
+        """Expired results produce a clear error, not 'Unknown result type'."""
+        response = {"custom_id": "test", "result": {"type": "expired"}}
+        error = provider._extract_error_from_response(response)
+        assert error is not None
+        assert "expired" in error.lower()
+        assert "Unknown result type" not in error
+
+    def test_canceled_result_returns_clear_error(self, provider):
+        """Canceled results produce a clear error."""
+        response = {"custom_id": "test", "result": {"type": "canceled"}}
+        error = provider._extract_error_from_response(response)
+        assert error is not None
+        assert "canceled" in error.lower()
+        assert "Unknown result type" not in error
+
+    def test_missing_result_returns_format_error(self, provider):
+        """Missing result field returns format error."""
+        error = provider._extract_error_from_response({"custom_id": "test"})
+        assert error is not None
+        assert "Invalid response format" in error
+
+    def test_unknown_result_type_includes_type_name(self, provider):
+        """Unknown result types include the type in the error message."""
+        response = {"custom_id": "test", "result": {"type": "new_type"}}
+        error = provider._extract_error_from_response(response)
+        assert error is not None
+        assert "new_type" in error
+
+    def test_errored_result_without_error_info_returns_fallback(self, provider):
+        """Errored result with no error details returns fallback message."""
+        response = {"custom_id": "test", "result": {"type": "errored"}}
+        error = provider._extract_error_from_response(response)
+        assert error is not None
+        assert "errored" in error.lower()
+
     def test_retrieve_invalid_batch_id_raises_error(self, tmp_path):
         """Override to test error handling with proper mock."""
         from agent_actions.errors import VendorAPIError

--- a/tests/integrations/providers/anthropic/test_anthropic_batch_client.py
+++ b/tests/integrations/providers/anthropic/test_anthropic_batch_client.py
@@ -228,9 +228,9 @@ class TestAnthropicBatchClient(BaseBatchClientTests):
         with patch.dict("sys.modules", {"anthropic": mock_anthropic_module}):
             provider = AnthropicBatchClient(api_key="test-key")
             provider.client = mock_client
-            mock_client.messages.batches.retrieve.side_effect = VendorAPIError(
+            mock_client.messages.batches.results.side_effect = VendorAPIError(
                 vendor="anthropic",
-                endpoint="messages.batches.retrieve",
+                endpoint="messages.batches.results",
                 context={"message": "Batch not found"},
             )
             with pytest.raises(VendorAPIError):

--- a/tests/unit/llm/batch/test_batch_parse_error_wrapping.py
+++ b/tests/unit/llm/batch/test_batch_parse_error_wrapping.py
@@ -1,0 +1,108 @@
+"""Tests for _parse_error wrapping when batch result content is unparsed string.
+
+When json_mode=True and the LLM response fails all parse strategies,
+batch_result_strategy must wrap the string in a _parse_error dict so
+the batch reprompt loop (EvaluationLoop) can detect and retry.
+"""
+
+from typing import Any
+
+import pytest
+
+from agent_actions.llm.batch.processing.batch_result_strategy import (
+    BatchProcessingContext,
+    BatchResultStrategy,
+)
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+from agent_actions.llm.providers.batch_base import BatchResult
+
+
+def _make_ctx(
+    agent_config: dict[str, Any],
+    custom_id: str,
+    original_row: dict[str, Any],
+    json_mode: bool = True,
+) -> BatchProcessingContext:
+    ctx = BatchProcessingContext(
+        batch_results=[],
+        context_map={custom_id: original_row},
+        output_directory="/tmp/output",
+        agent_config=agent_config,
+        json_mode=json_mode,
+    )
+    ctx.reconciler = BatchResultReconciler(context_map={custom_id: original_row})
+    return ctx
+
+
+@pytest.fixture
+def processor():
+    return BatchResultStrategy()
+
+
+class TestJsonModeParseErrorWrapping:
+    """String content in json_mode must produce _parse_error for reprompt."""
+
+    def test_string_content_in_json_mode_produces_parse_error(self, processor):
+        """Unparsed string in json_mode wraps as _parse_error dict."""
+        custom_id = "rec_001"
+        original_row = {"source_guid": "src_001", "content": {}}
+        agent_config = {"action_name": "my_action"}
+        ctx = _make_ctx(agent_config, custom_id, original_row, json_mode=True)
+
+        # Simulate a batch result where content stayed as raw string
+        # (all parse strategies in _parse_json_content failed)
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content="```json\nthis is not valid json\n```",
+            success=True,
+        )
+
+        result = processor._process_successful_result(ctx, batch_result, custom_id)
+
+        assert len(result.data) == 1
+        content = result.data[0]["content"]
+        action_ns = content["my_action"]
+        assert "_parse_error" in action_ns
+        assert "raw_response" in action_ns
+
+    def test_string_content_in_non_json_mode_uses_output_field(self, processor):
+        """Plain text in non-json mode wraps in output_field, not _parse_error."""
+        custom_id = "rec_001"
+        original_row = {"source_guid": "src_001", "content": {}}
+        agent_config = {"action_name": "my_action"}
+        ctx = _make_ctx(agent_config, custom_id, original_row, json_mode=False)
+
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content="Hello world",
+            success=True,
+        )
+
+        result = processor._process_successful_result(ctx, batch_result, custom_id)
+
+        assert len(result.data) == 1
+        content = result.data[0]["content"]
+        action_ns = content["my_action"]
+        assert "_parse_error" not in action_ns
+        assert action_ns.get("raw_response") == "Hello world"
+
+    def test_dict_content_in_json_mode_not_wrapped(self, processor):
+        """Successfully parsed dict content is NOT wrapped as _parse_error."""
+        custom_id = "rec_001"
+        original_row = {"source_guid": "src_001", "content": {}}
+        agent_config = {"action_name": "my_action"}
+        ctx = _make_ctx(agent_config, custom_id, original_row, json_mode=True)
+
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content={"question": "What?", "answer": "Yes"},
+            success=True,
+        )
+
+        result = processor._process_successful_result(ctx, batch_result, custom_id)
+
+        assert len(result.data) == 1
+        content = result.data[0]["content"]
+        action_ns = content["my_action"]
+        assert action_ns == {"question": "What?", "answer": "Yes"}
+        assert "_parse_error" not in action_ns

--- a/tests/unit/llm_invocation/providers/test_non_json_standardization.py
+++ b/tests/unit/llm_invocation/providers/test_non_json_standardization.py
@@ -870,7 +870,7 @@ class TestOpenAICallJsonParseErrors:
         result = OpenAIClient.call_json("key", config, "prompt", "data", schema)
 
         assert len(result) == 1
-        assert "Expecting value" in result[0]["_parse_error"]
+        assert "_parse_error" in result[0]
         assert result[0]["raw_response"] == "not valid json {{{"
 
 

--- a/tests/unit/utils/test_json_parsing.py
+++ b/tests/unit/utils/test_json_parsing.py
@@ -1,0 +1,81 @@
+"""Tests for agent_actions.utils.json_parsing — shared LLM JSON parsing."""
+
+import pytest
+
+from agent_actions.utils.json_parsing import parse_llm_json, strip_code_fences
+
+
+class TestStripCodeFences:
+    """strip_code_fences removes markdown code fences when present."""
+
+    def test_json_fence(self):
+        text = '```json\n{"a": 1}\n```'
+        assert strip_code_fences(text) == '{"a": 1}'
+
+    def test_plain_fence(self):
+        text = '```\n{"a": 1}\n```'
+        assert strip_code_fences(text) == '{"a": 1}'
+
+    def test_no_fence(self):
+        text = '{"a": 1}'
+        assert strip_code_fences(text) == '{"a": 1}'
+
+    def test_surrounding_whitespace(self):
+        text = '  \n```json\n{"a": 1}\n```\n  '
+        assert strip_code_fences(text) == '{"a": 1}'
+
+    def test_multiline_content(self):
+        text = '```json\n{\n  "a": 1,\n  "b": 2\n}\n```'
+        result = strip_code_fences(text)
+        assert '"a": 1' in result
+        assert '"b": 2' in result
+
+
+class TestParseLlmJson:
+    """parse_llm_json tries json.loads, fence strip, then json_repair."""
+
+    def test_plain_json_dict(self):
+        result = parse_llm_json('{"a": 1}')
+        assert result == {"a": 1}
+
+    def test_plain_json_list(self):
+        result = parse_llm_json('[{"a": 1}]')
+        assert result == [{"a": 1}]
+
+    def test_code_fenced_json(self):
+        result = parse_llm_json('```json\n{"question": "What?"}\n```')
+        assert isinstance(result, dict)
+        assert result["question"] == "What?"
+
+    def test_trailing_comma_repair(self):
+        result = parse_llm_json('{"a": 1, "b": 2,}')
+        assert isinstance(result, dict)
+        assert result["a"] == 1
+        assert result["b"] == 2
+
+    def test_garbage_returns_string(self):
+        content = "not valid json {{{"
+        result = parse_llm_json(content)
+        assert isinstance(result, str)
+        assert result == content
+
+    def test_empty_string_returns_string(self):
+        result = parse_llm_json("")
+        assert isinstance(result, str)
+
+    def test_whitespace_only_returns_string(self):
+        result = parse_llm_json("   \n  ")
+        assert isinstance(result, str)
+
+    @pytest.mark.parametrize(
+        "content,expected_key",
+        [
+            ('```json\n{"options": ["A", "B"]}\n```', "options"),
+            ('```\n{"score": 5}\n```', "score"),
+        ],
+        ids=["json-tag", "no-tag"],
+    )
+    def test_various_fence_styles(self, content, expected_key):
+        result = parse_llm_json(content)
+        assert isinstance(result, dict)
+        assert expected_key in result


### PR DESCRIPTION
## Summary
- Anthropic batch API returns `result.type = "errored"` for failed individual results, but `_extract_error_from_response` checked for `"failed"` — a value Anthropic never sends
- Errored results fell through to `"Unknown result type: errored"`, losing actual error info and triggering an infinite recovery loop (recovery submitted → skipped → parent reprocessed → repeat)
- Fix: change `"failed"` to `"errored"`, add handling for `"expired"` and `"canceled"` result types

## Verification
- 21 Anthropic batch tests pass (7 new for error extraction)
- 6516 full suite pass, 0 regressions
- 12 pre-existing vendor parity failures unchanged
- ruff check + ruff format clean