### PR TITLE
feat: reprompt observability events, counters, and fresh-run log reset

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260514-135000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260514-135000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Reprompt observability: retry/recovered events (R004/R005), fresh-run log reset, parse error warn level, failure-type counters"
+time: 2026-05-14T13:50:00.000000Z

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -296,6 +296,7 @@ def handle_reprompt_recovery(
                     attempt=next_attempt,
                     max_attempts=state.reprompt_max_attempts,
                     error=f"{len(still_failing)} records failed validation",
+                    failed_count=len(still_failing),
                 )
             )
             for fr in still_failing:
@@ -450,6 +451,7 @@ def check_and_submit_reprompt(
             attempt=next_attempt,
             max_attempts=max_attempts,
             error=f"{len(still_failing)} records failed validation",
+            failed_count=len(still_failing),
         )
     )
     logger.info(

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -31,6 +31,10 @@ from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import BatchCompleteEvent
+from agent_actions.logging.events.validation_events import (
+    RepromptRecoveredEvent,
+    RepromptRetryEvent,
+)
 from agent_actions.processing.result_collector import write_record_dispositions
 from agent_actions.processing.types import RecoveryMetadata
 from agent_actions.record.envelope import RecordEnvelope
@@ -286,6 +290,14 @@ def handle_reprompt_recovery(
             _register_recovery_batch(
                 manager, submission, parent_file_name, entry.provider, "reprompt", next_attempt
             )
+            fire_event(
+                RepromptRetryEvent(
+                    action_name=parent_file_name or "batch",
+                    attempt=next_attempt,
+                    max_attempts=state.reprompt_max_attempts,
+                    error=f"{len(still_failing)} records failed validation",
+                )
+            )
             for fr in still_failing:
                 state.reprompt_attempts_per_record[fr.custom_id] = (
                     state.reprompt_attempts_per_record.get(fr.custom_id, 0) + 1
@@ -308,6 +320,16 @@ def handle_reprompt_recovery(
     final_results = BatchRetryService.deserialize_results(state.graduated_results)
     if still_failing:
         final_results.extend(still_failing)
+
+    if state.graduated_results:
+        fire_event(
+            RepromptRecoveredEvent(
+                action_name=parent_file_name or "batch",
+                attempt=state.reprompt_attempt,
+                max_attempts=state.reprompt_max_attempts,
+                validation_name=strategy.name,
+            )
+        )
 
     # Rebuild exhausted_recovery from retry phase state (frozen at phase transition).
     exhausted_recovery = None
@@ -422,6 +444,14 @@ def check_and_submit_reprompt(
         }
 
     RecoveryStateManager.save(output_directory, file_name, state)
+    fire_event(
+        RepromptRetryEvent(
+            action_name=file_name or "batch",
+            attempt=next_attempt,
+            max_attempts=max_attempts,
+            error=f"{len(still_failing)} records failed validation",
+        )
+    )
     logger.info(
         "Async reprompt submitted for %s: %d failed records, batch %s",
         file_name,

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -215,6 +215,7 @@ def validate_and_reprompt(
                 attempt=attempt + 2,
                 max_attempts=max_attempts,
                 error=f"{len(still_failing)} records failed validation",
+                failed_count=len(still_failing),
             )
         )
 

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -10,6 +10,11 @@ from agent_actions.llm.batch.services.retry_polling import (
     wait_for_batch_completion,
 )
 from agent_actions.llm.providers.batch_base import BaseBatchClient, BatchResult
+from agent_actions.logging.core.manager import fire_event
+from agent_actions.logging.events.validation_events import (
+    RepromptRecoveredEvent,
+    RepromptRetryEvent,
+)
 from agent_actions.processing.types import RecoveryMetadata
 
 if TYPE_CHECKING:
@@ -204,6 +209,15 @@ def validate_and_reprompt(
             all_graduated.extend(still_failing)
             break
 
+        fire_event(
+            RepromptRetryEvent(
+                action_name=file_name or "batch",
+                attempt=attempt + 2,
+                max_attempts=max_attempts,
+                error=f"{len(still_failing)} records failed validation",
+            )
+        )
+
         use_critique = (raw_reprompt_config or {}).get("use_llm_critique", False)
         critique_after = (raw_reprompt_config or {}).get("critique_after_attempt", 2)
         apply_critique = use_critique and attempt + 1 >= critique_after
@@ -357,6 +371,7 @@ def validate_and_reprompt(
             all_graduated.extend(still_failing)
             break
 
+    recovered_count = 0
     for r in all_graduated:
         if r.custom_id not in reprompted_ids:
             continue
@@ -368,6 +383,17 @@ def validate_and_reprompt(
             attempts=reprompted_ids[r.custom_id],
             passed=True,
             validation=validation_name,
+        )
+        recovered_count += 1
+
+    if recovered_count:
+        fire_event(
+            RepromptRecoveredEvent(
+                action_name=file_name or "batch",
+                attempt=attempt + 1,
+                max_attempts=max_attempts,
+                validation_name=validation_name,
+            )
         )
 
     return all_graduated

--- a/agent_actions/logging/events/__init__.py
+++ b/agent_actions/logging/events/__init__.py
@@ -118,6 +118,8 @@ from agent_actions.logging.events.validation_events import (
     GuardEvaluationErrorEvent,
     GuardEvaluationTimeoutEvent,
     RecoveryErrorEvent,
+    RepromptRecoveredEvent,
+    RepromptRetryEvent,
     RepromptValidationFailedEvent,
     RetryExhaustedEvent,
     ValidationCompleteEvent,
@@ -195,6 +197,8 @@ __all__ = [
     # Recovery
     "RetryExhaustedEvent",
     "RepromptValidationFailedEvent",
+    "RepromptRetryEvent",
+    "RepromptRecoveredEvent",
     "RecoveryErrorEvent",
     # Configuration
     "ConfigLoadStartEvent",

--- a/agent_actions/logging/events/llm_events.py
+++ b/agent_actions/logging/events/llm_events.py
@@ -192,7 +192,7 @@ class LLMJSONParseErrorEvent(BaseEvent):
     error: str = ""
 
     def __post_init__(self) -> None:
-        self.level = EventLevel.ERROR
+        self.level = EventLevel.WARN
         self.category = EventCategories.LLM
         self.message = f"{self.provider}/{self.model} returned invalid JSON: {self.error}"
         self.data = {

--- a/agent_actions/logging/events/validation_events.py
+++ b/agent_actions/logging/events/validation_events.py
@@ -18,6 +18,8 @@ __all__ = [
     "GuardEvaluationErrorEvent",
     "RetryExhaustedEvent",
     "RepromptValidationFailedEvent",
+    "RepromptRetryEvent",
+    "RepromptRecoveredEvent",
     "RecoveryErrorEvent",
 ]
 
@@ -290,6 +292,63 @@ class RepromptValidationFailedEvent(BaseEvent):
     @property
     def code(self) -> str:
         return "R002"
+
+
+@dataclass
+class RepromptRetryEvent(BaseEvent):
+    """Fired before each reprompt retry attempt."""
+
+    action_name: str = ""
+    attempt: int = 0
+    max_attempts: int = 0
+    error: str = ""
+
+    def __post_init__(self) -> None:
+        self.level = EventLevel.INFO
+        self.category = EventCategories.RECOVERY
+        self.message = (
+            f"Reprompt retry for '{self.action_name}' "
+            f"(attempt {self.attempt}/{self.max_attempts}): {self.error}"
+        )
+        self.data = {
+            "action_name": self.action_name,
+            "attempt": self.attempt,
+            "max_attempts": self.max_attempts,
+            "error": self.error,
+        }
+
+    @property
+    def code(self) -> str:
+        return "R004"
+
+
+@dataclass
+class RepromptRecoveredEvent(BaseEvent):
+    """Fired when reprompt validation succeeds after retries."""
+
+    action_name: str = ""
+    attempt: int = 0
+    max_attempts: int = 0
+    validation_name: str = ""
+
+    def __post_init__(self) -> None:
+        self.level = EventLevel.INFO
+        self.category = EventCategories.RECOVERY
+        self.message = (
+            f"Reprompt recovered for '{self.action_name}' "
+            f"on attempt {self.attempt}/{self.max_attempts} "
+            f"(validation: {self.validation_name})"
+        )
+        self.data = {
+            "action_name": self.action_name,
+            "attempt": self.attempt,
+            "max_attempts": self.max_attempts,
+            "validation_name": self.validation_name,
+        }
+
+    @property
+    def code(self) -> str:
+        return "R005"
 
 
 @dataclass

--- a/agent_actions/logging/events/validation_events.py
+++ b/agent_actions/logging/events/validation_events.py
@@ -296,12 +296,19 @@ class RepromptValidationFailedEvent(BaseEvent):
 
 @dataclass
 class RepromptRetryEvent(BaseEvent):
-    """Fired before each reprompt retry attempt."""
+    """Fired before each reprompt retry attempt.
+
+    ``attempt`` is the 1-indexed attempt number that is **about to execute**
+    (e.g. attempt=2 means "the first attempt failed, starting attempt 2").
+    ``failed_count`` is set by batch emitters to indicate how many records
+    failed validation; online emitters leave it at 0 (single-record).
+    """
 
     action_name: str = ""
     attempt: int = 0
     max_attempts: int = 0
     error: str = ""
+    failed_count: int = 0
 
     def __post_init__(self) -> None:
         self.level = EventLevel.INFO
@@ -315,6 +322,7 @@ class RepromptRetryEvent(BaseEvent):
             "attempt": self.attempt,
             "max_attempts": self.max_attempts,
             "error": self.error,
+            "failed_count": self.failed_count,
         }
 
     @property
@@ -324,7 +332,12 @@ class RepromptRetryEvent(BaseEvent):
 
 @dataclass
 class RepromptRecoveredEvent(BaseEvent):
-    """Fired when reprompt validation succeeds after retries."""
+    """Fired when reprompt validation succeeds after retries.
+
+    ``attempt`` is the 1-indexed attempt number on which validation
+    **passed** (e.g. attempt=2 means "failed on attempt 1, succeeded
+    on attempt 2").
+    """
 
     action_name: str = ""
     attempt: int = 0

--- a/agent_actions/processing/evaluation/exhaustion.py
+++ b/agent_actions/processing/evaluation/exhaustion.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from agent_actions.llm.providers.batch_base import BatchResult
 
+from agent_actions.logging.core.manager import fire_event
+from agent_actions.logging.events.validation_events import RepromptValidationFailedEvent
 from agent_actions.processing.types import RecoveryMetadata, RepromptMetadata
 
 logger = logging.getLogger(__name__)
@@ -69,6 +71,15 @@ def apply_exhausted_reprompt(
             attempts=record_attempts,
             passed=False,
             validation=validation_name,
+        )
+
+    if failed_ids and on_exhausted != "raise":
+        fire_event(
+            RepromptValidationFailedEvent(
+                action_name="batch",
+                attempt=attempt,
+                error=f"Validation '{validation_name}' exhausted for {len(failed_ids)} records",
+            )
         )
 
     return results

--- a/agent_actions/processing/evaluation/exhaustion.py
+++ b/agent_actions/processing/evaluation/exhaustion.py
@@ -50,6 +50,15 @@ def apply_exhausted_reprompt(
     Raises:
         RuntimeError: When ``on_exhausted="raise"`` and failed records exist.
     """
+    if failed_ids:
+        fire_event(
+            RepromptValidationFailedEvent(
+                action_name="batch",
+                attempt=attempt,
+                error=f"Validation '{validation_name}' exhausted for {len(failed_ids)} records",
+            )
+        )
+
     for result in results:
         if result.custom_id not in failed_ids:
             continue
@@ -71,15 +80,6 @@ def apply_exhausted_reprompt(
             attempts=record_attempts,
             passed=False,
             validation=validation_name,
-        )
-
-    if failed_ids and on_exhausted != "raise":
-        fire_event(
-            RepromptValidationFailedEvent(
-                action_name="batch",
-                attempt=attempt,
-                error=f"Validation '{validation_name}' exhausted for {len(failed_ids)} records",
-            )
         )
 
     return results

--- a/agent_actions/processing/invocation/online.py
+++ b/agent_actions/processing/invocation/online.py
@@ -169,6 +169,9 @@ class OnlineStrategy(InvocationStrategy):
                 attempts=reprompt_result.attempts,
                 passed=reprompt_result.passed,
                 validation=reprompt_result.validation_name,
+                parse_error_count=reprompt_result.parse_error_count,
+                schema_fail_count=reprompt_result.schema_fail_count,
+                udf_fail_count=reprompt_result.udf_fail_count,
             )
 
         return reprompt_result.response, reprompt_result.executed, recovery_metadata
@@ -205,6 +208,9 @@ class OnlineStrategy(InvocationStrategy):
                 attempts=reprompt_result.attempts,
                 passed=reprompt_result.passed,
                 validation=reprompt_result.validation_name,
+                parse_error_count=reprompt_result.parse_error_count,
+                schema_fail_count=reprompt_result.schema_fail_count,
+                udf_fail_count=reprompt_result.udf_fail_count,
             )
 
         if reprompt_result.exhausted:

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from agent_actions.logging.core.manager import fire_event
-from agent_actions.logging.events.validation_events import RepromptValidationFailedEvent
+from agent_actions.logging.events.validation_events import (
+    RepromptRecoveredEvent,
+    RepromptRetryEvent,
+    RepromptValidationFailedEvent,
+)
 
 from .critique import format_critique_feedback
 from .response_validator import (
@@ -84,6 +88,9 @@ class RepromptResult:
     passed: bool  # Whether validation ultimately passed
     validation_name: str
     exhausted: bool = False
+    parse_error_count: int = 0
+    schema_fail_count: int = 0
+    udf_fail_count: int = 0
 
 
 @dataclass
@@ -193,6 +200,9 @@ class RepromptService:
         attempts = 0
         current_prompt = original_prompt
         last_response = None
+        parse_error_count = 0
+        schema_fail_count = 0
+        udf_fail_count = 0
 
         while attempts < self.max_attempts:
             attempts += 1
@@ -219,6 +229,9 @@ class RepromptService:
                     passed=False,
                     validation_name=self.validation_name,
                     exhausted=True,
+                    parse_error_count=parse_error_count,
+                    schema_fail_count=schema_fail_count,
+                    udf_fail_count=udf_fail_count,
                 )
 
             if not executed:
@@ -237,6 +250,7 @@ class RepromptService:
             parse_error = _get_parse_error(response)
             if parse_error is not None:
                 is_valid = False
+                parse_error_count += 1
                 logger.warning(
                     "[%s] Invalid JSON on attempt %d/%d — %s",
                     context,
@@ -255,6 +269,14 @@ class RepromptService:
                         attempts,
                         self.max_attempts,
                     )
+                    fire_event(
+                        RepromptRecoveredEvent(
+                            action_name=context or "NOT_SET",
+                            attempt=attempts,
+                            max_attempts=self.max_attempts,
+                            validation_name=self.validation_name,
+                        )
+                    )
                 return RepromptResult(
                     response=response,
                     executed=True,
@@ -262,9 +284,16 @@ class RepromptService:
                     passed=True,
                     validation_name=self.validation_name,
                     exhausted=False,
+                    parse_error_count=parse_error_count,
+                    schema_fail_count=schema_fail_count,
+                    udf_fail_count=udf_fail_count,
                 )
 
             if parse_error is None:
+                if isinstance(self._validator, UdfValidator):
+                    udf_fail_count += 1
+                else:
+                    schema_fail_count += 1
                 logger.warning(
                     "[%s] Schema validation failed on attempt %d/%d",
                     context,
@@ -307,6 +336,15 @@ class RepromptService:
 
             current_prompt = f"{original_prompt}\n\n{feedback}"
 
+            fire_event(
+                RepromptRetryEvent(
+                    action_name=context or "NOT_SET",
+                    attempt=attempts + 1,
+                    max_attempts=self.max_attempts,
+                    error=parse_error or "schema_validation_failed",
+                )
+            )
+
         logger.error(
             "[%s] Reprompt exhausted after %d attempts (validation: %s)",
             context,
@@ -343,6 +381,9 @@ class RepromptService:
             passed=False,
             validation_name=self.validation_name,
             exhausted=True,
+            parse_error_count=parse_error_count,
+            schema_fail_count=schema_fail_count,
+            udf_fail_count=udf_fail_count,
         )
 
 

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -57,7 +57,13 @@ class RetryMetadata:
 
 @dataclass
 class RepromptMetadata:
-    """Metadata for reprompt recovery, stored in output _recovery.reprompt field."""
+    """Metadata for reprompt recovery, stored in output _recovery.reprompt field.
+
+    Failure-type counters (``parse_error_count``, ``schema_fail_count``,
+    ``udf_fail_count``) are populated by the **online** reprompt path only.
+    Batch paths default to 0 because ``EvaluationLoop.split()`` returns
+    pass/fail without failure-type classification.
+    """
 
     attempts: int
     passed: bool

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -62,14 +62,24 @@ class RepromptMetadata:
     attempts: int
     passed: bool
     validation: str
+    parse_error_count: int = 0
+    schema_fail_count: int = 0
+    udf_fail_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
-        return {
+        result = {
             "attempts": self.attempts,
             "passed": self.passed,
             "validation": self.validation,
         }
+        if self.parse_error_count:
+            result["parse_error_count"] = self.parse_error_count
+        if self.schema_fail_count:
+            result["schema_fail_count"] = self.schema_fail_count
+        if self.udf_fail_count:
+            result["udf_fail_count"] = self.udf_fail_count
+        return result
 
 
 @dataclass

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -282,6 +282,7 @@ class AgentWorkflow:
         # Clear event log files so --fresh gives a clean debugging slate.
         # JSONFileHandler opens lazily (on first flush), so deleting between
         # handler init and first event write is safe.
+        # Path convention mirrors LoggerFactory.initialize() (logging/factory.py).
         project_root = self.config.resolve_project_root()
         target_dir = project_root / "agent_io" / "target"
         for events_file in ("events.json", "errors.json"):

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -270,7 +270,7 @@ class AgentWorkflow:
         return validate_guard_conditions(self.action_configs)
 
     def _clear_for_fresh_run(self) -> None:
-        """Clear stored results, dispositions, and status for a fresh run."""
+        """Clear stored results, dispositions, status, and event logs for a fresh run."""
         for action_name in self.execution_order:
             try:
                 self.storage_backend.delete_target(action_name)
@@ -278,6 +278,19 @@ class AgentWorkflow:
             except Exception as e:
                 logger.warning("Failed to clear stored data for %s: %s", action_name, e)
         self.services.core.state_manager.reset()
+
+        # Clear event log files so --fresh gives a clean debugging slate.
+        # JSONFileHandler opens lazily (on first flush), so deleting between
+        # handler init and first event write is safe.
+        project_root = self.config.resolve_project_root()
+        target_dir = project_root / "agent_io" / "target"
+        for events_file in ("events.json", "errors.json"):
+            events_path = target_dir / events_file
+            try:
+                events_path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.warning("Failed to clear %s: %s", events_file, e)
+
         self.console.print(
             "[yellow]--fresh: cleared stored results and reset all actions to pending[/yellow]"
         )

--- a/docs.agent-actions/docs/reference/cli/run.md
+++ b/docs.agent-actions/docs/reference/cli/run.md
@@ -40,6 +40,10 @@ agac run -a my_workflow --execution-mode parallel
 | `--use-tools` | Enable tool usage for actions |
 | `-e, --execution-mode` | Execution mode: `auto` (default), `parallel`, or `sequential` |
 | `--concurrency-limit` | Max concurrent actions (default: 5, range: 1-50) |
+| `--fresh` | Clear stored results, dispositions, status, and event logs (`events.json`, `errors.json`) before execution. Gives a clean slate for debugging. |
+| `--verify-keys` | Verify API keys before execution |
+| `--downstream` | Also run all downstream dependencies |
+| `--upstream` | Run all upstream dependencies first |
 
 ## Parallel Execution
 

--- a/docs.agent-actions/docs/reference/execution/artifacts.md
+++ b/docs.agent-actions/docs/reference/execution/artifacts.md
@@ -144,7 +144,20 @@ Complete telemetry of all system events in JSON Lines format (one event per line
 | Guard | G | `GuardEvaluationEvent`, `GuardPassEvent`, `GuardFailEvent` |
 | Data I/O | FIO | `FileWriteStartedEvent`, `FileWriteCompleteEvent` |
 | Cache | C | `CacheHitEvent`, `CacheMissEvent` |
-| Recovery | R | `RecoveryAttemptEvent`, `RecoverySuccessEvent` |
+| Recovery | R | `RetryExhaustedEvent` (R001), `RepromptValidationFailedEvent` (R002), `RecoveryErrorEvent` (R003), `RepromptRetryEvent` (R004), `RepromptRecoveredEvent` (R005) |
+
+#### Recovery Events (R004/R005)
+
+When reprompt validation retries, the event stream shows each attempt:
+
+- **R004 `RepromptRetryEvent`** — fired before each retry attempt (not on the first attempt). Contains `attempt` (the upcoming 1-indexed attempt), `max_attempts`, and `error` (reason for failure).
+- **R005 `RepromptRecoveredEvent`** — fired when validation passes after retries. Contains `attempt` (the 1-indexed attempt that succeeded) and `validation_name`.
+
+A successful run that needed no retries produces zero R004/R005 events. This is by design — the events only fire when recovery actually occurs.
+
+#### File Lifecycle
+
+Both `events.json` and `errors.json` accumulate across runs by default. When `--fresh` is passed, both files are **deleted before the run starts** and recreated on the first event write. File watchers must handle the file being absent between deletion and first event.
 
 ### Errors Log (`errors.json`)
 
@@ -156,6 +169,10 @@ ERROR-level events only — a filtered subset of `events.json` for quick error d
 {"type": "ValidationFailEvent", "action": "extract_data", "error": "Required field 'name' missing"}
 {"type": "ActionFailedEvent", "action": "generate_content", "error": "Rate limit exceeded"}
 ```
+
+:::caution Monitoring change
+`LLMJSONParseErrorEvent` (code L005) is now WARN level — it no longer appears in `errors.json`. Parse errors that reprompt recovers from are not true errors. Consumers monitoring parse failures must switch to `events.json` filtered by code `L005`.
+:::
 
 :::tip
 When debugging, check `errors.json` first for a quick overview, then dive into `events.json` for the full trace around the failure timestamp.

--- a/docs.agent-actions/docs/reference/execution/batch-recovery.md
+++ b/docs.agent-actions/docs/reference/execution/batch-recovery.md
@@ -170,7 +170,8 @@ Every record that goes through recovery gets a `_recovery` field in its output. 
     "reprompt": {
       "attempts": 2,
       "passed": true,
-      "validation": "check_format"
+      "validation": "check_format",
+      "parse_error_count": 1
     }
   }
 }
@@ -195,6 +196,15 @@ Every record that goes through recovery gets a `_recovery` field in its output. 
 | `attempts` | integer | Number of validation attempts |
 | `passed` | boolean | Whether validation ultimately passed |
 | `validation` | string | Name of the validation UDF used |
+| `parse_error_count` | integer | JSON parse failures (absent when 0) |
+| `schema_fail_count` | integer | Schema validation failures (absent when 0) |
+| `udf_fail_count` | integer | UDF validation failures (absent when 0) |
+
+:::note Sparse serialization
+Counter fields use a sparse contract: absent means zero. Consumers should use `record.get("parse_error_count", 0)`, not assume the key exists.
+
+Counter fields are populated by the **online** reprompt path. Batch paths default to 0 because the batch evaluation loop returns pass/fail without failure-type classification.
+:::
 
 ### Serialization
 

--- a/tests/integration/test_retry_reprompt_audit.py
+++ b/tests/integration/test_retry_reprompt_audit.py
@@ -20,6 +20,8 @@ from agent_actions.llm.batch.services.retry_serialization import (
 )
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.logging.events.validation_events import (
+    RepromptRecoveredEvent,
+    RepromptRetryEvent,
     RepromptValidationFailedEvent,
     RetryExhaustedEvent,
 )
@@ -787,11 +789,15 @@ class TestEventLogging:
             context="action=test",
         )
 
-        mock_fire.assert_called_once()
-        event = mock_fire.call_args[0][0]
-        assert isinstance(event, RepromptValidationFailedEvent)
-        assert event.action_name == "action=test"
-        assert event.attempt == 2
+        assert mock_fire.call_count == 2
+        retry_event = mock_fire.call_args_list[0][0][0]
+        assert isinstance(retry_event, RepromptRetryEvent)
+        assert retry_event.action_name == "action=test"
+        assert retry_event.attempt == 2
+        exhausted_event = mock_fire.call_args_list[1][0][0]
+        assert isinstance(exhausted_event, RepromptValidationFailedEvent)
+        assert exhausted_event.action_name == "action=test"
+        assert exhausted_event.attempt == 2
 
     @patch("agent_actions.processing.recovery.reprompt.fire_event")
     def test_reprompt_event_not_fired_on_success(self, mock_fire):
@@ -835,6 +841,252 @@ class TestEventLogging:
             ]
         finally:
             _VALIDATION_REGISTRY.clear()
+
+
+# ---------------------------------------------------------------------------
+# TestRepromptObservability — sub-items 1, 3, 4
+# ---------------------------------------------------------------------------
+
+
+class TestRepromptObservability:
+    """Tests for reprompt retry/recovered events, failure counters, and level changes."""
+
+    @patch("agent_actions.processing.recovery.reprompt.fire_event")
+    def test_retry_event_fires_before_each_retry(self, mock_fire):
+        """RepromptRetryEvent fires for each retry, not on the first attempt."""
+        validator = _StubValidator([False, False, True])
+        svc = RepromptService(validator=validator, max_attempts=3, on_exhausted="return_last")
+
+        result = svc.execute(
+            llm_operation=_llm_op_factory([({"a": 1}, True), ({"b": 2}, True), ({"c": 3}, True)]),
+            original_prompt="p",
+            context="action=test",
+        )
+
+        assert result.passed is True
+        assert result.attempts == 3
+        retry_events = [
+            c[0][0] for c in mock_fire.call_args_list if isinstance(c[0][0], RepromptRetryEvent)
+        ]
+        assert len(retry_events) == 2
+        assert retry_events[0].attempt == 2
+        assert retry_events[1].attempt == 3
+
+    @patch("agent_actions.processing.recovery.reprompt.fire_event")
+    def test_recovered_event_fires_on_success_after_retries(self, mock_fire):
+        """RepromptRecoveredEvent fires when validation passes after retries."""
+        validator = _StubValidator([False, True])
+        svc = RepromptService(validator=validator, max_attempts=3, on_exhausted="return_last")
+
+        result = svc.execute(
+            llm_operation=_llm_op_factory([({"a": 1}, True), ({"b": 2}, True)]),
+            original_prompt="p",
+            context="action=test",
+        )
+
+        assert result.passed is True
+        assert result.attempts == 2
+        recovered_events = [
+            c[0][0] for c in mock_fire.call_args_list if isinstance(c[0][0], RepromptRecoveredEvent)
+        ]
+        assert len(recovered_events) == 1
+        assert recovered_events[0].action_name == "action=test"
+        assert recovered_events[0].attempt == 2
+        assert recovered_events[0].max_attempts == 3
+        assert recovered_events[0].validation_name == "stub_validator"
+
+    @patch("agent_actions.processing.recovery.reprompt.fire_event")
+    def test_no_events_on_first_attempt_success(self, mock_fire):
+        """Neither retry nor recovered events fire when first attempt succeeds."""
+        validator = _StubValidator([True])
+        svc = RepromptService(validator=validator, max_attempts=3)
+
+        result = svc.execute(
+            llm_operation=_llm_op_factory([({"ok": True}, True)]),
+            original_prompt="p",
+        )
+
+        assert result.passed is True
+        assert result.attempts == 1
+        mock_fire.assert_not_called()
+
+    @patch("agent_actions.processing.recovery.reprompt.fire_event")
+    def test_retry_event_codes_no_collision(self, mock_fire):
+        """R004 and R005 are unique codes."""
+        validator = _StubValidator([False, True])
+        svc = RepromptService(validator=validator, max_attempts=3)
+
+        svc.execute(
+            llm_operation=_llm_op_factory([({"a": 1}, True), ({"b": 2}, True)]),
+            original_prompt="p",
+            context="ctx",
+        )
+
+        events = [c[0][0] for c in mock_fire.call_args_list]
+        codes = {e.code for e in events}
+        assert "R004" in codes
+        assert "R005" in codes
+
+    def test_failure_counters_parse_error(self):
+        """parse_error_count increments on JSON parse failures."""
+        validator = _StubValidator([True])
+        svc = RepromptService(validator=validator, max_attempts=3, on_exhausted="return_last")
+
+        result = svc.execute(
+            llm_operation=_llm_op_factory(
+                [
+                    ([{"_parse_error": "bad json"}], True),
+                    ({"ok": True}, True),
+                ]
+            ),
+            original_prompt="p",
+        )
+
+        assert result.passed is True
+        assert result.parse_error_count == 1
+        assert result.schema_fail_count == 0
+        assert result.udf_fail_count == 0
+
+    def test_failure_counters_schema_fail(self):
+        """schema_fail_count increments on non-UDF validation failures."""
+        from agent_actions.processing.recovery.response_validator import SchemaValidator
+
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+        validator = SchemaValidator(schema=schema, action_name="test", strict_mode=True)
+        svc = RepromptService(validator=validator, max_attempts=2, on_exhausted="return_last")
+
+        result = svc.execute(
+            llm_operation=_llm_op_factory(
+                [
+                    ([{}], True),
+                    ([{"name": "ok"}], True),
+                ]
+            ),
+            original_prompt="p",
+        )
+
+        assert result.schema_fail_count >= 1
+        assert result.parse_error_count == 0
+
+    def test_failure_counters_udf(self):
+        """udf_fail_count increments on UDF validation failures."""
+        validator = _StubValidator([False, True])
+        svc = RepromptService(validator=validator, max_attempts=3, on_exhausted="return_last")
+
+        result = svc.execute(
+            llm_operation=_llm_op_factory([({"a": 1}, True), ({"b": 2}, True)]),
+            original_prompt="p",
+        )
+
+        # _StubValidator is not UdfValidator or SchemaValidator, so
+        # schema_fail_count increments (default non-UDF path)
+        assert result.passed is True
+        assert result.schema_fail_count == 1
+
+    def test_reprompt_metadata_to_dict_omits_zero_counters(self):
+        """to_dict() omits counter fields when all are 0."""
+        meta = RepromptMetadata(attempts=1, passed=True, validation="check")
+        d = meta.to_dict()
+        assert "parse_error_count" not in d
+        assert "schema_fail_count" not in d
+        assert "udf_fail_count" not in d
+
+    def test_reprompt_metadata_to_dict_includes_nonzero_counters(self):
+        """to_dict() includes counter fields when > 0."""
+        meta = RepromptMetadata(
+            attempts=3,
+            passed=True,
+            validation="check",
+            parse_error_count=1,
+            schema_fail_count=2,
+        )
+        d = meta.to_dict()
+        assert d["parse_error_count"] == 1
+        assert d["schema_fail_count"] == 2
+        assert "udf_fail_count" not in d
+
+    def test_reprompt_metadata_deserialization_with_counters(self):
+        """RepromptMetadata(**dict) works with new counter fields."""
+        data = {
+            "attempts": 3,
+            "passed": True,
+            "validation": "check",
+            "parse_error_count": 1,
+            "schema_fail_count": 2,
+        }
+        meta = RepromptMetadata(**data)
+        assert meta.parse_error_count == 1
+        assert meta.schema_fail_count == 2
+        assert meta.udf_fail_count == 0
+
+    def test_reprompt_metadata_deserialization_without_counters(self):
+        """RepromptMetadata(**dict) works with old data missing counter fields."""
+        data = {"attempts": 2, "passed": False, "validation": "check_v1"}
+        meta = RepromptMetadata(**data)
+        assert meta.parse_error_count == 0
+        assert meta.schema_fail_count == 0
+        assert meta.udf_fail_count == 0
+
+    def test_serialization_roundtrip_with_counters(self):
+        """BatchResult with counter fields survives serialize → deserialize."""
+        original = BatchResult(
+            custom_id="rec_001",
+            content={"answer": "42"},
+            success=True,
+            recovery_metadata=RecoveryMetadata(
+                reprompt=RepromptMetadata(
+                    attempts=3,
+                    passed=True,
+                    validation="check",
+                    parse_error_count=2,
+                    schema_fail_count=1,
+                ),
+            ),
+        )
+
+        serialized = serialize_results([original])
+        deserialized = deserialize_results(serialized)
+
+        r = deserialized[0]
+        assert r.recovery_metadata.reprompt.parse_error_count == 2
+        assert r.recovery_metadata.reprompt.schema_fail_count == 1
+        assert r.recovery_metadata.reprompt.udf_fail_count == 0
+
+    def test_llm_json_parse_error_event_is_warn(self):
+        """LLMJSONParseErrorEvent level is WARN, not ERROR."""
+        from agent_actions.logging.core.events import EventLevel
+        from agent_actions.logging.events.llm_events import LLMJSONParseErrorEvent
+
+        event = LLMJSONParseErrorEvent(provider="openai", model="gpt-4", error="bad json")
+        assert event.level == EventLevel.WARN
+
+    @patch("agent_actions.processing.recovery.reprompt.fire_event")
+    def test_recovered_event_and_counters_consistent(self, mock_fire):
+        """R005 fires AND parse_error_count=1 when parse error then success."""
+        validator = _StubValidator([True])
+        svc = RepromptService(validator=validator, max_attempts=3, on_exhausted="return_last")
+
+        result = svc.execute(
+            llm_operation=_llm_op_factory(
+                [
+                    ([{"_parse_error": "bad json"}], True),
+                    ({"ok": True}, True),
+                ]
+            ),
+            original_prompt="p",
+            context="action=test",
+        )
+
+        assert result.passed is True
+        assert result.parse_error_count == 1
+        recovered_events = [
+            c[0][0] for c in mock_fire.call_args_list if isinstance(c[0][0], RepromptRecoveredEvent)
+        ]
+        assert len(recovered_events) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_retry_reprompt_audit.py
+++ b/tests/integration/test_retry_reprompt_audit.py
@@ -1137,6 +1137,38 @@ class TestRepromptObservability:
         assert event.code == "R002"
         assert "check_fn" in event.error
 
+    def test_batch_exhaustion_fires_r002_before_raise(self):
+        """R002 fires even when on_exhausted='raise' — audit before exception."""
+        from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
+
+        results = [BatchResult(custom_id="rec_1", content={"x": 1}, success=True)]
+
+        with patch("agent_actions.processing.evaluation.exhaustion.fire_event") as mock_fire:
+            with pytest.raises(RuntimeError, match="exhausted"):
+                apply_exhausted_reprompt(
+                    results=results,
+                    failed_ids={"rec_1"},
+                    validation_name="check_fn",
+                    attempt=3,
+                    on_exhausted="raise",
+                )
+
+        mock_fire.assert_called_once()
+        event = mock_fire.call_args[0][0]
+        assert isinstance(event, RepromptValidationFailedEvent)
+
+    def test_retry_event_has_failed_count_field(self):
+        """RepromptRetryEvent exposes failed_count in structured data."""
+        event = RepromptRetryEvent(
+            action_name="batch",
+            attempt=2,
+            max_attempts=3,
+            error="5 records failed validation",
+            failed_count=5,
+        )
+        assert event.data["failed_count"] == 5
+        assert event.failed_count == 5
+
     def test_fresh_run_clears_event_files(self, tmp_path):
         """_clear_for_fresh_run deletes events.json and errors.json."""
         target_dir = tmp_path / "agent_io" / "target"

--- a/tests/integration/test_retry_reprompt_audit.py
+++ b/tests/integration/test_retry_reprompt_audit.py
@@ -972,8 +972,8 @@ class TestRepromptObservability:
         assert result.schema_fail_count >= 1
         assert result.parse_error_count == 0
 
-    def test_failure_counters_udf(self):
-        """udf_fail_count increments on UDF validation failures."""
+    def test_failure_counters_non_udf_validator(self):
+        """Non-UDF validator failures increment schema_fail_count."""
         validator = _StubValidator([False, True])
         svc = RepromptService(validator=validator, max_attempts=3, on_exhausted="return_last")
 
@@ -982,10 +982,38 @@ class TestRepromptObservability:
             original_prompt="p",
         )
 
-        # _StubValidator is not UdfValidator or SchemaValidator, so
-        # schema_fail_count increments (default non-UDF path)
         assert result.passed is True
         assert result.schema_fail_count == 1
+        assert result.udf_fail_count == 0
+
+    def test_failure_counters_real_udf(self):
+        """udf_fail_count increments with a real UdfValidator."""
+        _VALIDATION_REGISTRY.clear()
+        try:
+
+            @reprompt_validation("bad output")
+            def check_valid(response):
+                if isinstance(response, list):
+                    return all(r.get("valid", False) for r in response)
+                return response.get("valid", False)
+
+            from agent_actions.processing.recovery.response_validator import UdfValidator
+
+            validator = UdfValidator("check_valid")
+            svc = RepromptService(validator=validator, max_attempts=3, on_exhausted="return_last")
+
+            result = svc.execute(
+                llm_operation=_llm_op_factory(
+                    [([{"valid": False}], True), ([{"valid": True}], True)]
+                ),
+                original_prompt="p",
+            )
+
+            assert result.passed is True
+            assert result.udf_fail_count == 1
+            assert result.schema_fail_count == 0
+        finally:
+            _VALIDATION_REGISTRY.clear()
 
     def test_reprompt_metadata_to_dict_omits_zero_counters(self):
         """to_dict() omits counter fields when all are 0."""
@@ -1087,6 +1115,56 @@ class TestRepromptObservability:
             c[0][0] for c in mock_fire.call_args_list if isinstance(c[0][0], RepromptRecoveredEvent)
         ]
         assert len(recovered_events) == 1
+
+    def test_batch_exhaustion_fires_r002(self):
+        """apply_exhausted_reprompt fires RepromptValidationFailedEvent (R002)."""
+        from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
+
+        results = [BatchResult(custom_id="rec_1", content={"x": 1}, success=True)]
+
+        with patch("agent_actions.processing.evaluation.exhaustion.fire_event") as mock_fire:
+            apply_exhausted_reprompt(
+                results=results,
+                failed_ids={"rec_1"},
+                validation_name="check_fn",
+                attempt=3,
+                on_exhausted="return_last",
+            )
+
+        mock_fire.assert_called_once()
+        event = mock_fire.call_args[0][0]
+        assert isinstance(event, RepromptValidationFailedEvent)
+        assert event.code == "R002"
+        assert "check_fn" in event.error
+
+    def test_fresh_run_clears_event_files(self, tmp_path):
+        """_clear_for_fresh_run deletes events.json and errors.json."""
+        target_dir = tmp_path / "agent_io" / "target"
+        target_dir.mkdir(parents=True)
+        (target_dir / "events.json").write_text('{"test": true}\n')
+        (target_dir / "errors.json").write_text('{"error": true}\n')
+
+        # Verify files exist
+        assert (target_dir / "events.json").exists()
+        assert (target_dir / "errors.json").exists()
+
+        # Simulate the clearing logic from coordinator._clear_for_fresh_run
+        for events_file in ("events.json", "errors.json"):
+            events_path = target_dir / events_file
+            events_path.unlink(missing_ok=True)
+
+        assert not (target_dir / "events.json").exists()
+        assert not (target_dir / "errors.json").exists()
+
+    def test_fresh_run_handles_missing_files(self, tmp_path):
+        """Clearing event files when they don't exist does not raise."""
+        target_dir = tmp_path / "agent_io" / "target"
+        target_dir.mkdir(parents=True)
+
+        # No error when files don't exist
+        for events_file in ("events.json", "errors.json"):
+            events_path = target_dir / events_file
+            events_path.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `RepromptRetryEvent` (R004) and `RepromptRecoveredEvent` (R005) to both online and batch reprompt paths — operators can now see retry activity in `events.json`
- Clear `events.json` and `errors.json` on `--fresh` so debugging starts from a clean slate
- Downgrade `LLMJSONParseErrorEvent` from ERROR to WARN — recoverable parse errors no longer inflate `errors.json` error counts
- Add `parse_error_count`, `schema_fail_count`, `udf_fail_count` counters to `RepromptMetadata` with sparse dict serialization (zero-valued counters omitted)

## Monitoring impact
- `LLMJSONParseErrorEvent` (code L005) no longer appears in `errors.json`. Consumers monitoring parse failures must switch to `events.json` filtered by code L005.
- New event codes R004 and R005 appear in `events.json` at INFO level.
- `RepromptMetadata.to_dict()` may now include `parse_error_count`, `schema_fail_count`, `udf_fail_count` keys (absent = zero).

## Verification
- `pytest tests/ --ignore=tests/manual --ignore=tests/simulation` — 6655 passed, 2 skipped
- `ruff check` and `ruff format --check` clean on all changed files
- 14 new tests in `TestRepromptObservability` covering: event emission timing, event codes, failure counters, serialization roundtrip, level downgrade, cross-sub-item interactions

Spec: `specs/backlog/3-low/135-reprompt-observability-events.md`