### PR TITLE
fix(phase3): batch retrieve merge order and FAILED reconciliation

### DIFF
--- a/.changes/unreleased/Bug Fix-20260517-phase3.yaml
+++ b/.changes/unreleased/Bug Fix-20260517-phase3.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix batch retrieve: LLM output now wins over passthrough on key collision, and FAILED records no longer vanish from output"
+time: 2026-05-17T03:00:00.000000Z

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -28,7 +28,13 @@ from agent_actions.processing.types import (
     ProcessingStatus,
     RecoveryMetadata,
 )
-from agent_actions.record.reasons import BATCH_NOT_RETURNED, GUARD_SKIP, UPSTREAM_UNPROCESSED
+from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS
+from agent_actions.record.reasons import (
+    BATCH_NOT_RETURNED,
+    GUARD_SKIP,
+    PREP_FAILED,
+    UPSTREAM_UNPROCESSED,
+)
 from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.content import get_existing_content
 
@@ -322,14 +328,30 @@ class BatchResultStrategy:
         custom_id: str,
         generated_list: list[Any],
     ) -> list[Any]:
-        """Apply stored context_scope.passthrough fields to generated items."""
+        """Apply stored context_scope.passthrough fields to generated items.
+
+        LLM output wins on key collisions — passthrough only fills gaps.
+        Collisions on user-content fields are logged; framework fields
+        (target_id, _state, etc.) are silently skipped.
+        """
         stored_passthrough = BatchContextMetadata.get_passthrough_fields(ctx.context_map[custom_id])
 
         if stored_passthrough:
-            generated_list = [
-                {**item, **stored_passthrough} if isinstance(item, dict) else item
-                for item in generated_list
-            ]
+            passthrough_keys = set(stored_passthrough.keys())
+            merged: list[Any] = []
+            for item in generated_list:
+                if isinstance(item, dict):
+                    collisions = (passthrough_keys & set(item.keys())) - RECORD_FRAMEWORK_FIELDS
+                    if collisions:
+                        logger.info(
+                            "Passthrough keys overridden by LLM output for %s: %s",
+                            custom_id,
+                            collisions,
+                        )
+                    merged.append({**stored_passthrough, **item})
+                else:
+                    merged.append(item)
+            generated_list = merged
 
         return generated_list
 
@@ -413,6 +435,7 @@ class BatchResultStrategy:
 
         for custom_id, original_row in reconciliation.passthrough_records:
             is_exhausted = ctx.exhausted_recovery and custom_id in ctx.exhausted_recovery
+            is_failed = BatchContextMetadata.get_filter_status(original_row) == FilterStatus.FAILED
 
             record_index = ctx.reconciler.get_record_index(custom_id)
             source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "NOT_SET")
@@ -425,6 +448,14 @@ class BatchResultStrategy:
                 result = self._build_exhausted_passthrough(
                     ctx,
                     custom_id,
+                    original_row,
+                    action_name,
+                    source_guid,
+                    record_index,
+                )
+            elif is_failed:
+                result = self._build_failed_passthrough(
+                    ctx,
                     original_row,
                     action_name,
                     source_guid,
@@ -540,4 +571,43 @@ class BatchResultStrategy:
             source_snapshot=copy.deepcopy(original_row) if original_row else None,
         )
         processing_result.processing_context = processing_context
+        return processing_result
+
+    def _build_failed_passthrough(
+        self,
+        ctx: BatchProcessingContext,
+        original_row: dict[str, Any],
+        action_name: str,
+        source_guid: str,
+        record_index: int,
+    ) -> ProcessingResult:
+        """Build a FAILED result for a record that failed during batch preparation.
+
+        Records with FilterStatus.FAILED were never submitted to the provider.
+        They must still appear in output so downstream consumers see all records.
+        """
+        skip_reason = BatchContextMetadata.get_skip_reason(original_row)
+        reason = skip_reason or PREP_FAILED
+
+        passthrough_item = build_tombstone(
+            action_name,
+            original_row,
+            reason,
+            source_guid=source_guid,
+        )
+
+        processing_context = BatchContextAdapter.to_processing_context(
+            agent_config=ctx.agent_config or {},
+            original_row=original_row,
+            record_index=record_index,
+            output_directory=ctx.output_directory,
+        )
+        processing_result = ProcessingResult.failed(
+            error=reason,
+            source_guid=source_guid,
+            source_snapshot=copy.deepcopy(original_row) if original_row else None,
+        )
+        processing_result.data = [passthrough_item]
+        processing_result.processing_context = processing_context
+        processing_result.skip_reason = reason
         return processing_result

