### PR TITLE
fix: record namespace schema-echo poison + file-level isolation

### DIFF
--- a/.changes/unreleased/Bug Fix-20260513-043000.yaml
+++ b/.changes/unreleased/Bug Fix-20260513-043000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Prevent schema-echo/empty JSON from poisoning target_data; isolate file-level failures so one bad record does not fail the whole directory"
+time: 2026-05-13T04:30:00.000000Z

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -21,19 +21,15 @@ from .retry import RetryExhaustedException
 
 
 def _extract_field_names(schema: dict) -> list[str]:
-    """Extract field names from any schema format."""
-    # fields-style (agent-actions format)
-    fields = schema.get("fields")
-    if isinstance(fields, list):
-        return [f.get("id") or f.get("name", "") for f in fields if isinstance(f, dict)]
-    # properties-style (JSON Schema format)
-    props = schema.get("properties")
-    if isinstance(props, dict):
-        return list(props.keys())
-    # Inline schema: keys are field names directly
-    if all(isinstance(v, str) for v in schema.values()):
-        return list(schema.keys())
-    return []
+    """Extract field names from any schema format.
+
+    Delegates to the canonical ``_extract_schema_fields`` in
+    ``schema_output_validator`` so field-extraction logic lives in one place.
+    """
+    from agent_actions.validation.schema_output_validator import _extract_schema_fields
+
+    all_fields, _required, _types = _extract_schema_fields(schema)
+    return sorted(all_fields)
 
 
 def _build_json_parse_feedback(validator: Any) -> str:

--- a/agent_actions/validation/schema_output_validator.py
+++ b/agent_actions/validation/schema_output_validator.py
@@ -6,32 +6,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 from agent_actions.errors import SchemaValidationError
+from agent_actions.validation.schema_validator import SchemaValidator
 
 logger = logging.getLogger(__name__)
 
-# Top-level keys that appear in JSON Schema definitions.  When an LLM "echoes"
-# the schema instead of conforming to it, these are the keys that show up.
-_JSON_SCHEMA_META_KEYS = frozenset(
-    {
-        "title",
-        "type",
-        "properties",
-        "required",
-        "additionalProperties",
-        "description",
-        "$schema",
-        "$id",
-        "definitions",
-        "$defs",
-        "items",
-        "enum",
-        "const",
-        "allOf",
-        "anyOf",
-        "oneOf",
-        "not",
-    }
-)
+# Reuse the canonical set of JSON Schema keywords defined in SchemaValidator
+# rather than maintaining a separate list.  When an LLM "echoes" the schema
+# instead of conforming to it, these are the keys that show up.
+_JSON_SCHEMA_META_KEYS: frozenset[str] = frozenset(SchemaValidator.JSON_SCHEMA_RESERVED_KEYWORDS)
 
 
 @dataclass

--- a/agent_actions/validation/schema_output_validator.py
+++ b/agent_actions/validation/schema_output_validator.py
@@ -9,6 +9,30 @@ from agent_actions.errors import SchemaValidationError
 
 logger = logging.getLogger(__name__)
 
+# Top-level keys that appear in JSON Schema definitions.  When an LLM "echoes"
+# the schema instead of conforming to it, these are the keys that show up.
+_JSON_SCHEMA_META_KEYS = frozenset(
+    {
+        "title",
+        "type",
+        "properties",
+        "required",
+        "additionalProperties",
+        "description",
+        "$schema",
+        "$id",
+        "definitions",
+        "$defs",
+        "items",
+        "enum",
+        "const",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "not",
+    }
+)
+
 
 @dataclass
 class SchemaValidationReport:
@@ -133,6 +157,33 @@ def validate_output_against_schema(
         is_compliant = False
 
     validation_errors: list[str] = schema_structure_errors
+
+    # --- Schema-echo / empty-object guard ---
+    # If the schema declares fields but the output contains NONE of them,
+    # the response is unusable (catches both {} and schema-echo payloads).
+    declared_fields_present = expected_fields & actual_fields
+    if expected_fields and not declared_fields_present:
+        is_compliant = False
+        # Determine whether this is specifically a schema-echo
+        undeclared_actual = actual_fields - expected_fields
+        if undeclared_actual and undeclared_actual <= _JSON_SCHEMA_META_KEYS:
+            validation_errors.append(
+                f"Schema-echo detected: output contains JSON Schema meta-keys "
+                f"{sorted(undeclared_actual)} instead of declared fields "
+                f"{sorted(expected_fields)}. The model returned the schema "
+                f"definition itself rather than conforming data."
+            )
+        elif not actual_fields:
+            validation_errors.append(
+                f"Empty object: output has no fields but schema declares {sorted(expected_fields)}"
+            )
+        else:
+            validation_errors.append(
+                f"No declared fields found in output. "
+                f"Expected at least one of {sorted(expected_fields)}, "
+                f"got {sorted(actual_fields)}"
+            )
+
     if missing_required:
         validation_errors.append(f"Missing required fields: {', '.join(missing_required)}")
     if type_errors:
@@ -271,6 +322,16 @@ def _extract_schema_fields(schema: dict[str, Any]) -> tuple[set[str], set[str], 
                 for prop_name, prop_def in properties.items():
                     if isinstance(prop_def, dict) and "type" in prop_def:
                         field_types[prop_name] = prop_def["type"]
+
+    # Handle inline schema: keys are field names, values are type strings
+    # e.g. {"optimal_code": "string", "score": "number"}
+    elif schema and all(isinstance(v, str) for v in schema.values() if v is not None):
+        # Exclude known meta-keys (name, description) that aren't field definitions
+        meta = {"name", "description"}
+        for k, v in schema.items():
+            if k not in meta and isinstance(v, str):
+                all_fields.add(k)
+                field_types[k] = v
 
     return all_fields, required_fields, field_types
 

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -446,8 +446,12 @@ class ActionRunner:
         input_directory: str,
         params: FileProcessParams,
         processed_paths: set,
-    ) -> int:
-        """Process all files in a single directory. Returns count of files processed."""
+    ) -> tuple[int, int]:
+        """Process all files in a single directory.
+
+        Returns:
+            (files_found, files_processed).
+        """
         return _process_directory_files(
             self, input_path, output_path, input_directory, params, processed_paths
         )
