### PR TITLE
fix: record fate on prompt template failure (#410)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260511-410000.yaml
+++ b/.changes/unreleased/Bug Fix-20260511-410000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Record fate on prompt template failure: failed records are now tracked with per-record dispositions and cascade correctly to downstream actions instead of being silently dropped"
+time: 2026-05-11T04:10:00.000000Z

--- a/agent_actions/errors/__init__.py
+++ b/agent_actions/errors/__init__.py
@@ -18,6 +18,7 @@ from agent_actions.errors.configuration import (
     DuplicateFunctionError,
     FunctionNotFoundError,
     ProjectNotFoundError,
+    RecordContextError,
     UDFLoadError,
 )
 
@@ -93,6 +94,7 @@ __all__ = [
     "UDFLoadError",
     "AgentNotFoundError",
     "ProjectNotFoundError",
+    "RecordContextError",
     # Validation
     "ValidationError",
     "PromptValidationError",

--- a/agent_actions/errors/configuration.py
+++ b/agent_actions/errors/configuration.py
@@ -115,3 +115,9 @@ class ProjectNotFoundError(ConfigurationError):
     """Raised when a command requires being in a project but agent_actions.yml is not found."""
 
     pass
+
+
+class RecordContextError(ConfigurationError):
+    """Raised when a record's context data is incomplete (per-record recoverable)."""
+
+    pass

--- a/agent_actions/llm/batch/core/batch_constants.py
+++ b/agent_actions/llm/batch/core/batch_constants.py
@@ -43,6 +43,7 @@ class FilterStatus(str, Enum):
     INCLUDED = "included"
     SKIPPED = "skipped"
     FILTERED = "filtered"
+    FAILED = "failed"
 
     def __str__(self) -> str:
         """Return the string value for str() conversion."""

--- a/agent_actions/llm/batch/processing/batch_passthrough_builder.py
+++ b/agent_actions/llm/batch/processing/batch_passthrough_builder.py
@@ -3,8 +3,9 @@
 from pathlib import Path
 from typing import Any
 
-from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys
+from agent_actions.llm.batch.core.batch_constants import ContextMetaKeys, FilterStatus
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.record.reasons import PREP_FAILED
 from agent_actions.utils.passthrough_builder import PassthroughItemBuilder
 
 
@@ -36,8 +37,10 @@ class BatchPassthroughBuilder:
     def from_context(self, context_map: dict[str, Any], reason: str) -> dict[str, Any]:
         processed_data = []
         for custom_id, original_row in context_map.items():
-            if BatchContextMetadata.is_skipped(original_row):
-                item = self._build_item(original_row, reason, custom_id)
+            status = BatchContextMetadata.get_filter_status(original_row)
+            if status in (FilterStatus.SKIPPED, FilterStatus.FAILED):
+                entry_reason = PREP_FAILED if status == FilterStatus.FAILED else reason
+                item = self._build_item(original_row, entry_reason, custom_id)
                 item.pop(ContextMetaKeys.FILTER_STATUS, None)
                 processed_data.append(item)
 

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -13,7 +13,11 @@ from agent_actions.llm.batch.core.batch_models import (
     PreparedBatchTasks,
 )
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
+from agent_actions.processing.result_collector import _safe_set_disposition
 from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
+from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.state import RecordState
+from agent_actions.storage.backend import DISPOSITION_FAILED
 from agent_actions.utils.constants import JSON_MODE_KEY
 from agent_actions.utils.id_generation import IDGenerator
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -119,6 +123,10 @@ class BatchTaskPreparator:
             except Exception as e:
                 logger.exception("Failed to prepare task for row: %s", e)
                 stats.error_items += 1
+                self._mark_prep_failed(
+                    row, context_map_builder, prep_context.agent_name, e,
+                    storage_backend=self.storage_backend,
+                )
 
         # Finalize tasks with provider
         provider_config = agent_config.copy()
@@ -200,6 +208,40 @@ class BatchTaskPreparator:
             "content": prepared.llm_context,
             "prompt": prepared.formatted_prompt,
         }
+
+    @staticmethod
+    def _mark_prep_failed(
+        row: dict[str, Any],
+        context_map_builder: dict[str, Any],
+        agent_name: str,
+        error: Exception,
+        *,
+        storage_backend: Any | None = None,
+    ) -> None:
+        """Stamp the context_map entry as FAILED with _state transition and disposition."""
+        custom_id = row.get("target_id")
+        if not custom_id or custom_id not in context_map_builder:
+            return
+        entry = context_map_builder[custom_id]
+        BatchContextMetadata.set_filter_status(entry, FilterStatus.FAILED)
+        error_str = str(error)
+        try:
+            RecordEnvelope.transition(entry, RecordState.FAILED, agent_name, error_str[:200])
+        except Exception:
+            logger.warning(
+                "Failed to transition record %s to FAILED state",
+                custom_id,
+                exc_info=True,
+            )
+            entry["_state"] = RecordState.FAILED.value
+
+        if storage_backend:
+            source_guid = row.get("source_guid")
+            if source_guid:
+                _safe_set_disposition(
+                    storage_backend, agent_name, source_guid,
+                    DISPOSITION_FAILED, reason=error_str[:500],
+                )
 
     def _validate_config(self, agent_config: dict[str, Any], provider) -> None:
         """Validate agent configuration."""

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -124,7 +124,10 @@ class BatchTaskPreparator:
                 logger.exception("Failed to prepare task for row: %s", e)
                 stats.error_items += 1
                 self._mark_prep_failed(
-                    row, context_map_builder, prep_context.agent_name, e,
+                    row,
+                    context_map_builder,
+                    prep_context.agent_name,
+                    e,
                     storage_backend=self.storage_backend,
                 )
 
@@ -239,8 +242,11 @@ class BatchTaskPreparator:
             source_guid = row.get("source_guid")
             if source_guid:
                 _safe_set_disposition(
-                    storage_backend, agent_name, source_guid,
-                    DISPOSITION_FAILED, reason=error_str[:500],
+                    storage_backend,
+                    agent_name,
+                    source_guid,
+                    DISPOSITION_FAILED,
+                    reason=error_str[:500],
                 )
 
     def _validate_config(self, agent_config: dict[str, Any], provider) -> None:

--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -94,12 +94,22 @@ class BatchSubmissionService:
             source_data=source_data,
             workflow_metadata=workflow_metadata,
         )
