### PR TITLE
fix(phase-7b): batch retrieve disposition parity with online collector

### DIFF
--- a/.changes/unreleased/Bug Fix-20260517-007500.yaml
+++ b/.changes/unreleased/Bug Fix-20260517-007500.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch retrieve dispositions now match online ResultCollector parity — SUCCESS written, FILTERED handled, input_snapshot included for EXHAUSTED/FAILED, prompt traces restricted to SUCCESS records"
+time: 2026-05-17T07:50:00.000000Z

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -162,6 +162,7 @@ class BatchProcessingService:
 
             if self._storage_backend and self._action_name:
                 self._write_record_dispositions(processed_data, self._action_name)
+                self._write_filtered_dispositions(context_map, self._action_name)
                 self._update_prompt_trace_responses(processed_data, self._action_name)
 
             if self._source_handler:
@@ -619,18 +620,68 @@ class BatchProcessingService:
         return output_path
 
     def _write_record_dispositions(self, items: list[dict[str, Any]], action_name: str) -> None:
-        """Write dispositions for non-success records in batch output.
+        """Write dispositions for batch output records.
 
         Delegates to result_collector.write_record_dispositions.
         """
         _write_record_dispositions_impl(self._storage_backend, items, action_name)
 
+    def _write_filtered_dispositions(self, context_map: dict[str, Any], action_name: str) -> None:
+        """Write FILTERED dispositions for records excluded from output.
+
+        FILTERED records are removed from the output stream by the reconciler
+        (they never reach write_record_dispositions). This method ensures they
+        still receive DISPOSITION_FILTERED to match online ResultCollector parity.
+        """
+        if not self._storage_backend or not context_map:
+            return
+        from agent_actions.llm.batch.core.batch_constants import FilterStatus
+        from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+        from agent_actions.record.reasons import GUARD_FILTER
+        from agent_actions.storage.backend import DISPOSITION_DEFERRED, DISPOSITION_FILTERED
+
+        for _custom_id, entry in context_map.items():
+            if BatchContextMetadata.get_filter_status(entry) != FilterStatus.FILTERED:
+                continue
+            source_guid = entry.get("source_guid")
+            if not source_guid:
+                continue
+            reason = BatchContextMetadata.get_skip_reason(entry) or GUARD_FILTER
+            try:
+                self._storage_backend.clear_disposition(
+                    action_name,
+                    disposition=DISPOSITION_DEFERRED,
+                    record_id=source_guid,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not clear DEFERRED disposition for %s (may not exist)",
+                    source_guid,
+                    exc_info=True,
+                )
+            try:
+                self._storage_backend.set_disposition(
+                    action_name, source_guid, DISPOSITION_FILTERED, reason=reason
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to write FILTERED disposition for %s", source_guid, exc_info=True
+                )
+
     def _update_prompt_trace_responses(self, items: list[dict[str, Any]], action_name: str) -> None:
-        """Update prompt traces with batch responses. Telemetry — non-fatal."""
+        """Update prompt traces with batch responses for SUCCESS records only.
+
+        Only records with _state=processed represent actual LLM responses.
+        Tombstones (exhausted, failed, skipped) must not pollute prompt traces.
+        """
         if not self._storage_backend:
             return
+        from agent_actions.record.state import RecordState
+
         try:
             for item in items:
+                if item.get("_state") != RecordState.PROCESSED.value:
+                    continue
                 target_id = item.get("target_id")
                 if not target_id:
                     continue

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -194,8 +194,8 @@ def write_record_dispositions(
 
     Called after batch results have been converted to workflow format.
     Clears any prior DEFERRED disposition for each record, then writes
-    the final status (EXHAUSTED, FAILED, FILTERED, PASSTHROUGH).
-    Success records only get their DEFERRED cleared — no new disposition.
+    the final status matching online ResultCollector parity:
+    SUCCESS, EXHAUSTED, FAILED, PASSTHROUGH, UNPROCESSED.
 
     Disposition writes are telemetry — errors are logged but never propagated.
     """
