### PR TITLE
fix(examples): harden all 6 examples with production patterns

### DIFF
--- a/.changes/unreleased/Bug Fix-20260516-541000.yaml
+++ b/.changes/unreleased/Bug Fix-20260516-541000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Harden all 6 examples with production patterns: fix FileUDFResult for FILE-granularity tools, fix output_field guard namespacing, add default reprompt/retry/batch_max_workers config, remove debug artifacts"
+time: 2026-05-16T12:55:00.000000Z

--- a/examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml
+++ b/examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml
@@ -29,6 +29,7 @@ defaults:
     max_attempts: 2
   reprompt:
     on_schema_mismatch: reprompt
+    max_attempts: 3
     use_self_reflection: true
     on_exhausted: return_last
 

--- a/examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml
+++ b/examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml
@@ -1,9 +1,8 @@
 ################################################################################
 # Book Catalog Enrichment Pipeline
-#  model_vendor: agac-provider
-#  model_name: agac-model
-#  api_key: not_required
-#AGAC_BATCH_COMPLETE_AFTER_SECONDS
+# Demonstrates: HITL review, tool actions, reprompt on schema mismatch,
+#   parallel branches with dependency merging, context_scope observe/passthrough,
+#   multi-model routing, and quality filtering with user views.
 ################################################################################
 name: book_catalog_enrichment
 description: "Enrich book catalog entries with BISAC classification, marketing descriptions, SEO keywords, recommendations, and quality scoring"
@@ -17,14 +16,21 @@ defaults:
   model_name: gpt-4o-mini
   api_key: OPENAI_API_KEY
   is_operational: true
-  prompt_debug: false  # Enable to see reprompt feedback in action
-  record_limit: 2      # Remove for full processing
+  batch_max_workers: 8
+  data_source:
+    type: local
+    folder: ./staging
+    file_type: [json]
   context_scope:
     seed_path:
       book_catalog: $file:book_catalog.json
   retry:
     enabled: true
     max_attempts: 2
+  reprompt:
+    on_schema_mismatch: reprompt
+    use_self_reflection: true
+    on_exhausted: return_last
 
 actions:
   # ============================================================================
@@ -34,9 +40,8 @@ actions:
     intent: "Classify book into BISAC categories based on title, author, and description"
     schema: classify_genre
     prompt: $book_catalog_enrichment.Classify_Book_Genre
-    model_vendor: ollama_local                     # BISAC classification — fixed taxonomy, works with local models
-    model_name: llama3.2:latest
-    prompt_debug: true
+    # model_vendor: ollama_local                   # Uncomment for local Ollama (taxonomy tasks work with small models)
+    # model_name: llama3.2:latest
     context_scope:
       observe:
         - source.*
@@ -78,6 +83,7 @@ actions:
     granularity: file
     hitl:
       port: 3001
+      timeout: 3600
       instructions: |
         **Human-AI Collaborative Review of BISAC Classification**
 
@@ -123,7 +129,6 @@ actions:
     intent: "Write compelling marketing description for the book"
     schema: write_description
     prompt: $book_catalog_enrichment.Write_Marketing_Description
-    prompt_debug: false
     context_scope:
       observe:
         - validate_bisac.*
@@ -213,7 +218,7 @@ actions:
   # STEP 8: SCORE CATALOG QUALITY (merges all parallel branches)
   # ============================================================================
   - name: score_quality
-    dependencies: [generate_recommendations]
+    dependencies: [generate_recommendations, generate_seo, assess_reading_level]
     intent: "Score the overall quality of the enriched catalog entry"
     schema: score_quality
     prompt: $book_catalog_enrichment.Score_Catalog_Quality

--- a/examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml
+++ b/examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml
@@ -23,13 +23,24 @@ defaults:
   model_vendor: gemini
   model_name: gemini-flash-lite-latest
   api_key: GEMINI_API_KEY
+  batch_max_workers: 4
 
   context_scope:
     seed_path:
       risk_criteria: $file:risk_criteria.json
+  reprompt:
+    on_schema_mismatch: reprompt
+    max_attempts: 3
+    use_self_reflection: true
+    on_exhausted: return_last
   retry:
     enabled: true
     max_attempts: 2
+
+  data_source:
+    type: local
+    folder: ./staging
+    file_type: [json]
 
 actions:
 

--- a/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
+++ b/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
@@ -162,5 +162,5 @@ def aggregate_clause_analyses(data: list[dict[str, Any]]) -> FileUDFResult:
         "negotiation_priority": negotiation_priority,
     }
 
