### PR TITLE
feat: record-level error isolation and selective retry

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260515-539000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260515-539000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Record-level error isolation: failed records are quarantined at the failure action and cascade-skipped downstream instead of polluting subsequent actions. New `retry` command re-processes only failed records from their failure point forward. New `dispositions` command shows per-action record outcome breakdown. **Breaking:** FAILED records now produce tombstone records in action output — external scripts reading target JSON files will see new records with `_state: failed`."
+time: 2026-05-15T05:39:00.000000Z

--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -1,0 +1,187 @@
+"""Dispositions command — inspect record-level processing outcomes per action.
+
+Shows per-action breakdown of record dispositions (success, failed,
+exhausted, quarantined, etc.) to help diagnose workflow issues and
+identify records that need retry.
+"""
+
+import logging
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
+from agent_actions.config.project_paths import ProjectPathsFactory
+from agent_actions.storage import get_storage_backend
+from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
+
+logger = logging.getLogger(__name__)
+
+
+class DispositionsCommand:
+    """Display per-action disposition breakdown for a workflow."""
+
+    def __init__(self, agent: str, action: str | None, quarantined: bool):
+        self.agent_name = Path(agent).stem
+        self.agent = agent
+        self.action_filter = action
+        self.quarantined_only = quarantined
+        self.console = Console()
+
+    def execute(self, project_root: Path | None = None) -> None:
+        paths = ProjectPathsFactory.create_project_paths(
+            self.agent_name, self.agent, auto_create=False, project_root=project_root
+        )
+
+        backend = get_storage_backend(
+            workflow_path=str(paths.io_dir.parent),
+            workflow_name=self.agent_name,
+        )
+
+        execution_order = self._load_execution_order(paths, project_root)
+
+        if self.action_filter:
+            if self.action_filter not in execution_order:
+                raise click.ClickException(
+                    f"Action '{self.action_filter}' not in execution order: {execution_order}"
+                )
+            actions = [self.action_filter]
+        else:
+            actions = execution_order
+
+        if self.quarantined_only:
+            self._show_quarantined(backend, actions)
+        else:
+            self._show_summary(backend, actions)
+
+    def _show_summary(self, backend, actions: list[str]) -> None:
+        """Show per-action disposition counts."""
+        table = Table(title=f"Dispositions: {self.agent_name}")
+        table.add_column("Action", style="cyan")
+        table.add_column("Success", justify="right", style="green")
+        table.add_column("Failed", justify="right", style="red")
+        table.add_column("Exhausted", justify="right", style="red")
+        table.add_column("Quarantined", justify="right", style="yellow")
+        table.add_column("Passthrough", justify="right", style="dim")
+        table.add_column("Filtered", justify="right", style="dim")
+        table.add_column("Total", justify="right", style="bold")
+
+        for action in actions:
+            rows = backend.get_disposition(action)
+            # Exclude node-level sentinel records
+            rows = [r for r in rows if r.get("record_id") != NODE_LEVEL_RECORD_ID]
+
+            counts: dict[str, int] = {}
+            for row in rows:
+                disp = row.get("disposition", "unknown")
+                counts[disp] = counts.get(disp, 0) + 1
+
+            total = sum(counts.values())
+            if total == 0:
+                continue
+
+            table.add_row(
+                action,
+                str(counts.get("success", 0)),
+                str(counts.get("failed", 0)),
+                str(counts.get("exhausted", 0)),
+                str(counts.get("unprocessed", 0)),
+                str(counts.get("passthrough", 0)),
+                str(counts.get("filtered", 0)),
+                str(total),
+            )
+
+        self.console.print(table)
+
+    def _show_quarantined(self, backend, actions: list[str]) -> None:
+        """Show details of failed/exhausted/unprocessed records."""
+        table = Table(title=f"Quarantined Records: {self.agent_name}")
+        table.add_column("Action", style="cyan")
+        table.add_column("Record ID", style="red")
+        table.add_column("Disposition", style="yellow")
+        table.add_column("Reason", style="dim", max_width=60)
+
+        found = 0
+        for action in actions:
+            for disp in ("failed", "exhausted", "unprocessed"):
+                rows = backend.get_disposition(action, disposition=disp)
+                rows = [r for r in rows if r.get("record_id") != NODE_LEVEL_RECORD_ID]
+                for row in rows:
+                    found += 1
+                    table.add_row(
+                        action,
+                        row.get("record_id", "?"),
+                        row.get("disposition", "?"),
+                        (row.get("reason") or "")[:60],
+                    )
+
+        if found:
+            self.console.print(table)
+        else:
+            self.console.print("[green]No quarantined records found.[/green]")
+
+    def _load_execution_order(self, paths, project_root: Path | None) -> list[str]:
+        """Load the workflow to extract execution order."""
+        from agent_actions.config.loader import find_config_file
+        from agent_actions.config.rendering import ConfigRenderingService
+        from agent_actions.workflow.coordinator import AgentWorkflow
+        from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
+
+        filename = f"{self.agent_name}.yml"
+        full_path = find_config_file(
+            self.agent_name,
+            paths.agent_config_dir,
+            filename,
+            check_alternatives=True,
+            project_root=project_root,
+        )
+        ConfigRenderingService().render_and_load_config(
+            self.agent_name,
+            full_path,
+            paths.template_dir,
+            paths.rendered_workflows_dir,
+            project_root=project_root,
+        )
+        workflow = AgentWorkflow(
+            WorkflowRuntimeConfig(
+                paths=WorkflowPaths(
+                    constructor_path=str(full_path),
+                    default_path=str(paths.default_config_path),
+                ),
+                project_root=project_root,
+            )
+        )
+        return list(workflow.execution_order)
+
+
+@click.command()
+@click.option(
+    "-a",
+    "--agent",
+    required=True,
+    help="Agent configuration file name without path or extension",
+)
+@click.option(
+    "--action",
+    default=None,
+    help="Show dispositions for a specific action only.",
+)
+@click.option(
+    "--quarantined",
+    is_flag=True,
+    default=False,
+    help="Show only failed/exhausted/unprocessed records with details.",
+)
+@handles_user_errors("dispositions")
+@requires_project
+def dispositions(
+    agent: str,
+    action: str | None,
+    quarantined: bool,
+    project_root: Path | None = None,
+) -> None:
+    """Inspect record-level processing dispositions per action."""
+    command = DispositionsCommand(agent, action, quarantined)
+    command.execute(project_root=project_root)

--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -19,15 +19,15 @@ from agent_actions.storage import get_storage_backend
 from agent_actions.storage.backend import (
     DISPOSITION_EXHAUSTED,
     DISPOSITION_FAILED,
-    DISPOSITION_UNPROCESSED,
     NODE_LEVEL_RECORD_ID,
 )
 
 logger = logging.getLogger(__name__)
 
-_QUARANTINE_DISPOSITIONS = frozenset(
-    {DISPOSITION_FAILED, DISPOSITION_EXHAUSTED, DISPOSITION_UNPROCESSED}
-)
+# Records shown by --quarantined: only primary failures that a user can
+# act on via `retry`.  UNPROCESSED (cascade casualties) are excluded —
+# they resolve automatically when the upstream failure is retried.
+_QUARANTINE_DISPOSITIONS = frozenset({DISPOSITION_FAILED, DISPOSITION_EXHAUSTED})
 
 
 class DispositionsCommand:

--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -16,11 +16,18 @@ from agent_actions.cli.cli_decorators import handles_user_errors, requires_proje
 from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.storage import get_storage_backend
-from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
+from agent_actions.storage.backend import (
+    DISPOSITION_EXHAUSTED,
+    DISPOSITION_FAILED,
+    DISPOSITION_UNPROCESSED,
+    NODE_LEVEL_RECORD_ID,
+)
 
 logger = logging.getLogger(__name__)
 
-_QUARANTINE_DISPOSITIONS = frozenset({"failed", "exhausted", "unprocessed"})
+_QUARANTINE_DISPOSITIONS = frozenset(
+    {DISPOSITION_FAILED, DISPOSITION_EXHAUSTED, DISPOSITION_UNPROCESSED}
+)
 
 
 class DispositionsCommand:

--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -13,11 +13,14 @@ from rich.console import Console
 from rich.table import Table
 
 from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
+from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.storage import get_storage_backend
 from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
 
 logger = logging.getLogger(__name__)
+
+_QUARANTINE_DISPOSITIONS = frozenset({"failed", "exhausted", "unprocessed"})
 
 
 class DispositionsCommand:
@@ -40,7 +43,8 @@ class DispositionsCommand:
             workflow_name=self.agent_name,
         )
 
-        execution_order = self._load_execution_order(paths, project_root)
+        workflow = load_workflow(self.agent_name, paths, project_root)
+        execution_order = list(workflow.execution_order)
 
         if self.action_filter:
             if self.action_filter not in execution_order:
@@ -70,7 +74,6 @@ class DispositionsCommand:
 
         for action in actions:
             rows = backend.get_disposition(action)
-            # Exclude node-level sentinel records
             rows = [r for r in rows if r.get("record_id") != NODE_LEVEL_RECORD_ID]
 
             counts: dict[str, int] = {}
@@ -105,55 +108,24 @@ class DispositionsCommand:
 
         found = 0
         for action in actions:
-            for disp in ("failed", "exhausted", "unprocessed"):
-                rows = backend.get_disposition(action, disposition=disp)
-                rows = [r for r in rows if r.get("record_id") != NODE_LEVEL_RECORD_ID]
-                for row in rows:
-                    found += 1
-                    table.add_row(
-                        action,
-                        row.get("record_id", "?"),
-                        row.get("disposition", "?"),
-                        (row.get("reason") or "")[:60],
-                    )
+            rows = backend.get_disposition(action)
+            for row in rows:
+                if row.get("record_id") == NODE_LEVEL_RECORD_ID:
+                    continue
+                if row.get("disposition") not in _QUARANTINE_DISPOSITIONS:
+                    continue
+                found += 1
+                table.add_row(
+                    action,
+                    row.get("record_id", "?"),
+                    row.get("disposition", "?"),
+                    (row.get("reason") or "")[:60],
+                )
 
         if found:
             self.console.print(table)
         else:
             self.console.print("[green]No quarantined records found.[/green]")
-
-    def _load_execution_order(self, paths, project_root: Path | None) -> list[str]:
-        """Load the workflow to extract execution order."""
-        from agent_actions.config.loader import find_config_file
-        from agent_actions.config.rendering import ConfigRenderingService
-        from agent_actions.workflow.coordinator import AgentWorkflow
-        from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
-
-        filename = f"{self.agent_name}.yml"
-        full_path = find_config_file(
-            self.agent_name,
-            paths.agent_config_dir,
-            filename,
-            check_alternatives=True,
-            project_root=project_root,
-        )
-        ConfigRenderingService().render_and_load_config(
-            self.agent_name,
-            full_path,
-            paths.template_dir,
-            paths.rendered_workflows_dir,
-            project_root=project_root,
-        )
-        workflow = AgentWorkflow(
-            WorkflowRuntimeConfig(
-                paths=WorkflowPaths(
-                    constructor_path=str(full_path),
-                    default_path=str(paths.default_config_path),
-                ),
-                project_root=project_root,
-            )
-        )
-        return list(workflow.execution_order)
 
 
 @click.command()

--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -103,7 +103,10 @@ class DispositionsCommand:
                 str(total),
             )
 
-        self.console.print(table)
+        if table.row_count:
+            self.console.print(table)
+        else:
+            self.console.print("[dim]No dispositions recorded. Has the workflow been run?[/dim]")
 
     def _show_quarantined(self, backend, actions: list[str]) -> None:
         """Show details of failed/exhausted/unprocessed records."""

--- a/agent_actions/cli/main.py
+++ b/agent_actions/cli/main.py
@@ -15,6 +15,7 @@ from agent_actions.cli.init import init
 from agent_actions.cli.inspect import inspect
 from agent_actions.cli.list_udfs import list_udfs_cmd
 from agent_actions.cli.preview import preview
+from agent_actions.cli.retry import retry
 from agent_actions.cli.run import run
 from agent_actions.cli.schema import schema
 from agent_actions.cli.skills import skills
@@ -73,6 +74,7 @@ class CLI:
         self.click_group.add_command(inspect)
         self.click_group.add_command(preview)
         self.click_group.add_command(render)
+        self.click_group.add_command(retry)
         self.click_group.add_command(run)
         self.click_group.add_command(batch)
         self.click_group.add_command(schema)

--- a/agent_actions/cli/main.py
+++ b/agent_actions/cli/main.py
@@ -10,6 +10,7 @@ import click
 from agent_actions.__version__ import __version__
 from agent_actions.cli.clean import clean_cli as clean
 from agent_actions.cli.compile import compile, render
+from agent_actions.cli.dispositions import dispositions
 from agent_actions.cli.docs import docs
 from agent_actions.cli.init import init
 from agent_actions.cli.inspect import inspect
@@ -70,6 +71,7 @@ class CLI:
         self.logger.debug("Registering CLI commands")
         self.click_group.add_command(clean)
         self.click_group.add_command(compile)
+        self.click_group.add_command(dispositions)
         self.click_group.add_command(init)
         self.click_group.add_command(inspect)
         self.click_group.add_command(preview)

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -88,6 +88,13 @@ class RetryCommand:
         downstream_actions = execution_order[from_idx:]
         record_ids = {r["record_id"] for r in target_records}
 
+        logger.warning(
+            "Clearing dispositions for retry: records=%s, actions=%s. "
+            "If the re-run fails, run 'retry' again to resume.",
+            sorted(record_ids),
+            downstream_actions,
+        )
+
         cleared = 0
         for action in downstream_actions:
             for record_id in record_ids:

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -16,7 +16,11 @@ from agent_actions.cli.cli_decorators import handles_user_errors, requires_proje
 from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.storage import get_storage_backend
-from agent_actions.storage.backend import DISPOSITION_EXHAUSTED, DISPOSITION_FAILED
+from agent_actions.storage.backend import (
+    DISPOSITION_EXHAUSTED,
+    DISPOSITION_FAILED,
+    NODE_LEVEL_RECORD_ID,
+)
 from agent_actions.validation.retry_validator import RetryCommandArgs
 
 logger = logging.getLogger(__name__)
@@ -99,6 +103,9 @@ class RetryCommand:
         for action in downstream_actions:
             for record_id in record_ids:
                 cleared += backend.clear_disposition(action, record_id=record_id)