@@ -208,10 +208,6 @@ def write_record_dispositions(
         metadata = item.get("metadata", {})
 
         try:
-            # Clear the DEFERRED disposition now that the batch result has
-            # arrived.  For success records this is the only disposition
-            # action; for non-success records the final disposition is
-            # written immediately below.
             storage_backend.clear_disposition(
                 action_name,
                 disposition=DISPOSITION_DEFERRED,
@@ -235,6 +231,7 @@ def write_record_dispositions(
                 source_guid,
                 DISPOSITION_EXHAUSTED,
                 reason=f"evaluation_exhausted:{validation}",
+                input_snapshot=_serialize_snapshot(item),
             )
         elif metadata.get("retry_exhausted"):
             _safe_set_disposition(
@@ -243,6 +240,7 @@ def write_record_dispositions(
                 source_guid,
                 DISPOSITION_EXHAUSTED,
                 reason=RETRY_EXHAUSTED,
+                input_snapshot=_serialize_snapshot(item),
             )
         elif item.get("_state") in (
             RecordState.CASCADE_SKIPPED.value,
@@ -258,12 +256,22 @@ def write_record_dispositions(
                 reason=metadata.get("reason", UNPROCESSED),
             )
         elif item.get("error"):
+            error_str = str(item["error"])[:500]
             _safe_set_disposition(
                 storage_backend,
                 action_name,
                 source_guid,
                 DISPOSITION_FAILED,
-                reason=str(item["error"])[:500],
+                reason=error_str,
+                input_snapshot=_serialize_snapshot(item),
+                detail=error_str,
+            )
+        elif item.get("_state") == RecordState.PROCESSED.value:
+            _safe_set_disposition(
+                storage_backend,
+                action_name,
+                source_guid,
+                DISPOSITION_SUCCESS,
             )
 
 

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -16,7 +16,6 @@ from agent_actions.llm.batch.infrastructure.recovery_state import (
 )
 from agent_actions.llm.batch.services.retry import BatchRetryService
 from agent_actions.llm.providers.batch_base import BatchResult
-from agent_actions.storage.backend import DISPOSITION_EXHAUSTED
 
 # Module path prefix for patching deferred imports in processing_recovery.
 _MOD = "agent_actions.llm.batch.services.processing_recovery"
@@ -395,9 +394,10 @@ class TestWriteRecordDispositionsEvaluationExhausted:
         )
 
         write_record_dispositions(service._storage_backend, items, "my_action")
-        service._storage_backend.set_disposition.assert_called_once_with(
-            "my_action", "sg-1", DISPOSITION_EXHAUSTED, reason="evaluation_exhausted:check_schema"
-        )
+        service._storage_backend.set_disposition.assert_called_once()
+        call_kwargs = service._storage_backend.set_disposition.call_args.kwargs
+        assert call_kwargs["reason"] == "evaluation_exhausted:check_schema"
+        assert "input_snapshot" in call_kwargs
 
     def test_evaluation_exhausted_takes_precedence_over_retry_exhausted(self):
         """If both _recovery.reprompt.passed=False AND retry_exhausted, evaluation wins."""
@@ -431,9 +431,10 @@ class TestWriteRecordDispositionsEvaluationExhausted:
         )
 
         write_record_dispositions(service._storage_backend, items, "my_action")
-        service._storage_backend.set_disposition.assert_called_once_with(
-            "my_action", "sg-1", DISPOSITION_EXHAUSTED, reason="retry_exhausted"
-        )
+        service._storage_backend.set_disposition.assert_called_once()
+        call_kwargs = service._storage_backend.set_disposition.call_args.kwargs
+        assert call_kwargs["reason"] == "retry_exhausted"
+        assert "input_snapshot" in call_kwargs
 
     def test_unknown_validation_fallback(self):
         """Missing validation name defaults to 'unknown'."""

--- a/tests/unit/unification/test_phase7b_disposition_parity.py
+++ b/tests/unit/unification/test_phase7b_disposition_parity.py
@@ -1,0 +1,382 @@
+"""Phase 7b: Batch retrieve dispositions must match online collector rules.
+
+U-3.2a: write_record_dispositions must produce the same disposition types,
+reasons, and auxiliary fields (input_snapshot, detail) as ResultCollector.
+collect_results() does for equivalent records.
+
+U-3.5a: Prompt trace responses must only be written for SUCCESS records,
+not for tombstones/passthroughs.
+"""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from agent_actions.llm.batch.core.batch_constants import FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.processing.result_collector import write_record_dispositions
+from agent_actions.record.state import RecordState
+from agent_actions.storage.backend import (
+    DISPOSITION_EXHAUSTED,
+    DISPOSITION_FAILED,
+    DISPOSITION_FILTERED,
+    DISPOSITION_SUCCESS,
+)
+
+
+def _make_storage_backend() -> MagicMock:
+    """Create a mock storage backend that tracks disposition calls."""
+    backend = MagicMock()
+    backend.set_disposition = MagicMock()
+    backend.clear_disposition = MagicMock()
+    return backend
+
+
+class TestSuccessDisposition:
+    """U-3.2a: SUCCESS records must get DISPOSITION_SUCCESS like online."""
+
+    def test_success_record_gets_success_disposition(self):
+        """Batch SUCCESS record (_state=processed) must write DISPOSITION_SUCCESS."""
+        backend = _make_storage_backend()
+
+        items = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "_state": RecordState.PROCESSED.value,
+                "content": {"result": "LLM output"},
+                "metadata": {},
+            },
+        ]
+
+        write_record_dispositions(backend, items, "test_action")
+
+        # Verify DISPOSITION_SUCCESS was written
+        success_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_SUCCESS
+        ]
+        assert len(success_calls) == 1, (
+            f"Expected 1 SUCCESS disposition write, got {len(success_calls)}. "
+            f"All calls: {backend.set_disposition.call_args_list}"
+        )
+        assert _get_record_id_arg(success_calls[0]) == "sg-001"
+
+    def test_multiple_success_records(self):
+        """Each SUCCESS record gets its own DISPOSITION_SUCCESS write."""
+        backend = _make_storage_backend()
+
+        items = [
+            {
+                "source_guid": "sg-001",
+                "_state": RecordState.PROCESSED.value,
+                "content": {"result": "output 1"},
+                "metadata": {},
+            },
+            {
+                "source_guid": "sg-002",
+                "_state": RecordState.PROCESSED.value,
+                "content": {"result": "output 2"},
+                "metadata": {},
+            },
+        ]
+
+        write_record_dispositions(backend, items, "test_action")
+
+        success_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_SUCCESS
+        ]
+        stamped_ids = {_get_record_id_arg(c) for c in success_calls}
+        assert stamped_ids == {"sg-001", "sg-002"}
+
+
+class TestFilteredDisposition:
+    """U-3.2a: FILTERED records must get DISPOSITION_FILTERED like online."""
+
+    def test_filtered_record_gets_filtered_disposition(self):
+        """Records filtered during batch prep must receive DISPOSITION_FILTERED.
+
+        The online path writes DISPOSITION_FILTERED for ProcessingStatus.FILTERED.
+        The batch path must do the same for records with FilterStatus.FILTERED
+        in the context_map.
+        """
+        backend = _make_storage_backend()
+
+        # Simulate the processing service calling write_filtered_dispositions
+        # (FILTERED records are excluded from workflow output items, so they
+        # must be handled separately from write_record_dispositions).
+        from agent_actions.llm.batch.services.processing import BatchProcessingService
+
+        service = _build_processing_service(storage_backend=backend)
+
+        context_map: dict[str, Any] = {}
+        filtered_entry = {"source_guid": "sg-filtered", "content": {"text": "data"}}
+        BatchContextMetadata.set_filter_status(filtered_entry, FilterStatus.FILTERED)
+        BatchContextMetadata.set_skip_reason(filtered_entry, "guard_filter")
+        context_map["t-filtered"] = filtered_entry
+
+        included_entry = {"source_guid": "sg-included", "content": {"text": "ok"}}
+        BatchContextMetadata.set_filter_status(included_entry, FilterStatus.INCLUDED)
+        context_map["t-included"] = included_entry
+
+        service._write_filtered_dispositions(context_map, "test_action")
+
+        # Only the FILTERED record should get DISPOSITION_FILTERED
+        filtered_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_FILTERED
+        ]
+        assert len(filtered_calls) == 1, (
+            f"Expected 1 FILTERED disposition, got {len(filtered_calls)}. "
+            f"All calls: {backend.set_disposition.call_args_list}"
+        )
+        assert _get_record_id_arg(filtered_calls[0]) == "sg-filtered"
+
+    def test_filtered_disposition_includes_reason(self):
+        """FILTERED disposition must include the skip_reason matching online."""
+        backend = _make_storage_backend()
+
+        from agent_actions.llm.batch.services.processing import BatchProcessingService
+
+        service = _build_processing_service(storage_backend=backend)
+
+        context_map: dict[str, Any] = {}
+        entry = {"source_guid": "sg-001", "content": {"text": "data"}}
+        BatchContextMetadata.set_filter_status(entry, FilterStatus.FILTERED)
+        BatchContextMetadata.set_skip_reason(entry, "guard_filter")
+        context_map["t-001"] = entry
+
+        service._write_filtered_dispositions(context_map, "test_action")
+
+        filtered_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_FILTERED
+        ]
+        assert len(filtered_calls) == 1
+        reason = _get_kwarg(filtered_calls[0], "reason")
+        assert reason == "guard_filter"
+
+
+class TestExhaustedInputSnapshot:
+    """U-3.2a: EXHAUSTED disposition must include input_snapshot like online."""
+
+    def test_exhausted_includes_input_snapshot(self):
+        """Batch EXHAUSTED disposition must write input_snapshot for forensics."""
+        backend = _make_storage_backend()
+
+        items = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "_state": RecordState.EXHAUSTED.value,
+                "content": {"text": "original input"},
+                "metadata": {"retry_exhausted": True},
+                "_recovery": {},
+            },
+        ]
+
+        write_record_dispositions(backend, items, "test_action")
+
+        exhausted_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_EXHAUSTED
+        ]
+        assert len(exhausted_calls) == 1
+        input_snapshot = _get_kwarg(exhausted_calls[0], "input_snapshot")
+        assert input_snapshot is not None, (
+            "EXHAUSTED disposition must include input_snapshot for debugging"
+        )
+        # Snapshot should be valid JSON containing the record content
+        parsed = json.loads(input_snapshot)
+        assert "source_guid" in parsed or "content" in parsed
+
+    def test_evaluation_exhausted_includes_input_snapshot(self):
+        """Evaluation exhaustion (reprompt.passed=False) also gets input_snapshot."""
+        backend = _make_storage_backend()
+
+        items = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "_state": RecordState.EXHAUSTED.value,
+                "content": {"text": "original"},
+                "metadata": {},
+                "_recovery": {"reprompt": {"passed": False, "validation": "schema_check"}},
+            },
+        ]
+
+        write_record_dispositions(backend, items, "test_action")
+
+        exhausted_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_EXHAUSTED
+        ]
+        assert len(exhausted_calls) == 1
+        input_snapshot = _get_kwarg(exhausted_calls[0], "input_snapshot")
+        assert input_snapshot is not None
+
+
+class TestFailedInputSnapshot:
+    """U-3.2a: FAILED disposition must include input_snapshot and detail like online."""
+
+    def test_failed_includes_input_snapshot(self):
+        """Batch FAILED disposition must write input_snapshot for debugging."""
+        backend = _make_storage_backend()
+
+        items = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "_state": RecordState.FAILED.value,
+                "content": {"text": "input data"},
+                "metadata": {},
+                "error": "provider returned 500 error",
+            },
+        ]
+
+        write_record_dispositions(backend, items, "test_action")
+
+        failed_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_FAILED
+        ]
+        assert len(failed_calls) == 1
+        input_snapshot = _get_kwarg(failed_calls[0], "input_snapshot")
+        assert input_snapshot is not None, (
+            "FAILED disposition must include input_snapshot"
+        )
+
+    def test_failed_includes_detail(self):
+        """Batch FAILED disposition must write detail field like online."""
+        backend = _make_storage_backend()
+
+        items = [
+            {
+                "target_id": "t-001",
+                "source_guid": "sg-001",
+                "_state": RecordState.FAILED.value,
+                "content": {"text": "input"},
+                "metadata": {},
+                "error": "model timeout after 30s",
+            },
+        ]
+
+        write_record_dispositions(backend, items, "test_action")
+
+        failed_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if _get_disposition_arg(c) == DISPOSITION_FAILED
+        ]
+        assert len(failed_calls) == 1
+        detail = _get_kwarg(failed_calls[0], "detail")
+        assert detail is not None, "FAILED disposition must include detail"
+        assert "model timeout" in detail
+
+
+class TestPromptTraceOnlyForSuccess:
+    """U-3.5a: Prompt trace responses written only for successful records."""
+
+    def test_tombstone_records_not_traced(self):
+        """Exhausted/failed/skipped records must NOT get prompt trace updates."""
+        from agent_actions.llm.batch.services.processing import BatchProcessingService
+
+        backend = _make_storage_backend()
+        backend.update_prompt_trace_response = MagicMock()
+
+        service = _build_processing_service(storage_backend=backend)
+
+        items = [
+            {
+                "target_id": "t-success",
+                "source_guid": "sg-001",
+                "_state": RecordState.PROCESSED.value,
+                "content": {"result": "LLM response"},
+                "metadata": {},
+            },
+            {
+                "target_id": "t-exhausted",
+                "source_guid": "sg-002",
+                "_state": RecordState.EXHAUSTED.value,
+                "content": {"text": "original input"},
+                "metadata": {"retry_exhausted": True},
+            },
+            {
+                "target_id": "t-failed",
+                "source_guid": "sg-003",
+                "_state": RecordState.FAILED.value,
+                "content": {"text": "input"},
+                "metadata": {},
+                "error": "provider error",
+            },
+        ]
+
+        service._update_prompt_trace_responses(items, "test_action")
+
+        # Only the SUCCESS record should have prompt trace updated
+        trace_calls = backend.update_prompt_trace_response.call_args_list
+        traced_ids = {c.kwargs.get("record_id") or c.args[1] for c in trace_calls}
+        assert "t-success" in traced_ids, "SUCCESS record must get prompt trace"
+        assert "t-exhausted" not in traced_ids, (
+            "EXHAUSTED record must NOT get prompt trace update"
+        )
+        assert "t-failed" not in traced_ids, (
+            "FAILED record must NOT get prompt trace update"
+        )
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _build_processing_service(*, storage_backend: Any = None) -> Any:
+    """Build a BatchProcessingService with minimal mocks for disposition tests."""
+    from unittest.mock import MagicMock
+
+    from agent_actions.llm.batch.services.processing import BatchProcessingService
+
+    return BatchProcessingService(
+        client_resolver=MagicMock(),
+        context_manager=MagicMock(),
+        result_processor=MagicMock(),
+        registry_manager_factory=MagicMock(),
+        source_handler=None,
+        action_indices={},
+        dependency_configs={},
+        storage_backend=storage_backend,
+        action_name="test_action",
+    )
+
+
+def _get_disposition_arg(call_obj) -> str | None:
+    """Extract the disposition argument from a mock call."""
+    if call_obj.kwargs.get("disposition"):
+        return call_obj.kwargs["disposition"]
+    if len(call_obj.args) >= 3:
+        return call_obj.args[2]
+    return None
+
+
+def _get_record_id_arg(call_obj) -> str | None:
+    """Extract the record_id argument from a mock call."""
+    if call_obj.kwargs.get("record_id"):
+        return call_obj.kwargs["record_id"]
+    if len(call_obj.args) >= 2:
+        return call_obj.args[1]
+    return None
+
+
+def _get_kwarg(call_obj, key: str) -> Any:
+    """Extract a keyword argument from a mock call."""
+    return call_obj.kwargs.get(key)

