### PR TITLE
fix: escape Jinja syntax inside markdown inline code spans

### DIFF
--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -3,6 +3,7 @@
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
+from agent_actions.utils.template_escape import escape_jinja_in_inline_code
 
 __all__ = [
     "parse_field_reference",
@@ -152,7 +153,7 @@ def extract_action_names_from_template(template: str | None) -> set:
 
     try:
         env = Environment()
-        ast = env.parse(template)
+        ast = env.parse(escape_jinja_in_inline_code(template))
     except TemplateSyntaxError:
         return set()
 

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -24,6 +24,7 @@ from agent_actions.prompt.context.static_loader import (
 )
 from agent_actions.prompt.formatter import PromptFormatter
 from agent_actions.prompt.prompt_utils import PromptUtils
+from agent_actions.utils.template_escape import escape_jinja_in_inline_code
 
 logger = logging.getLogger(__name__)
 
@@ -314,6 +315,7 @@ class PromptPreparationService:
                 keep_trailing_newline=True,
             )
 
+            raw_prompt = escape_jinja_in_inline_code(raw_prompt)
             template = jinja_env.from_string(raw_prompt)
             formatted_prompt = template.render(**prompt_context)
             logger.debug("Rendered prompt template with Jinja2")

--- a/agent_actions/utils/template_escape.py
+++ b/agent_actions/utils/template_escape.py
@@ -1,0 +1,75 @@
+"""Pre-process Jinja2 templates to escape syntax inside markdown inline code.
+
+Prompt templates frequently contain literal Jinja-like syntax as code examples
+(e.g., dbt's ``{% test %}``, Django's ``{% block %}``).  Jinja2 parses the
+entire template upfront and chokes on unknown tags, even when they appear
+inside markdown backtick spans that are clearly literal text.
+
+This module provides a single pre-processing function that wraps ``{% %}``
+and ``{{ }}`` tokens found inside markdown inline code spans with
+``{% raw %}...{% endraw %}``, so Jinja2 skips them.  The ``{% raw %}`` /
+``{% endraw %}`` directives are stripped during rendering, producing the
+original literal text in the output.
+
+Fenced code blocks (````` ``` `````) are **not** escaped because they can
+legitimately contain real Jinja2 expressions (e.g.,
+``{{ generate_optimal_code.optimal_code }}``).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Matches markdown inline code spans: `...` or ``...``
+# - Captures the opening backtick(s) as group 1
+# - (?!`) prevents matching the opening of a fenced code block (```)
+# - Captures content as group 2
+# - Uses a backreference (\1) to match the closing backtick(s)
+_INLINE_CODE_RE = re.compile(
+    r"(`{1,2})"  # group 1: opening backtick(s)
+    r"(?!`)"  # not followed by another backtick (excludes ```)
+    r"([^\n]*?)"  # group 2: content (non-greedy, single line only)
+    r"(?<!`)"  # content doesn't end with a backtick
+    r"\1",  # closing backtick(s) must match opening
+)
+
+_JINJA_BLOCK_OR_VAR = re.compile(r"\{[%{]")
+
+
+def escape_jinja_in_inline_code(template: str) -> str:
+    """Wrap Jinja2 syntax inside markdown inline code with ``{% raw %}``.
+
+    Only affects content within backtick-delimited inline code spans
+    (single or double backticks).  Real Jinja2 outside backticks and
+    content inside fenced code blocks (triple backticks) is untouched.
+
+    Parameters
+    ----------
+    template:
+        Raw template string, potentially containing markdown with inline
+        code spans that include Jinja-like syntax.
+
+    Returns
+    -------
+    str
+        Template with Jinja syntax inside inline code spans escaped.
+
+    Examples
+    --------
+    >>> escape_jinja_in_inline_code("Use `{% test %}` in your code")
+    'Use `{% raw %}{% test %}{% endraw %}` in your code'
+
+    >>> escape_jinja_in_inline_code("{% for x in items %}{{ x }}{% endfor %}")
+    '{% for x in items %}{{ x }}{% endfor %}'
+    """
+    if "{" not in template:
+        return template
+
+    def _escape_match(match: re.Match) -> str:
+        backticks = match.group(1)
+        content = match.group(2)
+        if _JINJA_BLOCK_OR_VAR.search(content):
+            return f"{backticks}{{% raw %}}{content}{{% endraw %}}{backticks}"
+        return match.group(0)
+
+    return _INLINE_CODE_RE.sub(_escape_match, template)

--- a/agent_actions/utils/template_escape.py
+++ b/agent_actions/utils/template_escape.py
@@ -65,11 +65,12 @@ def escape_jinja_in_inline_code(template: str) -> str:
     if "{" not in template:
         return template
 
-    def _escape_match(match: re.Match) -> str:
-        backticks = match.group(1)
-        content = match.group(2)
+    def _escape_match(match: re.Match[str]) -> str:
+        backticks: str = match.group(1)
+        content: str = match.group(2)
         if _JINJA_BLOCK_OR_VAR.search(content):
             return f"{backticks}{{% raw %}}{content}{{% endraw %}}{backticks}"
-        return match.group(0)
+        return str(match.group(0))
 
-    return _INLINE_CODE_RE.sub(_escape_match, template)
+    result: str = _INLINE_CODE_RE.sub(_escape_match, template)
+    return result

--- a/agent_actions/validation/prompt_ast.py
+++ b/agent_actions/validation/prompt_ast.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from jinja2 import Environment, TemplateSyntaxError, nodes
 
+from agent_actions.utils.template_escape import escape_jinja_in_inline_code
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,6 +26,10 @@ class PromptASTAnalyzer:
     def __init__(self):
         """Initialize Jinja2 environment for AST parsing."""
         self.env = Environment()
+
+    def _parse(self, template_source: str) -> nodes.Template:
+        """Parse template after escaping Jinja syntax in inline code spans."""
+        return self.env.parse(escape_jinja_in_inline_code(template_source))
 
     def _build_path_from_node(self, node: nodes.Node) -> str:
         """Build full attribute path by walking the AST node chain.
