### PR TITLE
fix: silence pre-reclassification guard log noise for missing fields

### DIFF
--- a/.changes/unreleased/Under the Hood-20260514-408000.yaml
+++ b/.changes/unreleased/Under the Hood-20260514-408000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Reduce guard missing-field log noise when error is reclassified to not-matched"
+time: 2026-05-14T04:08:00.000000Z

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -19,8 +19,6 @@ from agent_actions.input.preprocessing.filtering.guard_filter import (
     GuardFilter,
     get_global_guard_filter,
 )
-from agent_actions.logging.core.manager import fire_event
-from agent_actions.logging.events.validation_events import GuardEvaluationErrorEvent
 from agent_actions.utils.udf_management.tooling import execute_user_defined_function
 
 logger = logging.getLogger(__name__)
@@ -181,30 +179,9 @@ class GuardEvaluator:
             eval_context = self._prepare_eval_context(context)
 
             request = FilterItemRequest(data=eval_context, condition=clause)
-            raw_result = self._filter.filter_item(request)
+            filter_result = self._filter.filter_item(request)
 
-            filter_result = self._reclassify_missing_field_error(raw_result, clause)
-
-            # Log DATA errors that survived reclassification (not missing-field).
-            # Missing-field errors are logged at DEBUG inside _reclassify; flat-field
-            # references are logged at WARNING there.  Only non-reclassified DATA
-            # errors (e.g. type coercion ValueError) need the event here.
-            if (
-                not filter_result.success
-                and filter_result.error_category == ErrorCategory.DATA
-                and filter_result is raw_result  # not reclassified
-            ):
-                logger.warning(
-                    "Guard evaluation error in condition '%s': %s",
-                    clause,
-                    filter_result.error,
-                )
-                fire_event(
-                    GuardEvaluationErrorEvent(
-                        guard_clause=clause,
-                        error=filter_result.error or "",
-                    )
-                )
+            filter_result = self._reclassify_missing_field_error(filter_result, clause)
 
             return GuardResult.from_filter_result(filter_result, behavior, passthrough_on_error)
 

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -19,6 +19,8 @@ from agent_actions.input.preprocessing.filtering.guard_filter import (
     GuardFilter,
     get_global_guard_filter,
 )
+from agent_actions.logging.core.manager import fire_event
+from agent_actions.logging.events.validation_events import GuardEvaluationErrorEvent
 from agent_actions.utils.udf_management.tooling import execute_user_defined_function
 
 logger = logging.getLogger(__name__)
@@ -179,9 +181,30 @@ class GuardEvaluator:
             eval_context = self._prepare_eval_context(context)
 
             request = FilterItemRequest(data=eval_context, condition=clause)
-            filter_result = self._filter.filter_item(request)
+            raw_result = self._filter.filter_item(request)
 
-            filter_result = self._reclassify_missing_field_error(filter_result, clause)
+            filter_result = self._reclassify_missing_field_error(raw_result, clause)
+
+            # Log DATA errors that survived reclassification (not missing-field).
+            # Missing-field errors are logged at DEBUG inside _reclassify; flat-field
+            # references are logged at WARNING there.  Only non-reclassified DATA
+            # errors (e.g. type coercion ValueError) need the event here.
+            if (
+                not filter_result.success
+                and filter_result.error_category == ErrorCategory.DATA
+                and filter_result is raw_result  # not reclassified
+            ):
+                logger.warning(
+                    "Guard evaluation error in condition '%s': %s",
+                    clause,
+                    filter_result.error,
+                )
+                fire_event(
+                    GuardEvaluationErrorEvent(
+                        guard_clause=clause,
+                        error=filter_result.error or "",
+                    )
+                )
 
             return GuardResult.from_filter_result(filter_result, behavior, passthrough_on_error)
 

--- a/agent_actions/input/preprocessing/filtering/guard_filter.py
+++ b/agent_actions/input/preprocessing/filtering/guard_filter.py
@@ -167,9 +167,16 @@ class GuardFilter:
             execution_time = time.time() - start_time
             error_msg = f"Error evaluating guard condition: {str(e)}"
 
-            # No WARNING/event here — the evaluator decides log severity
-            # after _reclassify_missing_field_error (which may downgrade
-            # expected missing-field errors to DEBUG).
+            # Fire the G002 event for all callers (evaluator, skip.py).
+            # No WARNING log here — the evaluator's _reclassify may
+            # downgrade expected missing-field errors to DEBUG, so it
+            # owns the log-level decision.
+            fire_event(
+                GuardEvaluationErrorEvent(
+                    guard_clause=request.condition,
+                    error=str(e),
+                )
+            )
 
             if self.enable_metrics:
                 self._update_metrics(False, execution_time, False)

