### PR TITLE
fix: unify batch and online guard evaluation, preflight, and lifecycle paths

### DIFF
--- a/agent_actions/llm/batch/core/batch_constants.py
+++ b/agent_actions/llm/batch/core/batch_constants.py
@@ -56,8 +56,9 @@ class ContextMetaKeys:
     FILTER_STATUS = "_batch_filter_status"
     FILTER_PHASE = "_batch_filter_phase"  # "phase1" or "phase2" - which phase filtered
     PASSTHROUGH_FIELDS = "_passthrough_fields"
+    SKIP_REASON = "_batch_skip_reason"
 
     @classmethod
     def all_internal_keys(cls) -> set[str]:
         """Return set of all internal metadata key names."""
-        return {cls.FILTER_STATUS, cls.FILTER_PHASE, cls.PASSTHROUGH_FIELDS}
+        return {cls.FILTER_STATUS, cls.FILTER_PHASE, cls.PASSTHROUGH_FIELDS, cls.SKIP_REASON}

--- a/agent_actions/llm/batch/core/batch_context_metadata.py
+++ b/agent_actions/llm/batch/core/batch_context_metadata.py
@@ -64,6 +64,20 @@ class BatchContextMetadata:
         return record.pop(ContextMetaKeys.PASSTHROUGH_FIELDS, {})  # type: ignore[no-any-return]
 
     # =========================================================================
+    # Skip Reason Methods
+    # =========================================================================
+
+    @staticmethod
+    def set_skip_reason(record: dict[str, Any], reason: str) -> None:
+        """Store the reason a record was skipped during preparation."""
+        record[ContextMetaKeys.SKIP_REASON] = reason
+
+    @staticmethod
+    def get_skip_reason(record: dict[str, Any]) -> str | None:
+        """Get the skip reason from a record, or None if unset."""
+        return record.get(ContextMetaKeys.SKIP_REASON)  # type: ignore[return-value]
+
+    # =========================================================================
     # Utility Methods
     # =========================================================================
 

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -29,12 +29,15 @@ from agent_actions.processing.types import (
     RecoveryMetadata,
 )
 from agent_actions.record.reasons import BATCH_NOT_RETURNED, GUARD_SKIP, UPSTREAM_UNPROCESSED
-from agent_actions.record.state import CASCADE_BLOCKING_STATES
+from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
 
-_CASCADE_BLOCKING_VALUES: frozenset[str] = frozenset(s.value for s in CASCADE_BLOCKING_STATES)
+
+def _is_cascade_blocked(row: dict[str, Any]) -> bool:
+    """Return True if the row's _state is a cascade-blocking value."""
+    return row.get("_state") in CASCADE_BLOCKING_VALUES
 
 
 @dataclass
@@ -493,11 +496,15 @@ class BatchResultStrategy:
         record_index: int,
     ) -> ProcessingResult:
         """Build an UNPROCESSED result for a passthrough record."""
-        raw_state = original_row.get("_state")
-        if raw_state in _CASCADE_BLOCKING_VALUES:
-            reason = UPSTREAM_UNPROCESSED
+        # Prefer skip_reason set during preparation (single authority).
+        # Fall back to _state check for records that bypassed prep.
+        skip_reason = BatchContextMetadata.get_skip_reason(original_row)
+        if skip_reason:
+            reason = skip_reason
         elif BatchContextMetadata.get_filter_status(original_row) == FilterStatus.SKIPPED:
             reason = GUARD_SKIP
+        elif _is_cascade_blocked(original_row):
+            reason = UPSTREAM_UNPROCESSED
         else:
             reason = BATCH_NOT_RETURNED
 

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -16,6 +16,7 @@ from agent_actions.processing.prepared_task import GuardStatus, PreparationConte
 from agent_actions.processing.result_collector import _safe_set_disposition
 from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
 from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.reasons import GUARD_SKIP, UPSTREAM_UNPROCESSED
 from agent_actions.record.state import RecordState
 from agent_actions.storage.backend import DISPOSITION_FAILED
 from agent_actions.utils.constants import JSON_MODE_KEY
@@ -23,6 +24,8 @@ from agent_actions.utils.id_generation import IDGenerator
 from agent_actions.utils.tools_resolver import resolve_tools_path
 
 logger = logging.getLogger(__name__)
+
+_PREFLIGHT_SAMPLE_SIZE: int = 5
 
 
 class BatchTaskPreparator:
@@ -185,6 +188,9 @@ class BatchTaskPreparator:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.SKIPPED
             )
+            BatchContextMetadata.set_skip_reason(
+                context_map_builder[custom_id], UPSTREAM_UNPROCESSED
+            )
             stats.skipped_items += 1
             logger.debug("Upstream unprocessed item %s", custom_id)
             return None
@@ -201,6 +207,7 @@ class BatchTaskPreparator:
             BatchContextMetadata.set_filter_status(
                 context_map_builder[custom_id], FilterStatus.SKIPPED
             )