-        logger.debug(
-            "Task preparation complete: %d tasks, %d filtered, %d skipped",
-            prepared.task_count,
-            prepared.stats.total_filtered,
-            prepared.stats.total_skipped,
-        )
+        if prepared.stats.error_items:
+            logger.warning(
+                "Task preparation complete: %d tasks, %d filtered, %d skipped, "
+                "%d failed (prep errors)",
+                prepared.task_count,
+                prepared.stats.total_filtered,
+                prepared.stats.total_skipped,
+                prepared.stats.error_items,
+            )
+        else:
+            logger.debug(
+                "Task preparation complete: %d tasks, %d filtered, %d skipped",
+                prepared.task_count,
+                prepared.stats.total_filtered,
+                prepared.stats.total_skipped,
+            )
         return prepared.tasks, prepared.context_map
 
     def check_status(self, batch_id: str, output_directory: str | None = None) -> BatchStatus:

--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from agent_actions.errors import ConfigurationError, ConfigValidationError, ExternalServiceError
-from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_constants import BatchStatus, FilterStatus
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.core.batch_models import BatchJobEntry, SubmissionResult
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
@@ -29,6 +29,7 @@ from agent_actions.logging.events.batch_events import (
     BatchSubmissionFailedEvent,
 )
 from agent_actions.output.response.config_schema import WhereClauseBehavior
+from agent_actions.record.reasons import PREP_FAILED
 
 logger = logging.getLogger(__name__)
 
