### PR TITLE
feat: fan-in guard-filter null namespace (warn + errors)

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260514-415000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260514-415000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Preflight warning and enriched runtime error for fan-in when filter guard upstream leaves null observe namespace"
+time: 2026-05-14T04:15:00.000000Z

--- a/agent_actions/errors/operations.py
+++ b/agent_actions/errors/operations.py
@@ -38,6 +38,7 @@ class TemplateVariableError(TemplateRenderingError):
         template_line: int | None = None,
         field_context_metadata: dict | None = None,
         storage_hints: dict | None = None,
+        null_namespace_hints: dict | None = None,
     ):
         """
         Initialize TemplateVariableError.
@@ -53,6 +54,8 @@ class TemplateVariableError(TemplateRenderingError):
             field_context_metadata: Metadata about stored vs loaded fields per namespace
             storage_hints: Dict mapping var names to storage info when field exists
                 in storage but wasn't loaded (missing schema declaration)
+            null_namespace_hints: Dict mapping namespace names to remediation info
+                when namespace is null due to guard-filter at a fan-in point
         """
         self.missing_variables = missing_variables
         self.available_variables = available_variables
@@ -62,6 +65,7 @@ class TemplateVariableError(TemplateRenderingError):
         self.template_line = template_line
         self.field_context_metadata = field_context_metadata or {}
         self.storage_hints = storage_hints or {}