+            BatchContextMetadata.set_skip_reason(context_map_builder[custom_id], GUARD_SKIP)
             stats.skipped_items += 1
             logger.debug("Guard skipped item %s", custom_id)
             return None
@@ -228,15 +235,14 @@ class BatchTaskPreparator:
         entry = context_map_builder[custom_id]
         BatchContextMetadata.set_filter_status(entry, FilterStatus.FAILED)
         error_str = str(error)
-        try:
+        if RecordEnvelope.can_transition(entry, RecordState.FAILED):
             RecordEnvelope.transition(entry, RecordState.FAILED, agent_name, error_str[:200])
-        except Exception:
+        else:
             logger.warning(
-                "Failed to transition record %s to FAILED state",
+                "Cannot transition record %s to FAILED (current state: %s)",
                 custom_id,
-                exc_info=True,
+                entry.get("_state"),
             )
-            entry["_state"] = RecordState.FAILED.value
 
         if storage_backend:
             source_guid = row.get("source_guid")
@@ -325,11 +331,18 @@ class BatchTaskPreparator:
         source_data: list[Any] | None = None,
         workflow_metadata: dict[str, Any] | None = None,
     ) -> None:
-        """Run pre-flight validation on first data row to catch template errors early."""
+        """Run pre-flight validation on sample rows to catch template errors early.
+
+        Guard-aware: evaluates with ``skip_guard=False`` so guard-skipped rows
+        are advanced past rather than crashing on guard-conditional templates.
+        If all sampled rows are guard-skipped/filtered, preflight passes
+        silently — there are no prompts to validate.
+        """
         if not data:
             return
 
-        first_row = data[0]
+        task_preparer = get_task_preparer()
+        sample_size = min(len(data), _PREFLIGHT_SAMPLE_SIZE)
         tools_path = resolve_tools_path(agent_config)
         prep_context = self._build_preparation_context(
             agent_config=agent_config,
@@ -338,11 +351,25 @@ class BatchTaskPreparator:
             source_data=source_data,
             workflow_metadata=workflow_metadata,
             tools_path=tools_path,
-            current_item=first_row,
         )
 
-        # Run preparation on first row to catch template errors early
-        # Skip guard evaluation to ensure prompt is always rendered for validation
-        # (guards might filter the first row, hiding template errors)
-        task_preparer = get_task_preparer()
-        task_preparer.prepare(first_row, prep_context, skip_guard=True)
+        for row in data[:sample_size]:
+            prep_context.current_item = row
+
+            prepared = task_preparer.prepare(row, prep_context, skip_guard=False)
+
+            if prepared.guard_status in (
+                GuardStatus.SKIPPED,
+                GuardStatus.FILTERED,
+                GuardStatus.UPSTREAM_UNPROCESSED,
+            ):
+                continue  # No template rendered for this row — try next
+
+            return  # Template rendered successfully — preflight passed
+
+        # All sampled rows guard-skipped/filtered — nothing to validate
+        logger.info(
+            "Preflight skipped: all %d sampled rows filtered by guard for '%s'",
+            sample_size,
+            agent_config.get("name"),
+        )

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -252,15 +252,15 @@ class OnlineLLMStrategy:
         return results
 
     def process_record(
-        self, item: Any, context: ProcessingContext, *, skip_guard: bool = True
+        self, item: Any, context: ProcessingContext, *, skip_guard: bool = False
     ) -> ProcessingResult:
         """Process a single record: prepare, invoke LLM, handle response, transform.
 
         Args:
-            skip_guard: When True (default), guard evaluation is skipped because
-                UnifiedProcessor already filtered records at the batch level.
-                Pass False when calling directly without UnifiedProcessor's
-                batch-level guard filter.
+            skip_guard: When False (default), per-record guard evaluates with
+                full context from TaskPreparer._load_full_context().  The
+                prefilter in UnifiedProcessor is a fast-path optimization;
+                per-record guard is the authoritative evaluation.
 
         Does NOT enrich the result — enrichment is handled by UnifiedProcessor.
         """
@@ -285,13 +285,14 @@ class OnlineLLMStrategy:
 
         # Upstream unprocessed — passthrough as tombstone
         if prepared.guard_status == GuardStatus.UPSTREAM_UNPROCESSED:
-            preserved_item = dict(item) if isinstance(item, dict) else {"content": item}
-            if not isinstance(preserved_item.get("metadata"), dict):
-                preserved_item["metadata"] = {}
-            if "agent_type" not in preserved_item["metadata"]:
-                preserved_item["metadata"]["agent_type"] = "tombstone"
+            tombstone = build_tombstone(
+                context.action_name,
+                input_record,
+                UPSTREAM_UNPROCESSED,
+                source_guid=source_guid,
+            )
             return ProcessingResult.unprocessed(
-                data=[preserved_item],
+                data=[tombstone],
                 reason=UPSTREAM_UNPROCESSED,
                 source_guid=source_guid,
                 source_snapshot=source_snapshot,

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -12,13 +12,11 @@ from agent_actions.processing.prepared_task import (
     PreparationContext,
     PreparedTask,
 )
-from agent_actions.record.state import CASCADE_BLOCKING_STATES
+from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.content import get_existing_content
 from agent_actions.utils.id_generation import IDGenerator
 
 logger = logging.getLogger(__name__)
-
-_CASCADE_BLOCKING_VALUES: frozenset[str] = frozenset(s.value for s in CASCADE_BLOCKING_STATES)
 
 
 class TaskPreparer:
@@ -45,7 +43,7 @@ class TaskPreparer:
             skip_guard,
         )
 