@@ -456,8 +460,12 @@ class ActionRunner:
         """Log warning if no files were found in upstream directories."""
         _warn_no_files_found(params)
 
-    def _process_merged_files(self, params: FileProcessParams) -> int:
-        """Process files from multiple upstream directories with content merging."""
+    def _process_merged_files(self, params: FileProcessParams) -> tuple[int, int]:
+        """Process files from multiple upstream directories with content merging.
+
+        Returns:
+            (files_found, files_processed).
+        """
         return _process_merged_files(self, params)
 
     def _process_from_storage_backend(self, params: FileProcessParams) -> tuple[int, int]:

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -38,6 +38,35 @@ def is_target_directory(path: str) -> bool:
     return "target" in path and "staging" not in path
 
 
+_MAX_TRACKED_ERRORS = 10  # Cap to avoid unbounded memory on mass failure
+
+
+def _log_processing_errors(
+    processing_errors: list[str],
+    processed: int,
+    total: int,
+    action_name: str,
+    context: str,
+) -> None:
+    """Log a summary when some files failed processing."""
+    if not processing_errors or total == 0:
+        return
+    logger.error(
+        "%s incomplete for %s: %d/%d files processed. Errors: %s",
+        context,
+        action_name,
+        processed,
+        total,
+        "; ".join(processing_errors[:3]),
+        extra={
+            "action_name": action_name,
+            "files_found": total,
+            "files_processed": processed,
+            "error_count": len(processing_errors),
+        },
+    )
+
+
 def _file_limit_reached(action_config: dict, count: int, action_name: str) -> bool:
     """Return True (and log) if file_limit has been reached."""
     file_limit = action_config.get("file_limit")
@@ -173,8 +202,8 @@ def process_directory_files(
             )
             count += 1
         except Exception as e:
