### PR TITLE
fix: halt workflow when upstream action fails all records (#415)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260512-415000.yaml
+++ b/.changes/unreleased/Bug Fix-20260512-415000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Halt workflow when an action produces 0 successful outputs — escalate total item failure from COMPLETED_WITH_FAILURES to FAILED so downstream actions are skipped instead of crashing"
+time: 2026-05-12T04:15:00.000000Z

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -182,6 +182,13 @@ class StorageBackend(ABC):
             if d.get("record_id") != NODE_LEVEL_RECORD_ID
         ]
 
+    def has_successful_items(self, action_name: str) -> bool:
+        """Return True if at least one item-level success disposition exists."""
+        return any(
+            d.get("record_id") != NODE_LEVEL_RECORD_ID
+            for d in self.get_disposition(action_name, disposition=DISPOSITION_SUCCESS)
+        )
+
     # ------------------------------------------------------------------
     # Prompt trace methods (compilation-level observability)
     # ------------------------------------------------------------------

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -22,7 +22,6 @@ from agent_actions.record.reasons import GUARD_FILTERED_ALL
 from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_SKIPPED,
-    DISPOSITION_SUCCESS,
     NODE_LEVEL_RECORD_ID,
 )
 from agent_actions.tooling.docs.run_tracker import ActionCompleteConfig
@@ -508,7 +507,7 @@ class ActionExecutor:
                 )
 
     def _resolve_completion_status(self, action_name: str) -> ActionStatus:
-        """Return SKIPPED if all records guard-filtered, COMPLETED_WITH_FAILURES if item-level failures exist, else COMPLETED."""
+        """Classify action outcome: FAILED (all items failed), SKIPPED (all guard-filtered), COMPLETED_WITH_FAILURES (partial), or COMPLETED."""
         storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
         if storage_backend is None:
             return ActionStatus.COMPLETED
@@ -535,8 +534,7 @@ class ActionExecutor:
                 )
             item_failures = storage_backend.get_failed_items(action_name)
             if item_failures:
-                has_any_success = storage_backend.has_disposition(action_name, DISPOSITION_SUCCESS)
-                if not has_any_success:
+                if not storage_backend.has_successful_items(action_name):
                     logger.error(
                         "Action '%s' failed: 0 successful outputs out of %d records. "
                         "Halting workflow — all downstream actions will be skipped.",

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -22,6 +22,7 @@ from agent_actions.record.reasons import GUARD_FILTERED_ALL
 from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_SKIPPED,
+    DISPOSITION_SUCCESS,
     NODE_LEVEL_RECORD_ID,
 )
 from agent_actions.tooling.docs.run_tracker import ActionCompleteConfig
@@ -350,6 +351,24 @@ class ActionExecutor:
         if final_status == ActionStatus.SKIPPED:
             return self._handle_guard_all_filtered(params, output_folder, duration)
 
