### PR TITLE
Phase 5: Guard context alignment — online prefilter parity

### DIFF
--- a/.changes/unreleased/Bug Fix-20260517-phase5.yaml
+++ b/.changes/unreleased/Bug Fix-20260517-phase5.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Align online guard prefilter context with batch TaskPreparer.prepare() context so guards referencing source, version, workflow namespaces, or promoted output_fields produce identical decisions in both execution modes"
+time: 2026-05-17T00:50:00.000000Z

--- a/agent_actions/processing/guard_context.py
+++ b/agent_actions/processing/guard_context.py
@@ -1,0 +1,128 @@
+"""Shared guard context builder for batch and online paths.
+
+Ensures both prefilter_by_guard (online) and TaskPreparer.prepare (batch)
+evaluate guards with identical field_context, closing the "works in batch,
+fails online" guard class.
+
+This module is the SINGLE source of truth for guard context construction.
+Both paths MUST use build_guard_context — duplicating this logic is a
+merge-blocking anti-pattern.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def build_guard_context(
+    record: dict[str, Any],
+    *,
+    agent_name: str,
+    agent_config: dict[str, Any],
+    agent_indices: dict[str, int] | None = None,
+    source_data: list[dict[str, Any]] | None = None,
+    source_content: Any = None,
+    is_first_stage: bool = False,
+    version_context: dict[str, Any] | None = None,
+    workflow_metadata: dict[str, Any] | None = None,
+    dependency_configs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build full field_context for guard evaluation.
+
+    Replicates the context assembly performed by TaskPreparer._load_full_context
+    so that both online prefilter and batch prepare evaluate guards against
+    identical context structures.
+
+    Args:
+        record: The input record (must have "content" dict).
+        agent_name: Current action name.
+        agent_config: Action configuration (contains context_scope, guard, etc.).
+        agent_indices: Map of action names to workflow positions (enables dep loading).
+        source_data: Original source records (for resolving source_guid lookups).
+        source_content: Pre-resolved source content (batch path provides this
+            directly; when given, source_data resolution is skipped).
+        is_first_stage: Whether this is the first action in the workflow.
+        version_context: Loop iteration metadata (i, idx, length, first, last).
+        workflow_metadata: Workflow-level metadata.
+        dependency_configs: Per-dependency config (for output_field promotion).
+
+    Returns:
+        Full field_context dict with source, dependency, version, and workflow
+        namespaces — identical to what TaskPreparer.prepare() provides.
+    """
+    from agent_actions.prompt.context.scope_builder import build_field_context_with_history
+    from agent_actions.utils.content import get_existing_content
+
+    content = get_existing_content(record)
+
+    # Resolve source_content: use pre-resolved value if provided (batch path),
+    # otherwise resolve from source_data (online path).
+    if source_content is not None:
+        resolved_source = source_content
+    elif is_first_stage:
+        resolved_source = content
+    else:
+        resolved_source = _resolve_source_content(record, source_data)
+        if resolved_source is None:
+            resolved_source = content
+
+    field_context = build_field_context_with_history(
+        agent_name=agent_name,
+        agent_config=agent_config,
+        agent_indices=agent_indices,
+        source_content=resolved_source,
+        version_context=version_context,
+        workflow_metadata=workflow_metadata,
+        current_item=record,
+        context_scope=agent_config.get("context_scope"),
+    )
+    field_context.pop("_dependency_metadata", None)
+
+    # Promote output_field values to top-level so guards can reference them
+    # directly (e.g., "severity" instead of "assess.severity").
+    if dependency_configs:
+        for dep_name, dep_config in dependency_configs.items():
+            if not dep_config or "output_field" not in dep_config:
+                continue
+            of_name = dep_config["output_field"]
+            dep_data = field_context.get(dep_name)
+            # Unwrap single-item list (common storage shape for output_field actions)
+            if isinstance(dep_data, list) and len(dep_data) == 1:
+                dep_data = dep_data[0]
+            if isinstance(dep_data, dict) and of_name in dep_data:
+                if of_name not in field_context:
+                    field_context[of_name] = dep_data[of_name]
+                else:
+                    logger.warning(
+                        "output_field '%s' from action '%s' collides with existing "
+                        "field in context — use '%s.%s' in guard conditions instead",
+                        of_name,
+                        dep_name,
+                        dep_name,
+                        of_name,
+                    )
+
+    return field_context
+
+
+def _resolve_source_content(
+    record: dict[str, Any],
+    source_data: list[dict[str, Any]] | None,
+) -> Any | None:
+    """Look up source content by source_guid, matching TaskPreparer._get_source_content.
+
+    Uses DataTransformer.get_content_by_source_guid for consistency with the
+    batch path.
+    """
+    if not source_data:
+        return None
+    source_guid = record.get("source_guid")
+    if not source_guid:
+        return None
+
+    from agent_actions.input.preprocessing.transformation.transformer import (
+        DataTransformer,
+    )
+
+    return DataTransformer.get_content_by_source_guid(source_data, source_guid)

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -206,48 +206,24 @@ class TaskPreparer:
         context: PreparationContext,
         current_item: dict | None = None,
     ) -> dict[str, Any]:
