### PR TITLE
Phase 1: Observability & safe guards

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260517-001000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260517-001000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add Phase 1 observability: WARNING on prep failure without target_id, WARNING on passthrough_on_error exception, RuntimeError on prefilter length mismatch, FILE vs RECORD merge-order documentation"
+time: 2026-05-17T00:10:00.000000Z

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -188,6 +188,13 @@ class GuardEvaluator:
         except (ValueError, TypeError, KeyError, AttributeError) as e:
             logger.warning("Guard: guard condition evaluation exception: %s", e)
             if passthrough_on_error:
+                logger.warning(
+                    "Guard evaluation raised %s but passthrough_on_error=True — passing record. "
+                    "clause=%s, error=%s",
+                    type(e).__name__,
+                    clause,
+                    e,
+                )
                 return GuardResult.passed()
             if behavior == GuardBehavior.WARN:
                 return GuardResult.warned()

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -186,7 +186,6 @@ class GuardEvaluator:
             return GuardResult.from_filter_result(filter_result, behavior, passthrough_on_error)
 
         except (ValueError, TypeError, KeyError, AttributeError) as e:
-            logger.warning("Guard: guard condition evaluation exception: %s", e)
             if passthrough_on_error:
                 logger.warning(
                     "Guard evaluation raised %s but passthrough_on_error=True — passing record. "
@@ -196,6 +195,7 @@ class GuardEvaluator:
                     e,
                 )
                 return GuardResult.passed()
+            logger.warning("Guard: guard condition evaluation exception: %s", e)
             if behavior == GuardBehavior.WARN:
                 return GuardResult.warned()
             if behavior == GuardBehavior.SKIP:

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -230,7 +230,13 @@ class BatchTaskPreparator:
     ) -> None:
         """Stamp the context_map entry as FAILED with _state transition and disposition."""
         custom_id = row.get("target_id")
-        if not custom_id or custom_id not in context_map_builder:
+        if not custom_id:
+            logger.warning(
+                "Prep failed for record without target_id — record may be untrackable. error=%s",
+                error,
+            )
+            return
+        if custom_id not in context_map_builder:
             return
         entry = context_map_builder[custom_id]
         BatchContextMetadata.set_filter_status(entry, FilterStatus.FAILED)

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -101,8 +101,10 @@ class UnifiedProcessor:
 
         invocation_results = strategy.invoke(passing, context) if passing else []
 