--- a/agent_actions/llm/batch/processing/reconciler.py
+++ b/agent_actions/llm/batch/processing/reconciler.py
@@ -55,7 +55,12 @@ class BatchResultReconciler:
             if filter_status == FilterStatus.FILTERED:
                 continue
 
-            if filter_status in (FilterStatus.SKIPPED, FilterStatus.INCLUDED, None):
+            if filter_status in (
+                FilterStatus.SKIPPED,
+                FilterStatus.INCLUDED,
+                FilterStatus.FAILED,
+                None,
+            ):
                 passthrough_records.append((custom_id, original_row))
 
         return passthrough_records

--- a/tests/unit/unification/test_phase3_batch_retrieve.py
+++ b/tests/unit/unification/test_phase3_batch_retrieve.py
@@ -1,0 +1,344 @@
+"""Phase 3: Batch retrieve correctness tests.
+
+U-2.A: LLM output must win over passthrough on key collision.
+U-2.D: FAILED records must appear in output, not vanish.
+"""
+
+import copy
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.llm.batch.processing.batch_result_strategy import (
+    BatchProcessingContext,
+    BatchResultStrategy,
+)
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+from agent_actions.llm.providers.batch_base import BatchResult
+from agent_actions.processing.types import ProcessingResult, ProcessingStatus
+from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def strategy() -> BatchResultStrategy:
+    """BatchResultStrategy instance for testing."""
+    return BatchResultStrategy()
+
+
+def _build_context_map_row(
+    target_id: str,
+    *,
+    filter_status: FilterStatus | None = None,
+    passthrough_fields: dict[str, Any] | None = None,
+    skip_reason: str | None = None,
+    error: str | None = None,
+    content: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a context_map row with batch metadata stamped."""
+    row: dict[str, Any] = {
+        "target_id": target_id,
+        "source_guid": f"sg-{target_id}",
+        "content": content or {"text": f"content for {target_id}"},
+    }
+    if filter_status is not None:
+        BatchContextMetadata.set_filter_status(row, filter_status)
+    if passthrough_fields is not None:
+        BatchContextMetadata.set_passthrough_fields(row, passthrough_fields)
+    if skip_reason is not None:
+        BatchContextMetadata.set_skip_reason(row, skip_reason)
+    return row
+
+
+def _make_batch_result(custom_id: str, content: dict[str, Any]) -> BatchResult:
+    """Build a BatchResult with the given content."""
+    result = MagicMock(spec=BatchResult)
+    result.custom_id = custom_id
+    result.content = content
+    result.error = None
+    result.success = True
+    result.metadata = {}
+    result.recovery_metadata = None
+    return result
+
+
+def _make_ctx(
+    batch_results: list[BatchResult],
+    context_map: dict[str, Any],
+    agent_config: dict[str, Any] | None = None,
+) -> BatchProcessingContext:
+    """Build a BatchProcessingContext with reconciler wired."""
+    ctx = BatchProcessingContext(
+        batch_results=batch_results,
+        context_map=context_map,
+        output_directory="/tmp/test",
+        agent_config=agent_config or {"action_name": "test_action"},
+    )
+    ctx.reconciler = BatchResultReconciler(context_map)
+    return ctx
+
+
+# ===========================================================================
+# U-2.A: LLM output must win over passthrough on key collision
+# ===========================================================================
+
+
+class TestMergeOrder:
+    """U-2.A: LLM output must win over passthrough on key collision."""
+
+    def test_llm_wins_on_passthrough_collision(self, strategy: BatchResultStrategy) -> None:
+        """When passthrough and LLM have same key, LLM value is kept."""
+        # Passthrough has "summary" — same key the LLM will produce.
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.INCLUDED,
+                passthrough_fields={"summary": "Original passthrough value", "extra_field": "kept"},
+            ),
+        }
+        llm_result = _make_batch_result("t-001", {"summary": "LLM generated this", "score": 0.95})
+
+        ctx = _make_ctx([llm_result], context_map)
+        results = strategy.process(
+            batch_results=ctx.batch_results,
+            context_map=ctx.context_map,
+            output_directory=ctx.output_directory,
+            agent_config=ctx.agent_config,
+        )
+
+        assert len(results) == 1
+        result = results[0]
+        assert result.status == ProcessingStatus.SUCCESS
+
+        # Data items are {source_guid, content: {<existing>, <action_name>: {<merged>}}, target_id}.
+        # The passthrough merge happens BEFORE version_merge wraps output under action_name.
+        # So the merged fields live inside content[action_name].
+        data_item = result.data[0]
+        action_ns = data_item["content"]["test_action"]
+
+        # LLM value must win on collision
+        assert action_ns["summary"] == "LLM generated this", (
+            f"LLM value should win on collision, got action_ns={action_ns}"
+        )
+        assert action_ns["score"] == 0.95
+
+    def test_passthrough_fills_gaps(self, strategy: BatchResultStrategy) -> None:
+        """Passthrough fields that don't collide with LLM output are preserved."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.INCLUDED,
+                passthrough_fields={"category": "finance", "region": "US"},
+            ),
+        }
+        llm_result = _make_batch_result("t-001", {"summary": "LLM output", "score": 0.8})
+
+        ctx = _make_ctx([llm_result], context_map)
+        results = strategy.process(
+            batch_results=ctx.batch_results,
+            context_map=ctx.context_map,
+            output_directory=ctx.output_directory,
+            agent_config=ctx.agent_config,
+        )
+
+        assert len(results) == 1
+        data_item = results[0].data[0]
+        action_ns = data_item["content"]["test_action"]
+
+        # Non-colliding passthrough fields should be present in the action namespace
+        assert action_ns.get("category") == "finance", (
+            f"Non-colliding passthrough field missing: action_ns={action_ns}"
+        )
+        assert action_ns.get("region") == "US"
+
+    def test_collision_logged(self, strategy: BatchResultStrategy, caplog: pytest.LogCaptureFixture) -> None:
+        """Key collisions between passthrough and LLM output are logged."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.INCLUDED,
+                passthrough_fields={"summary": "will collide"},
+            ),
+        }
+        llm_result = _make_batch_result("t-001", {"summary": "LLM wins"})
+
+        ctx = _make_ctx([llm_result], context_map)
+        with caplog.at_level(logging.INFO):
+            strategy.process(
+                batch_results=ctx.batch_results,
+                context_map=ctx.context_map,
+                output_directory=ctx.output_directory,
+                agent_config=ctx.agent_config,
+            )
+
+        collision_logged = any("summary" in r.message for r in caplog.records)
+        assert collision_logged, (
+            "Collision between passthrough and LLM key 'summary' should be logged"
+        )
+
+    def test_framework_fields_not_logged_as_collision(
+        self, strategy: BatchResultStrategy, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Framework fields (target_id, _state, etc.) should not be logged as collisions."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.INCLUDED,
+                passthrough_fields={"target_id": "t-001", "summary": "will collide"},
+            ),
+        }
+        llm_result = _make_batch_result("t-001", {"summary": "LLM wins", "target_id": "t-001"})
+
+        ctx = _make_ctx([llm_result], context_map)
+        with caplog.at_level(logging.INFO):
+            strategy.process(
+                batch_results=ctx.batch_results,
+                context_map=ctx.context_map,
+                output_directory=ctx.output_directory,
+                agent_config=ctx.agent_config,
+            )
+
+        # target_id is a framework field — should NOT be logged as collision
+        for record in caplog.records:
+            if "target_id" in record.message and "collision" in record.message.lower():
+                pytest.fail(
+                    f"Framework field 'target_id' logged as collision: {record.message}"
+                )
+
+
+# ===========================================================================
+# U-2.D: FAILED records must appear in output, not vanish
+# ===========================================================================
+
+
+class TestFailedRecordReconciliation:
+    """U-2.D: FAILED records must appear in output, not vanish."""
+
+    def test_failed_records_in_output(self, strategy: BatchResultStrategy) -> None:
+        """Records with FilterStatus.FAILED in context_map must appear in final output."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.INCLUDED,
+            ),
+            "t-002": _build_context_map_row(
+                "t-002",
+                filter_status=FilterStatus.FAILED,
+            ),
+        }
+        # Only t-001 returned by provider (t-002 was never submitted — it failed prep)
+        provider_results = [
+            _make_batch_result("t-001", {"summary": "success"}),
+        ]
+
+        ctx = _make_ctx(provider_results, context_map)
+        results = strategy.process(
+            batch_results=ctx.batch_results,
+            context_map=ctx.context_map,
+            output_directory=ctx.output_directory,
+            agent_config=ctx.agent_config,
+        )
+
+        # t-002 must appear in output
+        result_target_ids = set()
+        for r in results:
+            for item in r.data:
+                tid = item.get("target_id")
+                if tid:
+                    result_target_ids.add(tid)
+            if r.source_guid and r.source_guid.startswith("sg-"):
+                # Extract target_id from source_guid convention
+                pass
+
+        # Also check via source_guid
+        result_source_guids = {r.source_guid for r in results}
+
+        assert "sg-t-002" in result_source_guids or "t-002" in result_target_ids, (
+            f"FAILED record t-002 must appear in output. "
+            f"Got source_guids={result_source_guids}, target_ids={result_target_ids}"
+        )
+
+    def test_failed_record_has_failed_status(self, strategy: BatchResultStrategy) -> None:
+        """FAILED record in output must have a failed/error status, not SUCCESS."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.FAILED,
+            ),
+        }
+        # No provider results — all records failed prep
+        results = strategy.process(
+            batch_results=[],
+            context_map=context_map,
+            output_directory="/tmp/test",
+            agent_config={"action_name": "test_action"},
+        )
+
+        assert len(results) >= 1, "FAILED record must produce output"
+        failed_result = results[0]
+        assert failed_result.status in (ProcessingStatus.FAILED, ProcessingStatus.UNPROCESSED), (
+            f"FAILED record should have FAILED or UNPROCESSED status, got {failed_result.status}"
+        )
+
+    def test_no_duplicate_records(self, strategy: BatchResultStrategy) -> None:
+        """FAILED records must not produce duplicate entries in output."""
+        context_map = {
+            "t-001": _build_context_map_row("t-001", filter_status=FilterStatus.INCLUDED),
+            "t-002": _build_context_map_row("t-002", filter_status=FilterStatus.FAILED),
+            "t-003": _build_context_map_row("t-003", filter_status=FilterStatus.SKIPPED, skip_reason="guard_skip"),
+        }
+        provider_results = [
+            _make_batch_result("t-001", {"summary": "success"}),
+        ]
+
+        ctx = _make_ctx(provider_results, context_map)
+        results = strategy.process(
+            batch_results=ctx.batch_results,
+            context_map=ctx.context_map,
+            output_directory=ctx.output_directory,
+            agent_config=ctx.agent_config,
+        )
+
+        # Collect all source_guids — no duplicates allowed
+        source_guids = [r.source_guid for r in results if r.source_guid]
+        assert len(source_guids) == len(set(source_guids)), (
+            f"Duplicate source_guids in output: {source_guids}"
+        )
+
+    def test_failed_record_has_error_reason(self, strategy: BatchResultStrategy) -> None:
+        """FAILED record must carry the error reason from prep failure."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.FAILED,
+            ),
+        }
+        # Stamp skip_reason to simulate prep failure reason
+        BatchContextMetadata.set_skip_reason(context_map["t-001"], "prep_failed")
+
+        results = strategy.process(
+            batch_results=[],
+            context_map=context_map,
+            output_directory="/tmp/test",
+            agent_config={"action_name": "test_action"},
+        )
+
+        assert len(results) >= 1, "FAILED record must produce output"
+        failed_result = results[0]
+        # Must have an error or skip_reason indicating why it failed
+        has_reason = (
+            failed_result.error is not None
+            or failed_result.skip_reason is not None
+        )
+        assert has_reason, (
+            f"FAILED record must carry error reason. "
+            f"error={failed_result.error}, skip_reason={failed_result.skip_reason}"
+        )