+        self.null_namespace_hints = null_namespace_hints or {}
 
         ctx: dict[str, Any] = {
             "missing_variables": missing_variables,
@@ -77,6 +81,16 @@ class TemplateVariableError(TemplateRenderingError):
             ctx["field_context_metadata"] = field_context_metadata
         if storage_hints:
             ctx["storage_hints"] = storage_hints
+        if null_namespace_hints:
+            ctx["null_namespace_hints"] = null_namespace_hints
 
-        msg = f"Template for '{agent_name}' references undefined variables: {', '.join(missing_variables)}"
+        if null_namespace_hints:
+            ns_names = ", ".join(sorted(null_namespace_hints.keys()))
+            msg = (
+                f"Template for '{agent_name}' failed: namespace(s) "
+                f"'{ns_names}' null (guard-filtered). "
+                + next(iter(null_namespace_hints.values()))["remediation"]
+            )
+        else:
+            msg = f"Template for '{agent_name}' references undefined variables: {', '.join(missing_variables)}"
         super().__init__(msg, context=ctx, cause=cause)

--- a/agent_actions/errors/operations.py
+++ b/agent_actions/errors/operations.py
@@ -83,8 +83,6 @@ class TemplateVariableError(TemplateRenderingError):
             ctx["storage_hints"] = storage_hints
         if null_namespace_hints:
             ctx["null_namespace_hints"] = null_namespace_hints
-
-        if null_namespace_hints:
             ns_names = ", ".join(sorted(null_namespace_hints.keys()))
             msg = (
                 f"Template for '{agent_name}' failed: namespace(s) "

--- a/agent_actions/errors/operations.py
+++ b/agent_actions/errors/operations.py
@@ -81,14 +81,10 @@ class TemplateVariableError(TemplateRenderingError):
             ctx["field_context_metadata"] = field_context_metadata
         if storage_hints:
             ctx["storage_hints"] = storage_hints
+        msg = f"Template for '{agent_name}' references undefined variables: {', '.join(missing_variables)}"
         if null_namespace_hints:
             ctx["null_namespace_hints"] = null_namespace_hints
-            ns_names = ", ".join(sorted(null_namespace_hints.keys()))
-            msg = (
-                f"Template for '{agent_name}' failed: namespace(s) "
-                f"'{ns_names}' null (guard-filtered). "
-                + next(iter(null_namespace_hints.values()))["remediation"]
-            )
-        else:
-            msg = f"Template for '{agent_name}' references undefined variables: {', '.join(missing_variables)}"
+            remediation = next(iter(null_namespace_hints.values())).get("remediation", "")
+            if remediation:
+                msg += f" — {remediation}"
         super().__init__(msg, context=ctx, cause=cause)

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -38,16 +38,44 @@ def _resolve_missing_field(
     When a dependency's guard triggers skip/filter, the namespace is stored
     as None in field_context.  This matches guard evaluation semantics where
     missing fields resolve to None rather than raising.
+
+    At fan-in points, a record may arrive via an alternate dependency path
+    with the filtered action's namespace as None.  This is logged at warning
+    level to aid debugging.
     """
     if ns_name in prompt_context and prompt_context[ns_name] is None:
-        logger.debug(
-            "[%s NULL-SAFE] '%s' on action '%s': namespace '%s' is "
-            "null (guard-skipped/filtered), resolving field as None",
-            directive.upper(),
-            field_ref,
-            action_name,
-            ns_name,
-        )
+        # Identify alternate namespaces that DID provide data (non-None, non-framework).
+        alt_deps = [
+            k
+            for k, v in prompt_context.items()
+            if v is not None
+            and isinstance(v, dict)
+            and k not in FRAMEWORK_NAMESPACES
+            and k != ns_name
+        ]
+        if alt_deps:
+            logger.warning(
+                "[%s NULL-NAMESPACE] '%s' on action '%s': namespace '%s' is null "
+                "(guard-skipped/filtered). Record arrived via alternate dependency "
+                "path(s): %s. Consider adding a matching guard to '%s' or using "
+                "'%s.*' (null-safe) instead of specific fields.",
+                directive.upper(),
+                field_ref,
+                action_name,
+                ns_name,
+                ", ".join(sorted(alt_deps)),
+                action_name,
+                ns_name,
+            )
+        else:
+            logger.debug(
+                "[%s NULL-SAFE] '%s' on action '%s': namespace '%s' is "
+                "null (guard-skipped/filtered), resolving field as None",
+                directive.upper(),
+                field_ref,
+                action_name,
+                ns_name,
+            )
         return None
 
     field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -55,8 +55,8 @@ def _resolve_missing_field(
         if alt_deps:
             logger.warning(
                 "[%s NULL-NAMESPACE] '%s' on action '%s': namespace '%s' is null "
-                "(guard-skipped/filtered). Record arrived via alternate dependency "
-                "path(s): %s. Consider adding a matching guard to '%s' or using "
+                "(likely guard-filtered or guard-skipped). Other namespaces "
+                "present: %s. Consider adding a guard to '%s' or using "
                 "'%s.*' (null-safe) instead of specific fields.",
                 directive.upper(),
                 field_ref,

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -38,43 +38,16 @@ def _resolve_missing_field(
     When a dependency's guard triggers skip/filter, the namespace is stored
     as None in field_context.  This matches guard evaluation semantics where
     missing fields resolve to None rather than raising.
-
-    At fan-in points, a record may arrive via an alternate dependency path
-    with the filtered action's namespace as None.  This is logged at warning
-    level to aid debugging.
     """
     if ns_name in prompt_context and prompt_context[ns_name] is None:
-        alt_deps = [
-            k
-            for k, v in prompt_context.items()
-            if v is not None
-            and isinstance(v, dict)
-            and k not in FRAMEWORK_NAMESPACES
-            and k != ns_name
-        ]
-        if alt_deps:
-            logger.warning(
-                "[%s NULL-NAMESPACE] '%s' on action '%s': namespace '%s' is null "
-                "(likely guard-filtered or guard-skipped). Other namespaces "
-                "present: %s. Consider adding a guard to '%s' or using "
-                "'%s.*' (null-safe) instead of specific fields.",
-                directive.upper(),
-                field_ref,
-                action_name,
-                ns_name,
-                ", ".join(sorted(alt_deps)),
-                action_name,
-                ns_name,
-            )
-        else:
-            logger.debug(
-                "[%s NULL-SAFE] '%s' on action '%s': namespace '%s' is "
-                "null (guard-skipped/filtered), resolving field as None",
-                directive.upper(),
-                field_ref,
-                action_name,
-                ns_name,
-            )
+        logger.debug(
+            "[%s NULL-SAFE] '%s' on action '%s': namespace '%s' is "
+            "null (guard-skipped/filtered), resolving field as None",
+            directive.upper(),
+            field_ref,
+            action_name,
+            ns_name,
+        )
         return None
 
     field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -44,7 +44,6 @@ def _resolve_missing_field(
     level to aid debugging.
     """
     if ns_name in prompt_context and prompt_context[ns_name] is None:
-        # Identify alternate namespaces that DID provide data (non-None, non-framework).
         alt_deps = [
             k
             for k, v in prompt_context.items()

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -16,7 +16,10 @@ from agent_actions.errors import ConfigurationError, TemplateVariableError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldNotFoundEvent
 from agent_actions.prompt.context.builder import LLMContextBuilder
-from agent_actions.prompt.context.scope_application import apply_context_scope
+from agent_actions.prompt.context.scope_application import (
+    FRAMEWORK_NAMESPACES,
+    apply_context_scope,
+)
 from agent_actions.prompt.context.scope_builder import build_field_context_with_history
 from agent_actions.prompt.context.static_loader import (
     StaticDataLoader,
@@ -424,12 +427,16 @@ class PromptPreparationService:
             # Null namespaces from guard-filter at fan-in (spec 415).
             null_namespace_hints: dict[str, dict[str, Any]] = {}
             if "has no attribute" in error_str:
-                null_ns = [k for k, v in prompt_context.items() if v is None]
+                null_ns = [
+                    k
+                    for k, v in prompt_context.items()
+                    if v is None and k not in FRAMEWORK_NAMESPACES
+                ]
                 if null_ns:
                     alt_deps = [
                         k
                         for k, v in prompt_context.items()
-                        if v is not None and isinstance(v, dict)
+                        if v is not None and isinstance(v, dict) and k not in FRAMEWORK_NAMESPACES
                     ]
                     for ns in null_ns:
                         null_namespace_hints[ns] = {

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -421,6 +421,37 @@ class PromptPreparationService:
                                 }
                                 break
 
+            # Detect null namespaces from guard-filter at fan-in points.
+            # When a NoneType attribute error occurs and the namespace is None
+            # in prompt_context, this is the filter+fan-in hazard (spec 415).
+            null_namespace_hints: dict[str, dict[str, Any]] = {}
+            if "has no attribute" in error_str:
+                # Find namespaces in prompt_context that are None.
+                null_ns = [k for k, v in prompt_context.items() if v is None]
+                if null_ns:
+                    # Identify alternate deps that DID provide data.
+                    alt_deps = [
+                        k
+                        for k, v in prompt_context.items()
+                        if v is not None and isinstance(v, dict)
+                    ]
+                    for ns in null_ns:
+                        null_namespace_hints[ns] = {
+                            "namespace": ns,
+                            "reason": "guard-filtered",
+                            "alternate_deps": alt_deps,
+                            "remediation": (
+                                f"Namespace '{ns}' is null (record was filtered "
+                                f"by '{ns}' guard). The record arrived via "
+                                f"alternate dependency path "
+                                f"'{', '.join(sorted(alt_deps))}'. Either: "
+                                f"(1) Add a guard to '{agent_name}' to exclude "
+                                f"these records, (2) Change '{ns}' guard to "
+                                f"on_false=\"skip\", or (3) Remove '{ns}' fields "
+                                f"from '{agent_name}' observe."
+                            ),
+                        }
+
             raise TemplateVariableError(
                 missing_variables=missing,
                 available_variables=available_refs,
@@ -430,6 +461,7 @@ class PromptPreparationService:
                 namespace_context=namespace_context,
                 field_context_metadata=field_context_metadata if field_context_metadata else None,
                 storage_hints=storage_hints if storage_hints else None,
+                null_namespace_hints=null_namespace_hints if null_namespace_hints else None,
             ) from e
 
     @staticmethod

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -424,32 +424,51 @@ class PromptPreparationService:
                                 }
                                 break
 
-            # Null namespaces from guard-filter at fan-in (spec 415).
+            # Null namespace hint for guard-filter at fan-in (spec 415).
+            # Only triggers when Jinja dereferences None (not a dict missing
+            # a key), and only blames the namespace the template actually
+            # tried to access — not every null namespace in scope.
             null_namespace_hints: dict[str, dict[str, Any]] = {}
-            if "has no attribute" in error_str:
-                null_ns = [
-                    k
-                    for k, v in prompt_context.items()
-                    if v is None and k not in FRAMEWORK_NAMESPACES
-                ]
-                if null_ns:
-                    alt_deps = [
+            if error_str.startswith("'None' has no attribute"):
+                attribute_name = missing[0] if missing else None
+                if attribute_name:
+                    # Find which null namespace the template referenced with
+                    # this attribute by scanning for {{ ns.attr }} patterns.
+                    import re as _re
+
+                    null_ns_set = {
                         k
                         for k, v in prompt_context.items()
-                        if v is not None and isinstance(v, dict) and k not in FRAMEWORK_NAMESPACES
-                    ]
-                    for ns in null_ns:
-                        null_namespace_hints[ns] = {
-                            "alternate_deps": alt_deps,
+                        if v is None and k not in FRAMEWORK_NAMESPACES
+                    }
+                    blamed_ns: str | None = None
+                    for ns in null_ns_set:
+                        if _re.search(
+                            r"\{\{[\s\-]*" + _re.escape(ns) + r"\." + _re.escape(attribute_name),
+                            raw_prompt,
+                        ):
+                            blamed_ns = ns
+                            break
+
+                    if blamed_ns:
+                        other_ns = [
+                            k
+                            for k, v in prompt_context.items()
+                            if v is not None
+                            and isinstance(v, dict)
+                            and k not in FRAMEWORK_NAMESPACES
+                        ]
+                        null_namespace_hints[blamed_ns] = {
+                            "alternate_deps": other_ns,
                             "remediation": (
-                                f"Namespace '{ns}' is null (record was filtered "
-                                f"by '{ns}' guard). The record arrived via "
-                                f"alternate dependency path "
-                                f"'{', '.join(sorted(alt_deps))}'. Either: "
-                                f"(1) Add a guard to '{agent_name}' to exclude "
-                                f"these records, (2) Change '{ns}' guard to "
-                                f"on_false=\"skip\", or (3) Remove '{ns}' fields "
-                                f"from '{agent_name}' observe."
+                                f"Namespace '{blamed_ns}' is null (likely "
+                                f"guard-filtered or guard-skipped). Other "
+                                f"namespaces present: "
+                                f"{', '.join(sorted(other_ns)) if other_ns else '(none)'}. "
+                                f"Consider adding a guard to '{agent_name}' to "
+                                f"exclude these records, or using "
+                                f"'{blamed_ns}.*' (null-safe) instead of "
+                                f"specific fields."
                             ),
                         }
 

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -421,15 +421,11 @@ class PromptPreparationService:
                                 }
                                 break
 
-            # Detect null namespaces from guard-filter at fan-in points.
-            # When a NoneType attribute error occurs and the namespace is None
-            # in prompt_context, this is the filter+fan-in hazard (spec 415).
+            # Null namespaces from guard-filter at fan-in (spec 415).
             null_namespace_hints: dict[str, dict[str, Any]] = {}
             if "has no attribute" in error_str:
-                # Find namespaces in prompt_context that are None.
                 null_ns = [k for k, v in prompt_context.items() if v is None]
                 if null_ns:
-                    # Identify alternate deps that DID provide data.
                     alt_deps = [
                         k
                         for k, v in prompt_context.items()
@@ -437,8 +433,6 @@ class PromptPreparationService:
                     ]
                     for ns in null_ns:
                         null_namespace_hints[ns] = {
-                            "namespace": ns,
-                            "reason": "guard-filtered",
                             "alternate_deps": alt_deps,
                             "remediation": (
                                 f"Namespace '{ns}' is null (record was filtered "

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -127,6 +127,9 @@ class WorkflowStaticAnalyzer:
         # because expansion turns safe wildcards into specific refs (false positives).
         guard_skip_observe_warnings = self._check_guard_skipped_observe_refs()
 
+        # Guard-filter + fan-in observe hazard: also before wildcard expansion.
+        filter_fanin_warnings = self._check_filter_fanin_observe_hazard()
+
         # Step 1: Build data flow graph
         self._build_graph()
 
@@ -179,6 +182,9 @@ class WorkflowStaticAnalyzer:
             result.add_warning(warning)
 
         for warning in guard_skip_observe_warnings:
+            result.add_warning(warning)
+
+        for warning in filter_fanin_warnings:
             result.add_warning(warning)
 
         # Step 3: Check for unused dependencies (add as warnings)
@@ -1205,6 +1211,147 @@ class WorkflowStaticAnalyzer:
                             f"Use '{source_name}.*' instead of "
                             f"'{source_name}.{field_name}' to handle the case "
                             f"when the guard skips."
+                        ),
+                    )
+                )
+
+        return warnings
+
+    def _check_filter_fanin_observe_hazard(self) -> list[StaticTypeWarning]:
+        """Warn when observe refs target a filter-guarded action at a fan-in point.
+
+        When action A has ``guard.on_false`` set to ``"filter"`` and a downstream
+        action C depends on both A and B (fan-in), records filtered by A can still
+        arrive at C via B.  The filtered action's namespace is null on those
+        records, so ``observe: ["A.field"]`` crashes at runtime.
+
+        Unlike ``_check_guard_skipped_observe_refs`` (which handles skip on any
+        dep topology), this check specifically targets the fan-in case where
+        filter creates a null namespace via an alternate dependency path.
+
+        Emits one warning per (filtered_action, consumer_action) pair.
+        """
+        warnings: list[StaticTypeWarning] = []
+        actions = self.workflow_config.get("actions", [])
+
+        # Step 1: Identify filter-guarded actions.
+        filter_guarded: set[str] = set()
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            name = action.get("name", "")
+            guard = action.get("guard")
+            if not guard:
+                continue
+            if isinstance(guard, dict):
+                behavior = guard.get("on_false", GuardBehavior.FILTER)
+            elif isinstance(guard, str):
+                behavior = GuardBehavior.FILTER  # string guards default to filter
+            else:
+                continue
+            if behavior == GuardBehavior.FILTER:
+                filter_guarded.add(name)
+
+        if not filter_guarded:
+            return warnings
+
+        # Step 2: Build dependency sets from raw config for each action.
+        action_deps: dict[str, set[str]] = {}
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            name = action.get("name", "unknown")
+            deps_list = action.get("depends_on") or action.get("dependencies", [])
+            deps: set[str] = set()
+            if isinstance(deps_list, list):
+                for dep in deps_list:
+                    if isinstance(dep, str):
+                        deps.add(dep)
+            # Also infer from context_scope references.
+            context_scope = action.get("context_scope", {})
+            if isinstance(context_scope, dict):
+                for directive in ("observe", "passthrough"):
+                    refs = context_scope.get(directive, [])
+                    if isinstance(refs, list):
+                        for ref in refs:
+                            if isinstance(ref, str) and "." in ref:
+                                ns = ref.split(".", 1)[0]
+                                if ns not in SPECIAL_NAMESPACES:
+                                    deps.add(ns)
+            action_deps[name] = deps
+
+        # Step 3: For each consumer with fan-in deps, check observe refs.
+        warned_pairs: set[tuple[str, str]] = set()
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            consumer_name = action.get("name", "unknown")
+            deps = action_deps.get(consumer_name, set())
+
+            # Fan-in requires at least 2 dependencies.
+            if len(deps) < 2:
+                continue
+
+            context_scope = action.get("context_scope", {})
+            if not isinstance(context_scope, dict):
+                continue
+            observe_refs = context_scope.get("observe", [])
+            if not isinstance(observe_refs, list):
+                continue
+
+            # Find observe refs targeting filter-guarded actions (specific fields only).
+            hazard_sources: dict[str, list[str]] = {}  # filtered_action -> [field_refs]
+            for ref in observe_refs:
+                if not isinstance(ref, str) or "." not in ref:
+                    continue
+                source_name, field_name = ref.split(".", 1)
+                if field_name == "*":
+                    continue  # wildcards are null-safe
+                if source_name not in filter_guarded:
+                    continue
+                if source_name not in deps:
+                    continue
+                hazard_sources.setdefault(source_name, []).append(ref)
+
+            if not hazard_sources:
+                continue
+
+            # Identify alternate dependency paths (deps that are NOT the
+            # filter-guarded action and could deliver the same record).
+            for filtered_action, field_refs in hazard_sources.items():
+                alt_deps = deps - {filtered_action}
+                if not alt_deps:
+                    continue  # No alternate path — record can't arrive
+
+                pair = (filtered_action, consumer_name)
+                if pair in warned_pairs:
+                    continue
+                warned_pairs.add(pair)
+
+                alt_dep_names = ", ".join(sorted(alt_deps))
+                example_ref = field_refs[0]
+
+                warnings.append(
+                    StaticTypeWarning(
+                        message=(
+                            f"Action '{consumer_name}' observes '{example_ref}' but "
+                            f"'{filtered_action}' has guard with on_false: \"filter\". "
+                            f"Records may arrive at '{consumer_name}' via alternate "
+                            f"dependency '{alt_dep_names}' with '{filtered_action}' "
+                            f"namespace as null."
+                        ),
+                        location=FieldLocation(
+                            agent_name=consumer_name,
+                            config_field="context_scope.observe",
+                            raw_reference=example_ref,
+                        ),
+                        referenced_agent=filtered_action,
+                        referenced_field=field_refs[0].split(".", 1)[1],
+                        hint=(
+                            f"Consider: (1) Add a matching guard to '{consumer_name}', "
+                            f"(2) Change '{filtered_action}' guard to on_false=\"skip\", "
+                            f"or (3) Use '{filtered_action}.*' (null-safe) instead of "
+                            f"specific fields."
                         ),
                     )
                 )

--- a/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
+++ b/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
@@ -139,8 +139,8 @@ class TestTemplateNullNamespaceError:
             )
 
         msg = str(exc_info.value)
-        assert "null" in msg.lower()
-        assert "guard-filtered" in msg.lower() or "filtered" in msg.lower()
+        assert "null (guard-filtered)" in msg.lower()
+        assert "alternate dependency path" in msg.lower()
 
     def test_normal_undefined_error_has_no_null_hints(self):
         """Regular undefined variable error -> no null_namespace_hints."""

--- a/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
+++ b/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
@@ -18,11 +18,16 @@ def _make_field_context(**namespaces):
     return dict(namespaces)
 
 
-# ── scope_application: enriched warning log on null namespace at fan-in ──
+# ── scope_application: null namespace resolves to None (debug only) ───
 
 
-class TestResolveNullNamespaceWarning:
-    """_resolve_missing_field logs warning with alt deps when namespace is null at fan-in."""
+class TestResolveNullNamespaceDebugLog:
+    """_resolve_missing_field logs at DEBUG on the success path — never WARNING.
+
+    Warnings about null-namespace hazards belong in the preflight static
+    analyzer (_check_filter_fanin_observe_hazard), not in the per-field
+    resolution function that fires N×M times per workflow.
+    """
 
     @pytest.fixture(autouse=True)
     def _enable_propagation(self):
@@ -33,33 +38,12 @@ class TestResolveNullNamespaceWarning:
         yield
         aa_logger.propagate = original
 
-    def test_null_namespace_with_alt_dep_logs_warning(self, caplog):
-        """Null namespace + alternate dep present -> warning-level log with alt dep name."""
+    def test_null_namespace_resolves_to_none_with_debug_log(self, caplog):
+        """Null namespace with alt deps present -> field resolves to None, logs at DEBUG."""
         fc = _make_field_context(
             filtered_action=None,
             other_dep={"score": 42},
         )
-        with caplog.at_level(logging.WARNING):
-            _, llm_ctx, _ = apply_context_scope(
-                field_context=fc,
-                context_scope={"observe": ["filtered_action.field_a"]},
-                action_name="consumer",
-            )
-
-        # Field resolves to None (existing null-safe behavior).
-        assert llm_ctx["filtered_action"]["field_a"] is None
-
-        # Warning log contains enriched context.
-        warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert len(warning_logs) >= 1
-        msg = warning_logs[0].message
-        assert "filtered_action" in msg
-        assert "other_dep" in msg
-        assert "NULL-NAMESPACE" in msg
-
-    def test_null_namespace_without_alt_dep_logs_debug(self, caplog):
-        """Null namespace with no alternate deps -> debug-level log (no fan-in signal)."""
-        fc = _make_field_context(filtered_action=None)
         with caplog.at_level(logging.DEBUG):
             _, llm_ctx, _ = apply_context_scope(
                 field_context=fc,
@@ -69,30 +53,12 @@ class TestResolveNullNamespaceWarning:
 
         assert llm_ctx["filtered_action"]["field_a"] is None
 
+        # No warnings on the success path.
         warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert len(warning_logs) == 0
 
         debug_logs = [r for r in caplog.records if "NULL-SAFE" in r.message]
         assert len(debug_logs) >= 1
-
-    def test_warning_includes_remediation_hints(self, caplog):
-        """Warning message includes remediation suggestions."""
-        fc = _make_field_context(
-            filtered_action=None,
-            alt_dep_a={"data": "ok"},
-            alt_dep_b={"data": "ok"},
-        )
-        with caplog.at_level(logging.WARNING):
-            apply_context_scope(
-                field_context=fc,
-                context_scope={"observe": ["filtered_action.field_a"]},
-                action_name="consumer",
-            )
-
-        warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        msg = warning_logs[0].message
-        assert "guard" in msg.lower() or "null-safe" in msg.lower()
-        assert "filtered_action.*" in msg
 
 
 # ── service.py: TemplateVariableError with null_namespace_hints ──────

--- a/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
+++ b/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
@@ -123,8 +123,8 @@ class TestTemplateNullNamespaceError:
         assert "other_dep" in hint["alternate_deps"]
         assert "filtered" in hint["remediation"].lower()
 
-    def test_error_message_includes_remediation(self):
-        """The error message itself contains remediation text."""
+    def test_error_message_appends_remediation_to_original(self):
+        """Error message includes both the original missing-var text AND remediation."""
         prompt_context = {
             "filtered_action": None,
             "other_dep": {"score": 42},
@@ -139,8 +139,11 @@ class TestTemplateNullNamespaceError:
             )
 
         msg = str(exc_info.value)
-        assert "null (guard-filtered)" in msg.lower()
-        assert "alternate dependency path" in msg.lower()
+        # Original message preserved.
+        assert "undefined variables" in msg.lower()
+        # Remediation appended.
+        assert "null" in msg.lower()
+        assert "null-safe" in msg.lower()
 
     def test_normal_undefined_error_has_no_null_hints(self):
         """Regular undefined variable error -> no null_namespace_hints."""
@@ -157,6 +160,29 @@ class TestTemplateNullNamespaceError:
             )
 
         err = exc_info.value
+        assert not err.null_namespace_hints
+
+    def test_typo_on_non_null_ns_with_null_ns_coexisting_no_false_blame(self):
+        """Typo on a non-null namespace while a null namespace coexists -> no false blame.
+
+        This is the key false-positive regression test: dep_a is None but
+        the error is {{ good.nonexistent_field }} — dep_a should NOT be blamed.
+        """
+        prompt_context = {
+            "dep_a": None,
+            "good": {"x": 1},
+        }
+        raw_prompt = "{{ good.nonexistent_field }}"
+
+        with pytest.raises(TemplateVariableError) as exc_info:
+            PromptPreparationService._render_prompt_template(
+                raw_prompt,
+                prompt_context,
+                agent_name="consumer",
+            )
+
+        err = exc_info.value
+        # dep_a is None but was never accessed — must NOT appear in hints.
         assert not err.null_namespace_hints
 
     def test_context_dict_includes_null_namespace_hints(self):

--- a/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
+++ b/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
@@ -120,7 +120,6 @@ class TestTemplateNullNamespaceError:
         assert err.null_namespace_hints
         assert "filtered_action" in err.null_namespace_hints
         hint = err.null_namespace_hints["filtered_action"]
-        assert hint["reason"] == "guard-filtered"
         assert "other_dep" in hint["alternate_deps"]
         assert "filtered" in hint["remediation"].lower()
 

--- a/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
+++ b/tests/unit/prompt/context/test_filter_fanin_runtime_error.py
@@ -1,0 +1,180 @@
+"""Tests for enriched runtime errors when filter+fan-in produces null namespaces.
+
+Spec 415 Option C: instead of bare 'NoneType has no attribute', errors should
+name the filtered namespace, alternate dependency path, and remediation options.
+"""
+
+import logging
+
+import pytest
+
+from agent_actions.errors.operations import TemplateVariableError
+from agent_actions.prompt.context.scope_application import apply_context_scope
+from agent_actions.prompt.service import PromptPreparationService
+
+
+def _make_field_context(**namespaces):
+    """Build a field_context dict from namespace kwargs."""
+    return dict(namespaces)
+
+
+# ── scope_application: enriched warning log on null namespace at fan-in ──
+
+
+class TestResolveNullNamespaceWarning:
+    """_resolve_missing_field logs warning with alt deps when namespace is null at fan-in."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_propagation(self):
+        """Ensure the agent_actions logger propagates to root so caplog captures records."""
+        aa_logger = logging.getLogger("agent_actions")
+        original = aa_logger.propagate
+        aa_logger.propagate = True
+        yield
+        aa_logger.propagate = original
+
+    def test_null_namespace_with_alt_dep_logs_warning(self, caplog):
+        """Null namespace + alternate dep present -> warning-level log with alt dep name."""
+        fc = _make_field_context(
+            filtered_action=None,
+            other_dep={"score": 42},
+        )
+        with caplog.at_level(logging.WARNING):
+            _, llm_ctx, _ = apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["filtered_action.field_a"]},
+                action_name="consumer",
+            )
+
+        # Field resolves to None (existing null-safe behavior).
+        assert llm_ctx["filtered_action"]["field_a"] is None
+
+        # Warning log contains enriched context.
+        warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warning_logs) >= 1
+        msg = warning_logs[0].message
+        assert "filtered_action" in msg
+        assert "other_dep" in msg
+        assert "NULL-NAMESPACE" in msg
+
+    def test_null_namespace_without_alt_dep_logs_debug(self, caplog):
+        """Null namespace with no alternate deps -> debug-level log (no fan-in signal)."""
+        fc = _make_field_context(filtered_action=None)
+        with caplog.at_level(logging.DEBUG):
+            _, llm_ctx, _ = apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["filtered_action.field_a"]},
+                action_name="consumer",
+            )
+
+        assert llm_ctx["filtered_action"]["field_a"] is None
+
+        warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warning_logs) == 0
+
+        debug_logs = [r for r in caplog.records if "NULL-SAFE" in r.message]
+        assert len(debug_logs) >= 1
+
+    def test_warning_includes_remediation_hints(self, caplog):
+        """Warning message includes remediation suggestions."""
+        fc = _make_field_context(
+            filtered_action=None,
+            alt_dep_a={"data": "ok"},
+            alt_dep_b={"data": "ok"},
+        )
+        with caplog.at_level(logging.WARNING):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["filtered_action.field_a"]},
+                action_name="consumer",
+            )
+
+        warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        msg = warning_logs[0].message
+        assert "guard" in msg.lower() or "null-safe" in msg.lower()
+        assert "filtered_action.*" in msg
+
+
+# ── service.py: TemplateVariableError with null_namespace_hints ──────
+
+
+class TestTemplateNullNamespaceError:
+    """Jinja render errors include null_namespace_hints when namespace is None."""
+
+    def test_nonetype_attribute_error_includes_null_namespace_hints(self):
+        """Template {{ action.field }} on null namespace -> error has null_namespace_hints."""
+        prompt_context = {
+            "filtered_action": None,
+            "other_dep": {"score": 42},
+        }
+        raw_prompt = "Score: {{ other_dep.score }}, Letter: {{ filtered_action.answer_letter }}"
+
+        with pytest.raises(TemplateVariableError) as exc_info:
+            PromptPreparationService._render_prompt_template(
+                raw_prompt,
+                prompt_context,
+                agent_name="write_scenario_question",
+            )
+
+        err = exc_info.value
+        assert err.null_namespace_hints
+        assert "filtered_action" in err.null_namespace_hints
+        hint = err.null_namespace_hints["filtered_action"]
+        assert hint["reason"] == "guard-filtered"
+        assert "other_dep" in hint["alternate_deps"]
+        assert "filtered" in hint["remediation"].lower()
+
+    def test_error_message_includes_remediation(self):
+        """The error message itself contains remediation text."""
+        prompt_context = {
+            "filtered_action": None,
+            "other_dep": {"score": 42},
+        }
+        raw_prompt = "{{ filtered_action.answer_letter }}"
+
+        with pytest.raises(TemplateVariableError) as exc_info:
+            PromptPreparationService._render_prompt_template(
+                raw_prompt,
+                prompt_context,
+                agent_name="consumer",
+            )
+
+        msg = str(exc_info.value)
+        assert "null" in msg.lower()
+        assert "guard-filtered" in msg.lower() or "filtered" in msg.lower()
+
+    def test_normal_undefined_error_has_no_null_hints(self):
+        """Regular undefined variable error -> no null_namespace_hints."""
+        prompt_context = {
+            "dep_a": {"score": 42},
+        }
+        raw_prompt = "{{ nonexistent_var.field }}"
+
+        with pytest.raises(TemplateVariableError) as exc_info:
+            PromptPreparationService._render_prompt_template(
+                raw_prompt,
+                prompt_context,
+                agent_name="consumer",
+            )
+
+        err = exc_info.value
+        assert not err.null_namespace_hints
+
+    def test_context_dict_includes_null_namespace_hints(self):
+        """The error context dict contains null_namespace_hints for downstream consumers."""
+        prompt_context = {
+            "filtered_ns": None,
+            "good_ns": {"val": 1},
+        }
+        raw_prompt = "{{ filtered_ns.some_field }}"
+
+        with pytest.raises(TemplateVariableError) as exc_info:
+            PromptPreparationService._render_prompt_template(
+                raw_prompt,
+                prompt_context,
+                agent_name="consumer",
+            )
+
+        err = exc_info.value
+        assert "null_namespace_hints" in err.context
+        assert "filtered_ns" in err.context["null_namespace_hints"]