-        """Load full context (source, upstream, version, workflow) for guard and prompt."""
-        from agent_actions.prompt.context.scope_builder import build_field_context_with_history
+        """Load full context (source, upstream, version, workflow) for guard and prompt.
 
-        field_context = build_field_context_with_history(
+        Delegates to the shared build_guard_context helper to ensure batch
+        and online paths always build identical guard context.
+        """
+        from agent_actions.processing.guard_context import build_guard_context
+
+        record = current_item if current_item is not None else {"content": content}
+        return build_guard_context(
+            record,
             agent_name=context.agent_name,
             agent_config=context.agent_config,
             agent_indices=context.agent_indices,
             source_content=source_content,
             version_context=context.version_context,
             workflow_metadata=context.workflow_metadata,
-            current_item=current_item,
-            context_scope=context.agent_config.get("context_scope"),
+            dependency_configs=context.dependency_configs,
         )
-        field_context.pop("_dependency_metadata", None)
-
-        # Promote output_field values to top-level so guards can reference them directly.
-        # E.g., if action "assess_severity" has output_field="severity", then
-        # field_context["severity"] = field_context["assess_severity"]["severity"]
-        # so guards can write `severity != "low"` instead of `assess_severity.severity != "low"`.
-        if context.dependency_configs:
-            for dep_name, dep_config in context.dependency_configs.items():
-                if not dep_config or "output_field" not in dep_config:
-                    continue
-                of_name = dep_config["output_field"]
-                dep_data = field_context.get(dep_name)
-                # Unwrap single-item list (common storage shape for output_field actions)
-                if isinstance(dep_data, list) and len(dep_data) == 1:
-                    dep_data = dep_data[0]
-                if isinstance(dep_data, dict) and of_name in dep_data:
-                    if of_name not in field_context:
-                        field_context[of_name] = dep_data[of_name]
-                    else:
-                        logger.warning(
-                            "output_field '%s' from action '%s' collides with existing "
-                            "field in context — use '%s.%s' in guard conditions instead",
-                            of_name,
-                            dep_name,
-                            dep_name,
-                            of_name,
-                        )
-
-        return field_context
 
     @staticmethod
     def _evaluate_guard(

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -129,6 +129,12 @@ class UnifiedProcessor:
             records,
             config,
             context.agent_name,
+            agent_indices=context.agent_indices,
+            source_data=context.source_data or None,
+            is_first_stage=context.is_first_stage,
+            version_context=context.version_context,
+            workflow_metadata=context.workflow_metadata,
+            dependency_configs=context.dependency_configs,
         )
 
         guard_results: list[ProcessingResult] = []
@@ -182,6 +188,12 @@ class UnifiedProcessor:
             config,
             context.agent_name,
             original_data=raw_records,