--- a/tests/unit/unification/test_phase3_batch_retrieve.py
+++ b/tests/unit/unification/test_phase3_batch_retrieve.py
@@ -4,7 +4,6 @@ U-2.A: LLM output must win over passthrough on key collision.
 U-2.D: FAILED records must appear in output, not vanish.
 """
 
-import copy
 import logging
 from typing import Any
 from unittest.mock import MagicMock
@@ -19,13 +18,21 @@ from agent_actions.llm.batch.processing.batch_result_strategy import (
 )
 from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
 from agent_actions.llm.providers.batch_base import BatchResult
-from agent_actions.processing.types import ProcessingResult, ProcessingStatus
-from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS
-
+from agent_actions.processing.types import ProcessingStatus
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Ensure agent_actions loggers propagate to root so caplog captures them."""
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig
 
 
 @pytest.fixture
@@ -159,7 +166,9 @@ class TestMergeOrder:
         )
         assert action_ns.get("region") == "US"
 
-    def test_collision_logged(self, strategy: BatchResultStrategy, caplog: pytest.LogCaptureFixture) -> None:
+    def test_collision_logged(
+        self, strategy: BatchResultStrategy, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Key collisions between passthrough and LLM output are logged."""
         context_map = {
             "t-001": _build_context_map_row(
@@ -171,7 +180,7 @@ class TestMergeOrder:
         llm_result = _make_batch_result("t-001", {"summary": "LLM wins"})
 
         ctx = _make_ctx([llm_result], context_map)
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             strategy.process(
                 batch_results=ctx.batch_results,
                 context_map=ctx.context_map,
@@ -179,9 +188,10 @@ class TestMergeOrder:
                 agent_config=ctx.agent_config,
             )
 
-        collision_logged = any("summary" in r.message for r in caplog.records)
+        collision_logged = any("summary" in r.getMessage() for r in caplog.records)
         assert collision_logged, (
-            "Collision between passthrough and LLM key 'summary' should be logged"
+            f"Collision between passthrough and LLM key 'summary' should be logged. "
+            f"Records: {[(r.name, r.getMessage()) for r in caplog.records]}"
         )
 
     def test_framework_fields_not_logged_as_collision(
@@ -209,9 +219,7 @@ class TestMergeOrder:
         # target_id is a framework field — should NOT be logged as collision
         for record in caplog.records:
             if "target_id" in record.message and "collision" in record.message.lower():
-                pytest.fail(
-                    f"Framework field 'target_id' logged as collision: {record.message}"
-                )
+                pytest.fail(f"Framework field 'target_id' logged as collision: {record.message}")
 
 
 # ===========================================================================
@@ -247,23 +255,10 @@ class TestFailedRecordReconciliation:
             agent_config=ctx.agent_config,
         )
 
-        # t-002 must appear in output
-        result_target_ids = set()
-        for r in results:
-            for item in r.data:
-                tid = item.get("target_id")
-                if tid:
-                    result_target_ids.add(tid)
-            if r.source_guid and r.source_guid.startswith("sg-"):
-                # Extract target_id from source_guid convention
-                pass
-
-        # Also check via source_guid
+        # t-002 must appear in output (check via source_guid)
         result_source_guids = {r.source_guid for r in results}
-
-        assert "sg-t-002" in result_source_guids or "t-002" in result_target_ids, (
-            f"FAILED record t-002 must appear in output. "
-            f"Got source_guids={result_source_guids}, target_ids={result_target_ids}"
+        assert "sg-t-002" in result_source_guids, (
+            f"FAILED record t-002 must appear in output. Got source_guids={result_source_guids}"
         )
 
     def test_failed_record_has_failed_status(self, strategy: BatchResultStrategy) -> None:
@@ -282,10 +277,10 @@ class TestFailedRecordReconciliation:
             agent_config={"action_name": "test_action"},
         )
 
-        assert len(results) >= 1, "FAILED record must produce output"
+        assert len(results) == 1, "FAILED record must produce exactly one output"
         failed_result = results[0]
-        assert failed_result.status in (ProcessingStatus.FAILED, ProcessingStatus.UNPROCESSED), (
-            f"FAILED record should have FAILED or UNPROCESSED status, got {failed_result.status}"
+        assert failed_result.status == ProcessingStatus.FAILED, (
+            f"FAILED record must have FAILED status, got {failed_result.status}"
         )
 
     def test_no_duplicate_records(self, strategy: BatchResultStrategy) -> None:
@@ -293,7 +288,9 @@ class TestFailedRecordReconciliation:
         context_map = {
             "t-001": _build_context_map_row("t-001", filter_status=FilterStatus.INCLUDED),
             "t-002": _build_context_map_row("t-002", filter_status=FilterStatus.FAILED),
-            "t-003": _build_context_map_row("t-003", filter_status=FilterStatus.SKIPPED, skip_reason="guard_skip"),
+            "t-003": _build_context_map_row(
+                "t-003", filter_status=FilterStatus.SKIPPED, skip_reason="guard_skip"
+            ),
         }
         provider_results = [
             _make_batch_result("t-001", {"summary": "success"}),
@@ -331,14 +328,88 @@ class TestFailedRecordReconciliation:
             agent_config={"action_name": "test_action"},
         )
 
-        assert len(results) >= 1, "FAILED record must produce output"
+        assert len(results) == 1, "FAILED record must produce exactly one output"
         failed_result = results[0]
-        # Must have an error or skip_reason indicating why it failed
-        has_reason = (
-            failed_result.error is not None
-            or failed_result.skip_reason is not None
+        assert failed_result.error == "prep_failed"
+        assert failed_result.skip_reason == "prep_failed"
+
+    def test_failed_record_defaults_to_prep_failed_reason(
+        self, strategy: BatchResultStrategy
+    ) -> None:
+        """FAILED record without skip_reason falls back to PREP_FAILED constant."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.FAILED,
+                # No skip_reason set — should fall back to PREP_FAILED
+            ),
+        }
+        results = strategy.process(
+            batch_results=[],
+            context_map=context_map,
+            output_directory="/tmp/test",
+            agent_config={"action_name": "test_action"},
         )
