### PR TITLE
fix: batch target materialization (DB + disk parity)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260513-batch000.yaml
+++ b/.changes/unreleased/Bug Fix-20260513-batch000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch mode: materialize processed JSON to agent_io/target/ alongside SQLite write (parity with online mode)"
+time: 2026-05-13T11:15:00.000000Z

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import csv
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -132,7 +132,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
             ensure_directory_exists(file_path, is_file=True)
             atomic_json_write(file_path, data)
 
-            return len(json.dumps(data))
+            return file_path.stat().st_size
 
         self._execute_write("Write target file", do_write)
 

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -16,6 +16,7 @@ from agent_actions.logging.events import (
 )
 from agent_actions.processing.error_handling import ProcessorErrorHandlerMixin
 from agent_actions.utils.atomic_write import atomic_json_write
+from agent_actions.utils.path_utils import ensure_directory_exists
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -108,16 +109,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
         self._execute_write("Write staging file", do_write)
 
     def write_target(self, data: list[dict[str, Any]]) -> None:
-        """Write data to target via storage backend and materialize to disk.
-
-        Writes to the storage backend (SQLite/TinyDB) first, then materializes
-        the processed JSON to the filesystem so that downstream consumers
-        reading from target directories (version_consumption merge, cross-workflow
-        deps) find the data.
-
-        Raises:
-            ValueError: If storage backend is not configured.
-        """
+        """Write data to storage backend and materialize to disk."""
 
         def do_write() -> int:
             if self.storage_backend is None or self.action_name is None:
@@ -135,13 +127,9 @@ class FileWriter(ProcessorErrorHandlerMixin):
             else:
                 relative_path = file_path.name
 
-            # 1. Persist to storage backend (SQLite/TinyDB)
             self.storage_backend.write_target(self.action_name, relative_path, data)
 
-            # 2. Materialize to disk: downstream consumers (version_consumption
-            # merge, cross-workflow dependencies) expect processed JSON files
-            # at agent_io/target/{action_name}/{file}.json.
-            file_path.parent.mkdir(parents=True, exist_ok=True)
+            ensure_directory_exists(file_path, is_file=True)
             atomic_json_write(file_path, data)
 
             return len(json.dumps(data))

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -108,7 +108,16 @@ class FileWriter(ProcessorErrorHandlerMixin):
         self._execute_write("Write staging file", do_write)
 
     def write_target(self, data: list[dict[str, Any]]) -> None:
-        """Write data to target via storage backend (raises ValueError if backend is missing)."""
+        """Write data to target via storage backend and materialize to disk.
+
+        Writes to the storage backend (SQLite/TinyDB) first, then materializes
+        the processed JSON to the filesystem so that downstream consumers
+        reading from target directories (version_consumption merge, cross-workflow
+        deps) find the data.
+
+        Raises:
+            ValueError: If storage backend is not configured.
+        """
 
         def do_write() -> int:
             if self.storage_backend is None or self.action_name is None:
@@ -125,7 +134,16 @@ class FileWriter(ProcessorErrorHandlerMixin):
                     relative_path = file_path.name
             else:
                 relative_path = file_path.name
+
+            # 1. Persist to storage backend (SQLite/TinyDB)
             self.storage_backend.write_target(self.action_name, relative_path, data)
+
+            # 2. Materialize to disk: downstream consumers (version_consumption
+            # merge, cross-workflow dependencies) expect processed JSON files
+            # at agent_io/target/{action_name}/{file}.json.
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            atomic_json_write(file_path, data)
+
             return len(json.dumps(data))
 
         self._execute_write("Write target file", do_write)

--- a/tests/integration/test_batch_content_materialization.py
+++ b/tests/integration/test_batch_content_materialization.py
@@ -1,11 +1,7 @@
-"""
-Integration tests for batch content materialization.
+"""Integration tests for batch content materialization.
 