+            agent_indices=context.agent_indices,
+            source_data=context.source_data or None,
+            is_first_stage=context.is_first_stage,
+            version_context=context.version_context,
+            workflow_metadata=context.workflow_metadata,
+            dependency_configs=context.dependency_configs,
         )
 
         guard_results: list[ProcessingResult] = []

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -310,6 +310,13 @@ def prefilter_by_guard(
     agent_config: dict[str, Any],
     agent_name: str,
     original_data: list[dict] | None = None,
+    *,
+    agent_indices: dict[str, int] | None = None,
+    source_data: list[dict[str, Any]] | None = None,
+    is_first_stage: bool = False,
+    version_context: dict[str, Any] | None = None,
+    workflow_metadata: dict[str, Any] | None = None,
+    dependency_configs: dict[str, Any] | None = None,
 ) -> tuple[list[dict], list[dict], list[dict]]:
     """Evaluate guard per-record and split into passing and skipped arrays.
 
@@ -323,12 +330,12 @@ def prefilter_by_guard(
     each passing record.  This preserves upstream fields that observe
     filtering may have stripped.
 
-    When no guard is configured, returns ``(data, [], original_data or data)``.
+    When pipeline context parameters are provided (agent_indices, source_data,
+    etc.), guard evaluation uses full field_context — identical to
+    TaskPreparer.prepare() — so guards referencing source, version, workflow,
+    or promoted output_fields produce correct decisions.
 
-    Note:
-        Guard evaluation uses the record's existing content as context so
-        that guard clauses can reference upstream namespace fields — matching
-        the per-record guard context used in batch mode.
+    When no guard is configured, returns ``(data, [], original_data or data)``.
 
     Returns:
         (passing, skipped, original_passing)
@@ -349,11 +356,24 @@ def prefilter_by_guard(
     from agent_actions.input.preprocessing.filtering.evaluator import (
         get_guard_evaluator,
     )
+    from agent_actions.processing.guard_context import build_guard_context
     from agent_actions.utils.content import get_existing_content
 
     evaluator = get_guard_evaluator()
     # The config expander normalizes user-facing "on_false" into "behavior"
     behavior = GuardBehavior(guard_config.get("behavior", "filter"))
+
+    # Determine whether full context building is available.
+    has_pipeline_context = any(
+        v is not None
+        for v in (
+            agent_indices,
+            source_data,
+            version_context,
+            workflow_metadata,
+            dependency_configs,
+        )
+    )
 
     passing: list[dict] = []
     skipped: list[dict] = []
@@ -361,10 +381,25 @@ def prefilter_by_guard(
     for idx, item in enumerate(data):
         eval_item = get_existing_content(item)
 
+        if has_pipeline_context:
+            context = build_guard_context(
+                item,
+                agent_name=agent_name,
+                agent_config=agent_config,
+                agent_indices=agent_indices,
+                source_data=source_data,
+                is_first_stage=is_first_stage,
+                version_context=version_context,
+                workflow_metadata=workflow_metadata,
+                dependency_configs=dependency_configs,
+            )
+        else:
+            context = eval_item
+
         result = evaluator.evaluate(
             item=eval_item,
             guard_config=guard_config,
-            context=eval_item,
+            context=context,
         )
 
         if result.should_execute:

--- a/tests/preprocessing/test_guard_evaluator.py
+++ b/tests/preprocessing/test_guard_evaluator.py
@@ -435,13 +435,13 @@ class TestOutputFieldPromotionInTaskPreparer:
             },
         )
 
-        tp_logger = logging.getLogger("agent_actions.processing.task_preparer")
+        gc_logger = logging.getLogger("agent_actions.processing.guard_context")
         with (
             patch(
                 "agent_actions.prompt.context.scope_builder.build_field_context_with_history",
                 return_value=mock_field_context,
             ),
-            patch.object(tp_logger, "warning") as mock_warn,
+            patch.object(gc_logger, "warning") as mock_warn,
         ):
             preparer._load_full_context(
                 content={},

--- a/tests/unit/unification/test_phase5_guard_context.py
+++ b/tests/unit/unification/test_phase5_guard_context.py
@@ -1,0 +1,300 @@
+"""Phase 5: Guard context alignment — TDD red tests.
+
+Proves that online prefilter and batch prepare produce different guard
+decisions for the same record when the guard references fields only
+available through full context building (source namespace, version
+namespace, output_field promotion).
+
+These tests MUST FAIL against current code.
+After Commit C (wire prefilter), they turn green.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_actions.input.preprocessing.filtering.evaluator import GuardEvaluator
+from agent_actions.prompt.context.scope_builder import build_field_context_with_history
+from agent_actions.utils.content import get_existing_content
+from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+# ---------------------------------------------------------------------------
+# Helpers — simulate batch and online guard evaluation paths
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_guard_online(
+    record: dict[str, Any],
+    guard_config: dict[str, Any],
+) -> bool:
+    """Simulate the online prefilter guard path (current behavior).
+
+    Mirrors prefilter_by_guard: context = eval_item = get_existing_content(record).
+    """
+    evaluator = GuardEvaluator()
+    eval_item = get_existing_content(record)
+    result = evaluator.evaluate(item=eval_item, guard_config=guard_config, context=eval_item)
+    return result.should_execute
+
+
+def _evaluate_guard_batch(
+    record: dict[str, Any],
+    guard_config: dict[str, Any],
+    *,
+    agent_name: str = "test_action",
+    agent_config: dict[str, Any] | None = None,
+    agent_indices: dict[str, int] | None = None,
+    source_content: Any = None,
+    version_context: dict[str, Any] | None = None,
+    workflow_metadata: dict[str, Any] | None = None,
+    dependency_configs: dict[str, Any] | None = None,
+) -> bool:
+    """Simulate the batch prepare guard path.
+
+    Mirrors TaskPreparer.prepare: builds full field_context via
+    build_field_context_with_history, then evaluates guard with that context.
+    """
+    evaluator = GuardEvaluator()
+    content = get_existing_content(record)
+    config = agent_config or {"name": agent_name}
+
+    if source_content is None:
+        source_content = content
+
+    field_context = build_field_context_with_history(
+        agent_name=agent_name,
+        agent_config=config,
+        agent_indices=agent_indices,
+        source_content=source_content,
+        version_context=version_context,
+        workflow_metadata=workflow_metadata,
+        current_item=record,
+        context_scope=config.get("context_scope"),
+    )
+    field_context.pop("_dependency_metadata", None)
+
+    # Promote output_field values (mirrors TaskPreparer._load_full_context)
+    if dependency_configs:
+        for dep_name, dep_config in dependency_configs.items():
+            if not dep_config or "output_field" not in dep_config:
+                continue
+            of_name = dep_config["output_field"]
+            dep_data = field_context.get(dep_name)
+            if isinstance(dep_data, list) and len(dep_data) == 1:
+                dep_data = dep_data[0]
+            if isinstance(dep_data, dict) and of_name in dep_data:
+                if of_name not in field_context:
+                    field_context[of_name] = dep_data[of_name]
+
+    result = evaluator.evaluate(item=content, guard_config=guard_config, context=field_context)
+    return result.should_execute
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGuardContextParity:
+    """U-1.1: Prefilter and prepare must use same guard context."""
+
+    def test_source_namespace_parity(self):
+        """Guard referencing source.name must produce same decision in both paths.
+
+        Currently FAILS: prefilter passes context=eval_item (no source namespace),
+        so source.name is missing → guard treats as 'not matched' → skip.
+        Batch builds full field_context with source namespace → guard passes.
+        """
+        record = {
+            "target_id": "t-001",
+            "source_guid": "sg-001",
+            "content": {"text": "hello"},
+        }
+        source_content = {"name": "test_source", "id": "src-1"}
+        guard_config = {
+            "clause": "source.name == 'test_source'",
+            "behavior": "skip",
+        }
+
+        online_passes = _evaluate_guard_online(record, guard_config)
+        batch_passes = _evaluate_guard_batch(
+            record,
+            guard_config,
+            source_content=source_content,
+        )
+
+        # Batch passes (source.name found and matches).
+        # Online must also pass — currently it doesn't.
+        assert batch_passes is True, "Batch should pass (baseline)"
+        assert online_passes == batch_passes, (
+            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
+            "Prefilter context is missing source namespace."
+        )
+
+    def test_version_namespace_parity(self):
+        """Guard referencing version.i must produce same decision in both paths.
+
+        Currently FAILS: prefilter context has no version namespace.
+        """
+        record = {
+            "target_id": "t-001",
+            "source_guid": "sg-001",
+            "content": {"text": "hello"},
+        }
+        # version.i > 0 means "not the first iteration"
+        guard_config = {
+            "clause": "version.i > 0",
+            "behavior": "skip",
+        }
+
+        online_passes = _evaluate_guard_online(record, guard_config)
+        batch_passes = _evaluate_guard_batch(
+            record,
+            guard_config,
+            version_context={"i": 1, "idx": 1, "length": 3},
+        )
+
+        assert batch_passes is True, "Batch should pass (version.i=1 > 0)"
+        assert online_passes == batch_passes, (
+            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
+            "Prefilter context is missing version namespace."
+        )
+
+    def test_output_field_promotion_parity(self):
+        """Guard referencing promoted output_field must produce same decision.
+
+        When upstream action 'assess' has output_field='severity', batch
+        promotes field_context['severity'] = 'high'. Prefilter doesn't.
+        """
+        record = {
+            "target_id": "t-001",
+            "source_guid": "sg-001",
+            "content": {"assess": {"severity": "high", "details": "..."}},
+        }
+        guard_config = {
+            "clause": "severity == 'high'",
+            "behavior": "skip",
+        }
+        dependency_configs = {
+            "assess": {"output_field": "severity"},
+        }
+
+        online_passes = _evaluate_guard_online(record, guard_config)
+        batch_passes = _evaluate_guard_batch(
+            record,
+            guard_config,
+            agent_indices={"assess": 0, "test_action": 1},
+            dependency_configs=dependency_configs,
+        )
+
+        assert batch_passes is True, "Batch should pass (promoted severity == 'high')"
+        assert online_passes == batch_passes, (
+            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
+            "Prefilter context is missing promoted output_field."
+        )
+
+
+class TestCodeCenteredQuizGuard:
+    """Acceptance criteria: code_centered_quiz guard with has_failures."""
+
+    def test_has_failures_true_passes_guard(self):
+        """has_failures=true → guard passes (action should run).
+
+        Guard clause: 'has_failures' (truthy check). When has_failures is True
+        the guard condition is matched → action executes.
+
+        Currently FAILS for online path when has_failures is a promoted
+        output_field (not directly in record content at top level).
+        """
+        record = {
+            "target_id": "t-001",
+            "source_guid": "sg-001",
+            "content": {"code_quiz": {"has_failures": True, "score": 0.3}},
+        }
+        guard_config = {
+            "clause": "has_failures",
+            "behavior": "skip",
+        }
+        dependency_configs = {
+            "code_quiz": {"output_field": "has_failures"},
+        }
+
+        online_passes = _evaluate_guard_online(record, guard_config)
+        batch_passes = _evaluate_guard_batch(
+            record,
+            guard_config,
+            agent_indices={"code_quiz": 0, "test_action": 1},
+            dependency_configs=dependency_configs,
+        )
+
+        assert batch_passes is True, "Batch should pass (has_failures=True → truthy)"
+        assert online_passes == batch_passes, (
+            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
+            "Prefilter doesn't promote output_field 'has_failures'."
+        )
+
+    def test_has_failures_false_skips_downstream(self):
+        """has_failures=false → guard skips (downstream action should not run).
+
+        Both paths should agree: has_failures=False is falsy → not matched → skip.
+        """
+        record = {
+            "target_id": "t-001",
+            "source_guid": "sg-001",
+            "content": {"code_quiz": {"has_failures": False, "score": 1.0}},
+        }
+        guard_config = {
+            "clause": "has_failures",
+            "behavior": "skip",
+        }
+        dependency_configs = {
+            "code_quiz": {"output_field": "has_failures"},
+        }
+
+        online_passes = _evaluate_guard_online(record, guard_config)
+        batch_passes = _evaluate_guard_batch(
+            record,
+            guard_config,
+            agent_indices={"code_quiz": 0, "test_action": 1},
+            dependency_configs=dependency_configs,
+        )
+
+        # Both should skip (has_failures is falsy)
+        assert batch_passes is False, "Batch should skip (has_failures=False)"
+        assert online_passes == batch_passes, (
+            f"Guard parity violation: online={online_passes}, batch={batch_passes}"
+        )
+
+
+class TestPrefilterByGuardContextAlignment:
+    """Integration: prefilter_by_guard must build full context when pipeline context available."""
+
+    def test_prefilter_passes_with_source_guard(self):
+        """prefilter_by_guard with source-referencing guard should pass record.
+
+        Currently FAILS: prefilter_by_guard doesn't accept or use pipeline
+        context, so source namespace is never built.
+        """
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"text": "hello"},
+            }
+        ]
+        guard_config = {
+            "clause": "source.name == 'test_source'",
+            "behavior": "skip",
+        }
+        agent_config = {"name": "test_action", "guard": guard_config}
+
+        # After fix: prefilter_by_guard will accept pipeline_context and build
+        # full context including source namespace. For now, this call uses the
+        # existing signature — the test fails because source.name is missing.
+        passing, skipped, _ = prefilter_by_guard(records, agent_config, "test_action")
+
+        assert len(passing) == 1, (
+            f"Expected 1 passing record (source.name matches) but got "
+            f"{len(passing)} passing, {len(skipped)} skipped. "
+            "prefilter_by_guard needs full context to evaluate source-referencing guards."
+        )