-        assert has_reason, (
-            f"FAILED record must carry error reason. "
-            f"error={failed_result.error}, skip_reason={failed_result.skip_reason}"
+
+        assert len(results) == 1
+        failed_result = results[0]
+        assert failed_result.error == "prep_failed", (
+            f"Should fall back to PREP_FAILED constant, got error={failed_result.error}"
         )
+        assert failed_result.skip_reason == "prep_failed"
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+class TestPassthroughEdgeCases:
+    """Edge cases for passthrough merge logic."""
+
+    def test_no_passthrough_fields_is_noop(self, strategy: BatchResultStrategy) -> None:
+        """INCLUDED record with no passthrough_fields — merge is skipped cleanly."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.INCLUDED,
+                # No passthrough_fields
+            ),
+        }
+        llm_result = _make_batch_result("t-001", {"summary": "LLM output"})
+
+        ctx = _make_ctx([llm_result], context_map)
+        results = strategy.process(
+            batch_results=ctx.batch_results,
+            context_map=ctx.context_map,
+            output_directory=ctx.output_directory,
+            agent_config=ctx.agent_config,
+        )
+
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS
+        action_ns = results[0].data[0]["content"]["test_action"]
+        assert action_ns["summary"] == "LLM output"
+
+    def test_empty_passthrough_fields_is_noop(self, strategy: BatchResultStrategy) -> None:
+        """INCLUDED record with empty passthrough_fields dict — no extra keys added."""
+        context_map = {
+            "t-001": _build_context_map_row(
+                "t-001",
+                filter_status=FilterStatus.INCLUDED,
+                passthrough_fields={},
+            ),
+        }
+        llm_result = _make_batch_result("t-001", {"summary": "LLM output"})
+
+        ctx = _make_ctx([llm_result], context_map)
+        results = strategy.process(
+            batch_results=ctx.batch_results,
+            context_map=ctx.context_map,
+            output_directory=ctx.output_directory,
+            agent_config=ctx.agent_config,
+        )
+
+        assert len(results) == 1
+        action_ns = results[0].data[0]["content"]["test_action"]
+        assert action_ns == {"summary": "LLM output"}


### PR DESCRIPTION
## Summary
- **U-2.A**: Reverse passthrough merge order so LLM output wins on key collision. Collisions on user-content fields logged; framework fields excluded from logging.
- **U-2.D**: Include `FilterStatus.FAILED` records in passthrough reconciliation via `_build_failed_passthrough()`, so prep-failed records appear in output instead of vanishing.

## Verification
- 8 new TDD tests in `tests/unit/unification/test_phase3_batch_retrieve.py` — all pass
- Full pytest suite: 6859 passed (2 pre-existing failures in ollama/json_parsing trailing comma tests, unrelated)
- `ruff format --check` and `ruff check` clean