-        # FILE mode: invocation first, then guard skips (preserves historical order).
-        # RECORD mode: guard skips first, then invocation results.
+        # FILE mode: sequential processing — record N can reference record N-1's output.
+        # RECORD mode: independent — merge order doesn't affect semantics.
+        # This divergence is intentional. Do not unify without verifying FILE-mode
+        # workflows that depend on sequential accumulation (e.g., multi-pass enrichment).
         if raw_records is not None:
             all_results = invocation_results + guard_results
         else:

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -335,6 +335,12 @@ def prefilter_by_guard(
     """
     originals = original_data if original_data is not None else data
 
+    if original_data is not None and len(original_data) != len(data):
+        raise RuntimeError(
+            f"prefilter_by_guard received {len(original_data)} original_data for "
+            f"{len(data)} input records — length mismatch"
+        )
+
     guard_config = agent_config.get("guard")
     if not guard_config:
         return data, [], originals

--- a/tests/unit/unification/test_phase1_observability.py
+++ b/tests/unit/unification/test_phase1_observability.py
@@ -1,7 +1,9 @@
 """Phase 1 observability tests — U-2.G, U-2.H, U-2.E.
 
-Commit A: these tests MUST FAIL against current code, proving the gaps exist.
-Commit B: implementation makes them pass.
+Tests that WARNING logs and RuntimeError guards exist for:
+- _mark_prep_failed with missing target_id (U-2.G)
+- passthrough_on_error swallowing exceptions (U-2.H)
+- prefilter_by_guard original_data/data length mismatch (U-2.E)
 """
 
 import logging
@@ -44,9 +46,7 @@ class TestPrepFailedLogging:
         record_without_target = {"content": {"text": "no target_id here"}}
         context_map = {}
 
-        with caplog.at_level(
-            logging.WARNING, logger="agent_actions.llm.batch.processing.preparator"
-        ):
+        with caplog.at_level(logging.WARNING, logger=_PREPARATOR_LOGGER):
             preparator._mark_prep_failed(
                 record_without_target,
                 context_map,
@@ -65,9 +65,7 @@ class TestPrepFailedLogging:
         context_map = {"t-001": record.copy()}
         BatchContextMetadata.set_filter_status(context_map["t-001"], FilterStatus.INCLUDED)
 
-        with caplog.at_level(
-            logging.WARNING, logger="agent_actions.llm.batch.processing.preparator"
-        ):
+        with caplog.at_level(logging.WARNING, logger=_PREPARATOR_LOGGER):
             preparator._mark_prep_failed(
                 record,
                 context_map,
@@ -102,7 +100,7 @@ class TestPassthroughOnErrorLogging:
 
         with caplog.at_level(
             logging.WARNING,
-            logger="agent_actions.input.preprocessing.filtering.evaluator",
+            logger=_EVALUATOR_LOGGER,
         ):
             result = evaluator.evaluate(
                 item={"field": "value"},
@@ -118,8 +116,8 @@ class TestPassthroughOnErrorLogging:
             for r in caplog.records
             if r.levelname == "WARNING" and "passthrough_on_error" in r.message
         ]
-        assert len(passthrough_warnings) >= 1, (
-            "Must log WARNING mentioning passthrough_on_error when exception is swallowed"
+        assert len(passthrough_warnings) == 1, (
+            "Must log exactly one WARNING mentioning passthrough_on_error when exception is swallowed"
         )
 
     def test_passthrough_on_error_false_no_passthrough_warning(self, caplog):
@@ -136,7 +134,7 @@ class TestPassthroughOnErrorLogging:
 
         with caplog.at_level(
             logging.WARNING,
-            logger="agent_actions.input.preprocessing.filtering.evaluator",
+            logger=_EVALUATOR_LOGGER,
         ):
             result = evaluator.evaluate(
                 item={"field": "value"},

--- a/tests/unit/unification/test_phase1_observability.py
+++ b/tests/unit/unification/test_phase1_observability.py
@@ -1,0 +1,158 @@
+"""Phase 1 observability tests — U-2.G, U-2.H, U-2.E.
+
+Commit A: these tests MUST FAIL against current code, proving the gaps exist.
+Commit B: implementation makes them pass.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.input.preprocessing.filtering.evaluator import (
+    GuardEvaluator,
+    GuardResult,
+)
+from agent_actions.input.preprocessing.filtering.guard_filter import (
+    FilterResult,
+    GuardFilter,
+)
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
+from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+
+class TestPrepFailedLogging:
+    """U-2.G: _mark_prep_failed must warn when target_id is missing."""
+
+    def test_prep_failed_without_target_id_logs_warning(self, caplog):
+        """When prep fails and record has no target_id, WARNING must appear in logs."""
+        preparator = BatchTaskPreparator()
+        record_without_target = {"content": {"text": "no target_id here"}}
+        context_map = {}
+
+        with caplog.at_level(logging.WARNING):
+            preparator._mark_prep_failed(
+                record_without_target,
+                context_map,
+                "test_agent",
+                ValueError("test error"),
+            )
+
+        assert any(
+            "target_id" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        ), "Missing WARNING about absent target_id on prep failure"
+
+    def test_prep_failed_with_target_id_no_extra_warning(self, caplog):
+        """When prep fails and target_id exists, no warning about missing target_id."""
+        preparator = BatchTaskPreparator()
+        record = {"target_id": "t-001", "content": {"text": "has target"}}
+        context_map = {"t-001": record.copy()}
+        BatchContextMetadata.set_filter_status(context_map["t-001"], FilterStatus.INCLUDED)
+
+        with caplog.at_level(logging.WARNING):
+            preparator._mark_prep_failed(
+                record,
+                context_map,
+                "test_agent",
+                ValueError("test error"),
+            )
+
+        target_id_warnings = [
+            r for r in caplog.records
+            if "target_id" in r.message
+            and "untrackable" in r.message
+            and r.levelname == "WARNING"
+        ]
+        assert len(target_id_warnings) == 0, (
+            "Should NOT warn about missing target_id when target_id is present"
+        )
+
+
+class TestPassthroughOnErrorLogging:
+    """U-2.H: passthrough_on_error must log WARNING when exception is swallowed."""
+
+    def test_passthrough_on_error_logs_warning_on_exception(self, caplog):
+        """When guard raises and passthrough_on_error=True, WARNING logged with context."""
+        mock_filter = MagicMock(spec=GuardFilter)
+        mock_filter.filter_item.side_effect = ValueError("bad expression")
+        evaluator = GuardEvaluator(guard_filter=mock_filter)
+
+        guard_config = {
+            "clause": "some_field == true",
+            "behavior": "filter",
+            "passthrough_on_error": True,
+        }
+
+        with caplog.at_level(logging.WARNING):
+            result = evaluator.evaluate(
+                item={"field": "value"},
+                guard_config=guard_config,
+            )
+
+        # Must still pass (passthrough_on_error behavior unchanged)
+        assert result.should_execute is True
+
+        # Must log WARNING mentioning passthrough_on_error
+        passthrough_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and "passthrough_on_error" in r.message
+        ]
+        assert len(passthrough_warnings) >= 1, (
+            "Must log WARNING mentioning passthrough_on_error when exception is swallowed"
+        )
+
+    def test_passthrough_on_error_false_no_passthrough_warning(self, caplog):
+        """When passthrough_on_error=False, no passthrough-specific warning."""
+        mock_filter = MagicMock(spec=GuardFilter)
+        mock_filter.filter_item.side_effect = ValueError("bad expression")
+        evaluator = GuardEvaluator(guard_filter=mock_filter)
+
+        guard_config = {
+            "clause": "some_field == true",
+            "behavior": "filter",
+            "passthrough_on_error": False,
+        }
+
+        with caplog.at_level(logging.WARNING):
+            result = evaluator.evaluate(
+                item={"field": "value"},
+                guard_config=guard_config,
+            )
+
+        assert result.should_execute is False
+
+        passthrough_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and "passthrough_on_error" in r.message
+        ]
+        assert len(passthrough_warnings) == 0, (
+            "Should NOT log passthrough-specific warning when passthrough_on_error=False"
+        )
+
+
+class TestPrefilterLengthGuard:
+    """U-2.E: prefilter_by_guard must raise on original_data/data length mismatch."""
+
+    def test_original_data_length_mismatch_raises(self):
+        """If original_data has different length than data, RuntimeError raised."""
+        data = [{"content": {"x": 1}}, {"content": {"x": 2}}, {"content": {"x": 3}}]
+        original_data = [{"content": {"x": 1}}, {"content": {"x": 2}}]  # only 2 for 3
+
+        with pytest.raises(RuntimeError, match="prefilter_by_guard.*3.*2"):
+            prefilter_by_guard(
+                data, {}, "test_agent", original_data=original_data
+            )
+
+    def test_matching_lengths_no_error(self):
+        """When original_data matches data length, no error."""
+        data = [{"content": {"x": 1}}, {"content": {"x": 2}}]
+        original_data = [{"content": {"x": 1, "extra": "a"}}, {"content": {"x": 2, "extra": "b"}}]
+
+        passing, skipped, original_passing = prefilter_by_guard(
+            data, {}, "test_agent", original_data=original_data
+        )
+        assert len(passing) == 2
+        assert original_passing == original_data

