### PR TITLE
fix(batch): move INCLUDED after prepare() succeeds (Phase 2)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260517-002000.yaml
+++ b/.changes/unreleased/Bug Fix-20260517-002000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix premature INCLUDED status in batch prep — context_map now marks INCLUDED only after prepare() succeeds, preventing false positives when prepare throws"
+time: 2026-05-17T00:20:00.000000Z

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -166,9 +166,8 @@ class BatchTaskPreparator:
             custom_id = IDGenerator.generate_target_id()
             row["target_id"] = custom_id
 
-        # 2. Store row in context map with initial status
+        # 2. Store row in context map (no status yet — INCLUDED only after prepare succeeds)
         row_with_meta = row.copy()
-        BatchContextMetadata.set_filter_status(row_with_meta, FilterStatus.INCLUDED)
         context_map_builder[custom_id] = row_with_meta
 
         # 3. Update prep_context with current item
@@ -212,7 +211,12 @@ class BatchTaskPreparator:
             logger.debug("Guard skipped item %s", custom_id)
             return None
 
-        # 7. Create and return task
+        # 7. Mark INCLUDED only now — prepare() succeeded and guard passed
+        BatchContextMetadata.set_filter_status(
+            context_map_builder[custom_id], FilterStatus.INCLUDED
+        )
+
+        # 8. Create and return task
         return {
             "target_id": custom_id,
             "content": prepared.llm_context,

--- a/tests/unit/unification/conftest.py
+++ b/tests/unit/unification/conftest.py
@@ -4,6 +4,7 @@ Provides reusable fixtures for testing both batch and online processing paths,
 guard evaluation, and paired-mode execution for parity verification.
 """
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,21 @@ from agent_actions.llm.batch.core.batch_models import BatchTaskPreparationStats
 from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Ensure agent_actions loggers propagate to root so caplog captures them.
+
+    The agent_actions root logger has propagate=False (set by LoggingBridgeHandler),
+    so caplog (which hooks the Python root logger) can't see child log records.
+    Temporarily enable propagation for the duration of each test.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig
 
 
 @pytest.fixture

--- a/tests/unit/unification/test_phase1_observability.py
+++ b/tests/unit/unification/test_phase1_observability.py
@@ -22,21 +22,6 @@ _PREPARATOR_LOGGER = "agent_actions.llm.batch.processing.preparator"
 _EVALUATOR_LOGGER = "agent_actions.input.preprocessing.filtering.evaluator"
 
 
-@pytest.fixture(autouse=True)
-def _enable_log_propagation():
-    """Ensure agent_actions loggers propagate to root so caplog captures them.
-
-    The agent_actions root logger has propagate=False (set by LoggingBridgeHandler),
-    so caplog (which hooks the Python root logger) can't see child log records.
-    Temporarily enable propagation for the duration of each test.
-    """
-    aa_logger = logging.getLogger("agent_actions")
-    orig = aa_logger.propagate
-    aa_logger.propagate = True
-    yield
-    aa_logger.propagate = orig
-
-
 class TestPrepFailedLogging:
     """U-2.G: _mark_prep_failed must warn when target_id is missing."""
 

--- a/tests/unit/unification/test_phase2_batch_prep_integrity.py
+++ b/tests/unit/unification/test_phase2_batch_prep_integrity.py
@@ -17,9 +17,7 @@ import pytest
 from agent_actions.llm.batch.core.batch_constants import FilterStatus
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.core.batch_models import BatchTaskPreparationStats
-from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
-from agent_actions.record.envelope import RecordEnvelope, RecordEnvelopeError
 from agent_actions.record.state import RecordState
 
 _PREPARATOR_LOGGER = "agent_actions.llm.batch.processing.preparator"
@@ -165,9 +163,8 @@ class TestEnvelopeTransitionIntegrity:
 
         # Must log a warning about the failed transition
         warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelname == "WARNING" and "Cannot transition" in r.message
         ]
-        assert len(warnings) > 0, (
-            "Must log WARNING when transition to FAILED is illegal"
-        )
+        assert len(warnings) > 0, "Must log WARNING when transition to FAILED is illegal"

--- a/tests/unit/unification/test_phase2_batch_prep_integrity.py
+++ b/tests/unit/unification/test_phase2_batch_prep_integrity.py
@@ -1,0 +1,173 @@
+"""Phase 2 batch prep integrity tests — U-2.B, U-1.3a, U-2.C.
+
+Tests that:
+- context_map does not show INCLUDED for rows where prepare() failed (U-2.B)
+- _mark_prep_failed uses transition() API, not raw _state writes (U-1.3a)
+- No RecordEnvelopeError catch-and-bypass pattern (U-2.C)
+
+U-2.B test MUST FAIL against current code (bug exists).
+U-1.3a and U-2.C tests confirm Phase 1 fixes hold (regression).
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.llm.batch.core.batch_models import BatchTaskPreparationStats
+from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
+from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
+from agent_actions.record.envelope import RecordEnvelope, RecordEnvelopeError
+from agent_actions.record.state import RecordState
+
+_PREPARATOR_LOGGER = "agent_actions.llm.batch.processing.preparator"
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Ensure agent_actions loggers propagate to root so caplog captures them."""
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig
+
+
+class TestContextMapIntegrity:
+    """U-2.B: context_map must not show INCLUDED for records where prepare() failed."""
+
+    def test_prepare_failure_not_marked_included(self, batch_preparator):
+        """If prepare() throws, context_map must NOT have INCLUDED for that row.
+
+        Bug: INCLUDED is set before prepare() runs, so when prepare() throws,
+        the exception propagates out of _process_single_item and the
+        context_map entry is left with INCLUDED — a lie.
+        """
+        row = {"target_id": "t-001", "content": {"text": "will fail"}}
+        context_map: dict = {}
+        stats = BatchTaskPreparationStats()
+        prep_context = MagicMock(spec=PreparationContext)
+
+        task_preparer = MagicMock()
+        task_preparer.prepare.side_effect = ValueError("schema validation failed")
+
+        with pytest.raises(ValueError, match="schema validation failed"):
+            batch_preparator._process_single_item(
+                row, prep_context, task_preparer, context_map, stats
+            )
+
+        # Row must be in context_map (for _mark_prep_failed to find it later)
+        assert "t-001" in context_map
+
+        # But it must NOT be marked INCLUDED — prepare() never succeeded
+        status = BatchContextMetadata.get_filter_status(context_map["t-001"])
+        assert status != FilterStatus.INCLUDED, (
+            f"context_map shows INCLUDED for row where prepare() failed — "
+            f"INCLUDED was set before prepare() ran (got status={status})"
+        )
+
+    def test_successful_prepare_marked_included(self, batch_preparator):
+        """When prepare() succeeds and guard passes, context_map shows INCLUDED."""
+        row = {"target_id": "t-002", "content": {"text": "will succeed"}}
+        context_map: dict = {}
+        stats = BatchTaskPreparationStats()
+        prep_context = MagicMock(spec=PreparationContext)
+
+        task_preparer = MagicMock()
+        prepared = MagicMock()
+        prepared.guard_status = GuardStatus.PASSED
+        prepared.passthrough_fields = {}
+        prepared.llm_context = {"text": "prepared"}
+        prepared.formatted_prompt = "Process this"
+        task_preparer.prepare.return_value = prepared
+
+        result = batch_preparator._process_single_item(
+            row, prep_context, task_preparer, context_map, stats
+        )
+
+        assert result is not None
+        status = BatchContextMetadata.get_filter_status(context_map["t-002"])
+        assert status == FilterStatus.INCLUDED, (
+            f"context_map must show INCLUDED after successful prepare (got status={status})"
+        )
+
+    def test_guard_skipped_not_marked_included(self, batch_preparator):
+        """When guard skips a record, context_map shows SKIPPED, not INCLUDED."""
+        row = {"target_id": "t-003", "content": {"text": "guard skip"}}
+        context_map: dict = {}
+        stats = BatchTaskPreparationStats()
+        prep_context = MagicMock(spec=PreparationContext)
+
+        task_preparer = MagicMock()
+        prepared = MagicMock()
+        prepared.guard_status = GuardStatus.SKIPPED
+        prepared.passthrough_fields = {}
+        task_preparer.prepare.return_value = prepared
+
+        result = batch_preparator._process_single_item(
+            row, prep_context, task_preparer, context_map, stats
+        )
+
+        assert result is None
+        status = BatchContextMetadata.get_filter_status(context_map["t-003"])
+        assert status == FilterStatus.SKIPPED
+
+
+class TestEnvelopeTransitionIntegrity:
+    """U-1.3a + U-2.C: _mark_prep_failed uses transition() API, no raw _state bypass.
+
+    These tests confirm Phase 1 fixes hold as regression coverage.
+    """
+
+    def test_mark_prep_failed_uses_transition_api(self, batch_preparator, caplog):
+        """_mark_prep_failed must call RecordEnvelope.transition(), not raw _state write."""
+        record = {"target_id": "t-001", "content": {"text": "will fail"}}
+        context_map = {"t-001": record.copy()}
+
+        with caplog.at_level(logging.DEBUG, logger=_PREPARATOR_LOGGER):
+            batch_preparator._mark_prep_failed(
+                record, context_map, "test_agent", ValueError("test error")
+            )
+
+        entry = context_map["t-001"]
+        # FilterStatus must be FAILED
+        assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.FAILED
+
+        # _state must be set via transition() — evidenced by _state_history existing
+        assert "_state_history" in entry, (
+            "_mark_prep_failed must use transition() which sets _state_history"
+        )
+        assert entry["_state"] == RecordState.FAILED.value
+
+    def test_illegal_transition_logs_warning_no_raw_write(self, batch_preparator, caplog):
+        """If transition is illegal, must log WARNING and NOT do raw _state write."""
+        record = {"target_id": "t-001", "content": {"text": "test"}}
+        # Put record in a state that cannot transition to FAILED
+        context_map = {"t-001": record.copy()}
+        # Force an illegal state value
+        context_map["t-001"]["_state"] = "NONEXISTENT_STATE"
+
+        with caplog.at_level(logging.WARNING, logger=_PREPARATOR_LOGGER):
+            batch_preparator._mark_prep_failed(
+                record, context_map, "test_agent", ValueError("test error")
+            )
+
+        entry = context_map["t-001"]
+        # FilterStatus should still be FAILED (context_map metadata is separate from _state)
+        assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.FAILED
+
+        # _state must NOT have been changed via raw write — it should still be the bad value
+        assert entry["_state"] == "NONEXISTENT_STATE", (
+            "Raw _state must not be overwritten when transition is illegal"
+        )
+
+        # Must log a warning about the failed transition
+        warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and "Cannot transition" in r.message
+        ]
+        assert len(warnings) > 0, (
+            "Must log WARNING when transition to FAILED is illegal"
+        )

--- a/tests/unit/unification/test_phase2_batch_prep_integrity.py
+++ b/tests/unit/unification/test_phase2_batch_prep_integrity.py
@@ -23,20 +23,30 @@ from agent_actions.record.state import RecordState
 _PREPARATOR_LOGGER = "agent_actions.llm.batch.processing.preparator"
 
 
-@pytest.fixture(autouse=True)
-def _enable_log_propagation():
-    """Ensure agent_actions loggers propagate to root so caplog captures them."""
-    aa_logger = logging.getLogger("agent_actions")
-    orig = aa_logger.propagate
-    aa_logger.propagate = True
-    yield
-    aa_logger.propagate = orig
-
-
 class TestContextMapIntegrity:
     """U-2.B: context_map must not show INCLUDED for records where prepare() failed."""
 
-    def test_prepare_failure_not_marked_included(self, batch_preparator):
+    @pytest.fixture()
+    def prep_harness(self, batch_preparator):
+        """Shared setup for _process_single_item tests."""
+        return {
+            "preparator": batch_preparator,
+            "context_map": {},
+            "stats": BatchTaskPreparationStats(),
+            "prep_context": MagicMock(spec=PreparationContext),
+        }
+
+    def _run(self, prep_harness, row, task_preparer):
+        """Run _process_single_item with the shared harness."""
+        return prep_harness["preparator"]._process_single_item(
+            row,
+            prep_harness["prep_context"],
+            task_preparer,
+            prep_harness["context_map"],
+            prep_harness["stats"],
+        )
+
+    def test_prepare_failure_not_marked_included(self, prep_harness):
         """If prepare() throws, context_map must NOT have INCLUDED for that row.
 
         Bug: INCLUDED is set before prepare() runs, so when prepare() throws,
@@ -44,35 +54,24 @@ class TestContextMapIntegrity:
         context_map entry is left with INCLUDED — a lie.
         """
         row = {"target_id": "t-001", "content": {"text": "will fail"}}
-        context_map: dict = {}
-        stats = BatchTaskPreparationStats()
-        prep_context = MagicMock(spec=PreparationContext)
-
         task_preparer = MagicMock()
         task_preparer.prepare.side_effect = ValueError("schema validation failed")
 
         with pytest.raises(ValueError, match="schema validation failed"):
-            batch_preparator._process_single_item(
-                row, prep_context, task_preparer, context_map, stats
-            )
+            self._run(prep_harness, row, task_preparer)
 
-        # Row must be in context_map (for _mark_prep_failed to find it later)
+        context_map = prep_harness["context_map"]
         assert "t-001" in context_map
 
-        # But it must NOT be marked INCLUDED — prepare() never succeeded
         status = BatchContextMetadata.get_filter_status(context_map["t-001"])
         assert status != FilterStatus.INCLUDED, (
             f"context_map shows INCLUDED for row where prepare() failed — "
             f"INCLUDED was set before prepare() ran (got status={status})"
         )
 
-    def test_successful_prepare_marked_included(self, batch_preparator):
+    def test_successful_prepare_marked_included(self, prep_harness):
         """When prepare() succeeds and guard passes, context_map shows INCLUDED."""
         row = {"target_id": "t-002", "content": {"text": "will succeed"}}
-        context_map: dict = {}
-        stats = BatchTaskPreparationStats()
-        prep_context = MagicMock(spec=PreparationContext)
-
         task_preparer = MagicMock()
         prepared = MagicMock()
         prepared.guard_status = GuardStatus.PASSED
@@ -81,35 +80,27 @@ class TestContextMapIntegrity:
         prepared.formatted_prompt = "Process this"
         task_preparer.prepare.return_value = prepared
 
-        result = batch_preparator._process_single_item(
-            row, prep_context, task_preparer, context_map, stats
-        )
+        result = self._run(prep_harness, row, task_preparer)
 
         assert result is not None
-        status = BatchContextMetadata.get_filter_status(context_map["t-002"])
+        status = BatchContextMetadata.get_filter_status(prep_harness["context_map"]["t-002"])
         assert status == FilterStatus.INCLUDED, (
             f"context_map must show INCLUDED after successful prepare (got status={status})"
         )
 
-    def test_guard_skipped_not_marked_included(self, batch_preparator):
+    def test_guard_skipped_not_marked_included(self, prep_harness):
         """When guard skips a record, context_map shows SKIPPED, not INCLUDED."""
         row = {"target_id": "t-003", "content": {"text": "guard skip"}}
-        context_map: dict = {}
-        stats = BatchTaskPreparationStats()
-        prep_context = MagicMock(spec=PreparationContext)
-
         task_preparer = MagicMock()
         prepared = MagicMock()
         prepared.guard_status = GuardStatus.SKIPPED
         prepared.passthrough_fields = {}
         task_preparer.prepare.return_value = prepared
 
-        result = batch_preparator._process_single_item(
-            row, prep_context, task_preparer, context_map, stats
-        )
+        result = self._run(prep_harness, row, task_preparer)
 
         assert result is None
-        status = BatchContextMetadata.get_filter_status(context_map["t-003"])
+        status = BatchContextMetadata.get_filter_status(prep_harness["context_map"]["t-003"])
         assert status == FilterStatus.SKIPPED
 
 

--- a/tests/unit/unification/test_phase2_batch_prep_integrity.py
+++ b/tests/unit/unification/test_phase2_batch_prep_integrity.py
@@ -87,6 +87,10 @@ class TestContextMapIntegrity:
         assert status == FilterStatus.INCLUDED, (
             f"context_map must show INCLUDED after successful prepare (got status={status})"
         )
+        stats = prep_harness["stats"]
+        assert stats.included_items == 0, (
+            "included_items is counted by caller, not _process_single_item"
+        )
 
     def test_guard_skipped_not_marked_included(self, prep_harness):
         """When guard skips a record, context_map shows SKIPPED, not INCLUDED."""
@@ -102,6 +106,40 @@ class TestContextMapIntegrity:
         assert result is None
         status = BatchContextMetadata.get_filter_status(prep_harness["context_map"]["t-003"])
         assert status == FilterStatus.SKIPPED
+        assert prep_harness["stats"].skipped_items == 1
+
+    def test_guard_filtered_marked_filtered(self, prep_harness):
+        """When guard filters a record, context_map shows FILTERED, not INCLUDED."""
+        row = {"target_id": "t-004", "content": {"text": "guard filter"}}
+        task_preparer = MagicMock()
+        prepared = MagicMock()
+        prepared.guard_status = GuardStatus.FILTERED
+        prepared.passthrough_fields = {}
+        task_preparer.prepare.return_value = prepared
+
+        result = self._run(prep_harness, row, task_preparer)
+
+        assert result is None
+        status = BatchContextMetadata.get_filter_status(prep_harness["context_map"]["t-004"])
+        assert status == FilterStatus.FILTERED
+        assert prep_harness["stats"].filtered_items == 1
+
+    def test_upstream_unprocessed_marked_skipped(self, prep_harness):
+        """When upstream is unprocessed, context_map shows SKIPPED with reason."""
+        row = {"target_id": "t-005", "content": {"text": "upstream unprocessed"}}
+        task_preparer = MagicMock()
+        prepared = MagicMock()
+        prepared.guard_status = GuardStatus.UPSTREAM_UNPROCESSED
+        prepared.passthrough_fields = {}
+        task_preparer.prepare.return_value = prepared
+
+        result = self._run(prep_harness, row, task_preparer)
+
+        assert result is None
+        entry = prep_harness["context_map"]["t-005"]
+        assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.SKIPPED
+        assert BatchContextMetadata.get_skip_reason(entry) == "upstream_unprocessed"
+        assert prep_harness["stats"].skipped_items == 1
 
 
 class TestEnvelopeTransitionIntegrity:
@@ -121,14 +159,18 @@ class TestEnvelopeTransitionIntegrity:
             )
 
         entry = context_map["t-001"]
-        # FilterStatus must be FAILED
         assert BatchContextMetadata.get_filter_status(entry) == FilterStatus.FAILED
-
-        # _state must be set via transition() — evidenced by _state_history existing
-        assert "_state_history" in entry, (
-            "_mark_prep_failed must use transition() which sets _state_history"
-        )
         assert entry["_state"] == RecordState.FAILED.value
+
+        # transition() writes structured history — assert on content, not just existence
+        history = entry.get("_state_history")
+        assert isinstance(history, list) and len(history) > 0, (
+            "_mark_prep_failed must use transition() which writes _state_history entries"
+        )
+        last = history[-1]
+        assert last["to"] == RecordState.FAILED.value
+        assert last["action"] == "test_agent"
+        assert "test error" in last["reason"]
 
     def test_illegal_transition_logs_warning_no_raw_write(self, batch_preparator, caplog):
         """If transition is illegal, must log WARNING and NOT do raw _state write."""


### PR DESCRIPTION
## Summary
- **U-2.B**: `_process_single_item` previously set `FilterStatus.INCLUDED` before `prepare()` ran. If `prepare()` threw, the context_map entry was left as INCLUDED — a lie that downstream phases (3, 6, 7) trust for reconciliation. Now INCLUDED is set only after `prepare()` succeeds and guard checks pass.
- **U-1.3a / U-2.C**: Already fixed by Phase 1. Added regression tests confirming `_mark_prep_failed` uses `transition()` API with no raw `_state` bypass.

## Verification
- TDD red/green: `test_prepare_failure_not_marked_included` FAILS before fix, PASSES after
- 5/5 Phase 2 tests pass
- Full suite: 6888 passed, 2 skipped
- `ruff check` + `ruff format --check`: clean