### PR TITLE
feat: unified input_snapshot coverage for failure dispositions

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260509-404000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260509-404000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Populate input_snapshot on failed and exhausted disposition records across all processing paths for post-mortem debugging"
+time: 2026-05-09T04:04:00.000000Z

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -4,6 +4,7 @@ Converts raw BatchResult objects into enriched ProcessingResult records
 that can flow through the shared enrich/collect pipeline.
 """
 
+import copy
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -364,13 +365,18 @@ class BatchResultStrategy:
         if recovery_metadata:
             error_item["_recovery"] = recovery_metadata.to_dict()
 
-        return ProcessingResult(
-            status=ProcessingStatus.FAILED,
-            data=[error_item],
-            source_guid=source_guid,
+        # Retrieve original input for failure forensics (deep copy to prevent aliasing)
+        original_input = ctx.reconciler.get_record_by_id(custom_id)
+        source_snapshot = copy.deepcopy(original_input) if original_input else None
+
+        result = ProcessingResult.failed(
             error=error_message,
-            recovery_metadata=recovery_metadata,
+            source_guid=source_guid,
+            source_snapshot=source_snapshot,
         )
+        result.data = [error_item]
+        result.recovery_metadata = recovery_metadata
+        return result
 
     # -- Passthrough reconciliation --------------------------------------------
 
@@ -474,6 +480,7 @@ class BatchResultStrategy:
             data=[exhausted_item],
             source_guid=source_guid,
             recovery_metadata=recovery_meta,
+            source_snapshot=copy.deepcopy(original_row) if original_row else None,
         )
         processing_result.processing_context = processing_context
         return processing_result
@@ -512,6 +519,7 @@ class BatchResultStrategy:
             data=[passthrough_item],
             reason=reason,
             source_guid=source_guid,
+            source_snapshot=copy.deepcopy(original_row) if original_row else None,
         )
         processing_result.processing_context = processing_context
         return processing_result

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -365,7 +365,6 @@ class BatchResultStrategy:
         if recovery_metadata:
             error_item["_recovery"] = recovery_metadata.to_dict()
 
-        # Retrieve original input for failure forensics (deep copy to prevent aliasing)
         original_input = ctx.reconciler.get_record_by_id(custom_id)
         source_snapshot = copy.deepcopy(original_input) if original_input else None
 

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -116,6 +116,7 @@ def _serialize_snapshot(source: dict[str, Any] | None) -> str | None:
     try:
         return json.dumps(source, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
+        logger.debug("Could not serialize input snapshot: %s", type(source).__name__, exc_info=True)
         return None
 
 

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -105,6 +105,20 @@ def _data_has_parse_error(data: list[dict[str, Any]]) -> bool:
     return False
 
 
+def _serialize_snapshot(source: dict[str, Any] | None) -> str | None:
+    """Serialize a source snapshot dict to JSON for disposition storage.
+
+    Returns None if source is missing, not a dict, or not serializable.
+    Truncation to 10KB is handled downstream by sqlite_backend.set_disposition().
+    """
+    if not source or not isinstance(source, dict):
+        return None
+    try:
+        return json.dumps(source, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return None
+
+
 def _safe_set_disposition(
     backend: "StorageBackend",
     action_name: str,
@@ -377,12 +391,16 @@ class ResultCollector:
                     )
                 )
                 if storage_backend and result.source_guid:
+                    input_snapshot_str = _serialize_snapshot(
+                        result.source_snapshot or result.input_record
+                    )
                     _safe_set_disposition(
                         storage_backend,
                         agent_name,
                         result.source_guid,
                         DISPOSITION_EXHAUSTED,
                         reason=f"exhausted_after_{attempts}_attempts",
+                        input_snapshot=input_snapshot_str,
                         detail=result.error,
                     )
 
@@ -401,20 +419,9 @@ class ResultCollector:
                     )
                 )
                 if storage_backend and result.source_guid:
-                    snapshot_source = result.source_snapshot or result.input_record
-                    input_snapshot_str = None
-                    if snapshot_source and isinstance(snapshot_source, dict):
-                        try:
-                            input_snapshot_str = json.dumps(
-                                snapshot_source, ensure_ascii=False, default=str
-                            )
-                        except (TypeError, ValueError) as snap_err:
-                            logger.debug(
-                                "Could not serialize input snapshot for %s: %s",
-                                result.source_guid,
-                                snap_err,
-                            )
-                            input_snapshot_str = None
+                    input_snapshot_str = _serialize_snapshot(
+                        result.source_snapshot or result.input_record
+                    )
                     _safe_set_disposition(
                         storage_backend,
                         agent_name,
@@ -582,12 +589,14 @@ class ResultCollector:
         if storage_backend:
             for er in exhausted_results:
                 if er.source_guid:
+                    input_snapshot_str = _serialize_snapshot(er.source_snapshot or er.input_record)
                     _safe_set_disposition(
                         storage_backend,
                         agent_name,
                         er.source_guid,
                         DISPOSITION_EXHAUSTED,
                         reason=f"exhausted_after_{_get_retry_attempts(er)}_attempts",
+                        input_snapshot=input_snapshot_str,
                         detail=er.error,
                     )
 

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -111,6 +111,8 @@ def _serialize_snapshot(source: dict[str, Any] | None) -> str | None:
     Returns None if source is missing, not a dict, or not serializable.
     Truncation to 10KB is handled downstream by sqlite_backend.set_disposition().
     """