-        if isinstance(item, dict) and item.get("_state") in _CASCADE_BLOCKING_VALUES:
+        if isinstance(item, dict) and item.get("_state") in CASCADE_BLOCKING_VALUES:
             target_id = existing_target_id or self._generate_target_id()
             return PreparedTask(
                 target_id=target_id,

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -136,6 +136,18 @@ class RecordEnvelope:
         return _carry_persistent_fields(result, input_record)
 
     @staticmethod
+    def can_transition(record: dict[str, Any], to_state: RecordState) -> bool:
+        """Return True if transitioning *record* to *to_state* is legal."""
+        from_state_raw = record.get("_state")
+        if from_state_raw is None:
+            return True
+        try:
+            from_state = RecordState(from_state_raw)
+        except ValueError:
+            return False
+        return _is_legal_transition(from_state, to_state)
+
+    @staticmethod
     def transition(
         record: dict[str, Any],
         to_state: RecordState,
@@ -192,21 +204,30 @@ class RecordEnvelope:
         return record
 
 
+def _is_legal_transition(from_state: RecordState | None, to_state: RecordState) -> bool:
+    """Return True if *from_state* → *to_state* is a legal edge."""
+    if from_state is None:
+        return True
+    if from_state == to_state:
+        return True
+    if from_state in PROCESSABLE_STATES:
+        return True
+    if from_state in RESETTABLE_DOWNSTREAM_STATES and to_state in PROCESSABLE_STATES:
+        return True
+    if from_state in CASCADE_BLOCKING_STATES and to_state == RecordState.CASCADE_SKIPPED:
+        return True
+    return False
+
+
 def _validate_transition(from_state: RecordState | None, to_state: RecordState) -> None:
     """Raise RecordEnvelopeError if the from→to edge violates state machine rules."""
-    if from_state is None:
-        return
-    if from_state == to_state:
-        return
-    if from_state in PROCESSABLE_STATES:
-        return
-    if from_state in RESETTABLE_DOWNSTREAM_STATES and to_state in PROCESSABLE_STATES:
-        return
-    if from_state in CASCADE_BLOCKING_STATES and to_state == RecordState.CASCADE_SKIPPED:
-        return
-    raise RecordEnvelopeError(
-        f"Illegal state transition: {from_state.value!r} → {to_state.value!r}"
-    )
+    if not _is_legal_transition(from_state, to_state):
+        # from_state is guaranteed non-None here because _is_legal_transition
+        # returns True for None.
+        assert from_state is not None  # narrowing for type checker
+        raise RecordEnvelopeError(
+            f"Illegal state transition: {from_state.value!r} → {to_state.value!r}"
+        )
 
 
 def _carry_persistent_fields(

--- a/agent_actions/record/state.py
+++ b/agent_actions/record/state.py
@@ -44,6 +44,8 @@ CASCADE_BLOCKING_STATES: frozenset[RecordState] = frozenset(
     }
 )
 
+CASCADE_BLOCKING_VALUES: frozenset[str] = frozenset(s.value for s in CASCADE_BLOCKING_STATES)
+
 RETRIABLE_STATES: frozenset[RecordState] = frozenset(
     {
         RecordState.FAILED,

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -326,10 +326,9 @@ def prefilter_by_guard(
     When no guard is configured, returns ``(data, [], original_data or data)``.
 
     Note:
-        Guard evaluation uses ``context={}`` because the pre-filter runs
-        before processing context (passthrough fields, source data) is
-        established.  Guard clauses in FILE-mode pre-filter can only
-        reference item-level fields, not workflow context variables.
+        Guard evaluation uses the record's existing content as context so
+        that guard clauses can reference upstream namespace fields — matching
+        the per-record guard context used in batch mode.
 
     Returns:
         (passing, skipped, original_passing)
@@ -356,11 +355,10 @@ def prefilter_by_guard(
     for idx, item in enumerate(data):
         eval_item = get_existing_content(item)
 
-        # context={} — see Note in docstring.
         result = evaluator.evaluate(
             item=eval_item,
             guard_config=guard_config,
-            context={},
+            context=eval_item,
         )
 
         if result.should_execute:

--- a/tests/unit/llm/batch/test_batch_online_guard_unification.py
+++ b/tests/unit/llm/batch/test_batch_online_guard_unification.py
@@ -1,0 +1,585 @@
+"""Regression tests for batch/online guard evaluation and lifecycle unification.
+
+Tests cover:
+1. Batch preflight with guard-skipped upstream (CHANGE 1)
+2. Duplicate CASCADE check removal in reconciliation (CHANGE 2)
+3. Online guard context parity with batch (CHANGE 3)
+4. State transition bypass prevention (CHANGE 4)
+
+Each test exercises the behavior that was broken before unification and
+verifies the correct outcome after the fix.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
+from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
+from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.state import RecordState
+
+
+def _make_preparator(**kwargs: Any) -> BatchTaskPreparator:
+    return BatchTaskPreparator(
+        action_indices=kwargs.get("action_indices", {}),
+        dependency_configs=kwargs.get("dependency_configs", {}),
+        storage_backend=kwargs.get("storage_backend"),
+        version_context=kwargs.get("version_context"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CHANGE 1: Batch preflight is guard-aware
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightGuardAware:
+    """Preflight must not crash when guard-skipped upstream records have
+    templates that reference fields only available when the guard passes."""
+
+    def test_preflight_skips_guard_filtered_rows_without_crash(self):
+        """When all sample rows are guard-skipped, preflight completes
+        without raising — it does not force-render guard-conditional templates."""
+        preparator = _make_preparator()
+        agent_config = {
+            "name": "test_action",
+            "prompt": "{{ upstream_ns.field }}",
+            "guard": {"clause": "upstream_ns.has_data == true", "behavior": "skip"},
+        }
+        # Rows where upstream_ns is absent (guard would skip these)
+        data = [
+            {"target_id": "1", "content": {}},
+            {"target_id": "2", "content": {}},
+        ]
+
+        mock_prepared_skipped = MagicMock()
+        mock_prepared_skipped.guard_status = GuardStatus.SKIPPED
+
+        with patch("agent_actions.llm.batch.processing.preparator.get_task_preparer") as mock_get:
+            mock_preparer = MagicMock()
+            mock_preparer.prepare.return_value = mock_prepared_skipped
+            mock_get.return_value = mock_preparer
+
+            # Should NOT raise — previously crashed with TemplateVariableError
+            preparator._run_preflight_validation(agent_config, data)
+
+            for call in mock_preparer.prepare.call_args_list:
+                assert call.kwargs.get("skip_guard") is False
+
+    def test_preflight_stops_at_first_passing_row(self):
+        """When a row passes the guard, preflight validates that row and stops."""
+        preparator = _make_preparator()
+        agent_config = {"name": "test_action", "prompt": "{{ content }}"}
+        data = [
+            {"target_id": "1", "content": {}},
+            {"target_id": "2", "content": {"field": "value"}},
+            {"target_id": "3", "content": {"field": "other"}},
+        ]
+
+        mock_skipped = MagicMock()
+        mock_skipped.guard_status = GuardStatus.SKIPPED
+
+        mock_passed = MagicMock()
+        mock_passed.guard_status = GuardStatus.PASSED
+
+        with patch("agent_actions.llm.batch.processing.preparator.get_task_preparer") as mock_get:
+            mock_preparer = MagicMock()
+            mock_preparer.prepare.side_effect = [mock_skipped, mock_passed]
+            mock_get.return_value = mock_preparer
+
+            preparator._run_preflight_validation(agent_config, data)
+
+            assert mock_preparer.prepare.call_count == 2
+
+    def test_preflight_propagates_real_template_errors(self):
+        """Real template errors (not guard-related) still raise."""
+        preparator = _make_preparator()
+        agent_config = {"name": "test_action", "prompt": "{{ nonexistent }}"}
+        data = [{"target_id": "1", "content": {}}]
+
+        with patch("agent_actions.llm.batch.processing.preparator.get_task_preparer") as mock_get:
+            mock_preparer = MagicMock()
+            mock_preparer.prepare.side_effect = Exception(
+                "Template variable 'nonexistent' not found"
+            )
+            mock_get.return_value = mock_preparer
+
+            with pytest.raises(Exception, match="Template variable"):
+                preparator._run_preflight_validation(agent_config, data)
+
+    def test_preflight_skips_upstream_unprocessed_rows(self):
+        """UPSTREAM_UNPROCESSED rows are skipped — no template was rendered."""
+        preparator = _make_preparator()
+        agent_config = {"name": "test_action", "prompt": "{{ content }}"}
+        data = [
+            {"target_id": "1", "_state": "failed", "content": {}},
+            {"target_id": "2", "content": {"field": "value"}},
+        ]
+
+        mock_unprocessed = MagicMock()
+        mock_unprocessed.guard_status = GuardStatus.UPSTREAM_UNPROCESSED
+
+        mock_passed = MagicMock()
+        mock_passed.guard_status = GuardStatus.PASSED
+
+        with patch("agent_actions.llm.batch.processing.preparator.get_task_preparer") as mock_get:
+            mock_preparer = MagicMock()
+            mock_preparer.prepare.side_effect = [mock_unprocessed, mock_passed]
+            mock_get.return_value = mock_preparer
+
+            preparator._run_preflight_validation(agent_config, data)
+
+            assert mock_preparer.prepare.call_count == 2
+
+    def test_preflight_calls_prepare_with_skip_guard_false(self):
+        """Preflight must call prepare with skip_guard=False so guards
+        are evaluated — not skip_guard=True which hides template errors."""
+        preparator = _make_preparator()
+        agent_config = {"name": "test_action", "prompt": "{{ content }}"}
+        data = [{"target_id": "1", "content": {"field": "value"}}]
+
+        mock_passed = MagicMock()
+        mock_passed.guard_status = GuardStatus.PASSED
+
+        with patch("agent_actions.llm.batch.processing.preparator.get_task_preparer") as mock_get:
+            mock_preparer = MagicMock()
+            mock_preparer.prepare.return_value = mock_passed
+            mock_get.return_value = mock_preparer
+
+            preparator._run_preflight_validation(agent_config, data)
+
+            call_kwargs = mock_preparer.prepare.call_args
+            assert call_kwargs.kwargs.get("skip_guard") is False
+
+
+# ---------------------------------------------------------------------------
+# CHANGE 2: No duplicate CASCADE check in reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestReconciliationSkipReason:
+    """Reconciliation uses skip_reason stored during prep, not re-derived
+    CASCADE_BLOCKING_VALUES check."""
+
+    def test_cascade_blocked_row_gets_upstream_unprocessed_reason(self):
+        """A cascade-blocked row stores UPSTREAM_UNPROCESSED as skip_reason
+        during preparation, and reconciliation reads it back."""
+        from agent_actions.llm.batch.core.batch_models import BatchTaskPreparationStats
+        from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
+
+        preparator = _make_preparator()
+        context_map: dict[str, Any] = {}
+        stats = BatchTaskPreparationStats()
+
+        # Row with a cascade-blocking state (upstream failed)
+        row = {
+            "target_id": "tid_cascade",
+            "_state": RecordState.FAILED.value,
+            "content": {"data": "value"},
+        }
+
+        mock_prepared = MagicMock()
+        mock_prepared.guard_status = GuardStatus.UPSTREAM_UNPROCESSED
+        mock_prepared.passthrough_fields = {}
+
+        mock_preparer = MagicMock()
+        mock_preparer.prepare.return_value = mock_prepared
+
+        prep_context = MagicMock(spec=PreparationContext)
+
+        result = preparator._process_single_item(
+            row, prep_context, mock_preparer, context_map, stats
+        )
+
+        assert result is None
+        entry = context_map["tid_cascade"]
+        assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.SKIPPED
+        assert BatchContextMetadata.get_skip_reason(entry) == UPSTREAM_UNPROCESSED
+
+    def test_guard_skipped_row_gets_guard_skip_reason(self):
+        """A guard-skipped row stores GUARD_SKIP as skip_reason."""
+        from agent_actions.llm.batch.core.batch_models import BatchTaskPreparationStats
+        from agent_actions.record.reasons import GUARD_SKIP
+
+        preparator = _make_preparator()
+        context_map: dict[str, Any] = {}
+        stats = BatchTaskPreparationStats()
+
+        row = {
+            "target_id": "tid_guard",
+            "content": {"data": "value"},
+        }
+
+        mock_prepared = MagicMock()
+        mock_prepared.guard_status = GuardStatus.SKIPPED
+        mock_prepared.passthrough_fields = {}
+
+        mock_preparer = MagicMock()
+        mock_preparer.prepare.return_value = mock_prepared
+
+        prep_context = MagicMock(spec=PreparationContext)
+
+        result = preparator._process_single_item(
+            row, prep_context, mock_preparer, context_map, stats
+        )
+
+        assert result is None
+        entry = context_map["tid_guard"]
+        assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.SKIPPED
+        assert BatchContextMetadata.get_skip_reason(entry) == GUARD_SKIP
+
+    def test_reconciliation_reads_skip_reason_not_state(self):
+        """_build_unprocessed_passthrough uses stored skip_reason, not
+        raw _state re-check against CASCADE_BLOCKING_VALUES."""
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchProcessingContext,
+            BatchResultStrategy,
+        )
+        from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+        from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
+
+        original_row = {
+            "target_id": "tid_cascade",
+            "_state": RecordState.FAILED.value,
+            "content": {"data": "value"},
+        }
+        BatchContextMetadata.set_filter_status(original_row, FilterStatus.SKIPPED)
+        BatchContextMetadata.set_skip_reason(original_row, UPSTREAM_UNPROCESSED)
+
+        ctx = BatchProcessingContext(
+            batch_results=[],
+            context_map={"tid_cascade": original_row},
+            output_directory="/tmp/test",
+            agent_config={"name": "test_action", "agent_type": "llm_agent"},
+        )
+        ctx.reconciler = BatchResultReconciler(context_map={"tid_cascade": original_row})
+
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_001", 0
+        )
+
+        assert result.skip_reason == UPSTREAM_UNPROCESSED
+
+    def test_reconciliation_fallback_guard_skip_when_no_skip_reason(self):
+        """Without skip_reason, FilterStatus.SKIPPED falls back to GUARD_SKIP."""
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchProcessingContext,
+            BatchResultStrategy,
+        )
+        from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+        from agent_actions.record.reasons import GUARD_SKIP
+
+        original_row = {"target_id": "tid_1", "content": {}}
+        BatchContextMetadata.set_filter_status(original_row, FilterStatus.SKIPPED)
+        # No skip_reason set — should fall back to GUARD_SKIP
+
+        ctx = BatchProcessingContext(
+            batch_results=[],
+            context_map={"tid_1": original_row},
+            output_directory="/tmp/test",
+            agent_config={"name": "test_action", "agent_type": "llm_agent"},
+        )
+        ctx.reconciler = BatchResultReconciler(context_map={"tid_1": original_row})
+
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_001", 0
+        )
+
+        assert result.skip_reason == GUARD_SKIP
+
+    def test_reconciliation_fallback_cascade_blocked_when_no_skip_reason(self):
+        """Without skip_reason, cascade-blocked _state falls back to UPSTREAM_UNPROCESSED."""
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchProcessingContext,
+            BatchResultStrategy,
+        )
+        from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+        from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
+
+        original_row = {
+            "target_id": "tid_2",
+            "_state": RecordState.CASCADE_SKIPPED.value,
+            "content": {},
+        }
+        # No filter_status, no skip_reason — should fall back to _state check
+
+        ctx = BatchProcessingContext(
+            batch_results=[],
+            context_map={"tid_2": original_row},
+            output_directory="/tmp/test",
+            agent_config={"name": "test_action", "agent_type": "llm_agent"},
+        )
+        ctx.reconciler = BatchResultReconciler(context_map={"tid_2": original_row})
+
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_002", 0
+        )
+
+        assert result.skip_reason == UPSTREAM_UNPROCESSED
+
+    def test_reconciliation_fallback_batch_not_returned(self):
+        """Without skip_reason, filter_status, or cascade state → BATCH_NOT_RETURNED."""
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchProcessingContext,
+            BatchResultStrategy,
+        )
+        from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+        from agent_actions.record.reasons import BATCH_NOT_RETURNED
+
+        original_row = {"target_id": "tid_3", "content": {}}
+        # Nothing set — default fallback
+
+        ctx = BatchProcessingContext(
+            batch_results=[],
+            context_map={"tid_3": original_row},
+            output_directory="/tmp/test",
+            agent_config={"name": "test_action", "agent_type": "llm_agent"},
+        )
+        ctx.reconciler = BatchResultReconciler(context_map={"tid_3": original_row})
+
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_003", 0
+        )
+
+        assert result.skip_reason == BATCH_NOT_RETURNED
+
+
+# ---------------------------------------------------------------------------
+# CHANGE 3: Online guard context parity
+# ---------------------------------------------------------------------------
+
+
+class TestOnlineGuardContextParity:
+    """Online prefilter and per-record guard must see the same context
+    as batch mode — not empty {}."""
+
+    def test_prefilter_passes_record_content_as_context(self):
+        """prefilter_by_guard must pass record content as context, not {}."""
+        from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+        guard_config = {
+            "clause": "upstream_ns.status == 'ready'",
+            "behavior": "skip",
+        }
+        agent_config = {"guard": guard_config}
+
+        data = [
+            {"content": {"upstream_ns": {"status": "ready"}}},
+            {"content": {"upstream_ns": {"status": "pending"}}},
+        ]
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator"
+        ) as mock_get_eval:
+            mock_evaluator = MagicMock()
+            captured_contexts: list[Any] = []
+
+            def capture_evaluate(*, item, guard_config, context=None, **kwargs):
+                captured_contexts.append(context)
+                mock_result = MagicMock()
+                mock_result.should_execute = True
+                return mock_result
+
+            mock_evaluator.evaluate.side_effect = capture_evaluate
+            mock_get_eval.return_value = mock_evaluator
+
+            prefilter_by_guard(data, agent_config, "test_action")
+
+            # Context must be the record's existing content, not empty
+            assert captured_contexts[0] == {"upstream_ns": {"status": "ready"}}
+            assert captured_contexts[1] == {"upstream_ns": {"status": "pending"}}
+
+    def test_online_process_record_skip_guard_false_by_default(self):
+        """process_record default skip_guard is False — per-record guard
+        evaluates with full context."""
+        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+
+        strategy = OnlineLLMStrategy.__new__(OnlineLLMStrategy)
+
+        import inspect
+
+        sig = inspect.signature(strategy.process_record)
+        skip_guard_param = sig.parameters["skip_guard"]
+        assert skip_guard_param.default is False, (
+            "skip_guard default must be False so per-record guard evaluates"
+        )
+
+    def test_same_guard_verdict_online_vs_batch_path(self):
+        """Given the same item and guard config, online prefilter and batch
+        TaskPreparer.prepare() produce the same pass/skip decision."""
+        from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+        # Item where guard should pass (upstream_ns.ready is truthy)
+        passing_item = {"content": {"upstream_ns": {"ready": True}}}
+        # Item where guard should skip (upstream_ns.ready is falsy)
+        skipping_item = {"content": {"upstream_ns": {"ready": False}}}
+
+        guard_config = {
+            "clause": "upstream_ns.ready == true",
+            "behavior": "skip",
+        }
+        agent_config = {"guard": guard_config}
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator"
+        ) as mock_get_eval:
+            mock_evaluator = MagicMock()
+
+            def evaluate_fn(*, item, guard_config, context=None, **kwargs):
+                # Simulate: if context has upstream_ns.ready=True → pass, else skip
+                ready = False
+                if isinstance(context, dict):
+                    ns = context.get("upstream_ns", {})
+                    ready = ns.get("ready", False) if isinstance(ns, dict) else False
+                mock_result = MagicMock()
+                mock_result.should_execute = bool(ready)
+                return mock_result
+
+            mock_evaluator.evaluate.side_effect = evaluate_fn
+            mock_get_eval.return_value = mock_evaluator
+
+            passing_out, skipped_out, _ = prefilter_by_guard(
+                [passing_item, skipping_item], agent_config, "test_action"
+            )
+
+            # passing_item passes, skipping_item is skipped
+            assert len(passing_out) == 1
+            assert len(skipped_out) == 1
+
+
+# ---------------------------------------------------------------------------
+# CHANGE 4: State transition bypass prevention
+# ---------------------------------------------------------------------------
+
+
+class TestStateTransitionBypass:
+    """_mark_prep_failed must not bypass the state machine by force-setting
+    _state when RecordEnvelope.transition() would fail."""
+
+    def test_illegal_transition_does_not_stomp_state(self):
+        """When the record is in CASCADE_SKIPPED state, transitioning to
+        FAILED is illegal. _mark_prep_failed must NOT force-set _state."""
+        row = {"target_id": "tid_001"}
+        context_map = {"tid_001": row.copy()}
+        entry = context_map["tid_001"]
+
+        # Set initial state to CASCADE_SKIPPED (transition to FAILED is illegal)
+        RecordEnvelope.transition(entry, RecordState.CASCADE_SKIPPED, "upstream_action", "cascade")
+
+        BatchTaskPreparator._mark_prep_failed(
+            row, context_map, "test_action", ValueError("some error")
+        )
+
+        # State must remain CASCADE_SKIPPED — NOT force-set to FAILED
+        assert entry["_state"] == RecordState.CASCADE_SKIPPED.value
+
+    def test_legal_transition_succeeds_normally(self):
+        """When the record has no state (fresh), transition to FAILED succeeds."""
+        row = {"target_id": "tid_002"}
+        context_map = {"tid_002": row.copy()}
+
+        BatchTaskPreparator._mark_prep_failed(
+            row, context_map, "test_action", ValueError("template error")
+        )
+
+        entry = context_map["tid_002"]
+        assert entry["_state"] == RecordState.FAILED.value
+        assert len(entry["_state_history"]) == 1
+
+    def test_can_transition_returns_false_for_illegal(self):
+        """RecordEnvelope.can_transition detects illegal edges."""
+        record = {"_state": RecordState.CASCADE_SKIPPED.value}
+        assert RecordEnvelope.can_transition(record, RecordState.FAILED) is False
+
+    def test_can_transition_returns_true_for_legal(self):
+        """RecordEnvelope.can_transition allows legal edges."""
+        record = {"_state": RecordState.ACTIVE.value}
+        assert RecordEnvelope.can_transition(record, RecordState.FAILED) is True
+
+    def test_can_transition_returns_true_for_no_state(self):
+        """RecordEnvelope.can_transition allows any transition from None state."""
+        record = {}
+        assert RecordEnvelope.can_transition(record, RecordState.FAILED) is True
+
+    def test_can_transition_returns_false_for_unknown_state(self):
+        """RecordEnvelope.can_transition returns False for garbage _state values."""
+        record = {"_state": "not_a_real_state"}
+        assert RecordEnvelope.can_transition(record, RecordState.FAILED) is False
+
+    def test_illegal_transition_does_not_append_history(self):
+        """When transition is illegal, no spurious _state_history entry is added."""
+        row = {"target_id": "tid_003"}
+        context_map = {"tid_003": row.copy()}
+        entry = context_map["tid_003"]
+
+        RecordEnvelope.transition(entry, RecordState.CASCADE_SKIPPED, "upstream", "cascade")
+        history_before = len(entry["_state_history"])
+
+        BatchTaskPreparator._mark_prep_failed(row, context_map, "test_action", ValueError("err"))
+
+        assert len(entry["_state_history"]) == history_before
+
+
+# ---------------------------------------------------------------------------
+# UPSTREAM_UNPROCESSED tombstone consistency (audit bug F — on code path)
+# ---------------------------------------------------------------------------
+
+
+class TestUpstreamUnprocessedTombstoneConsistency:
+    """UPSTREAM_UNPROCESSED and GUARD_SKIP tombstones must use the same
+    builder — build_tombstone() — so downstream code sees structurally
+    identical records."""
+
+    def test_upstream_unprocessed_uses_build_tombstone(self):
+        """process_record for UPSTREAM_UNPROCESSED must use build_tombstone,
+        not manual dict construction."""
+        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+
+        strategy = OnlineLLMStrategy.__new__(OnlineLLMStrategy)
+        strategy._invocation_strategy = MagicMock()
+
+        mock_prepared = MagicMock()
+        mock_prepared.guard_status = GuardStatus.UPSTREAM_UNPROCESSED
+        mock_prepared.source_guid = "sg_1"
+        mock_prepared.source_snapshot = {"field": "val"}
+        mock_prepared.original_content = {"field": "val"}
+
+        context = MagicMock()
+        context.agent_name = "test_action"
+        context.action_name = "test_action"
+        context.record_index = 0
+
+        item = {"content": {"field": "val"}, "_state": "failed"}
+
+        with (
+            patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_get,
+            patch(
+                "agent_actions.processing.strategies.online_llm.build_tombstone"
+            ) as mock_build_tombstone,
+            patch("agent_actions.processing.strategies.online_llm.fire_event"),
+        ):
+            mock_preparer = MagicMock()
+            mock_preparer.prepare.return_value = mock_prepared
+            mock_get.return_value = mock_preparer
+
+            mock_build_tombstone.return_value = {
+                "content": {},
+                "metadata": {"agent_type": "tombstone"},
+                "_state": "cascade_skipped",
+            }
+
+            strategy.process_record(item, context)
+
+            # build_tombstone must be called — not manual dict construction
+            mock_build_tombstone.assert_called_once()
+            call_args = mock_build_tombstone.call_args
+            assert call_args.args[0] == "test_action"  # action_name
+            assert call_args.args[2] == "upstream_unprocessed"  # reason

--- a/tests/unit/processing/test_online_llm_strategy.py
+++ b/tests/unit/processing/test_online_llm_strategy.py
@@ -110,8 +110,8 @@ class TestProcessRecordSuccess:
 
     @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
     @patch("agent_actions.processing.strategies.online_llm.fire_event")
-    def test_skip_guard_defaults_to_true(self, mock_fire, mock_get_preparer):
-        """process_record defaults to skip_guard=True for UnifiedProcessor path."""
+    def test_skip_guard_defaults_to_false(self, mock_fire, mock_get_preparer):
+        """process_record defaults to skip_guard=False — per-record guard evaluates."""
         prepared = _make_prepared()
         mock_get_preparer.return_value.prepare.return_value = prepared
 
@@ -130,9 +130,9 @@ class TestProcessRecordSuccess:
         context = _make_context()
         strategy.process_record({"field": "value"}, context)
 
-        # TaskPreparer.prepare() should receive skip_guard=True
+        # TaskPreparer.prepare() should receive skip_guard=False (per-record guard evaluates)
         call_kwargs = mock_get_preparer.return_value.prepare.call_args
-        assert call_kwargs[1]["skip_guard"] is True
+        assert call_kwargs[1]["skip_guard"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Batch preflight** now samples up to 5 rows with `skip_guard=False` instead of force-rendering the first row with `skip_guard=True` — fixes crash on guard-skipped upstream templates
- **Skip reasons** stored during prep via `BatchContextMetadata.set_skip_reason()` so reconciliation uses single authority instead of re-deriving CASCADE state
- **Online guard context** unified with batch: `process_record` default changed to `skip_guard=False`, prefilter passes record content as context (was `{}`)
- **State machine bypass** removed: `_mark_prep_failed` uses `RecordEnvelope.can_transition()` instead of `try/except` with direct `_state` force-set
- **Tombstone consistency**: UPSTREAM_UNPROCESSED uses `build_tombstone()` matching GUARD_SKIP structure
- **Dedup**: `CASCADE_BLOCKING_VALUES` consolidated to single constant in `state.py`; `_validate_transition` delegates to extracted `_is_legal_transition`

## Verification
- 22 regression tests covering all 4 changes + fallback branches + edge cases
- Full test suite: 6722 passed, 0 failed
- `ruff check` and `ruff format --check` clean