--- a/tests/unit/unification/test_phase5_guard_context.py
+++ b/tests/unit/unification/test_phase5_guard_context.py
@@ -1,12 +1,12 @@
-"""Phase 5: Guard context alignment — TDD red tests.
+"""Phase 5: Guard context alignment tests.
 
-Proves that online prefilter and batch prepare produce different guard
+Verifies that online prefilter and batch prepare produce identical guard
 decisions for the same record when the guard references fields only
 available through full context building (source namespace, version
 namespace, output_field promotion).
 
-These tests MUST FAIL against current code.
-After Commit C (wire prefilter), they turn green.
+Commit A: These tests FAIL (prefilter doesn't build full context).
+Commit C: Tests turn green (prefilter wired to build_guard_context).
 """
 
 from __future__ import annotations
@@ -14,30 +14,16 @@ from __future__ import annotations
 from typing import Any
 
 from agent_actions.input.preprocessing.filtering.evaluator import GuardEvaluator
-from agent_actions.prompt.context.scope_builder import build_field_context_with_history
+from agent_actions.processing.guard_context import build_guard_context
 from agent_actions.utils.content import get_existing_content
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 # ---------------------------------------------------------------------------
-# Helpers — simulate batch and online guard evaluation paths
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-def _evaluate_guard_online(
-    record: dict[str, Any],
-    guard_config: dict[str, Any],
-) -> bool:
-    """Simulate the online prefilter guard path (current behavior).
-
-    Mirrors prefilter_by_guard: context = eval_item = get_existing_content(record).
-    """
-    evaluator = GuardEvaluator()
-    eval_item = get_existing_content(record)
-    result = evaluator.evaluate(item=eval_item, guard_config=guard_config, context=eval_item)
-    return result.should_execute
-
-
-def _evaluate_guard_batch(
+def _evaluate_guard_with_full_context(
     record: dict[str, Any],
     guard_config: dict[str, Any],
     *,
@@ -45,53 +31,34 @@ def _evaluate_guard_batch(
     agent_config: dict[str, Any] | None = None,
     agent_indices: dict[str, int] | None = None,
     source_content: Any = None,
+    source_data: list[dict[str, Any]] | None = None,
     version_context: dict[str, Any] | None = None,
     workflow_metadata: dict[str, Any] | None = None,
     dependency_configs: dict[str, Any] | None = None,
 ) -> bool:
-    """Simulate the batch prepare guard path.
-
-    Mirrors TaskPreparer.prepare: builds full field_context via
-    build_field_context_with_history, then evaluates guard with that context.
-    """
+    """Evaluate guard using the shared build_guard_context (batch-equivalent path)."""
     evaluator = GuardEvaluator()
     content = get_existing_content(record)
     config = agent_config or {"name": agent_name}
 
-    if source_content is None:
-        source_content = content
-
-    field_context = build_field_context_with_history(
+    field_context = build_guard_context(
+        record,
         agent_name=agent_name,
         agent_config=config,
         agent_indices=agent_indices,
         source_content=source_content,
+        source_data=source_data,
         version_context=version_context,
         workflow_metadata=workflow_metadata,
-        current_item=record,
-        context_scope=config.get("context_scope"),
+        dependency_configs=dependency_configs,
     )
-    field_context.pop("_dependency_metadata", None)
-
-    # Promote output_field values (mirrors TaskPreparer._load_full_context)
-    if dependency_configs:
-        for dep_name, dep_config in dependency_configs.items():
-            if not dep_config or "output_field" not in dep_config:
-                continue
-            of_name = dep_config["output_field"]
-            dep_data = field_context.get(dep_name)
-            if isinstance(dep_data, list) and len(dep_data) == 1:
-                dep_data = dep_data[0]
-            if isinstance(dep_data, dict) and of_name in dep_data:
-                if of_name not in field_context:
-                    field_context[of_name] = dep_data[of_name]
 
     result = evaluator.evaluate(item=content, guard_config=guard_config, context=field_context)
     return result.should_execute
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Tests — Guard Context Parity via prefilter_by_guard
 # ---------------------------------------------------------------------------
 
 
@@ -99,98 +66,136 @@ class TestGuardContextParity:
     """U-1.1: Prefilter and prepare must use same guard context."""
 
     def test_source_namespace_parity(self):
-        """Guard referencing source.name must produce same decision in both paths.
+        """Guard referencing source.name passes when source_data provides it.
 
-        Currently FAILS: prefilter passes context=eval_item (no source namespace),
-        so source.name is missing → guard treats as 'not matched' → skip.
-        Batch builds full field_context with source namespace → guard passes.
+        prefilter_by_guard with source_data builds full context including
+        source namespace, so the guard finds source.name and passes.
         """
-        record = {
-            "target_id": "t-001",
-            "source_guid": "sg-001",
-            "content": {"text": "hello"},
-        }
-        source_content = {"name": "test_source", "id": "src-1"}
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"text": "hello"},
+            }
+        ]
+        source_data = [{"source_guid": "sg-001", "name": "test_source", "id": "src-1"}]
         guard_config = {
             "clause": "source.name == 'test_source'",
             "behavior": "skip",
         }