@@ -225,6 +226,16 @@ class BatchSubmissionService:
         Returns:
             SubmissionResult with passthrough dict
         """
+        has_failed_prep = any(
+            BatchContextMetadata.get_filter_status(row) == FilterStatus.FAILED
+            for row in context_map.values()
+        )
+        if has_failed_prep:
+            passthrough = BatchPassthroughBuilder(output_directory).from_context(
+                context_map, reason=PREP_FAILED
+            )
+            return SubmissionResult(passthrough=passthrough)
+
         has_guard_skipped = any(
             BatchContextMetadata.is_skipped(row) for row in context_map.values()
         )

--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -29,7 +29,6 @@ from agent_actions.logging.events.batch_events import (
     BatchSubmissionFailedEvent,
 )
 from agent_actions.output.response.config_schema import WhereClauseBehavior
-from agent_actions.record.reasons import PREP_FAILED
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +241,7 @@ class BatchSubmissionService:
         )
         if has_failed_prep:
             passthrough = BatchPassthroughBuilder(output_directory).from_context(
-                context_map, reason=PREP_FAILED
+                context_map, reason="guard_skip"
             )
             return SubmissionResult(passthrough=passthrough)
 

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 from agent_actions.config.types import RunMode
-from agent_actions.errors import ConfigurationError, SchemaValidationError
+from agent_actions.errors import ConfigurationError, RecordContextError, SchemaValidationError
 from agent_actions.errors.operations import TemplateVariableError
 from agent_actions.errors.processing import EmptyOutputError
 from agent_actions.logging.core.manager import fire_event
@@ -33,19 +33,24 @@ from agent_actions.processing.record_helpers import (
     build_tombstone,
     extract_existing_content,
 )
+from agent_actions.processing.result_collector import _safe_set_disposition
 from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
     ProcessingStatus,
 )
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.record.reasons import (
     GUARD_FILTER,
     GUARD_SKIP,
     LLM_LAYER_GUARD_FILTER,
     LLM_LAYER_GUARD_SKIP,
+    PREP_FAILED,
     UPSTREAM_UNPROCESSED,
 )
+from agent_actions.record.state import RecordState
+from agent_actions.storage.backend import DISPOSITION_FAILED
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +72,40 @@ def _create_item_context(
         base_context,
         record_index=index,
         current_item=item if isinstance(item, dict) else None,
+    )
+
+
+def _build_prep_failed_result(
+    item: Any,
+    context: ProcessingContext,
+    error_msg: str,
+) -> ProcessingResult:
+    """Build a tombstone ProcessingResult for a record that failed prompt preparation."""
+    input_record = item if isinstance(item, dict) else None
+    source_guid = input_record.get("source_guid") if input_record else None
+
+    tombstone = build_tombstone(
+        action_name=context.agent_name,
+        input_record=input_record,
+        reason=PREP_FAILED,
+        source_guid=source_guid,
+    )
+    RecordEnvelope.transition(tombstone, RecordState.FAILED, context.agent_name, error_msg[:200])
+
+    if context.storage_backend and source_guid:
+        _safe_set_disposition(
+            context.storage_backend,
+            context.agent_name,
+            source_guid,
+            DISPOSITION_FAILED,
+            reason=error_msg[:500],
+        )
+
+    return ProcessingResult.unprocessed(
+        data=[tombstone],
+        reason=PREP_FAILED,
+        source_guid=source_guid,
+        input_record=input_record,
     )
 
 
@@ -97,10 +136,10 @@ class OnlineLLMStrategy:
     ) -> list[ProcessingResult]:
         """Process records through the online LLM pipeline.
 
