### PR TITLE
fix: remove batch_max_workers from Ollama batch client

### DIFF
--- a/.changes/unreleased/Under the Hood-20260514-409000.yaml
+++ b/.changes/unreleased/Under the Hood-20260514-409000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove batch_max_workers config plumbing from Ollama batch client (never worked end-to-end)"
+time: 2026-05-14T04:09:00.000000Z

--- a/agent_actions/config/defaults.py
+++ b/agent_actions/config/defaults.py
@@ -18,14 +18,12 @@ class OllamaDefaults:
     """Defaults for Ollama local LLM provider."""
 
     BASE_URL: str = "http://localhost:11434"
-    BATCH_MAX_WORKERS: int = 1
 
 
 class OllamaCloudDefaults:
     """Defaults for Ollama Cloud provider (ollama.com)."""
 
     BASE_URL: str = "https://ollama.com"
-    BATCH_MAX_WORKERS: int = 1
 
 
 class ApiDefaults:

--- a/agent_actions/llm/providers/batch_client_factory.py
+++ b/agent_actions/llm/providers/batch_client_factory.py
@@ -90,10 +90,7 @@ def _create_ollama_local(config: dict[str, Any]) -> BaseBatchClient:
     from .ollama.batch_client import OllamaBatchClient
 
     base_url = config.get("base_url") or os.getenv("OLLAMA_HOST", OllamaDefaults.BASE_URL)
-    max_workers = config.get("batch_max_workers")
-    return OllamaBatchClient(
-        base_url=base_url, vendor_slug="ollama_local", cloud=False, max_workers=max_workers
-    )
+    return OllamaBatchClient(base_url=base_url, vendor_slug="ollama_local", cloud=False)
 
 
 def _create_ollama_cloud(config: dict[str, Any]) -> BaseBatchClient:
@@ -106,13 +103,11 @@ def _create_ollama_cloud(config: dict[str, Any]) -> BaseBatchClient:
     base_url = config.get("base_url") or os.getenv(
         "OLLAMA_CLOUD_HOST", OllamaCloudDefaults.BASE_URL
     )
-    max_workers = config.get("batch_max_workers")
     return OllamaBatchClient(
         base_url=base_url,
         api_key=api_key,
         vendor_slug="ollama_cloud",
         cloud=True,
-        max_workers=max_workers,
     )
 
 

--- a/agent_actions/llm/providers/ollama/batch_client.py
+++ b/agent_actions/llm/providers/ollama/batch_client.py
@@ -5,9 +5,7 @@ Both vendors use the same in-process loop (no real batch API exists for
 either). The ``cloud`` flag controls client construction (Bearer auth)
 and whether the ``format`` param is passed to ``client.chat()``.
 
-Records are processed concurrently via ``ThreadPoolExecutor``.  Concurrency
-is controlled by ``OLLAMA_BATCH_MAX_WORKERS`` (env var) or the constructor
-``max_workers`` parameter.  Default is 1 (sequential, matching prior behavior).
+Records are processed sequentially via ``ThreadPoolExecutor(max_workers=1)``.
 
 When Ollama ships a real cloud batch API, add a
 ``_submit_to_cloud_batch_api`` branch inside ``_submit_to_provider_api``.
@@ -53,11 +51,9 @@ class OllamaBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
         *,
         vendor_slug: str = "ollama_local",
         cloud: bool = False,
-        max_workers: int | None = None,
     ):
         self.vendor_slug = vendor_slug
         self.cloud = cloud
-        self._max_workers = max_workers
 
         if cloud:
             self.base_url = base_url or os.getenv("OLLAMA_CLOUD_HOST", OllamaCloudDefaults.BASE_URL)
@@ -121,43 +117,6 @@ class OllamaBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
     ) -> Path:
         return self._write_jsonl_file(tasks, batch_dir, batch_name, self.vendor_slug)
 