--- a/agent_actions/input/preprocessing/filtering/guard_filter.py
+++ b/agent_actions/input/preprocessing/filtering/guard_filter.py
@@ -166,14 +166,10 @@ class GuardFilter:
         except ValueError as e:
             execution_time = time.time() - start_time
             error_msg = f"Error evaluating guard condition: {str(e)}"
-            logger.warning(error_msg, exc_info=True)
 
-            fire_event(
-                GuardEvaluationErrorEvent(
-                    guard_clause=request.condition,
-                    error=str(e),
-                )
-            )
+            # No WARNING/event here — the evaluator decides log severity
+            # after _reclassify_missing_field_error (which may downgrade
+            # expected missing-field errors to DEBUG).
 
             if self.enable_metrics:
                 self._update_metrics(False, execution_time, False)

--- a/tests/preprocessing/test_guard_evaluator.py
+++ b/tests/preprocessing/test_guard_evaluator.py
@@ -770,7 +770,7 @@ class TestNamespacedContentGuardEvaluation:
 
 
 class TestGuardMissingFieldLogNoise:
-    """Spec 408: pre-reclassification WARNING/ERROR must not fire for missing-field paths."""
+    """Spec 408: missing-field WARNING log removed; G002 event preserved."""
 
     @pytest.fixture(scope="class")
     def evaluator(self):
@@ -778,11 +778,10 @@ class TestGuardMissingFieldLogNoise:
 
         return GuardEvaluator(guard_filter=GuardFilter())
 
-    def test_reclassified_missing_field_no_warning(self, evaluator):
-        """Missing field reclassified to not-matched must not emit WARNING."""
+    def test_reclassified_missing_field_no_warning_log(self, evaluator):
+        """Missing field path must not emit WARNING from guard_filter or evaluator."""
         import logging
 
-        # Capture from both guard_filter and evaluator loggers
         loggers_to_check = [
             logging.getLogger("agent_actions.input.preprocessing.filtering.guard_filter"),
             logging.getLogger("agent_actions.input.preprocessing.filtering.evaluator"),
@@ -790,25 +789,18 @@ class TestGuardMissingFieldLogNoise:
         captured: list[logging.LogRecord] = []
 
         class _CaptureHandler(logging.Handler):
-            def emit(self, record: logging.LogRecord) -> None:
-                captured.append(record)
+            def emit(self, rec: logging.LogRecord) -> None:
+                captured.append(rec)
 
         handler = _CaptureHandler(level=logging.WARNING)
         for lg in loggers_to_check:
             lg.addHandler(handler)
 
         try:
-            record = {
-                "content": {"validate": {"pass": True}},
-                "source_guid": "sg-1",
-            }
-            guard = {
-                "clause": "nonexistent_action.field == true",
-                "scope": "item",
-                "behavior": "skip",
-            }
-
-            result = evaluator.evaluate(record, guard)
+            result = evaluator.evaluate(
+                {"content": {"validate": {"pass": True}}, "source_guid": "sg-1"},
+                {"clause": "nonexistent_action.field == true", "scope": "item", "behavior": "skip"},
+            )
         finally:
             for lg in loggers_to_check:
                 lg.removeHandler(handler)
@@ -822,38 +814,31 @@ class TestGuardMissingFieldLogNoise:
             if "Error evaluating guard" in r.getMessage()
             or "Guard evaluation failed" in r.getMessage()
         ]
-        assert noise == [], f"Pre-reclassification noise found: {[r.getMessage() for r in noise]}"
+        assert noise == [], f"WARNING noise found: {[r.getMessage() for r in noise]}"
 
-    def test_reclassified_missing_field_no_error_event(self, evaluator):
-        """Missing field reclassified to not-matched must not fire G002 ERROR event."""
+    def test_g002_event_still_fires_for_missing_field(self, evaluator):
+        """G002 event must still fire from filter_item — skip.py callers depend on it."""
         from unittest.mock import patch
 
-        record = {
-            "content": {"validate": {"pass": True}},
-            "source_guid": "sg-1",
-        }
-        guard = {
-            "clause": "nonexistent_action.field == true",
-            "scope": "item",
-            "behavior": "skip",
-        }
+        from agent_actions.logging.events.validation_events import GuardEvaluationErrorEvent
 
-        with patch("agent_actions.input.preprocessing.filtering.evaluator.fire_event") as mock_fire:
-            result = evaluator.evaluate(record, guard)
+        with patch(
+            "agent_actions.input.preprocessing.filtering.guard_filter.fire_event"
+        ) as mock_fire:
+            result = evaluator.evaluate(
+                {"content": {"validate": {"pass": True}}, "source_guid": "sg-1"},
+                {"clause": "nonexistent_action.field == true", "scope": "item", "behavior": "skip"},
+            )
 
         assert result.should_execute is False
 