--- a/tests/unit/unification/test_phase7b_disposition_parity.py
+++ b/tests/unit/unification/test_phase7b_disposition_parity.py
@@ -10,9 +10,7 @@ not for tombstones/passthroughs.
 
 import json
 from typing import Any
-from unittest.mock import MagicMock, call
-
-import pytest
+from unittest.mock import MagicMock
 
 from agent_actions.llm.batch.core.batch_constants import FilterStatus
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
@@ -110,8 +108,6 @@ class TestFilteredDisposition:
         # Simulate the processing service calling write_filtered_dispositions
         # (FILTERED records are excluded from workflow output items, so they
         # must be handled separately from write_record_dispositions).
-        from agent_actions.llm.batch.services.processing import BatchProcessingService
-
         service = _build_processing_service(storage_backend=backend)
 
         context_map: dict[str, Any] = {}
@@ -141,8 +137,6 @@ class TestFilteredDisposition:
     def test_filtered_disposition_includes_reason(self):
         """FILTERED disposition must include the skip_reason matching online."""
         backend = _make_storage_backend()
-
-        from agent_actions.llm.batch.services.processing import BatchProcessingService
 
         service = _build_processing_service(storage_backend=backend)
 
@@ -252,9 +246,7 @@ class TestFailedInputSnapshot:
         ]
         assert len(failed_calls) == 1
         input_snapshot = _get_kwarg(failed_calls[0], "input_snapshot")