+        agent_config = {"name": "test_action", "guard": guard_config}
 
-        online_passes = _evaluate_guard_online(record, guard_config)
-        batch_passes = _evaluate_guard_batch(
-            record,
-            guard_config,
-            source_content=source_content,
+        passing, skipped, _ = prefilter_by_guard(
+            records,
+            agent_config,
+            "test_action",
+            source_data=source_data,
         )
 
-        # Batch passes (source.name found and matches).
-        # Online must also pass — currently it doesn't.
-        assert batch_passes is True, "Batch should pass (baseline)"
-        assert online_passes == batch_passes, (
-            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
+        assert len(passing) == 1, (
+            f"Guard should pass (source.name == 'test_source') but got "
+            f"{len(passing)} passing, {len(skipped)} skipped. "
             "Prefilter context is missing source namespace."
         )
 
     def test_version_namespace_parity(self):
-        """Guard referencing version.i must produce same decision in both paths.
+        """Guard referencing version.i passes when version_context is provided."""
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"text": "hello"},
+            }
+        ]
+        guard_config = {
+            "clause": "version.i > 0",
+            "behavior": "skip",
+        }
+        agent_config = {"name": "test_action", "guard": guard_config}
 
-        Currently FAILS: prefilter context has no version namespace.
+        passing, skipped, _ = prefilter_by_guard(
+            records,
+            agent_config,
+            "test_action",
+            version_context={"i": 1, "idx": 1, "length": 3},
+        )
+
+        assert len(passing) == 1, (
+            f"Guard should pass (version.i=1 > 0) but got "
+            f"{len(passing)} passing, {len(skipped)} skipped. "
+            "Prefilter context is missing version namespace."
+        )
+
+    def test_output_field_promotion_parity(self):
+        """Guard referencing promoted output_field passes with dependency_configs.
+
+        When upstream action 'assess' has output_field='severity', batch
+        promotes field_context['severity'] = 'high'. With proper config,
+        prefilter does the same via build_guard_context.
         """
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"assess": {"severity": "high", "details": "..."}},
+            }
+        ]
+        guard_config = {
+            "clause": "severity == 'high'",
+            "behavior": "skip",
+        }
+        agent_config = {
+            "name": "test_action",
+            "guard": guard_config,
+            "prompt": "Handle: {{ assess.severity }}",
+            "context_scope": {"observe": ["assess.*"]},
+        }
+        dependency_configs = {"assess": {"output_field": "severity"}}
+
+        passing, skipped, _ = prefilter_by_guard(
+            records,
+            agent_config,
+            "test_action",
+            agent_indices={"assess": 0, "test_action": 1},
+            dependency_configs=dependency_configs,
+        )
+
+        assert len(passing) == 1, (
+            f"Guard should pass (promoted severity == 'high') but got "
+            f"{len(passing)} passing, {len(skipped)} skipped. "
+            "Prefilter context is missing promoted output_field."
+        )
+
+    def test_prefilter_matches_batch_context(self):
+        """prefilter_by_guard with full context produces same decision as batch path."""
         record = {
             "target_id": "t-001",
             "source_guid": "sg-001",
             "content": {"text": "hello"},
         }
-        # version.i > 0 means "not the first iteration"
+        source_data = [{"source_guid": "sg-001", "name": "test_source"}]
         guard_config = {
-            "clause": "version.i > 0",
+            "clause": "source.name == 'test_source'",
             "behavior": "skip",
         }
+        agent_config = {"name": "test_action", "guard": guard_config}
 
-        online_passes = _evaluate_guard_online(record, guard_config)
-        batch_passes = _evaluate_guard_batch(
-            record,
-            guard_config,
-            version_context={"i": 1, "idx": 1, "length": 3},
+        # Online path: prefilter_by_guard with pipeline context
+        passing, _skipped, _ = prefilter_by_guard(
+            [record],
+            agent_config,
+            "test_action",
+            source_data=source_data,
+        )
+        online_passes = len(passing) == 1
+
+        # Batch path: build_guard_context directly
+        batch_passes = _evaluate_guard_with_full_context(
+            record, guard_config, source_data=source_data
         )
 
-        assert batch_passes is True, "Batch should pass (version.i=1 > 0)"
         assert online_passes == batch_passes, (
-            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
-            "Prefilter context is missing version namespace."
-        )
-
-    def test_output_field_promotion_parity(self):
-        """Guard referencing promoted output_field must produce same decision.
-
-        When upstream action 'assess' has output_field='severity', batch
-        promotes field_context['severity'] = 'high'. Prefilter doesn't.
-        """
-        record = {
-            "target_id": "t-001",
-            "source_guid": "sg-001",
-            "content": {"assess": {"severity": "high", "details": "..."}},
-        }
-        guard_config = {
-            "clause": "severity == 'high'",
-            "behavior": "skip",
-        }
-        dependency_configs = {
-            "assess": {"output_field": "severity"},
-        }
-
-        online_passes = _evaluate_guard_online(record, guard_config)
-        batch_passes = _evaluate_guard_batch(
-            record,
-            guard_config,
-            agent_indices={"assess": 0, "test_action": 1},
-            dependency_configs=dependency_configs,
-        )
-
-        assert batch_passes is True, "Batch should pass (promoted severity == 'high')"
-        assert online_passes == batch_passes, (
-            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
-            "Prefilter context is missing promoted output_field."
+            f"Guard parity violation: online={online_passes}, batch={batch_passes}"
         )
 
 
@@ -200,81 +205,106 @@ class TestCodeCenteredQuizGuard:
     def test_has_failures_true_passes_guard(self):
         """has_failures=true → guard passes (action should run).
 
-        Guard clause: 'has_failures' (truthy check). When has_failures is True
-        the guard condition is matched → action executes.
-
-        Currently FAILS for online path when has_failures is a promoted
-        output_field (not directly in record content at top level).
+        When has_failures is a promoted output_field from upstream code_quiz,
+        prefilter must promote it the same way batch does.
         """
-        record = {
-            "target_id": "t-001",
-            "source_guid": "sg-001",
-            "content": {"code_quiz": {"has_failures": True, "score": 0.3}},
-        }
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"code_quiz": {"has_failures": True, "score": 0.3}},
+            }
+        ]
         guard_config = {
             "clause": "has_failures",
             "behavior": "skip",
         }
-        dependency_configs = {
-            "code_quiz": {"output_field": "has_failures"},
+        agent_config = {
+            "name": "test_action",
+            "guard": guard_config,
+            "prompt": "Fix: {{ code_quiz.has_failures }}",
+            "context_scope": {"observe": ["code_quiz.*"]},
         }
+        dependency_configs = {"code_quiz": {"output_field": "has_failures"}}
 
-        online_passes = _evaluate_guard_online(record, guard_config)
-        batch_passes = _evaluate_guard_batch(
-            record,
-            guard_config,
+        passing, skipped, _ = prefilter_by_guard(
+            records,
+            agent_config,
+            "test_action",
             agent_indices={"code_quiz": 0, "test_action": 1},
             dependency_configs=dependency_configs,
         )
 
-        assert batch_passes is True, "Batch should pass (has_failures=True → truthy)"
-        assert online_passes == batch_passes, (
-            f"Guard parity violation: online={online_passes}, batch={batch_passes}. "
+        assert len(passing) == 1, (
+            f"Guard should pass (has_failures=True → truthy) but got "
+            f"{len(passing)} passing, {len(skipped)} skipped. "
             "Prefilter doesn't promote output_field 'has_failures'."
         )
 
     def test_has_failures_false_skips_downstream(self):
         """has_failures=false → guard skips (downstream action should not run).
 
-        Both paths should agree: has_failures=False is falsy → not matched → skip.
+        Both paths agree: has_failures=False is falsy → not matched → skip.
         """
-        record = {
-            "target_id": "t-001",
-            "source_guid": "sg-001",
-            "content": {"code_quiz": {"has_failures": False, "score": 1.0}},
-        }
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"code_quiz": {"has_failures": False, "score": 1.0}},
+            }
+        ]
         guard_config = {
             "clause": "has_failures",
             "behavior": "skip",
         }
-        dependency_configs = {
-            "code_quiz": {"output_field": "has_failures"},
+        agent_config = {
+            "name": "test_action",
+            "guard": guard_config,
+            "prompt": "Fix: {{ code_quiz.has_failures }}",
+            "context_scope": {"observe": ["code_quiz.*"]},
         }
+        dependency_configs = {"code_quiz": {"output_field": "has_failures"}}
 
-        online_passes = _evaluate_guard_online(record, guard_config)
-        batch_passes = _evaluate_guard_batch(
-            record,
-            guard_config,
+        passing, skipped, _ = prefilter_by_guard(
+            records,
+            agent_config,
+            "test_action",
             agent_indices={"code_quiz": 0, "test_action": 1},
             dependency_configs=dependency_configs,
         )
 
-        # Both should skip (has_failures is falsy)
-        assert batch_passes is False, "Batch should skip (has_failures=False)"
-        assert online_passes == batch_passes, (
-            f"Guard parity violation: online={online_passes}, batch={batch_passes}"
+        # has_failures=False → falsy → guard skips
+        assert len(passing) == 0, (
+            f"Guard should skip (has_failures=False) but {len(passing)} passed"
         )
+        assert len(skipped) == 1
 
 
 class TestPrefilterByGuardContextAlignment:
-    """Integration: prefilter_by_guard must build full context when pipeline context available."""
+    """Integration: prefilter_by_guard builds full context when pipeline params available."""
 
-    def test_prefilter_passes_with_source_guard(self):
-        """prefilter_by_guard with source-referencing guard should pass record.
+    def test_no_pipeline_context_uses_eval_item(self):
+        """Without pipeline context, prefilter falls back to eval_item (backward compat)."""
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"upstream_ns": {"status": "ready"}},
+            }
+        ]
+        guard_config = {
+            "clause": "upstream_ns.status == 'ready'",
+            "behavior": "skip",
+        }
+        agent_config = {"name": "test_action", "guard": guard_config}
 
