### PR TITLE
fix: render long text fields as markdown in inspector

### DIFF
--- a/agent_actions/tooling/docs/frontend/app/globals.css
+++ b/agent_actions/tooling/docs/frontend/app/globals.css
@@ -294,6 +294,13 @@
     padding: 0.75em 1em;
     margin: 0.5em 0;
   }
+  .dc-prose pre code {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    color: inherit;
+    font-size: inherit;
+  }
 
   /* ─── JSON syntax highlighting ─── */
   .dc-json {
@@ -328,15 +335,6 @@
   }
 
   /* ─── Long text prose block in tree ─── */
-  .dc-tree-prose {
-    @apply rounded-md border px-3 py-2;
-    border-color: hsl(var(--border) / 0.3);
-    background: hsl(var(--secondary) / 0.3);
-    font-size: 13px;
-    line-height: 1.65;
-    color: hsl(var(--foreground) / 0.85);
-  }
-
   /* ─── Copy button ─── */
   .dc-copy-btn {
     @apply ml-auto shrink-0 rounded-md p-1 transition-colors;

--- a/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
+++ b/agent_actions/tooling/docs/frontend/components/ui/data-card.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useCallback, useEffect } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
+import rehypeRaw from "rehype-raw"
+import rehypeSanitize from "rehype-sanitize"
 import { ChevronRight, Copy, Check } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -89,7 +91,12 @@ function CopyButton({ text }: { text: string }) {
 function MarkdownProse({ text }: { text: string }) {
   return (
     <article className="dc-prose">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeSanitize]}
+      >
+        {text}
+      </ReactMarkdown>
     </article>
   )
 }
@@ -274,9 +281,9 @@ function FieldValue({ fieldKey, value }: { fieldKey: string; value: unknown }) {
   if (isSourceQuoteField(fieldKey) && typeof value === "string") {
     return <div className="dc-source-quote">{value}</div>
   }
-  // Long text — Notion prose block
+  // Long text — markdown prose block (supports <br>, code blocks, etc.)
   if (typeof value === "string" && value.length > 80) {
-    return <div className="dc-tree-prose">{value}</div>
+    return <MarkdownProse text={value} />
   }
   return <CellValue value={value} />
 }


### PR DESCRIPTION
## Summary
- Long text fields in data cards (OPTIMAL CODE, ALTERNATIVE CODE, etc.) rendered `<br>` as literal text and had no markdown support
- Switch `FieldValue` from plain `dc-tree-prose` div to `MarkdownProse` with `rehype-raw` + `rehype-sanitize` plugins
- Add `pre code` CSS reset so fenced code blocks don't inherit inline-code pill styling
- Remove dead `dc-tree-prose` class from `globals.css` (VS Code extension has its own standalone copy in `webview.css`)

## Verification
- `npm run build` passes
- Confirmed `dc-tree-prose` has no remaining references in frontend source files
- `rehype-sanitize` default schema blocks `<script>`, `on*` handlers, `javascript:` URIs