+            # Clear node-level disposition so the executor doesn't see a
+            # stale action-level FAILED/SKIPPED signal.
+            backend.clear_disposition(action, record_id=NODE_LEVEL_RECORD_ID)
 
         self.console.print(
             f"\n[cyan]Cleared {cleared} disposition(s) for {len(record_ids)} record(s) "
@@ -107,6 +114,15 @@ class RetryCommand:
 
         self.console.print("\n[bold]Re-running workflow...[/bold]\n")
         workflow = load_workflow(self.agent_name, paths, project_root)
+
+        # Reset action-level status for downstream actions to PENDING so the
+        # coordinator doesn't skip them as "already completed."
+        from agent_actions.workflow.managers.state import ActionStatus
+
+        state_mgr = workflow.services.core.state_manager
+        for action in downstream_actions:
+            state_mgr.update_status(action, ActionStatus.PENDING)
+
         workflow.run()
         self.console.print("\n[green]Retry complete.[/green]")
 

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -170,7 +170,7 @@ class RetryCommand:
 @click.option(
     "--record",
     default=None,
-    help="Specific record source_guid to retry.",
+    help="Restrict retry to a single record (by source_guid) at the --from action.",
 )
 @click.option(
     "--dry-run",

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -1,0 +1,263 @@
+"""Retry command for the Agent Actions CLI.
+
+Retries failed/exhausted records from a specific action forward.
+Uses the disposition table to identify what failed and delegates to
+the existing workflow execution engine for re-processing.
+"""
+
+import logging
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
+from agent_actions.config.project_paths import ProjectPathsFactory
+from agent_actions.storage import get_storage_backend
+from agent_actions.storage.backend import DISPOSITION_EXHAUSTED, DISPOSITION_FAILED
+from agent_actions.validation.retry_validator import RetryCommandArgs
+
+logger = logging.getLogger(__name__)
+
+
+class RetryCommand:
+    """Retry failed/exhausted records from a given action forward."""
+
+    def __init__(self, args: RetryCommandArgs):
+        self.args = args
+        self.agent_name = Path(args.agent).stem
+        self.console = Console()
+
+    def execute(self, project_root: Path | None = None) -> None:
+        paths = ProjectPathsFactory.create_project_paths(
+            self.agent_name, self.args.agent, auto_create=False, project_root=project_root
+        )
+
+        backend = get_storage_backend(
+            workflow_path=str(paths.io_dir.parent),
+            workflow_name=self.agent_name,
+        )
+
+        # Load execution order from the workflow config
+        execution_order = self._load_execution_order(paths, project_root)
+
+        # Find failed/exhausted records
+        failures = self._find_failures(backend, execution_order)
+
+        if not failures:
+            self.console.print(
+                "[green]No failed or exhausted records found. Nothing to retry.[/green]"
+            )
+            return
+
+        # Determine the retry start action
+        from_action = self.args.from_action
+        if from_action:
+            if from_action not in execution_order:
+                raise click.ClickException(
+                    f"Action '{from_action}' not found in execution order: {execution_order}"
+                )
+        else:
+            # Find the earliest failure action in execution order
+            for action in execution_order:
+                if action in failures:
+                    from_action = action
+                    break
+
+        if not from_action:
+            self.console.print("[green]No actionable failures found.[/green]")
+            return
+
+        # Filter failures to only include the target action (or specific record)
+        target_records = failures.get(from_action, [])
+        if self.args.record:
+            target_records = [r for r in target_records if r["record_id"] == self.args.record]
+            if not target_records:
+                raise click.ClickException(
+                    f"Record '{self.args.record}' not found in failed records for action '{from_action}'"
+                )
+
+        # Display what will be retried
+        self._display_retry_plan(from_action, target_records, execution_order)
+
+        if self.args.dry_run:
+            self.console.print("\n[yellow]Dry run — no changes made.[/yellow]")
+            return
+
+        # Clear dispositions for failed records from the retry action forward
+        from_idx = execution_order.index(from_action)
+        downstream_actions = execution_order[from_idx:]
+        record_ids = {r["record_id"] for r in target_records}
+
+        cleared = 0
+        for action in downstream_actions:
+            for record_id in record_ids:
+                cleared += backend.clear_disposition(action, record_id=record_id)
+
+        self.console.print(
+            f"\n[cyan]Cleared {cleared} disposition(s) for {len(record_ids)} record(s) "
+            f"across {len(downstream_actions)} action(s).[/cyan]"
+        )
+
+        # Re-run the workflow — it will pick up where it left off
+        self.console.print("\n[bold]Re-running workflow...[/bold]\n")
+        self._rerun_workflow(paths, project_root)
+
+    def _load_execution_order(self, paths, project_root: Path | None) -> list[str]:
+        """Load the workflow to extract execution order."""
+        from agent_actions.config.loader import find_config_file
+        from agent_actions.config.rendering import ConfigRenderingService
+        from agent_actions.workflow.coordinator import AgentWorkflow
+        from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
+
+        filename = f"{self.agent_name}.yml"
+        full_path = find_config_file(
+            self.agent_name,
+            paths.agent_config_dir,
+            filename,
+            check_alternatives=True,
+            project_root=project_root,
+        )
+        ConfigRenderingService().render_and_load_config(
+            self.agent_name,
+            full_path,
+            paths.template_dir,
+            paths.rendered_workflows_dir,
+            project_root=project_root,
+        )
+
+        workflow = AgentWorkflow(
+            WorkflowRuntimeConfig(
+                paths=WorkflowPaths(
+                    constructor_path=str(full_path),
+                    default_path=str(paths.default_config_path),
+                ),
+                project_root=project_root,
+            )
+        )
+        return list(workflow.execution_order)
+
+    def _find_failures(
+        self,
+        backend,
+        execution_order: list[str],
+    ) -> dict[str, list[dict]]:
+        """Query disposition table for failed/exhausted records per action."""
+        failures: dict[str, list[dict]] = {}
+        for action in execution_order:
+            action_failures = []
+            for disposition in (DISPOSITION_FAILED, DISPOSITION_EXHAUSTED):
+                rows = backend.get_disposition(action, disposition=disposition)
+                action_failures.extend(rows)
+            if action_failures:
+                failures[action] = action_failures
+        return failures
+
+    def _display_retry_plan(
+        self,
+        from_action: str,
+        target_records: list[dict],
+        execution_order: list[str],
+    ) -> None:
+        """Display what will be retried."""
+        from_idx = execution_order.index(from_action)
+        downstream = execution_order[from_idx:]
+
+        self.console.print("\n[bold]Retry Plan[/bold]")
+        self.console.print(f"  From action: [cyan]{from_action}[/cyan]")
+        self.console.print(f"  Actions to re-run: {' → '.join(downstream)}")
+        self.console.print(f"  Records to retry: {len(target_records)}")
+
+        table = Table(title="Failed Records")
+        table.add_column("Record ID", style="red")
+        table.add_column("Disposition", style="yellow")
+        table.add_column("Reason", style="dim", max_width=60)
+
+        for record in target_records:
+            table.add_row(
+                record.get("record_id", "?"),
+                record.get("disposition", "?"),
+                (record.get("reason") or "")[:60],
+            )
+
+        self.console.print(table)
+
+    def _rerun_workflow(self, paths, project_root: Path | None) -> None:
+        """Re-run the workflow using the standard execution path."""
+        from agent_actions.config.loader import find_config_file
+        from agent_actions.config.rendering import ConfigRenderingService
+        from agent_actions.workflow.coordinator import AgentWorkflow
+        from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
+
+        filename = f"{self.agent_name}.yml"
+        full_path = find_config_file(
+            self.agent_name,
+            paths.agent_config_dir,
+            filename,
+            check_alternatives=True,
+            project_root=project_root,
+        )
+        ConfigRenderingService().render_and_load_config(
+            self.agent_name,
+            full_path,
+            paths.template_dir,
+            paths.rendered_workflows_dir,
+            project_root=project_root,
+        )
+
+        workflow = AgentWorkflow(
+            WorkflowRuntimeConfig(
+                paths=WorkflowPaths(
+                    constructor_path=str(full_path),
+                    default_path=str(paths.default_config_path),
+                ),
+                project_root=project_root,
+            )
+        )
+        workflow.run()
+        self.console.print("\n[green]Retry complete.[/green]")
+
+
+@click.command()
+@click.option(
+    "-a",
+    "--agent",
+    required=True,
+    help="Agent configuration file name without path or extension",
+)
+@click.option(
+    "--from",
+    "from_action",
+    default=None,
+    help="Action to retry from. If omitted, retries from earliest failure.",
+)
+@click.option(
+    "--record",
+    default=None,
+    help="Specific record source_guid to retry.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be retried without executing.",
+)
+@handles_user_errors("retry")
+@requires_project
+def retry(
+    agent: str,
+    from_action: str | None,
+    record: str | None,
+    dry_run: bool,
+    project_root: Path | None = None,
+) -> None:
+    """Retry failed/exhausted records from a specific action forward."""
+    args = RetryCommandArgs(
+        agent=agent,
+        from_action=from_action,
+        record=record,
+        dry_run=dry_run,
+    )
+    command = RetryCommand(args)
+    command.execute(project_root=project_root)

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -25,6 +25,16 @@ from agent_actions.validation.retry_validator import RetryCommandArgs
 
 logger = logging.getLogger(__name__)
 
+# Dispositions eligible for retry.  Allowlist — new disposition types
+# won't accidentally become retryable.
+#
+# Excluded (and why):
+#   success     — already done
+#   unprocessed — cascade casualty; resolves when upstream failure is retried
+#   passthrough — guard-skipped; not a failure
+#   skipped     — deliberately skipped (WHERE clause)
+#   filtered    — removed by predicate; not a failure
+#   deferred    — pending HITL/batch; retrying would clobber in-flight state
 _FAILURE_DISPOSITIONS = (DISPOSITION_FAILED, DISPOSITION_EXHAUSTED)
 
 
@@ -87,7 +97,7 @@ class RetryCommand:
                     f"for action '{from_action}'"
                 )
 
-        self._display_retry_plan(from_action, target_records, execution_order)
+        self._display_retry_plan(from_action, target_records, execution_order, failures)
 
         if self.args.dry_run:
             self.console.print("\n[yellow]Dry run — no changes made.[/yellow]")
@@ -153,6 +163,7 @@ class RetryCommand:
         from_action: str,
         target_records: list[dict],
         execution_order: list[str],
+        all_failures: dict[str, list[dict]],
     ) -> None:
         """Display what will be retried."""
         from_idx = execution_order.index(from_action)
@@ -176,6 +187,14 @@ class RetryCommand:
             )
 
         self.console.print(table)
+
+        # Alert user if there are failures at other actions too
+        other_actions = [a for a in all_failures if a != from_action]
+        if other_actions:
+            self.console.print(
+                f"\n[dim]Note: failures also exist at: {', '.join(other_actions)}. "
+                f"Run 'retry' again after this completes to address them.[/dim]"
+            )
 
 
 @click.command()

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -13,12 +13,15 @@ from rich.console import Console
 from rich.table import Table
 
 from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
+from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.storage import get_storage_backend
 from agent_actions.storage.backend import DISPOSITION_EXHAUSTED, DISPOSITION_FAILED
 from agent_actions.validation.retry_validator import RetryCommandArgs
 
 logger = logging.getLogger(__name__)
+
+_FAILURE_DISPOSITIONS = (DISPOSITION_FAILED, DISPOSITION_EXHAUSTED)
 
 
 class RetryCommand:
@@ -39,10 +42,9 @@ class RetryCommand:
             workflow_name=self.agent_name,
         )
 
-        # Load execution order from the workflow config
-        execution_order = self._load_execution_order(paths, project_root)
+        workflow = load_workflow(self.agent_name, paths, project_root)
+        execution_order = list(workflow.execution_order)
 
-        # Find failed/exhausted records
         failures = self._find_failures(backend, execution_order)
 
         if not failures:
@@ -51,7 +53,6 @@ class RetryCommand:
             )
             return
 
-        # Determine the retry start action
         from_action = self.args.from_action
         if from_action:
             if from_action not in execution_order:
@@ -59,7 +60,6 @@ class RetryCommand:
                     f"Action '{from_action}' not found in execution order: {execution_order}"
                 )
         else:
-            # Find the earliest failure action in execution order
             for action in execution_order:
                 if action in failures:
                     from_action = action
@@ -69,23 +69,21 @@ class RetryCommand:
             self.console.print("[green]No actionable failures found.[/green]")
             return
 
-        # Filter failures to only include the target action (or specific record)
         target_records = failures.get(from_action, [])
         if self.args.record:
             target_records = [r for r in target_records if r["record_id"] == self.args.record]
             if not target_records:
                 raise click.ClickException(
-                    f"Record '{self.args.record}' not found in failed records for action '{from_action}'"
+                    f"Record '{self.args.record}' not found in failed records "
+                    f"for action '{from_action}'"
                 )
 
-        # Display what will be retried
         self._display_retry_plan(from_action, target_records, execution_order)
 
         if self.args.dry_run:
             self.console.print("\n[yellow]Dry run — no changes made.[/yellow]")
             return
 
-        # Clear dispositions for failed records from the retry action forward
         from_idx = execution_order.index(from_action)
         downstream_actions = execution_order[from_idx:]
         record_ids = {r["record_id"] for r in target_records}
@@ -100,56 +98,21 @@ class RetryCommand:
             f"across {len(downstream_actions)} action(s).[/cyan]"
         )
 
-        # Re-run the workflow — it will pick up where it left off
         self.console.print("\n[bold]Re-running workflow...[/bold]\n")
-        self._rerun_workflow(paths, project_root)
+        workflow = load_workflow(self.agent_name, paths, project_root)
+        workflow.run()
+        self.console.print("\n[green]Retry complete.[/green]")
 
-    def _load_execution_order(self, paths, project_root: Path | None) -> list[str]:
-        """Load the workflow to extract execution order."""
-        from agent_actions.config.loader import find_config_file
-        from agent_actions.config.rendering import ConfigRenderingService
-        from agent_actions.workflow.coordinator import AgentWorkflow
-        from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
-
-        filename = f"{self.agent_name}.yml"
-        full_path = find_config_file(
-            self.agent_name,
-            paths.agent_config_dir,
-            filename,
-            check_alternatives=True,
-            project_root=project_root,
-        )
-        ConfigRenderingService().render_and_load_config(
-            self.agent_name,
-            full_path,
-            paths.template_dir,
-            paths.rendered_workflows_dir,
-            project_root=project_root,
-        )
-
-        workflow = AgentWorkflow(
-            WorkflowRuntimeConfig(
-                paths=WorkflowPaths(
-                    constructor_path=str(full_path),
-                    default_path=str(paths.default_config_path),
-                ),
-                project_root=project_root,
-            )
-        )
-        return list(workflow.execution_order)
-
+    @staticmethod
     def _find_failures(
-        self,
         backend,
         execution_order: list[str],
     ) -> dict[str, list[dict]]:
         """Query disposition table for failed/exhausted records per action."""
         failures: dict[str, list[dict]] = {}
         for action in execution_order:
-            action_failures = []
-            for disposition in (DISPOSITION_FAILED, DISPOSITION_EXHAUSTED):
-                rows = backend.get_disposition(action, disposition=disposition)
-                action_failures.extend(rows)
+            rows = backend.get_disposition(action)
+            action_failures = [r for r in rows if r.get("disposition") in _FAILURE_DISPOSITIONS]
             if action_failures:
                 failures[action] = action_failures
         return failures
@@ -182,41 +145,6 @@ class RetryCommand:
             )
 
         self.console.print(table)
-
-    def _rerun_workflow(self, paths, project_root: Path | None) -> None:
-        """Re-run the workflow using the standard execution path."""
-        from agent_actions.config.loader import find_config_file
-        from agent_actions.config.rendering import ConfigRenderingService
-        from agent_actions.workflow.coordinator import AgentWorkflow
-        from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
-
-        filename = f"{self.agent_name}.yml"
-        full_path = find_config_file(
-            self.agent_name,
-            paths.agent_config_dir,
-            filename,
-            check_alternatives=True,
-            project_root=project_root,
-        )
-        ConfigRenderingService().render_and_load_config(
-            self.agent_name,
-            full_path,
-            paths.template_dir,
-            paths.rendered_workflows_dir,
-            project_root=project_root,
-        )
-
-        workflow = AgentWorkflow(
-            WorkflowRuntimeConfig(
-                paths=WorkflowPaths(
-                    constructor_path=str(full_path),
-                    default_path=str(paths.default_config_path),
-                ),
-                project_root=project_root,
-            )
-        )
-        workflow.run()
-        self.console.print("\n[green]Retry complete.[/green]")
 
 
 @click.command()

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -74,6 +74,11 @@ class RetryCommand:
             return
 
         target_records = failures.get(from_action, [])