-    _MAX_WORKERS_LIMIT: int = 32
-
-    def _get_max_workers(self) -> int:
-        """Resolve batch concurrency: constructor param > env var > class default."""
-        default = (
-            OllamaCloudDefaults.BATCH_MAX_WORKERS
-            if self.cloud
-            else OllamaDefaults.BATCH_MAX_WORKERS
-        )
-
-        if self._max_workers is not None:
-            val = self._max_workers
-        else:
-            env_val = os.getenv("OLLAMA_BATCH_MAX_WORKERS")
-            if env_val:
-                try:
-                    val = int(env_val)
-                except ValueError:
-                    logger.warning(
-                        "OLLAMA_BATCH_MAX_WORKERS=%s is not an integer, using default", env_val
-                    )
-                    return default
-            else:
-                return default
-
-        if val < 1:
-            logger.warning("batch_max_workers=%s invalid (must be >= 1), using default", val)
-            return default
-        if val > self._MAX_WORKERS_LIMIT:
-            logger.warning(
-                "batch_max_workers=%s exceeds limit of %s, clamping",
-                val,
-                self._MAX_WORKERS_LIMIT,
-            )
-            return self._MAX_WORKERS_LIMIT
-        return val
-
     def _process_single_task(
         self, task: dict[str, Any], idx: int, total: int
     ) -> dict[str, Any] | None:
@@ -220,7 +179,7 @@ class OllamaBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
             }
 
     def _submit_to_provider_api(self, input_file: Path, batch_name: str) -> tuple[str, str]:
-        """Process batch with concurrent workers (default: 1 = sequential)."""
+        """Process batch sequentially (no real batch API for Ollama)."""
         batch_id = f"batch_{uuid.uuid4().hex}"
 
         tasks: list[dict[str, Any]] = []
@@ -230,10 +189,9 @@ class OllamaBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
                     tasks.append(json.loads(line))
 
         total = len(tasks)
-        max_workers = self._get_max_workers()
         results: list[dict[str, Any]] = []
 
-        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ollama_batch") as pool:
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="ollama_batch") as pool:
             futures: dict[Future[dict[str, Any] | None], str] = {
                 pool.submit(self._process_single_task, task, idx, total): task["custom_id"]
                 for idx, task in enumerate(tasks)

--- a/tests/integrations/providers/ollama/test_ollama_batch_client.py
+++ b/tests/integrations/providers/ollama/test_ollama_batch_client.py
@@ -128,76 +128,12 @@ def _make_task(custom_id: str) -> dict:
     }
 
 
-class TestOllamaBatchConcurrency:
-    """Tests for concurrent batch processing and max_workers config."""
+class TestOllamaBatchProcessing:
+    """Tests for batch processing via ThreadPoolExecutor."""
 
-    def test_default_max_workers_is_one(self):
-        """No behavior change without opt-in."""
+    def test_processes_all_records(self, tmp_path):
+        """All custom_ids present in results."""
         client = OllamaBatchClient(base_url="http://localhost:11434")