@@ -124,7 +130,7 @@ class PromptASTAnalyzer:
             ['seed.exam_syllabus.platform_name', 'source.url']
         """
         try:
-            ast = self.env.parse(template_source)
+            ast = self._parse(template_source)
             return self._extract_full_paths(ast)
 
         except TemplateSyntaxError as e:
@@ -144,7 +150,7 @@ class PromptASTAnalyzer:
             ['seed.exam_syllabus', 'source.content']
         """
         try:
-            ast = self.env.parse(template_source)
+            ast = self._parse(template_source)
 
             # Get all referenced variables (with full paths)
             full_paths = self._extract_full_paths(ast)
@@ -177,7 +183,7 @@ class PromptASTAnalyzer:
             unexpected end of template...
         """
         try:
-            self.env.parse(template_source)
+            self._parse(template_source)
             return (True, None)
         except TemplateSyntaxError as e:
             return (False, str(e))
@@ -244,7 +250,7 @@ class PromptASTAnalyzer:
             >>> usage[0]['name']  # Returns 'seed', not 'seed.exam_syllabus'
             'seed'
         """
-        template_ast = self.env.parse(template_source)
+        template_ast = self._parse(template_source)
         usage_list = []
 
         for node in template_ast.find_all(nodes.Name):

--- a/agent_actions/validation/static_analyzer/reference_extractor.py
+++ b/agent_actions/validation/static_analyzer/reference_extractor.py
@@ -7,6 +7,7 @@ from jinja2 import Environment, nodes
 from jinja2.exceptions import TemplateSyntaxError
 
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
+from agent_actions.utils.template_escape import escape_jinja_in_inline_code
 
 from .data_flow_graph import InputRequirement
 
@@ -43,6 +44,10 @@ class ReferenceExtractor:
     def __init__(self) -> None:
         """Initialize with a Jinja2 environment for AST parsing."""
         self._env = Environment()
+
+    def _parse(self, template: str) -> nodes.Template:
+        """Parse template after escaping Jinja syntax in inline code spans."""
+        return self._env.parse(escape_jinja_in_inline_code(template))
 
     def extract_from_agent(self, agent_config: dict[str, Any]) -> list[InputRequirement]:
         """Extract all field references from an action configuration."""
