### PR TITLE
fix(config): allow batch_max_workers on individual actions

### DIFF
--- a/.changes/unreleased/Bug Fix-20260514-409000.yaml
+++ b/.changes/unreleased/Bug Fix-20260514-409000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Allow batch_max_workers on individual actions (ActionConfig + SIMPLE_CONFIG_FIELDS + resolver forwarding)"
+time: 2026-05-14T04:09:00.000000Z

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -261,6 +261,11 @@ class ActionConfig(BaseModel):
     )
     file_limit: int | None = Field(default=None, ge=1, description="Max files to walk per action")
 
+    # --- Batch concurrency (Ollama only) ---
+    batch_max_workers: int | None = Field(
+        default=None, ge=1, description="Max concurrent workers for Ollama batch processing"
+    )
+
     # --- Expander-consumed keys ---
     interceptors: list[dict[str, Any]] | None = Field(
         default=None, description="Interceptor configuration"
@@ -385,6 +390,11 @@ class DefaultsConfig(BaseModel):
     # --- Limit controls ---
     record_limit: int | None = Field(default=None, ge=1, description="Default record limit")
     file_limit: int | None = Field(default=None, ge=1, description="Default file limit")
+
+    # --- Batch concurrency (Ollama only) ---
+    batch_max_workers: int | None = Field(
+        default=None, ge=1, description="Default max concurrent workers for Ollama batch processing"
+    )
 
     @field_validator("retry", mode="before")
     @classmethod

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -263,7 +263,7 @@ class ActionConfig(BaseModel):
 
     # --- Batch concurrency (Ollama only) ---
     batch_max_workers: int | None = Field(
-        default=None, ge=1, description="Max concurrent workers for Ollama batch processing"
+        default=None, ge=1, le=32, description="Max concurrent workers for Ollama batch processing"
     )
 
     # --- Expander-consumed keys ---
@@ -393,7 +393,7 @@ class DefaultsConfig(BaseModel):
 
     # --- Batch concurrency (Ollama only) ---
     batch_max_workers: int | None = Field(
-        default=None, ge=1, description="Default max concurrent workers for Ollama batch processing"
+        default=None, ge=1, le=32, description="Default max concurrent workers for Ollama batch processing"
     )
 
     @field_validator("retry", mode="before")

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -393,7 +393,10 @@ class DefaultsConfig(BaseModel):
 
     # --- Batch concurrency (Ollama only) ---
     batch_max_workers: int | None = Field(
-        default=None, ge=1, le=32, description="Default max concurrent workers for Ollama batch processing"
+        default=None,
+        ge=1,
+        le=32,
+        description="Default max concurrent workers for Ollama batch processing",
     )
 
     @field_validator("retry", mode="before")

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -96,6 +96,8 @@ class BatchClientResolver:
                 client_config["api_key"] = BaseClient.get_api_key(agent_config)
             if agent_config.get("base_url"):
                 client_config["base_url"] = agent_config["base_url"]
+            if agent_config.get("batch_max_workers") is not None:
+                client_config["batch_max_workers"] = agent_config["batch_max_workers"]
 
             client = BatchClientFactory.create_client(client_type, client_config)
 

--- a/agent_actions/output/response/config_fields.py
+++ b/agent_actions/output/response/config_fields.py
@@ -55,6 +55,8 @@ SIMPLE_CONFIG_FIELDS = {
     # Limit controls (None = unlimited)
     "record_limit": None,
     "file_limit": None,
+    # Batch concurrency (Ollama only; None = use env var or default)
+    "batch_max_workers": None,
 }
 
 

--- a/tests/unit/config/test_batch_max_workers_plumbing.py
+++ b/tests/unit/config/test_batch_max_workers_plumbing.py
@@ -42,6 +42,14 @@ class TestSchemaAcceptsBatchMaxWorkers:
         config = DefaultsConfig.model_validate({"batch_max_workers": 6})
         assert config.batch_max_workers == 6
 
+    def test_action_config_accepts_at_limit(self):
+        config = ActionConfig.model_validate({"name": "a", "intent": "i", "batch_max_workers": 32})
+        assert config.batch_max_workers == 32
+
+    def test_action_config_rejects_above_limit(self):
+        with pytest.raises(ValidationError, match="batch_max_workers"):
+            ActionConfig.model_validate({"name": "a", "intent": "i", "batch_max_workers": 33})
+
     def test_defaults_config_rejects_zero(self):
         with pytest.raises(ValidationError, match="batch_max_workers"):
             DefaultsConfig.model_validate({"batch_max_workers": 0})

--- a/tests/unit/config/test_batch_max_workers_plumbing.py
+++ b/tests/unit/config/test_batch_max_workers_plumbing.py
@@ -1,0 +1,115 @@
+"""Tests for batch_max_workers plumbing: schema → inheritance → resolver → factory.
+
+Validates the full config path from YAML action-level batch_max_workers
+through to OllamaBatchClient construction.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from agent_actions.config.schema import ActionConfig, DefaultsConfig
+from agent_actions.llm.batch.infrastructure.batch_client_resolver import BatchClientResolver
+from agent_actions.output.response.config_fields import inherit_simple_fields
+
+
+class TestSchemaAcceptsBatchMaxWorkers:
+    """ActionConfig and DefaultsConfig accept batch_max_workers."""
+
+    def test_action_config_accepts_batch_max_workers(self):
+        config = ActionConfig.model_validate({"name": "a", "intent": "i", "batch_max_workers": 12})
+        assert config.batch_max_workers == 12
+
+    def test_action_config_batch_max_workers_survives_round_trip(self):
+        config = ActionConfig.model_validate({"name": "a", "intent": "i", "batch_max_workers": 8})
+        dumped = config.model_dump()
+        assert dumped["batch_max_workers"] == 8
+
+    def test_action_config_rejects_zero(self):
+        with pytest.raises(ValidationError, match="batch_max_workers"):
+            ActionConfig.model_validate({"name": "a", "intent": "i", "batch_max_workers": 0})
+
+    def test_action_config_rejects_negative(self):
+        with pytest.raises(ValidationError, match="batch_max_workers"):
+            ActionConfig.model_validate({"name": "a", "intent": "i", "batch_max_workers": -1})
+
+    def test_action_config_none_by_default(self):
+        config = ActionConfig.model_validate({"name": "a", "intent": "i"})
+        assert config.batch_max_workers is None
+
+    def test_defaults_config_accepts_batch_max_workers(self):
+        config = DefaultsConfig.model_validate({"batch_max_workers": 6})
+        assert config.batch_max_workers == 6
+
+    def test_defaults_config_rejects_zero(self):
+        with pytest.raises(ValidationError, match="batch_max_workers"):
+            DefaultsConfig.model_validate({"batch_max_workers": 0})
+
+
+class TestInheritanceBatchMaxWorkers:
+    """batch_max_workers inherits through SIMPLE_CONFIG_FIELDS."""
+
+    def test_action_level_value_used(self):
+        agent: dict = {}
+        action = {"batch_max_workers": 12}
+        defaults = {"batch_max_workers": 4}
+        inherit_simple_fields(agent, action, defaults)
+        assert agent["batch_max_workers"] == 12
+
+    def test_inherits_from_defaults_when_action_omits(self):
+        agent: dict = {}
+        action = {}
+        defaults = {"batch_max_workers": 4}
+        inherit_simple_fields(agent, action, defaults)
+        assert agent["batch_max_workers"] == 4
+
+    def test_none_when_neither_set(self):
+        agent: dict = {}
+        inherit_simple_fields(agent, {}, {})
+        assert agent["batch_max_workers"] is None
+
+
+class TestResolverForwardsBatchMaxWorkers:
+    """BatchClientResolver passes batch_max_workers to client_config."""
+
+    def test_batch_max_workers_reaches_factory(self):
+        agent_config = {
+            "model_vendor": "ollama_local",
+            "model_name": "llama2",
+            "batch_max_workers": 12,
+        }
+
+        with patch(
+            "agent_actions.llm.batch.infrastructure.batch_client_resolver.BatchClientFactory"
+        ) as mock_factory:
+            mock_client = MagicMock()
+            mock_client.validate_config.return_value = (True, None)
+            mock_factory.create_client.return_value = mock_client
+
+            resolver = BatchClientResolver()
+            resolver.get_for_config(agent_config)
+
+            call_args = mock_factory.create_client.call_args
+            client_config = call_args[0][1]
+            assert client_config["batch_max_workers"] == 12
+
+    def test_batch_max_workers_absent_when_none(self):
+        agent_config = {
+            "model_vendor": "ollama_local",
+            "model_name": "llama2",
+        }
+
+        with patch(
+            "agent_actions.llm.batch.infrastructure.batch_client_resolver.BatchClientFactory"
+        ) as mock_factory:
+            mock_client = MagicMock()
+            mock_client.validate_config.return_value = (True, None)
+            mock_factory.create_client.return_value = mock_client
+
+            resolver = BatchClientResolver()
+            resolver.get_for_config(agent_config)
+
+            call_args = mock_factory.create_client.call_args
+            client_config = call_args[0][1]
+            assert "batch_max_workers" not in client_config

--- a/tests/unit/config/test_schema_extra_forbid.py
+++ b/tests/unit/config/test_schema_extra_forbid.py
@@ -65,6 +65,8 @@ class TestActionConfigForbidsUnknownKeys:
             "enable_prompt_caching": True,
             "max_execution_time": 600,
             "enable_caching": True,
+            # Batch concurrency
+            "batch_max_workers": 4,
             # Expander-consumed
             "interceptors": [{"name": "log"}],
             "chunk_config": {"size": 100},


### PR DESCRIPTION
## Summary
- `batch_max_workers` was rejected at action level in workflow YAML because three layers of config plumbing were missing
- Added `batch_max_workers: Optional[int] = Field(None, ge=1)` to both `ActionConfig` and `DefaultsConfig`
- Registered in `SIMPLE_CONFIG_FIELDS` for standard defaults→action inheritance
- Forwarded through `BatchClientResolver.client_config` so the value reaches `BatchClientFactory`
- The env var (`OLLAMA_BATCH_MAX_WORKERS`) and constructor paths already worked; this closes the YAML gap

## Files changed
| File | Change |
|------|--------|
| `config/schema.py` | Added `batch_max_workers` field to `ActionConfig` and `DefaultsConfig` |
| `output/response/config_fields.py` | Added `batch_max_workers` to `SIMPLE_CONFIG_FIELDS` |
| `llm/batch/infrastructure/batch_client_resolver.py` | Forward `batch_max_workers` into `client_config` dict |
| `tests/unit/config/test_batch_max_workers_plumbing.py` | New: schema validation, inheritance, resolver forwarding tests |
| `tests/unit/config/test_schema_extra_forbid.py` | Added `batch_max_workers` to comprehensive field acceptance test |

## Verification
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- `pytest` — 6779 passed (2 pre-existing failures in JSON trailing comma repair, unrelated)
- New test file covers: schema accepts/rejects, round-trip, inheritance priority, resolver forwarding, and absence when unset