### PR TITLE
Phase 9b: NullNamespace sentinel for skipped namespace observe

### DIFF
--- a/.changes/unreleased/Under the Hood-20260517-009002.yaml
+++ b/.changes/unreleased/Under the Hood-20260517-009002.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Introduce NullNamespace sentinel for skipped upstream namespaces so observe/passthrough resolve fields to None with reason introspection instead of crashing"
+time: 2026-05-17T00:90:02.000000Z

--- a/agent_actions/input/preprocessing/parsing/ast_nodes.py
+++ b/agent_actions/input/preprocessing/parsing/ast_nodes.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from agent_actions.prompt.context.null_namespace import is_null_namespace
 from agent_actions.utils.dict import get_nested_value
 
 from .operators import FUNCTIONS, OPERATORS
@@ -29,6 +30,11 @@ class GuardSemanticError(ValueError):
     """
 
     pass
+
+
+def _is_null_or_empty_namespace(ns_value: Any) -> bool:
+    """Return True if namespace value is null (NullNamespace/None) or empty dict."""
+    return is_null_namespace(ns_value) or (isinstance(ns_value, dict) and not ns_value)
 
 
 def _field_exists(data: Any, field_path: str) -> bool:
@@ -189,7 +195,7 @@ def evaluate_node(
                 top_key = node.field_path.split(".", 1)[0]
                 if top_key in data:
                     ns_value = data[top_key]
-                    if ns_value is None or (isinstance(ns_value, dict) and not ns_value):
+                    if _is_null_or_empty_namespace(ns_value):
                         return None
 
             available = (

--- a/agent_actions/prompt/context/_MANIFEST.md
+++ b/agent_actions/prompt/context/_MANIFEST.md
@@ -14,6 +14,7 @@ loaders for cataloging prompts at documentation time.
 | ~~`scope.py`~~ | Deleted | Facade removed. Consumers import directly from the 6 `scope_*` modules. | — |
 | `scope_parsing.py` | Module | Field reference parsing and action name extraction utilities. `parse_field_reference()` delegates to `ReferenceParser` from `field_resolution` package. | `preprocessing` |
 | `scope_inference.py` | Module | Dependency inference: fan-in detection, version branch expansion, input/context source resolution. | `preprocessing` |
+| `null_namespace.py` | Module | `NullNamespace` sentinel and `is_null_namespace()` helper for skipped/filtered upstream namespaces. Used by `scope_application`, `scope_builder`, and guard evaluator `ast_nodes`. | `preprocessing` |
 | `scope_application.py` | Module | Context scope application: observe/passthrough/drop filtering for RECORD mode (`apply_context_scope`) and FILE mode (`apply_context_scope_for_records`), LLM context formatting. | `preprocessing` |
 | `scope_namespace.py` | Module | Namespace enrichment, field filtering, and allowed-fields extraction. | `preprocessing` |
 | `scope_builder.py` | Module | `build_field_context_with_history`: assembles source/dependency/version/workflow namespaces via composable builder classes (`SourceNamespaceBuilder`, `DependencyNamespaceBuilder`, `VersionNamespaceBuilder`, `WorkflowMetadataBuilder`). Convergence point for source data validation (see design note). | `preprocessing`, `staging.field_validation` |

--- a/agent_actions/prompt/context/null_namespace.py
+++ b/agent_actions/prompt/context/null_namespace.py
@@ -1,0 +1,50 @@
+"""Null namespace sentinel for skipped/filtered upstream actions.
+
+When a guard skips or filters an upstream action, the downstream record's
+content contains ``{action_name: None}``.  At the ``DependencyNamespaceBuilder``
+layer we wrap that ``None`` in a ``NullNamespace`` so downstream code can
+distinguish *why* the namespace is absent and resolve observe/passthrough
+fields to ``None`` instead of crashing.
+
+Phase 9b introduces the sentinel for guard-skipped namespaces.
+Phase 9c will extend it for guard-filtered namespaces.
+"""
+
+from __future__ import annotations
+
+
+class NullNamespace:
+    """Sentinel replacing ``None`` for a namespace that was intentionally absent.
+
+    Attributes:
+        reason: Why the namespace is null (e.g. ``"skipped"``, ``"filtered"``).
+    """
+
+    __slots__ = ("reason",)
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+    def __bool__(self) -> bool:
+        """Falsy — so ``if ns_data:`` still skips null namespaces."""
+        return False
+
+    def __repr__(self) -> str:
+        return f"NullNamespace(reason={self.reason!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, NullNamespace):
+            return self.reason == other.reason
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(("NullNamespace", self.reason))
+
+
+def is_null_namespace(value: object) -> bool:
+    """Return True if *value* is a null namespace marker.
+
+    Handles both the new ``NullNamespace`` sentinel and legacy ``None``
+    (used by tests and any code that constructs field_context manually).
+    """
+    return value is None or isinstance(value, NullNamespace)

--- a/agent_actions/prompt/context/null_namespace.py
+++ b/agent_actions/prompt/context/null_namespace.py
@@ -41,6 +41,18 @@ class NullNamespace:
         return hash(("NullNamespace", self.reason))
 
 
+# ── Reason constants ──────────────────────────────────────────────────
+# Use these instead of bare string literals so typos are caught at import time.
+
+REASON_SKIPPED = "skipped"
+REASON_FILTERED = "filtered"
+
+# ── Pre-built singletons ─────────────────────────────────────────────
+# Avoids repeated allocation for the common case.
+
+SKIPPED_NAMESPACE = NullNamespace(reason=REASON_SKIPPED)
+
+
 def is_null_namespace(value: object) -> bool:
     """Return True if *value* is a null namespace marker.
 

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -12,6 +12,7 @@ from agent_actions.logging.events.io_events import (
     ContextFieldSkippedEvent,
     ContextScopeAppliedEvent,
 )