-        Currently FAILS: prefilter_by_guard doesn't accept or use pipeline
-        context, so source namespace is never built.
-        """
+        # No pipeline context → uses eval_item (record content has upstream_ns)
+        passing, skipped, _ = prefilter_by_guard(records, agent_config, "test_action")
+
+        assert len(passing) == 1, "Should pass — field is in record content"
+
+    def test_pipeline_context_enables_source_guard(self):
+        """With source_data, guard referencing source namespace passes."""
         records = [
             {
                 "target_id": "t-001",
@@ -282,19 +312,60 @@ class TestPrefilterByGuardContextAlignment:
                 "content": {"text": "hello"},
             }
         ]
+        source_data = [{"source_guid": "sg-001", "name": "test_source"}]
         guard_config = {
             "clause": "source.name == 'test_source'",
             "behavior": "skip",
         }
         agent_config = {"name": "test_action", "guard": guard_config}
 
-        # After fix: prefilter_by_guard will accept pipeline_context and build
-        # full context including source namespace. For now, this call uses the
-        # existing signature — the test fails because source.name is missing.
-        passing, skipped, _ = prefilter_by_guard(records, agent_config, "test_action")
+        passing, skipped, _ = prefilter_by_guard(
+            records,
+            agent_config,
+            "test_action",
+            source_data=source_data,
+        )
 
         assert len(passing) == 1, (
-            f"Expected 1 passing record (source.name matches) but got "
-            f"{len(passing)} passing, {len(skipped)} skipped. "
-            "prefilter_by_guard needs full context to evaluate source-referencing guards."
+            f"Expected 1 passing (source.name matches) but got "
+            f"{len(passing)} passing, {len(skipped)} skipped"
         )
+
+    def test_multiple_records_mixed_decisions(self):
+        """Multiple records with different guard outcomes are correctly split."""
+        records = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "content": {"assess": {"severity": "high"}},
+            },
+            {
+                "target_id": "t-002",
+                "source_guid": "sg-002",
+                "content": {"assess": {"severity": "low"}},
+            },
+        ]
+        guard_config = {
+            "clause": "severity == 'high'",
+            "behavior": "skip",
+        }
+        agent_config = {
+            "name": "test_action",
+            "guard": guard_config,
+            "prompt": "Handle: {{ assess.severity }}",
+            "context_scope": {"observe": ["assess.*"]},
+        }
+        dependency_configs = {"assess": {"output_field": "severity"}}
+
+        passing, skipped, _ = prefilter_by_guard(
+            records,
+            agent_config,
+            "test_action",
+            agent_indices={"assess": 0, "test_action": 1},
+            dependency_configs=dependency_configs,
+        )
+
+        assert len(passing) == 1, f"Only high-severity should pass, got {len(passing)}"
+        assert passing[0]["target_id"] == "t-001"
+        assert len(skipped) == 1
+        assert skipped[0]["target_id"] == "t-002"


### PR DESCRIPTION
## Summary
- Extract shared `build_guard_context` helper (`processing/guard_context.py`) that builds identical field_context for both online prefilter and batch prepare guard evaluation
- Wire `prefilter_by_guard` to accept optional pipeline context params (agent_indices, source_data, version_context, workflow_metadata, dependency_configs) and use `build_guard_context` when available
- Refactor `TaskPreparer._load_full_context` to delegate to the same shared helper, preventing drift
- Wire both `_guard_filter` and `_guard_filter_file_mode` in `unified.py` to pass ProcessingContext fields through

Closes the "works in batch, fails online" guard class: guards referencing source namespace, version namespace, workflow metadata, or promoted output_fields now produce identical decisions in both execution modes.

## Verification
- 9 new Phase 5 parity tests pass (source, version, output_field promotion, code_centered_quiz)
- 6847 existing tests pass (2 pre-existing failures excluded: ollama trailing comma, json parsing)
- `ruff format --check` and `ruff check` clean
- No changes to batch path behavior (TaskPreparer.prepare still produces identical output)
- No `GUARD_SKIPPED` in `CASCADE_BLOCKING_STATES` (U-1.4 constraint)