-        Iterates records, calling process_record() for each. Handles
-        per-item exceptions: re-raises critical errors (ConfigurationError,
-        EmptyOutputError, TemplateVariableError, SchemaValidationError),
-        wraps others as ProcessingResult.failed().
+        Iterates records, calling process_record() for each. Record-specific
+        errors (RecordContextError, TemplateVariableError with missing vars)
+        produce tombstones and continue. Action-fatal errors (ConfigurationError,
+        TemplateSyntaxError, EmptyOutputError, SchemaValidationError) re-raise.
         """
         start_time = datetime.now(UTC)
 
@@ -137,10 +176,17 @@ class OnlineLLMStrategy:
                         )
                     )
 
-            except ConfigurationError:
-                raise
-            except EmptyOutputError:
-                raise
+            except RecordContextError as e:
+                # Per-record recoverable — build tombstone, continue processing
+                logger.warning(
+                    "[%s] Record %d prep failed (context incomplete): %s",
+                    context.agent_name,
+                    idx,
+                    e,
+                )
+                result = _build_prep_failed_result(item, context, str(e))
+                results.append(result)
+                failures += 1
             except TemplateVariableError as e:
                 fire_event(
                     TemplateRenderingFailedEvent(
@@ -149,6 +195,22 @@ class OnlineLLMStrategy:
                         error_message=str(e),
                     )
                 )
+                if not e.missing_variables:
+                    # TemplateSyntaxError wrapped — broken template, action-fatal
+                    raise
+                # Missing variables — per-record recoverable
+                logger.warning(
+                    "[%s] Record %d prep failed (missing template vars): %s",
+                    context.agent_name,
+                    idx,
+                    e,
+                )
+                result = _build_prep_failed_result(item, context, str(e))
+                results.append(result)
+                failures += 1
+            except ConfigurationError:
+                raise
+            except EmptyOutputError:
                 raise
             except SchemaValidationError:
                 raise

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -6,7 +6,7 @@ from collections import Counter
 from copy import deepcopy
 from typing import Any
 
-from agent_actions.errors import ConfigurationError
+from agent_actions.errors import ConfigurationError, RecordContextError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import (
     ContextFieldSkippedEvent,
@@ -51,7 +51,7 @@ def _resolve_missing_field(
         return None
 
     field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref
-    raise ConfigurationError(
+    raise RecordContextError(
         f"context_scope.{directive} field '{field_ref}' not found at runtime",
         context={
             "action": action_name,

--- a/agent_actions/prompt/context/scope_namespace.py
+++ b/agent_actions/prompt/context/scope_namespace.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from agent_actions.errors import ConfigurationError
+from agent_actions.errors import ConfigurationError, RecordContextError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
 from agent_actions.prompt.context.scope_parsing import parse_field_reference
@@ -136,7 +136,7 @@ def _filter_and_store_fields(
                     continue
                 missing_fields.add(field)
             if missing_fields:
-                raise ConfigurationError(
+                raise RecordContextError(
                     f"[{source_type}] '{name}': declared fields {sorted(missing_fields)} "
                     f"not found. Available: {list(data.keys())}",
                     context={

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -19,6 +19,9 @@ LLM_LAYER_GUARD_FILTER = "llm_layer_guard_filter"
 # -- Cascade / upstream ------------------------------------------------------
 UPSTREAM_UNPROCESSED = "upstream_unprocessed"
 
+# -- Prep failures -----------------------------------------------------------
+PREP_FAILED = "prep_failed"
+
 # -- Batch -------------------------------------------------------------------
 BATCH_NOT_RETURNED = "batch_not_returned"
 

--- a/tests/unit/llm/batch/test_batch_prep_failure.py
+++ b/tests/unit/llm/batch/test_batch_prep_failure.py
@@ -1,0 +1,189 @@
+"""Tests for batch preparator handling of per-record prep failures.
+
+When prompt preparation fails for a record (TemplateVariableError,
+RecordContextError), the record must be stamped FAILED in the context_map
+and written as a disposition, not silently dropped.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.llm.batch.processing.batch_passthrough_builder import (
+    BatchPassthroughBuilder,
+)
+from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
+from agent_actions.llm.batch.services.submission import BatchSubmissionService
+from agent_actions.record.state import RecordState
+
+
+def _make_preparator(**kwargs: Any) -> BatchTaskPreparator:
+    return BatchTaskPreparator(
+        action_indices=kwargs.get("action_indices", {}),
+        dependency_configs=kwargs.get("dependency_configs", {}),
+        storage_backend=kwargs.get("storage_backend"),
+        version_context=kwargs.get("version_context"),
+    )
+
+
+class TestMarkPrepFailed:
+    """_mark_prep_failed stamps context_map entry with FilterStatus.FAILED and _state."""
+
+    def test_stamps_filter_status_and_state(self):
+        row = {"target_id": "tid_001", "source_guid": "sg_001"}
+        context_map = {"tid_001": row.copy()}
+        context_map["tid_001"]["_batch_filter_status"] = "included"
+
+        BatchTaskPreparator._mark_prep_failed(
+            row, context_map, "test_action", ValueError("missing field")
+        )
+
+        entry = context_map["tid_001"]
+        assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.FAILED
+        assert entry["_state"] == RecordState.FAILED.value
+        assert len(entry["_state_history"]) == 1
+        assert entry["_state_history"][0]["reason"].startswith("missing field")
+
+    def test_no_target_id_is_noop(self):
+        """If row has no target_id, _mark_prep_failed is a no-op."""
+        row = {"source_guid": "sg_001"}
+        context_map = {}
+
+        # Should not raise
+        BatchTaskPreparator._mark_prep_failed(
+            row, context_map, "test_action", ValueError("boom")
+        )
+
+    def test_target_id_not_in_context_map_is_noop(self):
+        """If target_id exists but isn't in context_map, _mark_prep_failed is a no-op."""
+        row = {"target_id": "tid_orphan"}
+        context_map = {}
+
+        BatchTaskPreparator._mark_prep_failed(
+            row, context_map, "test_action", ValueError("boom")
+        )
+
+
+class TestBatchPreparatorCatchBlock:
+    """Integration test: prep failure flows through the full prepare_tasks loop."""
+
+    @patch("agent_actions.llm.batch.processing.preparator.get_task_preparer")
+    @patch("agent_actions.prompt.formatter.PromptFormatter.get_raw_prompt", return_value="prompt")
+    @patch.object(BatchTaskPreparator, "_run_preflight_validation")
+    def test_failed_record_in_context_map(
+        self, _mock_preflight, _mock_prompt, mock_get_preparer
+    ):
+        """Record that fails prep is stamped FAILED in context_map, not dropped."""
+        mock_preparer = MagicMock()
+        mock_preparer.prepare.side_effect = ValueError("Template rendering failed")
+        mock_get_preparer.return_value = mock_preparer
+
+        mock_provider = MagicMock()
+        mock_provider.prepare_tasks.return_value = []
+
+        preparator = _make_preparator()
+        result = preparator.prepare_tasks(
+            agent_config={
+                "agent_type": "test",
+                "action_name": "test_action",
+                "model_vendor": "openai",
+                "model_name": "gpt-4",
+                "json_mode": False,
+            },
+            data=[{"target_id": "tid_001", "source_guid": "sg_001", "content": {}}],
+            provider=mock_provider,
+            output_directory="/tmp/test",
+        )
+
+        assert "tid_001" in result.context_map
+        entry = result.context_map["tid_001"]
+        assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.FAILED
+        assert entry["_state"] == RecordState.FAILED.value
+        assert result.stats.error_items == 1
+
+    @patch("agent_actions.llm.batch.processing.preparator.get_task_preparer")
+    @patch("agent_actions.prompt.formatter.PromptFormatter.get_raw_prompt", return_value="prompt")
+    @patch.object(BatchTaskPreparator, "_run_preflight_validation")
+    def test_disposition_written_on_failure(
+        self, _mock_preflight, _mock_prompt, mock_get_preparer
+    ):
+        """When storage_backend is available, DISPOSITION_FAILED is written."""
+        mock_preparer = MagicMock()
+        mock_preparer.prepare.side_effect = ValueError("boom")
+        mock_get_preparer.return_value = mock_preparer
+
+        mock_backend = MagicMock()
+        mock_provider = MagicMock()
+        mock_provider.prepare_tasks.return_value = []
+
+        preparator = _make_preparator(storage_backend=mock_backend)
+        preparator.prepare_tasks(
+            agent_config={
+                "agent_type": "test",
+                "action_name": "test_action",
+                "model_vendor": "openai",
+                "model_name": "gpt-4",
+                "json_mode": False,
+            },
+            data=[{"target_id": "tid_001", "source_guid": "sg_001", "content": {}}],
+            provider=mock_provider,
+            output_directory="/tmp/test",
+        )
+
+        mock_backend.set_disposition.assert_called_once()
+        call_kwargs = mock_backend.set_disposition.call_args
+        assert call_kwargs[0][2] == "failed"  # disposition arg
+
+
+class TestPassthroughBuilderIncludesFailed:
+    """BatchPassthroughBuilder.from_context includes FAILED entries."""
+
+    def test_failed_entries_included_in_passthrough(self):
+        context_map = {
+            "tid_001": {
+                "source_guid": "sg_001",
+                "content": {},
+                "_batch_filter_status": "failed",
+            },
+            "tid_002": {
+                "source_guid": "sg_002",
+                "content": {},
+                "_batch_filter_status": "included",
+            },
+        }
+
+        builder = BatchPassthroughBuilder(output_directory="/tmp/test/my_action")
+        result = builder.from_context(context_map, reason="prep_failed")
+
+        assert len(result["data"]) == 1
+        assert result["data"][0]["source_guid"] == "sg_001"
+
+
+class TestHandleEmptyTasksPrepFailed:
+    """_handle_empty_tasks returns passthrough when all records failed prep."""
+
+    def test_all_records_failed_returns_passthrough(self):
+        service = BatchSubmissionService(
+            task_preparator=MagicMock(),
+            client_resolver=MagicMock(),
+            context_manager=MagicMock(),
+            registry_manager_factory=MagicMock(),
+        )
+
+        context_map = {
+            "tid_001": {
+                "source_guid": "sg_001",
+                "_batch_filter_status": "failed",
+            },
+        }
+
+        result = service._handle_empty_tasks(
+            agent_config={},
+            context_map=context_map,
+            data=[{"id": 1}],
+            output_directory="/tmp/out",
+        )
+
+        assert result.passthrough is not None
+        assert result.passthrough["type"] == "tombstone"