-        assert client._get_max_workers() == 1
-
-    def test_max_workers_from_constructor(self):
-        """Constructor param is used directly."""
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=4)
-        assert client._get_max_workers() == 4
-
-    def test_max_workers_from_env_var(self, monkeypatch):
-        """Env var OLLAMA_BATCH_MAX_WORKERS is respected."""
-        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "6")
-        client = OllamaBatchClient(base_url="http://localhost:11434")
-        assert client._get_max_workers() == 6
-
-    def test_max_workers_constructor_overrides_env(self, monkeypatch):
-        """Constructor param takes precedence over env var."""
-        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "8")
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=2)
-        assert client._get_max_workers() == 2
-
-    def test_max_workers_env_invalid_uses_default(self, monkeypatch):
-        """Non-integer env var falls back to default."""
-        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "not_a_number")
-        client = OllamaBatchClient(base_url="http://localhost:11434")
-        assert client._get_max_workers() == 1
-
-    def test_max_workers_env_zero_uses_default(self, monkeypatch):
-        """Zero env var falls back to default (must be >= 1)."""
-        monkeypatch.setenv("OLLAMA_BATCH_MAX_WORKERS", "0")
-        client = OllamaBatchClient(base_url="http://localhost:11434")
-        assert client._get_max_workers() == 1
-
-    def test_max_workers_constructor_negative_uses_default(self):
-        """Negative constructor value falls back to default."""
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=-1)
-        assert client._get_max_workers() == 1
-
-    def test_max_workers_constructor_zero_uses_default(self):
-        """Zero constructor value falls back to default."""
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=0)
-        assert client._get_max_workers() == 1
-
-    def test_max_workers_clamped_at_limit(self):
-        """Values above limit are clamped to 32."""
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=500)
-        assert client._get_max_workers() == 32
-
-    def test_max_workers_at_limit_is_allowed(self):
-        """Exactly at the limit is fine."""
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=32)
-        assert client._get_max_workers() == 32
-
-    def test_cloud_default_max_workers(self):
-        """Cloud client also defaults to 1."""
-        client = OllamaBatchClient(
-            base_url="https://ollama.com",
-            api_key="test-key-1234567890",
-            cloud=True,
-            vendor_slug="ollama_cloud",
-        )
-        assert client._get_max_workers() == 1
-
-    def test_concurrent_processes_all_records(self, tmp_path):
-        """All custom_ids present in results with max_workers=4."""
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=4)
         client.client = MagicMock()
         client.client.chat = MagicMock(return_value=_make_ollama_response())
 
@@ -223,13 +159,12 @@ class TestOllamaBatchConcurrency:
         expected_ids = {f"rec-{i}" for i in range(10)}
         assert result_ids == expected_ids
 
-    def test_concurrent_error_isolation(self, tmp_path):
+    def test_error_isolation(self, tmp_path):
         """One task error doesn't kill others."""
-        client = OllamaBatchClient(base_url="http://localhost:11434", max_workers=3)
+        client = OllamaBatchClient(base_url="http://localhost:11434")
         client.client = MagicMock()
 
         def side_effect(model, messages, options, format):
-            # Fail for rec-2 only
             if messages == [{"role": "user", "content": "fail"}]:
                 raise RuntimeError("simulated error")
             return _make_ollama_response()
@@ -237,7 +172,6 @@ class TestOllamaBatchConcurrency:
         client.client.chat = MagicMock(side_effect=side_effect)
 
         tasks = [_make_task(f"rec-{i}") for i in range(5)]
-        # Make rec-2 trigger the error
         tasks[2]["body"]["messages"] = [{"role": "user", "content": "fail"}]
 
         input_file = tmp_path / "batch" / "input.jsonl"
@@ -261,8 +195,8 @@ class TestOllamaBatchConcurrency:
         assert error_results[0]["custom_id"] == "rec-2"
         assert len(success_results) == 4
 
-    def test_sequential_preserved_with_default(self, tmp_path):
-        """max_workers=1 (default) produces correct results."""
+    def test_sequential_produces_correct_results(self, tmp_path):
+        """Sequential processing produces correct results."""
         client = OllamaBatchClient(base_url="http://localhost:11434")
         client.client = MagicMock()
         client.client.chat = MagicMock(return_value=_make_ollama_response("sequential"))


### PR DESCRIPTION
## Summary
- Removes `batch_max_workers` config plumbing entirely from Ollama batch client, factory, and defaults
- The feature never worked end-to-end: rejected by `ActionConfig` (extra="forbid"), missing from `SIMPLE_CONFIG_FIELDS`, and never forwarded by `BatchClientResolver`
- Ollama batch processing stays sequential (`max_workers=1`) via `ThreadPoolExecutor`
- Removes 11 config-knob tests, keeps 3 behavioral tests (record processing, error isolation, sequential correctness)

## Verification
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- `pytest` — 6756 passed (2 pre-existing failures in JSON trailing comma repair, unrelated)
- `grep -r batch_max_workers` — zero references remain

Closes #409