### PR TITLE
fix: render newlines in HITL approval UI field values

### DIFF
--- a/agent_actions/llm/providers/hitl/server.py
+++ b/agent_actions/llm/providers/hitl/server.py
@@ -211,6 +211,7 @@ class HitlServer:
                 "img-src 'self' data:; "
                 "connect-src 'self'"
             )
+            response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
             return response
 
         app.add_url_rule("/", "index", self._handle_index)

--- a/agent_actions/llm/providers/hitl/templates/approval.html
+++ b/agent_actions/llm/providers/hitl/templates/approval.html
@@ -868,7 +868,7 @@ h4.md-heading { font-size: 13.5px; }
                     continue;
                 }
                 /* Paragraph */
-                html += '<p>' + inlineFmt(block.split('\n').join('<br>')) + '</p>';
+                html += '<p>' + block.split('\n').map(function(ln) { return inlineFmt(ln); }).join('<br>') + '</p>';
             }
             return html;
         }
@@ -926,8 +926,12 @@ h4.md-heading { font-size: 13.5px; }
             if (typeof val === 'number') return '<span class="tv-num">' + val + '</span>';
             if (typeof val === 'string') {
                 if (isUrl(val)) return '<a class="fv-link" href="' + esc(val.trim()) + '" target="_blank" rel="noopener">' + esc(val) + '</a>';
-                var clean = stripHtml(val);
-                if (clean.length < 80 && clean.indexOf('\n') === -1) return '<span class="tv-str">' + inlineFmt(clean) + '</span>';
+                /* Short plain-text path: only if the raw value is short AND
+                   has no newlines AND has no HTML tags. Otherwise render as
+                   rich markdown (which handles newlines, <br>, code blocks). */
+                var hasNewlines = val.indexOf('\n') !== -1;
+                var hasHtml = val.indexOf('<') >= 0 && val.indexOf('>') > val.indexOf('<');
+                if (!hasNewlines && !hasHtml && val.length < 80) return '<span class="tv-str">' + inlineFmt(val) + '</span>';
                 return renderMarkdown(val);
             }
             if (Array.isArray(val)) return renderArray(val, depth);

--- a/agent_actions/llm/providers/hitl/templates/approval.html
+++ b/agent_actions/llm/providers/hitl/templates/approval.html
@@ -779,7 +779,7 @@ h4.md-heading { font-size: 13.5px; }
         function renderMarkdown(text) {
             var s = String(text);
             /* Convert HTML to markdown if present */
-            if (s.indexOf('<') >= 0 && s.indexOf('>') > s.indexOf('<')) s = htmlToMarkdown(s);
+            if (/<[a-zA-Z\/][^>]*>/.test(s)) s = htmlToMarkdown(s);
             /* Split into fenced code blocks vs text */
             var segments = splitFencedCode(s);
             var html = '';
@@ -926,11 +926,9 @@ h4.md-heading { font-size: 13.5px; }
             if (typeof val === 'number') return '<span class="tv-num">' + val + '</span>';
             if (typeof val === 'string') {
                 if (isUrl(val)) return '<a class="fv-link" href="' + esc(val.trim()) + '" target="_blank" rel="noopener">' + esc(val) + '</a>';
-                /* Short plain-text path: only if the raw value is short AND
-                   has no newlines AND has no HTML tags. Otherwise render as
-                   rich markdown (which handles newlines, <br>, code blocks). */
+                /* Rich-render anything with newlines, HTML tags, or length >= 80 */
                 var hasNewlines = val.indexOf('\n') !== -1;
-                var hasHtml = val.indexOf('<') >= 0 && val.indexOf('>') > val.indexOf('<');
+                var hasHtml = /<[a-zA-Z\/][^>]*>/.test(val);
                 if (!hasNewlines && !hasHtml && val.length < 80) return '<span class="tv-str">' + inlineFmt(val) + '</span>';
                 return renderMarkdown(val);
             }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-actions",
   "displayName": "Agent Actions",
   "description": "Language support and workflow navigation for Agent Actions projects",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "publisher": "runagac",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Fix literal `<br>` text showing in HITL field values instead of actual line breaks
- Two root causes: `stripHtml` collapsing newlines made strings look short enough for the plain-text path, and `inlineFmt` escaping `<br>` join tokens back to `&lt;br&gt;`
- Add `Cache-Control: no-cache` header to prevent stale template caching

## What was broken
Fields containing newlines (e.g. multi-line code snippets) displayed `<br>` as literal text instead of rendering line breaks. The VS Code extension rendered these correctly; only the HITL approval UI was affected.

## Verification
- Tested with 404-record quiz dataset containing multi-line code fields
- Newlines now render as proper line breaks in the HITL UI
- Short single-line strings still render inline (no regression)