--- a/tests/unit/llm/batch/test_batch_prep_failure.py
+++ b/tests/unit/llm/batch/test_batch_prep_failure.py
@@ -51,18 +51,14 @@ class TestMarkPrepFailed:
         context_map = {}
 
         # Should not raise
-        BatchTaskPreparator._mark_prep_failed(
-            row, context_map, "test_action", ValueError("boom")
-        )
+        BatchTaskPreparator._mark_prep_failed(row, context_map, "test_action", ValueError("boom"))
 
     def test_target_id_not_in_context_map_is_noop(self):
         """If target_id exists but isn't in context_map, _mark_prep_failed is a no-op."""
         row = {"target_id": "tid_orphan"}
         context_map = {}
 
-        BatchTaskPreparator._mark_prep_failed(
-            row, context_map, "test_action", ValueError("boom")
-        )
+        BatchTaskPreparator._mark_prep_failed(row, context_map, "test_action", ValueError("boom"))
 
 
 class TestBatchPreparatorCatchBlock:
@@ -71,9 +67,7 @@ class TestBatchPreparatorCatchBlock:
     @patch("agent_actions.llm.batch.processing.preparator.get_task_preparer")
     @patch("agent_actions.prompt.formatter.PromptFormatter.get_raw_prompt", return_value="prompt")
     @patch.object(BatchTaskPreparator, "_run_preflight_validation")