-        assert input_snapshot is not None, (
-            "FAILED disposition must include input_snapshot"
-        )
+        assert input_snapshot is not None, "FAILED disposition must include input_snapshot"
 
     def test_failed_includes_detail(self):
         """Batch FAILED disposition must write detail field like online."""
@@ -289,8 +281,6 @@ class TestPromptTraceOnlyForSuccess:
 
     def test_tombstone_records_not_traced(self):
         """Exhausted/failed/skipped records must NOT get prompt trace updates."""
-        from agent_actions.llm.batch.services.processing import BatchProcessingService
-
         backend = _make_storage_backend()
         backend.update_prompt_trace_response = MagicMock()
 
@@ -327,12 +317,8 @@ class TestPromptTraceOnlyForSuccess:
         trace_calls = backend.update_prompt_trace_response.call_args_list
         traced_ids = {c.kwargs.get("record_id") or c.args[1] for c in trace_calls}
         assert "t-success" in traced_ids, "SUCCESS record must get prompt trace"
-        assert "t-exhausted" not in traced_ids, (
-            "EXHAUSTED record must NOT get prompt trace update"
-        )
-        assert "t-failed" not in traced_ids, (
-            "FAILED record must NOT get prompt trace update"
-        )
+        assert "t-exhausted" not in traced_ids, "EXHAUSTED record must NOT get prompt trace update"
+        assert "t-failed" not in traced_ids, "FAILED record must NOT get prompt trace update"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Batch retrieve dispositions now match online `ResultCollector.collect_results()` rules (U-3.2a, U-3.5a)
- SUCCESS records get `DISPOSITION_SUCCESS` (previously only DEFERRED was cleared)
- FILTERED records get `DISPOSITION_FILTERED` via new `_write_filtered_dispositions` method
- EXHAUSTED/FAILED dispositions include `input_snapshot` and `detail` for forensics
- Prompt trace updates restricted to SUCCESS records only (tombstones no longer pollute traces)

## Verification
- 9 new parity tests in `test_phase7b_disposition_parity.py` (TDD: committed failing first, then green)
- Updated 2 existing tests in `test_async_evaluation_wiring.py` to expect new `input_snapshot` field
- Full test suite: 6932 passed, 2 skipped
- `ruff format` + `ruff check` clean