-    # source_index: 0 — aggregated from all clauses, anchored to first record
+    # source_index: None — synthetic aggregation record, not derived from a single input
     return FileUDFResult(outputs=[{"source_index": None, "data": result}])

--- a/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
+++ b/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
@@ -2,22 +2,21 @@
 Aggregate all clause-level risk analyses into a unified contract risk report.
 
 FILE granularity — receives ALL clause records at once and emits a single
-aggregated summary. This is
-the REDUCE step of the Map-Reduce pattern.
+aggregated summary. This is the REDUCE step of the Map-Reduce pattern.
 
-Since this tool creates a NEW record (not derived from a single input),
-the output dict has no node_id — the framework treats it as a new root
-with fresh lineage.
+Uses FileUDFResult with source_index to indicate which input record each
+output derives from (required by the framework for FILE-granularity tools).
 """
 
 from typing import Any
 
 from agent_actions import udf_tool
 from agent_actions.config.types import Granularity
+from agent_actions.utils.udf_management.registry import FileUDFResult
 
 
 @udf_tool(granularity=Granularity.FILE)
-def aggregate_clause_analyses(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def aggregate_clause_analyses(data: list[dict[str, Any]]) -> FileUDFResult:
     """
     Combine clause-level risk analyses into a single contract risk report.
 