-    def test_failed_record_in_context_map(
-        self, _mock_preflight, _mock_prompt, mock_get_preparer
-    ):
+    def test_failed_record_in_context_map(self, _mock_preflight, _mock_prompt, mock_get_preparer):
         """Record that fails prep is stamped FAILED in context_map, not dropped."""
         mock_preparer = MagicMock()
         mock_preparer.prepare.side_effect = ValueError("Template rendering failed")
@@ -105,9 +99,7 @@ class TestBatchPreparatorCatchBlock:
     @patch("agent_actions.llm.batch.processing.preparator.get_task_preparer")
     @patch("agent_actions.prompt.formatter.PromptFormatter.get_raw_prompt", return_value="prompt")
     @patch.object(BatchTaskPreparator, "_run_preflight_validation")
-    def test_disposition_written_on_failure(
-        self, _mock_preflight, _mock_prompt, mock_get_preparer
-    ):
+    def test_disposition_written_on_failure(self, _mock_preflight, _mock_prompt, mock_get_preparer):
         """When storage_backend is available, DISPOSITION_FAILED is written."""
         mock_preparer = MagicMock()
         mock_preparer.prepare.side_effect = ValueError("boom")

--- a/tests/unit/processing/test_online_llm_strategy.py
+++ b/tests/unit/processing/test_online_llm_strategy.py
@@ -18,6 +18,7 @@ from agent_actions.processing.types import (
     RetryMetadata,
 )
 from agent_actions.processing.unified import ProcessingStrategy
+from agent_actions.record.state import RecordState
 
 
 def _make_context(
@@ -415,8 +416,10 @@ class TestInvokeBatchLoop:
 
     @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
     @patch("agent_actions.processing.strategies.online_llm.fire_event")
-    def test_reraises_template_variable_error(self, mock_fire, mock_get_preparer):
-        """TemplateVariableError propagates through invoke() — it's a code bug, not a data error."""
+    def test_template_variable_error_with_missing_vars_produces_tombstone(
+        self, mock_fire, mock_get_preparer
+    ):
+        """TemplateVariableError with non-empty missing_variables is per-record — tombstone."""
         from jinja2 import UndefinedError
 
         from agent_actions.errors.operations import TemplateVariableError
@@ -436,8 +439,58 @@ class TestInvokeBatchLoop:
         )
 
         context = _make_context()
+        results = strategy.invoke([{"f": "1"}], context)
+
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].data[0]["_state"] == RecordState.FAILED.value
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_template_syntax_error_still_reraises(self, mock_fire, mock_get_preparer):
+        """TemplateVariableError with empty missing_variables (syntax error) is action-fatal."""
+        from agent_actions.errors.operations import TemplateVariableError
+
+        mock_get_preparer.return_value.prepare.side_effect = TemplateVariableError(
+            missing_variables=[],
+            available_variables=["source"],
+            agent_name="test",
+            mode="online",
+            cause=Exception("invalid syntax"),
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        context = _make_context()
         with pytest.raises(TemplateVariableError):
             strategy.invoke([{"f": "1"}], context)
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_record_context_error_produces_tombstone(self, mock_fire, mock_get_preparer):
+        """RecordContextError is per-record — tombstone, remaining records continue."""
+        from agent_actions.errors import RecordContextError
+
+        mock_get_preparer.return_value.prepare.side_effect = RecordContextError(
+            "declared fields ['question'] not found"
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=MagicMock(),
+        )
+
+        context = _make_context()
+        results = strategy.invoke([{"f": "1"}], context)
+
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].data[0]["_state"] == RecordState.FAILED.value
 
     @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
     @patch("agent_actions.processing.strategies.online_llm.fire_event")

