### PR TITLE
fix: Phase 6 — remove duplicate cascade check, single reconcile authority

### DIFF
--- a/.changes/unreleased/Under the Hood-20260517-phase6.yaml
+++ b/.changes/unreleased/Under the Hood-20260517-phase6.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove _is_cascade_blocked fallback from batch reconciliation — get_skip_reason() is sole authority (Phase 6)"
+time: 2026-05-17T06:00:00.000000Z

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -33,17 +33,10 @@ from agent_actions.record.reasons import (
     BATCH_NOT_RETURNED,
     GUARD_SKIP,
     PREP_FAILED,
-    UPSTREAM_UNPROCESSED,
 )
-from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
-
-
-def _is_cascade_blocked(row: dict[str, Any]) -> bool:
-    """Return True if the row's _state is a cascade-blocking value."""
-    return row.get("_state") in CASCADE_BLOCKING_VALUES
 
 
 @dataclass
@@ -539,15 +532,12 @@ class BatchResultStrategy:
         record_index: int,
     ) -> ProcessingResult:
         """Build an UNPROCESSED result for a passthrough record."""
-        # Prefer skip_reason set during preparation (single authority).
-        # Fall back to _state check for records that bypassed prep.
+        # Single authority: skip_reason set during preparation is canonical.
         skip_reason = BatchContextMetadata.get_skip_reason(original_row)
         if skip_reason:
             reason = skip_reason
         elif BatchContextMetadata.get_filter_status(original_row) == FilterStatus.SKIPPED:
             reason = GUARD_SKIP
-        elif _is_cascade_blocked(original_row):
-            reason = UPSTREAM_UNPROCESSED
         else:
             reason = BATCH_NOT_RETURNED
 

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -312,6 +312,7 @@ class TestBatchPathReasonDetection:
         from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchResultStrategy,
         )
+        from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
 
         row = {
             "content": {"upstream_action": {"field": "value"}},
@@ -320,7 +321,7 @@ class TestBatchPathReasonDetection:
             "_state_schema_version": 1,
         }
         BatchContextMetadata.set_filter_status(row, FilterStatus.SKIPPED)
-        BatchContextMetadata.set_skip_reason(row, "upstream_unprocessed")
+        BatchContextMetadata.set_skip_reason(row, UPSTREAM_UNPROCESSED)
         ctx = self._make_ctx(passthrough_records=[("cid_1", row)])
         processor = BatchResultStrategy()
         results = processor._reconcile_passthroughs(ctx)

--- a/tests/unit/core/test_upstream_unprocessed_filter.py
+++ b/tests/unit/core/test_upstream_unprocessed_filter.py
@@ -302,7 +302,13 @@ class TestBatchPathReasonDetection:
         )
 
     def test_upstream_unprocessed_reason(self):
-        """Records with cascade-blocking _state get reason=upstream_unprocessed."""
+        """Records with cascade-blocking _state get reason=upstream_unprocessed.
+
+        After Phase 6, skip_reason must be set during prep (single authority).
+        The _is_cascade_blocked fallback no longer exists.
+        """
+        from agent_actions.llm.batch.core.batch_constants import FilterStatus
+        from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
         from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchResultStrategy,
         )
@@ -313,6 +319,8 @@ class TestBatchPathReasonDetection:
             "_state": "cascade_skipped",
             "_state_schema_version": 1,
         }
+        BatchContextMetadata.set_filter_status(row, FilterStatus.SKIPPED)
+        BatchContextMetadata.set_skip_reason(row, "upstream_unprocessed")
         ctx = self._make_ctx(passthrough_records=[("cid_1", row)])
         processor = BatchResultStrategy()
         results = processor._reconcile_passthroughs(ctx)

--- a/tests/unit/llm/batch/test_batch_online_guard_unification.py
+++ b/tests/unit/llm/batch/test_batch_online_guard_unification.py
@@ -293,21 +293,25 @@ class TestReconciliationSkipReason:
 
         assert result.skip_reason == GUARD_SKIP
 
