### PR TITLE
React Flow workflow DAG in VS Code (shared docs transformer)

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260513-dag-reactflow.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260513-dag-reactflow.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Workflow DAG panel can render with React Flow using the same DAG→ReactFlow transformer as the docs site; optional Mermaid renderer remains via agentActions.dagRenderer."
+time: 2026-05-13T12:00:00.000000Z

--- a/agent_actions/tooling/docs/frontend/components/workflow-dag.tsx
+++ b/agent_actions/tooling/docs/frontend/components/workflow-dag.tsx
@@ -20,16 +20,20 @@ import {
 import "@xyflow/react/dist/style.css"
 import { ChevronDown, ChevronRight } from "lucide-react"
 import {
-  transformWorkflowToReactFlow,
+  adaptDocsActionsToDAGActions,
+  transformActionsToReactFlow,
+  DAG_LAYOUT_DEFAULTS,
+  type DAGAction,
   type DAGNodeData,
 } from "@/lib/dag-transformer"
 import type { Action } from "@/lib/mock-data"
 
 // ─── DAG Node (expandable to show fields) ────────────────────────
 
-function ExpandableDAGNode({ data, isConnectable, isLlm, selected }: { data: DAGNodeData; isConnectable: boolean; isLlm: boolean; selected: boolean }) {
+function ExpandableDAGNode({ data, isConnectable, selected }: { data: DAGNodeData; isConnectable: boolean; selected: boolean }) {
   const [expanded, setExpanded] = useState(false)
   const hasFields = data.inputFields.length > 0 || data.outputFields.length > 0
+  const isLlm = data.kind === "llm"
 
   return (
     <div className={`rounded-lg border-2 bg-card shadow hover:shadow-md transition-shadow w-[320px] ${
@@ -120,23 +124,26 @@ function ExpandableDAGNode({ data, isConnectable, isLlm, selected }: { data: DAG
 }
 
 function ModelNode({ data, isConnectable, selected }: NodeProps<Node<DAGNodeData>>) {
-  return <ExpandableDAGNode data={data} isConnectable={isConnectable ?? false} isLlm selected={selected ?? false} />
+  return <ExpandableDAGNode data={data} isConnectable={isConnectable ?? false} selected={selected ?? false} />
 }
 
 function ToolNode({ data, isConnectable, selected }: NodeProps<Node<DAGNodeData>>) {
-  return <ExpandableDAGNode data={data} isConnectable={isConnectable ?? false} isLlm={false} selected={selected ?? false} />
+  return <ExpandableDAGNode data={data} isConnectable={isConnectable ?? false} selected={selected ?? false} />
 }
 
 // ─── DAG Content ────────────────────────────────────────────────────────────
 
-function DAGContent({
-  actions,
-  workflowId,
+/** Shared ReactFlow DAG body for Docs and the VS Code webview (same transform path). */
+export function WorkflowDAGRuntime({
+  dagActions,
+  direction,
   onNodeClick,
+  disableMinimap,
 }: {
-  actions: Record<string, Action>
-  workflowId: string
+  dagActions: DAGAction[]
+  direction: "LR" | "TB"
   onNodeClick?: (name: string) => void
+  disableMinimap?: boolean
 }) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
@@ -151,7 +158,11 @@ function DAGContent({
   )
 
   useEffect(() => {
-    const transformed = transformWorkflowToReactFlow(actions, workflowId)
+    const transformed = transformActionsToReactFlow(dagActions, {
+      direction,
+      unknownDeps: "filter",
+      ...DAG_LAYOUT_DEFAULTS,
+    })
 
     setNodes(transformed.nodes)
     setEdges(transformed.edges)
@@ -163,7 +174,7 @@ function DAGContent({
         // fitView can fail before render
       }
     }, 100)
-  }, [actions, workflowId, fitView, setNodes, setEdges])
+  }, [dagActions, direction, fitView, setNodes, setEdges])
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {
@@ -195,15 +206,17 @@ function DAGContent({
     >
       <Background gap={24} size={1} className="!bg-background" />
       <Controls className="!bg-card !border-border !shadow-md !rounded-lg" showInteractive={false} />
-      <MiniMap
-        nodeColor={(n) =>
-          n.type === "modelNode" ? "hsl(var(--chart-2))"
-          : n.type === "toolNode" ? "hsl(var(--success))"
-          : "hsl(var(--muted-foreground))"
-        }
-        className="!bg-card !border-border !rounded-lg"
-        nodeBorderRadius={4}
-      />
+      {!disableMinimap && (
+        <MiniMap
+          nodeColor={(n) =>
+            n.type === "modelNode" ? "hsl(var(--chart-2))"
+            : n.type === "toolNode" ? "hsl(var(--success))"
+            : "hsl(var(--muted-foreground))"
+          }
+          className="!bg-card !border-border !rounded-lg"
+          nodeBorderRadius={4}
+        />
+      )}
     </ReactFlow>
   )
 }
@@ -219,11 +232,16 @@ export function WorkflowDAGView({
   workflowId: string
   onNodeClick?: (name: string) => void
 }) {
+  const dagActions = useMemo(
+    () => adaptDocsActionsToDAGActions(actions, workflowId),
+    [actions, workflowId],
+  )
+
   // 280px ≈ top header (48px) + workflow detail header/tabs (~120px) + outer padding (112px)
   return (
     <div className="w-full rounded-xl border border-border bg-card overflow-hidden" style={{ height: 'clamp(300px, calc(100vh - 280px), 100vh)' }}>
       <ReactFlowProvider>
-        <DAGContent actions={actions} workflowId={workflowId} onNodeClick={onNodeClick} />
+        <WorkflowDAGRuntime dagActions={dagActions} direction="LR" onNodeClick={onNodeClick} />
       </ReactFlowProvider>
     </div>
   )

--- a/agent_actions/tooling/docs/frontend/lib/dag-transformer.ts
+++ b/agent_actions/tooling/docs/frontend/lib/dag-transformer.ts
@@ -2,6 +2,66 @@ import dagre from "dagre"
 import type { Node, Edge } from "@xyflow/react"
 import type { Action } from "./mock-data"
 
+// ─── Shared action shape (Docs + VS Code) ───────────────────────────────────
+
+export type DAGActionKind = "llm" | "tool" | "unknown"
+
+export type DAGActionStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "skipped"
+
+export interface DAGAction {
+  name: string
+  deps: string[]
+  kind: DAGActionKind
+  intent?: string
+  model?: string
+  impl?: string
+  status?: DAGActionStatus
+  inputs?: string[]
+  observe?: string[]
+  outputs?: string[]
+  outputFields?: string[]
+  drops?: string[]
+}
+
+/** Minimal shape the VS Code host sends; kept UI-agnostic (no vscode types). */
+export interface VsCodeDagActionInput {
+  name: string
+  dependencies: string[]
+  kind?: DAGActionKind
+  status?: DAGActionStatus
+  intent?: string
+  model?: string
+  impl?: string
+  inputs?: string[]
+  observe?: string[]
+  outputs?: string[]
+  outputFields?: string[]
+  drops?: string[]
+}
+
+export const DAG_LAYOUT_DEFAULTS = {
+  nodeWidth: 320,
+  nodeHeight: 100,
+  nodesep: 120,
+  ranksep: 240,
+} as const
+
+export type UnknownDepsPolicy = "filter" | "materialize"
+
+export interface TransformActionsToReactFlowOptions {
+  direction: "LR" | "TB"
+  unknownDeps?: UnknownDepsPolicy
+  nodeWidth?: number
+  nodeHeight?: number
+  nodesep?: number
+  ranksep?: number
+}
+
 // ─── Provider detection ──────────────────────────────────────────────────────
 
 function getProvider(model?: string): string {
@@ -13,7 +73,7 @@ function getProvider(model?: string): string {
   return "unknown"
 }
 
-// ─── Field extraction ────────────────────────────────────────────────────────
+// ─── Field extraction (docs Action records) ────────────────────────────────
 
 export function extractActionFields(action: Action) {
   const inputFieldSet = new Set<string>()
@@ -35,10 +95,33 @@ export function extractActionFields(action: Action) {
   return { inputFields, outputFields, droppedFields }
 }
 
-// ─── DAG view (action-level nodes) ──────────────────────────────────────────
+function collectFieldArraysFromDAGAction(a: DAGAction): {
+  inputFields: string[]
+  outputFields: string[]
+  droppedFields: string[]
+} {
+  const inputFieldSet = new Set<string>()
+  for (const field of a.inputs ?? []) inputFieldSet.add(field)
+  for (const field of a.observe ?? []) inputFieldSet.add(field)
+  const inputFields = Array.from(inputFieldSet)
+
+  let outputFields: string[] = []
+  if ((a.outputFields?.length ?? 0) > 0) {
+    outputFields = [...(a.outputFields ?? [])]
+  } else if ((a.outputs?.length ?? 0) > 0) {
+    outputFields = [...(a.outputs ?? [])]
+  }
+
+  const droppedFields = [...(a.drops ?? [])]
+  return { inputFields, outputFields, droppedFields }
+}
+
+// ─── DAG node render payload ────────────────────────────────────────────────
 
 export interface DAGNodeData {
   label: string
+  kind: DAGActionKind
+  status?: DAGActionStatus
   model: string
   provider: string
   impl: string
@@ -49,38 +132,134 @@ export interface DAGNodeData {
   [key: string]: unknown
 }
 
-export function buildDAGNodesAndEdges(actions: Record<string, Action>, workflowId: string) {
+function dagActionToNodeData(a: DAGAction): DAGNodeData {
+  const provider =
+    a.kind === "llm" ? getProvider(a.model) : a.kind === "tool" ? "Tool" : "Unknown"
+  const { inputFields, outputFields, droppedFields } = collectFieldArraysFromDAGAction(a)
+  return {
+    label: a.name,
+    kind: a.kind,
+    status: a.status,
+    model: a.model ?? "unknown",
+    provider,
+    impl: a.impl ?? "tool",
+    description: a.intent ?? "",
+    inputFields,
+    outputFields,
+    droppedFields,
+  }
+}
+
+function reactFlowNodeType(kind: DAGActionKind): "modelNode" | "toolNode" {
+  return kind === "llm" ? "modelNode" : "toolNode"
+}
+
+// ─── Adapters ───────────────────────────────────────────────────────────────
+
+export function adaptDocsActionsToDAGActions(
+  actions: Record<string, Action>,
+  workflowId: string,
+): DAGAction[] {
+  const out: DAGAction[] = []
+  for (const [name, action] of Object.entries(actions)) {
+    if (action.wf !== workflowId) continue
+    out.push({
+      name,
+      deps: [...action.deps],
+      kind: action.type === "llm" ? "llm" : "tool",
+      intent: action.intent,
+      model: action.model,
+      impl: action.impl,
+      inputs: action.inputs,
+      observe: action.observe,
+      outputs: action.outputs,
+      outputFields: action.outputFields.map((f) => f.name),
+      drops: action.drops,
+    })
+  }
+  return out
+}
+
+export function adaptVsCodeDagInputsToDAGActions(actions: VsCodeDagActionInput[]): DAGAction[] {
+  return actions.map((a) => ({
+    name: a.name,
+    deps: [...a.dependencies],
+    kind: a.kind ?? "tool",
+    intent: a.intent,
+    model: a.model,
+    impl: a.impl,
+    status: a.status,
+    inputs: a.inputs,
+    observe: a.observe,
+    outputs: a.outputs,
+    outputFields: a.outputFields,
+    drops: a.drops,
+  }))
+}
+
+// ─── Build graph + layout ───────────────────────────────────────────────────
+
+export function transformActionsToReactFlow(
+  actions: DAGAction[],
+  opts: TransformActionsToReactFlowOptions,
+): { nodes: Node<DAGNodeData>[]; edges: Edge[] } {
+  const unknownDeps = opts.unknownDeps ?? "filter"
+  const nodeWidth = opts.nodeWidth ?? DAG_LAYOUT_DEFAULTS.nodeWidth
+  const nodeHeight = opts.nodeHeight ?? DAG_LAYOUT_DEFAULTS.nodeHeight
+  const nodesep = opts.nodesep ?? DAG_LAYOUT_DEFAULTS.nodesep
+  const ranksep = opts.ranksep ?? DAG_LAYOUT_DEFAULTS.ranksep
+
+  const nameSet = new Set(actions.map((a) => a.name))
+  const placeholderNames = new Set<string>()
+
+  if (unknownDeps === "materialize") {
+    for (const a of actions) {
+      for (const dep of a.deps) {
+        if (!nameSet.has(dep)) placeholderNames.add(dep)
+      }
+    }
+  }
+
   const nodes: Node<DAGNodeData>[] = []
+
+  for (const depName of placeholderNames) {
+    nodes.push({
+      id: depName,
+      type: "toolNode",
+      data: dagActionToNodeData({
+        name: depName,
+        deps: [],
+        kind: "unknown",
+        intent: "Unknown dependency (no matching action)",
+      }),
+      position: { x: 0, y: 0 },
+    })
+  }
+
+  for (const a of actions) {
+    nodes.push({
+      id: a.name,
+      type: reactFlowNodeType(a.kind),
+      data: dagActionToNodeData(a),
+      position: { x: 0, y: 0 },
+    })
+  }
+
   const edges: Edge[] = []
   let edgeId = 0
 
-  for (const [name, action] of Object.entries(actions)) {
-    if (action.wf !== workflowId) continue
-
-    const provider = action.type === "llm" ? getProvider(action.model) : "Tool"
-    const { inputFields, outputFields, droppedFields } = extractActionFields(action)
-
-    nodes.push({
-      id: name,
-      type: action.type === "llm" ? "modelNode" : "toolNode",
-      data: {
-        label: name,
-        model: action.model || "unknown",
-        provider,
-        impl: action.impl || "tool",
-        description: action.intent || "",
-        inputFields,
-        outputFields,
-        droppedFields,
-      },
-      position: { x: 0, y: 0 },
-    })
-
-    for (const dep of action.deps) {
+  for (const a of actions) {
+    for (const dep of a.deps) {
+      if (unknownDeps === "filter" && !nameSet.has(dep)) {
+        continue
+      }
+      if (unknownDeps === "materialize" && !nameSet.has(dep) && !placeholderNames.has(dep)) {
+        continue
+      }
       edges.push({
         id: `e${edgeId++}`,
         source: dep,
-        target: name,
+        target: a.name,
         type: "default",
         animated: false,
         style: { stroke: "hsl(var(--muted-foreground))", strokeWidth: 1.5, opacity: 0.7 },
@@ -88,15 +267,25 @@ export function buildDAGNodesAndEdges(actions: Record<string, Action>, workflowI
     }
   }
 
-  return { nodes, edges }
+  return applyDagreLayout(nodes, edges, {
+    direction: opts.direction,
+    nodeWidth,
+    nodeHeight,
+    nodesep,
+    ranksep,
+  })
 }
-
-// ─── Layout ─────────────────────────────────────────────────────────────────
 
 export function applyDagreLayout<T extends Record<string, unknown>>(
   nodes: Node<T>[],
   edges: Edge[],
-  opts: { direction?: "LR" | "TB"; nodeWidth?: number; nodeHeight?: number; nodesep?: number; ranksep?: number } = {},
+  opts: {
+    direction?: "LR" | "TB"
+    nodeWidth?: number
+    nodeHeight?: number
+    nodesep?: number
+    ranksep?: number
+  } = {},
 ) {
   const {
     direction = "LR",
@@ -117,7 +306,15 @@ export function applyDagreLayout<T extends Record<string, unknown>>(
     g.setEdge(edge.source, edge.target)
   }
 
-  dagre.layout(g)
+  try {
+    dagre.layout(g)
+  } catch {
+    const fallback = nodes.map((node, i) => ({
+      ...node,
+      position: { x: (i % 4) * (nodeWidth + 40), y: Math.floor(i / 4) * (nodeHeight + 40) },
+    }))
+    return { nodes: fallback, edges }
+  }
 
   const positioned = nodes.map((node) => {
     const pos = g.node(node.id)
@@ -133,10 +330,12 @@ export function applyDagreLayout<T extends Record<string, unknown>>(
   return { nodes: positioned, edges }
 }
 
-// ─── Public API ─────────────────────────────────────────────────────────────
-
+/** @deprecated Prefer `adaptDocsActionsToDAGActions` + `transformActionsToReactFlow` with explicit `direction`. */
 export function transformWorkflowToReactFlow(actions: Record<string, Action>, workflowId: string) {
-  const { nodes, edges } = buildDAGNodesAndEdges(actions, workflowId)
-  return applyDagreLayout(nodes, edges, { nodeWidth: 320, nodeHeight: 100, nodesep: 120, ranksep: 240 })
+  const dagActions = adaptDocsActionsToDAGActions(actions, workflowId)
+  return transformActionsToReactFlow(dagActions, {
+    direction: "LR",
+    unknownDeps: "filter",
+    ...DAG_LAYOUT_DEFAULTS,
+  })
 }
-

--- a/prompt-contracts/reactflow-dag-webview-shared-transformer.md
+++ b/prompt-contracts/reactflow-dag-webview-shared-transformer.md
@@ -1,0 +1,289 @@
+```markdown
+## Prompt Contract: Shared ReactFlow DAG (Docs + VS Code)
+
+### GOAL
+Add a ReactFlow-based workflow DAG inside the VS Code extension webview that reuses the existing docs DAG UI code, and refactor the docs DAG transformer so **both Docs and VS Code use one shared DAG→ReactFlow transform function** (single pathway for IDs, edge policy, and layout). The VS Code DAG must preserve current behaviors: workflow selection, `agentActions.dagLayout`, and click-to-open action config.
+
+### FAILURE MODES
+1. **CSS missing in VS Code webview**: `@xyflow/react/dist/style.css` isn’t bundled/loaded, causing broken layout/controls/minimap. The design must explicitly produce and load webview CSS assets.
+2. **Multiple React copies in the webview bundle**: React hooks break if the docs-imported components pull another React instance. The build must force React/ReactDOM singletons (reuse the existing aliasing approach in `vscode-extension/esbuild.js`).
+3. **Node ID mismatch breaks click-to-open**: VS Code must post the exact action name used by `WorkflowModel.getActionByName`. The shared transformer must not sanitize/alter IDs, and the webview must post the exact `node.id`.
+4. **Unknown dependencies crash or spam errors**: Some dependency names may not correspond to any action node. The transformer must define a policy: drop invalid edges (default) or materialize placeholder nodes (optional).
+5. **Cycles in dependency graph**: Graph may not be a strict DAG. The transformer must not throw; layout should be best-effort, with predictable behavior even if cycles exist.
+6. **Layout direction drift between Docs and VS Code**: Docs and VS Code could render different graphs if they each map “vertical/horizontal” differently. The shared transformer must accept an explicit `direction` and both callers must use it.
+7. **Theme readability regressions**: Webview must remain legible in light/dark/high-contrast. Node/edge colors must not assume a single theme.
+8. **Large graph perf cliff**: Big workflows can freeze the webview (layout + render). Must define a threshold behavior (warn/simplify) rather than unbounded work.
+9. **CSP/resource loading failures**: Webview may fail to load scripts/styles due to CSP or `localResourceRoots` misconfiguration. The host must set CSP with nonce and allow only local resources.
+10. **Policy drift over time**: Docs and VS Code accidentally reintroduce separate transforms. The code structure must make the shared transformer the obvious/only choice (named export; local wrappers only adapt input types).
+11. **Ambiguous action identity across workflows**: If two workflows expose the same `ActionInfo.name`, `getActionByName` may open the wrong config. Payload or lookup must be extended if this is possible in production data.
+
+### CONSTRAINTS
+- **Use the existing docs DAG components** (`agent_actions/tooling/docs/frontend/components/workflow-dag.tsx`) where practical, because reimplementing UI would diverge and defeat the “single pathway” intent.
+- **Single shared transformer** must live in `agent_actions/tooling/docs/frontend/lib/dag-transformer.ts` and be imported by both Docs and VS Code webview via the existing `@/…` alias, because the extension already resolves `@/` into the docs frontend and this avoids duplicating transformer logic.
+- **No remote assets** in webviews, because VS Code webviews must work offline and must not loosen CSP to allow CDNs.
+- **Preserve existing commands/config** (`agentActions.showDAG`, `agentActions.openConfig`, `agentActions.dagLayout`), because users already depend on these and Mermaid parity is the baseline.
+- **Do not introduce a second layout algorithm** (e.g. ELK) unless Dagre cannot meet requirements, because it increases bundle size and makes the “single pathway” harder to maintain.
+
+### FORMAT
+- **End-to-end context & data flows (Docs vs VS Code)**
+  - **Docs path**
+    - UI entry: `agent_actions/tooling/docs/frontend/components/workflow-dag.tsx`
+    - Data acquisition: docs catalog/context provides `Action` records; filter by `workflowId`
+    - Transform: `adaptDocsActionsToDAGActions(...)` → `transformActionsToReactFlow(...)`
+    - Render: `@xyflow/react` with docs nodeTypes (expandable node UI)
+  - **VS Code path**
+    - Host entry: `vscode-extension/src/views/dagWebview.ts` creates/reveals a `WebviewPanel`
+    - Data source: `WorkflowModel.getWorkflows()` → `WorkflowInfo.actions: ActionInfo[]`
+    - Transport: `panel.webview.postMessage({ type: "dag:update", payload })`
+    - Webview: `vscode-extension/src/webview/dag.tsx` adapts payload → `DAGAction[]` → shared transformer → ReactFlow render
+    - Control return: node click → `{ type: "openAction", actionName }` → host executes `agentActions.openConfig`
+  - **Boundary rule**
+    - Only the transformer owns node/edge construction + layout policy.
+    - Callers own: data acquisition, IPC transport, and node renderer components.
+
+- **Shared transformer API (single pathway)**
+  - Update `agent_actions/tooling/docs/frontend/lib/dag-transformer.ts` to export:
+    - `type DAGAction` (UI-agnostic action shape)
+    - `type DAGNodeData` (node render data; includes label, kind, optional status, and field lists)
+    - `function transformActionsToReactFlow(actions: DAGAction[], opts): { nodes, edges }`
+  - Transformer policy (must be enforced in one place):
+    - **IDs**: `node.id === action.name` (exact string; no sanitization).
+    - **Unknown deps policy**: `opts.unknownDeps` with default `"filter"`:
+      - `"filter"`: drop edges whose endpoints are missing.
+      - `"materialize"`: add placeholder nodes for missing endpoints.
+    - **Cycles**: do not throw; layout is best-effort.
+    - **Direction**: accept `opts.direction: "LR" | "TB"` and never infer it internally.
+    - **Layout defaults**: document and centralize defaults (nodeWidth/Height/nodesep/ranksep) so both surfaces evolve together.
+  - **Adapter responsibilities (explicit mapping rules)**
+    - Docs adapter must map:
+      - `Action.deps` → `DAGAction.deps`
+      - `Action.type ("llm" | "tool")` → `DAGAction.kind`
+      - `Action.intent` → `DAGAction.intent`
+      - `Action.model` / `Action.impl` → `DAGAction.model` / `DAGAction.impl`
+      - fields: `inputs/observe/outputs/outputFields/drops` → corresponding `DAGAction` arrays
+      - workflow scoping: filter to `workflowId` before transforming
+    - VS Code adapter must map (minimum viable):
+      - `ActionInfo.name` → `DAGAction.name`
+      - `ActionInfo.dependencies` → `DAGAction.deps`
+      - `ActionInfo.status` → `DAGAction.status`
+      - `ActionInfo.type` → `DAGAction.kind` (initially `"tool"` unless you later enrich with real tool-vs-LLM classification)
+      - optional: `ActionInfo.outputFields` → `DAGAction.outputFields` (flatten to string names)
+    - **Invariant**: adapters must not normalize/escape `name`; `name` is the stable key for click-to-open.
+
+- **Docs DAG wiring**
+  - Update `agent_actions/tooling/docs/frontend/components/workflow-dag.tsx` to:
+    - Adapt its existing `Action` records to `DAGAction[]`.
+    - Call `transformActionsToReactFlow` with the docs’ desired direction/defaults.
+  - Node rendering remains in Docs (expandable nodes, minimap, controls) but uses the shared transformer output.
+
+- **Centralization opportunities (Docs + VS Code shareable pieces)**
+  - **DAG adapter utilities**: add a small helper (either alongside the transformer or in a sibling `lib/`) that converts from “caller shapes” → `DAGAction[]`.
+    - Docs adapter: `Record<string, Action> + workflowId` → `DAGAction[]`
+    - VS Code adapter: `ActionInfo[]` (plus optional enriched fields) → `DAGAction[]`
+    - Rationale: keeps mapping rules (what counts as deps, what fields are shown, what’s “kind”) consistent; prevents each surface inventing its own inference logic.
+  - **Layout defaults**: keep layout constants (`nodeWidth/nodeHeight/nodesep/ranksep`) in one exported object so both surfaces stay visually consistent as spacing changes.
+  - **Status palette + edge styling tokens**: export a small `dagTheme` map (status→colors, edge stroke defaults) consumed by both node renderers so “completed/running/failed” reads the same everywhere.
+  - **Unknown-deps policy**: keep the “filter vs materialize” implementation inside the transformer (already required), but also centralize the *default* and document it so callers don’t diverge.
+  - **Message contract types (webview IPC)**: define and share TypeScript types for `{type:"ready" | "dag:update" | "openAction"}` payloads.
+    - Location options:
+      - extension-only: `vscode-extension/src/webview/ipc.ts` (safest if docs never needs it)
+      - shared with docs: a lightweight `agent_actions/tooling/docs/frontend/lib/vscode-webview-ipc.ts` imported by the VS Code webview bundle via `@/…`
+    - Rationale: prevents silent drift (renamed message types, missing fields) and makes refactors safe.
+  - **VS Code theme sync helper**: extract the existing CSS-variable→HSL mapping logic from `vscode-extension/src/webview/main.tsx` into `vscode-extension/src/webview/themeSync.ts`, and reuse in both Query Results and DAG webviews.
+    - Rationale: one place to maintain theme edge cases (high contrast, missing variables) and prevents partial copies.
+  - **Webview HTML shell builder**: factor out a shared helper in the extension host layer for building webview HTML with CSP+nonce+asset URIs (Query Results + DAG share the pattern).
+    - Location: `vscode-extension/src/views/webviewHtml.ts` (extension-only)
+    - Rationale: reduces repeated CSP mistakes and makes it easy to add new webviews.
+  - **Last-write-wins “ready gate”**: centralize the `ready` handshake and pending payload logic (Query Results already has it; DAG will need it).
+    - Location: `vscode-extension/src/views/webviewMessagePump.ts` (extension-only)
+    - Rationale: avoids each panel inventing a subtly broken “isReady boolean” flow; encapsulates queued update invariants.
+  - **What NOT to centralize (avoid coupling)**:
+    - Don’t share VS Code host-side `vscode.*` logic into docs frontend code (keeps docs build independent).
+    - Don’t share Next.js/React Router assumptions into the VS Code webview (it must be standalone).
+  - **Optional next step (if you want identical node UI)**
+    - Reuse docs node components in VS Code by importing `@/components/workflow-dag` into the webview bundle.
+    - Caveat: this couples the extension’s webview styling to docs tailwind tokens and xyflow CSS; treat docs frontend as a “design system” dependency if you do this.
+
+- **VS Code DAG webview**
+  - Add a new entrypoint `vscode-extension/src/webview/dag.tsx` that:
+    - Mounts a ReactFlow renderer (either reuse `WorkflowDAGView` directly or a thin VS Code wrapper).
+    - Receives `{ type: "dag:update", payload }` from the host.
+    - Adapts extension workflow actions to `DAGAction[]` and calls the shared transformer.
+    - Posts `{ type: "openAction", actionName }` on node click where `actionName === node.id`.
+    - Implements a `{ type: "ready" }` handshake so the host can defer updates until mounted.
+  - Theme handling:
+    - Prefer a small shared helper (copied or extracted from `src/webview/main.tsx`) to sync VS Code theme tokens to CSS variables used by the UI.
+
+- **VS Code host panel**
+  - Modify `vscode-extension/src/views/dagWebview.ts` to:
+    - Render a webview HTML shell that loads `out/dagWebview.js` (and CSS).
+    - Set CSP with nonce; load only local assets via `webview.asWebviewUri`.
+    - Set `localResourceRoots` to include `out/` and any other required directories.
+    - Handle messages:
+      - `openAction` → execute `agentActions.openConfig`.
+      - `ready` → mark the panel ready and send the latest payload (queue last-write-wins).
+    - On model change/theme change/layout setting change, send updates via `postMessage` (do not regenerate HTML each time).
+
+- **Build & packaging**
+  - Update `vscode-extension/esbuild.js`:
+    - Add a build context for `src/webview/dag.tsx` → `out/dagWebview.js`.
+    - Ensure React singleton aliasing applies to this bundle.
+    - Ensure CSS is emitted and loaded (choose one):
+      - **Preferred**: esbuild bundles CSS imports from `@xyflow/react/dist/style.css` into an output CSS file and the host loads it.
+      - **Acceptable**: a dedicated Tailwind-built `src/webview/dag.css` that includes required xyflow base styles (must be documented as a maintenance trade-off).
+  - Update `vscode-extension/package.json` to add runtime deps `@xyflow/react` and `dagre` (and types if needed).
+  - Update `vscode-extension/.vscodeignore` to include `out/dagWebview.js` and any CSS outputs.
+
+- **Webview IPC contract (explicit schema)**
+  - Host → webview:
+    - `{ type: "dag:update", payload: { workflowName: string; layout: "vertical"|"horizontal"; actions: Array<{ name: string; deps: string[]; kind: "llm"|"tool"|"unknown"; status?: "pending"|"running"|"completed"|"failed"|"skipped"; model?: string; impl?: string; intent?: string; inputs?: string[]; observe?: string[]; outputs?: string[]; outputFields?: string[]; drops?: string[]; }> } }`
+  - Webview → host:
+    - `{ type: "ready" }`
+    - `{ type: "openAction", actionName: string }`
+  - Host must treat messages as untrusted:
+    - validate `typeof actionName === "string"` and look it up in the model before executing `agentActions.openConfig`.
+
+- **CSP + resource loading requirements (concrete)**
+  - The DAG webview HTML shell must:
+    - set CSP with nonce for scripts
+    - load scripts/styles only via `webview.asWebviewUri(...)`
+    - avoid remote fonts/images/scripts entirely
+  - `localResourceRoots` must include the directory that contains:
+    - `out/dagWebview.js`
+    - the emitted css (if separate)
+
+- **Rollout / fallback strategy (risk control)**
+  - Preferred: introduce `agentActions.dagRenderer: "mermaid" | "reactflow"` and keep Mermaid as fallback for one release cycle.
+  - If no setting is desired: keep commits separated so reverting the host swap is a one-commit rollback.
+
+- **Large graph behavior**
+  - Define a threshold (e.g., nodes > 500) where the VS Code webview:
+    - shows a warning banner and disables minimap/animations, and/or
+    - uses `unknownDeps:"filter"` forcibly, and/or
+    - skips expandable field rendering.
+  - Must not silently hang; if layout takes too long, show an actionable message.
+
+- **Host update triggers (when to send `dag:update`)**
+  - After `WorkflowModel.onDidChange` while the panel is visible (same as today’s Mermaid `update()`).
+  - After `vscode.window.onDidChangeActiveColorTheme` (webview may need theme hint or rely on body class + theme sync).
+  - After `vscode.workspace.onDidChangeConfiguration` when `agentActions.dagLayout` or `agentActions.dagRenderer` (if added) changes.
+  - After `showWorkflow(workflow)` / workflow pick changes `currentWorkflowName` (keep last-selected workflow stable across refreshes; match existing `DagWebview` behavior).
+  - Do **not** replace full `webview.html` on every refresh once the shell is loaded; use `postMessage` only to avoid white flashes and script re-init cost.
+
+- **Layout mapping (single table — no drift)**
+  | `agentActions.dagLayout` | Transformer `opts.direction` | Dagre `rankdir` mental model |
+  |--------------------------|------------------------------|------------------------------|
+  | `vertical`               | `TB`                         | Top → bottom                 |
+  | `horizontal`             | `LR`                         | Left → right                 |
+
+- **Sequence (happy path, VS Code)**
+  1. User: `agentActions.showDAG` → host picks workflow → creates/reveals panel → sets HTML shell (nonce CSP, script + css URIs).
+  2. Webview loads `dagWebview.js` → React mounts → `postMessage({ type: "ready" })`.
+  3. Host receives `ready` → flushes latest pending `dag:update` (last-write-wins).
+  4. Host (or model listener) sends `dag:update` with actions + layout.
+  5. Webview applies adapter → `transformActionsToReactFlow` → `setNodes/setEdges` → `fitView` (debounce if needed).
+  6. User clicks node → `postMessage({ type: "openAction", actionName })` → host validates → `executeCommand("agentActions.openConfig", action)`.
+
+- **Multi-workflow & identity**
+  - Payload should include `workflowName` for masthead/debug; graph nodes still use global action `name` as `id` (matches `WorkflowModel.getActionByName` which searches all workflows).
+  - If two workflows could ever expose the same action name, document whether `openAction` must become `(workflowName, actionName)` — today the model assumes names are unique across the workspace for lookup.
+
+- **Dependency alignment**
+  - Pin `@xyflow/react` and `dagre` in `vscode-extension/package.json` to the **same major/minor** as `agent_actions/tooling/docs/frontend/package.json` where possible, to avoid subtle API differences between docs build and extension bundle.
+
+- **File inventory (expected touch list)**
+  | Area | Path |
+  |------|------|
+  | Shared transformer | `agent_actions/tooling/docs/frontend/lib/dag-transformer.ts` |
+  | Docs DAG UI | `agent_actions/tooling/docs/frontend/components/workflow-dag.tsx` |
+  | VS Code webview entry | `vscode-extension/src/webview/dag.tsx` (new) |
+  | VS Code host | `vscode-extension/src/views/dagWebview.ts` |
+  | Build | `vscode-extension/esbuild.js` |
+  | Deps / package | `vscode-extension/package.json`, `vscode-extension/package-lock.json` |
+  | Packaging | `vscode-extension/.vscodeignore` |
+  | Optional shared host helpers | `vscode-extension/src/views/webviewHtml.ts`, `vscode-extension/src/views/webviewMessagePump.ts` (new) |
+  | Optional theme | `vscode-extension/src/webview/themeSync.ts` (new), refactor `src/webview/main.tsx` to import |
+  | Settings (optional) | `vscode-extension/package.json` `contributes.configuration` for `dagRenderer` |
+  | Commands | `vscode-extension/src/commands/index.ts` (only if new command or setting wiring) |
+  | Changelog | `.changes/unreleased/*.yaml` per repo policy |
+
+- **Manual testing matrix (minimum)**
+  | Scenario | Pass criterion |
+  |----------|----------------|
+  | 0 workflows | Same as today: info message, no crash |
+  | 1 workflow | DAG opens; nodes/edges match config; click opens YAML |
+  | 2+ workflows | Quick pick; switching workflow updates graph + title |
+  | Toggle `dagLayout` | Direction changes without reload loop |
+  | Model refresh | Edit manifest/status file; graph updates without losing panel |
+  | Theme switch | Light/dark/HC readable; no CSP console errors |
+  | Unknown dep | Edge dropped or placeholder per policy; no throw |
+  | Large graph | Threshold path triggers; UI remains responsive |
+
+- **Troubleshooting (symptom → likely cause)**
+  | Symptom | Likely cause |
+  |---------|----------------|
+  | Blank panel, CSP error in webview devtools | Wrong `script-src` nonce, or script URI not under `localResourceRoots` |
+  | ReactFlow renders but unstyled | `@xyflow/react` CSS not linked or not emitted by build |
+  | `useState` / hooks crash | Duplicate React; check `esbuild.js` aliases for DAG bundle |
+  | Click does nothing / wrong action | `node.id` ≠ `ActionInfo.name`; adapter mutated name |
+  | Graph empty but actions exist | All edges filtered; deps don’t match node ids (versioned names?) |
+  | Updates stop after tab switch | `ready` / pending queue bug; or panel disposed |
+
+- **Observability (extension host)**
+  - Log at **debug** when: panel created, `ready` received, `dag:update` sent (workflow name + action count only — no record payloads).
+  - Log at **warning** when: `openAction` for unknown name, or transform threw (should never throw per contract).
+
+### DELIVERY
+- Commit 1: **Docs transformer refactor (low risk, isolated)**
+  - Update `agent_actions/tooling/docs/frontend/lib/dag-transformer.ts` to export the shared transformer/types.
+  - Update `agent_actions/tooling/docs/frontend/components/workflow-dag.tsx` to use the new API.
+  - Verification:
+    - `cd agent_actions/tooling/docs/frontend && npm run build`
+
+- Commit 2: **VS Code DAG webview scaffolding (medium risk)**
+  - Add `vscode-extension/src/webview/dag.tsx`.
+  - Add/adjust CSS strategy for xyflow styles.
+  - Update `vscode-extension/esbuild.js` to build `out/dagWebview.js` (+ css).
+  - Verification:
+    - `cd vscode-extension && npm run build` (or `npm run compile` depending on repo norms)
+
+- Commit 3: **Host panel switch (behavioral change)**
+  - Update `vscode-extension/src/views/dagWebview.ts` to host the React webview and message passing.
+  - Add deps and packaging updates (`package.json`, `.vscodeignore`).
+  - Verification:
+    - `cd vscode-extension && npm run typecheck && npm run build`
+    - Manual: open VS Code extension dev host, run “Agent Actions: Show Workflow DAG”, click node opens config, toggle `dagLayout`.
+  - Optional Commit 4: **Settings + rollback ergonomics**
+    - Add `agentActions.dagRenderer` (and wire host to branch Mermaid vs ReactFlow).
+    - Verification: toggle setting; both renderers work; default matches product decision.
+
+- **Local dev loop (engineer)**
+  1. From repo root: `cd agent-actions/vscode-extension && npm install && npm run compile` (or `watch` if available).
+  2. Open `vscode-extension` in VS Code → Run Extension (F5) → test command palette `Agent Actions: Show Workflow DAG`.
+  3. Webview debug: Command Palette → “Developer: Open Webview Developer Tools” on the DAG panel.
+  4. After docs transformer changes: `cd agent_actions/tooling/docs/frontend && npm install && npm run build`.
+
+- **Ship checklist**
+  - Add **Changie** entry under `.changes/unreleased/` per `CLAUDE.local.md` (Enhancement or Under the Hood).
+  - Run `vsce package` (or CI equivalent) and confirm the `.vsix` contains `out/dagWebview.js` and emitted CSS (unzip and inspect if unsure).
+
+### FAILURE CONDITIONS
+Design anti-patterns:
+- A second, duplicate DAG transformer is introduced (Docs and VS Code do not share the same exported transformer function).
+- Node IDs are sanitized/hashed in one surface but not the other, breaking click-to-open or diverging edge policy.
+- CSS for `@xyflow/react` is “fixed” by loosening CSP or using a remote CDN.
+- Concurrency/ready handling drops updates (no last-write-wins queue; updates sent before `ready` are lost without retry).
+
+Output defects:
+- VS Code webview fails to load due to CSP errors, missing `localResourceRoots`, or missing packaged assets.
+- `npm run build` for docs frontend or VS Code extension fails (type errors, missing deps).
+- React hooks error at runtime (“Cannot read properties of null (reading 'useState')”) indicating multiple React copies.
+- Wrong action opens on click when multiple workflows define the same action name without disambiguation in the contract.
+```
+
+Assumptions I Made:
+- The VS Code extension build can be extended to emit/load CSS for `@xyflow/react/dist/style.css` without introducing a new bundler.
+- VS Code DAG nodes can be rendered acceptably with the fields available from `WorkflowModel` today; richer fields (inputs/observe/intent/model) can be empty unless we explicitly extend the model later.
+- The repo wants prompt contracts stored under `agent-actions/prompt-contracts/` (this directory didn’t exist yet in this clone).
+- Action names remain **globally unique** across workflows in a workspace for `getActionByName`; if that is false in the wild, the contract must be revised to pass `workflowName` with `openAction` and resolve actions per-workflow.
+- Engineers have access to the full `agent-actions` repo (docs frontend + extension) in one workspace for path resolution and CI.

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -76,6 +76,15 @@ const reactSingletonAliases = {
   ),
 };
 
+const webviewShimBanner = {
+  js: [
+    `var process=(typeof globalThis!=='undefined'&&globalThis.process)||{env:{NODE_ENV:${production ? '"production"' : '"development"'}},platform:"browser",browser:true,cwd:function(){return"/"},versions:{},nextTick:function(cb){Promise.resolve().then(cb)},emit:function(){}};`,
+    `var global=(typeof globalThis!=='undefined')?globalThis:self;`,
+    `var setImmediate=(typeof globalThis!=='undefined'&&globalThis.setImmediate)||function(cb){return setTimeout(cb,0)};`,
+    `var clearImmediate=(typeof globalThis!=='undefined'&&globalThis.clearImmediate)||function(id){clearTimeout(id)};`,
+  ].join(""),
+};
+
 async function buildWebview() {
   return esbuild.context({
     entryPoints: ["src/webview/main.tsx"],
@@ -95,12 +104,30 @@ async function buildWebview() {
     banner: {
       // Shim Node globals that some transitive deps (react-markdown, remark-gfm,
       // micromark) reference. These are unbounded globals in the bundle if not shimmed.
-      js: [
-        `var process=(typeof globalThis!=='undefined'&&globalThis.process)||{env:{NODE_ENV:${production ? '"production"' : '"development"'}},platform:"browser",browser:true,cwd:function(){return"/"},versions:{},nextTick:function(cb){Promise.resolve().then(cb)},emit:function(){}};`,
-        `var global=(typeof globalThis!=='undefined')?globalThis:self;`,
-        `var setImmediate=(typeof globalThis!=='undefined'&&globalThis.setImmediate)||function(cb){return setTimeout(cb,0)};`,
-        `var clearImmediate=(typeof globalThis!=='undefined'&&globalThis.clearImmediate)||function(id){clearTimeout(id)};`,
-      ].join(""),
+      js: webviewShimBanner.js,
+    },
+    plugins: [aliasPlugin],
+  });
+}
+
+async function buildDagWebview() {
+  return esbuild.context({
+    entryPoints: ["src/webview/dag.tsx"],
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "ES2020",
+    outfile: "out/dagWebview.js",
+    alias: reactSingletonAliases,
+    sourcemap: !production,
+    minify: production,
+    logLevel: "info",
+    jsx: "automatic",
+    define: {
+      "process.env.NODE_ENV": production ? '"production"' : '"development"',
+    },
+    banner: {
+      js: webviewShimBanner.js,
     },
     plugins: [aliasPlugin],
   });
@@ -144,18 +171,20 @@ function buildCss() {
 }
 
 async function main() {
-  const [extCtx, webCtx] = await Promise.all([
+  const [extCtx, webCtx, dagCtx] = await Promise.all([
     buildExtension(),
     buildWebview(),
+    buildDagWebview(),
   ]);
 
   if (watch) {
-    await Promise.all([extCtx.watch(), webCtx.watch(), buildCss()]);
+    await Promise.all([extCtx.watch(), webCtx.watch(), dagCtx.watch(), buildCss()]);
     console.log("[esbuild] watching for changes...");
   } else {
-    await Promise.all([extCtx.rebuild(), webCtx.rebuild(), buildCss()]);
+    await Promise.all([extCtx.rebuild(), webCtx.rebuild(), dagCtx.rebuild(), buildCss()]);
     await extCtx.dispose();
     await webCtx.dispose();
+    await dagCtx.dispose();
   }
 }
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -10,8 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",
+        "@xyflow/react": "^12.10.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dagre": "^0.8.5",
         "lucide-react": "^0.544.0",
         "react": "^19",
         "react-dom": "^19",
@@ -22,6 +24,7 @@
         "yaml": "^2.7.0"
       },
       "devDependencies": {
+        "@types/dagre": "^0.7.53",
         "@types/node": "^20.0.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1045,6 +1048,62 @@
         "@textlint/ast-node-types": "15.5.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/dagre": {
+      "version": "0.7.54",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
+      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1371,6 +1430,38 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -1986,6 +2077,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2128,6 +2225,121 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2927,6 +3139,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3576,7 +3797,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -6770,6 +6990,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7028,6 +7257,34 @@
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -118,6 +118,15 @@
           "default": "vertical",
           "description": "Layout direction for the workflow DAG visualization."
         },
+        "agentActions.dagRenderer": {
+          "type": "string",
+          "enum": [
+            "reactflow",
+            "mermaid"
+          ],
+          "default": "reactflow",
+          "description": "Renderer for the workflow DAG panel: React Flow (shared with docs) or Mermaid (legacy)."
+        },
         "agentActions.refreshInterval": {
           "type": "number",
           "default": 0,
@@ -374,8 +383,10 @@
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",
+    "@xyflow/react": "^12.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dagre": "^0.8.5",
     "lucide-react": "^0.544.0",
     "react": "^19",
     "react-dom": "^19",
@@ -386,6 +397,7 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
+    "@types/dagre": "^0.7.53",
     "@types/node": "^20.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/vscode-extension/src/views/dagWebview.ts
+++ b/vscode-extension/src/views/dagWebview.ts
@@ -1,28 +1,51 @@
 /**
  * DAG Webview
  *
- * Displays a Mermaid-based visual DAG of the workflow.
- *
- * Combines best approaches:
- * - PR #820: Layout configuration (vertical/horizontal)
- * - PR #821: Click-to-navigate callbacks
- * - PR #823: Status-colored nodes, multi-workflow support
+ * Renders the workflow dependency graph in a VS Code webview. When
+ * `agentActions.dagRenderer` is `reactflow`, the panel loads a React bundle that
+ * shares the docs DAG transformer. When set to `mermaid`, the legacy Mermaid
+ * diagram is used instead.
  */
 
 import * as vscode from 'vscode';
 import { ActionInfo, ActionStatus, WorkflowInfo } from '../model/types';
 import { WorkflowModel } from '../model/workflowModel';
+import { logger } from '../utils/logger';
+
+type DagRendererMode = 'reactflow' | 'mermaid';
+
+/** Host → webview payload for React Flow mode (mirrors contract). */
+export interface DagUpdatePayload {
+    workflowName: string;
+    layout: 'vertical' | 'horizontal';
+    actions: Array<{
+        name: string;
+        deps: string[];
+        kind: 'llm' | 'tool' | 'unknown';
+        status?: ActionInfo['status'];
+        model?: string;
+        impl?: string;
+        intent?: string;
+        inputs?: string[];
+        observe?: string[];
+        outputs?: string[];
+        outputFields?: string[];
+        drops?: string[];
+    }>;
+}
 
 export class DagWebview implements vscode.Disposable {
     private panel: vscode.WebviewPanel | undefined;
     private readonly disposables: vscode.Disposable[] = [];
     private currentWorkflowName: string | undefined;
+    private webviewReady = false;
+    private pendingReactPayload: DagUpdatePayload | undefined;
+    private activeMode: DagRendererMode | undefined;
 
     constructor(
         private readonly context: vscode.ExtensionContext,
         private readonly model: WorkflowModel
     ) {
-        // Auto-update when model changes or theme switches
         this.disposables.push(
             this.model.onDidChange(() => {
                 if (this.panel) {
@@ -31,6 +54,15 @@ export class DagWebview implements vscode.Disposable {
             }),
             vscode.window.onDidChangeActiveColorTheme(() => {
                 if (this.panel) {
+                    this.update();
+                }
+            }),
+            vscode.workspace.onDidChangeConfiguration((e) => {
+                if (
+                    this.panel &&
+                    (e.affectsConfiguration('agentActions.dagLayout') ||
+                        e.affectsConfiguration('agentActions.dagRenderer'))
+                ) {
                     this.update();
                 }
             })
@@ -42,9 +74,6 @@ export class DagWebview implements vscode.Disposable {
         this.disposables.forEach((d) => d.dispose());
     }
 
-    /**
-     * Show the DAG panel
-     */
     async show(): Promise<void> {
         const workflows = this.model.getWorkflows();
 
@@ -53,7 +82,6 @@ export class DagWebview implements vscode.Disposable {
             return;
         }
 
-        // If multiple workflows, let user select
         let workflow: WorkflowInfo;
         if (workflows.length === 1) {
             workflow = workflows[0];
@@ -75,11 +103,7 @@ export class DagWebview implements vscode.Disposable {
         this.showWorkflow(workflow);
     }
 
-    /**
-     * Show DAG for a specific workflow
-     */
     showWorkflow(workflow: WorkflowInfo): void {
-        // Track which workflow we're showing
         this.currentWorkflowName = workflow.name;
 
         if (this.panel) {
@@ -92,36 +116,71 @@ export class DagWebview implements vscode.Disposable {
                 {
                     enableScripts: true,
                     retainContextWhenHidden: true,
-                    localResourceRoots: [
-                        vscode.Uri.joinPath(this.context.extensionUri, 'media')
-                    ],
+                    localResourceRoots: [this.context.extensionUri],
                 }
             );
 
             this.panel.onDidDispose(() => {
                 this.panel = undefined;
                 this.currentWorkflowName = undefined;
+                this.webviewReady = false;
+                this.pendingReactPayload = undefined;
+                this.activeMode = undefined;
             }, null, this.disposables);
 
-            // Handle messages from webview
             this.panel.webview.onDidReceiveMessage(
                 (message) => {
+                    if (!message || typeof message !== 'object') {
+                        return;
+                    }
+                    if (message.type === 'ready') {
+                        this.onWebviewReady();
+                        return;
+                    }
                     if (message.type === 'openAction') {
-                        const action = this.model.getActionByName(message.actionName);
+                        const actionName = message.actionName;
+                        if (typeof actionName !== 'string' || actionName.length === 0) {
+                            logger.warn('DAG webview: openAction ignored (invalid actionName)');
+                            return;
+                        }
+                        const action = this.model.getActionByName(actionName);
                         if (action) {
                             vscode.commands.executeCommand('agentActions.openConfig', action);
                         } else {
-                            vscode.window.showWarningMessage(`Action "${message.actionName}" not found`);
+                            logger.warn(`DAG webview: openAction for unknown action "${actionName}"`);
+                            vscode.window.showWarningMessage(`Action "${actionName}" not found`);
                         }
                     }
                 },
                 null,
                 this.disposables
             );
+
+            logger.debug('DAG webview: panel created');
         }
 
         this.panel.title = `${workflow.name} - Workflow DAG`;
         this.update();
+    }
+
+    private getRendererMode(): DagRendererMode {
+        const v = vscode.workspace
+            .getConfiguration('agentActions')
+            .get<string>('dagRenderer', 'reactflow');
+        return v === 'mermaid' ? 'mermaid' : 'reactflow';
+    }
+
+    private onWebviewReady(): void {
+        this.webviewReady = true;
+        if (!this.panel) {
+            return;
+        }
+        const payload = this.pendingReactPayload ?? this.buildReactPayload();
+        this.pendingReactPayload = undefined;
+        this.panel.webview.postMessage({ type: 'dag:update', payload });
+        logger.debug(
+            `DAG webview: ready → dag:update (${payload.workflowName}, ${payload.actions.length} actions)`
+        );
     }
 
     private update(): void {
@@ -129,7 +188,6 @@ export class DagWebview implements vscode.Disposable {
             return;
         }
 
-        // Find the workflow we're currently showing (not just the first one)
         const workflows = this.model.getWorkflows();
         const workflow = this.currentWorkflowName
             ? workflows.find((w) => w.name === this.currentWorkflowName) ?? workflows[0]
@@ -139,14 +197,72 @@ export class DagWebview implements vscode.Disposable {
             return;
         }
 
-        const config = vscode.workspace.getConfiguration('agentActions');
-        const layout = config.get<string>('dagLayout', 'vertical');
-        const direction = layout === 'horizontal' ? 'LR' : 'TD';
+        const mode = this.getRendererMode();
 
-        const diagram = this.buildMermaidDiagram(workflow.actions, direction);
-        const isDark = vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
-                       vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast;
-        this.panel.webview.html = this.renderHtml(this.panel.webview, diagram, workflow.name, isDark);
+        if (mode === 'mermaid') {
+            this.webviewReady = false;
+            this.pendingReactPayload = undefined;
+            if (this.activeMode !== 'mermaid') {
+                this.activeMode = 'mermaid';
+            }
+            const config = vscode.workspace.getConfiguration('agentActions');
+            const layout = config.get<string>('dagLayout', 'vertical');
+            const direction = layout === 'horizontal' ? 'LR' : 'TD';
+            const diagram = this.buildMermaidDiagram(workflow.actions, direction);
+            const isDark =
+                vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
+                vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast;
+            this.panel.webview.html = this.renderMermaidHtml(
+                this.panel.webview,
+                diagram,
+                workflow.name,
+                isDark
+            );
+            return;
+        }
+
+        // React Flow path
+        if (this.activeMode !== 'reactflow') {
+            this.activeMode = 'reactflow';
+            this.webviewReady = false;
+            this.pendingReactPayload = undefined;
+            this.panel.webview.html = renderReactDagShell(this.panel.webview, this.context.extensionUri);
+            logger.debug('DAG webview: React shell loaded');
+        }
+
+        const payload = this.buildReactPayload();
+        if (this.webviewReady) {
+            this.panel.webview.postMessage({ type: 'dag:update', payload });
+            logger.debug(
+                `DAG webview: dag:update (${payload.workflowName}, ${payload.actions.length} actions)`
+            );
+        } else {
+            this.pendingReactPayload = payload;
+        }
+    }
+
+    private buildReactPayload(): DagUpdatePayload {
+        const workflows = this.model.getWorkflows();
+        const workflow = this.currentWorkflowName
+            ? workflows.find((w) => w.name === this.currentWorkflowName) ?? workflows[0]
+            : workflows[0];
+        if (!workflow) {
+            return { workflowName: '', layout: 'vertical', actions: [] };
+        }
+        const config = vscode.workspace.getConfiguration('agentActions');
+        const layout = config.get<string>('dagLayout', 'vertical') === 'horizontal' ? 'horizontal' : 'vertical';
+
+        return {
+            workflowName: workflow.name,
+            layout,
+            actions: workflow.actions.map((a) => ({
+                name: a.name,
+                deps: [...a.dependencies],
+                kind: 'tool' as const,
+                status: a.status,
+                outputFields: [...a.outputFields],
+            })),
+        };
     }
 
     private buildMermaidDiagram(actions: ActionInfo[], direction: string): string {
@@ -156,7 +272,6 @@ export class DagWebview implements vscode.Disposable {
 
         const lines: string[] = [`flowchart ${direction}`];
 
-        // Define nodes with status styling
         for (const action of actions) {
             const nodeId = this.sanitizeId(action.name);
             const label = action.name.replace(/["\]\\]/g, '_');
@@ -165,7 +280,6 @@ export class DagWebview implements vscode.Disposable {
             lines.push(`  ${nodeId}["[${action.index}] ${label}"]:::${statusClass}`);
         }
 
-        // Define edges
         for (const action of actions) {
             const nodeId = this.sanitizeId(action.name);
             for (const dep of action.dependencies) {
@@ -174,15 +288,12 @@ export class DagWebview implements vscode.Disposable {
             }
         }
 
-        // Add click handlers using sanitized action names for security
         for (const action of actions) {
             const nodeId = this.sanitizeId(action.name);
-            // Use sanitized name in callback to prevent XSS
             const sanitizedName = this.sanitizeForCallback(action.name);
             lines.push(`  click ${nodeId} callback "${sanitizedName}"`);
         }
 
-        // Add style definitions
         lines.push('');
         lines.push('  classDef completed fill:#28a745,stroke:#1e7e34,color:#fff');
         lines.push('  classDef running fill:#ffc107,stroke:#e0a800,color:#000');
@@ -197,11 +308,7 @@ export class DagWebview implements vscode.Disposable {
         return name.replace(/[^a-zA-Z0-9_]/g, '_');
     }
 
-    /**
-     * Sanitize action name for use in Mermaid callback to prevent XSS
-     */
     private sanitizeForCallback(name: string): string {
-        // Remove any characters that could break out of the string or execute code
         return name.replace(/[<>"'`\\]/g, '').replace(/\s+/g, '_');
     }
 
@@ -209,10 +316,14 @@ export class DagWebview implements vscode.Disposable {
         return status;
     }
 
-    private renderHtml(webview: vscode.Webview, diagram: string, workflowName: string, isDark: boolean): string {
-        const nonce = this.getNonce();
+    private renderMermaidHtml(
+        webview: vscode.Webview,
+        diagram: string,
+        workflowName: string,
+        isDark: boolean
+    ): string {
+        const nonce = getNonce();
 
-        // Use locally bundled Mermaid for security and offline support
         const mermaidUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this.context.extensionUri, 'media', 'mermaid.min.js')
         );
@@ -223,7 +334,7 @@ export class DagWebview implements vscode.Disposable {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webview.cspSource} 'nonce-${nonce}'; style-src 'unsafe-inline';">
-    <title>${this.escapeHtml(workflowName)} - Workflow DAG</title>
+    <title>${escapeHtml(workflowName)} - Workflow DAG</title>
     <style>
         body {
             margin: 0;
@@ -272,7 +383,6 @@ export class DagWebview implements vscode.Disposable {
             max-width: 100%;
             height: auto;
         }
-        /* Make nodes clickable */
         .node { cursor: pointer; }
         .node:hover rect, .node:hover polygon {
             filter: brightness(1.2);
@@ -281,7 +391,7 @@ export class DagWebview implements vscode.Disposable {
 </head>
 <body>
     <div class="header">
-        <h1>${this.escapeHtml(workflowName)}</h1>
+        <h1>${escapeHtml(workflowName)}</h1>
         <div class="legend">
             <div class="legend-item"><div class="legend-dot completed"></div> Completed</div>
             <div class="legend-item"><div class="legend-dot running"></div> Running</div>
@@ -302,16 +412,13 @@ ${diagram}
             theme: '${isDark ? 'dark' : 'default'}',
             flowchart: {
                 curve: 'basis',
-                htmlLabels: false,  // Disable HTML labels for security
+                htmlLabels: false,
                 padding: 15
             },
             securityLevel: 'strict'
         });
 
-        // Handle click events - Mermaid will call this via the callback mechanism
-        // With securityLevel: 'strict', we use mermaid's built-in click handler
         window.callback = function(actionName) {
-            // Validate actionName contains only safe characters
             if (/^[a-zA-Z0-9_-]+$/.test(actionName)) {
                 vscode.postMessage({ type: 'openAction', actionName });
             }
@@ -320,21 +427,55 @@ ${diagram}
 </body>
 </html>`;
     }
+}
 
-    private getNonce(): string {
-        let text = '';
-        const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-        for (let i = 0; i < 32; i++) {
-            text += possible.charAt(Math.floor(Math.random() * possible.length));
-        }
-        return text;
-    }
+function renderReactDagShell(webview: vscode.Webview, extensionUri: vscode.Uri): string {
+    const nonce = getNonce();
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'out', 'dagWebview.js'));
+    const styleBaseUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'out', 'webview.css'));
+    const dagStyleUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'out', 'dagWebview.css'));
+    const csp = [
+        `default-src 'none'`,
+        `style-src ${webview.cspSource} 'unsafe-inline'`,
+        `script-src 'nonce-${nonce}' ${webview.cspSource}`,
+        `img-src ${webview.cspSource} data:`,
+        `font-src ${webview.cspSource}`,
+    ].join('; ');
 
-    private escapeHtml(value: string): string {
-        return value
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="${styleBaseUri}">
+    <link rel="stylesheet" href="${dagStyleUri}">
+    <title>Workflow DAG</title>
+    <style>
+        html, body { height: 100%; margin: 0; }
+        #root { height: 100%; }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+}
+
+function getNonce(): string {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
     }
+    return text;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
 }

--- a/vscode-extension/src/webview/dag.tsx
+++ b/vscode-extension/src/webview/dag.tsx
@@ -1,0 +1,143 @@
+import "@xyflow/react/dist/style.css";
+import React, { useEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { ReactFlowProvider } from "@xyflow/react";
+import {
+  adaptVsCodeDagInputsToDAGActions,
+  type VsCodeDagActionInput,
+} from "@/lib/dag-transformer";
+import { WorkflowDAGRuntime } from "@/components/workflow-dag";
+import { initVscodeThemeSync } from "./themeSync";
+
+initVscodeThemeSync();
+
+declare global {
+  interface Window {
+    acquireVsCodeApi: () => {
+      postMessage: (msg: unknown) => void;
+      getState: () => unknown;
+      setState: (state: unknown) => void;
+    };
+  }
+}
+
+const vscode = window.acquireVsCodeApi();
+
+const LARGE_NODE_THRESHOLD = 500;
+
+interface DagUpdatePayload {
+  workflowName: string;
+  layout: "vertical" | "horizontal";
+  actions: Array<{
+    name: string;
+    deps: string[];
+    kind: "llm" | "tool" | "unknown";
+    status?: VsCodeDagActionInput["status"];
+    model?: string;
+    impl?: string;
+    intent?: string;
+    inputs?: string[];
+    observe?: string[];
+    outputs?: string[];
+    outputFields?: string[];
+    drops?: string[];
+  }>;
+}
+
+function directionFromLayout(layout: DagUpdatePayload["layout"]): "LR" | "TB" {
+  return layout === "horizontal" ? "LR" : "TB";
+}
+
+function App() {
+  const [payload, setPayload] = useState<DagUpdatePayload>({
+    workflowName: "",
+    layout: "vertical",
+    actions: [],
+  });
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const msg = event.data;
+      if (!msg || typeof msg !== "object") return;
+      if (msg.type === "dag:update" && msg.payload) {
+        setPayload(msg.payload as DagUpdatePayload);
+      }
+    };
+    window.addEventListener("message", handler);
+    vscode.postMessage({ type: "ready" });
+    return () => window.removeEventListener("message", handler);
+  }, []);
+
+  const inputs: VsCodeDagActionInput[] = useMemo(
+    () =>
+      payload.actions.map((a) => ({
+        name: a.name,
+        dependencies: a.deps,
+        kind: a.kind,
+        status: a.status,
+        model: a.model,
+        impl: a.impl,
+        intent: a.intent,
+        inputs: a.inputs,
+        observe: a.observe,
+        outputs: a.outputs,
+        outputFields: a.outputFields,
+        drops: a.drops,
+      })),
+    [payload.actions],
+  );
+
+  const dagActions = useMemo(() => adaptVsCodeDagInputsToDAGActions(inputs), [inputs]);
+
+  const isLarge = dagActions.length > LARGE_NODE_THRESHOLD;
+  const direction = directionFromLayout(payload.layout);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      {isLarge && (
+        <div
+          className="shrink-0 border-b px-3 py-2 text-xs"
+          style={{
+            borderColor: "hsl(var(--border) / 0.55)",
+            background: "hsl(var(--card))",
+            color: "hsl(var(--muted-foreground))",
+          }}
+          role="status"
+        >
+          Large workflow ({dagActions.length} actions). Minimap is off to keep the panel responsive.
+        </div>
+      )}
+      <div className="min-h-0 flex-1 w-full">
+        <ReactFlowProvider>
+          <WorkflowDAGRuntime
+            dagActions={dagActions}
+            direction={direction}
+            disableMinimap={isLarge}
+            onNodeClick={(name) => vscode.postMessage({ type: "openAction", actionName: name })}
+          />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
+}
+
+function showFatal(err: unknown) {
+  const msg = err instanceof Error ? err.stack || err.message : String(err);
+  const el = document.getElementById("root");
+  if (el) {
+    el.innerHTML =
+      '<pre style="color:#f88;background:#222;padding:16px;font-family:monospace;font-size:12px;white-space:pre-wrap;border-radius:6px;margin:16px;">' +
+      msg.replace(/[<>&]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" })[c]!) +
+      "</pre>";
+  }
+}
+
+window.addEventListener("error", (ev) => showFatal(ev.error || ev.message));
+window.addEventListener("unhandledrejection", (ev) => showFatal(ev.reason));
+
+try {
+  const root = createRoot(document.getElementById("root")!);
+  root.render(<App />);
+} catch (e) {
+  showFatal(e);
+}

--- a/vscode-extension/src/webview/main.tsx
+++ b/vscode-extension/src/webview/main.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { DataCard, type ActionInfo } from "@/components/ui/data-card";
+import { initVscodeThemeSync } from "./themeSync";
 
 // Webview entry — mounts the docs DataCard and pushes records straight
 // through. Only navigational chrome and integrity diagnostics are added
@@ -197,116 +198,7 @@ function App({ initial }: { initial: PreviewPayload }) {
   );
 }
 
-/* ── VS Code theme sync ──────────────────────────────────────────────── */
-// Reads VS Code's native CSS variables (auto-updated on theme change) and
-// converts them to HSL component format so our variable-based CSS adapts
-// to any installed theme — light, dark, or high-contrast.
-
-function colorToHsl(raw: string): string | null {
-  let r: number, g: number, b: number;
-  const hex = raw.match(/^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
-  if (hex) {
-    const h = hex[1];
-    if (h.length === 3) {
-      r = parseInt(h[0] + h[0], 16);
-      g = parseInt(h[1] + h[1], 16);
-      b = parseInt(h[2] + h[2], 16);
-    } else if (h.length >= 6) {
-      r = parseInt(h.slice(0, 2), 16);
-      g = parseInt(h.slice(2, 4), 16);
-      b = parseInt(h.slice(4, 6), 16);
-    } else return null;
-  } else {
-    const rgb = raw.match(/rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/);
-    if (rgb) {
-      r = parseInt(rgb[1], 10);
-      g = parseInt(rgb[2], 10);
-      b = parseInt(rgb[3], 10);
-    } else return null;
-  }
-  const rn = r / 255,
-    gn = g / 255,
-    bn = b / 255;
-  const max = Math.max(rn, gn, bn),
-    min = Math.min(rn, gn, bn);
-  const l = (max + min) / 2;
-  let hue = 0,
-    sat = 0;
-  if (max !== min) {
-    const d = max - min;
-    sat = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    if (max === rn) hue = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6;
-    else if (max === gn) hue = ((bn - rn) / d + 2) / 6;
-    else hue = ((rn - gn) / d + 4) / 6;
-  }
-  return `${Math.round(hue * 360)} ${Math.round(sat * 100)}% ${Math.round(l * 100)}%`;
-}
-
-const VSCODE_THEME_MAP: [string, ...string[]][] = [
-  ["--background", "--vscode-editor-background"],
-  ["--foreground", "--vscode-editor-foreground"],
-  ["--card", "--vscode-editorWidget-background", "--vscode-sideBar-background", "--vscode-editor-background"],
-  ["--card-foreground", "--vscode-editor-foreground"],
-  ["--card-elevated", "--vscode-editorHoverWidget-background", "--vscode-tab-activeBackground", "--vscode-editorWidget-background"],
-  ["--popover", "--vscode-editorWidget-background"],
-  ["--popover-foreground", "--vscode-editor-foreground"],
-  ["--primary", "--vscode-textLink-foreground"],
-  ["--primary-foreground", "--vscode-button-foreground", "--vscode-editor-background"],
-  ["--secondary", "--vscode-input-background", "--vscode-editor-background"],
-  ["--secondary-foreground", "--vscode-input-foreground", "--vscode-editor-foreground"],
-  ["--muted", "--vscode-input-background", "--vscode-editor-background"],
-  ["--muted-foreground", "--vscode-descriptionForeground"],
-  ["--accent", "--vscode-list-hoverBackground", "--vscode-editor-background"],
-  ["--accent-foreground", "--vscode-editor-foreground"],
-  ["--destructive", "--vscode-errorForeground"],
-  ["--border", "--vscode-panel-border", "--vscode-editorWidget-border"],
-  ["--border-strong", "--vscode-contrastBorder", "--vscode-panel-border"],
-  ["--input", "--vscode-input-background"],
-  ["--ring", "--vscode-focusBorder"],
-  ["--success", "--vscode-testing-iconPassed", "--vscode-debugIcon-startForeground"],
-  ["--warning", "--vscode-editorWarning-foreground"],
-];
-
-function syncVscodeTheme() {
-  const cs = getComputedStyle(document.documentElement);
-  const el = document.documentElement;
-  for (const [target, ...sources] of VSCODE_THEME_MAP) {
-    for (const src of sources) {
-      const raw = cs.getPropertyValue(src).trim();
-      if (raw) {
-        const hsl = colorToHsl(raw);
-        if (hsl) {
-          el.style.setProperty(target, hsl);
-          break;
-        }
-      }
-    }
-  }
-  const isDark =
-    document.body.classList.contains("vscode-dark") ||
-    document.body.classList.contains("vscode-high-contrast");
-  el.style.setProperty("color-scheme", isDark ? "dark" : "light");
-}
-
-// Run immediately; re-sync when VS Code flips the body class on theme change.
-syncVscodeTheme();
-let lastBodyClass = document.body.className;
-let rafPending = false;
-new MutationObserver(() => {
-  const cls = document.body.className;
-  if (cls === lastBodyClass) return;
-  lastBodyClass = cls;
-  if (!rafPending) {
-    rafPending = true;
-    requestAnimationFrame(() => {
-      rafPending = false;
-      syncVscodeTheme();
-    });
-  }
-}).observe(document.body, {
-  attributes: true,
-  attributeFilter: ["class"],
-});
+initVscodeThemeSync();
 
 /* ── Bootstrap ───────────────────────────────────────────────────────── */
 

--- a/vscode-extension/src/webview/themeSync.ts
+++ b/vscode-extension/src/webview/themeSync.ts
@@ -1,0 +1,117 @@
+/**
+ * Maps VS Code theme tokens to HSL component variables used by shared UI
+ * (query preview, DAG webview). Call `initVscodeThemeSync()` once at webview startup.
+ */
+
+function colorToHsl(raw: string): string | null {
+  let r: number, g: number, b: number;
+  const hex = raw.match(/^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
+  if (hex) {
+    const h = hex[1];
+    if (h.length === 3) {
+      r = parseInt(h[0] + h[0], 16);
+      g = parseInt(h[1] + h[1], 16);
+      b = parseInt(h[2] + h[2], 16);
+    } else if (h.length >= 6) {
+      r = parseInt(h.slice(0, 2), 16);
+      g = parseInt(h.slice(2, 4), 16);
+      b = parseInt(h.slice(4, 6), 16);
+    } else return null;
+  } else {
+    const rgb = raw.match(/rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/);
+    if (rgb) {
+      r = parseInt(rgb[1], 10);
+      g = parseInt(rgb[2], 10);
+      b = parseInt(rgb[3], 10);
+    } else return null;
+  }
+  const rn = r / 255,
+    gn = g / 255,
+    bn = b / 255;
+  const max = Math.max(rn, gn, bn),
+    min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  let hue = 0,
+    sat = 0;
+  if (max !== min) {
+    const d = max - min;
+    sat = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === rn) hue = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6;
+    else if (max === gn) hue = ((bn - rn) / d + 2) / 6;
+    else hue = ((rn - gn) / d + 4) / 6;
+  }
+  return `${Math.round(hue * 360)} ${Math.round(sat * 100)}% ${Math.round(l * 100)}%`;
+}
+
+const VSCODE_THEME_MAP: [string, ...string[]][] = [
+  ["--background", "--vscode-editor-background"],
+  ["--foreground", "--vscode-editor-foreground"],
+  ["--card", "--vscode-editorWidget-background", "--vscode-sideBar-background", "--vscode-editor-background"],
+  ["--card-foreground", "--vscode-editor-foreground"],
+  ["--card-elevated", "--vscode-editorHoverWidget-background", "--vscode-tab-activeBackground", "--vscode-editorWidget-background"],
+  ["--popover", "--vscode-editorWidget-background"],
+  ["--popover-foreground", "--vscode-editor-foreground"],
+  ["--primary", "--vscode-textLink-foreground"],
+  ["--primary-foreground", "--vscode-button-foreground", "--vscode-editor-background"],
+  ["--secondary", "--vscode-input-background", "--vscode-editor-background"],
+  ["--secondary-foreground", "--vscode-input-foreground", "--vscode-editor-foreground"],
+  ["--muted", "--vscode-input-background", "--vscode-editor-background"],
+  ["--muted-foreground", "--vscode-descriptionForeground"],
+  ["--accent", "--vscode-list-hoverBackground", "--vscode-editor-background"],
+  ["--accent-foreground", "--vscode-editor-foreground"],
+  ["--destructive", "--vscode-errorForeground"],
+  ["--border", "--vscode-panel-border", "--vscode-editorWidget-border"],
+  ["--border-strong", "--vscode-contrastBorder", "--vscode-panel-border"],
+  ["--input", "--vscode-input-background"],
+  ["--ring", "--vscode-focusBorder"],
+  ["--success", "--vscode-testing-iconPassed", "--vscode-debugIcon-startForeground"],
+  ["--warning", "--vscode-editorWarning-foreground"],
+];
+
+function syncVscodeTheme() {
+  const cs = getComputedStyle(document.documentElement);
+  const el = document.documentElement;
+  for (const [target, ...sources] of VSCODE_THEME_MAP) {
+    for (const src of sources) {
+      const raw = cs.getPropertyValue(src).trim();
+      if (raw) {
+        const hsl = colorToHsl(raw);
+        if (hsl) {
+          el.style.setProperty(target, hsl);
+          break;
+        }
+      }
+    }
+  }
+  const isDark =
+    document.body.classList.contains("vscode-dark") ||
+    document.body.classList.contains("vscode-high-contrast");
+  el.style.setProperty("color-scheme", isDark ? "dark" : "light");
+}
+
+let observerInstalled = false;
+
+export function initVscodeThemeSync(): void {
+  syncVscodeTheme();
+  if (observerInstalled || typeof MutationObserver === "undefined") {
+    return;
+  }
+  observerInstalled = true;
+  let lastBodyClass = document.body.className;
+  let rafPending = false;
+  new MutationObserver(() => {
+    const cls = document.body.className;
+    if (cls === lastBodyClass) return;
+    lastBodyClass = cls;
+    if (!rafPending) {
+      rafPending = true;
+      requestAnimationFrame(() => {
+        rafPending = false;
+        syncVscodeTheme();
+      });
+    }
+  }).observe(document.body, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+}

--- a/vscode-extension/src/webview/webview.css
+++ b/vscode-extension/src/webview/webview.css
@@ -23,6 +23,9 @@
     --primary-foreground:   225 28%  6%;
     --primary-soft:         192 60% 24%;
 
+    /* Docs DAG parity — LLM node accent in shared ReactFlow graph */
+    --chart-2:              192 78% 62%;
+
     --secondary:            225 18% 14%;
     --secondary-foreground: 210 15% 78%;
     --muted:                225 16% 14%;
@@ -75,6 +78,8 @@
     --primary:              198 88% 38%;
     --primary-foreground:   0 0% 100%;
     --primary-soft:         198 70% 92%;
+
+    --chart-2:              198 88% 38%;
 
     --secondary:            220 18% 92%;
     --secondary-foreground: 225 28% 16%;


### PR DESCRIPTION
## Summary
Adds a React Flow–based workflow DAG in the VS Code extension webview that reuses the same `transformActionsToReactFlow` pipeline as the docs frontend (`dag-transformer.ts`), so node IDs, edges, layout direction, and unknown-dependency policy stay aligned.

## Key changes
- **Shared transformer** (`agent_actions/tooling/docs/frontend/lib/dag-transformer.ts`): `DAGAction`, `adaptDocsActionsToDAGActions`, `adaptVsCodeDagInputsToDAGActions`, `transformActionsToReactFlow` with explicit `direction`, optional `unknownDeps`, Dagre wrapped in try/catch.
- **Docs** (`workflow-dag.tsx`): `WorkflowDAGRuntime` for reuse; node styling uses `data.kind`.
- **Extension**: new webview bundle `dag.tsx` + `themeSync.ts`; `dagWebview.ts` loads CSP shell, `ready` + pending `dag:update`, `postMessage` updates; `agentActions.dagRenderer` (`reactflow` default, `mermaid` fallback); esbuild + deps (`@xyflow/react`, `dagre`).
- **Changie** + **prompt contract** under `prompt-contracts/`.

## Verification
- `cd vscode-extension && npm run compile && npm run typecheck`
- `cd agent_actions/tooling/docs/frontend && npm run build`

## Note
`vscode-extension/out/` remains gitignored; CI or local `npm run compile` produces `dagWebview.js` / `dagWebview.css`.

Made with [Cursor](https://cursor.com)