--- a/tests/unit/processing/test_prep_failure_e2e.py
+++ b/tests/unit/processing/test_prep_failure_e2e.py
@@ -1,0 +1,196 @@
+"""End-to-end tests for record fate on prompt template/context failures.
+
+Verifies the complete chain: prep failure → tombstone → cascade detection →
+downstream UPSTREAM_UNPROCESSED, across both online and batch paths.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from agent_actions.errors import RecordContextError
+from agent_actions.errors.operations import TemplateVariableError
+from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
+from agent_actions.processing.result_collector import ResultCollector
+from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+from agent_actions.processing.task_preparer import TaskPreparer
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+)
+from agent_actions.record.state import RecordState
+
+
+def _make_context(**kwargs: Any) -> ProcessingContext:
+    config: dict[str, Any] = {"agent_type": "test_action", "name": "test_action"}
+    return ProcessingContext(
+        agent_config=config,
+        agent_name="test_action",
+        **kwargs,
+    )
+
+
+class TestOnlineMultiRecordContinuation:
+    """One record fails prep, remaining records continue processing."""
+
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_first_record_fails_others_succeed(self, _mock_fire):
+        """3 records: record 0 fails via TemplateVariableError, records 1-2 succeed."""
+        from jinja2 import UndefinedError
+
+        error = TemplateVariableError(
+            missing_variables=["question"],
+            available_variables=["source"],
+            agent_name="test_action",
+            mode="online",
+            cause=UndefinedError("'question' is undefined"),
+        )
+        success_result = ProcessingResult.success(
+            data=[{"content": {"test_action": {"answer": "yes"}}}],
+            source_guid="sg_success",
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test_action"},
+            agent_name="test_action",
+            invocation_strategy=MagicMock(),
+        )
+        # Mock process_record: first call raises, rest succeed
+        strategy.process_record = MagicMock(
+            side_effect=[error, success_result, success_result]
+        )
+
+        context = _make_context()
+        records = [
+            {"source_guid": "sg_fail", "content": {}},
+            {"source_guid": "sg_ok1", "content": {}},
+            {"source_guid": "sg_ok2", "content": {}},
+        ]
+        results = strategy.invoke(records, context)
+
+        assert len(results) == 3
+        # Record 0: tombstone
+        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].data[0]["_state"] == RecordState.FAILED.value
+        # Records 1-2: success
+        assert results[1].status == ProcessingStatus.SUCCESS
+        assert results[2].status == ProcessingStatus.SUCCESS
+
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_record_context_error_others_continue(self, _mock_fire):
+        """RecordContextError on one record doesn't block others."""
+        success_result = ProcessingResult.success(
+            data=[{"content": {"test_action": {"ok": True}}}],
+            source_guid="sg_ok",
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test_action"},
+            agent_name="test_action",
+            invocation_strategy=MagicMock(),
+        )
+        strategy.process_record = MagicMock(
+            side_effect=[
+                RecordContextError("declared fields ['options'] not found"),
+                success_result,
+            ]
+        )
+
+        context = _make_context()
+        results = strategy.invoke(
+            [{"source_guid": "sg_fail"}, {"source_guid": "sg_ok"}], context
+        )
+
+        assert len(results) == 2
+        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[1].status == ProcessingStatus.SUCCESS
+
+
+class TestCascadePropagation:
+    """Prep-failed tombstone cascades to downstream action via _state detection."""
+
+    def test_failed_record_detected_as_upstream_unprocessed(self):
+        """TaskPreparer.prepare() returns UPSTREAM_UNPROCESSED for _state=failed record."""
+        # Build a tombstone like _build_prep_failed_result produces
+        from agent_actions.processing.record_helpers import build_tombstone
+        from agent_actions.record.envelope import RecordEnvelope
+        from agent_actions.record.reasons import PREP_FAILED
+
+        tombstone = build_tombstone(
+            action_name="action_a",
+            input_record={"source_guid": "sg_001", "content": {}},
+            reason=PREP_FAILED,
+            source_guid="sg_001",
+        )
+        RecordEnvelope.transition(
+            tombstone, RecordState.FAILED, "action_a", "missing field"
+        )
+
+        # Downstream action sees this tombstone
+        preparer = TaskPreparer()
+        downstream_ctx = PreparationContext(
+            agent_config={
+                "agent_type": "action_b",
+                "context_scope": {"observe": ["action_a.*"]},
+            },
+            agent_name="action_b",
+            is_first_stage=False,
+        )
+        result = preparer.prepare(tombstone, downstream_ctx)
+        assert result.guard_status == GuardStatus.UPSTREAM_UNPROCESSED
+
+    def test_failed_state_history_preserved_through_cascade(self):
+        """Original failure reason is preserved in _state_history after cascade."""
+        from agent_actions.processing.record_helpers import build_tombstone
+        from agent_actions.record.envelope import RecordEnvelope
+        from agent_actions.record.reasons import PREP_FAILED
+
+        tombstone = build_tombstone(
+            action_name="action_a",
+            input_record={"source_guid": "sg_001", "content": {}},
+            reason=PREP_FAILED,
+            source_guid="sg_001",
+        )
+        RecordEnvelope.transition(
+            tombstone, RecordState.FAILED, "action_a", "Template var 'question' missing"
+        )
+
+        assert tombstone["_state"] == RecordState.FAILED.value
+        assert len(tombstone["_state_history"]) == 1
+        assert "question" in tombstone["_state_history"][0]["reason"]
+
+
+class TestResultCollectorPrepFailedDisposition:
+    """ResultCollector counts prep-failed tombstones correctly."""
+
+    def test_unprocessed_result_counted_separately(self):
+        """Prep-failed results (UNPROCESSED) don't inflate success or failure counts."""
+        from agent_actions.record.reasons import PREP_FAILED
+
+        mock_backend = MagicMock()
+
+        results = [
+            ProcessingResult.success(
+                data=[{"content": {"test_action": {"ok": True}}, "source_guid": "sg_1"}],
+                source_guid="sg_1",
+            ),
+            ProcessingResult.unprocessed(
+                data=[{
+                    "content": {"test_action": None},
+                    "_state": RecordState.FAILED.value,
+                    "source_guid": "sg_2",
+                }],
+                reason=PREP_FAILED,
+                source_guid="sg_2",
+            ),
+        ]
+
+        output, stats = ResultCollector.collect_results(
+            results,
+            agent_config={"agent_type": "test_action"},
+            agent_name="test_action",
+            is_first_stage=False,
+            storage_backend=mock_backend,
+        )
+        assert stats.success > 0
+        assert stats.unprocessed > 0