+from agent_actions.prompt.context.null_namespace import is_null_namespace
 from agent_actions.prompt.context.scope_namespace import _extract_content_data
 from agent_actions.prompt.context.scope_parsing import (
     extract_action_fields,
@@ -36,11 +37,11 @@ def _resolve_missing_field(
     """Return None if namespace exists (null or present), raise if namespace absent.
 
     Three cases:
-    1. Namespace is None (guard-skipped/filtered) → return None
+    1. Namespace is null (NullNamespace sentinel or legacy None) → return None
     2. Namespace exists as dict but field is missing → return None (match guard semantics)
     3. Namespace not in prompt_context at all → raise (config bug / typo)
     """
-    if ns_name in prompt_context and prompt_context[ns_name] is None:
+    if ns_name in prompt_context and is_null_namespace(prompt_context[ns_name]):
         logger.debug(
             "[%s NULL-SAFE] '%s' on action '%s': namespace '%s' is "
             "null (guard-skipped/filtered), resolving field as None",

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -13,6 +13,7 @@ from typing import Any
 from agent_actions.errors import ConfigurationError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextNamespaceLoadedEvent
+from agent_actions.prompt.context.null_namespace import NullNamespace
 from agent_actions.prompt.context.scope_inference import infer_dependencies
 from agent_actions.prompt.context.scope_namespace import (
     _extract_allowed_fields_per_dependency,
@@ -133,16 +134,18 @@ class DependencyNamespaceBuilder:
                     dep_data = namespaced_content.get(dep_name)
                     if dep_data is None:
                         # Namespace is null (guard-skipped) or absent (guard-filtered /
-                        # arrived via a different branch).  Store None so downstream
-                        # observe/passthrough can distinguish "declared but absent" from
-                        # "undeclared" and yield None instead of crashing.
+                        # arrived via a different branch).  Wrap in NullNamespace so
+                        # downstream observe/passthrough can distinguish "declared but
+                        # absent" from "undeclared" and resolve fields to None instead
+                        # of crashing.  The reason is "skipped" by default; Phase 9c
+                        # will refine this to distinguish filtered namespaces.
                         logger.debug(
                             "[RECORD NAMESPACE] '%s' null/absent on record for action '%s' "
                             "(likely guard-skipped or guard-filtered)",
                             dep_name,
                             agent_name,
                         )
-                        dep_namespaces[dep_name] = None
+                        dep_namespaces[dep_name] = NullNamespace(reason="skipped")
                         continue
 
                     if not isinstance(dep_data, dict):

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -13,7 +13,7 @@ from typing import Any
 from agent_actions.errors import ConfigurationError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextNamespaceLoadedEvent
-from agent_actions.prompt.context.null_namespace import NullNamespace
+from agent_actions.prompt.context.null_namespace import SKIPPED_NAMESPACE
 from agent_actions.prompt.context.scope_inference import infer_dependencies
 from agent_actions.prompt.context.scope_namespace import (
     _extract_allowed_fields_per_dependency,
@@ -145,7 +145,7 @@ class DependencyNamespaceBuilder:
                             dep_name,
                             agent_name,
                         )
-                        dep_namespaces[dep_name] = NullNamespace(reason="skipped")
+                        dep_namespaces[dep_name] = SKIPPED_NAMESPACE
                         continue
 
                     if not isinstance(dep_data, dict):

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -16,6 +16,7 @@ from agent_actions.errors import ConfigurationError, TemplateVariableError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldNotFoundEvent
 from agent_actions.prompt.context.builder import LLMContextBuilder
+from agent_actions.prompt.context.null_namespace import is_null_namespace
 from agent_actions.prompt.context.scope_application import (
     FRAMEWORK_NAMESPACES,
     apply_context_scope,
@@ -439,7 +440,7 @@ class PromptPreparationService:
                     null_ns_set = {
                         k
                         for k, v in prompt_context.items()
-                        if v is None and k not in FRAMEWORK_NAMESPACES
+                        if is_null_namespace(v) and k not in FRAMEWORK_NAMESPACES
                     }
                     blamed_ns: str | None = None
                     for ns in null_ns_set:

--- a/tests/integration/test_context_scope_split_records.py
+++ b/tests/integration/test_context_scope_split_records.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from agent_actions.prompt.context.null_namespace import is_null_namespace
 from agent_actions.prompt.context.scope_builder import build_field_context_with_history
 
 
@@ -174,7 +175,7 @@ class TestContextScopeSplitRecordsEdgeCases:
 
         assert (
             "split_operation" not in field_context
-            or field_context.get("split_operation") is None
+            or is_null_namespace(field_context.get("split_operation"))
             or field_context.get("split_operation") == {}
         ), "Should not load split_operation without lineage or ancestry matching"
 
@@ -217,6 +218,6 @@ class TestContextScopeSplitRecordsEdgeCases:
 
         assert (
             "split_operation" not in field_context
-            or field_context.get("split_operation") is None
+            or is_null_namespace(field_context.get("split_operation"))
             or field_context.get("split_operation") == {}
         ), "Should not load split_operation without storage backend"

--- a/tests/unit/prompt/test_scope_builder_builders.py
+++ b/tests/unit/prompt/test_scope_builder_builders.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from agent_actions.errors import ConfigurationError
+from agent_actions.prompt.context.null_namespace import is_null_namespace
 from agent_actions.prompt.context.scope_builder import build_field_context_with_history
 
 _EVENT_PATH = "agent_actions.prompt.context.scope_builder.fire_event"
@@ -138,8 +139,8 @@ class TestDependencyNamespace:
         )
         assert result == {}
 
-    def test_absent_namespace_marked_none(self):
-        """Absent dependency namespace stored as None (guard-skipped)."""
+    def test_absent_namespace_marked_null(self):
+        """Absent dependency namespace stored as NullNamespace (guard-skipped)."""
         current_item = self._make_current_item(
             {
                 "extract": {"text": "hello"},
@@ -159,7 +160,7 @@ class TestDependencyNamespace:
             context_scope=agent_config["context_scope"],
         )
 
-        assert result["classify"] is None
+        assert is_null_namespace(result["classify"])
 
     def test_batch_mode_skipped_without_current_item(self):
         """Without current_item, batch mode is skipped — no dep namespaces loaded."""

--- a/tests/unit/prompt/test_scope_builder_warning.py
+++ b/tests/unit/prompt/test_scope_builder_warning.py
@@ -9,6 +9,7 @@ import logging
 
 import pytest
 
+from agent_actions.prompt.context.null_namespace import is_null_namespace
 from agent_actions.prompt.context.scope_builder import build_field_context_with_history
 
 _LOGGER_NAME = "agent_actions.prompt.context.scope_builder"
@@ -58,9 +59,9 @@ class TestMissingNamespaceLogging:
         assert "extract" in result
         assert result["extract"]["text"] == "hello"
 
-        # classify namespace marked as None (guard-skipped/filtered)
+        # classify namespace marked as NullNamespace (guard-skipped/filtered)
         assert "classify" in result
-        assert result["classify"] is None
+        assert is_null_namespace(result["classify"])
 
         # Should log at DEBUG, not WARNING or ERROR
         debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]

--- a/tests/unit/unification/test_phase9b_observe_skipped_ns.py
+++ b/tests/unit/unification/test_phase9b_observe_skipped_ns.py
@@ -1,0 +1,219 @@
+"""Phase 9b: Observe Skipped Namespace — U-4.1.
+
+When a dependency namespace is skipped (conditional HITL, optional LLM
+fallback), observe must resolve all fields from that namespace to None
+instead of crashing.  The ``NullNamespace`` sentinel carries the *reason*
+the namespace is absent so downstream code can introspect it.
+
+Key invariant: ``NullNamespace(reason="skipped")`` in field_context →
+observe/passthrough fields resolve to ``None``.  A namespace that is
+*absent entirely* from field_context is still a configuration error.
+"""
+
+import pytest
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.prompt.context.null_namespace import NullNamespace
+from agent_actions.prompt.context.scope_application import apply_context_scope
+
+
+def _make_field_context(**namespaces):
+    """Build a field_context dict from namespace kwargs."""
+    return dict(namespaces)
+
+
+# ── Observe: NullNamespace sentinel ──────────────────────────────────
+
+
+class TestObserveSkippedNamespace:
+    """U-4.1: Skipped namespace must be observable as null, not crash."""
+
+    def test_observe_field_from_skipped_namespace_returns_none(self):
+        """Observing a field from a NullNamespace(reason='skipped') → None."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped_step.any_field"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped_step"]["any_field"] is None
+
+    def test_observe_multiple_fields_from_skipped_namespace(self):
+        """All fields from a skipped namespace resolve to None."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": [
+                "skipped_step.field_a",
+                "skipped_step.field_b",
+                "skipped_step.field_c",
+            ]},
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped_step"] == {
+            "field_a": None,
+            "field_b": None,
+            "field_c": None,
+        }
+
+    def test_observe_wildcard_on_skipped_namespace_is_empty(self):
+        """Wildcard observe on NullNamespace → no fields extracted (safe)."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped_step.*"]},
+            action_name="downstream",
+        )
+        assert "skipped_step" not in llm_ctx
+
+    def test_observe_from_missing_namespace_still_errors(self):
+        """Namespace absent from field_context entirely → ConfigurationError."""
+        fc = _make_field_context(present={"f": 1})
+        with pytest.raises(ConfigurationError, match="not found at runtime"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["nonexistent_step.field"]},
+                action_name="downstream",
+            )
+
+    def test_mixed_skipped_and_present_namespaces(self):
+        """Normal namespace resolves normally; skipped resolves to None."""
+        fc = _make_field_context(
+            present={"score": 95},
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["present.score", "skipped_step.status"]},
+            action_name="downstream",
+        )
+        assert llm_ctx["present"]["score"] == 95
+        assert llm_ctx["skipped_step"]["status"] is None
+
+
+# ── Passthrough: NullNamespace sentinel ──────────────────────────────
+
+
+class TestPassthroughSkippedNamespace:
+    """Passthrough from NullNamespace must also resolve to None."""
+
+    def test_passthrough_field_from_skipped_namespace(self):
+        """Passthrough from skipped namespace → None."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        _, _, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"passthrough": ["skipped_step.trace_id"]},
+            action_name="downstream",
+        )
+        assert pt["skipped_step"]["trace_id"] is None
+
+
+# ── Drop: NullNamespace sentinel ─────────────────────────────────────
+
+
+class TestDropSkippedNamespace:
+    """Drop on NullNamespace must not crash."""
+
+    def test_drop_on_skipped_namespace_no_crash(self):
+        """Drop on NullNamespace → no crash, valid return."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        prompt_ctx, llm_ctx, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={"drop": ["skipped_step.field"]},
+            action_name="downstream",
+        )
+        assert isinstance(prompt_ctx, dict)
+        assert isinstance(llm_ctx, dict)
+        assert isinstance(pt, dict)
+
+
+# ── Gating: NullNamespace sentinel ───────────────────────────────────
+
+
+class TestGatingSkippedNamespace:
+    """NullNamespace passes through the prompt_context gating phase."""
+
+    def test_skipped_namespace_passes_through_gate(self):
+        """NullNamespace in allowed set passes gating."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+            present={"f": 1},
+        )
+        prompt_ctx, _, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={"observe": ["skipped_step.status", "present.f"]},
+            action_name="downstream",
+        )
+        # NullNamespace should be in prompt_context (for template rendering awareness)
+        assert "skipped_step" in prompt_ctx
+        assert prompt_ctx["present"]["f"] == 1
+
+
+# ── NullNamespace reason introspection ───────────────────────────────
+
+
+class TestNullNamespaceReason:
+    """The reason attribute is accessible for downstream introspection."""
+
+    def test_reason_attribute(self):
+        """NullNamespace carries the reason for null-ness."""
+        ns = NullNamespace(reason="skipped")
+        assert ns.reason == "skipped"
+
+    def test_falsy(self):
+        """NullNamespace is falsy (like None)."""
+        ns = NullNamespace(reason="skipped")
+        assert not ns
+
+    def test_equality(self):
+        """NullNamespace with same reason are equal."""
+        assert NullNamespace(reason="skipped") == NullNamespace(reason="skipped")
+        assert NullNamespace(reason="skipped") != NullNamespace(reason="filtered")
+
+
+# ── Combined directives on NullNamespace ─────────────────────────────
+
+
+class TestCombinedDirectivesSkippedNamespace:
+    """Interaction of multiple directives when namespace is NullNamespace."""
+
+    def test_observe_and_passthrough_both_null_safe(self):
+        """Both observe and passthrough on skipped namespace yield None."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        _, llm_ctx, pt = apply_context_scope(
+            field_context=fc,
+            context_scope={
+                "observe": ["skipped_step.status"],
+                "passthrough": ["skipped_step.trace_id"],
+            },
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped_step"]["status"] is None
+        assert pt["skipped_step"]["trace_id"] is None
+
+    def test_drop_then_observe_on_skipped_no_crash(self):
+        """Drop + observe on NullNamespace: drop is no-op, observe yields None."""
+        fc = _make_field_context(
+            skipped_step=NullNamespace(reason="skipped"),
+        )
+        _, llm_ctx, _ = apply_context_scope(
+            field_context=fc,
+            context_scope={
+                "drop": ["skipped_step.secret"],
+                "observe": ["skipped_step.status"],
+            },
+            action_name="downstream",
+        )
+        assert llm_ctx["skipped_step"]["status"] is None

--- a/tests/unit/unification/test_phase9b_observe_skipped_ns.py
+++ b/tests/unit/unification/test_phase9b_observe_skipped_ns.py
@@ -47,11 +47,13 @@ class TestObserveSkippedNamespace:
         )
         _, llm_ctx, _ = apply_context_scope(
             field_context=fc,
-            context_scope={"observe": [
-                "skipped_step.field_a",
-                "skipped_step.field_b",
-                "skipped_step.field_c",
-            ]},
+            context_scope={
+                "observe": [
+                    "skipped_step.field_a",
+                    "skipped_step.field_b",
+                    "skipped_step.field_c",
+                ]
+            },
             action_name="downstream",
         )
         assert llm_ctx["skipped_step"] == {


### PR DESCRIPTION
## Summary
- Introduces `NullNamespace(reason="skipped")` sentinel class replacing plain `None` for guard-skipped upstream namespaces
- `_resolve_missing_field()` uses `is_null_namespace()` to handle both `NullNamespace` and legacy `None`
- `DependencyNamespaceBuilder.build()` wraps null deps in `NullNamespace` instead of storing `None`
- Guard evaluator `ast_nodes.py` recognizes `NullNamespace` via `_is_null_or_empty_namespace()` helper
- Existing tests updated from `is None` to `is_null_namespace()` assertions

## Verification
- 13 new Phase 9b tests pass (observe, passthrough, drop, gating, combined directives on `NullNamespace`)
- All 58 null-safety related tests pass (Phase 9a, null_safe_observe, guard_empty_namespace, filter_fanin)
- Full suite: 6937 passed, 0 failed, 2 skipped
- `ruff format --check` and `ruff check` clean