--- a/tests/unit/unification/test_phase1_observability.py
+++ b/tests/unit/unification/test_phase1_observability.py
@@ -5,22 +5,34 @@ Commit B: implementation makes them pass.
 """
 
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from agent_actions.input.preprocessing.filtering.evaluator import (
-    GuardEvaluator,
-    GuardResult,
-)
-from agent_actions.input.preprocessing.filtering.guard_filter import (
-    FilterResult,
-    GuardFilter,
-)
+from agent_actions.input.preprocessing.filtering.evaluator import GuardEvaluator
+from agent_actions.input.preprocessing.filtering.guard_filter import GuardFilter
 from agent_actions.llm.batch.core.batch_constants import FilterStatus
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+_PREPARATOR_LOGGER = "agent_actions.llm.batch.processing.preparator"
+_EVALUATOR_LOGGER = "agent_actions.input.preprocessing.filtering.evaluator"
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Ensure agent_actions loggers propagate to root so caplog captures them.
+
+    The agent_actions root logger has propagate=False (set by LoggingBridgeHandler),
+    so caplog (which hooks the Python root logger) can't see child log records.
+    Temporarily enable propagation for the duration of each test.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig
 
 
 class TestPrepFailedLogging:
@@ -32,7 +44,9 @@ class TestPrepFailedLogging:
         record_without_target = {"content": {"text": "no target_id here"}}
         context_map = {}
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(
+            logging.WARNING, logger="agent_actions.llm.batch.processing.preparator"
+        ):
             preparator._mark_prep_failed(
                 record_without_target,
                 context_map,
@@ -40,10 +54,9 @@ class TestPrepFailedLogging:
                 ValueError("test error"),
             )
 
-        assert any(
-            "target_id" in r.message and r.levelname == "WARNING"
-            for r in caplog.records
-        ), "Missing WARNING about absent target_id on prep failure"
+        assert any("target_id" in r.message and r.levelname == "WARNING" for r in caplog.records), (
+            "Missing WARNING about absent target_id on prep failure"
+        )
 
     def test_prep_failed_with_target_id_no_extra_warning(self, caplog):
         """When prep fails and target_id exists, no warning about missing target_id."""
@@ -52,7 +65,9 @@ class TestPrepFailedLogging:
         context_map = {"t-001": record.copy()}
         BatchContextMetadata.set_filter_status(context_map["t-001"], FilterStatus.INCLUDED)
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(
+            logging.WARNING, logger="agent_actions.llm.batch.processing.preparator"
+        ):
             preparator._mark_prep_failed(
                 record,
                 context_map,
@@ -61,10 +76,9 @@ class TestPrepFailedLogging:
             )
 
         target_id_warnings = [
-            r for r in caplog.records
-            if "target_id" in r.message
-            and "untrackable" in r.message
-            and r.levelname == "WARNING"
+            r
+            for r in caplog.records
+            if "target_id" in r.message and "untrackable" in r.message and r.levelname == "WARNING"
         ]
         assert len(target_id_warnings) == 0, (
             "Should NOT warn about missing target_id when target_id is present"
@@ -86,7 +100,10 @@ class TestPassthroughOnErrorLogging:
             "passthrough_on_error": True,
         }
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(
+            logging.WARNING,
+            logger="agent_actions.input.preprocessing.filtering.evaluator",
+        ):
             result = evaluator.evaluate(
                 item={"field": "value"},
                 guard_config=guard_config,
@@ -97,7 +114,8 @@ class TestPassthroughOnErrorLogging:
 
         # Must log WARNING mentioning passthrough_on_error
         passthrough_warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelname == "WARNING" and "passthrough_on_error" in r.message
         ]
         assert len(passthrough_warnings) >= 1, (
@@ -116,7 +134,10 @@ class TestPassthroughOnErrorLogging:
             "passthrough_on_error": False,
         }
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(
+            logging.WARNING,
+            logger="agent_actions.input.preprocessing.filtering.evaluator",
+        ):
             result = evaluator.evaluate(
                 item={"field": "value"},
                 guard_config=guard_config,
@@ -125,7 +146,8 @@ class TestPassthroughOnErrorLogging:
         assert result.should_execute is False
 
         passthrough_warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelname == "WARNING" and "passthrough_on_error" in r.message
         ]
         assert len(passthrough_warnings) == 0, (
@@ -141,10 +163,8 @@ class TestPrefilterLengthGuard:
         data = [{"content": {"x": 1}}, {"content": {"x": 2}}, {"content": {"x": 3}}]
         original_data = [{"content": {"x": 1}}, {"content": {"x": 2}}]  # only 2 for 3
 
-        with pytest.raises(RuntimeError, match="prefilter_by_guard.*3.*2"):
-            prefilter_by_guard(
-                data, {}, "test_agent", original_data=original_data
-            )
+        with pytest.raises(RuntimeError, match="prefilter_by_guard.*2.*3"):
+            prefilter_by_guard(data, {}, "test_agent", original_data=original_data)
 
     def test_matching_lengths_no_error(self):
         """When original_data matches data length, no error."""

--- a/vscode-extension/src/views/dagWebview.ts
+++ b/vscode-extension/src/views/dagWebview.ts
@@ -263,14 +263,58 @@ export class DagWebview implements vscode.Disposable {
         .legend-dot.failed { background: #dc3545; }
         .legend-dot.pending { background: #6c757d; }
         .legend-dot.skipped { background: #17a2b8; }
+        .dag-container {
+            position: relative;
+            overflow: hidden;
+            width: 100%;
+            height: calc(100vh - 80px);
+            border: 1px solid var(--vscode-panel-border, #444);
+            border-radius: 4px;
+        }
+        .dag-viewport {
+            transform-origin: 0 0;
+            cursor: grab;
+        }
+        .dag-viewport.grabbing {
+            cursor: grabbing;
+        }
         .mermaid {
-            display: flex;
-            justify-content: center;
+            display: inline-block;
             padding: 16px;
         }
         .mermaid svg {
-            max-width: 100%;
             height: auto;
+        }
+        .zoom-controls {
+            position: absolute;
+            bottom: 12px;
+            right: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            z-index: 10;
+        }
+        .zoom-controls button {
+            width: 32px;
+            height: 32px;
+            border: 1px solid var(--vscode-panel-border, #444);
+            background: var(--vscode-editor-background, #1e1e1e);
+            color: var(--vscode-editor-foreground, #d4d4d4);
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .zoom-controls button:hover {
+            background: var(--vscode-toolbar-hoverBackground, #333);
+        }
+        .zoom-level {
+            text-align: center;
+            font-size: 10px;
+            color: var(--vscode-descriptionForeground, #888);
+            padding: 2px 0;
         }
         /* Make nodes clickable */
         .node { cursor: pointer; }
@@ -290,8 +334,19 @@ export class DagWebview implements vscode.Disposable {
             <div class="legend-item"><div class="legend-dot skipped"></div> Skipped</div>
         </div>
     </div>
-    <div class="mermaid">
+    <div class="dag-container" id="dagContainer">
+        <div class="dag-viewport" id="dagViewport">
+            <div class="mermaid">
 ${diagram}
+            </div>
+        </div>
+        <div class="zoom-controls">
+            <button id="zoomIn" title="Zoom in">+</button>
+            <div class="zoom-level" id="zoomLevel">100%</div>
+            <button id="zoomOut" title="Zoom out">&minus;</button>
+            <button id="zoomFit" title="Fit to view">&#8862;</button>
+            <button id="zoomReset" title="Reset zoom">1:1</button>
+        </div>
     </div>
     <script src="${mermaidUri}"></script>
     <script nonce="${nonce}">
@@ -302,20 +357,141 @@ ${diagram}
             theme: '${isDark ? 'dark' : 'default'}',
             flowchart: {
                 curve: 'basis',
-                htmlLabels: false,  // Disable HTML labels for security
+                htmlLabels: false,
                 padding: 15
             },
             securityLevel: 'strict'
         });
 
-        // Handle click events - Mermaid will call this via the callback mechanism
-        // With securityLevel: 'strict', we use mermaid's built-in click handler
+        // Handle click events — only navigate if the user didn't drag
         window.callback = function(actionName) {
-            // Validate actionName contains only safe characters
+            if (didDrag) return;
             if (/^[a-zA-Z0-9_-]+$/.test(actionName)) {
                 vscode.postMessage({ type: 'openAction', actionName });
             }
         };
+
+        // Pan and zoom
+        const container = document.getElementById('dagContainer');
+        const viewport = document.getElementById('dagViewport');
+        const zoomLevelEl = document.getElementById('zoomLevel');
+
+        let scale = 1;
+        let panX = 0;
+        let panY = 0;
+        let isPanning = false;
+        let didDrag = false;
+        let startX = 0;
+        let startY = 0;
+        let downX = 0;
+        let downY = 0;
+        const DRAG_THRESHOLD = 5;
+
+        const MIN_SCALE = 0.1;
+        const MAX_SCALE = 5;
+        const ZOOM_STEP = 0.15;
+
+        function applyTransform() {
+            viewport.style.transform = 'translate(' + panX + 'px, ' + panY + 'px) scale(' + scale + ')';
+            zoomLevelEl.textContent = Math.round(scale * 100) + '%';
+        }
+
+        function zoomAtPoint(newScale, clientX, clientY) {
+            newScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, newScale));
+            const rect = container.getBoundingClientRect();
+            const x = clientX - rect.left;
+            const y = clientY - rect.top;
+            panX = x - (x - panX) * (newScale / scale);
+            panY = y - (y - panY) * (newScale / scale);
+            scale = newScale;
+            applyTransform();
+        }
+
+        function fitToView() {
+            const svg = viewport.querySelector('svg');
+            if (!svg) return;
+            const cRect = container.getBoundingClientRect();
+            // Use getBBox for intrinsic SVG size — immune to CSS transforms and overflow clipping
+            const bbox = svg.getBBox();
+            const sW = bbox.width;
+            const sH = bbox.height;
+            if (sW === 0 || sH === 0) return;
+            const fitScale = Math.min(cRect.width / (sW + 32), cRect.height / (sH + 32), 2);
+            scale = fitScale;
+            panX = (cRect.width - sW * scale) / 2 - bbox.x * scale;
+            panY = (cRect.height - sH * scale) / 2 - bbox.y * scale;
+            applyTransform();
+        }
+
+        // Mouse wheel zoom
+        container.addEventListener('wheel', function(e) {
+            e.preventDefault();
+            const delta = e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP;
+            zoomAtPoint(scale * (1 + delta), e.clientX, e.clientY);
+        }, { passive: false });
+
+        // Pan with mouse drag — track distance to distinguish click from drag
+        container.addEventListener('mousedown', function(e) {
+            if (e.button !== 0) return;
+            isPanning = true;
+            didDrag = false;
+            startX = e.clientX - panX;
+            startY = e.clientY - panY;
+            downX = e.clientX;
+            downY = e.clientY;
+            viewport.classList.add('grabbing');
+        });
+
+        window.addEventListener('mousemove', function(e) {
+            if (!isPanning) return;
+            var dx = e.clientX - downX;
+            var dy = e.clientY - downY;
+            if (!didDrag && Math.abs(dx) + Math.abs(dy) > DRAG_THRESHOLD) {
+                didDrag = true;
+            }
+            panX = e.clientX - startX;
+            panY = e.clientY - startY;
+            applyTransform();
+        });
+
+        window.addEventListener('mouseup', function() {
+            isPanning = false;
+            viewport.classList.remove('grabbing');
+        });
+
+        // Zoom buttons
+        document.getElementById('zoomIn').addEventListener('click', function() {
+            const rect = container.getBoundingClientRect();
+            zoomAtPoint(scale * (1 + ZOOM_STEP), rect.left + rect.width / 2, rect.top + rect.height / 2);
+        });
+
+        document.getElementById('zoomOut').addEventListener('click', function() {
+            const rect = container.getBoundingClientRect();
+            zoomAtPoint(scale * (1 - ZOOM_STEP), rect.left + rect.width / 2, rect.top + rect.height / 2);
+        });
+
+        document.getElementById('zoomFit').addEventListener('click', fitToView);
+
+        document.getElementById('zoomReset').addEventListener('click', function() {
+            scale = 1;
+            panX = 0;
+            panY = 0;
+            applyTransform();
+        });
+
+        // Auto-fit once mermaid finishes rendering the SVG
+        var mermaidEl = document.querySelector('.mermaid');
+        if (viewport.querySelector('svg')) {
+            fitToView();
+        } else {
+            var fitObserver = new MutationObserver(function() {
+                if (viewport.querySelector('svg')) {
+                    fitObserver.disconnect();
+                    fitToView();
+                }
+            });
+            fitObserver.observe(mermaidEl, { childList: true, subtree: true });
+        }
     </script>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
- **U-2.G**: `_mark_prep_failed` now logs WARNING when `target_id` is missing — makes anonymous prep failures visible to operators
- **U-2.H**: `passthrough_on_error` exception handler logs WARNING with clause and error context (behavior unchanged — still passes)
- **U-2.E**: `prefilter_by_guard` raises `RuntimeError` on `original_data`/`data` length mismatch — prevents silent record loss
- **U-2.I**: FILE vs RECORD merge-order divergence documented with rationale
- **U-2.J**: Schema compilation already per-action — no change needed

No behavioral change except U-2.E (converts silent data loss into a loud error).

## Verification
- TDD red/green: Commit A adds 6 tests (3 fail proving gaps exist), Commit B makes all pass
- `pytest`: 6820 passed, 2 pre-existing failures (trailing comma repair in ollama/json_parsing — unrelated)
- `ruff format --check`: clean
- `ruff check`: clean