+        if not target_records:
+            self.console.print(
+                f"[yellow]No failed records at action '{from_action}'. Nothing to retry.[/yellow]"
+            )
+            return
         if self.args.record:
             target_records = [r for r in target_records if r["record_id"] == self.args.record]
             if not target_records:
@@ -113,6 +118,8 @@ class RetryCommand:
         )
 
         self.console.print("\n[bold]Re-running workflow...[/bold]\n")
+        # Fresh workflow: dispositions were cleared above, so the coordinator
+        # needs to see the updated storage state at construction time.
         workflow = load_workflow(self.agent_name, paths, project_root)
 
         # Reset action-level status for downstream actions to PENDING so the

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -97,7 +97,7 @@ class RetryCommand:
         downstream_actions = execution_order[from_idx:]
         record_ids = {r["record_id"] for r in target_records}
 
-        logger.warning(
+        logger.info(
             "Clearing dispositions for retry: records=%s, actions=%s. "
             "If the re-run fails, run 'retry' again to resume.",
             sorted(record_ids),
@@ -124,6 +124,7 @@ class RetryCommand:
 
         # Reset action-level status for downstream actions to PENDING so the
         # coordinator doesn't skip them as "already completed."
+        # Deferred import: avoid circular import at module load time.
         from agent_actions.workflow.managers.state import ActionStatus
 
         state_mgr = workflow.services.core.state_manager

--- a/agent_actions/cli/workflow_loader.py
+++ b/agent_actions/cli/workflow_loader.py
@@ -11,13 +11,14 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agent_actions.config.project_paths import ProjectPaths
+    from agent_actions.workflow.coordinator import AgentWorkflow
 
 
 def load_workflow(
     agent_name: str,
     paths: ProjectPaths,
     project_root: Path | None = None,
-):
+) -> AgentWorkflow:
     """Load and return an initialized AgentWorkflow.
 
     Handles config file resolution, template rendering, and workflow

--- a/agent_actions/cli/workflow_loader.py
+++ b/agent_actions/cli/workflow_loader.py
@@ -24,10 +24,10 @@ def load_workflow(
     construction.  Callers can access ``workflow.execution_order``,
     ``workflow.run()``, etc. on the returned object.
     """
-    from agent_actions.config.loader import find_config_file
-    from agent_actions.config.rendering import ConfigRenderingService
+    from agent_actions.config.project_paths import find_config_file
+    from agent_actions.prompt.renderer import ConfigRenderingService
     from agent_actions.workflow.coordinator import AgentWorkflow
-    from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
+    from agent_actions.workflow.models import WorkflowPaths, WorkflowRuntimeConfig
 
     filename = f"{agent_name}.yml"
     full_path = find_config_file(
@@ -48,8 +48,10 @@ def load_workflow(
         WorkflowRuntimeConfig(
             paths=WorkflowPaths(
                 constructor_path=str(full_path),
+                user_code_path=None,
                 default_path=str(paths.default_config_path),
             ),
+            use_tools=False,
             project_root=project_root,
         )
     )

--- a/agent_actions/cli/workflow_loader.py
+++ b/agent_actions/cli/workflow_loader.py
@@ -1,0 +1,55 @@
+"""Shared workflow loading utility for CLI commands.
+
+Provides a single function to initialize an AgentWorkflow from project
+paths, avoiding duplicate config loading / rendering across commands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_actions.config.project_paths import ProjectPaths
+
+
+def load_workflow(
+    agent_name: str,
+    paths: ProjectPaths,
+    project_root: Path | None = None,
+):
+    """Load and return an initialized AgentWorkflow.
+
+    Handles config file resolution, template rendering, and workflow
+    construction.  Callers can access ``workflow.execution_order``,
+    ``workflow.run()``, etc. on the returned object.
+    """
+    from agent_actions.config.loader import find_config_file
+    from agent_actions.config.rendering import ConfigRenderingService
+    from agent_actions.workflow.coordinator import AgentWorkflow
+    from agent_actions.workflow.runtime_config import WorkflowPaths, WorkflowRuntimeConfig
+
+    filename = f"{agent_name}.yml"
+    full_path = find_config_file(
+        agent_name,
+        paths.agent_config_dir,
+        filename,
+        check_alternatives=True,
+        project_root=project_root,
+    )
+    ConfigRenderingService().render_and_load_config(
+        agent_name,
+        full_path,
+        paths.template_dir,
+        paths.rendered_workflows_dir,
+        project_root=project_root,
+    )
+    return AgentWorkflow(
+        WorkflowRuntimeConfig(
+            paths=WorkflowPaths(
+                constructor_path=str(full_path),
+                default_path=str(paths.default_config_path),
+            ),
+            project_root=project_root,
+        )
+    )

--- a/agent_actions/processing/cascade_filter.py
+++ b/agent_actions/processing/cascade_filter.py
@@ -1,0 +1,86 @@
+"""Cascade-blocking record filter for processing strategies.
+
+Partitions input records into processable (ACTIVE) and quarantined
+(CASCADE_BLOCKING) sets before any strategy-specific logic runs.
+Quarantined records produce UNPROCESSED results immediately — no LLM
+call, no tool invocation, no compute wasted.
+
+Every processing strategy must call :func:`partition_cascade_records`
+at the top of its ``invoke()`` method.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agent_actions.processing.record_helpers import build_tombstone
+from agent_actions.processing.types import ProcessingResult
+from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
+from agent_actions.record.state import CASCADE_BLOCKING_VALUES
+
+logger = logging.getLogger(__name__)
+
+CASCADE_QUARANTINE_REASON = "cascade_quarantine"
+
+
+def partition_cascade_records(
+    records: list[dict[str, Any]],
+    *,
+    action_name: str,
+) -> tuple[list[dict[str, Any]], list[ProcessingResult]]:
+    """Split records into (processable, quarantined_results).
+
+    Records whose ``_state`` is in :data:`CASCADE_BLOCKING_VALUES`
+    (``cascade_skipped``, ``failed``, ``exhausted``) are converted to
+    :class:`ProcessingResult.unprocessed` immediately.  All other records
+    are returned for normal processing.
+
+    Args:
+        records: Input records (may include cascade-blocking records).
+        action_name: Current action name (for tombstone construction).
+
+    Returns:
+        Tuple of (processable_records, quarantined_results).
+        processable_records preserves original ordering.
+        quarantined_results are ready to merge into the strategy's output.
+    """
+    processable: list[dict[str, Any]] = []
+    quarantined: list[ProcessingResult] = []
+
+    for record in records:
+        state = record.get("_state") if isinstance(record, dict) else None
+        if state in CASCADE_BLOCKING_VALUES:
+            source_guid = record.get("source_guid") if isinstance(record, dict) else None
+            tombstone = build_tombstone(
+                action_name,
+                record,
+                UPSTREAM_UNPROCESSED,
+                source_guid=source_guid,
+            )
+            quarantined.append(
+                ProcessingResult.unprocessed(
+                    data=[tombstone],
+                    reason=UPSTREAM_UNPROCESSED,
+                    source_guid=source_guid,
+                    input_record=record,
+                )
+            )
+            logger.info(
+                "Quarantining record %s at action '%s': upstream %s",
+                source_guid or "?",
+                action_name,
+                state,
+            )
+        else:
+            processable.append(record)
+
+    if quarantined:
+        logger.info(
+            "Action '%s': %d record(s) quarantined, %d processable",
+            action_name,
+            len(quarantined),
+            len(processable),
+        )
+
+    return processable, quarantined

--- a/agent_actions/processing/cascade_filter.py
+++ b/agent_actions/processing/cascade_filter.py
@@ -21,8 +21,6 @@ from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 
 logger = logging.getLogger(__name__)
 
-CASCADE_QUARANTINE_REASON = "cascade_quarantine"
-
 
 def partition_cascade_records(
     records: list[dict[str, Any]],
@@ -49,9 +47,9 @@ def partition_cascade_records(
     quarantined: list[ProcessingResult] = []
 
     for record in records:
-        state = record.get("_state") if isinstance(record, dict) else None
+        state = record.get("_state")
         if state in CASCADE_BLOCKING_VALUES:
-            source_guid = record.get("source_guid") if isinstance(record, dict) else None
+            source_guid = record.get("source_guid")
             tombstone = build_tombstone(
                 action_name,
                 record,
@@ -66,7 +64,7 @@ def partition_cascade_records(
                     input_record=record,
                 )
             )
-            logger.info(
+            logger.debug(
                 "Quarantining record %s at action '%s': upstream %s",
                 source_guid or "?",
                 action_name,

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -87,6 +87,31 @@ class CollectionStats:
         return bool((self.skipped + self.filtered) == total)
 
 
+def _build_failed_tombstone(
+    agent_name: str,
+    source_guid: str | None,
+    input_record: dict[str, Any] | None,
+    error: str | None,
+) -> dict[str, Any]:
+    """Build a tombstone record for a FAILED processing result.
+
+    The tombstone preserves lineage fields (source_guid, root_target_id,
+    content from upstream) so downstream actions see the record and can
+    cascade-skip it.  This closes the "vanishing record" gap where FAILED
+    records previously disappeared from the output stream.
+    """
+    from agent_actions.processing.record_helpers import build_tombstone
+
+    tombstone = build_tombstone(
+        agent_name,
+        input_record,
+        error or "processing_error",
+        source_guid=source_guid,
+    )
+    _stamp(tombstone, RecordState.FAILED, agent_name, error or "processing_error")
+    return tombstone
+
+
 def _data_has_parse_error(data: list[dict[str, Any]]) -> bool:
     """Check if any data item contains a ``_parse_error`` from the LLM provider.
 
@@ -414,6 +439,14 @@ class ResultCollector:
                     result.source_guid,
                     result.error,
                 )
+
+                # Build a tombstone so downstream actions see this record
+                # and can cascade-skip it (record-level error isolation).
+                tombstone = _build_failed_tombstone(
+                    agent_name, result.source_guid, result.input_record, result.error
+                )
+                output.append(tombstone)
+
                 fire_event(
                     ResultCollectedEvent(
                         action_name=agent_name,

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -58,7 +58,7 @@ class FileToolStrategy:
             records, action_name=context.agent_name
         )
 
-        if not processable:
+        if not processable and quarantined_results:
             return list(quarantined_results)
 
         original_data = context.source_data

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -13,6 +13,7 @@ from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
 )
+from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -61,7 +62,11 @@ class FileToolStrategy:
         if not processable and quarantined_results:
             return quarantined_results
 
-        original_data = context.source_data
+        # Filter original_data to exclude quarantined records so
+        # TrackedItem.source_index aligns with reconcile_outputs lookups.
+        original_data = [
+            r for r in (context.source_data or []) if r.get("_state") not in CASCADE_BLOCKING_VALUES
+        ]
         try:
             context_scope = context.agent_config.get("context_scope") or {}
             clean_input: list[TrackedItem] = []

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
+from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.types import (
     ProcessingContext,
@@ -45,15 +46,26 @@ class FileToolStrategy:
     ) -> list[ProcessingResult]:
         """Invoke a FILE-mode tool and reconcile outputs.
 
+        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
+        upstream) are partitioned out before the tool runs — no tool
+        invocation for quarantined records.
+
         ``context.source_data`` must contain the pre-context-scope records
         that passed the guard filter (set by UnifiedProcessor before
         invoking the strategy).  These are used for output reconciliation.
         """
+        processable, quarantined_results = partition_cascade_records(
+            records, action_name=context.agent_name
+        )
+
+        if not processable:
+            return list(quarantined_results)
+
         original_data = context.source_data
         try:
             context_scope = context.agent_config.get("context_scope") or {}
             clean_input: list[TrackedItem] = []
-            for i, record in enumerate(records):
+            for i, record in enumerate(processable):
                 business = extract_tool_input(record, context_scope)
                 clean_input.append(TrackedItem(business, source_index=i))
 
@@ -67,17 +79,17 @@ class FileToolStrategy:
                 skip_guard_eval=True,
             )
 
-            if is_empty_response(raw_response) and records:
+            if is_empty_response(raw_response) and processable:
                 # FILE mode collapses all input records into one failure result.
-                # Snapshot captures only records[0] — for multi-record batches the
+                # Snapshot captures only processable[0] — for multi-record batches the
                 # error message includes the total count for context.
-                return [
+                return quarantined_results + [
                     ProcessingResult.failed(
                         error=(
                             f"Tool '{context.agent_name}' returned empty result "
-                            f"from {len(records)} input record(s)"
+                            f"from {len(processable)} input record(s)"
                         ),
-                        source_snapshot=copy.deepcopy(records[0]) if records else None,
+                        source_snapshot=copy.deepcopy(processable[0]) if processable else None,
                     )
                 ]
 
@@ -92,12 +104,12 @@ class FileToolStrategy:
                 data=structured_data,
                 source_guid=None,  # FILE mode has no single source
                 raw_response=raw_response,
-                is_expansion=len(structured_data) > len(records),
+                is_expansion=len(structured_data) > len(processable),
             )
             result.executed = executed
             result.source_mapping = source_mapping
 
-            return [result]
+            return quarantined_results + [result]
 
         except AgentActionsError:
             raise
@@ -107,7 +119,7 @@ class FileToolStrategy:
                 f"FILE mode tool '{context.agent_name}' failed: {e}",
                 context={
                     "agent_name": context.agent_name,
-                    "record_count": len(records),
+                    "record_count": len(processable),
                     "operation": "file_mode_tool",
                 },
                 cause=e,

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -59,7 +59,7 @@ class FileToolStrategy:
         )
 
         if not processable and quarantined_results:
-            return list(quarantined_results)
+            return quarantined_results
 
         original_data = context.source_data
         try:

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import AgentActionsError
+from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.record_helpers import carry_framework_fields
 from agent_actions.processing.types import (
@@ -41,10 +42,20 @@ class HITLStrategy:
     ) -> list[ProcessingResult]:
         """Invoke a FILE-mode HITL action and broadcast the decision.
 
+        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
+        upstream) are partitioned out before the HITL tool runs.
+
         ``context.source_data`` must contain the pre-context-scope records
         that passed the guard filter (set by UnifiedProcessor before
         invoking the strategy).  These are used to build structured output.
         """
+        processable, quarantined_results = partition_cascade_records(
+            records, action_name=context.agent_name
+        )
+
+        if not processable:
+            return list(quarantined_results)
+
         original_data = context.source_data
         try:
             # Inject HITL state persistence metadata into agent config
@@ -62,7 +73,7 @@ class HITLStrategy:
                 hitl_agent_config["_hitl_file_stem"] = file_stem
 
             context_scope = context.agent_config.get("context_scope") or {}
-            filtered_records = [extract_tool_input(r, context_scope) for r in records]
+            filtered_records = [extract_tool_input(r, context_scope) for r in processable]
 
             empty_count = sum(1 for r in filtered_records if not r)
             if empty_count:
@@ -107,11 +118,11 @@ class HITLStrategy:
                     1 for r in (decision_payload.get("record_reviews") or []) if r is not None
                 )
                 raise AgentActionsError(
-                    f"HITL review timed out ({reviewed}/{len(records)} records reviewed). "
+                    f"HITL review timed out ({reviewed}/{len(processable)} records reviewed). "
                     "Partial reviews saved. Re-run workflow to resume.",
                     context={
                         "agent_name": context.agent_name,
-                        "record_count": len(records),
+                        "record_count": len(processable),
                     },
                 )
 
@@ -154,7 +165,7 @@ class HITLStrategy:
                 source_mapping={i: i for i in range(len(structured_data))},
             )
 
-            return [result]
+            return list(quarantined_results) + [result]
         except AgentActionsError:
             raise
         except Exception:

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -53,7 +53,7 @@ class HITLStrategy:
             records, action_name=context.agent_name
         )
 
-        if not processable:
+        if not processable and quarantined_results:
             return list(quarantined_results)
 
         original_data = context.source_data

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -17,6 +17,7 @@ from agent_actions.processing.types import (
     ProcessingStatus,
 )
 from agent_actions.record.envelope import RecordEnvelope
+from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.tools_resolver import resolve_tools_path
 from agent_actions.workflow.pipeline_file_mode import extract_tool_input
 
@@ -56,7 +57,11 @@ class HITLStrategy:
         if not processable and quarantined_results:
             return quarantined_results
 
-        original_data = context.source_data
+        # Filter original_data to exclude quarantined records so positional
+        # indexing of record_reviews aligns with what the HITL tool received.
+        original_data = [
+            r for r in (context.source_data or []) if r.get("_state") not in CASCADE_BLOCKING_VALUES
+        ]
         try:
             # Inject HITL state persistence metadata into agent config
             hitl_agent_config = dict(context.agent_config)

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -54,7 +54,7 @@ class HITLStrategy:
         )
 
         if not processable and quarantined_results:
-            return list(quarantined_results)
+            return quarantined_results
 
         original_data = context.source_data
         try:
@@ -165,7 +165,7 @@ class HITLStrategy:
                 source_mapping={i: i for i in range(len(structured_data))},
             )
 
-            return list(quarantined_results) + [result]
+            return quarantined_results + [result]
         except AgentActionsError:
             raise
         except Exception:

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -25,6 +25,7 @@ from agent_actions.logging.events.data_pipeline_events import (
     RecordTransformedEvent,
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
+from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 from agent_actions.processing.invocation import InvocationStrategy, InvocationStrategyFactory
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
@@ -137,25 +138,34 @@ class OnlineLLMStrategy:
     ) -> list[ProcessingResult]:
         """Process records through the online LLM pipeline.
 
-        Iterates records, calling process_record() for each. Record-specific
-        errors (RecordContextError, TemplateVariableError with missing vars)
-        produce tombstones and continue. Action-fatal errors (ConfigurationError,
-        TemplateSyntaxError, EmptyOutputError, SchemaValidationError) re-raise.
+        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
+        upstream) are partitioned out before processing — no LLM calls
+        are made for quarantined records.
+
+        Iterates remaining records, calling process_record() for each.
+        Record-specific errors (RecordContextError, TemplateVariableError
+        with missing vars) produce tombstones and continue. Action-fatal
+        errors (ConfigurationError, TemplateSyntaxError, EmptyOutputError,
+        SchemaValidationError) re-raise.
         """
+        processable, quarantined_results = partition_cascade_records(
+            records, action_name=context.agent_name
+        )
+
         start_time = datetime.now(UTC)
 
         fire_event(
             BatchProcessingStartedEvent(
                 action_name=context.agent_name,
-                batch_size=len(records),
+                batch_size=len(processable),
             )
         )
 
-        results: list[ProcessingResult] = []
+        results: list[ProcessingResult] = list(quarantined_results)
         successes = 0
         failures = 0
 
-        for idx, item in enumerate(records):
+        for idx, item in enumerate(processable):
             try:
                 item_context = _create_item_context(context, idx, item)
                 result = self.process_record(item, item_context)
@@ -166,12 +176,12 @@ class OnlineLLMStrategy:
                 elif result.status == ProcessingStatus.FAILED:
                     failures += 1
 
-                if (idx + 1) % 10 == 0 or (idx + 1) == len(records):
+                if (idx + 1) % 10 == 0 or (idx + 1) == len(processable):
                     fire_event(
                         BatchProcessingProgressEvent(
                             action_name=context.agent_name,
                             processed=idx + 1,
-                            total=len(records),
+                            total=len(processable),
                             successes=successes,
                             failures=failures,
                         )
@@ -245,7 +255,7 @@ class OnlineLLMStrategy:
         fire_event(
             BatchDataProcessingCompleteEvent(
                 action_name=context.agent_name,
-                total_records=len(records),
+                total_records=len(processable),
                 elapsed_time=elapsed_time,
             )
         )

--- a/agent_actions/validation/retry_validator.py
+++ b/agent_actions/validation/retry_validator.py
@@ -1,0 +1,23 @@
+"""Retry command validation module."""
+
+from pydantic import BaseModel, Field
+
+
+class RetryCommandArgs(BaseModel):
+    """Pydantic model for the retry command arguments."""
+
+    agent: str = Field(
+        ..., min_length=1, description="Agent configuration file name without path or extension"
+    )
+    from_action: str | None = Field(
+        default=None,
+        description="Action to retry from. If omitted, retries from earliest failure point.",
+    )
+    record: str | None = Field(
+        default=None,
+        description="Specific record source_guid to retry. If omitted, retries all failed records.",
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="Show what would be retried without executing.",
+    )

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from agent_actions.record.state import CASCADE_BLOCKING_VALUES
+from agent_actions.record.state import CASCADE_BLOCKING_VALUES, RecordState
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
@@ -253,7 +253,7 @@ def _propagate_cascade_blocking(merged: dict[str, Any], group: list[dict[str, An
     for rec in group:
         state = rec.get("_state")
         if state in CASCADE_BLOCKING_VALUES:
-            merged["_state"] = "cascade_skipped"
+            merged["_state"] = RecordState.CASCADE_SKIPPED.value
             logger.debug(
                 "Merge fan-in: propagating cascade-blocking state '%s' "
                 "from branch to merged record (source_guid=%s)",

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
@@ -219,7 +220,9 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
             continue
 
         if reduce_key:
-            merged_results.append(_merge_group_deep(group))
+            result = _merge_group_deep(group)
+            _propagate_cascade_blocking(result, group)
+            merged_results.append(result)
             continue
 
         branch_mapping = _identify_branch_mapping(group)
@@ -229,11 +232,35 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
             # merged["node_id"] == group[0]["node_id"] (from {**base, ...}).
             for rec in group[1:]:
                 _populate_lineage_sources(merged, rec)
+            _propagate_cascade_blocking(merged, group)
             merged_results.append(merged)
         else:
-            merged_results.append(_merge_group_deep(group))
+            result = _merge_group_deep(group)
+            _propagate_cascade_blocking(result, group)
+            merged_results.append(result)
 
     return merged_results + records_without_key
+
+
+def _propagate_cascade_blocking(merged: dict[str, Any], group: list[dict[str, Any]]) -> None:
+    """If ANY record in the group has cascade-blocking state, propagate it.
+
+    Fan-in merge with mixed quarantine: if record R2 failed in branch A
+    but succeeded in branch B, the merged record inherits cascade_skipped.
+    Incomplete data from one branch means the merge is incomplete — the
+    record should be retried from the branch where it failed.
+    """
+    for rec in group:
+        state = rec.get("_state")
+        if state in CASCADE_BLOCKING_VALUES:
+            merged["_state"] = "cascade_skipped"
+            logger.debug(
+                "Merge fan-in: propagating cascade-blocking state '%s' "
+                "from branch to merged record (source_guid=%s)",
+                state,
+                merged.get("source_guid", "?"),
+            )
+            return
 
 
 def merge_json_files(file_paths: list[Path], reduce_key: str | None = None) -> list[Any]:

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -249,6 +249,12 @@ def _propagate_cascade_blocking(merged: dict[str, Any], group: list[dict[str, An
     but succeeded in branch B, the merged record inherits cascade_skipped.
     Incomplete data from one branch means the merge is incomplete — the
     record should be retried from the branch where it failed.
+
+    This is an all-or-nothing policy: a single failed branch taints the
+    entire merge.  The successful branch data is still present in the
+    merged content (the merge runs before this function), but downstream
+    actions will cascade-skip the record.  A per-merge ``cascade_policy``
+    config (e.g. ``any_success``) could relax this in a future iteration.
     """
     for rec in group:
         state = rec.get("_state")

--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -216,6 +216,8 @@ def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> l
     merged_results: list[Any] = []
     for group in groups_by_key.values():
         if len(group) == 1:
+            # Single-branch passthrough — not a fan-in, so no cascade
+            # propagation needed.  The record keeps its original _state.
             merged_results.append(group[0])
             continue
 

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -578,10 +578,16 @@ class ProcessingPipeline:
         # Zero-success failure: raise so executor marks FAILED and circuit
         # breaker skips downstream.  Uses stats.success (not `not output`)
         # because EXHAUSTED tombstones inflate the output list.
-        if data and stats.success == 0 and (stats.failed + stats.exhausted) > 0:
+        #
+        # Exclude cascade-quarantined records from the denominator: if all
+        # ACTIVE input records failed but some records were quarantined
+        # pass-throughs, the action should not be marked FAILED (the
+        # quarantined records flow through untouched).
+        active_input_count = len(data) - stats.unprocessed
+        if active_input_count > 0 and stats.success == 0 and (stats.failed + stats.exhausted) > 0:
             raise RuntimeError(
                 f"Action '{self.config.action_name}' produced 0 successful records — "
-                f"all {len(data)} input item(s) failed or exhausted "
+                f"all {active_input_count} active input item(s) failed or exhausted "
                 f"({stats.failed} failed, {stats.exhausted} exhausted)"
             )
 

--- a/tests/helpers/cascade_helpers.py
+++ b/tests/helpers/cascade_helpers.py
@@ -1,0 +1,85 @@
+"""Shared test helpers for cascade/quarantine/retry tests.
+
+Centralizes record construction, result collection, and action simulation
+so cascade-related tests across unit/ and integration/ use one code path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_actions.processing.cascade_filter import partition_cascade_records
+from agent_actions.processing.result_collector import ResultCollector
+from agent_actions.processing.types import ProcessingResult
+
+
+def make_record(
+    source_guid: str,
+    state: str | None = None,
+    content: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal pipeline record with optional _state and content."""
+    r: dict[str, Any] = {
+        "source_guid": source_guid,
+        "content": content or {"upstream": {"val": source_guid}},
+    }
+    if state is not None:
+        r["_state"] = state
+    return r
+
+
+def collect_results(
+    results: list[ProcessingResult],
+    action_name: str,
+    storage_backend: Any = None,
+):
+    """Run results through the real ResultCollector."""
+    return ResultCollector.collect_results(
+        results,
+        agent_config={"agent_type": action_name},
+        agent_name=action_name,
+        is_first_stage=False,
+        storage_backend=storage_backend,
+    )
+
+
+def simulate_action(
+    input_records: list[dict[str, Any]],
+    action_name: str,
+    failing_guids: set[str],
+    storage_backend: Any = None,
+) -> tuple[list[dict[str, Any]], Any]:
+    """Simulate a processing action: partition → process → collect.
+
+    Records whose source_guid is in failing_guids produce FAILED results.
+    All others produce SUCCESS results. Uses real partition_cascade_records
+    and ResultCollector — no mocks.
+    """
+    processable, quarantined = partition_cascade_records(input_records, action_name=action_name)
+
+    results: list[ProcessingResult] = list(quarantined)
+
+    for record in processable:
+        guid = record.get("source_guid", "")
+        if guid in failing_guids:
+            results.append(
+                ProcessingResult.failed(
+                    error=f"Simulated failure for {guid}",
+                    source_guid=guid,
+                    input_record=record,
+                )
+            )
+        else:
+            output_data = dict(record)
+            output_data["content"] = {
+                **(record.get("content") or {}),
+                action_name: {"processed": True, "source": guid},
+            }
+            results.append(
+                ProcessingResult.success(
+                    data=[output_data],
+                    source_guid=guid,
+                )
+            )
+
+    return collect_results(results, action_name, storage_backend)

--- a/tests/integration/test_retry_lifecycle.py
+++ b/tests/integration/test_retry_lifecycle.py
@@ -12,20 +12,18 @@ Scenarios tested:
 """
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from agent_actions.cli.retry import RetryCommand
-from agent_actions.processing.cascade_filter import partition_cascade_records
-from agent_actions.processing.result_collector import ResultCollector
-from agent_actions.processing.types import ProcessingResult
 from agent_actions.storage.backend import (
     DISPOSITION_EXHAUSTED,
     DISPOSITION_FAILED,
     DISPOSITION_SUCCESS,
 )
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+from tests.helpers.cascade_helpers import make_record as _record
+from tests.helpers.cascade_helpers import simulate_action as _simulate_action
 
 
 @pytest.fixture
@@ -34,73 +32,6 @@ def backend(tmp_path: Path) -> SQLiteBackend:
     b = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
     b.initialize()
     return b
-
-
-def _record(guid: str, state: str | None = None, content: dict | None = None) -> dict[str, Any]:
-    r: dict[str, Any] = {
-        "source_guid": guid,
-        "content": content or {"upstream": {"val": guid}},
-    }
-    if state is not None:
-        r["_state"] = state
-    return r
-
-
-def _collect(
-    results: list[ProcessingResult],
-    action_name: str,
-    backend: SQLiteBackend | None = None,
-):
-    """Run results through the real ResultCollector with storage backend."""
-    return ResultCollector.collect_results(
-        results,
-        agent_config={"agent_type": action_name},
-        agent_name=action_name,
-        is_first_stage=False,
-        storage_backend=backend,
-    )
-
-
-def _simulate_action(
-    input_records: list[dict[str, Any]],
-    action_name: str,
-    failing_guids: set[str],
-    backend: SQLiteBackend | None = None,
-) -> tuple[list[dict[str, Any]], Any]:
-    """Simulate a processing action: partition, process, collect.
-
-    Records whose source_guid is in failing_guids produce FAILED results.
-    All others produce SUCCESS results.
-    """
-    processable, quarantined = partition_cascade_records(input_records, action_name=action_name)
-
-    results: list[ProcessingResult] = list(quarantined)
-
-    for record in processable:
-        guid = record.get("source_guid", "")
-        if guid in failing_guids:
-            results.append(
-                ProcessingResult.failed(
-                    error=f"Simulated failure for {guid}",
-                    source_guid=guid,
-                    input_record=record,
-                )
-            )
-        else:
-            output_data = dict(record)
-            output_data["content"] = {
-                **(record.get("content") or {}),
-                action_name: {"processed": True, "source": guid},
-            }
-            results.append(
-                ProcessingResult.success(
-                    data=[output_data],
-                    source_guid=guid,
-                )
-            )
-
-    output, stats = _collect(results, action_name, backend)
-    return output, stats
 
 
 class TestRetryLifecycle:

--- a/tests/integration/test_retry_lifecycle.py
+++ b/tests/integration/test_retry_lifecycle.py
@@ -1,0 +1,305 @@
+"""Integration test: full retry lifecycle — failure → quarantine → retry → success.
+
+Exercises the real components (SQLite backend, ResultCollector, cascade_filter,
+disposition queries) to prove that the retry flow actually works end-to-end.
+No mocks on the core path — only the LLM/tool invocation is simulated.
+
+Scenarios tested:
+1. Records fail at action B → cascade-skipped at C, D → retry from B → all succeed
+2. Partial failure: some records fail, others succeed → retry only re-processes failures
+3. Retry after retry: first retry partially fails again → second retry completes
+4. Multi-action failures: records fail at different actions → two retry passes fix all
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent_actions.cli.retry import RetryCommand
+from agent_actions.processing.cascade_filter import partition_cascade_records
+from agent_actions.processing.result_collector import ResultCollector
+from agent_actions.processing.types import ProcessingResult
+from agent_actions.storage.backend import (
+    DISPOSITION_EXHAUSTED,
+    DISPOSITION_FAILED,
+    DISPOSITION_SUCCESS,
+)
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+@pytest.fixture
+def backend(tmp_path: Path) -> SQLiteBackend:
+    """Create a real SQLite backend for testing."""
+    b = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
+    b.initialize()
+    return b
+
+
+def _record(guid: str, state: str | None = None, content: dict | None = None) -> dict[str, Any]:
+    r: dict[str, Any] = {
+        "source_guid": guid,
+        "content": content or {"upstream": {"val": guid}},
+    }
+    if state is not None:
+        r["_state"] = state
+    return r
+
+
+def _collect(
+    results: list[ProcessingResult],
+    action_name: str,
+    backend: SQLiteBackend | None = None,
+):
+    """Run results through the real ResultCollector with storage backend."""
+    return ResultCollector.collect_results(
+        results,
+        agent_config={"agent_type": action_name},
+        agent_name=action_name,
+        is_first_stage=False,
+        storage_backend=backend,
+    )
+
+
+def _simulate_action(
+    input_records: list[dict[str, Any]],
+    action_name: str,
+    failing_guids: set[str],
+    backend: SQLiteBackend | None = None,
+) -> tuple[list[dict[str, Any]], Any]:
+    """Simulate a processing action: partition, process, collect.
+
+    Records whose source_guid is in failing_guids produce FAILED results.
+    All others produce SUCCESS results.
+    """
+    processable, quarantined = partition_cascade_records(input_records, action_name=action_name)
+
+    results: list[ProcessingResult] = list(quarantined)
+
+    for record in processable:
+        guid = record.get("source_guid", "")
+        if guid in failing_guids:
+            results.append(
+                ProcessingResult.failed(
+                    error=f"Simulated failure for {guid}",
+                    source_guid=guid,
+                    input_record=record,
+                )
+            )
+        else:
+            output_data = dict(record)
+            output_data["content"] = {
+                **(record.get("content") or {}),
+                action_name: {"processed": True, "source": guid},
+            }
+            results.append(
+                ProcessingResult.success(
+                    data=[output_data],
+                    source_guid=guid,
+                )
+            )
+
+    output, stats = _collect(results, action_name, backend)
+    return output, stats
+
+
+class TestRetryLifecycle:
+    """Full lifecycle: failure → quarantine → disposition → retry → success."""
+
+    def test_fail_at_b_cascade_through_cd_retry_succeeds(self, backend):
+        """R1-R5 enter. R2, R4 fail at classify.
+        Enrich and summarize cascade-skip R2, R4.
+        Retry from classify with no failures → all 5 succeed.
+        """
+        # === Initial run ===
+        initial_input = [_record(f"r{i}", "active") for i in range(1, 6)]
+
+        # classify: R2 and R4 fail
+        classify_output, classify_stats = _simulate_action(
+            initial_input, "classify", {"r2", "r4"}, backend
+        )
+        assert classify_stats.success == 3
+        assert classify_stats.failed == 2
+
+        # Verify dispositions written
+        failed_disps = backend.get_disposition("classify", disposition=DISPOSITION_FAILED)
+        assert {d["record_id"] for d in failed_disps} == {"r2", "r4"}
+
+        # enrich: R2, R4 should be cascade-skipped
+        enrich_output, enrich_stats = _simulate_action(classify_output, "enrich", set(), backend)
+        assert enrich_stats.success == 3
+        assert enrich_stats.unprocessed == 2
+
+        # summarize: same cascade
+        summarize_output, summarize_stats = _simulate_action(
+            enrich_output, "summarize", set(), backend
+        )
+        assert summarize_stats.success == 3
+        assert summarize_stats.unprocessed == 2
+
+        # Verify cascade dispositions written downstream
+        enrich_unproc = backend.get_disposition("enrich", disposition="unprocessed")
+        assert {d["record_id"] for d in enrich_unproc} == {"r2", "r4"}
+
+        # === Retry from classify ===
+        # Clear dispositions (mimics what RetryCommand does)
+        execution_order = ["classify", "enrich", "summarize"]
+        for action in execution_order:
+            for record_id in ("r2", "r4"):
+                backend.clear_disposition(action, record_id=record_id)
+
+        # Verify dispositions cleared
+        assert backend.get_disposition("classify", disposition=DISPOSITION_FAILED) == []
+
+        # Re-run classify with original input — R2, R4 now succeed
+        retry_classify_output, retry_stats = _simulate_action(
+            initial_input,
+            "classify",
+            set(),
+            backend,  # no failures this time
+        )
+        assert retry_stats.success == 5
+        assert retry_stats.failed == 0
+
+        # Re-run enrich — all active (no cascade-blocked records now)
+        retry_enrich_output, retry_enrich_stats = _simulate_action(
+            retry_classify_output, "enrich", set(), backend
+        )
+        assert retry_enrich_stats.success == 5
+        assert retry_enrich_stats.unprocessed == 0
+
+        # Re-run summarize — all succeed
+        retry_summarize_output, retry_summarize_stats = _simulate_action(
+            retry_enrich_output, "summarize", set(), backend
+        )
+        assert retry_summarize_stats.success == 5
+        assert retry_summarize_stats.unprocessed == 0
+
+        # Final: all 5 records have success disposition at every action
+        for action in execution_order:
+            success_disps = backend.get_disposition(action, disposition=DISPOSITION_SUCCESS)
+            assert len(success_disps) == 5, f"{action} has {len(success_disps)} successes"
+
+    def test_retry_fails_again_then_second_retry_succeeds(self, backend):
+        """R1 fails at classify. First retry: R1 fails again.
+        Second retry: R1 succeeds. Proves idempotent retry.
+        """
+        initial = [_record("r1", "active"), _record("r2", "active")]
+
+        # Run 1: R1 fails
+        output1, stats1 = _simulate_action(initial, "classify", {"r1"}, backend)
+        assert stats1.failed == 1
+        assert stats1.success == 1
+
+        # Retry 1: clear and re-run — R1 fails AGAIN
+        backend.clear_disposition("classify", record_id="r1")
+        output2, stats2 = _simulate_action(initial, "classify", {"r1"}, backend)
+        assert stats2.failed == 1  # still failing
+
+        # Retry 2: clear and re-run — R1 succeeds this time
+        backend.clear_disposition("classify", record_id="r1")
+        output3, stats3 = _simulate_action(initial, "classify", set(), backend)
+        assert stats3.success == 2
+        assert stats3.failed == 0
+
+        # Final state: both records succeeded
+        success_disps = backend.get_disposition("classify", disposition=DISPOSITION_SUCCESS)
+        assert {d["record_id"] for d in success_disps} == {"r1", "r2"}
+
+    def test_multi_action_failures_require_two_retry_passes(self, backend):
+        """R2 fails at classify, R3 fails at enrich.
+        First retry (from classify): fixes R2, but R3 still fails at enrich.
+        Second retry (from enrich): fixes R3.
+        """
+        initial = [_record("r1", "active"), _record("r2", "active"), _record("r3", "active")]
+
+        # classify: R2 fails, R1 and R3 pass
+        classify_out, _ = _simulate_action(initial, "classify", {"r2"}, backend)
+
+        # enrich: R2 cascade-skipped, R3 fails here, R1 passes
+        enrich_out, enrich_stats = _simulate_action(classify_out, "enrich", {"r3"}, backend)
+        assert enrich_stats.success == 1  # R1
+        assert enrich_stats.failed == 1  # R3
+        assert enrich_stats.unprocessed == 1  # R2 cascade-skipped
+
+        # === Retry pass 1: from classify ===
+        # Use _find_failures to verify it picks up R2 at classify
+        failures = RetryCommand._find_failures(backend, ["classify", "enrich"])
+        assert "classify" in failures
+        assert any(d["record_id"] == "r2" for d in failures["classify"])
+        assert "enrich" in failures
+        assert any(d["record_id"] == "r3" for d in failures["enrich"])
+
+        # Clear classify + downstream for R2
+        backend.clear_disposition("classify", record_id="r2")
+        backend.clear_disposition("enrich", record_id="r2")
+
+        # Re-run classify: all succeed now
+        classify_out2, _ = _simulate_action(initial, "classify", set(), backend)
+
+        # Re-run enrich: R2 now processes, R3 still fails
+        enrich_out2, enrich_stats2 = _simulate_action(classify_out2, "enrich", {"r3"}, backend)
+        assert enrich_stats2.success == 2  # R1, R2
+        assert enrich_stats2.failed == 1  # R3 still failing
+
+        # === Retry pass 2: from enrich ===
+        backend.clear_disposition("enrich", record_id="r3")
+
+        # Re-run enrich: R3 succeeds now
+        enrich_out3, enrich_stats3 = _simulate_action(classify_out2, "enrich", set(), backend)
+        assert enrich_stats3.success == 3
+        assert enrich_stats3.failed == 0
+
+        # Final: all records have success at enrich
+        success_disps = backend.get_disposition("enrich", disposition=DISPOSITION_SUCCESS)
+        assert len(success_disps) == 3
+
+    def test_find_failures_matches_retry_command_semantics(self, backend):
+        """Verify _find_failures only returns FAILED and EXHAUSTED,
+        not unprocessed/passthrough/success.
+        """
+        # Write various dispositions
+        backend.set_disposition("action_a", "r1", DISPOSITION_SUCCESS)
+        backend.set_disposition("action_a", "r2", DISPOSITION_FAILED, reason="error")
+        backend.set_disposition("action_a", "r3", DISPOSITION_EXHAUSTED, reason="retry")
+        backend.set_disposition("action_a", "r4", "unprocessed", reason="cascade")
+        backend.set_disposition("action_a", "r5", "passthrough", reason="guard")
+
+        failures = RetryCommand._find_failures(backend, ["action_a"])
+
+        assert "action_a" in failures
+        record_ids = {d["record_id"] for d in failures["action_a"]}
+        # Only FAILED and EXHAUSTED — not success, unprocessed, passthrough
+        assert record_ids == {"r2", "r3"}
+
+    def test_cascade_chain_preserves_successful_records_on_retry(self, backend):
+        """On retry, previously-successful records should NOT be disturbed.
+
+        Proves that only the targeted records are cleared and re-run,
+        while other records retain their success disposition.
+        """
+        initial = [_record("r1", "active"), _record("r2", "active"), _record("r3", "active")]
+
+        # Initial run: R2 fails, R1 and R3 succeed
+        output, _ = _simulate_action(initial, "classify", {"r2"}, backend)
+
+        # Verify: R1 and R3 have success, R2 has failed
+        success = backend.get_disposition("classify", disposition=DISPOSITION_SUCCESS)
+        assert {d["record_id"] for d in success} == {"r1", "r3"}
+        failed = backend.get_disposition("classify", disposition=DISPOSITION_FAILED)
+        assert {d["record_id"] for d in failed} == {"r2"}
+
+        # Retry: clear ONLY R2's disposition
+        backend.clear_disposition("classify", record_id="r2")
+
+        # R1 and R3's success dispositions are still intact
+        success_after = backend.get_disposition("classify", disposition=DISPOSITION_SUCCESS)
+        assert {d["record_id"] for d in success_after} == {"r1", "r3"}
+
+        # Re-run: R2 succeeds now
+        output2, stats2 = _simulate_action(initial, "classify", set(), backend)
+        assert stats2.success == 3
+
+        # All three now have success
+        final_success = backend.get_disposition("classify", disposition=DISPOSITION_SUCCESS)
+        assert {d["record_id"] for d in final_success} == {"r1", "r2", "r3"}

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,26 @@
+"""Shared test fixtures for CLI command tests."""
+
+from unittest.mock import MagicMock
+
+
+def make_mock_backend(dispositions: dict[str, list[dict]] | None = None):
+    """Create a mock storage backend with disposition data.
+
+    Args:
+        dispositions: Mapping of action_name → list of disposition dicts.
+            Each dict should have at minimum ``record_id`` and ``disposition``.
+    """
+    dispositions = dispositions or {}
+    backend = MagicMock()
+
+    def get_disposition(action_name, record_id=None, disposition=None):
+        rows = dispositions.get(action_name, [])
+        if disposition:
+            rows = [r for r in rows if r.get("disposition") == disposition]
+        if record_id:
+            rows = [r for r in rows if r.get("record_id") == record_id]
+        return rows
+
+    backend.get_disposition = MagicMock(side_effect=get_disposition)
+    backend.clear_disposition = MagicMock(return_value=1)
+    return backend

--- a/tests/unit/cli/test_dispositions_command.py
+++ b/tests/unit/cli/test_dispositions_command.py
@@ -1,0 +1,96 @@
+"""Tests for the dispositions CLI command logic."""
+
+from unittest.mock import MagicMock
+
+from agent_actions.cli.dispositions import DispositionsCommand
+from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
+
+
+def _make_backend(dispositions: dict[str, list[dict]] | None = None):
+    """Create a mock storage backend with disposition data."""
+    dispositions = dispositions or {}
+    backend = MagicMock()
+
+    def get_disposition(action_name, record_id=None, disposition=None):
+        rows = dispositions.get(action_name, [])
+        if disposition:
+            rows = [r for r in rows if r.get("disposition") == disposition]
+        if record_id:
+            rows = [r for r in rows if r.get("record_id") == record_id]
+        return rows
+
+    backend.get_disposition = MagicMock(side_effect=get_disposition)
+    return backend
+
+
+class TestShowSummary:
+    """DispositionsCommand._show_summary renders disposition table."""
+
+    def test_summary_no_crash(self):
+        backend = _make_backend(
+            {
+                "extract": [
+                    {"record_id": "r1", "disposition": "success"},
+                    {"record_id": "r2", "disposition": "success"},
+                ],
+                "classify": [
+                    {"record_id": "r1", "disposition": "success"},
+                    {"record_id": "r2", "disposition": "failed", "reason": "LLM error"},
+                ],
+            }
+        )
+        cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
+        cmd.console = MagicMock()
+        cmd._show_summary(backend, ["extract", "classify"])
+        cmd.console.print.assert_called_once()
+
+    def test_summary_excludes_node_level_records(self):
+        backend = _make_backend(
+            {
+                "extract": [
+                    {"record_id": NODE_LEVEL_RECORD_ID, "disposition": "success"},
+                    {"record_id": "r1", "disposition": "success"},
+                ],
+            }
+        )
+        cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
+        cmd.console = MagicMock()
+        cmd._show_summary(backend, ["extract"])
+        # Should not crash, and node-level record should be excluded
+        cmd.console.print.assert_called_once()
+
+    def test_summary_skips_empty_actions(self):
+        backend = _make_backend({})
+        cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
+        cmd.console = MagicMock()
+        cmd._show_summary(backend, ["extract"])
+        cmd.console.print.assert_called_once()
+
+
+class TestShowQuarantined:
+    """DispositionsCommand._show_quarantined shows failed/exhausted details."""
+
+    def test_quarantined_shows_failed_records(self):
+        backend = _make_backend(
+            {
+                "classify": [
+                    {"record_id": "r2", "disposition": "failed", "reason": "LLM error"},
+                    {"record_id": "r4", "disposition": "exhausted", "reason": "retry_exhausted"},
+                ],
+            }
+        )
+        cmd = DispositionsCommand("test_workflow", action=None, quarantined=True)
+        cmd.console = MagicMock()
+        cmd._show_quarantined(backend, ["extract", "classify"])
+        # Should display the table (not the "no quarantined" message)
+        call_args = cmd.console.print.call_args_list
+        assert len(call_args) == 1
+
+    def test_quarantined_empty(self):
+        backend = _make_backend({})
+        cmd = DispositionsCommand("test_workflow", action=None, quarantined=True)
+        cmd.console = MagicMock()
+        cmd._show_quarantined(backend, ["extract"])
+        # Should print "no quarantined records" message
+        call_args = str(cmd.console.print.call_args_list[0])
+        assert "No quarantined" in call_args

--- a/tests/unit/cli/test_dispositions_command.py
+++ b/tests/unit/cli/test_dispositions_command.py
@@ -4,30 +4,14 @@ from unittest.mock import MagicMock
 
 from agent_actions.cli.dispositions import DispositionsCommand
 from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
-
-
-def _make_backend(dispositions: dict[str, list[dict]] | None = None):
-    """Create a mock storage backend with disposition data."""
-    dispositions = dispositions or {}
-    backend = MagicMock()
-
-    def get_disposition(action_name, record_id=None, disposition=None):
-        rows = dispositions.get(action_name, [])
-        if disposition:
-            rows = [r for r in rows if r.get("disposition") == disposition]
-        if record_id:
-            rows = [r for r in rows if r.get("record_id") == record_id]
-        return rows
-
-    backend.get_disposition = MagicMock(side_effect=get_disposition)
-    return backend
+from tests.unit.cli.conftest import make_mock_backend
 
 
 class TestShowSummary:
     """DispositionsCommand._show_summary renders disposition table."""
 
     def test_summary_no_crash(self):
-        backend = _make_backend(
+        backend = make_mock_backend(
             {
                 "extract": [
                     {"record_id": "r1", "disposition": "success"},
@@ -45,7 +29,7 @@ class TestShowSummary:
         cmd.console.print.assert_called_once()
 
     def test_summary_excludes_node_level_records(self):
-        backend = _make_backend(
+        backend = make_mock_backend(
             {
                 "extract": [
                     {"record_id": NODE_LEVEL_RECORD_ID, "disposition": "success"},
@@ -56,11 +40,10 @@ class TestShowSummary:
         cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
         cmd.console = MagicMock()
         cmd._show_summary(backend, ["extract"])
-        # Should not crash, and node-level record should be excluded
         cmd.console.print.assert_called_once()
 
     def test_summary_skips_empty_actions(self):
-        backend = _make_backend({})
+        backend = make_mock_backend({})
         cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
         cmd.console = MagicMock()
         cmd._show_summary(backend, ["extract"])
@@ -71,7 +54,7 @@ class TestShowQuarantined:
     """DispositionsCommand._show_quarantined shows failed/exhausted details."""
 
     def test_quarantined_shows_failed_records(self):
-        backend = _make_backend(
+        backend = make_mock_backend(
             {
                 "classify": [
                     {"record_id": "r2", "disposition": "failed", "reason": "LLM error"},
@@ -82,15 +65,13 @@ class TestShowQuarantined:
         cmd = DispositionsCommand("test_workflow", action=None, quarantined=True)
         cmd.console = MagicMock()
         cmd._show_quarantined(backend, ["extract", "classify"])
-        # Should display the table (not the "no quarantined" message)
         call_args = cmd.console.print.call_args_list
         assert len(call_args) == 1
 
     def test_quarantined_empty(self):
-        backend = _make_backend({})
+        backend = make_mock_backend({})
         cmd = DispositionsCommand("test_workflow", action=None, quarantined=True)
         cmd.console = MagicMock()
         cmd._show_quarantined(backend, ["extract"])
-        # Should print "no quarantined records" message
         call_args = str(cmd.console.print.call_args_list[0])
         assert "No quarantined" in call_args

--- a/tests/unit/cli/test_dispositions_command.py
+++ b/tests/unit/cli/test_dispositions_command.py
@@ -1,16 +1,26 @@
 """Tests for the dispositions CLI command logic."""
 
-from unittest.mock import MagicMock
+from io import StringIO
+
+from rich.console import Console
 
 from agent_actions.cli.dispositions import DispositionsCommand
 from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
 from tests.unit.cli.conftest import make_mock_backend
 
 
+def _make_cmd(agent="test_workflow", action=None, quarantined=False):
+    """Create a DispositionsCommand with captured console output."""
+    cmd = DispositionsCommand(agent, action=action, quarantined=quarantined)
+    buf = StringIO()
+    cmd.console = Console(file=buf, force_terminal=False, width=120)
+    return cmd, buf
+
+
 class TestShowSummary:
     """DispositionsCommand._show_summary renders disposition table."""
 
-    def test_summary_no_crash(self):
+    def test_summary_shows_correct_counts(self):
         backend = make_mock_backend(
             {
                 "extract": [
@@ -23,10 +33,13 @@ class TestShowSummary:
                 ],
             }
         )
-        cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
-        cmd.console = MagicMock()
+        cmd, buf = _make_cmd()
         cmd._show_summary(backend, ["extract", "classify"])
-        cmd.console.print.assert_called_once()
+        output = buf.getvalue()
+        # extract row: 2 success
+        assert "extract" in output
+        # classify row: 1 success, 1 failed
+        assert "classify" in output
 
     def test_summary_excludes_node_level_records(self):
         backend = make_mock_backend(
@@ -37,23 +50,24 @@ class TestShowSummary:
                 ],
             }
         )
-        cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
-        cmd.console = MagicMock()
+        cmd, buf = _make_cmd()
         cmd._show_summary(backend, ["extract"])
-        cmd.console.print.assert_called_once()
+        output = buf.getvalue()
+        # Should show extract with 1 record (node-level excluded)
+        assert "extract" in output
 
-    def test_summary_skips_empty_actions(self):
+    def test_summary_empty_shows_message(self):
         backend = make_mock_backend({})
-        cmd = DispositionsCommand("test_workflow", action=None, quarantined=False)
-        cmd.console = MagicMock()
+        cmd, buf = _make_cmd()
         cmd._show_summary(backend, ["extract"])
-        cmd.console.print.assert_called_once()
+        output = buf.getvalue()
+        assert "No dispositions recorded" in output
 
 
 class TestShowQuarantined:
     """DispositionsCommand._show_quarantined shows failed/exhausted details."""
 
-    def test_quarantined_shows_failed_records(self):
+    def test_quarantined_shows_record_details(self):
         backend = make_mock_backend(
             {
                 "classify": [
@@ -62,16 +76,17 @@ class TestShowQuarantined:
                 ],
             }
         )
-        cmd = DispositionsCommand("test_workflow", action=None, quarantined=True)
-        cmd.console = MagicMock()
+        cmd, buf = _make_cmd(quarantined=True)
         cmd._show_quarantined(backend, ["extract", "classify"])
-        call_args = cmd.console.print.call_args_list
-        assert len(call_args) == 1
+        output = buf.getvalue()
+        assert "r2" in output
+        assert "r4" in output
+        assert "failed" in output
+        assert "exhausted" in output
 
-    def test_quarantined_empty(self):
+    def test_quarantined_empty_shows_message(self):
         backend = make_mock_backend({})
-        cmd = DispositionsCommand("test_workflow", action=None, quarantined=True)
-        cmd.console = MagicMock()
+        cmd, buf = _make_cmd(quarantined=True)
         cmd._show_quarantined(backend, ["extract"])
-        call_args = str(cmd.console.print.call_args_list[0])
-        assert "No quarantined" in call_args
+        output = buf.getvalue()
+        assert "No quarantined records found" in output

--- a/tests/unit/cli/test_retry_command.py
+++ b/tests/unit/cli/test_retry_command.py
@@ -95,7 +95,32 @@ class TestRetryPlan:
             "classify",
             [{"record_id": "r2", "disposition": "failed", "reason": "LLM error"}],
             ["extract", "classify", "enrich", "summarize"],
+            all_failures={"classify": [{"record_id": "r2"}]},
         )
+
+    def test_display_retry_plan_shows_other_failures(self):
+        """When failures exist at later actions, the plan notes them."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        args = RetryCommandArgs(agent="test_workflow")
+        cmd = RetryCommand(args)
+        buf = StringIO()
+        cmd.console = Console(file=buf, force_terminal=False, width=120)
+
+        cmd._display_retry_plan(
+            "classify",
+            [{"record_id": "r2", "disposition": "failed", "reason": "error"}],
+            ["extract", "classify", "enrich", "summarize"],
+            all_failures={
+                "classify": [{"record_id": "r2"}],
+                "enrich": [{"record_id": "r5"}],
+            },
+        )
+        output = buf.getvalue()
+        assert "enrich" in output
+        assert "Run 'retry' again" in output
 
 
 class TestRetryCommandArgs:

--- a/tests/unit/cli/test_retry_command.py
+++ b/tests/unit/cli/test_retry_command.py
@@ -1,0 +1,148 @@
+"""Tests for the retry CLI command logic."""
+
+from unittest.mock import MagicMock
+
+from agent_actions.cli.retry import RetryCommand
+from agent_actions.validation.retry_validator import RetryCommandArgs
+
+
+def _make_backend(dispositions: dict[str, list[dict]] | None = None):
+    """Create a mock storage backend with disposition data."""
+    dispositions = dispositions or {}
+    backend = MagicMock()
+
+    def get_disposition(action_name, record_id=None, disposition=None):
+        rows = dispositions.get(action_name, [])
+        if disposition:
+            rows = [r for r in rows if r.get("disposition") == disposition]
+        if record_id:
+            rows = [r for r in rows if r.get("record_id") == record_id]
+        return rows
+
+    backend.get_disposition = MagicMock(side_effect=get_disposition)
+    backend.clear_disposition = MagicMock(return_value=1)
+    return backend
+
+
+class TestFindFailures:
+    """RetryCommand._find_failures queries disposition table correctly."""
+
+    def test_finds_failed_records(self):
+        backend = _make_backend(
+            {
+                "classify": [
+                    {
+                        "record_id": "r2",
+                        "disposition": "failed",
+                        "reason": "LLM error",
+                    }
+                ],
+            }
+        )
+        args = RetryCommandArgs(agent="test_workflow")
+        cmd = RetryCommand(args)
+        failures = cmd._find_failures(backend, ["extract", "classify", "enrich"])
+
+        assert "classify" in failures
+        assert len(failures["classify"]) == 1
+        assert failures["classify"][0]["record_id"] == "r2"
+
+    def test_finds_exhausted_records(self):
+        backend = _make_backend(
+            {
+                "classify": [
+                    {
+                        "record_id": "r4",
+                        "disposition": "exhausted",
+                        "reason": "retry_exhausted",
+                    }
+                ],
+            }
+        )
+        args = RetryCommandArgs(agent="test_workflow")
+        cmd = RetryCommand(args)
+        failures = cmd._find_failures(backend, ["extract", "classify"])
+
+        assert "classify" in failures
+        assert failures["classify"][0]["record_id"] == "r4"
+
+    def test_no_failures_returns_empty(self):
+        backend = _make_backend({})
+        args = RetryCommandArgs(agent="test_workflow")
+        cmd = RetryCommand(args)
+        failures = cmd._find_failures(backend, ["extract", "classify"])
+        assert failures == {}
+
+    def test_ignores_success_dispositions(self):
+        backend = _make_backend(
+            {
+                "classify": [
+                    {
+                        "record_id": "r1",
+                        "disposition": "success",
+                        "reason": "success",
+                    }
+                ],
+            }
+        )
+        args = RetryCommandArgs(agent="test_workflow")
+        cmd = RetryCommand(args)
+        failures = cmd._find_failures(backend, ["extract", "classify"])
+        assert failures == {}
+
+    def test_multiple_actions_with_failures(self):
+        backend = _make_backend(
+            {
+                "classify": [
+                    {"record_id": "r2", "disposition": "failed", "reason": "error"},
+                ],
+                "enrich": [
+                    {"record_id": "r3", "disposition": "exhausted", "reason": "retry"},
+                ],
+            }
+        )
+        args = RetryCommandArgs(agent="test_workflow")
+        cmd = RetryCommand(args)
+        failures = cmd._find_failures(backend, ["extract", "classify", "enrich"])
+        assert len(failures) == 2
+        assert "classify" in failures
+        assert "enrich" in failures
+
+
+class TestRetryPlan:
+    """RetryCommand._display_retry_plan builds correct output."""
+
+    def test_display_retry_plan_no_crash(self):
+        """Ensure display doesn't crash with valid input."""
+        args = RetryCommandArgs(agent="test_workflow")
+        cmd = RetryCommand(args)
+        cmd.console = MagicMock()
+
+        # Should not raise
+        cmd._display_retry_plan(
+            "classify",
+            [{"record_id": "r2", "disposition": "failed", "reason": "LLM error"}],
+            ["extract", "classify", "enrich", "summarize"],
+        )
+
+
+class TestRetryCommandArgs:
+    """Validation of retry command arguments."""
+
+    def test_minimal_args(self):
+        args = RetryCommandArgs(agent="my_workflow")
+        assert args.agent == "my_workflow"
+        assert args.from_action is None
+        assert args.record is None
+        assert args.dry_run is False
+
+    def test_full_args(self):
+        args = RetryCommandArgs(
+            agent="my_workflow",
+            from_action="classify",
+            record="r2",
+            dry_run=True,
+        )
+        assert args.from_action == "classify"
+        assert args.record == "r2"
+        assert args.dry_run is True

--- a/tests/unit/cli/test_retry_command.py
+++ b/tests/unit/cli/test_retry_command.py
@@ -4,31 +4,14 @@ from unittest.mock import MagicMock
 
 from agent_actions.cli.retry import RetryCommand
 from agent_actions.validation.retry_validator import RetryCommandArgs
-
-
-def _make_backend(dispositions: dict[str, list[dict]] | None = None):
-    """Create a mock storage backend with disposition data."""
-    dispositions = dispositions or {}
-    backend = MagicMock()
-
-    def get_disposition(action_name, record_id=None, disposition=None):
-        rows = dispositions.get(action_name, [])
-        if disposition:
-            rows = [r for r in rows if r.get("disposition") == disposition]
-        if record_id:
-            rows = [r for r in rows if r.get("record_id") == record_id]
-        return rows
-
-    backend.get_disposition = MagicMock(side_effect=get_disposition)
-    backend.clear_disposition = MagicMock(return_value=1)
-    return backend
+from tests.unit.cli.conftest import make_mock_backend
 
 
 class TestFindFailures:
     """RetryCommand._find_failures queries disposition table correctly."""
 
     def test_finds_failed_records(self):
-        backend = _make_backend(
+        backend = make_mock_backend(
             {
                 "classify": [
                     {
@@ -39,16 +22,14 @@ class TestFindFailures:
                 ],
             }
         )
-        args = RetryCommandArgs(agent="test_workflow")
-        cmd = RetryCommand(args)
-        failures = cmd._find_failures(backend, ["extract", "classify", "enrich"])
+        failures = RetryCommand._find_failures(backend, ["extract", "classify", "enrich"])
 
         assert "classify" in failures
         assert len(failures["classify"]) == 1
         assert failures["classify"][0]["record_id"] == "r2"
 
     def test_finds_exhausted_records(self):
-        backend = _make_backend(
+        backend = make_mock_backend(
             {
                 "classify": [
                     {
@@ -59,22 +40,18 @@ class TestFindFailures:
                 ],
             }
         )
-        args = RetryCommandArgs(agent="test_workflow")
-        cmd = RetryCommand(args)
-        failures = cmd._find_failures(backend, ["extract", "classify"])
+        failures = RetryCommand._find_failures(backend, ["extract", "classify"])
 
         assert "classify" in failures
         assert failures["classify"][0]["record_id"] == "r4"
 
     def test_no_failures_returns_empty(self):
-        backend = _make_backend({})
-        args = RetryCommandArgs(agent="test_workflow")
-        cmd = RetryCommand(args)
-        failures = cmd._find_failures(backend, ["extract", "classify"])
+        backend = make_mock_backend({})
+        failures = RetryCommand._find_failures(backend, ["extract", "classify"])
         assert failures == {}
 
     def test_ignores_success_dispositions(self):
-        backend = _make_backend(
+        backend = make_mock_backend(
             {
                 "classify": [
                     {
@@ -85,13 +62,11 @@ class TestFindFailures:
                 ],
             }
         )
-        args = RetryCommandArgs(agent="test_workflow")
-        cmd = RetryCommand(args)
-        failures = cmd._find_failures(backend, ["extract", "classify"])
+        failures = RetryCommand._find_failures(backend, ["extract", "classify"])
         assert failures == {}
 
     def test_multiple_actions_with_failures(self):
-        backend = _make_backend(
+        backend = make_mock_backend(
             {
                 "classify": [
                     {"record_id": "r2", "disposition": "failed", "reason": "error"},
@@ -101,9 +76,7 @@ class TestFindFailures:
                 ],
             }
         )
-        args = RetryCommandArgs(agent="test_workflow")
-        cmd = RetryCommand(args)
-        failures = cmd._find_failures(backend, ["extract", "classify", "enrich"])
+        failures = RetryCommand._find_failures(backend, ["extract", "classify", "enrich"])
         assert len(failures) == 2
         assert "classify" in failures
         assert "enrich" in failures
@@ -118,7 +91,6 @@ class TestRetryPlan:
         cmd = RetryCommand(args)
         cmd.console = MagicMock()
 
-        # Should not raise
         cmd._display_retry_plan(
             "classify",
             [{"record_id": "r2", "disposition": "failed", "reason": "LLM error"}],

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -105,7 +105,12 @@ def test_result_collector_aggregates_statuses_first_stage():
         "items": [],
         "obj": {},
     }
-    assert len(output) == 3
+    # FAILED record now produces a tombstone in output (record-level error isolation)
+    failed_tombstone = output[3]
+    assert failed_tombstone["source_guid"] == "src-4"
+    assert failed_tombstone["_state"] == "failed"
+    assert failed_tombstone["metadata"]["agent_type"] == "tombstone"
+    assert len(output) == 4
 
 
 def test_result_collector_uses_input_record_downstream():
@@ -504,7 +509,10 @@ class TestResultCollectorDispositions:
             is_first_stage=False,
             storage_backend=None,
         )
-        assert output == []
+        # FAILED now produces a tombstone (record-level error isolation)
+        assert len(output) == 1
+        assert output[0]["_state"] == "failed"
+        assert output[0]["source_guid"] == "src-fail"
 
     def test_no_source_guid_no_disposition(self):
         """Records without source_guid should not attempt disposition writes."""

--- a/tests/unit/processing/test_cascade_filter.py
+++ b/tests/unit/processing/test_cascade_filter.py
@@ -1,0 +1,119 @@
+"""Tests for cascade_filter — record-level quarantine before strategy invocation."""
+
+from agent_actions.processing.cascade_filter import partition_cascade_records
+from agent_actions.processing.types import ProcessingStatus
+from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
+
+
+def _record(source_guid: str, state: str | None = None) -> dict:
+    """Build a minimal record with optional _state."""
+    r: dict = {"source_guid": source_guid, "content": {"data": source_guid}}
+    if state is not None:
+        r["_state"] = state
+    return r
+
+
+class TestPartitionCascadeRecords:
+    """partition_cascade_records splits records by CASCADE_BLOCKING state."""
+
+    def test_all_active_records_pass_through(self):
+        records = [_record("r1", "active"), _record("r2", "active")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 2
+        assert len(quarantined) == 0
+
+    def test_no_state_records_pass_through(self):
+        """Records without _state (e.g. first-stage) are processable."""
+        records = [_record("r1"), _record("r2")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 2
+        assert len(quarantined) == 0
+
+    def test_failed_record_quarantined(self):
+        records = [_record("r1", "active"), _record("r2", "failed")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 1
+        assert processable[0]["source_guid"] == "r1"
+        assert len(quarantined) == 1
+        assert quarantined[0].status == ProcessingStatus.UNPROCESSED
+        assert quarantined[0].source_guid == "r2"
+
+    def test_exhausted_record_quarantined(self):
+        records = [_record("r1", "active"), _record("r2", "exhausted")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 1
+        assert len(quarantined) == 1
+        assert quarantined[0].source_guid == "r2"
+
+    def test_cascade_skipped_record_quarantined(self):
+        records = [_record("r1", "active"), _record("r2", "cascade_skipped")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 1
+        assert len(quarantined) == 1
+
+    def test_mixed_states(self):
+        """Multiple blocking states intermixed with active records."""
+        records = [
+            _record("r1", "active"),
+            _record("r2", "failed"),
+            _record("r3", "active"),
+            _record("r4", "exhausted"),
+            _record("r5", "cascade_skipped"),
+        ]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert [r["source_guid"] for r in processable] == ["r1", "r3"]
+        assert len(quarantined) == 3
+
+    def test_all_quarantined(self):
+        """When all records are cascade-blocked, processable is empty."""
+        records = [_record("r1", "failed"), _record("r2", "exhausted")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 0
+        assert len(quarantined) == 2
+
+    def test_empty_input(self):
+        processable, quarantined = partition_cascade_records([], action_name="test_action")
+        assert processable == []
+        assert quarantined == []
+
+    def test_quarantined_result_has_tombstone_data(self):
+        """Quarantined results carry a tombstone record with lineage fields."""
+        records = [_record("r1", "failed")]
+        _, quarantined = partition_cascade_records(records, action_name="test_action")
+        result = quarantined[0]
+        assert result.data is not None
+        assert len(result.data) == 1
+        tombstone = result.data[0]
+        assert tombstone["source_guid"] == "r1"
+        assert tombstone["metadata"]["reason"] == UPSTREAM_UNPROCESSED
+        assert tombstone["metadata"]["agent_type"] == "tombstone"
+
+    def test_quarantined_result_reason(self):
+        records = [_record("r1", "cascade_skipped")]
+        _, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert quarantined[0].skip_reason == UPSTREAM_UNPROCESSED
+
+    def test_processable_preserves_order(self):
+        """Processable records maintain original ordering."""
+        records = [
+            _record("r1", "active"),
+            _record("r2", "failed"),
+            _record("r3", "active"),
+            _record("r4", "active"),
+        ]
+        processable, _ = partition_cascade_records(records, action_name="test_action")
+        assert [r["source_guid"] for r in processable] == ["r1", "r3", "r4"]
+
+    def test_processed_state_not_quarantined(self):
+        """PROCESSED records are resettable, not cascade-blocking."""
+        records = [_record("r1", "processed")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 1
+        assert len(quarantined) == 0
+
+    def test_guard_skipped_not_quarantined(self):
+        """GUARD_SKIPPED records are resettable, not cascade-blocking."""
+        records = [_record("r1", "guard_skipped")]
+        processable, quarantined = partition_cascade_records(records, action_name="test_action")
+        assert len(processable) == 1
+        assert len(quarantined) == 0

--- a/tests/unit/processing/test_cascade_filter.py
+++ b/tests/unit/processing/test_cascade_filter.py
@@ -3,14 +3,7 @@
 from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.types import ProcessingStatus
 from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
-
-
-def _record(source_guid: str, state: str | None = None) -> dict:
-    """Build a minimal record with optional _state."""
-    r: dict = {"source_guid": source_guid, "content": {"data": source_guid}}
-    if state is not None:
-        r["_state"] = state
-    return r
+from tests.helpers.cascade_helpers import make_record as _record
 
 
 class TestPartitionCascadeRecords:

--- a/tests/unit/processing/test_cascade_propagation_chain.py
+++ b/tests/unit/processing/test_cascade_propagation_chain.py
@@ -1,0 +1,153 @@
+"""Integration test: cascade-skip state propagates through a 3-stage chain.
+
+Proves the invariant that a FAILED record at stage 1 arrives at stage 3
+with _state=cascade_skipped — i.e. the tombstone produced by
+partition_cascade_records is properly stamped by ResultCollector and
+recognized by partition_cascade_records at the next stage.
+
+This is the critical end-to-end guarantee for record-level error isolation.
+"""
+
+from typing import Any
+
+from agent_actions.processing.cascade_filter import partition_cascade_records
+from agent_actions.processing.result_collector import ResultCollector
+from agent_actions.processing.types import ProcessingResult, ProcessingStatus
+from agent_actions.record.state import RecordState
+
+
+def _make_record(source_guid: str, state: str | None = None) -> dict[str, Any]:
+    r: dict[str, Any] = {
+        "source_guid": source_guid,
+        "content": {"upstream": {"val": source_guid}},
+    }
+    if state is not None:
+        r["_state"] = state
+    return r
+
+
+def _collect(results: list[ProcessingResult], action_name: str):
+    """Run results through ResultCollector like the real pipeline does."""
+    return ResultCollector.collect_results(
+        results,
+        agent_config={"agent_type": action_name},
+        agent_name=action_name,
+        is_first_stage=False,
+    )
+
+
+class TestThreeStageCascadePropagation:
+    """Prove that a failed record cascades through 3 stages correctly."""
+
+    def test_failed_record_cascades_through_three_stages(self):
+        """Stage 1: R1 succeeds, R2 fails.
+        Stage 2: R1 processes, R2 cascade-skipped.
+        Stage 3: R1 processes, R2 still cascade-skipped.
+        """
+        # === Stage 1: classify ===
+        # R1 succeeds, R2 fails
+        stage1_results = [
+            ProcessingResult.success(
+                data=[{"source_guid": "r1", "content": {"classify": {"label": "A"}}}],
+                source_guid="r1",
+            ),
+            ProcessingResult.failed(
+                error="LLM timeout",
+                source_guid="r2",
+                input_record=_make_record("r2", "active"),
+            ),
+        ]
+        stage1_output, stage1_stats = _collect(stage1_results, "classify")
+
+        assert stage1_stats.success == 1
+        assert stage1_stats.failed == 1
+        # R1 is PROCESSED, R2 is a FAILED tombstone
+        assert len(stage1_output) == 2
+        r1_out = next(r for r in stage1_output if r["source_guid"] == "r1")
+        r2_out = next(r for r in stage1_output if r["source_guid"] == "r2")
+        assert r1_out["_state"] == RecordState.PROCESSED.value
+        assert r2_out["_state"] == RecordState.FAILED.value
+
+        # === Stage 2: enrich ===
+        # Feed stage 1 output as input to stage 2.
+        # partition_cascade_records should quarantine R2 (FAILED → CASCADE_BLOCKING).
+        processable_s2, quarantined_s2 = partition_cascade_records(
+            stage1_output, action_name="enrich"
+        )
+        assert len(processable_s2) == 1
+        assert processable_s2[0]["source_guid"] == "r1"
+        assert len(quarantined_s2) == 1
+        assert quarantined_s2[0].source_guid == "r2"
+        assert quarantined_s2[0].status == ProcessingStatus.UNPROCESSED
+
+        # Simulate: R1 processes successfully, R2 is quarantined
+        stage2_results = quarantined_s2 + [
+            ProcessingResult.success(
+                data=[{"source_guid": "r1", "content": {"enrich": {"score": 0.9}}}],
+                source_guid="r1",
+            ),
+        ]
+        stage2_output, stage2_stats = _collect(stage2_results, "enrich")
+
+        assert stage2_stats.success == 1
+        assert stage2_stats.unprocessed == 1
+        # R2's tombstone should now be stamped CASCADE_SKIPPED by ResultCollector
+        r2_stage2 = next(r for r in stage2_output if r["source_guid"] == "r2")
+        assert r2_stage2["_state"] == RecordState.CASCADE_SKIPPED.value
+
+        # === Stage 3: summarize ===
+        # Feed stage 2 output. R2 should still be quarantined.
+        processable_s3, quarantined_s3 = partition_cascade_records(
+            stage2_output, action_name="summarize"
+        )
+        assert len(processable_s3) == 1
+        assert processable_s3[0]["source_guid"] == "r1"
+        assert len(quarantined_s3) == 1
+        assert quarantined_s3[0].source_guid == "r2"
+
+        # Simulate: R1 processes, R2 quarantined again
+        stage3_results = quarantined_s3 + [
+            ProcessingResult.success(
+                data=[{"source_guid": "r1", "content": {"summarize": {"text": "done"}}}],
+                source_guid="r1",
+            ),
+        ]
+        stage3_output, stage3_stats = _collect(stage3_results, "summarize")
+
+        assert stage3_stats.success == 1
+        assert stage3_stats.unprocessed == 1
+        # R2 still cascade-skipped at stage 3
+        r2_stage3 = next(r for r in stage3_output if r["source_guid"] == "r2")
+        assert r2_stage3["_state"] == RecordState.CASCADE_SKIPPED.value
+        # R1 fully processed
+        r1_stage3 = next(r for r in stage3_output if r["source_guid"] == "r1")
+        assert r1_stage3["_state"] == RecordState.PROCESSED.value
+
+    def test_all_quarantined_no_zero_success_error(self):
+        """When all active records fail but quarantined records pass through,
+        the zero-success check should NOT fire.
+
+        This tests the pipeline.py denominator fix: active_input_count
+        excludes unprocessed (quarantined) records.
+        """
+        # 3 records: 2 cascade-skipped from upstream, 1 active
+        records = [
+            _make_record("r1", "cascade_skipped"),
+            _make_record("r2", "cascade_skipped"),
+        ]
+        # All records are quarantined — no active records to fail
+        processable, quarantined = partition_cascade_records(records, action_name="enrich")
+        assert len(processable) == 0
+        assert len(quarantined) == 2
+
+        # Collect: only unprocessed results, zero success, zero failures
+        output, stats = _collect(quarantined, "enrich")
+        assert stats.success == 0
+        assert stats.failed == 0
+        assert stats.unprocessed == 2
+
+        # The zero-success check uses: active_input_count = len(data) - stats.unprocessed
+        # With all quarantined: active_input_count = 2 - 2 = 0
+        # Condition: active_input_count > 0 → False → no RuntimeError
+        active_input_count = len(records) - stats.unprocessed
+        assert active_input_count == 0  # proves the check would not fire

--- a/tests/unit/processing/test_cascade_propagation_chain.py
+++ b/tests/unit/processing/test_cascade_propagation_chain.py
@@ -8,32 +8,11 @@ recognized by partition_cascade_records at the next stage.
 This is the critical end-to-end guarantee for record-level error isolation.
 """
 
-from typing import Any
-
 from agent_actions.processing.cascade_filter import partition_cascade_records
-from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingResult, ProcessingStatus
 from agent_actions.record.state import RecordState
-
-
-def _make_record(source_guid: str, state: str | None = None) -> dict[str, Any]:
-    r: dict[str, Any] = {
-        "source_guid": source_guid,
-        "content": {"upstream": {"val": source_guid}},
-    }
-    if state is not None:
-        r["_state"] = state
-    return r
-
-
-def _collect(results: list[ProcessingResult], action_name: str):
-    """Run results through ResultCollector like the real pipeline does."""
-    return ResultCollector.collect_results(
-        results,
-        agent_config={"agent_type": action_name},
-        agent_name=action_name,
-        is_first_stage=False,
-    )
+from tests.helpers.cascade_helpers import collect_results as _collect
+from tests.helpers.cascade_helpers import make_record as _make_record
 
 
 class TestThreeStageCascadePropagation:

--- a/tests/unit/processing/test_hitl_cascade_mixed.py
+++ b/tests/unit/processing/test_hitl_cascade_mixed.py
@@ -1,0 +1,109 @@
+"""Test HITL strategy with cascade-blocked records mixed in.
+
+Proves that when cascade-blocked records are present in input,
+HITL review decisions are applied to the correct active records
+by position (not misattributed to quarantined records).
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+from agent_actions.processing.strategies.hitl import HITLStrategy
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+
+
+def _make_context(agent_name: str = "hitl_review", **kwargs) -> ProcessingContext:
+    config: dict[str, Any] = {
+        "agent_type": agent_name,
+        "name": agent_name,
+        "context_scope": {},
+    }
+    return ProcessingContext(
+        agent_config=config,
+        agent_name=agent_name,
+        **kwargs,
+    )
+
+
+def _record(guid: str, state: str | None = None) -> dict[str, Any]:
+    r: dict[str, Any] = {
+        "source_guid": guid,
+        "content": {"upstream": {"val": guid}},
+    }
+    if state is not None:
+        r["_state"] = state
+    return r
+
+
+class TestHITLCascadeMixed:
+    """HITL with mixed active + cascade-blocked records."""
+
+    def test_reviews_applied_to_correct_records(self):
+        """Input: [R1 active, R2 failed, R3 active].
+        HITL sees [R1, R3] (processable only).
+        Returns record_reviews for [R1, R3].
+        R1 gets review_for_R1, R3 gets review_for_R3.
+        R2 appears only as a quarantined tombstone.
+        """
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "failed")
+        r3 = _record("r3", "active")
+
+        context = _make_context()
+        # source_data is set by UnifiedProcessor — includes all passing records
+        context.source_data = [r1, r2, r3]
+
+        hitl_response = {
+            "hitl_status": "approved",
+            "record_reviews": [
+                {"hitl_status": "approved", "user_comment": "R1 looks good"},
+                {"hitl_status": "rejected", "user_comment": "R3 needs work"},
+            ],
+        }
+
+        with patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=([hitl_response], True),
+        ):
+            results = HITLStrategy().invoke([r1, r2, r3], context)
+
+        # Should have quarantined results + 1 SUCCESS result
+        unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
+        assert len(unprocessed) == 1  # R2 quarantined
+        assert unprocessed[0].source_guid == "r2"
+
+        assert len(successes) == 1
+        success_data = successes[0].data
+        # Should have exactly 2 records (R1 and R3), not 3
+        assert len(success_data) == 2
+
+        # R1 should have "R1 looks good" comment
+        r1_out = success_data[0]
+        r1_content = r1_out.get("content", {})
+        hitl_ns = r1_content.get("hitl_review", {})
+        assert hitl_ns.get("user_comment") == "R1 looks good"
+
+        # R3 should have "R3 needs work" comment (not misattributed to R2)
+        r3_out = success_data[1]
+        r3_content = r3_out.get("content", {})
+        hitl_ns_r3 = r3_content.get("hitl_review", {})
+        assert hitl_ns_r3.get("user_comment") == "R3 needs work"
+
+    def test_all_quarantined_returns_only_tombstones(self):
+        """When all records are cascade-blocked, no HITL invocation happens."""
+        r1 = _record("r1", "failed")
+        r2 = _record("r2", "exhausted")
+
+        context = _make_context()
+        context.source_data = [r1, r2]
+
+        # run_dynamic_agent should NOT be called
+        with patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+        ) as mock_agent:
+            results = HITLStrategy().invoke([r1, r2], context)
+
+        mock_agent.assert_not_called()
+        assert len(results) == 2
+        assert all(r.status == ProcessingStatus.UNPROCESSED for r in results)

--- a/tests/unit/processing/test_hitl_cascade_mixed.py
+++ b/tests/unit/processing/test_hitl_cascade_mixed.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from agent_actions.processing.strategies.hitl import HITLStrategy
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from tests.helpers.cascade_helpers import make_record as _record
 
 
 def _make_context(agent_name: str = "hitl_review", **kwargs) -> ProcessingContext:
@@ -23,16 +24,6 @@ def _make_context(agent_name: str = "hitl_review", **kwargs) -> ProcessingContex
         agent_name=agent_name,
         **kwargs,
     )
-
-
-def _record(guid: str, state: str | None = None) -> dict[str, Any]:
-    r: dict[str, Any] = {
-        "source_guid": guid,
-        "content": {"upstream": {"val": guid}},
-    }
-    if state is not None:
-        r["_state"] = state
-    return r
 
 
 class TestHITLCascadeMixed:

--- a/tests/unit/processing/test_hitl_cascade_mixed.py
+++ b/tests/unit/processing/test_hitl_cascade_mixed.py
@@ -107,3 +107,44 @@ class TestHITLCascadeMixed:
         mock_agent.assert_not_called()
         assert len(results) == 2
         assert all(r.status == ProcessingStatus.UNPROCESSED for r in results)
+
+    def test_interleaved_cascade_blocked_at_start_and_end(self):
+        """Input: [R1 failed, R2 active, R3 failed, R4 active, R5 failed].
+        Processable: [R2, R4]. Reviews indexed correctly despite gaps.
+        """
+        r1 = _record("r1", "failed")
+        r2 = _record("r2", "active")
+        r3 = _record("r3", "exhausted")
+        r4 = _record("r4", "active")
+        r5 = _record("r5", "cascade_skipped")
+
+        context = _make_context()
+        context.source_data = [r1, r2, r3, r4, r5]
+
+        hitl_response = {
+            "hitl_status": "approved",
+            "record_reviews": [
+                {"hitl_status": "approved", "user_comment": "R2 approved"},
+                {"hitl_status": "rejected", "user_comment": "R4 rejected"},
+            ],
+        }
+
+        with patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=([hitl_response], True),
+        ):
+            results = HITLStrategy().invoke([r1, r2, r3, r4, r5], context)
+
+        unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
+        assert len(unprocessed) == 3  # R1, R3, R5 quarantined
+        assert len(successes) == 1
+
+        success_data = successes[0].data
+        assert len(success_data) == 2  # R2 and R4 only
+
+        r2_content = success_data[0].get("content", {}).get("hitl_review", {})
+        assert r2_content.get("user_comment") == "R2 approved"
+
+        r4_content = success_data[1].get("content", {}).get("hitl_review", {})
+        assert r4_content.get("user_comment") == "R4 rejected"

--- a/tests/unit/workflow/test_merge.py
+++ b/tests/unit/workflow/test_merge.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 from agent_actions.workflow.merge import (
     _identify_branch_mapping,
     _merge_group_deep,
+    _propagate_cascade_blocking,
     deep_merge_record,
     get_correlation_value,
     merge_json_files,
@@ -788,3 +789,70 @@ class TestMergeGroupDeep:
 
         assert result["content"]["ns_a"]["a"] == 1
         assert result["content"]["ns_b"]["b"] == 2
+
+
+class TestPropagateCascadeBlocking:
+    """Fan-in merge must propagate cascade-blocking state from any branch."""
+
+    def test_no_blocking_state_leaves_merged_unchanged(self):
+        merged = {"_state": "processed", "source_guid": "r1"}
+        group = [
+            {"_state": "processed", "source_guid": "r1"},
+            {"_state": "processed", "source_guid": "r1"},
+        ]
+        _propagate_cascade_blocking(merged, group)
+        assert merged["_state"] == "processed"
+
+    def test_failed_branch_propagates_cascade_skipped(self):
+        merged = {"_state": "processed", "source_guid": "r1"}
+        group = [
+            {"_state": "processed", "source_guid": "r1"},
+            {"_state": "failed", "source_guid": "r1"},
+        ]
+        _propagate_cascade_blocking(merged, group)
+        assert merged["_state"] == "cascade_skipped"
+
+    def test_exhausted_branch_propagates_cascade_skipped(self):
+        merged = {"_state": "processed", "source_guid": "r1"}
+        group = [
+            {"_state": "processed", "source_guid": "r1"},
+            {"_state": "exhausted", "source_guid": "r1"},
+        ]
+        _propagate_cascade_blocking(merged, group)
+        assert merged["_state"] == "cascade_skipped"
+
+    def test_cascade_skipped_branch_propagates(self):
+        merged = {"_state": "processed", "source_guid": "r1"}
+        group = [
+            {"_state": "processed", "source_guid": "r1"},
+            {"_state": "cascade_skipped", "source_guid": "r1"},
+        ]
+        _propagate_cascade_blocking(merged, group)
+        assert merged["_state"] == "cascade_skipped"
+
+    def test_all_healthy_no_change(self):
+        merged = {"_state": "active", "source_guid": "r1"}
+        group = [
+            {"_state": "active", "source_guid": "r1"},
+            {"_state": "guard_skipped", "source_guid": "r1"},
+        ]
+        _propagate_cascade_blocking(merged, group)
+        assert merged["_state"] == "active"
+
+    def test_merge_records_by_key_propagates_blocking(self):
+        """End-to-end: merge_records_by_key applies cascade propagation."""
+        records = [
+            {
+                "source_guid": "r1",
+                "_state": "processed",
+                "content": {"branch_a": {"val": 1}},
+            },
+            {
+                "source_guid": "r1",
+                "_state": "failed",
+                "content": {"branch_b": None},
+            },
+        ]
+        result = merge_records_by_key(records)
+        assert len(result) == 1
+        assert result[0]["_state"] == "cascade_skipped"

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -1736,3 +1736,44 @@ def test_file_tool_version_merge_spreads_not_wraps():
     # Existing version namespaces preserved
     assert content["extract_1"]["vote"] == "keep"
     assert content["extract_2"]["vote"] == "drop"
+
+
+def test_file_tool_cascade_blocked_source_index_alignment():
+    """Regression: TrackedItem.source_index must align with original_data.
+
+    Input: [R1 active, R2 failed, R3 active]. Processable = [R1, R3].
+    Tool returns TrackedItem results indexed 0→R1, 1→R3.
+    reconcile_outputs must map source_index=1 to R3 (not R2).
+    """
+    r1 = {"source_guid": "sg-1", "_state": "active", "content": {"prev": {"id": 1}}}
+    r2 = {"source_guid": "sg-2", "_state": "failed", "content": {"prev": {"id": 2}}}
+    r3 = {"source_guid": "sg-3", "_state": "active", "content": {"prev": {"id": 3}}}
+
+    context = _make_context()
+    context.source_data = [r1, r2, r3]
+
+    tool_output = [
+        TrackedItem({"result": "for_r1"}, source_index=0),
+        TrackedItem({"result": "for_r3"}, source_index=1),
+    ]
+
+    with patch(
+        "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+        return_value=(tool_output, True),
+    ):
+        results = FileToolStrategy().invoke([r1, r2, r3], context)
+
+    # R2 should be quarantined (UNPROCESSED), R1 and R3 processed
+    unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+    successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
+    assert len(unprocessed) == 1
+    assert unprocessed[0].source_guid == "sg-2"
+
+    assert len(successes) == 1
+    success_data = successes[0].data
+    assert len(success_data) == 2
+
+    # R1's output should carry R1's source_guid (not R2's)
+    assert success_data[0].get("source_guid") == "sg-1"
+    # R3's output should carry R3's source_guid (not R2's — the bug)
+    assert success_data[1].get("source_guid") == "sg-3"

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -445,7 +445,9 @@ def test_file_tool_empty_response_feeds_existing_failure_check():
 
     assert stats.failed == 1
     assert stats.success == 0
-    assert output == []
+    # FAILED now produces a tombstone for record-level error isolation
+    assert len(output) == 1
+    assert output[0]["_state"] == "failed"
 
 
 def test_file_udf_result_empty_with_input_returns_failed():
@@ -822,8 +824,10 @@ def test_result_collector_does_not_raise_on_partial_failure():
         is_first_stage=False,
     )
 
-    assert len(output) == 1
+    # 1 success + 1 failed tombstone
+    assert len(output) == 2
     assert output[0]["content"]["val"] == 1
+    assert output[1]["_state"] == "failed"
 
 
 def test_result_collector_does_not_raise_when_all_filtered():


### PR DESCRIPTION
## Summary

When a record fails at any action in a workflow, it is now **quarantined at the failure point** and excluded from all downstream processing — without affecting healthy records. After the workflow completes, a new `retry` command re-processes only the failed records from their failure action forward.

### What changed

- **Cascade filter** (`processing/cascade_filter.py`): Partitions records into processable and quarantined sets before any strategy runs. Wired into all three strategies (OnlineLLM, FileTool, HITL) — previously FileTool and HITL passed cascade-blocked records directly to tools
- **FAILED tombstone output**: FAILED records now produce tombstone records in the output stream (previously they vanished), so downstream actions can detect and cascade-skip them
- **Zero-success check fix**: Excludes quarantined pass-through records from the denominator — prevents false action-level FAILED status when only quarantined records remain
- **Merge fan-in quarantine**: When merging records from multiple branches, if any branch has a cascade-blocked record the merged result inherits `cascade_skipped`
- **`retry` CLI command**: `agent-actions retry -a <workflow> [--from <action>] [--dry-run] [--record <guid>]` — queries dispositions, displays retry plan, clears downstream dispositions, re-runs workflow
- **`dispositions` CLI command**: `agent-actions dispositions -a <workflow> [--quarantined]` — per-action breakdown of record outcomes for observability
- **Shared workflow loader**: Extracted `cli/workflow_loader.py` to avoid duplicate config loading across CLI commands

### Flow example

```
extract:   R1 ✓  R2 ✓  R3 ✓  R4 ✓  R5 ✓
classify:  R1 ✓  R2 ✗  R3 ✓  R4 ✗  R5 ✓   → R2, R4 quarantined
enrich:    R1 ✓  R2 ⊘  R3 ✓  R4 ⊘  R5 ✓   → R2, R4 cascade-skipped (no LLM call)
summarize: R1 ✓  R2 ⊘  R3 ✓  R4 ⊘  R5 ✓

$ agent-actions retry -a workflow --from classify
→ re-runs ONLY R2, R4 through classify → enrich → summarize
```

## Verification

- All 6833 tests pass (`pytest tests/ --ignore=tests/manual`)
- `ruff check` and `ruff format --check` clean
- New tests cover: cascade filter (13 tests), merge propagation (6 tests), retry command (8 tests), dispositions command (5 tests)
- Existing tests updated where FAILED tombstone output changed expected counts