-        from agent_actions.logging.events.validation_events import (
-            GuardEvaluationErrorEvent,
-        )
-
-        error_events = [
+        g002_events = [
             c for c in mock_fire.call_args_list if isinstance(c[0][0], GuardEvaluationErrorEvent)
         ]
-        assert error_events == [], f"G002 events fired for reclassified path: {error_events}"
+        assert len(g002_events) == 1, f"Expected exactly 1 G002 event, got {len(g002_events)}"
 
-    def test_real_config_typo_still_warns(self, evaluator):
-        """Non-reclassifiable DATA errors preserve identity (evaluator logs them)."""
+    def test_non_missing_field_data_error_not_reclassified(self, evaluator):
+        """DATA errors without 'does not exist' are not reclassified."""
         from agent_actions.input.preprocessing.filtering.guard_filter import (
             ErrorCategory,
             FilterResult,
@@ -864,38 +849,30 @@ class TestGuardMissingFieldLogNoise:
             error="Error evaluating guard condition: cannot compare types",
             error_category=ErrorCategory.DATA,
         )
-        reclassified = evaluator._reclassify_missing_field_error(raw, "x > y")
+        result = evaluator._reclassify_missing_field_error(raw, "x > y")
 
-        # Not reclassified — identity preserved
-        assert reclassified is raw
+        assert result.error_category == ErrorCategory.DATA
+        assert not result.success
 
     def test_flat_field_semantic_reclassification_still_warns(self, evaluator):
-        """Flat field reference ('Did you mean:') is reclassified to SEMANTIC
-        and still logs WARNING — only the missing-field path is silenced."""
+        """Flat field 'Did you mean:' path is reclassified to SEMANTIC and still warns."""
         import logging
 
         target_logger = logging.getLogger("agent_actions.input.preprocessing.filtering.evaluator")
         captured: list[logging.LogRecord] = []
 
         class _CaptureHandler(logging.Handler):
-            def emit(self, record: logging.LogRecord) -> None:
-                captured.append(record)
+            def emit(self, rec: logging.LogRecord) -> None:
+                captured.append(rec)
 
         handler = _CaptureHandler(level=logging.WARNING)
         target_logger.addHandler(handler)
 
         try:
-            record = {
-                "content": {"validate": {"pass": True}},
-                "source_guid": "sg-1",
-            }
-            guard = {
-                "clause": "pass == false",
-                "scope": "item",
-                "behavior": "skip",
-            }
-
-            result = evaluator.evaluate(record, guard)
+            result = evaluator.evaluate(
+                {"content": {"validate": {"pass": True}}, "source_guid": "sg-1"},
+                {"clause": "pass == false", "scope": "item", "behavior": "skip"},
+            )
         finally:
             target_logger.removeHandler(handler)
 

--- a/tests/preprocessing/test_guard_evaluator.py
+++ b/tests/preprocessing/test_guard_evaluator.py
@@ -767,3 +767,140 @@ class TestNamespacedContentGuardEvaluation:
         # First clause matches, but second field is missing → whole condition not matched
         assert result.should_execute is False
         assert result.behavior == "skip"
+
+
+class TestGuardMissingFieldLogNoise:
+    """Spec 408: pre-reclassification WARNING/ERROR must not fire for missing-field paths."""
+
+    @pytest.fixture(scope="class")
+    def evaluator(self):
+        from agent_actions.input.preprocessing.filtering.guard_filter import GuardFilter
+
+        return GuardEvaluator(guard_filter=GuardFilter())
+
+    def test_reclassified_missing_field_no_warning(self, evaluator):
+        """Missing field reclassified to not-matched must not emit WARNING."""
+        import logging
+
+        # Capture from both guard_filter and evaluator loggers
+        loggers_to_check = [
+            logging.getLogger("agent_actions.input.preprocessing.filtering.guard_filter"),
+            logging.getLogger("agent_actions.input.preprocessing.filtering.evaluator"),
+        ]
+        captured: list[logging.LogRecord] = []
+
+        class _CaptureHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        handler = _CaptureHandler(level=logging.WARNING)
+        for lg in loggers_to_check:
+            lg.addHandler(handler)
+
+        try:
+            record = {
+                "content": {"validate": {"pass": True}},
+                "source_guid": "sg-1",
+            }
+            guard = {
+                "clause": "nonexistent_action.field == true",
+                "scope": "item",
+                "behavior": "skip",
+            }
+
+            result = evaluator.evaluate(record, guard)
+        finally:
+            for lg in loggers_to_check:
+                lg.removeHandler(handler)
+
+        assert result.should_execute is False
+        assert result.behavior == "skip"
+
+        noise = [
+            r
+            for r in captured
+            if "Error evaluating guard" in r.getMessage()
+            or "Guard evaluation failed" in r.getMessage()
+        ]
+        assert noise == [], f"Pre-reclassification noise found: {[r.getMessage() for r in noise]}"
+
+    def test_reclassified_missing_field_no_error_event(self, evaluator):
+        """Missing field reclassified to not-matched must not fire G002 ERROR event."""
+        from unittest.mock import patch
+
+        record = {
+            "content": {"validate": {"pass": True}},
+            "source_guid": "sg-1",
+        }
+        guard = {
+            "clause": "nonexistent_action.field == true",
+            "scope": "item",
+            "behavior": "skip",
+        }
+
+        with patch("agent_actions.input.preprocessing.filtering.evaluator.fire_event") as mock_fire:
+            result = evaluator.evaluate(record, guard)
+
+        assert result.should_execute is False
+
+        from agent_actions.logging.events.validation_events import (
+            GuardEvaluationErrorEvent,
+        )
+
+        error_events = [
+            c for c in mock_fire.call_args_list if isinstance(c[0][0], GuardEvaluationErrorEvent)
+        ]
+        assert error_events == [], f"G002 events fired for reclassified path: {error_events}"
+
+    def test_real_config_typo_still_warns(self, evaluator):
+        """Non-reclassifiable DATA errors preserve identity (evaluator logs them)."""
+        from agent_actions.input.preprocessing.filtering.guard_filter import (
+            ErrorCategory,
+            FilterResult,
+        )
+
+        raw = FilterResult(
+            success=False,
+            error="Error evaluating guard condition: cannot compare types",
+            error_category=ErrorCategory.DATA,
+        )
+        reclassified = evaluator._reclassify_missing_field_error(raw, "x > y")
+
+        # Not reclassified — identity preserved
+        assert reclassified is raw
+
+    def test_flat_field_semantic_reclassification_still_warns(self, evaluator):
+        """Flat field reference ('Did you mean:') is reclassified to SEMANTIC
+        and still logs WARNING — only the missing-field path is silenced."""
+        import logging
+
+        target_logger = logging.getLogger("agent_actions.input.preprocessing.filtering.evaluator")
+        captured: list[logging.LogRecord] = []
+
+        class _CaptureHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        handler = _CaptureHandler(level=logging.WARNING)
+        target_logger.addHandler(handler)
+
+        try:
+            record = {
+                "content": {"validate": {"pass": True}},
+                "source_guid": "sg-1",
+            }
+            guard = {
+                "clause": "pass == false",
+                "scope": "item",
+                "behavior": "skip",
+            }
+
+            result = evaluator.evaluate(record, guard)
+        finally:
+            target_logger.removeHandler(handler)
+
+        assert result.should_execute is False
+        assert result.behavior == "skip"
+
+        flat_field_warnings = [r for r in captured if "flat field reference" in r.getMessage()]
+        assert len(flat_field_warnings) > 0, "Flat field reference should still warn"


### PR DESCRIPTION
## Summary
- When a guard references a field from an upstream-filtered action, `guard_filter.py` emitted **WARNING log + G002 ERROR event** per record before `_reclassify_missing_field_error` correctly downgraded to "not matched"
- In `qanalabs_quiz_gen`, 574 records × WARNING log = 574 scary log lines for normal behavior
- **Fix:** Remove only the `logger.warning()` call from `filter_item`'s `ValueError` catch block. Keep `GuardEvaluationErrorEvent` (G002) — it's the single source of truth for all 4 callers (`evaluator.py` + 3 paths in `skip.py`)
- The evaluator's `_reclassify_missing_field_error` already owns log-level decisions: DEBUG for genuinely missing fields, WARNING for flat-field references ("Did you mean:")

### Logger name change
WARNINGs for the reclassified missing-field path are **eliminated** (was `guard_filter`, now nothing). WARNINGs for flat-field references remain on `evaluator` (unchanged). No downstream consumers are known to key on the `guard_filter` logger name for this specific message.

### Before/after
```
# BEFORE: 574 records × 1 WARNING line each
WARNING  Error evaluating guard condition: Guard condition references field
         'auto_review_quality.hitl_recommendation' which does not exist...

# AFTER: 0 WARNING lines (reclassified path is silent; G002 event still fires)
```

## Verification
- 4 tests in `TestGuardMissingFieldLogNoise`:
  - No WARNING log noise for reclassified missing-field path
  - G002 event still fires from filter_item (skip.py callers preserved)
  - Non-missing-field DATA errors are not reclassified
  - Flat-field semantic reclassification still logs WARNING
- All 48 guard evaluator tests pass
- Full suite: 6768 passed, 0 failures
- `ruff format --check` and `ruff check` clean