--- a/tests/unit/validation/test_filter_fanin_observe_hazard.py
+++ b/tests/unit/validation/test_filter_fanin_observe_hazard.py
@@ -1,0 +1,433 @@
+"""Tests for _check_filter_fanin_observe_hazard() preflight warnings.
+
+Validates that preflight warns when a downstream fan-in action observes specific
+fields from an upstream action with guard.on_false: "filter", and an alternate
+dependency path exists that can deliver the same record with a null namespace.
+"""
+
+from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+    WorkflowStaticAnalyzer,
+)
+
+
+def _make_workflow(*actions):
+    """Build a minimal workflow config from action dicts."""
+    return {"actions": list(actions)}
+
+
+def _llm_action(name, *, schema_fields=None, guard=None, depends_on=None, observe=None):
+    """Build an LLM action config."""
+    action = {"name": name, "prompt": f"Process {name}"}
+    if schema_fields:
+        action["schema"] = {
+            "type": "object",
+            "properties": {f: {"type": "string"} for f in schema_fields},
+        }
+    if guard:
+        action["guard"] = guard
+    if depends_on:
+        action["depends_on"] = depends_on
+    if observe:
+        action["context_scope"] = {"observe": observe}
+    return action
+
+
+# ── Marker for filtering hazard warnings ──────────────────────────────
+
+_FILTER_FANIN_MARKER = 'on_false: "filter"'
+
+
+def _filter_fanin_warnings(result):
+    """Extract only filter+fan-in hazard warnings from a validation result."""
+    return [w for w in result.warnings if _FILTER_FANIN_MARKER in w.message]
+
+
+class TestFilterFaninObserveHazard:
+    """Preflight warns on filter+fan-in null namespace hazard."""
+
+    def test_fanin_with_filter_guard_warns(self):
+        """Classic qana_quiz pattern: filter-guarded action + alternate dep path."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "assign_option_layout",
+                schema_fields=["answer_letter", "longest_option"],
+                guard={"condition": "approved == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "auto_review_quality",
+                schema_fields=["telegraph_score"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "write_scenario_question",
+                depends_on=["assign_option_layout", "auto_review_quality"],
+                observe=[
+                    "assign_option_layout.answer_letter",
+                    "auto_review_quality.telegraph_score",
+                ],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        assert len(warnings) == 1
+        assert "assign_option_layout" in warnings[0].message
+        assert "write_scenario_question" in warnings[0].message
+
+    def test_single_dep_no_fanin_no_warning(self):
+        """Filter-guarded action as sole dependency -> no fan-in, no warning."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["score"],
+                guard={"condition": "score >= 6", "on_false": "filter"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.score"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        assert len(_filter_fanin_warnings(result)) == 0
+
+    def test_wildcard_observe_no_warning(self):
+        """Wildcard refs to filter-guarded action at fan-in -> no warning (null-safe)."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filtered_action",
+                schema_fields=["field_a"],
+                guard={"condition": "ok == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_b"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["filtered_action", "other_dep"],
+                observe=["filtered_action.*", "other_dep.field_b"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        assert len(_filter_fanin_warnings(result)) == 0
+
+    def test_one_warning_per_pair_not_per_field(self):
+        """Multiple field refs to same filter-guarded action -> one warning per pair."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filtered_action",
+                schema_fields=["field_a", "field_b", "field_c"],
+                guard={"condition": "ok == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_x"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["filtered_action", "other_dep"],
+                observe=[
+                    "filtered_action.field_a",
+                    "filtered_action.field_b",
+                    "filtered_action.field_c",
+                    "other_dep.field_x",
+                ],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        assert len(warnings) == 1
+
+    def test_skip_guard_does_not_trigger_filter_fanin_warning(self):
+        """Skip-guarded action at fan-in -> handled by _check_guard_skipped_observe_refs, not here."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "skip_action",
+                schema_fields=["field_a"],
+                guard={"condition": "ok == true", "on_false": "skip"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_b"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["skip_action", "other_dep"],
+                observe=["skip_action.field_a", "other_dep.field_b"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        assert len(_filter_fanin_warnings(result)) == 0
+
+    def test_string_guard_defaults_to_filter_warns_at_fanin(self):
+        """String-style guard defaults to filter -> warns at fan-in."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filtered_action",
+                schema_fields=["field_a"],
+                guard="score >= 6",
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_b"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["filtered_action", "other_dep"],
+                observe=["filtered_action.field_a", "other_dep.field_b"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        assert len(warnings) == 1
+
+    def test_warning_location_references_consumer(self):
+        """Warning location points to the consumer, referenced_agent to the filtered action."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filtered_action",
+                schema_fields=["field_a"],
+                guard={"condition": "ok == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_b"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["filtered_action", "other_dep"],
+                observe=["filtered_action.field_a", "other_dep.field_b"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        assert len(warnings) == 1
+        assert warnings[0].location.agent_name == "consumer"
+        assert warnings[0].referenced_agent == "filtered_action"
+
+    def test_warning_hint_includes_remediation(self):
+        """Warning hint includes all three remediation options."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filtered_action",
+                schema_fields=["field_a"],
+                guard={"condition": "ok == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_b"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["filtered_action", "other_dep"],
+                observe=["filtered_action.field_a", "other_dep.field_b"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        assert len(warnings) == 1
+        hint = warnings[0].hint
+        assert "guard" in hint  # add a matching guard
+        assert "skip" in hint  # change to on_false=skip
+        assert "filtered_action.*" in hint  # use wildcard
+
+    def test_no_guard_at_fanin_no_warning(self):
+        """Fan-in with no guard on either dep -> no warning."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "dep_a",
+                schema_fields=["field_a"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "dep_b",
+                schema_fields=["field_b"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["dep_a", "dep_b"],
+                observe=["dep_a.field_a", "dep_b.field_b"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        assert len(_filter_fanin_warnings(result)) == 0
+
+    def test_multiple_filter_guarded_deps_warn_each(self):
+        """Two filter-guarded deps at fan-in -> one warning per pair."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filter_a",
+                schema_fields=["fa"],
+                guard={"condition": "x == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "filter_b",
+                schema_fields=["fb"],
+                guard={"condition": "y == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer",
+                depends_on=["filter_a", "filter_b"],
+                observe=["filter_a.fa", "filter_b.fb"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        assert len(warnings) == 2
+        warned_sources = {w.referenced_agent for w in warnings}
+        assert warned_sources == {"filter_a", "filter_b"}
+
+    def test_mixed_wildcard_and_specific_warns_for_specific_only(self):
+        """Mixed refs: wildcard safe, specific field triggers warning."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filtered_action",
+                schema_fields=["field_a", "field_b"],
+                guard={"condition": "ok == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_x"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "consumer_wildcard",
+                depends_on=["filtered_action", "other_dep"],
+                observe=["filtered_action.*", "other_dep.field_x"],
+            ),
+            _llm_action(
+                "consumer_specific",
+                depends_on=["filtered_action", "other_dep"],
+                observe=["filtered_action.field_a", "other_dep.field_x"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        consumer_names = {w.location.agent_name for w in warnings}
+        assert "consumer_specific" in consumer_names
+        assert "consumer_wildcard" not in consumer_names
+
+    def test_deps_inferred_from_context_scope(self):
+        """Dependencies inferred from observe refs (no explicit depends_on) still detect fan-in."""
+        workflow = _make_workflow(
+            _llm_action("source_action", schema_fields=["data"]),
+            _llm_action(
+                "filtered_action",
+                schema_fields=["field_a"],
+                guard={"condition": "ok == true", "on_false": "filter"},
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            _llm_action(
+                "other_dep",
+                schema_fields=["field_b"],
+                depends_on=["source_action"],
+                observe=["source_action.data"],
+            ),
+            # No explicit depends_on — deps inferred from observe refs
+            _llm_action(
+                "consumer",
+                observe=["filtered_action.field_a", "other_dep.field_b"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        warnings = _filter_fanin_warnings(result)
+        assert len(warnings) == 1
+
+    def test_existing_guard_skip_tests_unaffected(self):
+        """Existing skip-guard warnings still work — no regression."""
+        workflow = _make_workflow(
+            _llm_action(
+                "review",
+                schema_fields=["hitl_status"],
+                guard={"condition": "needs_review == true", "on_false": "skip"},
+            ),
+            _llm_action(
+                "downstream",
+                depends_on=["review"],
+                observe=["review.hitl_status"],
+            ),
+        )
+
+        result = WorkflowStaticAnalyzer(workflow).analyze()
+
+        skip_warnings = [
+            w
+            for w in result.warnings
+            if "may be null" in w.message and 'on_false: "skip"' in w.message
+        ]
+        assert len(skip_warnings) == 1
+
+        # No filter-fanin warning (single dep, not fan-in)
+        assert len(_filter_fanin_warnings(result)) == 0


### PR DESCRIPTION
## Summary
- Preflight static analyzer warning when a fan-in consumer observes specific fields from a filter-guarded upstream and an alternate dependency path exists (one warning per hazard pair, wildcards excluded)
- Enriched runtime error when Jinja template hits null namespace from guard-filter at fan-in — names the filtered namespace, alternate deps, and three remediation options instead of bare `NoneType has no attribute`
- No behavioral change to fan-in semantics (Option A explicitly excluded per spec)

Spec: `specs/backlog/3-low/415-fan-in-null-namespace-from-filtered-upstream.md`

## Verification
- 13 preflight tests + 7 runtime tests added
- All 6789 existing tests pass
- ruff format + ruff check clean
- Existing guard-skip and null-safe observe tests unaffected