-Verifies that batch LLM results are correctly injected into
-content.{action_name} and persisted to the storage backend.
-
-Reproduces the bug: batch-mode actions produce hollow records
-(content.{action_name}: {}) despite valid LLM responses.
+Verifies that batch LLM results are injected into content.{action_name}
+and persisted to both the storage backend and the filesystem.
 """
 
 import json
@@ -14,17 +10,28 @@ from typing import Any
 import pytest
 
 from agent_actions.llm.batch.processing.batch_result_strategy import BatchResultStrategy
-from agent_actions.llm.batch.services.processing_recovery import (
-    _stamp_batch_records,
-)
+from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.writer import FileWriter
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
 
-def _enrich_and_stamp(results, action_name: str = "verify_answer") -> list[dict[str, Any]]:
-    """Run enrichment pipeline + stamp lifecycle (matches production path)."""
+def _process_batch(
+    batch_results: list[BatchResult],
+    context_map: dict[str, Any],
+    action_config: dict[str, Any],
+    output_directory: str,
+    action_name: str = "verify_answer",
+) -> list[dict[str, Any]]:
+    """Process batch results through strategy + enrichment + stamp (production path)."""
+    strategy = BatchResultStrategy()
+    results = strategy.process(
+        batch_results=batch_results,
+        context_map=context_map,
+        output_directory=output_directory,
+        agent_config=action_config,
+    )
     enrichment = EnrichmentPipeline()
     output: list[dict[str, Any]] = []
     for result in results:
@@ -42,7 +49,6 @@ def _enrich_and_stamp(results, action_name: str = "verify_answer") -> list[dict[
 
 @pytest.fixture
 def action_config() -> dict[str, Any]:
-    """Realistic LLM action config for batch processing."""
     return {
         "name": "verify_answer",
         "action_name": "verify_answer",
@@ -59,18 +65,15 @@ def action_config() -> dict[str, Any]:
 
 @pytest.fixture
 def upstream_record() -> dict[str, Any]:
-    """Input record with upstream content namespaces."""
     return {
         "source_guid": "src_001",
         "target_id": "tid_001",
         "version_correlation_id": "corr_001",
         "content": {
-            "summarize_page_content": {
-                "summary": "AWS S3 bucket policies control access...",
-            },
+            "summarize_page_content": {"summary": "AWS S3 bucket policies..."},
             "write_scenario_question": {
                 "question_text": "What is the correct S3 bucket policy?",
-                "answer_text": "Option C: Allow principal *",
+                "answer_text": "Option C",
             },
         },
     }
@@ -78,7 +81,6 @@ def upstream_record() -> dict[str, Any]:
 
 @pytest.fixture
 def llm_response() -> dict[str, Any]:
-    """Parsed LLM response (what the provider returns after JSON parsing)."""
     return {
         "verified_answer": "C",
         "verification_reasoning": "Option C correctly allows all principals.",
@@ -87,7 +89,6 @@ def llm_response() -> dict[str, Any]:
 
 @pytest.fixture
 def batch_result(llm_response) -> BatchResult:
-    """BatchResult as returned by provider.retrieve_results()."""
     return BatchResult(
         custom_id="tid_001",
         content=llm_response,
@@ -99,7 +100,6 @@ def batch_result(llm_response) -> BatchResult:
 
 @pytest.fixture
 def context_map(upstream_record) -> dict[str, Any]:
-    """Context map as saved at batch submission time."""
     record = upstream_record.copy()
     record["_filter_status"] = "included"
     return {"tid_001": record}
@@ -107,25 +107,22 @@ def context_map(upstream_record) -> dict[str, Any]:
 
 @pytest.fixture
 def sqlite_backend(tmp_path) -> SQLiteBackend:
-    """Real SQLite backend for integration testing."""
-    db_path = tmp_path / "test.db"
-    backend = SQLiteBackend(str(db_path), workflow_name="test_workflow")
+    backend = SQLiteBackend(str(tmp_path / "test.db"), workflow_name="test_workflow")
     backend.initialize()
     return backend
 
 
 # ---------------------------------------------------------------------------
-# Test 1: Content assembly in BatchResultStrategy
+# Content assembly
 # ---------------------------------------------------------------------------
 
 
 class TestBatchContentAssembly:
-    """Verify that BatchResultStrategy correctly builds content[action_name]."""
+    """BatchResultStrategy correctly builds content[action_name]."""
 
     def test_successful_result_populates_action_namespace(
-        self, action_config, batch_result, context_map, llm_response
+        self, action_config, batch_result, context_map
     ):
-        """Core test: content[action_name] must contain the parsed LLM response."""
         strategy = BatchResultStrategy()
         results = strategy.process(
             batch_results=[batch_result],
@@ -134,58 +131,34 @@ class TestBatchContentAssembly:
             agent_config=action_config,
         )
 
-        assert len(results) == 1, f"Expected 1 result, got {len(results)}"
-        result = results[0]
-        assert result.data, "ProcessingResult.data is empty"
+        item = results[0].data[0]
+        content = item["content"]
 
-        # Check the first item's content
-        item = result.data[0]
-        content = item.get("content", {})
-
-        # THE CRITICAL ASSERTION: action namespace must have LLM response
-        action_ns = content.get("verify_answer")
-        assert action_ns is not None, (
-            f"content['verify_answer'] is missing. Content keys: {list(content.keys())}"
-        )
-        assert action_ns != {}, (
-            f"content['verify_answer'] is empty dict. Expected LLM response: {llm_response}"
-        )
-        assert action_ns.get("verified_answer") == "C", (
-            f"content['verify_answer'] missing 'verified_answer'. Got: {action_ns}"
-        )
-        assert "verification_reasoning" in action_ns
-
-        # Upstream namespaces must be preserved
+        assert content["verify_answer"]["verified_answer"] == "C"
+        assert "verification_reasoning" in content["verify_answer"]
         assert "summarize_page_content" in content
         assert "write_scenario_question" in content
 
-    def test_string_content_parsed_to_dict(self, action_config, context_map):
-        """When provider returns parsed string, it should be re-wrapped."""
-        # Simulate provider returning string content (json_mode but unparsed)
-        batch_result = BatchResult(
+    def test_string_content_wrapped_as_parse_error(self, action_config, context_map):
+        """Unparsed string in json_mode gets wrapped as _parse_error."""
+        result = BatchResult(
             custom_id="tid_001",
-            content='{"verified_answer": "C"}',  # String, not dict
+            content='{"verified_answer": "C"}',
             success=True,
             error=None,
         )
         strategy = BatchResultStrategy()
         results = strategy.process(
-            batch_results=[batch_result],
+            batch_results=[result],
             context_map=context_map,
             output_directory="/tmp/test",
             agent_config=action_config,
         )
 
-        item = results[0].data[0]
-        content = item.get("content", {})
-        action_ns = content.get("verify_answer", {})
-
-        # String in json_mode gets wrapped as _parse_error
-        # (the string should have been parsed by the provider, not here)
+        action_ns = results[0].data[0]["content"]["verify_answer"]
         assert "_parse_error" in action_ns or "verified_answer" in action_ns
 
     def test_framework_fields_carried(self, action_config, batch_result, context_map):
-        """target_id and version_correlation_id must be carried from input."""
         strategy = BatchResultStrategy()
         results = strategy.process(
             batch_results=[batch_result],
@@ -195,97 +168,46 @@ class TestBatchContentAssembly:
         )
 
         item = results[0].data[0]
-        assert item.get("target_id") == "tid_001"
-        assert item.get("version_correlation_id") == "corr_001"
+        assert item["target_id"] == "tid_001"
+        assert item["version_correlation_id"] == "corr_001"
 
 
 # ---------------------------------------------------------------------------
-# Test 2: Full pipeline → DB write
+# Full pipeline → DB roundtrip
 # ---------------------------------------------------------------------------
 
 
 class TestBatchToDBPipeline:
-    """End-to-end: batch result → processing → enrichment → DB write."""
+    """Batch result → enrichment → stamp → DB write → DB read."""
 
-    def test_content_survives_enrichment_and_db_write(
+    def test_content_survives_enrichment_and_db_roundtrip(
         self, action_config, batch_result, context_map, sqlite_backend, tmp_path
     ):
-        """Content[action_name] must contain LLM response after enrichment and DB write."""
-        # 1. Process batch results
-        strategy = BatchResultStrategy()
-        results = strategy.process(
-            batch_results=[batch_result],
-            context_map=context_map,
-            output_directory=str(tmp_path),
-            agent_config=action_config,
-        )
+        output = _process_batch([batch_result], context_map, action_config, str(tmp_path))
 
-        # 2. Enrich + stamp (same as production finalize_batch_output)
-        output = _enrich_and_stamp(results, "verify_answer")
-        assert len(output) > 0, "No output records after enrichment"
-
-        # 3. Verify content BEFORE write
-        for record in output:
-            content = record.get("content", {})
-            action_ns = content.get("verify_answer")
-            assert action_ns is not None, (
-                f"Pre-write: content['verify_answer'] is None. "
-                f"Full content: {json.dumps(content, indent=2, default=str)}"
-            )
-            assert action_ns != {}, (
-                f"Pre-write: content['verify_answer'] is empty. "
-                f"Full record keys: {list(record.keys())}"
-            )
-
-        # 4. Write to SQLite backend
-        output_file = tmp_path / "test_output.json"
         writer = FileWriter(
-            str(output_file),
+            str(tmp_path / "out.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
             output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
-        # 5. Read back from SQLite and verify
-        target_files = sqlite_backend.list_target_files("verify_answer")
-        assert len(target_files) > 0, "No target files in SQLite after write"
-
-        for rel_path in target_files:
-            data = sqlite_backend.read_target("verify_answer", rel_path)
-            assert isinstance(data, list), f"Expected list, got {type(data)}"
-            assert len(data) > 0, "Empty data list from SQLite"
-
-            for record in data:
-                content = record.get("content", {})
-                action_ns = content.get("verify_answer")
-                assert action_ns is not None, (
-                    f"Post-write: content['verify_answer'] is None in DB. "
-                    f"Content keys: {list(content.keys())}"
-                )
-                assert action_ns != {}, (
-                    f"Post-write: content['verify_answer'] is EMPTY in DB. "
-                    f"This is the bug! Content: {json.dumps(content, indent=2, default=str)}"
-                )
-                assert action_ns.get("verified_answer") == "C", (
-                    f"Post-write: LLM response not in DB. Got: {action_ns}"
-                )
+        data = sqlite_backend.read_target("verify_answer", "out.json")
+        assert data[0]["content"]["verify_answer"]["verified_answer"] == "C"
 
     def test_multiple_records_all_populated(
         self, action_config, context_map, sqlite_backend, tmp_path
     ):
-        """All records in a batch should have content populated, not just the first."""
-        # Build 3 batch results with different custom_ids
         records = []
         for i in range(3):
             tid = f"tid_{i:03d}"
-            upstream = {
+            context_map[tid] = {
                 "source_guid": f"src_{i:03d}",
                 "target_id": tid,
                 "content": {"upstream_action": {"field": f"value_{i}"}},
                 "_filter_status": "included",
             }
-            context_map[tid] = upstream
             records.append(
                 BatchResult(
                     custom_id=tid,
@@ -295,50 +217,28 @@ class TestBatchToDBPipeline:
                 )
             )
 
-        strategy = BatchResultStrategy()
-        results = strategy.process(
-            batch_results=records,
-            context_map=context_map,
-            output_directory=str(tmp_path),
-            agent_config=action_config,
-        )
-
-        output = _enrich_and_stamp(results, "verify_answer")
-
-        # Write to DB
+        output = _process_batch(records, context_map, action_config, str(tmp_path))
         writer = FileWriter(
-            str(tmp_path / "batch_output.json"),
+            str(tmp_path / "batch.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
             output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
-        # Read back and verify ALL records
-        data = sqlite_backend.read_target("verify_answer", "batch_output.json")
-        hollow_count = 0
-        for record in data:
-            action_ns = record.get("content", {}).get("verify_answer")
-            if action_ns is None or action_ns == {}:
-                hollow_count += 1
-
-        assert hollow_count == 0, (
-            f"{hollow_count}/{len(data)} records have hollow content['verify_answer']. "
-            f"This is the batch materialization bug."
-        )
+        data = sqlite_backend.read_target("verify_answer", "batch.json")
+        hollow = [r for r in data if r.get("content", {}).get("verify_answer") in (None, {})]
+        assert hollow == [], f"{len(hollow)}/{len(data)} records have hollow content"
 
 
 # ---------------------------------------------------------------------------
-# Test 3: Versioned action content
+# Versioned actions
 # ---------------------------------------------------------------------------
 
 
 class TestVersionedBatchContent:
-    """Batch content for versioned actions (e.g., verify_answer_1)."""
-
     def test_versioned_action_name_in_content(self, context_map, sqlite_backend, tmp_path):
-        """Versioned action writes content under versioned name (verify_answer_1)."""
-        versioned_config = {
+        config = {
             "name": "verify_answer_1",
             "action_name": "verify_answer_1",
             "kind": "llm",
@@ -349,8 +249,7 @@ class TestVersionedBatchContent:
             "is_versioned_agent": True,
             "version_base_name": "verify_answer",
         }
-
-        batch_result = BatchResult(
+        result = BatchResult(
             custom_id="tid_001",
             content={"verified_answer": "C", "verification_reasoning": "Correct"},
             success=True,
@@ -358,52 +257,32 @@ class TestVersionedBatchContent:
             metadata={"model": "gpt-4o-mini"},
         )
 
-        strategy = BatchResultStrategy()
-        results = strategy.process(
-            batch_results=[batch_result],
-            context_map=context_map,
-            output_directory=str(tmp_path),
-            agent_config=versioned_config,
-        )
-
-        output = _enrich_and_stamp(results, "verify_answer_1")
-
+        output = _process_batch([result], context_map, config, str(tmp_path), "verify_answer_1")
         writer = FileWriter(
-            str(tmp_path / "output.json"),
+            str(tmp_path / "out.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer_1",
             output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
-        data = sqlite_backend.read_target("verify_answer_1", "output.json")
-        record = data[0]
-        content = record.get("content", {})
-
-        # Must be under the versioned name
-        assert "verify_answer_1" in content, (
-            f"Expected 'verify_answer_1' in content. Got keys: {list(content.keys())}"
-        )
-        assert content["verify_answer_1"].get("verified_answer") == "C"
-        assert record.get("version_correlation_id") == "corr_001"
+        data = sqlite_backend.read_target("verify_answer_1", "out.json")
+        assert data[0]["content"]["verify_answer_1"]["verified_answer"] == "C"
+        assert data[0]["version_correlation_id"] == "corr_001"
 
 
 # ---------------------------------------------------------------------------
-# Test 4: Failed + successful records in same batch
+# Partial failures
 # ---------------------------------------------------------------------------
 
 
 class TestPartialBatchFailure:
-    """When some records fail, successful ones must still have content."""
-
     def test_successful_records_populated_despite_failures(
         self, action_config, sqlite_backend, tmp_path
     ):
-        """1 failed + 2 successful: successful records must have full content."""
-        context_map = {}
+        context_map: dict[str, Any] = {}
         batch_results = []
 
-        # 2 successful results
         for i in range(2):
             tid = f"tid_ok_{i}"
             context_map[tid] = {
@@ -415,40 +294,23 @@ class TestPartialBatchFailure:
             batch_results.append(
                 BatchResult(
                     custom_id=tid,
-                    content={"answer": f"Answer {i}", "reasoning": f"Because {i}"},
+                    content={"answer": f"Answer {i}"},
                     success=True,
                     error=None,
                 )
             )
 
-        # 1 failed result
-        tid_fail = "tid_fail"
-        context_map[tid_fail] = {
+        context_map["tid_fail"] = {
             "source_guid": "src_fail",
-            "target_id": tid_fail,
+            "target_id": "tid_fail",
             "content": {"upstream": {"data": "val_fail"}},
             "_filter_status": "included",
         }
         batch_results.append(
-            BatchResult(
-                custom_id=tid_fail,
-                content=None,
-                success=False,
-                error="HTTP 500 Internal Server Error",
-            )
+            BatchResult(custom_id="tid_fail", content=None, success=False, error="HTTP 500")
         )
 
-        strategy = BatchResultStrategy()
-        results = strategy.process(
-            batch_results=batch_results,
-            context_map=context_map,
-            output_directory=str(tmp_path),
-            agent_config=action_config,
-        )
-
-        output = _enrich_and_stamp(results, "verify_answer")
-
-        # Write ALL records (including failed) to DB
+        output = _process_batch(batch_results, context_map, action_config, str(tmp_path))
         writer = FileWriter(
             str(tmp_path / "partial.json"),
             storage_backend=sqlite_backend,
@@ -458,44 +320,22 @@ class TestPartialBatchFailure:
         writer.write_target(output)
 
         data = sqlite_backend.read_target("verify_answer", "partial.json")
-
-        # Successful records must have content
-        successful_records = [
-            r
-            for r in data
-            if r.get("content", {}).get("verify_answer") is not None
-            and r.get("content", {}).get("verify_answer") != {}
-        ]
-        assert len(successful_records) >= 2, (
-            f"Expected at least 2 records with populated content, got {len(successful_records)}. "
-            f"Record contents: {[r.get('content', {}).get('verify_answer') for r in data]}"
-        )
+        populated = [r for r in data if r.get("content", {}).get("verify_answer") not in (None, {})]
+        assert len(populated) >= 2
 
 
 # ---------------------------------------------------------------------------
-# Test 5: Disk materialization (currently expected to fail — the gap)
+# Disk materialization
 # ---------------------------------------------------------------------------
 
 
 class TestDiskMaterialization:
-    """Target directory files must be written alongside DB records."""
-
-    def test_target_json_exists_on_disk(
+    def test_target_json_materialized_on_disk(
         self, action_config, batch_result, context_map, sqlite_backend, tmp_path
     ):
-        """After batch finalization, processed JSON must exist on disk."""
-        strategy = BatchResultStrategy()
-        results = strategy.process(
-            batch_results=[batch_result],
-            context_map=context_map,
-            output_directory=str(tmp_path),
-            agent_config=action_config,
-        )
+        output = _process_batch([batch_result], context_map, action_config, str(tmp_path))
 
-        output = _enrich_and_stamp(results, "verify_answer")
-
-        # Write via FileWriter (production path)
-        output_file = tmp_path / "test_output.json"
+        output_file = tmp_path / "target.json"
         writer = FileWriter(
             str(output_file),
             storage_backend=sqlite_backend,
@@ -504,41 +344,26 @@ class TestDiskMaterialization:
         )
         writer.write_target(output)
 
-        # After fix: FileWriter.write_target writes to BOTH SQLite and disk
-        assert output_file.exists(), (
-            f"Target file not materialized at {output_file}. "
-            f"FileWriter.write_target must write to both SQLite and disk."
-        )
+        assert output_file.exists(), "Target file not materialized to disk"
 
-        # Verify disk file contains correct content
         with open(output_file) as f:
             disk_data = json.load(f)
-        assert isinstance(disk_data, list)
-        assert len(disk_data) > 0
-        disk_content = disk_data[0].get("content", {})
-        assert disk_content.get("verify_answer", {}).get("verified_answer") == "C"
+        assert disk_data[0]["content"]["verify_answer"]["verified_answer"] == "C"
 
 
 # ---------------------------------------------------------------------------
-# Test 6: Provider parse chain (simulates Ollama .jsonl reading)
+# Provider parse chain (Ollama .jsonl simulation)
 # ---------------------------------------------------------------------------
 
 
 class TestProviderParseChain:
-    """Simulate reading from a .jsonl file as the Ollama batch client does."""
-
-    def test_jsonl_string_content_parsed_correctly(
+    def test_jsonl_string_content_parsed_and_written(
         self, action_config, context_map, sqlite_backend, tmp_path
     ):
-        """Simulate Ollama .jsonl: content is a JSON STRING, not pre-parsed dict.
-
-        The provider writes results to .jsonl, then _read_jsonl_file calls
-        parse_provider_response which extracts and parses the content string.
-        """
+        """Content arrives as JSON string in .jsonl — must parse and persist."""
         from agent_actions.llm.providers.batch_base import BaseBatchClient
         from agent_actions.llm.providers.mixins import OpenAICompatibleResponseMixin
 
-        # Build a raw OpenAI-format response as would appear in .jsonl
         raw_response = {
             "custom_id": "tid_001",
             "response": {
@@ -560,8 +385,7 @@ class TestProviderParseChain:
             "error": None,
         }
 
-        # Create a minimal concrete batch client to access parse_provider_response
-        class _TestClient(OpenAICompatibleResponseMixin, BaseBatchClient):
+        class _StubClient(OpenAICompatibleResponseMixin, BaseBatchClient):
             vendor_slug = "test"
 
             def _fetch_status(self, batch_id):
@@ -588,68 +412,30 @@ class TestProviderParseChain:
             def _fetch_raw_results(self, batch_id):
                 return b""
 
-        client = _TestClient()
-        batch_result = client.parse_provider_response(raw_response)
+        batch_result = _StubClient().parse_provider_response(raw_response)
+        assert isinstance(batch_result.content, dict)
+        assert batch_result.content["verified_answer"] == "C"
 
-        # Verify the provider correctly parsed the string content
-        assert batch_result.success is True
-        assert batch_result.content is not None
-        assert isinstance(batch_result.content, dict), (
-            f"Expected parsed dict, got {type(batch_result.content).__name__}: "
-            f"{batch_result.content!r}"
-        )
-        assert batch_result.content.get("verified_answer") == "C"
-
-        # Now run through the full batch strategy + DB write
-        strategy = BatchResultStrategy()
-        results = strategy.process(
-            batch_results=[batch_result],
-            context_map=context_map,
-            output_directory=str(tmp_path),
-            agent_config=action_config,
-        )
-
-        output = _enrich_and_stamp(results, "verify_answer")
-
+        output = _process_batch([batch_result], context_map, action_config, str(tmp_path))
         writer = FileWriter(
-            str(tmp_path / "ollama_output.json"),
+            str(tmp_path / "ollama.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
             output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
-        data = sqlite_backend.read_target("verify_answer", "ollama_output.json")
-        record = data[0]
-        action_ns = record.get("content", {}).get("verify_answer")
-        assert action_ns != {}, f"Hollow record! content.verify_answer is empty: {action_ns}"
-        assert action_ns.get("verified_answer") == "C"
+        data = sqlite_backend.read_target("verify_answer", "ollama.json")
+        assert data[0]["content"]["verify_answer"]["verified_answer"] == "C"
 
-    def test_empty_json_response_detected(self, action_config, context_map):
-        """When LLM returns '{}' (empty JSON), the record should not be hollow."""
-        # This simulates the Ollama Cloud case where format=json isn't sent
-        batch_result = BatchResult(
-            custom_id="tid_001",
-            content={},  # Parsed from "{}" — empty dict
-            success=True,
-            error=None,
-        )
-
+    def test_empty_json_response_produces_hollow_namespace(self, action_config, context_map):
+        """Empty dict from LLM produces content.{action_name}: {} — hollow but valid."""
+        result = BatchResult(custom_id="tid_001", content={}, success=True, error=None)
         strategy = BatchResultStrategy()
         results = strategy.process(
-            batch_results=[batch_result],
+            batch_results=[result],
             context_map=context_map,
             output_directory="/tmp/test",
             agent_config=action_config,
         )
-
-        item = results[0].data[0]
-        content = item.get("content", {})
-        action_ns = content.get("verify_answer")
-
-        # Even with empty LLM response, the namespace exists (it's just empty)
-        # This IS a hollow record — the framework processed it "successfully"
-        # but the LLM didn't return useful data
-        assert action_ns == {}, (
-            "Expected empty dict for empty LLM response — this is the hollow record pattern"
-        )
+        assert results[0].data[0]["content"]["verify_answer"] == {}

--- a/tests/integration/test_batch_content_materialization.py
+++ b/tests/integration/test_batch_content_materialization.py
@@ -1,0 +1,655 @@
+"""
+Integration tests for batch content materialization.
+
+Verifies that batch LLM results are correctly injected into
+content.{action_name} and persisted to the storage backend.
+
+Reproduces the bug: batch-mode actions produce hollow records
+(content.{action_name}: {}) despite valid LLM responses.
+"""
+
+import json
+from typing import Any
+
+import pytest
+
+from agent_actions.llm.batch.processing.batch_result_strategy import BatchResultStrategy
+from agent_actions.llm.batch.services.processing_recovery import (
+    _stamp_batch_records,
+)
+from agent_actions.llm.providers.batch_base import BatchResult
+from agent_actions.output.writer import FileWriter
+from agent_actions.processing.enrichment import EnrichmentPipeline
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+def _enrich_and_stamp(results, action_name: str = "verify_answer") -> list[dict[str, Any]]:
+    """Run enrichment pipeline + stamp lifecycle (matches production path)."""
+    enrichment = EnrichmentPipeline()
+    output: list[dict[str, Any]] = []
+    for result in results:
+        if result.processing_context is not None:
+            result = enrichment.enrich(result, result.processing_context)
+        output.extend(result.data or [])
+    _stamp_batch_records(output, action_name)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def action_config() -> dict[str, Any]:
+    """Realistic LLM action config for batch processing."""
+    return {
+        "name": "verify_answer",
+        "action_name": "verify_answer",
+        "kind": "llm",
+        "model_vendor": "openai",
+        "model_name": "gpt-4o-mini",
+        "json_mode": True,
+        "output_field": "raw_response",
+        "context_scope": {
+            "observe": ["source.question", "write_scenario_question.verified_answer"],
+        },
+    }
+
+
+@pytest.fixture
+def upstream_record() -> dict[str, Any]:
+    """Input record with upstream content namespaces."""
+    return {
+        "source_guid": "src_001",
+        "target_id": "tid_001",
+        "version_correlation_id": "corr_001",
+        "content": {
+            "summarize_page_content": {
+                "summary": "AWS S3 bucket policies control access...",
+            },
+            "write_scenario_question": {
+                "question_text": "What is the correct S3 bucket policy?",
+                "answer_text": "Option C: Allow principal *",
+            },
+        },
+    }
+
+
+@pytest.fixture
+def llm_response() -> dict[str, Any]:
+    """Parsed LLM response (what the provider returns after JSON parsing)."""
+    return {
+        "verified_answer": "C",
+        "verification_reasoning": "Option C correctly allows all principals.",
+    }
+
+
+@pytest.fixture
+def batch_result(llm_response) -> BatchResult:
+    """BatchResult as returned by provider.retrieve_results()."""
+    return BatchResult(
+        custom_id="tid_001",
+        content=llm_response,
+        success=True,
+        error=None,
+        metadata={"model": "gpt-4o-mini", "finish_reason": "stop"},
+    )
+
+
+@pytest.fixture
+def context_map(upstream_record) -> dict[str, Any]:
+    """Context map as saved at batch submission time."""
+    record = upstream_record.copy()
+    record["_filter_status"] = "included"
+    return {"tid_001": record}
+
+
+@pytest.fixture
+def sqlite_backend(tmp_path) -> SQLiteBackend:
+    """Real SQLite backend for integration testing."""
+    db_path = tmp_path / "test.db"
+    backend = SQLiteBackend(str(db_path), workflow_name="test_workflow")
+    backend.initialize()
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Content assembly in BatchResultStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestBatchContentAssembly:
+    """Verify that BatchResultStrategy correctly builds content[action_name]."""
+
+    def test_successful_result_populates_action_namespace(
+        self, action_config, batch_result, context_map, llm_response
+    ):
+        """Core test: content[action_name] must contain the parsed LLM response."""
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory="/tmp/test",
+            agent_config=action_config,
+        )
+
+        assert len(results) == 1, f"Expected 1 result, got {len(results)}"
+        result = results[0]
+        assert result.data, "ProcessingResult.data is empty"
+
+        # Check the first item's content
+        item = result.data[0]
+        content = item.get("content", {})
+
+        # THE CRITICAL ASSERTION: action namespace must have LLM response
+        action_ns = content.get("verify_answer")
+        assert action_ns is not None, (
+            f"content['verify_answer'] is missing. Content keys: {list(content.keys())}"
+        )
+        assert action_ns != {}, (
+            f"content['verify_answer'] is empty dict. Expected LLM response: {llm_response}"
+        )
+        assert action_ns.get("verified_answer") == "C", (
+            f"content['verify_answer'] missing 'verified_answer'. Got: {action_ns}"
+        )
+        assert "verification_reasoning" in action_ns
+
+        # Upstream namespaces must be preserved
+        assert "summarize_page_content" in content
+        assert "write_scenario_question" in content
+
+    def test_string_content_parsed_to_dict(self, action_config, context_map):
+        """When provider returns parsed string, it should be re-wrapped."""
+        # Simulate provider returning string content (json_mode but unparsed)
+        batch_result = BatchResult(
+            custom_id="tid_001",
+            content='{"verified_answer": "C"}',  # String, not dict
+            success=True,
+            error=None,
+        )
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory="/tmp/test",
+            agent_config=action_config,
+        )
+
+        item = results[0].data[0]
+        content = item.get("content", {})
+        action_ns = content.get("verify_answer", {})
+
+        # String in json_mode gets wrapped as _parse_error
+        # (the string should have been parsed by the provider, not here)
+        assert "_parse_error" in action_ns or "verified_answer" in action_ns
+
+    def test_framework_fields_carried(self, action_config, batch_result, context_map):
+        """target_id and version_correlation_id must be carried from input."""
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory="/tmp/test",
+            agent_config=action_config,
+        )
+
+        item = results[0].data[0]
+        assert item.get("target_id") == "tid_001"
+        assert item.get("version_correlation_id") == "corr_001"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Full pipeline → DB write
+# ---------------------------------------------------------------------------
+
+
+class TestBatchToDBPipeline:
+    """End-to-end: batch result → processing → enrichment → DB write."""
+
+    def test_content_survives_enrichment_and_db_write(
+        self, action_config, batch_result, context_map, sqlite_backend, tmp_path
+    ):
+        """Content[action_name] must contain LLM response after enrichment and DB write."""
+        # 1. Process batch results
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory=str(tmp_path),
+            agent_config=action_config,
+        )
+
+        # 2. Enrich + stamp (same as production finalize_batch_output)
+        output = _enrich_and_stamp(results, "verify_answer")
+        assert len(output) > 0, "No output records after enrichment"
+
+        # 3. Verify content BEFORE write
+        for record in output:
+            content = record.get("content", {})
+            action_ns = content.get("verify_answer")
+            assert action_ns is not None, (
+                f"Pre-write: content['verify_answer'] is None. "
+                f"Full content: {json.dumps(content, indent=2, default=str)}"
+            )
+            assert action_ns != {}, (
+                f"Pre-write: content['verify_answer'] is empty. "
+                f"Full record keys: {list(record.keys())}"
+            )
+
+        # 4. Write to SQLite backend
+        output_file = tmp_path / "test_output.json"
+        writer = FileWriter(
+            str(output_file),
+            storage_backend=sqlite_backend,
+            action_name="verify_answer",
+            output_directory=str(tmp_path),
+        )
+        writer.write_target(output)
+
+        # 5. Read back from SQLite and verify
+        target_files = sqlite_backend.list_target_files("verify_answer")
+        assert len(target_files) > 0, "No target files in SQLite after write"
+
+        for rel_path in target_files:
+            data = sqlite_backend.read_target("verify_answer", rel_path)
+            assert isinstance(data, list), f"Expected list, got {type(data)}"
+            assert len(data) > 0, "Empty data list from SQLite"
+
+            for record in data:
+                content = record.get("content", {})
+                action_ns = content.get("verify_answer")
+                assert action_ns is not None, (
+                    f"Post-write: content['verify_answer'] is None in DB. "
+                    f"Content keys: {list(content.keys())}"
+                )
+                assert action_ns != {}, (
+                    f"Post-write: content['verify_answer'] is EMPTY in DB. "
+                    f"This is the bug! Content: {json.dumps(content, indent=2, default=str)}"
+                )
+                assert action_ns.get("verified_answer") == "C", (
+                    f"Post-write: LLM response not in DB. Got: {action_ns}"
+                )
+
+    def test_multiple_records_all_populated(
+        self, action_config, context_map, sqlite_backend, tmp_path
+    ):
+        """All records in a batch should have content populated, not just the first."""
+        # Build 3 batch results with different custom_ids
+        records = []
+        for i in range(3):
+            tid = f"tid_{i:03d}"
+            upstream = {
+                "source_guid": f"src_{i:03d}",
+                "target_id": tid,
+                "content": {"upstream_action": {"field": f"value_{i}"}},
+                "_filter_status": "included",
+            }
+            context_map[tid] = upstream
+            records.append(
+                BatchResult(
+                    custom_id=tid,
+                    content={"score": i * 10, "reasoning": f"Reason {i}"},
+                    success=True,
+                    error=None,
+                )
+            )
+
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=records,
+            context_map=context_map,
+            output_directory=str(tmp_path),
+            agent_config=action_config,
+        )
+
+        output = _enrich_and_stamp(results, "verify_answer")
+
+        # Write to DB
+        writer = FileWriter(
+            str(tmp_path / "batch_output.json"),
+            storage_backend=sqlite_backend,
+            action_name="verify_answer",
+            output_directory=str(tmp_path),
+        )
+        writer.write_target(output)
+
+        # Read back and verify ALL records
+        data = sqlite_backend.read_target("verify_answer", "batch_output.json")
+        hollow_count = 0
+        for record in data:
+            action_ns = record.get("content", {}).get("verify_answer")
+            if action_ns is None or action_ns == {}:
+                hollow_count += 1
+
+        assert hollow_count == 0, (
+            f"{hollow_count}/{len(data)} records have hollow content['verify_answer']. "
+            f"This is the batch materialization bug."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Versioned action content
+# ---------------------------------------------------------------------------
+
+
+class TestVersionedBatchContent:
+    """Batch content for versioned actions (e.g., verify_answer_1)."""
+
+    def test_versioned_action_name_in_content(self, context_map, sqlite_backend, tmp_path):
+        """Versioned action writes content under versioned name (verify_answer_1)."""
+        versioned_config = {
+            "name": "verify_answer_1",
+            "action_name": "verify_answer_1",
+            "kind": "llm",
+            "model_vendor": "openai",
+            "model_name": "gpt-4o-mini",
+            "json_mode": True,
+            "output_field": "raw_response",
+            "is_versioned_agent": True,
+            "version_base_name": "verify_answer",
+        }
+
+        batch_result = BatchResult(
+            custom_id="tid_001",
+            content={"verified_answer": "C", "verification_reasoning": "Correct"},
+            success=True,
+            error=None,
+            metadata={"model": "gpt-4o-mini"},
+        )
+
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory=str(tmp_path),
+            agent_config=versioned_config,
+        )
+
+        output = _enrich_and_stamp(results, "verify_answer_1")
+
+        writer = FileWriter(
+            str(tmp_path / "output.json"),
+            storage_backend=sqlite_backend,
+            action_name="verify_answer_1",
+            output_directory=str(tmp_path),
+        )
+        writer.write_target(output)
+
+        data = sqlite_backend.read_target("verify_answer_1", "output.json")
+        record = data[0]
+        content = record.get("content", {})
+
+        # Must be under the versioned name
+        assert "verify_answer_1" in content, (
+            f"Expected 'verify_answer_1' in content. Got keys: {list(content.keys())}"
+        )
+        assert content["verify_answer_1"].get("verified_answer") == "C"
+        assert record.get("version_correlation_id") == "corr_001"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Failed + successful records in same batch
+# ---------------------------------------------------------------------------
+
+
+class TestPartialBatchFailure:
+    """When some records fail, successful ones must still have content."""
+
+    def test_successful_records_populated_despite_failures(
+        self, action_config, sqlite_backend, tmp_path
+    ):
+        """1 failed + 2 successful: successful records must have full content."""
+        context_map = {}
+        batch_results = []
+
+        # 2 successful results
+        for i in range(2):
+            tid = f"tid_ok_{i}"
+            context_map[tid] = {
+                "source_guid": f"src_{i}",
+                "target_id": tid,
+                "content": {"upstream": {"data": f"val_{i}"}},
+                "_filter_status": "included",
+            }
+            batch_results.append(
+                BatchResult(
+                    custom_id=tid,
+                    content={"answer": f"Answer {i}", "reasoning": f"Because {i}"},
+                    success=True,
+                    error=None,
+                )
+            )
+
+        # 1 failed result
+        tid_fail = "tid_fail"
+        context_map[tid_fail] = {
+            "source_guid": "src_fail",
+            "target_id": tid_fail,
+            "content": {"upstream": {"data": "val_fail"}},
+            "_filter_status": "included",
+        }
+        batch_results.append(
+            BatchResult(
+                custom_id=tid_fail,
+                content=None,
+                success=False,
+                error="HTTP 500 Internal Server Error",
+            )
+        )
+
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=batch_results,
+            context_map=context_map,
+            output_directory=str(tmp_path),
+            agent_config=action_config,
+        )
+
+        output = _enrich_and_stamp(results, "verify_answer")
+
+        # Write ALL records (including failed) to DB
+        writer = FileWriter(
+            str(tmp_path / "partial.json"),
+            storage_backend=sqlite_backend,
+            action_name="verify_answer",
+            output_directory=str(tmp_path),
+        )
+        writer.write_target(output)
+
+        data = sqlite_backend.read_target("verify_answer", "partial.json")
+
+        # Successful records must have content
+        successful_records = [
+            r
+            for r in data
+            if r.get("content", {}).get("verify_answer") is not None
+            and r.get("content", {}).get("verify_answer") != {}
+        ]
+        assert len(successful_records) >= 2, (
+            f"Expected at least 2 records with populated content, got {len(successful_records)}. "
+            f"Record contents: {[r.get('content', {}).get('verify_answer') for r in data]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Disk materialization (currently expected to fail — the gap)
+# ---------------------------------------------------------------------------
+
+
+class TestDiskMaterialization:
+    """Target directory files must be written alongside DB records."""
+
+    def test_target_json_exists_on_disk(
+        self, action_config, batch_result, context_map, sqlite_backend, tmp_path
+    ):
+        """After batch finalization, processed JSON must exist on disk."""
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory=str(tmp_path),
+            agent_config=action_config,
+        )
+
+        output = _enrich_and_stamp(results, "verify_answer")
+
+        # Write via FileWriter (production path)
+        output_file = tmp_path / "test_output.json"
+        writer = FileWriter(
+            str(output_file),
+            storage_backend=sqlite_backend,
+            action_name="verify_answer",
+            output_directory=str(tmp_path),
+        )
+        writer.write_target(output)
+
+        # After fix: FileWriter.write_target writes to BOTH SQLite and disk
+        assert output_file.exists(), (
+            f"Target file not materialized at {output_file}. "
+            f"FileWriter.write_target must write to both SQLite and disk."
+        )
+
+        # Verify disk file contains correct content
+        with open(output_file) as f:
+            disk_data = json.load(f)
+        assert isinstance(disk_data, list)
+        assert len(disk_data) > 0
+        disk_content = disk_data[0].get("content", {})
+        assert disk_content.get("verify_answer", {}).get("verified_answer") == "C"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Provider parse chain (simulates Ollama .jsonl reading)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderParseChain:
+    """Simulate reading from a .jsonl file as the Ollama batch client does."""
+
+    def test_jsonl_string_content_parsed_correctly(
+        self, action_config, context_map, sqlite_backend, tmp_path
+    ):
+        """Simulate Ollama .jsonl: content is a JSON STRING, not pre-parsed dict.
+
+        The provider writes results to .jsonl, then _read_jsonl_file calls
+        parse_provider_response which extracts and parses the content string.
+        """
+        from agent_actions.llm.providers.batch_base import BaseBatchClient
+        from agent_actions.llm.providers.mixins import OpenAICompatibleResponseMixin
+
+        # Build a raw OpenAI-format response as would appear in .jsonl
+        raw_response = {
+            "custom_id": "tid_001",
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": '{"verified_answer": "C", "verification_reasoning": "Correct"}',
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "model": "llama3.3",
+                    "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+                },
+            },
+            "error": None,
+        }
+
+        # Create a minimal concrete batch client to access parse_provider_response
+        class _TestClient(OpenAICompatibleResponseMixin, BaseBatchClient):
+            vendor_slug = "test"
+
+            def _fetch_status(self, batch_id):
+                return "completed"
+
+            def _normalize_status(self, raw_status):
+                return raw_status
+
+            def _get_default_model(self):
+                return "test-model"
+
+            def _get_result_file_name(self, batch_id):
+                return f"{batch_id}_results.jsonl"
+
+            def format_task_for_provider(self, batch_task, schema=None):
+                return {}
+
+            def _submit_to_provider_api(self, input_file, batch_name):
+                return ("test", "completed")
+
+            def _prepare_batch_input_file(self, tasks, batch_dir, batch_name):
+                return batch_dir / "test.jsonl"
+
+            def _fetch_raw_results(self, batch_id):
+                return b""
+
+        client = _TestClient()
+        batch_result = client.parse_provider_response(raw_response)
+
+        # Verify the provider correctly parsed the string content
+        assert batch_result.success is True
+        assert batch_result.content is not None
+        assert isinstance(batch_result.content, dict), (
+            f"Expected parsed dict, got {type(batch_result.content).__name__}: "
+            f"{batch_result.content!r}"
+        )
+        assert batch_result.content.get("verified_answer") == "C"
+
+        # Now run through the full batch strategy + DB write
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory=str(tmp_path),
+            agent_config=action_config,
+        )
+
+        output = _enrich_and_stamp(results, "verify_answer")
+
+        writer = FileWriter(
+            str(tmp_path / "ollama_output.json"),
+            storage_backend=sqlite_backend,
+            action_name="verify_answer",
+            output_directory=str(tmp_path),
+        )
+        writer.write_target(output)
+
+        data = sqlite_backend.read_target("verify_answer", "ollama_output.json")
+        record = data[0]
+        action_ns = record.get("content", {}).get("verify_answer")
+        assert action_ns != {}, f"Hollow record! content.verify_answer is empty: {action_ns}"
+        assert action_ns.get("verified_answer") == "C"
+
+    def test_empty_json_response_detected(self, action_config, context_map):
+        """When LLM returns '{}' (empty JSON), the record should not be hollow."""
+        # This simulates the Ollama Cloud case where format=json isn't sent
+        batch_result = BatchResult(
+            custom_id="tid_001",
+            content={},  # Parsed from "{}" — empty dict
+            success=True,
+            error=None,
+        )
+
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[batch_result],
+            context_map=context_map,
+            output_directory="/tmp/test",
+            agent_config=action_config,
+        )
+
+        item = results[0].data[0]
+        content = item.get("content", {})
+        action_ns = content.get("verify_answer")
+
+        # Even with empty LLM response, the namespace exists (it's just empty)
+        # This IS a hollow record — the framework processed it "successfully"
+        # but the LLM didn't return useful data
+        assert action_ns == {}, (
+            "Expected empty dict for empty LLM response — this is the hollow record pattern"
+        )

--- a/tests/unit/output/test_writer.py
+++ b/tests/unit/output/test_writer.py
@@ -334,8 +334,10 @@ class TestExecuteWriteErrors:
 
         with patch.object(writer, "handle_processing_error") as mock_handler:
             mock_handler.side_effect = Exception("handled")
-            # json.dump will fail on non-serializable data
-            with patch("agent_actions.output.writer.json.dump", side_effect=TypeError("bad")):
+            with patch(
+                "agent_actions.output.writer.atomic_json_write",
+                side_effect=TypeError("bad"),
+            ):
                 with pytest.raises(Exception, match="handled"):
                     writer.write_staging({"x": 1})
             mock_handler.assert_called_once()


### PR DESCRIPTION
## Summary
- `FileWriter.write_target()` now writes to BOTH the storage backend (SQLite) AND the filesystem
- Previously, batch-mode actions only wrote to SQLite, leaving `agent_io/target/{action_name}/` empty on disk
- Downstream consumers reading from target directories (version_consumption merge, cross-workflow deps) found nothing and failed

## Root Cause
`FileWriter.write_target()` delegated entirely to `storage_backend.write_target()` (SQLite INSERT), with no disk materialization step. Online mode happened to work because the runner's `process_from_storage_backend()` reads from SQLite. But certain downstream patterns (version_consumption merge, cross-workflow export) expect filesystem layout.

## Fix
Added `atomic_json_write(file_path, data)` after the storage backend write in `write_target()`. This creates processed JSON files at the expected `agent_io/target/{action_name}/{file}.json` path.

## Before / After

| | Before | After |
|---|--------|--------|
| `ls agent_io/target/{action}/` | Only `batch/*.jsonl` (raw) | Processed `{file}.json` + `batch/*.jsonl` |
| SQLite `target_data` | Written correctly | Written correctly (unchanged) |
| Downstream merge/tool | Missing field errors | Succeeds |

## Investigation findings
- Content assembly in `BatchResultStrategy` is **correct** — `content[action_name]` gets the LLM response
- Enrichment pipeline preserves content correctly
- DB roundtrip (write → read) preserves content correctly
- The gap was exclusively in disk materialization
- Ollama Cloud batch simulation goes through the same shared pipeline — all providers affected equally

## Verification
- 10 new integration tests covering: content assembly, DB roundtrip, versioned actions, partial failures, disk materialization, provider parse chain
- All 6626 existing tests pass (0 regressions)
- `ruff check` and `ruff format` clean

## Spec
`specs/bugs/pending/batch_target_materialization_gap.md`