--- a/tests/unit/processing/test_prep_failure_e2e.py
+++ b/tests/unit/processing/test_prep_failure_e2e.py
@@ -56,9 +56,7 @@ class TestOnlineMultiRecordContinuation:
             invocation_strategy=MagicMock(),
         )
         # Mock process_record: first call raises, rest succeed
-        strategy.process_record = MagicMock(
-            side_effect=[error, success_result, success_result]
-        )
+        strategy.process_record = MagicMock(side_effect=[error, success_result, success_result])
 
         context = _make_context()
         records = [
@@ -97,9 +95,7 @@ class TestOnlineMultiRecordContinuation:
         )
 
         context = _make_context()
-        results = strategy.invoke(
-            [{"source_guid": "sg_fail"}, {"source_guid": "sg_ok"}], context
-        )
+        results = strategy.invoke([{"source_guid": "sg_fail"}, {"source_guid": "sg_ok"}], context)
 
         assert len(results) == 2
         assert results[0].status == ProcessingStatus.UNPROCESSED
@@ -122,9 +118,7 @@ class TestCascadePropagation:
             reason=PREP_FAILED,
             source_guid="sg_001",
         )
-        RecordEnvelope.transition(
-            tombstone, RecordState.FAILED, "action_a", "missing field"
-        )
+        RecordEnvelope.transition(tombstone, RecordState.FAILED, "action_a", "missing field")
 
         # Downstream action sees this tombstone
         preparer = TaskPreparer()
@@ -175,11 +169,13 @@ class TestResultCollectorPrepFailedDisposition:
                 source_guid="sg_1",
             ),
             ProcessingResult.unprocessed(
-                data=[{
-                    "content": {"test_action": None},
-                    "_state": RecordState.FAILED.value,
-                    "source_guid": "sg_2",
-                }],
+                data=[
+                    {
+                        "content": {"test_action": None},
+                        "_state": RecordState.FAILED.value,
+                        "source_guid": "sg_2",
+                    }
+                ],
                 reason=PREP_FAILED,
                 source_guid="sg_2",
             ),

--- a/tests/utilities/test_context_scope_processor.py
+++ b/tests/utilities/test_context_scope_processor.py
@@ -347,12 +347,12 @@ class TestNestedDictFieldResolution:
         assert "action_a" in field_context
 
     def test_filter_and_store_fields_raises_on_missing_field(self):
-        """fail_on_missing=True raises ConfigurationError when declared fields are absent."""
-        from agent_actions.errors import ConfigurationError
+        """fail_on_missing=True raises RecordContextError when declared fields are absent."""
+        from agent_actions.errors import RecordContextError
 
         field_context = {}
         data = {"existing": "value"}
-        with pytest.raises(ConfigurationError, match="declared fields.*missing_field"):
+        with pytest.raises(RecordContextError, match="declared fields.*missing_field"):
             _filter_and_store_fields(
                 field_context,
                 "action_a",


### PR DESCRIPTION
## Summary
- Records that fail prompt preparation (missing template variables, incomplete upstream context) were silently dropped in batch path and crashed the entire action in online path
- Introduced `RecordContextError` to distinguish per-record data issues from action-level config errors
- Online path: per-record errors now produce tombstones with `_state=failed`, remaining records continue processing
- Batch path: failed records stamped `FilterStatus.FAILED` in context_map with disposition and state history
- Downstream actions cascade-skip failed records via existing `CASCADE_BLOCKING_STATES` detection
- `error_items` count now surfaced in batch submission logs at WARNING level

## Verification
- 6616 tests pass (16 new), 2 skipped
- `ruff check` and `ruff format --check` clean
- Cascade chain verified: prep failure → tombstone → UPSTREAM_UNPROCESSED downstream
- Both online and batch paths tested for single-record and multi-record scenarios
- FILE-mode catch at `scope_application.py:523` still works (RecordContextError extends ConfigurationError)