-    def test_reconciliation_fallback_cascade_blocked_when_no_skip_reason(self):
-        """Without skip_reason, cascade-blocked _state falls back to UPSTREAM_UNPROCESSED."""
+    def test_reconciliation_no_cascade_fallback_without_skip_reason(self):
+        """Without skip_reason, cascade-blocked _state gets BATCH_NOT_RETURNED.
+
+        Phase 6: _is_cascade_blocked fallback removed. Prep is the single
+        authority — if it didn't set skip_reason, reconciliation defaults.
+        """
         from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchProcessingContext,
             BatchResultStrategy,
         )
         from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
-        from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
+        from agent_actions.record.reasons import BATCH_NOT_RETURNED
 
         original_row = {
             "target_id": "tid_2",
             "_state": RecordState.CASCADE_SKIPPED.value,
             "content": {},
         }
-        # No filter_status, no skip_reason — should fall back to _state check
+        # No filter_status, no skip_reason — no cascade fallback anymore
 
         ctx = BatchProcessingContext(
             batch_results=[],
@@ -322,7 +326,7 @@ class TestReconciliationSkipReason:
             ctx, original_row, "test_action", "sg_002", 0
         )
 
-        assert result.skip_reason == UPSTREAM_UNPROCESSED
+        assert result.skip_reason == BATCH_NOT_RETURNED
 
     def test_reconciliation_fallback_batch_not_returned(self):
         """Without skip_reason, filter_status, or cascade state → BATCH_NOT_RETURNED."""