-            error_msg = f"{relative_path}: {e}"
-            processing_errors.append(error_msg)
+            if len(processing_errors) < _MAX_TRACKED_ERRORS:
+                processing_errors.append(f"{relative_path}: {e}")
             logger.warning(
                 "Failed to process file %s: %s",
                 relative_path,
@@ -185,15 +214,9 @@ def process_directory_files(
         if _file_limit_reached(params.action_config, count, params.action_name):
             break
 
-    if processing_errors and files_seen > 0:
-        logger.error(
-            "Directory processing incomplete for %s: %d/%d files processed. Errors: %s",
-            params.action_name,
-            count,
-            files_seen,
-            "; ".join(processing_errors[:3]),
-        )
-
+    _log_processing_errors(
+        processing_errors, count, files_seen, params.action_name, "Directory processing"
+    )
     return count
 
 
@@ -238,8 +261,8 @@ def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> int
 
             files_processed_count += 1
         except Exception as e:
-            error_msg = f"{relative_path}: {e}"
-            processing_errors.append(error_msg)
+            if len(processing_errors) < _MAX_TRACKED_ERRORS:
+                processing_errors.append(f"{relative_path}: {e}")
             logger.warning(
                 "Failed to process merged file %s: %s",
                 relative_path,
@@ -250,15 +273,13 @@ def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> int
         if _file_limit_reached(params.action_config, files_processed_count, params.action_name):
             break
 
-    if processing_errors and files_seen > 0:
-        logger.error(
-            "Merged file processing incomplete for %s: %d/%d files processed. Errors: %s",
-            params.action_name,
-            files_processed_count,
-            files_seen,
-            "; ".join(processing_errors[:3]),
-        )
-
+    _log_processing_errors(
+        processing_errors,
+        files_processed_count,
+        files_seen,
+        params.action_name,
+        "Merged file processing",
+    )
     return files_processed_count
 
 
@@ -370,8 +391,8 @@ def process_from_storage_backend(
                 break
 
         except Exception as e:
-            error_msg = f"{relative_path}: {e}"
-            processing_errors.append(error_msg)
+            if len(processing_errors) < _MAX_TRACKED_ERRORS:
+                processing_errors.append(f"{relative_path}: {e}")
             logger.warning(
                 "Failed to process backend entry %s: %s",
                 relative_path,
@@ -379,21 +400,13 @@ def process_from_storage_backend(
                 exc_info=True,
             )
 
-    if files_found > 0 and files_processed < files_found:
-        logger.error(
-            "Storage backend processing incomplete: %d/%d files processed for %s. Errors: %s",
-            files_processed,
-            files_found,
-            params.action_name,
-            "; ".join(processing_errors[:3]),  # Show first 3 errors
-            extra={
-                "action_name": params.action_name,
-                "files_found": files_found,
-                "files_processed": files_processed,
-                "error_count": len(processing_errors),
-            },
-        )
-
+    _log_processing_errors(
+        processing_errors,
+        files_processed,
+        files_found,
+        params.action_name,
+        "Storage backend processing",
+    )
     return (files_found, files_processed)
 
 

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -157,19 +157,43 @@ def process_directory_files(
 ) -> int:
     """Process all files in a single directory. Returns count of files processed."""
     count = 0
+    processing_errors: list[str] = []
+    files_seen = 0
     for item in input_path.rglob("*"):
         if runner._should_skip_item(item, input_path, processed_paths, params.file_type_filter):
             continue
 
         relative_path = item.relative_to(input_path)
         processed_paths.add(relative_path)
+        files_seen += 1
 
-        runner._process_single_file(
-            _build_file_params(params, item, input_path, output_path, input_directory)
-        )
-        count += 1
+        try:
+            runner._process_single_file(
+                _build_file_params(params, item, input_path, output_path, input_directory)
+            )
+            count += 1
+        except Exception as e:
+            error_msg = f"{relative_path}: {e}"
+            processing_errors.append(error_msg)
+            logger.warning(
+                "Failed to process file %s: %s",
+                relative_path,
+                e,
+                exc_info=True,
+            )
+
         if _file_limit_reached(params.action_config, count, params.action_name):
             break
+
+    if processing_errors and files_seen > 0:
+        logger.error(
+            "Directory processing incomplete for %s: %d/%d files processed. Errors: %s",
+            params.action_name,
+            count,
+            files_seen,
+            "; ".join(processing_errors[:3]),
+        )
+
     return count
 
 
@@ -178,39 +202,62 @@ def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> int
     output_path = Path(params.output_directory)
     files_by_path = runner._collect_files_from_upstream(params.upstream_data_dirs)
     files_processed_count = 0
+    processing_errors: list[str] = []
+    files_seen = 0
 
     for relative_path, file_paths in files_by_path.items():
-        if len(file_paths) == 1:
-            file_path = file_paths[0]
-            input_path = _resolve_upstream_root(file_path, params.upstream_data_dirs)
-
-            runner._process_single_file(
-                _build_file_params(params, file_path, input_path, output_path, str(input_path))
-            )
-        else:
-            reduce_key = params.action_config.get("reduce_key")
-            logger.debug(
-                "Merging %d files for %s (reduce_key=%s)",
-                len(file_paths),
-                relative_path,
-                reduce_key or "auto",
-            )
-            merged_data = merge_json_files(file_paths, reduce_key=reduce_key)
-
-            # TemporaryDirectory instead of in-place overwrite: the old approach
-            # (overwrite + restore in finally) left corrupt files on SIGKILL.
-            with tempfile.TemporaryDirectory() as td:
-                tmp_file = Path(td) / relative_path
-                tmp_file.parent.mkdir(parents=True, exist_ok=True)
-                atomic_json_write(tmp_file, merged_data, fsync=False)
+        files_seen += 1
+        try:
+            if len(file_paths) == 1:
+                file_path = file_paths[0]
+                input_path = _resolve_upstream_root(file_path, params.upstream_data_dirs)
 
                 runner._process_single_file(
-                    _build_file_params(params, tmp_file, Path(td), output_path, td)
+                    _build_file_params(params, file_path, input_path, output_path, str(input_path))
                 )
+            else:
+                reduce_key = params.action_config.get("reduce_key")
+                logger.debug(
+                    "Merging %d files for %s (reduce_key=%s)",
+                    len(file_paths),
+                    relative_path,
+                    reduce_key or "auto",
+                )
+                merged_data = merge_json_files(file_paths, reduce_key=reduce_key)
 
-        files_processed_count += 1
+                # TemporaryDirectory instead of in-place overwrite: the old approach
+                # (overwrite + restore in finally) left corrupt files on SIGKILL.
+                with tempfile.TemporaryDirectory() as td:
+                    tmp_file = Path(td) / relative_path
+                    tmp_file.parent.mkdir(parents=True, exist_ok=True)
+                    atomic_json_write(tmp_file, merged_data, fsync=False)
+
+                    runner._process_single_file(
+                        _build_file_params(params, tmp_file, Path(td), output_path, td)
+                    )
+
+            files_processed_count += 1
+        except Exception as e:
+            error_msg = f"{relative_path}: {e}"
+            processing_errors.append(error_msg)
+            logger.warning(
+                "Failed to process merged file %s: %s",
+                relative_path,
+                e,
+                exc_info=True,
+            )
+
         if _file_limit_reached(params.action_config, files_processed_count, params.action_name):
             break
+
+    if processing_errors and files_seen > 0:
+        logger.error(
+            "Merged file processing incomplete for %s: %d/%d files processed. Errors: %s",
+            params.action_name,
+            files_processed_count,
+            files_seen,
+            "; ".join(processing_errors[:3]),
+        )
 
     return files_processed_count
 

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -51,18 +51,23 @@ def _log_processing_errors(
     """Log a summary when some files failed processing."""
     if not processing_errors or total == 0:
         return
+    error_count = len(processing_errors)
+    sample = "; ".join(processing_errors[:3])
+    suffix = f" (and {error_count - 3} more)" if error_count > 3 else ""
     logger.error(
-        "%s incomplete for %s: %d/%d files processed. Errors: %s",
+        "%s incomplete for %s: %d/%d files processed (%d errors). Errors: %s%s",
         context,
         action_name,
         processed,
         total,
-        "; ".join(processing_errors[:3]),
+        error_count,
+        sample,
+        suffix,
         extra={
             "action_name": action_name,
             "files_found": total,
             "files_processed": processed,
-            "error_count": len(processing_errors),
+            "error_count": error_count,
         },
     )
 

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -67,6 +67,21 @@ def _log_processing_errors(
     )
 
 
+def _raise_all_files_failed(action_name: str, files_found: int, upstream_dirs: list[str]) -> None:
+    """Raise DependencyError when files were found but all failed processing."""
+    from agent_actions.errors import DependencyError
+
+    raise DependencyError(
+        f"Action '{action_name}': Found {files_found} files but failed to process any. "
+        f"Check logs for details.",
+        context={
+            "action": action_name,
+            "files_found": files_found,
+            "upstream_dirs": upstream_dirs,
+        },
+    )
+
+
 def _file_limit_reached(action_config: dict, count: int, action_name: str) -> bool:
     """Return True (and log) if file_limit has been reached."""
     file_limit = action_config.get("file_limit")
@@ -183,8 +198,13 @@ def process_directory_files(
     input_directory: str,
     params: FileProcessParams,
     processed_paths: set,
-) -> int:
-    """Process all files in a single directory. Returns count of files processed."""
+) -> tuple[int, int]:
+    """Process all files in a single directory.
+
+    Returns:
+        (files_found, files_processed) so callers can distinguish
+        "no files" from "all files failed".
+    """
     count = 0
     processing_errors: list[str] = []
     files_seen = 0
@@ -217,11 +237,16 @@ def process_directory_files(
     _log_processing_errors(
         processing_errors, count, files_seen, params.action_name, "Directory processing"
     )
-    return count
+    return (files_seen, count)
 
 
-def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> int:
-    """Process files from multiple upstream directories with content merging."""
+def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> tuple[int, int]:
+    """Process files from multiple upstream directories with content merging.
+
+    Returns:
+        (files_found, files_processed) so callers can distinguish
+        "no files" from "all files failed".
+    """
     output_path = Path(params.output_directory)
     files_by_path = runner._collect_files_from_upstream(params.upstream_data_dirs)
     files_processed_count = 0
@@ -280,7 +305,7 @@ def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> int
         params.action_name,
         "Merged file processing",
     )
-    return files_processed_count
+    return (files_seen, files_processed_count)
 
 
 def _resolve_upstream_root(file_path: Path, upstream_data_dirs: list[str]) -> Path:
@@ -421,17 +446,7 @@ def process_files(runner: ActionRunner, params: FileProcessParams) -> None:
             if files_found > 0:
                 # Data was found in DB but processing failed
                 # Don't fall through to filesystem (virtual paths don't exist)
-                from agent_actions.errors import DependencyError
-
-                raise DependencyError(
-                    f"Action '{params.action_name}': Found {files_found} files in storage "
-                    f"backend but failed to process any. Check logs for details.",
-                    context={
-                        "action": params.action_name,
-                        "files_found": files_found,
-                        "upstream_dirs": params.upstream_data_dirs,
-                    },
-                )
+                _raise_all_files_failed(params.action_name, files_found, params.upstream_data_dirs)
             # Fall through to filesystem if backend had no data
 
     if len(params.upstream_data_dirs) > 1:
@@ -448,12 +463,15 @@ def process_files(runner: ActionRunner, params: FileProcessParams) -> None:
         else:
             logger.info("Multiple dependencies detected: %s. Merging all inputs.", dep_names)
 
-        files_processed_count = process_merged_files(runner, params)
-        if files_processed_count == 0:
+        files_found, files_processed = process_merged_files(runner, params)
+        if files_processed == 0:
+            if files_found > 0:
+                _raise_all_files_failed(params.action_name, files_found, params.upstream_data_dirs)
             warn_no_files_found(params)
         return
 
-    files_processed_count = 0
+    total_found = 0
+    total_processed = 0
     output_path = Path(params.output_directory)
     processed_relative_paths: set = set()
 
@@ -463,9 +481,13 @@ def process_files(runner: ActionRunner, params: FileProcessParams) -> None:
             logger.warning("Upstream directory not found: %s", input_directory)
             continue
 
-        files_processed_count += process_directory_files(
+        found, processed = process_directory_files(
             runner, input_path, output_path, input_directory, params, processed_relative_paths
         )
+        total_found += found
+        total_processed += processed
 
-    if files_processed_count == 0:
+    if total_processed == 0:
+        if total_found > 0:
+            _raise_all_files_failed(params.action_name, total_found, params.upstream_data_dirs)
         warn_no_files_found(params)

--- a/docs.agent-actions/docs/guides/troubleshooting.md
+++ b/docs.agent-actions/docs/guides/troubleshooting.md
@@ -48,6 +48,25 @@ ProcessingError: Failed to process item
 | `source_guid` | UUID of the record being processed |
 | `agent_name` | Action that failed |
 
+### RecordContextError (Record Namespace)
+
+Occurs when a downstream action tries to read fields from an upstream action's output, but the expected fields are missing. This typically means the upstream action stored corrupted or empty data.
+
+```
+[RECORD NAMESPACE] 'generate_optimal_code': declared fields ['optimal_code'] not found.
+Available: ['title', 'type', 'properties', 'required', 'additionalProperties']
+```
+
+**Common causes:**
+
+| Cause | What happened | Fix |
+|-------|--------------|-----|
+| Schema-echo | LLM returned the JSON Schema definition instead of data | Enable `on_schema_mismatch: reprompt` — the validator now detects schema-echo payloads and triggers reprompt |
+| Empty object | LLM returned `{}` | Same fix — empty objects are now rejected when the schema declares fields |
+| Existing poison | Bad data already in `target_data` from a previous run | Re-run the upstream action with reprompt enabled, or manually clean the SQLite row |
+
+**Behavior:** When a single record has corrupted namespace data, that record is skipped and processing continues for the remaining records in the file. The skipped record is logged at WARNING level. This prevents one bad record from failing an entire file of valid records.
+
 ### AgentActionsError
 
 Top-level agentic workflow failure. This wraps other errors to provide the full context of what went wrong.

--- a/docs.agent-actions/docs/reference/validation/output-validation.md
+++ b/docs.agent-actions/docs/reference/validation/output-validation.md
@@ -137,6 +137,26 @@ properties:
     # Rejects: [] (empty) or arrays with 11+ items
 ```
 
+### Schema-Echo and Empty-Object Detection
+
+Beyond type and field checks, schema validation detects two common LLM failure modes that produce valid JSON but useless data:
+
+**Schema-echo** — The model returns the JSON Schema definition itself instead of conforming data. For example, given a schema expecting `{ optimal_code: string }`, the LLM returns:
+
+```json
+{"title": "InlineSchema", "type": "object", "properties": {"optimal_code": {"type": "string"}}, "required": [], "additionalProperties": false}
+```
+
+This is valid JSON and structurally matches a JSON object, but contains zero declared fields. The validator detects this by checking whether the output's top-level keys are JSON Schema meta-keys (`title`, `type`, `properties`, `required`, `additionalProperties`) rather than the expected output fields.
+
+**Empty object** — The model returns `{}`. This passes structural validation when no fields are `required`, but is semantically useless. The validator now rejects empty objects when the schema declares any output fields, even if none are marked required.
+
+Both failures trigger reprompt when `on_schema_mismatch: reprompt` is configured, giving the model another chance to produce valid output.
+
+:::note Meta-key nuance
+If your schema legitimately declares a field named `type` (or another JSON Schema keyword), outputs containing that field are **not** rejected. The check only triggers when the output has *zero* declared schema fields.
+:::
+
 ### Reprompt on Schema Failure
 
 When schema validation fails, reprompting retries with error context. Set `on_schema_mismatch: reprompt` inside the `reprompt` block to enable this:

--- a/docs.agent-actions/docs/reference/validation/reprompting.md
+++ b/docs.agent-actions/docs/reference/validation/reprompting.md
@@ -284,6 +284,10 @@ Options:
 - Improve prompt clarity
 - Use more capable model
 
+### Schema-Echo or Empty Response
+
+If the LLM returns the JSON Schema definition itself (a "schema-echo") or an empty `{}`, the validator treats this as a schema failure and triggers reprompt. The retry feedback includes the expected field names so the model understands what to produce. This is most common with smaller/local models (e.g., via Ollama) that have weaker instruction following.
+
 ### Persistent Validation Failure
 
 Some responses may never validate—this is a limitation of reprompting. If the model fundamentally can't produce what you're asking for, no amount of retries will help. Consider:

--- a/tests/unit/workflow/test_limits.py
+++ b/tests/unit/workflow/test_limits.py
@@ -64,8 +64,10 @@ class TestFileLimitDirectoryFiles:
         params.idx = 0
         params.file_type_filter = None
 
-        count = process_directory_files(runner, input_dir, output, str(input_dir), params, set())
-        assert count == 2
+        _found, processed = process_directory_files(
+            runner, input_dir, output, str(input_dir), params, set()
+        )
+        assert processed == 2
         assert runner._process_single_file.call_count == 2
 
     def test_no_file_limit_processes_all(self, tmp_path):
@@ -85,8 +87,10 @@ class TestFileLimitDirectoryFiles:
         params.idx = 0
         params.file_type_filter = None
 
-        count = process_directory_files(runner, input_dir, output, str(input_dir), params, set())
-        assert count == 5
+        _found, processed = process_directory_files(
+            runner, input_dir, output, str(input_dir), params, set()
+        )
+        assert processed == 5
 
     def test_file_limit_greater_than_total(self, tmp_path):
         input_dir = tmp_path / "input"
@@ -105,8 +109,10 @@ class TestFileLimitDirectoryFiles:
         params.idx = 0
         params.file_type_filter = None
 
-        count = process_directory_files(runner, input_dir, output, str(input_dir), params, set())
-        assert count == 3
+        _found, processed = process_directory_files(
+            runner, input_dir, output, str(input_dir), params, set()
+        )
+        assert processed == 3
 
 
 # ── file_limit in process_merged_files ────────────────────────────────
@@ -136,8 +142,8 @@ class TestFileLimitMergedFiles:
         params.strategy = MagicMock()
         params.idx = 0
 
-        count = process_merged_files(runner, params)
-        assert count == 2
+        _found, processed = process_merged_files(runner, params)
+        assert processed == 2
         assert runner._process_single_file.call_count == 2
 
 

--- a/tests/unit/workflow/test_runner_file_processing_merge.py
+++ b/tests/unit/workflow/test_runner_file_processing_merge.py
@@ -9,9 +9,10 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
-
-from agent_actions.workflow.runner_file_processing import process_merged_files
+from agent_actions.workflow.runner_file_processing import (
+    process_directory_files,
+    process_merged_files,
+)
 
 
 def _make_params(upstream_dirs, output_dir, action_config=None):
@@ -78,8 +79,9 @@ class TestProcessMergedFilesDoesNotMutateUpstream:
 
         params = _make_params([str(upstream_a), str(upstream_b)], output)
 
-        with pytest.raises(RuntimeError, match="processing failed"):
-            process_merged_files(runner, params)
+        # Error is now caught per-file (no propagation), returns 0 processed
+        result = process_merged_files(runner, params)
+        assert result == 0
 
         # Upstream files must still be unchanged
         assert json.loads((upstream_a / "data.json").read_text()) == original_a
@@ -129,8 +131,8 @@ class TestProcessMergedFilesDoesNotMutateUpstream:
 
         params = _make_params([str(upstream_a), str(upstream_b)], output)
 
-        with pytest.raises(RuntimeError, match="boom"):
-            process_merged_files(runner, params)
+        # Error is now caught per-file (no propagation)
+        process_merged_files(runner, params)
 
         remaining = list(upstream_a.glob("tmp*"))
         assert remaining == [], f"Temp files leaked on error: {remaining}"
@@ -163,3 +165,97 @@ class TestProcessMergedFilesDoesNotMutateUpstream:
         assert relative == Path("data.json"), (
             f"Output filename should be 'data.json', got '{relative}'"
         )
+
+
+# ---------------------------------------------------------------------------
+# File-level error isolation (spec #43 Fix 2)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessDirectoryFilesIsolation:
+    """One failing file must not block processing of remaining files."""
+
+    def test_continues_after_single_file_failure(self, tmp_path):
+        """3 files, middle one fails → 2 processed, 1 error logged."""
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        for name in ["a.json", "b.json", "c.json"]:
+            (input_dir / name).write_text(json.dumps([{"id": name}]))
+
+        call_count = 0
+
+        def _process(single_params):
+            nonlocal call_count
+            call_count += 1
+            rel = single_params.locations.item.name
+            if rel == "b.json":
+                raise RuntimeError("record namespace failure on b.json")
+
+        runner = MagicMock()
+        runner._should_skip_item.return_value = False
+        runner._process_single_file.side_effect = _process
+
+        params = _make_params([str(input_dir)], output_dir)
+
+        processed = process_directory_files(
+            runner, input_dir, output_dir, str(input_dir), params, set()
+        )
+
+        assert processed == 2  # a.json + c.json
+        assert call_count == 3  # all 3 attempted
+
+    def test_all_files_succeed_returns_full_count(self, tmp_path):
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        for name in ["a.json", "b.json"]:
+            (input_dir / name).write_text(json.dumps([{"id": name}]))
+
+        runner = MagicMock()
+        runner._should_skip_item.return_value = False
+        runner._process_single_file = MagicMock()
+
+        params = _make_params([str(input_dir)], output_dir)
+
+        processed = process_directory_files(
+            runner, input_dir, output_dir, str(input_dir), params, set()
+        )
+
+        assert processed == 2
+
+
+class TestProcessMergedFilesIsolation:
+    """One failing merged file must not block the rest."""
+
+    def test_continues_after_one_merged_file_fails(self, tmp_path):
+        upstream = tmp_path / "upstream"
+        output = tmp_path / "output"
+        upstream.mkdir()
+        output.mkdir()
+
+        (upstream / "good.json").write_text(json.dumps([{"id": 1}]))
+        (upstream / "bad.json").write_text(json.dumps([{"id": 2}]))
+
+        def _process(single_params):
+            rel = str(single_params.locations.item.relative_to(single_params.locations.input_path))
+            if "bad" in rel:
+                raise RuntimeError("poisoned record")
+
+        runner = MagicMock()
+        runner._collect_files_from_upstream.return_value = {
+            Path("good.json"): [upstream / "good.json"],
+            Path("bad.json"): [upstream / "bad.json"],
+        }
+        runner._process_single_file.side_effect = _process
+
+        params = _make_params([str(upstream)], output)
+
+        result = process_merged_files(runner, params)
+
+        assert result == 1  # good.json processed, bad.json skipped
+        assert runner._process_single_file.call_count == 2

--- a/tests/unit/workflow/test_runner_file_processing_merge.py
+++ b/tests/unit/workflow/test_runner_file_processing_merge.py
@@ -80,8 +80,9 @@ class TestProcessMergedFilesDoesNotMutateUpstream:
         params = _make_params([str(upstream_a), str(upstream_b)], output)
 
         # Error is now caught per-file (no propagation), returns 0 processed
-        result = process_merged_files(runner, params)
-        assert result == 0
+        files_found, files_processed = process_merged_files(runner, params)
+        assert files_processed == 0
+        assert files_found == 1
 
         # Upstream files must still be unchanged
         assert json.loads((upstream_a / "data.json").read_text()) == original_a
@@ -200,11 +201,12 @@ class TestProcessDirectoryFilesIsolation:
 
         params = _make_params([str(input_dir)], output_dir)
 
-        processed = process_directory_files(
+        files_found, files_processed = process_directory_files(
             runner, input_dir, output_dir, str(input_dir), params, set()
         )
 
-        assert processed == 2  # a.json + c.json
+        assert files_processed == 2  # a.json + c.json
+        assert files_found == 3  # all 3 seen
         assert call_count == 3  # all 3 attempted
 
     def test_all_files_succeed_returns_full_count(self, tmp_path):
@@ -222,11 +224,12 @@ class TestProcessDirectoryFilesIsolation:
 
         params = _make_params([str(input_dir)], output_dir)
 
-        processed = process_directory_files(
+        files_found, files_processed = process_directory_files(
             runner, input_dir, output_dir, str(input_dir), params, set()
         )
 
-        assert processed == 2
+        assert files_found == 2
+        assert files_processed == 2
 
 
 class TestProcessMergedFilesIsolation:
@@ -255,7 +258,8 @@ class TestProcessMergedFilesIsolation:
 
         params = _make_params([str(upstream)], output)
 
-        result = process_merged_files(runner, params)
+        files_found, files_processed = process_merged_files(runner, params)
 
-        assert result == 1  # good.json processed, bad.json skipped
+        assert files_found == 2
+        assert files_processed == 1  # good.json processed, bad.json skipped
         assert runner._process_single_file.call_count == 2

--- a/tests/unit/workflow/test_runner_file_processing_merge.py
+++ b/tests/unit/workflow/test_runner_file_processing_merge.py
@@ -263,3 +263,37 @@ class TestProcessMergedFilesIsolation:
         assert files_found == 2
         assert files_processed == 1  # good.json processed, bad.json skipped
         assert runner._process_single_file.call_count == 2
+
+    def test_continues_after_merge_branch_failure(self, tmp_path):
+        """Error in the len>1 merge path (merge_json_files + tempfile) is isolated."""
+        upstream_a = tmp_path / "upstream_a"
+        upstream_b = tmp_path / "upstream_b"
+        output = tmp_path / "output"
+        for d in [upstream_a, upstream_b, output]:
+            d.mkdir()
+
+        (upstream_a / "good.json").write_text(json.dumps([{"id": 1}]))
+        (upstream_a / "bad.json").write_text(json.dumps([{"id": 10}]))
+        (upstream_b / "bad.json").write_text(json.dumps([{"id": 20}]))
+
+        def _process(single_params):
+            rel = single_params.locations.item.name
+            if rel == "bad.json":
+                raise RuntimeError("merge branch failure")
+
+        runner = MagicMock()
+        runner._collect_files_from_upstream.return_value = {
+            # good.json: single-file path (len==1)
+            Path("good.json"): [upstream_a / "good.json"],
+            # bad.json: merge path (len==2)
+            Path("bad.json"): [upstream_a / "bad.json", upstream_b / "bad.json"],
+        }
+        runner._process_single_file.side_effect = _process
+
+        params = _make_params([str(upstream_a), str(upstream_b)], output)
+
+        files_found, files_processed = process_merged_files(runner, params)
+
+        assert files_found == 2
+        assert files_processed == 1  # good.json ok, bad.json (merged) failed
+        assert runner._process_single_file.call_count == 2

--- a/tests/validation/test_schema_output_validator.py
+++ b/tests/validation/test_schema_output_validator.py
@@ -458,8 +458,34 @@ class TestMetaKeyFalsePositive:
         }
         output = {"answer": "yes", "type": "object"}  # 'type' is extra but 'answer' matches
         report = validate_output_against_schema(output, schema, "test_action")
-        # Has at least one declared field → not a zero-declared-fields failure
-        assert any("answer" in f for f in report.actual_fields)
+        assert report.is_compliant
+        assert not any("Schema-echo" in e for e in report.validation_errors)
+        assert not any("No declared fields" in e for e in report.validation_errors)
+
+
+class TestInlineSchemaFormat:
+    """Inline schema shorthand: keys are field names, values are type strings."""
+
+    def test_inline_schema_extracts_fields(self):
+        schema = {"optimal_code": "string", "score": "number"}
+        output = {"optimal_code": "const x = 1;", "score": 95}
+        report = validate_output_against_schema(output, schema, "generate_code")
+        assert report.is_compliant
+        assert report.expected_fields == {"optimal_code", "score"}
+
+    def test_inline_schema_rejects_empty_output(self):
+        schema = {"optimal_code": "string"}
+        report = validate_output_against_schema({}, schema, "generate_code")
+        assert not report.is_compliant
+        assert any("Empty object" in e for e in report.validation_errors)
+
+    def test_inline_schema_excludes_name_and_description(self):
+        """'name' and 'description' are meta-keys, not output fields."""
+        schema = {"name": "my_schema", "description": "does stuff", "result": "string"}
+        output = {"result": "hello"}
+        report = validate_output_against_schema(output, schema, "test_action")
+        assert report.is_compliant
+        assert report.expected_fields == {"result"}
 
 
 class TestNamespacedKeyHint:

--- a/tests/validation/test_schema_output_validator.py
+++ b/tests/validation/test_schema_output_validator.py
@@ -244,7 +244,12 @@ class TestValidateOutputAgainstSchema:
         assert "name" in report.missing_required
 
     def test_fields_format_no_required_anywhere(self):
-        """Fields with no required annotation and no top-level array are optional."""
+        """Empty output fails when schema declares fields, even if none are required.
+
+        An empty object is semantically useless when fields are declared — the
+        LLM produced nothing.  This guards against {} slipping through when
+        ``required`` is empty (see spec #43).
+        """
         schema = {
             "name": "test_schema",
             "fields": [
@@ -252,13 +257,12 @@ class TestValidateOutputAgainstSchema:
                 {"id": "age", "type": "number"},
             ],
         }
-        output = {}  # All missing but all optional
+        output = {}  # All missing — now rejected even without required
 
         report = validate_output_against_schema(output, schema, "test_action")
 
-        assert report.is_compliant
-        assert "name" in report.missing_optional
-        assert "age" in report.missing_optional
+        assert not report.is_compliant
+        assert any("Empty object" in e for e in report.validation_errors)
 
     def test_fields_format_top_level_unknown_field_ignored(self):
         """Top-level required referencing a non-existent field ID is ignored."""
@@ -338,6 +342,124 @@ class TestValidateAndRaiseIfInvalid:
 
         error = exc_info.value
         assert "extra" in error.extra_fields
+
+
+# ---------------------------------------------------------------------------
+# Schema-echo / empty-object detection (spec #43)
+# ---------------------------------------------------------------------------
+
+# Fixture: exact schema-echo payload from bug evidence
+SCHEMA_ECHO_PAYLOAD = {
+    "title": "InlineSchema",
+    "type": "object",
+    "properties": {"optimal_code": {"type": "string"}},
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+class TestSchemaEchoRejection:
+    """LLM returns the JSON Schema definition itself instead of conforming data."""
+
+    def test_schema_echo_is_non_compliant(self):
+        schema = {
+            "name": "code_schema",
+            "properties": {"optimal_code": {"type": "string"}},
+            "required": ["optimal_code"],
+        }
+        report = validate_output_against_schema(
+            SCHEMA_ECHO_PAYLOAD, schema, "generate_optimal_code"
+        )
+        assert not report.is_compliant
+        assert any("Schema-echo" in e for e in report.validation_errors)
+        assert "optimal_code" not in report.actual_fields
+
+    def test_schema_echo_with_optional_fields(self):
+        """Schema-echo fails even when no fields are required."""
+        schema = {
+            "name": "code_schema",
+            "properties": {"optimal_code": {"type": "string"}},
+        }
+        report = validate_output_against_schema(
+            SCHEMA_ECHO_PAYLOAD, schema, "generate_optimal_code"
+        )
+        assert not report.is_compliant
+        assert any("Schema-echo" in e for e in report.validation_errors)
+
+    def test_schema_echo_fields_format(self):
+        """Schema-echo detected for fields-format schemas too."""
+        schema = {
+            "name": "code_schema",
+            "fields": [{"id": "optimal_code", "type": "string", "required": True}],
+        }
+        report = validate_output_against_schema(
+            SCHEMA_ECHO_PAYLOAD, schema, "generate_optimal_code"
+        )
+        assert not report.is_compliant
+        assert any("Schema-echo" in e for e in report.validation_errors)
+
+
+class TestEmptyObjectRejection:
+    """LLM returns {} when schema declares fields."""
+
+    def test_empty_dict_rejected_with_required_fields(self):
+        schema = {
+            "name": "quote_schema",
+            "properties": {"final_source_quote": {"type": "string"}},
+            "required": ["final_source_quote"],
+        }
+        report = validate_output_against_schema({}, schema, "consolidate_answer")
+        assert not report.is_compliant
+        assert any("Empty object" in e for e in report.validation_errors)
+
+    def test_empty_dict_rejected_even_without_required(self):
+        """Empty {} fails even when schema has no required fields (spec #43)."""
+        schema = {
+            "name": "quote_schema",
+            "properties": {"final_source_quote": {"type": "string"}},
+        }
+        report = validate_output_against_schema({}, schema, "consolidate_answer")
+        assert not report.is_compliant
+        assert any("Empty object" in e for e in report.validation_errors)
+
+    def test_empty_dict_ok_when_schema_has_no_fields(self):
+        """Schema with no declared fields: {} is valid (nothing expected)."""
+        schema = {"name": "empty_schema", "properties": {}}
+        report = validate_output_against_schema({}, schema, "noop_action")
+        assert report.is_compliant
+
+
+class TestMetaKeyFalsePositive:
+    """Schema that legitimately declares a field named 'type' or other meta-key."""
+
+    def test_legitimate_type_field_allowed(self):
+        """If schema declares 'type' as an output field, output with 'type' is valid."""
+        schema = {
+            "name": "classify_schema",
+            "properties": {
+                "type": {"type": "string"},
+                "confidence": {"type": "number"},
+            },
+            "required": ["type"],
+        }
+        output = {"type": "question", "confidence": 0.95}
+        report = validate_output_against_schema(output, schema, "classify")
+        assert report.is_compliant
+        assert not any("Schema-echo" in e for e in report.validation_errors)
+
+    def test_partial_declared_fields_present(self):
+        """Output has some declared fields — not a schema-echo even with extra meta-keys."""
+        schema = {
+            "name": "test_schema",
+            "properties": {
+                "answer": {"type": "string"},
+                "score": {"type": "number"},
+            },
+        }
+        output = {"answer": "yes", "type": "object"}  # 'type' is extra but 'answer' matches
+        report = validate_output_against_schema(output, schema, "test_action")
+        # Has at least one declared field → not a zero-declared-fields failure
+        assert any("answer" in f for f in report.actual_fields)
 
 
 class TestNamespacedKeyHint:

--- a/tests/workflow/test_runner.py
+++ b/tests/workflow/test_runner.py
@@ -409,10 +409,10 @@ class TestProcessDirectoryFiles:
             output_directory=str(output_dir),
             idx=0,
         )
-        count = runner._process_directory_files(
+        _found, processed = runner._process_directory_files(
             input_dir, output_dir, str(input_dir), params, set()
         )
-        assert count == 2
+        assert processed == 2
         assert strategy.execute.call_count == 2
 
     def test_skips_per_should_skip(self, runner, tmp_path):
@@ -432,10 +432,10 @@ class TestProcessDirectoryFiles:
             output_directory=str(output_dir),
             idx=0,
         )
-        count = runner._process_directory_files(
+        _found, processed = runner._process_directory_files(
             input_dir, output_dir, str(input_dir), params, set()
         )
-        assert count == 1
+        assert processed == 1
 
 
 # ---------------------------------------------------------------------------
@@ -496,8 +496,8 @@ class TestProcessMergedFiles:
             output_directory=str(output),
             idx=0,
         )
-        count = runner._process_merged_files(params)
-        assert count == 1
+        _found, processed = runner._process_merged_files(params)
+        assert processed == 1
         strategy.execute.assert_called_once()
 
     @patch("agent_actions.workflow.runner_file_processing.merge_json_files")
@@ -518,8 +518,8 @@ class TestProcessMergedFiles:
             output_directory=str(output),
             idx=0,
         )
-        count = runner._process_merged_files(params)
-        assert count == 1
+        _found, processed = runner._process_merged_files(params)
+        assert processed == 1
         mock_merge.assert_called_once()
         strategy.execute.assert_called_once()
 
@@ -815,7 +815,7 @@ class TestProcessFiles:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        with pytest.raises(DependencyError, match="Found .* files in storage"):
+        with pytest.raises(DependencyError, match="Found .* files but failed to process"):
             runner_with_backend.process_files(params)
 
     def test_storage_backend_no_data_falls_through(self, runner_with_backend, tmp_path):


### PR DESCRIPTION
## Summary

- **Fix 1 (prevention):** Reject schema-echo and empty-object LLM responses before storage. When a schema declares fields but the output contains none of them (zero declared fields present), the response is marked non-compliant and triggers reprompt. Detects three patterns: schema-echo (output keys are JSON Schema meta-keys), empty object (`{}`), and outputs with no matching declared fields.
- **Fix 2 (blast radius):** Isolate file-level failures in `process_directory_files()` and `process_merged_files()` so one bad file does not halt the entire directory walk. Matches the per-file error handling already in `process_from_storage_backend()`.
- **Unification:** Replaced duplicate `_extract_field_names()` in `reprompt.py` with delegation to the canonical `_extract_schema_fields()` in `schema_output_validator.py`, which handles all 5 schema formats (the reprompt copy only handled 3). Unified file-level error isolation pattern across all three processing paths.

Spec: `specs/backlog/1-high/43-record-namespace-schema-echo-breaks-downstream.md`

## Verification

```
ruff format --check agent_actions tests  # 856 files already formatted
ruff check agent_actions tests           # All checks passed
pytest                                    # 6628 passed, 2 skipped
```

- Schema-echo payload (`{"title": "InlineSchema", ...}`) rejected for schema declaring `optimal_code`
- Empty `{}` rejected when schema declares fields (even with `required: []`)
- Legitimate `type` field in schema not false-positive rejected
- File processing continues after single file failure (2/3 processed when middle file fails)