+        if final_status == ActionStatus.FAILED:
+            reason = f"Action '{params.action_name}' failed: all records produced errors"
+            self.deps.state_manager.update_status(
+                params.action_name,
+                ActionStatus.FAILED,
+                execution_time=duration,
+                error_message=reason,
+            )
+            self._write_failed_disposition(params.action_name, reason)
+            self._track_action_complete(params.action_name, duration, ActionStatus.FAILED)
+            return ActionExecutionResult(
+                success=False,
+                output_folder=output_folder,
+                status=ActionStatus.FAILED,
+                error=RuntimeError(reason),
+                metrics=ExecutionMetrics(duration=duration),
+            )
+
         self.deps.state_manager.update_status(
             params.action_name,
             final_status,
@@ -425,6 +444,8 @@ class ActionExecutor:
             tracker_status = "skipped"
         elif status == ActionStatus.COMPLETED:
             tracker_status = "success"
+        elif status == ActionStatus.FAILED:
+            tracker_status = "failed"
         else:
             tracker_status = "partial"
         config = ActionCompleteConfig(
@@ -502,6 +523,21 @@ class ActionExecutor:
                 )
             item_failures = storage_backend.get_failed_items(action_name)
             if item_failures:
+                success_dispositions = [
+                    d
+                    for d in storage_backend.get_disposition(
+                        action_name, disposition=DISPOSITION_SUCCESS
+                    )
+                    if d.get("record_id") != NODE_LEVEL_RECORD_ID
+                ]
+                if not success_dispositions and len(item_failures) > 0:
+                    logger.error(
+                        "Action '%s' failed: 0 successful outputs out of %d records. "
+                        "Halting workflow — all downstream actions will be skipped.",
+                        action_name,
+                        len(item_failures),
+                    )
+                    return ActionStatus.FAILED
                 logger.warning(
                     "Action '%s' completed with %d item-level failure(s)",
                     action_name,

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -899,6 +899,36 @@ class ActionExecutor:
         if batch_status == "completed":
             wall_clock = self._compute_batch_wall_clock(action_name, duration)
             final_status = self._resolve_completion_status(action_name)
+
+            if final_status == ActionStatus.FAILED:
+                reason = f"Action '{action_name}' failed: all records produced errors"
+                self.deps.state_manager.update_status(
+                    action_name,
+                    ActionStatus.FAILED,
+                    execution_time=wall_clock,
+                    execution_mode="batch",
+                    error_message=reason,
+                )
+                self._write_failed_disposition(action_name, reason)
+                self._track_action_complete(action_name, wall_clock, ActionStatus.FAILED)
+                fire_event(
+                    BatchCompleteEvent(
+                        batch_id=action_config.get("batch_id", ""),
+                        action_name=action_name,
+                        total=1,
+                        completed=0,
+                        failed=1,
+                        elapsed_time=wall_clock,
+                    )
+                )
+                return ActionExecutionResult(
+                    success=False,
+                    output_folder=output_folder,
+                    status=ActionStatus.FAILED,
+                    error=RuntimeError(reason),
+                    metrics=ExecutionMetrics(duration=wall_clock),
+                )
+
             self.deps.state_manager.update_status(
                 action_name,
                 final_status,

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -352,22 +352,7 @@ class ActionExecutor:
             return self._handle_guard_all_filtered(params, output_folder, duration)
 
         if final_status == ActionStatus.FAILED:
-            reason = f"Action '{params.action_name}' failed: all records produced errors"
-            self.deps.state_manager.update_status(
-                params.action_name,
-                ActionStatus.FAILED,
-                execution_time=duration,
-                error_message=reason,
-            )
-            self._write_failed_disposition(params.action_name, reason)
-            self._track_action_complete(params.action_name, duration, ActionStatus.FAILED)
-            return ActionExecutionResult(
-                success=False,
-                output_folder=output_folder,
-                status=ActionStatus.FAILED,
-                error=RuntimeError(reason),
-                metrics=ExecutionMetrics(duration=duration),
-            )
+            return self._finalize_total_failure(params.action_name, duration, output_folder)
 
         self.deps.state_manager.update_status(
             params.action_name,
@@ -459,6 +444,33 @@ class ActionExecutor:
         )
         self.run_tracker.record_action_complete(config=config)
 
+    def _finalize_total_failure(
+        self,
+        action_name: str,
+        duration: float,
+        output_folder: str | None = None,
+        *,
+        execution_mode: str | None = None,
+    ) -> ActionExecutionResult:
+        """Handle total item-level failure: update state, write disposition, track, return result."""
+        reason = f"Action '{action_name}' failed: all records produced errors"
+        status_kwargs: dict[str, Any] = {
+            "execution_time": duration,
+            "error_message": reason,
+        }
+        if execution_mode is not None:
+            status_kwargs["execution_mode"] = execution_mode
+        self.deps.state_manager.update_status(action_name, ActionStatus.FAILED, **status_kwargs)
+        self._write_failed_disposition(action_name, reason)
+        self._track_action_complete(action_name, duration, ActionStatus.FAILED)
+        return ActionExecutionResult(
+            success=False,
+            output_folder=output_folder,
+            status=ActionStatus.FAILED,
+            error=RuntimeError(reason),
+            metrics=ExecutionMetrics(duration=duration),
+        )
+
     def _write_failed_disposition(self, action_name: str, reason: str) -> None:
         """Write DISPOSITION_FAILED to storage so downstream and future runs detect the failure."""
         storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
@@ -523,14 +535,8 @@ class ActionExecutor:
                 )
             item_failures = storage_backend.get_failed_items(action_name)
             if item_failures:
-                success_dispositions = [
-                    d
-                    for d in storage_backend.get_disposition(
-                        action_name, disposition=DISPOSITION_SUCCESS
-                    )
-                    if d.get("record_id") != NODE_LEVEL_RECORD_ID
-                ]
-                if not success_dispositions and len(item_failures) > 0:
+                has_any_success = storage_backend.has_disposition(action_name, DISPOSITION_SUCCESS)
+                if not has_any_success:
                     logger.error(
                         "Action '%s' failed: 0 successful outputs out of %d records. "
                         "Halting workflow — all downstream actions will be skipped.",
@@ -901,16 +907,6 @@ class ActionExecutor:
             final_status = self._resolve_completion_status(action_name)
 
             if final_status == ActionStatus.FAILED:
-                reason = f"Action '{action_name}' failed: all records produced errors"
-                self.deps.state_manager.update_status(
-                    action_name,
-                    ActionStatus.FAILED,
-                    execution_time=wall_clock,
-                    execution_mode="batch",
-                    error_message=reason,
-                )
-                self._write_failed_disposition(action_name, reason)
-                self._track_action_complete(action_name, wall_clock, ActionStatus.FAILED)
                 fire_event(
                     BatchCompleteEvent(
                         batch_id=action_config.get("batch_id", ""),
@@ -921,12 +917,8 @@ class ActionExecutor:
                         elapsed_time=wall_clock,
                     )
                 )
-                return ActionExecutionResult(
-                    success=False,
-                    output_folder=output_folder,
-                    status=ActionStatus.FAILED,
-                    error=RuntimeError(reason),
-                    metrics=ExecutionMetrics(duration=wall_clock),
+                return self._finalize_total_failure(
+                    action_name, wall_clock, output_folder, execution_mode="batch"
                 )
 
             self.deps.state_manager.update_status(

--- a/tests/unit/workflow/test_batch_check_outcomes.py
+++ b/tests/unit/workflow/test_batch_check_outcomes.py
@@ -122,7 +122,6 @@ class TestBatchTotalFailure:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
 
         with patch("agent_actions.workflow.executor.fire_event") as mock_fire:
             result = executor.execute_action_sync(

--- a/tests/unit/workflow/test_batch_check_outcomes.py
+++ b/tests/unit/workflow/test_batch_check_outcomes.py
@@ -122,6 +122,7 @@ class TestBatchTotalFailure:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = False
 
         with patch("agent_actions.workflow.executor.fire_event") as mock_fire:
             result = executor.execute_action_sync(

--- a/tests/unit/workflow/test_batch_check_outcomes.py
+++ b/tests/unit/workflow/test_batch_check_outcomes.py
@@ -107,6 +107,44 @@ class TestBatchCheckCompleteEvent:
         assert complete_events[0].completed == 0
 
 
+class TestBatchTotalFailure:
+    """Batch completion with 100% item-level failure must halt the workflow."""
+
+    def test_batch_total_failure_returns_failed(self, executor, mock_deps):
+        """Batch-completed action with all records failed returns success=False."""
+        mock_deps.state_manager.get_status.return_value = ActionStatus.BATCH_SUBMITTED
+        mock_deps.batch_manager.handle_batch_agent.return_value = ("/output/file.json", "completed")
+        mock_deps.state_manager.get_status_details.return_value = {
+            "status": ActionStatus.BATCH_SUBMITTED,
+            "batch_submitted_at": "2026-05-01T10:00:00",
+        }
+        # All records failed, zero successes
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+        ]
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
+
+        with patch("agent_actions.workflow.executor.fire_event") as mock_fire:
+            result = executor.execute_action_sync(
+                "agent_a", action_idx=0, action_config={"kind": "llm"}, is_last_action=False
+            )
+
+        assert result.success is False
+        assert result.status == ActionStatus.FAILED
+        assert result.error is not None
+        # Disposition sentinel written
+        mock_deps.action_runner.storage_backend.set_disposition.assert_called()
+        # BatchCompleteEvent with failed=1
+        complete_events = [
+            call[0][0]
+            for call in mock_fire.call_args_list
+            if isinstance(call[0][0], BatchCompleteEvent)
+        ]
+        assert len(complete_events) == 1
+        assert complete_events[0].failed == 1
+        assert complete_events[0].completed == 0
+
+
 class TestBatchCheckStatusTransitions:
     """Status transitions during _handle_batch_check."""
 

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -583,13 +583,12 @@ class TestResolveCompletionStatus:
     def test_returns_completed_with_failures_when_items_failed(
         self, mock_fire, executor, mock_deps
     ):
-        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        # has_disposition: False for SKIPPED check, True for SUCCESS check
+        mock_deps.action_runner.storage_backend.has_disposition.side_effect = (
+            lambda action, disp, **kw: disp == "success"
+        )
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "timeout"}
-        ]
-        # At least one record succeeded — partial failure, not total
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = [
-            {"record_id": "guid-2", "disposition": "success"}
         ]
         assert (
             executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED_WITH_FAILURES
@@ -655,19 +654,17 @@ class TestTotalFailureEscalation:
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
             {"record_id": "guid-2", "disposition": "failed", "reason": "503"},
         ]
-        # No success dispositions — total failure
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
         assert executor._resolve_completion_status("agent_a") == ActionStatus.FAILED
 
     @patch("agent_actions.workflow.executor.fire_event")
     def test_partial_failure_still_completed_with_failures(self, mock_fire, executor, mock_deps):
         """When some records fail but others succeed, status stays COMPLETED_WITH_FAILURES."""
-        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        # has_disposition: False for SKIPPED check, True for SUCCESS check
+        mock_deps.action_runner.storage_backend.has_disposition.side_effect = (
+            lambda action, disp, **kw: disp == "success"
+        )
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
-        ]
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = [
-            {"record_id": "guid-2", "disposition": "success"},
         ]
         assert (
             executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED_WITH_FAILURES
@@ -681,17 +678,11 @@ class TestTotalFailureEscalation:
         assert executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED
 
     @patch("agent_actions.workflow.executor.fire_event")
-    def test_total_failure_ignores_node_level_success_sentinel(
-        self, mock_fire, executor, mock_deps
-    ):
-        """Node-level sentinels in success dispositions must not prevent total-failure detection."""
+    def test_total_failure_with_no_success_disposition(self, mock_fire, executor, mock_deps):
+        """When has_disposition returns False for SUCCESS, total failure is detected."""
         mock_deps.action_runner.storage_backend.has_disposition.return_value = False
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
-        ]
-        # Only a node-level sentinel, no real success records
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = [
-            {"record_id": NODE_LEVEL_RECORD_ID, "disposition": "success"},
         ]
         assert executor._resolve_completion_status("agent_a") == ActionStatus.FAILED
 
@@ -704,8 +695,6 @@ class TestTotalFailureEscalation:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
-
         from agent_actions.workflow.executor import ActionRunParams
 
         params = ActionRunParams(
@@ -727,8 +716,6 @@ class TestTotalFailureEscalation:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
-
         from agent_actions.workflow.executor import ActionRunParams
 
         params = ActionRunParams(
@@ -757,8 +744,6 @@ class TestTotalFailureEscalation:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
-        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
-
         from agent_actions.workflow.executor import ActionRunParams
 
         params = ActionRunParams(

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -583,13 +583,11 @@ class TestResolveCompletionStatus:
     def test_returns_completed_with_failures_when_items_failed(
         self, mock_fire, executor, mock_deps
     ):
-        # has_disposition: False for SKIPPED check, True for SUCCESS check
-        mock_deps.action_runner.storage_backend.has_disposition.side_effect = (
-            lambda action, disp, **kw: disp == "success"
-        )
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "timeout"}
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = True
         assert (
             executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED_WITH_FAILURES
         )
@@ -654,18 +652,17 @@ class TestTotalFailureEscalation:
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
             {"record_id": "guid-2", "disposition": "failed", "reason": "503"},
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = False
         assert executor._resolve_completion_status("agent_a") == ActionStatus.FAILED
 
     @patch("agent_actions.workflow.executor.fire_event")
     def test_partial_failure_still_completed_with_failures(self, mock_fire, executor, mock_deps):
         """When some records fail but others succeed, status stays COMPLETED_WITH_FAILURES."""
-        # has_disposition: False for SKIPPED check, True for SUCCESS check
-        mock_deps.action_runner.storage_backend.has_disposition.side_effect = (
-            lambda action, disp, **kw: disp == "success"
-        )
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = True
         assert (
             executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED_WITH_FAILURES
         )
@@ -678,12 +675,13 @@ class TestTotalFailureEscalation:
         assert executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED
 
     @patch("agent_actions.workflow.executor.fire_event")
-    def test_total_failure_with_no_success_disposition(self, mock_fire, executor, mock_deps):
-        """When has_disposition returns False for SUCCESS, total failure is detected."""
+    def test_skipped_and_failed_items_with_no_successes(self, mock_fire, executor, mock_deps):
+        """Skipped + failed items with zero successes should still escalate to FAILED."""
         mock_deps.action_runner.storage_backend.has_disposition.return_value = False
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = False
         assert executor._resolve_completion_status("agent_a") == ActionStatus.FAILED
 
     @patch("agent_actions.workflow.executor.fire_event")
@@ -695,6 +693,7 @@ class TestTotalFailureEscalation:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = False
         from agent_actions.workflow.executor import ActionRunParams
 
         params = ActionRunParams(
@@ -716,6 +715,7 @@ class TestTotalFailureEscalation:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = False
         from agent_actions.workflow.executor import ActionRunParams
 
         params = ActionRunParams(
@@ -744,6 +744,7 @@ class TestTotalFailureEscalation:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
         ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = False
         from agent_actions.workflow.executor import ActionRunParams
 
         params = ActionRunParams(
@@ -757,6 +758,42 @@ class TestTotalFailureEscalation:
         call_args = run_tracker.record_action_complete.call_args
         assert call_args is not None
         assert call_args.kwargs["config"].status == "failed"
+
+
+class TestTotalFailureDownstreamSkip:
+    """End-to-end: total item failure → FAILED → circuit breaker skips downstream."""
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_total_failure_skips_downstream_via_circuit_breaker(
+        self, mock_fire, executor, mock_deps
+    ):
+        """After total failure sets FAILED, circuit breaker blocks dependent actions."""
+        # Step 1: agent_a total-fails
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+        ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = False
+
+        from agent_actions.workflow.executor import ActionRunParams
+
+        params = ActionRunParams(
+            action_name="agent_a",
+            action_idx=0,
+            action_config={"kind": "llm"},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+        result = executor._handle_run_success(params, "/output", 1.0, None)
+        assert result.success is False
+        assert result.status == ActionStatus.FAILED
+
+        # Step 2: agent_b depends on agent_a — circuit breaker detects failure
+        mock_deps.state_manager.is_failed.return_value = True
+        mock_deps.state_manager.is_skipped.return_value = False
+        config_b = {"dependencies": ["agent_a"]}
+        failed_dep = executor._check_upstream_health("agent_b", config_b)
+        assert failed_dep == "agent_a"
 
 
 class TestCircuitBreakerIgnoresPartial:

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -587,6 +587,10 @@ class TestResolveCompletionStatus:
         mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
             {"record_id": "guid-1", "disposition": "failed", "reason": "timeout"}
         ]
+        # At least one record succeeded — partial failure, not total
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = [
+            {"record_id": "guid-2", "disposition": "success"}
+        ]
         assert (
             executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED_WITH_FAILURES
         )
@@ -638,6 +642,136 @@ class TestResolveCompletionStatus:
         mock_deps.action_runner.storage_backend.clear_disposition.assert_called_once_with(
             "agent_a", DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
         )
+
+
+class TestTotalFailureEscalation:
+    """100% item-level failure must escalate to FAILED, not COMPLETED_WITH_FAILURES."""
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_total_failure_returns_failed(self, mock_fire, executor, mock_deps):
+        """When all records fail and none succeed, status should be FAILED."""
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+            {"record_id": "guid-2", "disposition": "failed", "reason": "503"},
+        ]
+        # No success dispositions — total failure
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
+        assert executor._resolve_completion_status("agent_a") == ActionStatus.FAILED
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_partial_failure_still_completed_with_failures(self, mock_fire, executor, mock_deps):
+        """When some records fail but others succeed, status stays COMPLETED_WITH_FAILURES."""
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+        ]
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = [
+            {"record_id": "guid-2", "disposition": "success"},
+        ]
+        assert (
+            executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED_WITH_FAILURES
+        )
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_empty_input_not_treated_as_failure(self, mock_fire, executor, mock_deps):
+        """Zero records processed (no failures, no successes) is COMPLETED, not FAILED."""
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = []
+        assert executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_total_failure_ignores_node_level_success_sentinel(
+        self, mock_fire, executor, mock_deps
+    ):
+        """Node-level sentinels in success dispositions must not prevent total-failure detection."""
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+        ]
+        # Only a node-level sentinel, no real success records
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = [
+            {"record_id": NODE_LEVEL_RECORD_ID, "disposition": "success"},
+        ]
+        assert executor._resolve_completion_status("agent_a") == ActionStatus.FAILED
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_total_failure_handle_run_success_returns_failure_result(
+        self, mock_fire, executor, mock_deps
+    ):
+        """_handle_run_success must return success=False when _resolve_completion_status returns FAILED."""
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+        ]
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
+
+        from agent_actions.workflow.executor import ActionRunParams
+
+        params = ActionRunParams(
+            action_name="agent_a",
+            action_idx=0,
+            action_config={"kind": "llm"},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+        result = executor._handle_run_success(params, "/output", 1.0, None)
+        assert result.success is False
+        assert result.status == ActionStatus.FAILED
+        assert result.error is not None
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_total_failure_writes_failed_disposition(self, mock_fire, executor, mock_deps):
+        """Total failure must write DISPOSITION_FAILED node-level sentinel for re-run safety."""
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+        ]
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
+
+        from agent_actions.workflow.executor import ActionRunParams
+
+        params = ActionRunParams(
+            action_name="agent_a",
+            action_idx=0,
+            action_config={"kind": "llm"},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+        executor._handle_run_success(params, "/output", 1.0, None)
+        mock_deps.action_runner.storage_backend.set_disposition.assert_called_once_with(
+            action_name="agent_a",
+            record_id=NODE_LEVEL_RECORD_ID,
+            disposition=DISPOSITION_FAILED,
+            reason="Action 'agent_a' failed: all records produced errors"[:500],
+        )
+
+    @patch("agent_actions.workflow.executor.fire_event")
+    def test_total_failure_tracker_records_failed_not_partial(self, mock_fire, executor, mock_deps):
+        """Run tracker must record 'failed', not 'partial', for total failure."""
+        run_tracker = MagicMock()
+        executor.run_tracker = run_tracker
+        executor.run_id = "test-run-id"
+
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "guid-1", "disposition": "failed", "reason": "503"},
+        ]
+        mock_deps.action_runner.storage_backend.get_disposition.return_value = []
+
+        from agent_actions.workflow.executor import ActionRunParams
+
+        params = ActionRunParams(
+            action_name="agent_a",
+            action_idx=0,
+            action_config={"kind": "llm"},
+            is_last_action=False,
+            start_time=datetime.now(),
+        )
+        executor._handle_run_success(params, "/output", 1.0, None)
+        call_args = run_tracker.record_action_complete.call_args
+        assert call_args is not None
+        assert call_args.kwargs["config"].status == "failed"
 
 
 class TestCircuitBreakerIgnoresPartial:

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -80,6 +80,7 @@ class TestExecuteAgentSync:
         storage = MagicMock()
         storage.list_target_files.return_value = []
         storage.has_disposition.return_value = False
+        storage.get_failed_items.return_value = []
         mock_deps.action_runner.storage_backend = storage
 
         mock_deps.skip_evaluator.should_skip_action.return_value = False
@@ -106,6 +107,7 @@ class TestExecuteAgentSync:
         storage = MagicMock()
         storage.list_target_files.side_effect = OSError("SQLite lock")
         storage.has_disposition.return_value = False
+        storage.get_failed_items.return_value = []
         mock_deps.action_runner.storage_backend = storage
 
         mock_deps.skip_evaluator.should_skip_action.return_value = False


### PR DESCRIPTION
## Summary
- Escalate 100% item-level failure from `COMPLETED_WITH_FAILURES` to `FAILED` in `_resolve_completion_status()`
- Existing circuit breaker skips downstream actions; existing `reset_retryable()` handles retry
- No new status enum, no config changes — three targeted edits in one file

## Problem
When an upstream action fails all records (e.g. provider 503), the workflow continues and downstream actions crash with cryptic errors like `"Version correlation failed"`. The operator has no path to diagnosis.

## Behavioral change
- `run_results.json`: total-failure actions now report `"status": "failed"` instead of `"partial"` or `"success"`
- Users with monitoring on `run_results.json` may see new error statuses for previously-silent total failures

## Changes
- `_resolve_completion_status()`: query `DISPOSITION_SUCCESS` to detect zero successes; return `FAILED` instead of `COMPLETED_WITH_FAILURES`
- `_handle_run_success()`: add `FAILED` branch — sets `success=False`, writes `DISPOSITION_FAILED` sentinel, returns error result
- `_track_action_complete()`: add `FAILED` → `"failed"` mapping (was falling through to `"partial"`)

## Verification
- 7 new tests: total failure → FAILED, partial failure → COMPLETED_WITH_FAILURES (unchanged), empty input → COMPLETED, sentinel filtering, disposition write, success=False propagation, tracker status
- Existing partial-failure test mock updated to include success dispositions (prevents silent regression)
- Batch tests unaffected (mock has `get_failed_items = []`)
- Full suite: 6615 passed, 2 skipped, ruff clean