--- a/tests/unit/llm/batch/test_batch_online_guard_unification.py
+++ b/tests/unit/llm/batch/test_batch_online_guard_unification.py
@@ -296,8 +296,8 @@ class TestReconciliationSkipReason:
     def test_reconciliation_no_cascade_fallback_without_skip_reason(self):
         """Without skip_reason, cascade-blocked _state gets BATCH_NOT_RETURNED.
 
-        Phase 6: _is_cascade_blocked fallback removed. Prep is the single
-        authority — if it didn't set skip_reason, reconciliation defaults.
+        Prep is the single authority for skip reasons. If prep didn't set
+        skip_reason, reconciliation does not re-derive from _state.
         """
         from agent_actions.llm.batch.processing.batch_result_strategy import (
             BatchProcessingContext,

--- a/tests/unit/unification/test_phase6_reconcile_authority.py
+++ b/tests/unit/unification/test_phase6_reconcile_authority.py
@@ -1,0 +1,130 @@
+"""Phase 6 tests — reconciliation trusts prep as single cascade authority.
+
+U-1.2: Reconciliation must not re-check cascade via _is_cascade_blocked().
+After Phase 2 makes context_map trustworthy, get_skip_reason() is the sole
+authority for CASCADE decisions during passthrough reconciliation.
+"""
+
+from typing import Any
+
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.llm.batch.processing.batch_result_strategy import (
+    BatchProcessingContext,
+    BatchResultStrategy,
+)
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+from agent_actions.record.reasons import (
+    BATCH_NOT_RETURNED,
+    GUARD_SKIP,
+    UPSTREAM_UNPROCESSED,
+)
+from agent_actions.record.state import RecordState
+
+
+def _make_ctx(
+    original_row: dict[str, Any],
+    custom_id: str = "t-001",
+) -> BatchProcessingContext:
+    """Build a minimal BatchProcessingContext for passthrough testing."""
+    ctx = BatchProcessingContext(
+        batch_results=[],
+        context_map={custom_id: original_row},
+        output_directory="/tmp/test",
+        agent_config={
+            "name": "test_action",
+            "action_name": "test_action",
+            "agent_type": "llm_agent",
+        },
+    )
+    ctx.reconciler = BatchResultReconciler(context_map={custom_id: original_row})
+    return ctx
+
+
+class TestSingleCascadeAuthority:
+    """U-1.2: Reconciliation must not re-check cascade — trust prep."""
+
+    def test_no_cascade_blocked_function_exists(self):
+        """_is_cascade_blocked must not exist in the module — single authority is prep.
+
+        After Phase 6, the function is deleted entirely. Reconciliation uses
+        get_skip_reason() as the sole authority for CASCADE decisions.
+        """
+        import agent_actions.llm.batch.processing.batch_result_strategy as mod
+
+        assert not hasattr(mod, "_is_cascade_blocked"), (
+            "_is_cascade_blocked must be deleted — get_skip_reason() is sole authority"
+        )
+
+    def test_prep_skip_reason_is_authority(self):
+        """get_skip_reason() provides passthrough reason without re-evaluation."""
+        original_row = {
+            "target_id": "t-001",
+            "_state": RecordState.FAILED.value,
+            "content": {"data": "value"},
+        }
+        BatchContextMetadata.set_filter_status(original_row, FilterStatus.SKIPPED)
+        BatchContextMetadata.set_skip_reason(original_row, UPSTREAM_UNPROCESSED)
+
+        ctx = _make_ctx(original_row)
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_001", 0
+        )
+
+        assert result.skip_reason == UPSTREAM_UNPROCESSED
+
+    def test_cascade_blocked_without_skip_reason_falls_to_default(self):
+        """Without skip_reason, cascade-blocked _state should NOT trigger special handling.
+
+        After Phase 6, there is no _is_cascade_blocked fallback.
+        Records that somehow bypass prep without skip_reason get BATCH_NOT_RETURNED.
+        """
+        original_row = {
+            "target_id": "t-002",
+            "_state": RecordState.CASCADE_SKIPPED.value,
+            "content": {},
+        }
+        # No filter_status, no skip_reason — previously fell back to _is_cascade_blocked
+
+        ctx = _make_ctx(original_row, custom_id="t-002")
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_002", 0
+        )
+
+        # Single authority: without skip_reason, default is BATCH_NOT_RETURNED
+        assert result.skip_reason == BATCH_NOT_RETURNED
+
+    def test_guard_skip_fallback_still_works(self):
+        """FilterStatus.SKIPPED without skip_reason still falls back to GUARD_SKIP."""
+        original_row = {"target_id": "t-003", "content": {}}
+        BatchContextMetadata.set_filter_status(original_row, FilterStatus.SKIPPED)
+        # No skip_reason — should fall back to GUARD_SKIP via FilterStatus check
+
+        ctx = _make_ctx(original_row, custom_id="t-003")
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_003", 0
+        )
+
+        assert result.skip_reason == GUARD_SKIP
+
+    def test_explicit_skip_reason_takes_priority_over_state(self):
+        """Even if _state is cascade-blocked, skip_reason from prep wins."""
+        original_row = {
+            "target_id": "t-004",
+            "_state": RecordState.FAILED.value,
+            "content": {},
+        }
+        BatchContextMetadata.set_filter_status(original_row, FilterStatus.SKIPPED)
+        BatchContextMetadata.set_skip_reason(original_row, GUARD_SKIP)
+
+        ctx = _make_ctx(original_row, custom_id="t-004")
+        strategy = BatchResultStrategy()
+        result = strategy._build_unprocessed_passthrough(
+            ctx, original_row, "test_action", "sg_004", 0
+        )
+
+        # skip_reason from prep wins over _state
+        assert result.skip_reason == GUARD_SKIP


### PR DESCRIPTION
## Summary
- Delete `_is_cascade_blocked()` function — zero remaining callers after this change
- Remove cascade fallback from `_build_unprocessed_passthrough()` — `get_skip_reason()` is now the sole authority for CASCADE decisions during reconciliation
- Clean up unused imports (`CASCADE_BLOCKING_VALUES`, `UPSTREAM_UNPROCESSED`)
- Update 2 existing tests that relied on the old `_is_cascade_blocked` fallback path
- Add 5 Phase 6 regression tests: function deletion, skip_reason authority, default fallback, guard_skip preservation, priority ordering

## Verification
- `pytest tests/unit/unification/test_phase6_reconcile_authority.py -v` → 5 passed
- `pytest tests/unit/llm/batch/test_batch_online_guard_unification.py -v` → 22 passed
- `pytest tests/unit/core/test_upstream_unprocessed_filter.py -v` → 21 passed
- `pytest` full suite → 6915 passed (pre-existing manual test failures unrelated)
- `ruff format --check` + `ruff check` → clean