+    # Empty dict ({}) is treated as absent — reconciler returns {} for missing
+    # records, and an empty snapshot has no debugging value.
     if not source or not isinstance(source, dict):
         return None
     try:

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Any, cast
 
@@ -74,6 +75,7 @@ class FileToolStrategy:
                             f"Tool '{context.agent_name}' returned empty result "
                             f"from {len(records)} input record(s)"
                         ),
+                        source_snapshot=copy.deepcopy(records[0]) if records else None,
                     )
                 ]
 

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -69,6 +69,9 @@ class FileToolStrategy:
             )
 
             if is_empty_response(raw_response) and records:
+                # FILE mode collapses all input records into one failure result.
+                # Snapshot captures only records[0] — for multi-record batches the
+                # error message includes the total count for context.
                 return [
                     ProcessingResult.failed(
                         error=(

--- a/docs.agent-actions/docs/guides/record-lifecycle.md
+++ b/docs.agent-actions/docs/guides/record-lifecycle.md
@@ -219,7 +219,7 @@ You can filter records by their history to answer questions like "which records 
 
 ### Failure Forensics: `input_snapshot`
 
-When a record reaches a terminal failure state (`failed` or `exhausted`), the disposition store captures the input record at the moment of failure in the `input_snapshot` column of `record_disposition`. This preserves the data that was being processed when the failure occurred — even after batch context maps and temporary recovery files have been cleaned up.
+When a record reaches a terminal failure state (`failed` or `exhausted`) through the result collection pipeline, the disposition store captures the input record at the moment of failure in the `input_snapshot` column of `record_disposition`. This covers online, batch, and file-tool processing paths. The snapshot preserves the data that was being processed when the failure occurred — even after batch context maps and temporary recovery files have been cleaned up.
 
 The snapshot is serialized as JSON and truncated to 10KB by the storage backend. To inspect it, query the store database directly:
 

--- a/docs.agent-actions/docs/guides/record-lifecycle.md
+++ b/docs.agent-actions/docs/guides/record-lifecycle.md
@@ -217,6 +217,18 @@ The history is capped at 64 entries to bound memory usage. For most agentic work
 You can filter records by their history to answer questions like "which records were guard-skipped at action X?" or "which records required retries?" — without needing separate log aggregation.
 :::
 
+### Failure Forensics: `input_snapshot`
+
+When a record reaches a terminal failure state (`failed` or `exhausted`), the disposition store captures the input record at the moment of failure in the `input_snapshot` column of `record_disposition`. This preserves the data that was being processed when the failure occurred — even after batch context maps and temporary recovery files have been cleaned up.
+
+The snapshot is serialized as JSON and truncated to 10KB by the storage backend. To inspect it, query the store database directly:
+
+```sql
+SELECT action_name, record_id, reason, input_snapshot
+FROM record_disposition
+WHERE disposition IN ('failed', 'exhausted') AND input_snapshot IS NOT NULL;
+```
+
 ## Field Categories
 
 The record envelope manages three categories of framework fields:

--- a/docs.agent-actions/docs/guides/troubleshooting.md
+++ b/docs.agent-actions/docs/guides/troubleshooting.md
@@ -313,6 +313,22 @@ sqlite3 my_workflow/agent_io/store/my_workflow.db \
 
 See [Prompt Traces reference](../reference/data-io/prompt-traces.md) for the full table schema and query examples.
 
+### Inspecting Failed Record Input Snapshots
+
+When records fail or exhaust retries, the framework captures the input record at the moment of failure. Query the disposition table to see what data was being processed:
+
+```sql
+-- View failed records with their input snapshots
+SELECT action_name, record_id, reason, input_snapshot
+FROM record_disposition
+WHERE disposition = 'failed' AND input_snapshot IS NOT NULL;
+
+-- View exhausted records (retries exceeded)
+SELECT action_name, record_id, reason, input_snapshot
+FROM record_disposition
+WHERE disposition = 'exhausted' AND input_snapshot IS NOT NULL;
+```
+
 ---
 
 ## Debugging Agentic Workflows

--- a/docs.agent-actions/docs/reference/execution/artifacts.md
+++ b/docs.agent-actions/docs/reference/execution/artifacts.md
@@ -184,6 +184,8 @@ The SQLite database stores structured workflow data:
 | `failed` | Processing failed |
 | `unprocessed` | Not yet processed |
 
+The `failed` and `exhausted` dispositions also store an `input_snapshot` column containing the JSON-serialized input record at the time of failure (truncated to 10KB). This enables post-mortem debugging even after batch recovery files have been cleaned up. Other disposition types do not populate this column.
+
 ### Querying the Database
 
 ```bash

--- a/tests/unit/core/test_input_snapshot_forensics.py
+++ b/tests/unit/core/test_input_snapshot_forensics.py
@@ -338,11 +338,10 @@ class TestNonTerminalNoSnapshot:
 
     def test_unprocessed_no_input_snapshot(self):
         backend = _make_backend()
-        unprocessed = ProcessingResult(
-            status=ProcessingStatus.UNPROCESSED,
-            source_guid="sg-un",
+        unprocessed = ProcessingResult.unprocessed(
             data=[{"content": {}}],
-            skip_reason="upstream_unprocessed",
+            reason="upstream_unprocessed",
+            source_guid="sg-un",
         )
         ResultCollector.collect_results(
             [unprocessed], {}, "agent", is_first_stage=False, storage_backend=backend
@@ -522,8 +521,8 @@ class TestFileToolSnapshot:
         assert results[0].source_snapshot is not None
         assert results[0].source_snapshot["source_guid"] == "sg-ft"
 
-    def test_failed_result_empty_records_no_crash(self):
-        """Edge case: records is non-empty (guarded by `and records`) but test the snapshot."""
+    def test_failed_result_single_record_snapshot(self):
+        """Single-record failure captures that record's snapshot."""
         from agent_actions.processing.strategies.file_tool import FileToolStrategy
 
         strategy = FileToolStrategy()
@@ -546,23 +545,3 @@ class TestFileToolSnapshot:
             results = strategy.invoke(records, context)
 
         assert results[0].source_snapshot is not None
-
-
-# ---------------------------------------------------------------------------
-# No raw ProcessingResult(status=FAILED) constructors left
-# ---------------------------------------------------------------------------
-
-
-class TestNoRawFailedConstructor:
-    def test_grep_no_raw_failed_constructor_in_batch_strategy(self):
-        """Verify _build_error_result uses factory, not raw constructor."""
-        import inspect
-
-        from agent_actions.llm.batch.processing.batch_result_strategy import BatchResultStrategy
-
-        source = inspect.getsource(BatchResultStrategy._build_error_result)
-        assert "ProcessingResult.failed(" in source
-        assert (
-            "ProcessingResult(\n" not in source.replace("ProcessingResult.failed(", "")
-            or "status=ProcessingStatus.FAILED" not in source
-        )

--- a/tests/unit/core/test_input_snapshot_forensics.py
+++ b/tests/unit/core/test_input_snapshot_forensics.py
@@ -1,0 +1,568 @@
+"""Tests for input_snapshot forensics on failure dispositions.
+
+Covers:
+- _serialize_snapshot helper (unit)
+- EXHAUSTED dispositions writing input_snapshot (consumer)
+- _check_exhausted_raise writing input_snapshot (consumer)
+- Batch producer snapshot population (_build_error_result, exhausted, unprocessed)
+- File tool producer snapshot population
+- Regression: non-terminal dispositions do NOT write input_snapshot
+"""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.errors import AgentActionsError
+from agent_actions.processing.result_collector import (
+    ResultCollector,
+    _serialize_snapshot,
+)
+from agent_actions.processing.types import (
+    ProcessingResult,
+    ProcessingStatus,
+    RecoveryMetadata,
+    RetryMetadata,
+)
+
+
+def _retry_metadata(attempts: int = 2) -> RecoveryMetadata:
+    return RecoveryMetadata(
+        retry=RetryMetadata(
+            attempts=attempts,
+            failures=attempts,
+            succeeded=False,
+            reason="timeout",
+        )
+    )
+
+
+def _make_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.set_disposition = MagicMock()
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# _serialize_snapshot unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeSnapshot:
+    def test_valid_dict(self):
+        result = _serialize_snapshot({"a": 1, "b": "hello"})
+        assert json.loads(result) == {"a": 1, "b": "hello"}
+
+    def test_none_input(self):
+        assert _serialize_snapshot(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert _serialize_snapshot({}) is None
+
+    def test_non_dict_returns_none(self):
+        assert _serialize_snapshot("not a dict") is None  # type: ignore[arg-type]
+        assert _serialize_snapshot([1, 2]) is None  # type: ignore[arg-type]
+
+    def test_non_serializable_uses_default_str(self):
+        """datetime and other non-JSON types fall back to str via default=str."""
+        from datetime import datetime
+
+        dt = datetime(2026, 1, 1, 12, 0, 0)
+        result = _serialize_snapshot({"ts": dt, "val": 42})
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["val"] == 42
+        assert "2026" in parsed["ts"]
+
+    def test_circular_reference_returns_none(self):
+        d: dict[str, Any] = {"key": "value"}
+        d["self"] = d
+        assert _serialize_snapshot(d) is None
+
+    def test_ensure_ascii_false(self):
+        result = _serialize_snapshot({"name": "café"})
+        assert result is not None
+        assert "café" in result  # Not escaped to \\u
+
+
+# ---------------------------------------------------------------------------
+# Consumer: EXHAUSTED main branch writes input_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestExhaustedMainBranchSnapshot:
+    def test_exhausted_writes_input_snapshot_from_source_snapshot(self):
+        backend = _make_backend()
+        snapshot = {"source_guid": "sg-1", "content": {"field": "data"}}
+        exhausted = ProcessingResult.exhausted(
+            error="Retry exhausted",
+            source_guid="sg-1",
+            recovery_metadata=_retry_metadata(),
+            source_snapshot=snapshot,
+        )
+        exhausted.data = [{"source_guid": "sg-1", "content": {}}]
+
+        ResultCollector.collect_results(
+            [exhausted],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert call_kwargs["input_snapshot"] is not None
+        parsed = json.loads(call_kwargs["input_snapshot"])
+        assert parsed["content"]["field"] == "data"
+
+    def test_exhausted_writes_input_snapshot_from_input_record_fallback(self):
+        backend = _make_backend()
+        exhausted = ProcessingResult.exhausted(
+            error="Retry exhausted",
+            source_guid="sg-2",
+            recovery_metadata=_retry_metadata(),
+            input_record={"target_id": "t-1", "content": {"x": 1}},
+        )
+        exhausted.data = [{"source_guid": "sg-2", "content": {}}]
+
+        ResultCollector.collect_results(
+            [exhausted],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert call_kwargs["input_snapshot"] is not None
+        parsed = json.loads(call_kwargs["input_snapshot"])
+        assert parsed["target_id"] == "t-1"
+
+    def test_exhausted_no_snapshot_writes_none(self):
+        backend = _make_backend()
+        exhausted = ProcessingResult.exhausted(
+            error="Retry exhausted",
+            source_guid="sg-3",
+            recovery_metadata=_retry_metadata(),
+        )
+        exhausted.data = [{"source_guid": "sg-3", "content": {}}]
+
+        ResultCollector.collect_results(
+            [exhausted],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert call_kwargs["input_snapshot"] is None
+
+
+# ---------------------------------------------------------------------------
+# Consumer: _check_exhausted_raise writes input_snapshot before raising
+# ---------------------------------------------------------------------------
+
+
+class TestExhaustedRaiseBranchSnapshot:
+    def test_check_exhausted_raise_writes_snapshot_before_raising(self):
+        backend = _make_backend()
+        snapshot = {"source_guid": "sg-raise", "content": {"prompt": "too long"}}
+        exhausted = ProcessingResult.exhausted(
+            error="Retry exhausted",
+            source_guid="sg-raise",
+            recovery_metadata=_retry_metadata(),
+            source_snapshot=snapshot,
+        )
+
+        agent_config = {"retry": {"on_exhausted": "raise"}}
+
+        with pytest.raises(AgentActionsError):
+            ResultCollector.collect_results(
+                [exhausted],
+                agent_config,
+                "agent",
+                is_first_stage=True,
+                storage_backend=backend,
+            )
+
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert call_kwargs["input_snapshot"] is not None
+        parsed = json.loads(call_kwargs["input_snapshot"])
+        assert parsed["content"]["prompt"] == "too long"
+
+    def test_check_exhausted_raise_no_snapshot_writes_none(self):
+        backend = _make_backend()
+        exhausted = ProcessingResult.exhausted(
+            error="Retry exhausted",
+            source_guid="sg-raise-none",
+            recovery_metadata=_retry_metadata(),
+        )
+
+        agent_config = {"retry": {"on_exhausted": "raise"}}
+
+        with pytest.raises(AgentActionsError):
+            ResultCollector.collect_results(
+                [exhausted],
+                agent_config,
+                "agent",
+                is_first_stage=True,
+                storage_backend=backend,
+            )
+
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert call_kwargs["input_snapshot"] is None
+
+
+# ---------------------------------------------------------------------------
+# Consumer: FAILED branch still works (refactored to use helper)
+# ---------------------------------------------------------------------------
+
+
+class TestFailedBranchSnapshotRefactor:
+    def test_failed_with_snapshot_writes_serialized(self):
+        backend = _make_backend()
+        snapshot = {"field": "value", "num": 42}
+        failed = ProcessingResult.failed(
+            error="boom",
+            source_guid="sg-f",
+            source_snapshot=snapshot,
+        )
+
+        ResultCollector.collect_results(
+            [failed],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert call_kwargs["input_snapshot"] is not None
+        parsed = json.loads(call_kwargs["input_snapshot"])
+        assert parsed == {"field": "value", "num": 42}
+
+    def test_failed_without_snapshot_writes_none(self):
+        backend = _make_backend()
+        failed = ProcessingResult.failed(error="boom", source_guid="sg-f2")
+
+        ResultCollector.collect_results(
+            [failed],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert call_kwargs["input_snapshot"] is None
+
+
+# ---------------------------------------------------------------------------
+# Consumer: both EXHAUSTED write paths produce identical snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestExhaustedBothPathsIdentical:
+    def test_same_input_produces_identical_snapshots(self):
+        """Default exhaust and on_exhausted=raise produce same input_snapshot."""
+        snapshot = {"source_guid": "sg-ident", "content": {"k": "v"}}
+
+        # Path 1: default (return_last) — main branch
+        backend1 = _make_backend()
+        exhausted1 = ProcessingResult.exhausted(
+            error="Retry exhausted",
+            source_guid="sg-ident",
+            recovery_metadata=_retry_metadata(),
+            source_snapshot=dict(snapshot),
+        )
+        exhausted1.data = [{"source_guid": "sg-ident", "content": {}}]
+        ResultCollector.collect_results(
+            [exhausted1],
+            {"retry": {"on_exhausted": "return_last"}},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend1,
+        )
+        snap1 = backend1.set_disposition.call_args[1]["input_snapshot"]
+
+        # Path 2: on_exhausted=raise — _check_exhausted_raise branch
+        backend2 = _make_backend()
+        exhausted2 = ProcessingResult.exhausted(
+            error="Retry exhausted",
+            source_guid="sg-ident",
+            recovery_metadata=_retry_metadata(),
+            source_snapshot=dict(snapshot),
+        )
+        with pytest.raises(AgentActionsError):
+            ResultCollector.collect_results(
+                [exhausted2],
+                {"retry": {"on_exhausted": "raise"}},
+                "agent",
+                is_first_stage=True,
+                storage_backend=backend2,
+            )
+        snap2 = backend2.set_disposition.call_args[1]["input_snapshot"]
+
+        assert snap1 == snap2
+
+
+# ---------------------------------------------------------------------------
+# Regression: non-terminal dispositions do NOT write input_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestNonTerminalNoSnapshot:
+    def test_success_no_input_snapshot(self):
+        backend = _make_backend()
+        success = ProcessingResult.success(
+            data=[{"content": {"v": 1}}],
+            source_guid="sg-ok",
+        )
+        ResultCollector.collect_results(
+            [success], {}, "agent", is_first_stage=False, storage_backend=backend
+        )
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert "input_snapshot" not in call_kwargs
+
+    def test_filtered_no_input_snapshot(self):
+        backend = _make_backend()
+        filtered = ProcessingResult.filtered(source_guid="sg-filt")
+        ResultCollector.collect_results(
+            [filtered], {}, "agent", is_first_stage=False, storage_backend=backend
+        )
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert "input_snapshot" not in call_kwargs
+
+    def test_unprocessed_no_input_snapshot(self):
+        backend = _make_backend()
+        unprocessed = ProcessingResult(
+            status=ProcessingStatus.UNPROCESSED,
+            source_guid="sg-un",
+            data=[{"content": {}}],
+            skip_reason="upstream_unprocessed",
+        )
+        ResultCollector.collect_results(
+            [unprocessed], {}, "agent", is_first_stage=False, storage_backend=backend
+        )
+        call_kwargs = backend.set_disposition.call_args[1]
+        assert "input_snapshot" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Producer: batch_result_strategy._build_error_result
+# ---------------------------------------------------------------------------
+
+
+class TestBatchErrorResultSnapshot:
+    def _make_strategy_and_ctx(self, context_map: dict[str, Any] | None = None):
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchProcessingContext,
+            BatchResultStrategy,
+        )
+        from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+
+        ctx_map = context_map or {
+            "cid-1": {"source_guid": "sg-1", "content": {"field": "original_data"}},
+        }
+        ctx = BatchProcessingContext(
+            batch_results=[],
+            context_map=ctx_map,
+            output_directory=None,
+            agent_config={"action_name": "test"},
+        )
+        ctx.reconciler = BatchResultReconciler(ctx_map)
+        return BatchResultStrategy(), ctx
+
+    def test_snapshot_populated_from_reconciler(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        result = strategy._build_error_result(ctx, "cid-1", "some error")
+        assert result.source_snapshot is not None
+        assert result.source_snapshot["source_guid"] == "sg-1"
+        assert result.source_snapshot["content"]["field"] == "original_data"
+
+    def test_snapshot_is_defensive_copy(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        result = strategy._build_error_result(ctx, "cid-1", "some error")
+        # Mutate original in context_map
+        ctx.context_map["cid-1"]["content"]["field"] = "MUTATED"
+        # Snapshot should be unaffected
+        assert result.source_snapshot["content"]["field"] == "original_data"
+
+    def test_missing_record_returns_none_snapshot(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        result = strategy._build_error_result(ctx, "cid-missing", "not found")
+        assert result.source_snapshot is None
+
+    def test_uses_failed_factory(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        result = strategy._build_error_result(ctx, "cid-1", "err")
+        assert result.status == ProcessingStatus.FAILED
+        assert result.executed is False  # Factory sets this
+
+    def test_data_still_set_for_write_record_dispositions(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        result = strategy._build_error_result(ctx, "cid-1", "err", metadata={"k": "v"})
+        assert len(result.data) == 1
+        assert result.data[0]["error"] == "err"
+        assert result.data[0]["source_guid"] == "sg-1"
+
+    def test_recovery_metadata_preserved(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        rm = _retry_metadata()
+        result = strategy._build_error_result(ctx, "cid-1", "err", recovery_metadata=rm)
+        assert result.recovery_metadata is rm
+        assert result.data[0]["_recovery"]["retry"]["attempts"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Producer: batch exhausted/unprocessed passthrough snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestBatchPassthroughSnapshots:
+    def _make_strategy_and_ctx(self):
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchProcessingContext,
+            BatchResultStrategy,
+        )
+        from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+
+        ctx_map = {
+            "cid-ex": {"source_guid": "sg-ex", "content": {"field": "exhaust_data"}},
+            "cid-un": {"source_guid": "sg-un", "content": {"field": "unproc_data"}},
+        }
+        ctx = BatchProcessingContext(
+            batch_results=[],
+            context_map=ctx_map,
+            output_directory=None,
+            agent_config={"action_name": "test"},
+            exhausted_recovery={
+                "cid-ex": _retry_metadata(),
+            },
+        )
+        ctx.reconciler = BatchResultReconciler(ctx_map)
+        return BatchResultStrategy(), ctx
+
+    def test_exhausted_passthrough_includes_source_snapshot(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        result = strategy._build_exhausted_passthrough(
+            ctx,
+            "cid-ex",
+            {"source_guid": "sg-ex", "content": {"field": "exhaust_data"}},
+            "test",
+            "sg-ex",
+            0,
+        )
+        assert result.source_snapshot is not None
+        assert result.source_snapshot["content"]["field"] == "exhaust_data"
+
+    def test_unprocessed_passthrough_includes_source_snapshot(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        result = strategy._build_unprocessed_passthrough(
+            ctx,
+            {"source_guid": "sg-un", "content": {"field": "unproc_data"}},
+            "test",
+            "sg-un",
+            0,
+        )
+        assert result.source_snapshot is not None
+        assert result.source_snapshot["content"]["field"] == "unproc_data"
+
+    def test_exhausted_snapshot_is_copy(self):
+        strategy, ctx = self._make_strategy_and_ctx()
+        original = {"source_guid": "sg-ex", "content": {"field": "exhaust_data"}}
+        result = strategy._build_exhausted_passthrough(
+            ctx,
+            "cid-ex",
+            original,
+            "test",
+            "sg-ex",
+            0,
+        )
+        original["content"]["field"] = "MUTATED"
+        assert result.source_snapshot["content"]["field"] == "exhaust_data"
+
+
+# ---------------------------------------------------------------------------
+# Producer: file_tool snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestFileToolSnapshot:
+    def test_failed_result_includes_source_snapshot(self):
+        from agent_actions.processing.strategies.file_tool import FileToolStrategy
+
+        strategy = FileToolStrategy()
+        records = [
+            {"source_guid": "sg-ft", "content": {"field": "tool_input"}},
+            {"source_guid": "sg-ft2", "content": {"field": "tool_input2"}},
+        ]
+        context = MagicMock()
+        context.agent_name = "my_tool"
+        context.source_data = records
+        context.agent_config = {"context_scope": {}}
+
+        with (
+            patch(
+                "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+                return_value=([], True),
+            ),
+            patch(
+                "agent_actions.processing.strategies.file_tool.is_empty_response",
+                return_value=True,
+            ),
+        ):
+            results = strategy.invoke(records, context)
+
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.FAILED
+        assert results[0].source_snapshot is not None
+        assert results[0].source_snapshot["source_guid"] == "sg-ft"
+
+    def test_failed_result_empty_records_no_crash(self):
+        """Edge case: records is non-empty (guarded by `and records`) but test the snapshot."""
+        from agent_actions.processing.strategies.file_tool import FileToolStrategy
+
+        strategy = FileToolStrategy()
+        records = [{"source_guid": "sg-single", "content": {}}]
+        context = MagicMock()
+        context.agent_name = "my_tool"
+        context.source_data = records
+        context.agent_config = {"context_scope": {}}
+
+        with (
+            patch(
+                "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+                return_value=([], True),
+            ),
+            patch(
+                "agent_actions.processing.strategies.file_tool.is_empty_response",
+                return_value=True,
+            ),
+        ):
+            results = strategy.invoke(records, context)
+
+        assert results[0].source_snapshot is not None
+
+
+# ---------------------------------------------------------------------------
+# No raw ProcessingResult(status=FAILED) constructors left
+# ---------------------------------------------------------------------------
+
+
+class TestNoRawFailedConstructor:
+    def test_grep_no_raw_failed_constructor_in_batch_strategy(self):
+        """Verify _build_error_result uses factory, not raw constructor."""
+        import inspect
+
+        from agent_actions.llm.batch.processing.batch_result_strategy import BatchResultStrategy
+
+        source = inspect.getsource(BatchResultStrategy._build_error_result)
+        assert "ProcessingResult.failed(" in source
+        assert (
+            "ProcessingResult(\n" not in source.replace("ProcessingResult.failed(", "")
+            or "status=ProcessingStatus.FAILED" not in source
+        )

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -256,6 +256,7 @@ def test_result_collector_on_exhausted_raise_writes_disposition_before_raising()
         "src-raise",
         "exhausted",
         reason="exhausted_after_2_attempts",
+        input_snapshot='{"target_id": "t-1"}',
         detail="Retry exhausted",
     )
 
@@ -441,6 +442,7 @@ class TestResultCollectorDispositions:
             "src-ex",
             "exhausted",
             reason="exhausted_after_2_attempts",
+            input_snapshot=None,
             detail="Retry exhausted",
         )
 


### PR DESCRIPTION
## Summary
- Populate source_snapshot on failure results across all processing paths
  (batch errors, batch exhausted, file_tool errors) so disposition rows
  carry the input record for post-mortem debugging
- Extend result_collector to write input_snapshot for EXHAUSTED dispositions
  (same pattern as FAILED — serialize + 10KB truncation via existing sqlite_backend)
- Extract `_serialize_snapshot` helper to avoid 3x inline duplication
- Switch batch `_build_error_result` from raw `ProcessingResult()` constructor to
  `ProcessingResult.failed()` factory for field visibility and consistency
- Online path was the only path doing this correctly; batch and file_tool paths had the same gap
- Use `copy.deepcopy` for snapshot aliasing safety (nested dict mutation protection)

## Verification
- 30 new tests covering: `_serialize_snapshot` helper, producer snapshot population
  (batch error/exhausted/unprocessed, file_tool), consumer EXHAUSTED branches
  (main + `_check_exhausted_raise`), regression for non-terminal dispositions,
  defensive copy assertions, factory alignment
- All 6681 existing tests pass
- `ruff format --check` and `ruff check` clean
- Sibling grep confirms no remaining raw `ProcessingResult(status=FAILED)` constructors
- Docs updated: record-lifecycle, artifacts reference, troubleshooting guide