@@ -33,20 +32,23 @@ def aggregate_clause_analyses(data: list[dict[str, Any]]) -> list[dict[str, Any]
         - negotiation_priority
     """
     if not data:
-        return [
+        return FileUDFResult(outputs=[
             {
-                "contract_id": "unknown",
-                "contract_title": "unknown",
-                "overall_risk_level": "low",
-                "overall_risk_score": 0.0,
-                "total_clauses_analyzed": 0,
-                "risk_distribution": {"high": 0, "medium": 0, "low": 0},
-                "high_risk_clauses": [],
-                "total_obligations": [],
-                "key_deadlines": [],
-                "negotiation_priority": [],
+                "source_index": 0,
+                "data": {
+                    "contract_id": "unknown",
+                    "contract_title": "unknown",
+                    "overall_risk_level": "low",
+                    "overall_risk_score": 0.0,
+                    "total_clauses_analyzed": 0,
+                    "risk_distribution": {"high": 0, "medium": 0, "low": 0},
+                    "high_risk_clauses": [],
+                    "total_obligations": [],
+                    "key_deadlines": [],
+                    "negotiation_priority": [],
+                },
             }
-        ]
+        ])
 
     # Extract contract metadata from the first record's source namespace
     first_source = data[0].get("source", {})
@@ -161,4 +163,5 @@ def aggregate_clause_analyses(data: list[dict[str, Any]]) -> list[dict[str, Any]
         "negotiation_priority": negotiation_priority,
     }
 
-    return [result]
+    # source_index: 0 — aggregated from all clauses, anchored to first record
+    return FileUDFResult(outputs=[{"source_index": 0, "data": result}])

--- a/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
+++ b/examples/contract_reviewer/tools/contract_reviewer/aggregate_clause_analyses.py
@@ -10,9 +10,8 @@ output derives from (required by the framework for FILE-granularity tools).
 
 from typing import Any
 
-from agent_actions import udf_tool
+from agent_actions import FileUDFResult, udf_tool
 from agent_actions.config.types import Granularity
-from agent_actions.utils.udf_management.registry import FileUDFResult
 
 
 @udf_tool(granularity=Granularity.FILE)
@@ -34,7 +33,7 @@ def aggregate_clause_analyses(data: list[dict[str, Any]]) -> FileUDFResult:
     if not data:
         return FileUDFResult(outputs=[
             {
-                "source_index": 0,
+                "source_index": None,
                 "data": {
                     "contract_id": "unknown",
                     "contract_title": "unknown",
@@ -164,4 +163,4 @@ def aggregate_clause_analyses(data: list[dict[str, Any]]) -> FileUDFResult:
     }
 
     # source_index: 0 — aggregated from all clauses, anchored to first record
-    return FileUDFResult(outputs=[{"source_index": 0, "data": result}])
+    return FileUDFResult(outputs=[{"source_index": None, "data": result}])

--- a/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
+++ b/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
@@ -24,7 +24,7 @@ defaults:
   model_name: gemini-flash-lite-latest
   model_vendor: gemini
   api_key: GEMINI_API_KEY
-  record_limit: 2      # Remove for full processing
+  batch_max_workers: 6
   context_scope:
     seed_path:
       team_roster: $file:team_roster.json
@@ -33,6 +33,15 @@ defaults:
   retry:
     enabled: true
     max_attempts: 2
+  reprompt:
+    on_schema_mismatch: reprompt
+    use_self_reflection: true
+    on_exhausted: return_last
+    max_attempts: 3
+  data_source:
+    type: local
+    folder: ./staging
+    file_type: [json]
 
 
 actions:
@@ -172,6 +181,12 @@ actions:
   # ==========================================================================
   # STAGE 8: FORMAT FINAL TRIAGE OUTPUT
   # ==========================================================================
+  # NOTE: generate_executive_summary is guarded (SEV1/SEV2 only). For lower
+  # severity records, the guard filters them so generate_executive_summary
+  # produces no output. AGAC handles guarded dependencies gracefully — when a
+  # dependency is filtered out, downstream actions still execute with whatever
+  # fields are available. format_triage_output will simply not receive
+  # generate_executive_summary.* fields for non-SEV1/SEV2 records.
   - name: format_triage_output
     dependencies: [generate_response_plan, generate_executive_summary]
     kind: tool

--- a/examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_config/product_listing_enrichment.yml
+++ b/examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_config/product_listing_enrichment.yml
@@ -32,12 +32,16 @@ defaults:
   model_vendor: gemini
   api_key: GEMINI_API_KEY
   is_operational: true
-  prompt_debug: false
-  record_limit: 2      # Remove for full processing
+  batch_max_workers: 6
   context_scope:
     seed_path:
       brand_voice: $file:brand_voice.json
       marketplace_rules: $file:marketplace_rules.json
+  reprompt:
+    on_schema_mismatch: reprompt
+    max_attempts: 3
+    use_self_reflection: true
+    on_exhausted: return_last
   retry:
     enabled: true
     max_attempts: 2

--- a/examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml
+++ b/examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml
@@ -34,14 +34,18 @@ defaults:
   model_name: gemini-flash-lite-latest
   model_vendor: gemini
   api_key: GEMINI_API_KEY
-  is_operational: true
-  record_limit: 2      # Remove for full processing
+  batch_max_workers: 6
   context_scope:
     seed_path:
       rubric: $file:evaluation_rubric.json
   retry:
     enabled: true
     max_attempts: 2
+  reprompt:
+    on_schema_mismatch: reprompt
+    max_attempts: 3
+    use_self_reflection: true
+    on_exhausted: return_last
 
   data_source:
     type: local

--- a/examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml
+++ b/examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml
@@ -25,13 +25,19 @@ version: "1.0.0"
 
 defaults:
   json_mode: false                    # ← Plain text responses, no JSON required
+  # Note: reprompt: on_schema_mismatch is NOT used here because json_mode is false
+  # and outputs are named via output_field. Schema mismatch reprompt only applies
+  # when json_mode is true and a structured schema is expected.
   granularity: Record
   is_operational: true
-  run_mode: batch
+  run_mode: online                    # ← Use "batch" for async Gemini batch API
+  batch_max_workers: 8
   model_vendor: gemini
   model_name: gemini-flash-lite-latest
   api_key: GEMINI_API_KEY
-  record_limit: 2      # Remove for full processing
+  retry:
+    enabled: true
+    max_attempts: 2
   data_source:
     type: local
     folder: ./staging
@@ -130,7 +136,7 @@ actions:
     output_field: suggested_response
     prompt: $support_resolution.Draft_Response
     guard:
-      condition: 'severity != "low"'
+      condition: 'assess_severity.severity != "low"'
       on_false: "skip"
     context_scope:
       observe:

--- a/examples/support_resolution/tools/support_resolution/package_triage_result.py
+++ b/examples/support_resolution/tools/support_resolution/package_triage_result.py
@@ -21,10 +21,11 @@ def package_triage_result(data: dict[str, Any]) -> list[dict[str, Any]]:
     # The value may be a raw string OR a dict like {"field_name": "value"} —
     # handle both for resilience.
     def _extract(val: Any) -> str:
+        if val is None:
+            return ""
         if isinstance(val, dict):
-            # Take the first value from the dict wrapper
             return str(next(iter(val.values()), "")) if val else ""
-        return str(val) if val else ""
+        return str(val)
 
     issue_type = _extract(data.get("classify_issue", data.get("issue_type", "unclassified")))
     severity = _extract(data.get("assess_severity", data.get("severity", "medium")))

--- a/examples/support_resolution/tools/support_resolution/package_triage_result.py
+++ b/examples/support_resolution/tools/support_resolution/package_triage_result.py
@@ -17,13 +17,21 @@ def package_triage_result(data: dict[str, Any]) -> list[dict[str, Any]]:
         title = data.get("title", "")
         reporter = data.get("reporter", "")
 
-    # output_field values arrive under the ACTION name, not the field name
-    issue_type = data.get("classify_issue", data.get("issue_type", "unclassified"))
-    severity = data.get("assess_severity", data.get("severity", "medium"))
-    product_area = data.get("identify_area", data.get("product_area", "unknown"))
-    assigned_team = data.get("assign_team", data.get("assigned_team", "support"))
-    summary = data.get("summarize_issue", data.get("summary", ""))
-    suggested_response = data.get("draft_response", data.get("suggested_response", ""))
+    # output_field values arrive namespaced under the ACTION name.
+    # The value may be a raw string OR a dict like {"field_name": "value"} —
+    # handle both for resilience.
+    def _extract(val: Any) -> str:
+        if isinstance(val, dict):
+            # Take the first value from the dict wrapper
+            return str(next(iter(val.values()), "")) if val else ""
+        return str(val) if val else ""
+
+    issue_type = _extract(data.get("classify_issue", data.get("issue_type", "unclassified")))
+    severity = _extract(data.get("assess_severity", data.get("severity", "medium")))
+    product_area = _extract(data.get("identify_area", data.get("product_area", "unknown")))
+    assigned_team = _extract(data.get("assign_team", data.get("assigned_team", "support")))
+    summary = _extract(data.get("summarize_issue", data.get("summary", "")))
+    suggested_response = _extract(data.get("draft_response", data.get("suggested_response", "")))
 
     return [
         {


### PR DESCRIPTION
## Summary

- **Config hardening (all 6 examples):** Added default-level `reprompt: on_schema_mismatch` with `use_self_reflection: true` and `max_attempts: 3`, `batch_max_workers`, `data_source` declarations, `retry` blocks. Removed debug artifacts (`record_limit: 2`, `prompt_debug` flags, stale comments).
- **Bug fixes (3 examples):** Fixed `aggregate_clause_analyses` to return `FileUDFResult` with `source_index: None` for synthetic aggregation records (contract_reviewer), fixed guard condition namespacing to `assess_severity.severity` and `output_field` dict unwrapping in `package_triage_result` (support_resolution), fixed implicit deps on `score_quality` and added HITL timeout (book_catalog_enrichment).
- **Behavior change:** `support_resolution` switched from `run_mode: batch` to `run_mode: online` — the Gemini batch API requires additional setup (storage bucket config) that isn't included in the example. Online mode works out of the box. Comment added pointing users to batch mode.

## Changes by example

| Example | Config | Bug Fix |
|---------|--------|---------|
| review_analyzer | reprompt, batch_max_workers, removed dup is_operational | — |
| incident_triage | reprompt, batch_max_workers, data_source, guarded-dep comment | — |
| product_listing_enrichment | reprompt, batch_max_workers, removed prompt_debug | — |
| contract_reviewer | reprompt, batch_max_workers, data_source | `FileUDFResult(source_index=None)` for FILE aggregation tool |
| book_catalog_enrichment | reprompt, batch_max_workers, data_source, removed debug header | Fixed deps on score_quality, HITL timeout |
| support_resolution | batch_max_workers, retry, non-JSON comment, run_mode→online | Guard namespace fix, output_field dict unwrap |

## Known follow-up

The `_extract()` helper in `package_triage_result.py` works around an inconsistency in how `output_field` values are materialized — the batch path wraps values in `{field_name: value}` dicts while online may not. This should be normalized in the framework. Tracked for a follow-up.

## Test plan

- [x] `agac run -a review_analyzer --fresh` → 8/8 OK (61.8s)
- [x] `agac run -a incident_triage --fresh` → 11/11 OK (20.7s)
- [x] `agac run -a product_listing_enrichment --fresh` → 6/6 OK (47.7s)
- [x] `agac run -a contract_reviewer --fresh` → 4/4 OK (40.4s, re-verified after source_index→None fix)
- [x] `agac run -a book_catalog_enrichment --fresh` → 14/14 OK (345s)
- [x] `agac run -a support_resolution --fresh` → 7/7 OK (8.9s, guard correctly filters 2/4 low-severity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)