@@ -140,7 +145,7 @@ class ReferenceExtractor:
         references: list[tuple] = []
 
         try:
-            ast = self._env.parse(template)
+            ast = self._parse(template)
         except TemplateSyntaxError:
             # If template has syntax errors, fall back to empty (simple patterns will catch it)
             return references

--- a/tests/unit/utils/test_template_escape.py
+++ b/tests/unit/utils/test_template_escape.py
@@ -1,0 +1,153 @@
+"""Tests for Jinja2 inline code escaping.
+
+Verifies that escape_jinja_in_inline_code correctly wraps Jinja syntax
+inside markdown inline code spans with {% raw %} while leaving real
+Jinja2 constructs and fenced code blocks untouched.
+"""
+
+import pytest
+from jinja2 import Environment, StrictUndefined, TemplateSyntaxError
+
+from agent_actions.utils.template_escape import escape_jinja_in_inline_code
+
+
+class TestEscapeJinjaInInlineCode:
+    """Unit tests for the escape function itself."""
+
+    def test_single_backtick_block_tag(self):
+        result = escape_jinja_in_inline_code("Use `{% test %}` here")
+        assert result == "Use `{% raw %}{% test %}{% endraw %}` here"
+
+    def test_single_backtick_variable(self):
+        result = escape_jinja_in_inline_code('Use `{{ ref("model") }}` in dbt')
+        assert result == 'Use `{% raw %}{{ ref("model") }}{% endraw %}` in dbt'
+
+    def test_double_backtick(self):
+        result = escape_jinja_in_inline_code("Use ``{% test %}`` here")
+        assert result == "Use ``{% raw %}{% test %}{% endraw %}`` here"
+
+    def test_multiple_inline_spans(self):
+        line = "`{% test %}` to `{% macro %}`"
+        result = escape_jinja_in_inline_code(line)
+        assert "{% raw %}{% test %}{% endraw %}" in result
+        assert "{% raw %}{% macro %}{% endraw %}" in result
+
+    def test_real_jinja_untouched(self):
+        template = "{% for x in items %}{{ x }}{% endfor %}"
+        assert escape_jinja_in_inline_code(template) == template
+
+    def test_mixed_real_and_inline(self):
+        template = "Use `{% test %}` like this: {% for x in items %}{{ x }}{% endfor %}"
+        result = escape_jinja_in_inline_code(template)
+        assert "{% raw %}{% test %}{% endraw %}" in result
+        assert "{% for x in items %}" in result
+        assert "{% endfor %}" in result
+
+    def test_fenced_code_block_not_escaped(self):
+        template = "```\n{% test %}\n```"
+        result = escape_jinja_in_inline_code(template)
+        assert "{% raw %}" not in result
+
+    def test_fenced_code_block_with_lang_not_escaped(self):
+        template = "```sql\n{% test %}\n```"
+        result = escape_jinja_in_inline_code(template)
+        assert "{% raw %}" not in result
+
+    def test_plain_text_unchanged(self):
+        text = "Just plain text with no special characters"
+        assert escape_jinja_in_inline_code(text) == text
+
+    def test_inline_code_without_jinja_unchanged(self):
+        text = "Use `print('hello')` to debug"
+        assert escape_jinja_in_inline_code(text) == text
+
+    def test_empty_string(self):
+        assert escape_jinja_in_inline_code("") == ""
+
+    def test_no_braces_fast_path(self):
+        """Templates without { skip regex entirely."""
+        text = "No braces here at all"
+        assert escape_jinja_in_inline_code(text) == text
+
+    def test_actual_failing_line(self):
+        """The exact line from code_options_quiz.md that caused the bug."""
+        line = (
+            "- Must be syntactically valid \u2014 if you change an opening block tag "
+            "(e.g. `{% test %}` to `{% macro %}`), update the closing tag to match "
+            "(e.g. `{% endtest %}` to `{% endmacro %}`)"
+        )
+        result = escape_jinja_in_inline_code(line)
+        assert "{% raw %}{% test %}{% endraw %}" in result
+        assert "{% raw %}{% macro %}{% endraw %}" in result
+        assert "{% raw %}{% endtest %}{% endraw %}" in result
+        assert "{% raw %}{% endmacro %}{% endraw %}" in result
+
+
+class TestRenderIntegration:
+    """Integration tests: escape + Jinja2 rendering end-to-end."""
+
+    @pytest.fixture()
+    def jinja_env(self):
+        return Environment(
+            undefined=StrictUndefined,
+            trim_blocks=True,
+            lstrip_blocks=True,
+            keep_trailing_newline=True,
+        )
+
+    def test_inline_code_survives_rendering(self, jinja_env):
+        """Literal {% test %} in backticks renders as literal text."""
+        template = "Use `{% test %}` in your code\n{% for x in items %}- {{ x }}\n{% endfor %}"
+        escaped = escape_jinja_in_inline_code(template)
+        rendered = jinja_env.from_string(escaped).render(items=["a", "b"])
+        assert "{% test %}" in rendered
+        assert "- a" in rendered
+        assert "- b" in rendered
+        assert "{% raw %}" not in rendered
+
+    def test_inline_variable_survives_rendering(self, jinja_env):
+        """Literal {{ ref() }} in backticks renders as literal text."""
+        template = 'Use `{{ ref("model") }}` for references. Value: {{ value }}'
+        escaped = escape_jinja_in_inline_code(template)
+        rendered = jinja_env.from_string(escaped).render(value="hello")
+        assert '{{ ref("model") }}' in rendered
+        assert "Value: hello" in rendered
+
+    def test_without_escape_raises(self, jinja_env):
+        """Confirm that without escaping, the template fails."""
+        template = "Use `{% test %}` in your code"
+        with pytest.raises(TemplateSyntaxError):
+            jinja_env.from_string(template)
+
+    def test_full_prompt_template_pattern(self, jinja_env):
+        """Simulates the real-world pattern: rules with code examples + seed data loop."""
+        template = """## RULES
+- Copy the code EXACTLY
+- Must be syntactically valid \u2014 if you change `{% test %}` to `{% macro %}`, update the closing tag
+- No inline comments
+
+## PATTERNS
+{% for p in seed_patterns %}
+- {{ p }}
+{% endfor %}"""
+        escaped = escape_jinja_in_inline_code(template)
+        rendered = jinja_env.from_string(escaped).render(seed_patterns=["pattern_a", "pattern_b"])
+        assert "{% test %}" in rendered
+        assert "{% macro %}" in rendered
+        assert "- pattern_a" in rendered
+        assert "- pattern_b" in rendered
+
+    def test_fenced_block_with_real_jinja_renders(self, jinja_env):
+        """Fenced code blocks with real Jinja must still render."""
+        template = "```\n{{ code_output }}\n```"
+        escaped = escape_jinja_in_inline_code(template)
+        rendered = jinja_env.from_string(escaped).render(code_output="print('hi')")
+        assert "print('hi')" in rendered
+
+    def test_known_tag_in_inline_code(self, jinja_env):
+        """Known Jinja tags (macro, for) in inline code are also escaped."""
+        template = "Use `{% for x in y %}` syntax. {% for i in items %}{{ i }}{% endfor %}"
+        escaped = escape_jinja_in_inline_code(template)
+        rendered = jinja_env.from_string(escaped).render(items=["a"])
+        assert "{% for x in y %}" in rendered
+        assert "a" in rendered


### PR DESCRIPTION
## Summary
- Prompt templates containing literal Jinja-like syntax as code examples (e.g., dbt's `{% test %}`, Django's `{% block %}`) crash with `TemplateSyntaxError` because Jinja2 parses the entire template upfront
- Adds `escape_jinja_in_inline_code()` utility that wraps `{% %}` and `{{ }}` tokens found inside markdown backtick spans with `{% raw %}...{% endraw %}` before Jinja parsing
- Integrated into all 4 prompt-facing Jinja entry points (`service.py`, `prompt_ast.py`, `reference_extractor.py`, `scope_parsing.py`). `render_workflow.py` excluded — it processes YAML config, not markdown

## Verification
- 19 new tests (unit + integration) covering single/double backtick, fenced blocks excluded, mixed real Jinja + inline code, end-to-end rendering
- Full suite: 6680 passed, 0 failures
- Lint and format clean
- Manually verified against the `code_centered_quiz` workflow that triggered the bug