### PR TITLE
Phase 8a: Shared collect helper extraction

### DIFF
--- a/.changes/unreleased/Under the Hood-20260518-080000.yaml
+++ b/.changes/unreleased/Under the Hood-20260518-080000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Extract collect_results_from_processing_results() shared helper from ResultCollector for batch/online convergence"
+time: 2026-05-18T08:00:00.000000Z

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -302,7 +302,7 @@ def collect_results_from_processing_results(
     Raises:
         AgentActionsError: If on_exhausted=raise and records exhausted retries.
     """
-    effective_config: dict[str, Any] = agent_config or {}
+    effective_config: dict[str, Any] = agent_config if agent_config is not None else {}
 
     fire_event(
         ResultCollectionStartedEvent(
@@ -311,7 +311,7 @@ def collect_results_from_processing_results(
         )
     )
 
-    if effective_config:
+    if agent_config is not None:
         ResultCollector._check_exhausted_raise(
             results, effective_config, action_name, storage_backend
         )

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -275,6 +275,348 @@ def write_record_dispositions(
             )
 
 
+def collect_results_from_processing_results(
+    results: list[ProcessingResult],
+    action_name: str,
+    *,
+    storage_backend: Optional["StorageBackend"] = None,
+    agent_config: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], CollectionStats]:
+    """Shared collect logic for both online and batch retrieve paths.
+
+    Flattens ProcessingResult entries into output records, stamps lifecycle
+    state on each, writes dispositions to storage, and fires telemetry events.
+
+    Args:
+        results: ProcessingResult objects to collect (enriched).
+        action_name: Name of the action being processed.
+        storage_backend: Optional storage for disposition writes.
+        agent_config: Agent configuration (used for exhausted-raise check
+            and guard metadata in completion events). Pass ``None`` when
+            calling from batch retrieve — exhausted-raise is not applicable
+            and guard metadata is absent.
+
+    Returns:
+        Tuple of (output_records, stats). Stats contain counts by status.
+
+    Raises:
+        AgentActionsError: If on_exhausted=raise and records exhausted retries.
+    """
+    effective_config: dict[str, Any] = agent_config or {}
+
+    fire_event(
+        ResultCollectionStartedEvent(
+            action_name=action_name,
+            total_results=len(results),
+        )
+    )
+
+    if effective_config:
+        ResultCollector._check_exhausted_raise(
+            results, effective_config, action_name, storage_backend
+        )
+
+    output: list[dict[str, Any]] = []
+    stats: collections.Counter[str] = collections.Counter()
+
+    for idx, result in enumerate(results):
+        status = result.status
+        status_key = status.value
+        stats[status_key] += 1
+
+        if status == ProcessingStatus.SUCCESS:
+            data = result.data or []
+
+            # Detect parse-error records masquerading as SUCCESS.
+            # The LLM provider returns {"_parse_error": ...} on JSON
+            # parse failure, which flows through as SUCCESS data.
+            # Reprompt has already had its chance to repair (it runs
+            # during invocation, before result collection).
+            if data and _data_has_parse_error(data):
+                result.status = ProcessingStatus.FAILED
+                for d in data:
+                    _stamp(d, RecordState.FAILED, action_name, PARSE_ERROR)
+                output.extend(data)
+                stats[status_key] -= 1
+                stats["failed"] += 1
+                logger.warning(
+                    "[%s] SUCCESS result source_guid=%s contains _parse_error "
+                    "— dispositioned as FAILED",
+                    action_name,
+                    result.source_guid,
+                )
+                fire_event(
+                    ResultCollectedEvent(
+                        action_name=action_name,
+                        result_index=idx,
+                        status="failed",
+                    )
+                )
+                if storage_backend and result.source_guid:
+                    _safe_set_disposition(
+                        storage_backend,
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_FAILED,
+                        reason=PARSE_ERROR,
+                    )
+                continue
+
+            if data:
+                for d in data:
+                    _stamp(d, RecordState.PROCESSED, action_name, SUCCESS)
+                output.extend(data)
+            logger.debug(
+                "Collected SUCCESS result source_guid=%s count=%d",
+                result.source_guid,
+                len(data),
+            )
+            fire_event(
+                ResultCollectedEvent(
+                    action_name=action_name,
+                    result_index=idx,
+                    status="success",
+                )
+            )
+            if storage_backend and result.source_guid:
+                _safe_set_disposition(
+                    storage_backend,
+                    action_name,
+                    result.source_guid,
+                    DISPOSITION_SUCCESS,
+                )
+
+        elif status == ProcessingStatus.SKIPPED:
+            data = result.data or []
+            if data:
+                for d in data:
+                    _stamp(
+                        d,
+                        RecordState.GUARD_SKIPPED,
+                        action_name,
+                        result.skip_reason or GUARD_SKIP,
+                    )
+                output.extend(data)
+            logger.debug(
+                "Collected SKIPPED result source_guid=%s count=%d",
+                result.source_guid,
+                len(data),
+            )
+            fire_event(
+                ResultCollectedEvent(
+                    action_name=action_name,
+                    result_index=idx,
+                    status="skipped",
+                )
+            )
+            if storage_backend and result.source_guid:
+                _safe_set_disposition(
+                    storage_backend,
+                    action_name,
+                    result.source_guid,
+                    DISPOSITION_PASSTHROUGH,
+                    reason=result.skip_reason or GUARD_SKIP,
+                )
+
+        elif status == ProcessingStatus.EXHAUSTED:
+            data = result.data or []
+            if data:
+                for d in data:
+                    _stamp(d, RecordState.EXHAUSTED, action_name, RETRY_EXHAUSTED)
+                output.extend(data)
+            attempts = _get_retry_attempts(result)
+            logger.debug(
+                "Collected EXHAUSTED result source_guid=%s attempts=%s",
+                result.source_guid,
+                attempts,
+            )
+            fire_event(
+                ExhaustedRecordEvent(
+                    action_name=action_name,
+                    record_index=idx,
+                    source_guid=result.source_guid or "",
+                    reason=f"exhausted_after_{attempts}_attempts",
+                )
+            )
+            if storage_backend and result.source_guid:
+                input_snapshot_str = _serialize_snapshot(
+                    result.source_snapshot or result.input_record
+                )
+                _safe_set_disposition(
+                    storage_backend,
+                    action_name,
+                    result.source_guid,
+                    DISPOSITION_EXHAUSTED,
+                    reason=f"exhausted_after_{attempts}_attempts",
+                    input_snapshot=input_snapshot_str,
+                    detail=result.error,
+                )
+
+        elif status == ProcessingStatus.FAILED:
+            logger.error(
+                "[%s] Processing failed for source_guid=%s: %s",
+                action_name,
+                result.source_guid,
+                result.error,
+            )
+
+            # Build a tombstone so downstream actions see this record
+            # and can cascade-skip it (record-level error isolation).
+            tombstone = _build_failed_tombstone(
+                action_name, result.source_guid, result.input_record, result.error
+            )
+            output.append(tombstone)
+
+            fire_event(
+                ResultCollectedEvent(
+                    action_name=action_name,
+                    result_index=idx,
+                    status="failed",
+                )
+            )
+            if storage_backend and result.source_guid:
+                input_snapshot_str = _serialize_snapshot(
+                    result.source_snapshot or result.input_record
+                )
+                _safe_set_disposition(
+                    storage_backend,
+                    action_name,
+                    result.source_guid,
+                    DISPOSITION_FAILED,
+                    reason=result.error or "processing_error",
+                    input_snapshot=input_snapshot_str,
+                    detail=result.error,
+                )
+
+        elif status == ProcessingStatus.FILTERED:
+            logger.debug("Collected FILTERED result source_guid=%s", result.source_guid)
+            fire_event(
+                ResultCollectedEvent(
+                    action_name=action_name,
+                    result_index=idx,
+                    status="filtered",
+                )
+            )
+            if storage_backend and result.source_guid:
+                _safe_set_disposition(
+                    storage_backend,
+                    action_name,
+                    result.source_guid,
+                    DISPOSITION_FILTERED,
+                    reason=result.skip_reason or GUARD_FILTER,
+                )
+
+        elif status == ProcessingStatus.UNPROCESSED:
+            data = result.data or []
+            if data:
+                reason = result.skip_reason or UNPROCESSED
+                # FILE prefilter uses UNPROCESSED for ordering (FM13) but is a guard decision
+                state = (
+                    RecordState.GUARD_SKIPPED
+                    if reason in (GUARD_PREFILTER_SKIP, GUARD_SKIP, GUARD_FILTER)
+                    else RecordState.CASCADE_SKIPPED
+                )
+                for d in data:
+                    _stamp(d, state, action_name, reason)
+                output.extend(data)  # Preserve in output for lineage
+            logger.debug(
+                "Collected UNPROCESSED result source_guid=%s count=%d",
+                result.source_guid,
+                len(data),
+            )
+            fire_event(
+                ResultCollectedEvent(
+                    action_name=action_name,
+                    result_index=idx,
+                    status="unprocessed",
+                )
+            )
+            if storage_backend and result.source_guid:
+                _safe_set_disposition(
+                    storage_backend,
+                    action_name,
+                    result.source_guid,
+                    DISPOSITION_UNPROCESSED,
+                    reason=result.skip_reason or UNPROCESSED,
+                )
+
+        elif status == ProcessingStatus.DEFERRED:
+            task_id = result.task_id or ""
+            logger.info(
+                "Collected DEFERRED result source_guid=%s task_id=%s",
+                result.source_guid,
+                task_id,
+            )
+            fire_event(
+                ResultCollectedEvent(
+                    action_name=action_name,
+                    result_index=idx,
+                    status="deferred",
+                )
+            )
+            if storage_backend and result.source_guid:
+                _safe_set_disposition(
+                    storage_backend,
+                    action_name,
+                    result.source_guid,
+                    DISPOSITION_DEFERRED,
+                    reason=f"batch_queued:task_id={task_id}",
+                )
+
+        else:
+            logger.debug("Unhandled result status=%s", status)  # type: ignore[unreachable]
+
+    guard_config = effective_config.get("guard", {})
+    guard_condition = guard_config.get("clause", "") if isinstance(guard_config, dict) else ""
+    guard_on_false = guard_config.get("behavior", "") if isinstance(guard_config, dict) else ""
+
+    fire_event(
+        ResultCollectionCompleteEvent(
+            action_name=action_name,
+            total_success=stats["success"],
+            total_skipped=stats["skipped"],
+            total_filtered=stats["filtered"],
+            total_failed=stats["failed"],
+            total_exhausted=stats["exhausted"],
+            total_unprocessed=stats["unprocessed"],
+            total_deferred=stats["deferred"],
+            guard_condition=guard_condition,
+            guard_on_false=guard_on_false,
+        )
+    )
+
+    total_input = len(results)
+    if stats["filtered"] > 0 and stats["filtered"] == total_input and total_input > 0:
+        logger.warning(
+            "[%s] All %d records filtered by guard (%s). Downstream actions will receive no input.",
+            action_name,
+            total_input,
+            guard_condition or "unknown condition",
+        )
+
+    tombstone_count = stats["skipped"] + stats["exhausted"] + stats["unprocessed"]
+    if tombstone_count > 0:
+        logger.info(
+            "[%s] %d/%d records are tombstones (skipped=%d, exhausted=%d, unprocessed=%d)",
+            action_name,
+            tombstone_count,
+            len(results),
+            stats["skipped"],
+            stats["exhausted"],
+            stats["unprocessed"],
+        )
+
+    return output, CollectionStats(
+        success=stats["success"],
+        failed=stats["failed"],
+        skipped=stats["skipped"],
+        filtered=stats["filtered"],
+        exhausted=stats["exhausted"],
+        deferred=stats["deferred"],
+        unprocessed=stats["unprocessed"],
+    )
+
+
 class ResultCollector:
     """Collect output records from processing results."""
 
@@ -289,320 +631,20 @@ class ResultCollector:
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Flatten ProcessingResult entries into output records.
 
+        Delegates to ``collect_results_from_processing_results()`` — the
+        shared helper used by both online and batch retrieve paths.
+
         Returns:
             Tuple of (output_records, stats). Stats contain counts by status.
 
         Raises:
             AgentActionsError: If on_exhausted=raise and records exhausted retries.
         """
-        fire_event(
-            ResultCollectionStartedEvent(
-                action_name=agent_name,
-                total_results=len(results),
-            )
-        )
-
-        ResultCollector._check_exhausted_raise(results, agent_config, agent_name, storage_backend)
-
-        output: list[dict[str, Any]] = []
-        stats: collections.Counter[str] = collections.Counter()
-
-        for idx, result in enumerate(results):
-            status = result.status
-            status_key = status.value
-            stats[status_key] += 1
-
-            if status == ProcessingStatus.SUCCESS:
-                data = result.data or []
-
-                # Detect parse-error records masquerading as SUCCESS.
-                # The LLM provider returns {"_parse_error": ...} on JSON
-                # parse failure, which flows through as SUCCESS data.
-                # Reprompt has already had its chance to repair (it runs
-                # during invocation, before result collection).
-                if data and _data_has_parse_error(data):
-                    result.status = ProcessingStatus.FAILED
-                    for d in data:
-                        _stamp(d, RecordState.FAILED, agent_name, PARSE_ERROR)
-                    output.extend(data)
-                    stats[status_key] -= 1
-                    stats["failed"] += 1
-                    logger.warning(
-                        "[%s] SUCCESS result source_guid=%s contains _parse_error "
-                        "— dispositioned as FAILED",
-                        agent_name,
-                        result.source_guid,
-                    )
-                    fire_event(
-                        ResultCollectedEvent(
-                            action_name=agent_name,
-                            result_index=idx,
-                            status="failed",
-                        )
-                    )
-                    if storage_backend and result.source_guid:
-                        _safe_set_disposition(
-                            storage_backend,
-                            agent_name,
-                            result.source_guid,
-                            DISPOSITION_FAILED,
-                            reason=PARSE_ERROR,
-                        )
-                    continue
-
-                if data:
-                    for d in data:
-                        _stamp(d, RecordState.PROCESSED, agent_name, SUCCESS)
-                    output.extend(data)
-                logger.debug(
-                    "Collected SUCCESS result source_guid=%s count=%d",
-                    result.source_guid,
-                    len(data),
-                )
-                fire_event(
-                    ResultCollectedEvent(
-                        action_name=agent_name,
-                        result_index=idx,
-                        status="success",
-                    )
-                )
-                if storage_backend and result.source_guid:
-                    _safe_set_disposition(
-                        storage_backend,
-                        agent_name,
-                        result.source_guid,
-                        DISPOSITION_SUCCESS,
-                    )
-
-            elif status == ProcessingStatus.SKIPPED:
-                data = result.data or []
-                if data:
-                    for d in data:
-                        _stamp(
-                            d,
-                            RecordState.GUARD_SKIPPED,
-                            agent_name,
-                            result.skip_reason or GUARD_SKIP,
-                        )
-                    output.extend(data)
-                logger.debug(
-                    "Collected SKIPPED result source_guid=%s count=%d",
-                    result.source_guid,
-                    len(data),
-                )
-                fire_event(
-                    ResultCollectedEvent(
-                        action_name=agent_name,
-                        result_index=idx,
-                        status="skipped",
-                    )
-                )
-                if storage_backend and result.source_guid:
-                    _safe_set_disposition(
-                        storage_backend,
-                        agent_name,
-                        result.source_guid,
-                        DISPOSITION_PASSTHROUGH,
-                        reason=result.skip_reason or GUARD_SKIP,
-                    )
-
-            elif status == ProcessingStatus.EXHAUSTED:
-                data = result.data or []
-                if data:
-                    for d in data:
-                        _stamp(d, RecordState.EXHAUSTED, agent_name, RETRY_EXHAUSTED)
-                    output.extend(data)
-                attempts = _get_retry_attempts(result)
-                logger.debug(
-                    "Collected EXHAUSTED result source_guid=%s attempts=%s",
-                    result.source_guid,
-                    attempts,
-                )
-                fire_event(
-                    ExhaustedRecordEvent(
-                        action_name=agent_name,
-                        record_index=idx,
-                        source_guid=result.source_guid or "",
-                        reason=f"exhausted_after_{attempts}_attempts",
-                    )
-                )
-                if storage_backend and result.source_guid:
-                    input_snapshot_str = _serialize_snapshot(
-                        result.source_snapshot or result.input_record
-                    )
-                    _safe_set_disposition(
-                        storage_backend,
-                        agent_name,
-                        result.source_guid,
-                        DISPOSITION_EXHAUSTED,
-                        reason=f"exhausted_after_{attempts}_attempts",
-                        input_snapshot=input_snapshot_str,
-                        detail=result.error,
-                    )
-
-            elif status == ProcessingStatus.FAILED:
-                logger.error(
-                    "[%s] Processing failed for source_guid=%s: %s",
-                    agent_name,
-                    result.source_guid,
-                    result.error,
-                )
-
-                # Build a tombstone so downstream actions see this record
-                # and can cascade-skip it (record-level error isolation).
-                tombstone = _build_failed_tombstone(
-                    agent_name, result.source_guid, result.input_record, result.error
-                )
-                output.append(tombstone)
-
-                fire_event(
-                    ResultCollectedEvent(
-                        action_name=agent_name,
-                        result_index=idx,
-                        status="failed",
-                    )
-                )
-                if storage_backend and result.source_guid:
-                    input_snapshot_str = _serialize_snapshot(
-                        result.source_snapshot or result.input_record
-                    )
-                    _safe_set_disposition(
-                        storage_backend,
-                        agent_name,
-                        result.source_guid,
-                        DISPOSITION_FAILED,
-                        reason=result.error or "processing_error",
-                        input_snapshot=input_snapshot_str,
-                        detail=result.error,
-                    )
-
-            elif status == ProcessingStatus.FILTERED:
-                logger.debug("Collected FILTERED result source_guid=%s", result.source_guid)
-                fire_event(
-                    ResultCollectedEvent(
-                        action_name=agent_name,
-                        result_index=idx,
-                        status="filtered",
-                    )
-                )
-                if storage_backend and result.source_guid:
-                    _safe_set_disposition(
-                        storage_backend,
-                        agent_name,
-                        result.source_guid,
-                        DISPOSITION_FILTERED,
-                        reason=result.skip_reason or GUARD_FILTER,
-                    )
-
-            elif status == ProcessingStatus.UNPROCESSED:
-                data = result.data or []
-                if data:
-                    reason = result.skip_reason or UNPROCESSED
-                    # FILE prefilter uses UNPROCESSED for ordering (FM13) but is a guard decision
-                    state = (
-                        RecordState.GUARD_SKIPPED
-                        if reason in (GUARD_PREFILTER_SKIP, GUARD_SKIP, GUARD_FILTER)
-                        else RecordState.CASCADE_SKIPPED
-                    )
-                    for d in data:
-                        _stamp(d, state, agent_name, reason)
-                    output.extend(data)  # Preserve in output for lineage
-                logger.debug(
-                    "Collected UNPROCESSED result source_guid=%s count=%d",
-                    result.source_guid,
-                    len(data),
-                )
-                fire_event(
-                    ResultCollectedEvent(
-                        action_name=agent_name,
-                        result_index=idx,
-                        status="unprocessed",
-                    )
-                )
-                if storage_backend and result.source_guid:
-                    _safe_set_disposition(
-                        storage_backend,
-                        agent_name,
-                        result.source_guid,
-                        DISPOSITION_UNPROCESSED,
-                        reason=result.skip_reason or UNPROCESSED,
-                    )
-
-            elif status == ProcessingStatus.DEFERRED:
-                task_id = result.task_id or ""
-                logger.info(
-                    "Collected DEFERRED result source_guid=%s task_id=%s",
-                    result.source_guid,
-                    task_id,
-                )
-                fire_event(
-                    ResultCollectedEvent(
-                        action_name=agent_name,
-                        result_index=idx,
-                        status="deferred",
-                    )
-                )
-                if storage_backend and result.source_guid:
-                    _safe_set_disposition(
-                        storage_backend,
-                        agent_name,
-                        result.source_guid,
-                        DISPOSITION_DEFERRED,
-                        reason=f"batch_queued:task_id={task_id}",
-                    )
-
-            else:
-                logger.debug("Unhandled result status=%s", status)  # type: ignore[unreachable]
-
-        guard_config = agent_config.get("guard", {})
-        guard_condition = guard_config.get("clause", "") if isinstance(guard_config, dict) else ""
-        guard_on_false = guard_config.get("behavior", "") if isinstance(guard_config, dict) else ""
-
-        fire_event(
-            ResultCollectionCompleteEvent(
-                action_name=agent_name,
-                total_success=stats["success"],
-                total_skipped=stats["skipped"],
-                total_filtered=stats["filtered"],
-                total_failed=stats["failed"],
-                total_exhausted=stats["exhausted"],
-                total_unprocessed=stats["unprocessed"],
-                total_deferred=stats["deferred"],
-                guard_condition=guard_condition,
-                guard_on_false=guard_on_false,
-            )
-        )
-
-        total_input = len(results)
-        if stats["filtered"] > 0 and stats["filtered"] == total_input and total_input > 0:
-            logger.warning(
-                "[%s] All %d records filtered by guard (%s). "
-                "Downstream actions will receive no input.",
-                agent_name,
-                total_input,
-                guard_condition or "unknown condition",
-            )
-
-        tombstone_count = stats["skipped"] + stats["exhausted"] + stats["unprocessed"]
-        if tombstone_count > 0:
-            logger.info(
-                "[%s] %d/%d records are tombstones (skipped=%d, exhausted=%d, unprocessed=%d)",
-                agent_name,
-                tombstone_count,
-                len(results),
-                stats["skipped"],
-                stats["exhausted"],
-                stats["unprocessed"],
-            )
-
-        return output, CollectionStats(
-            success=stats["success"],
-            failed=stats["failed"],
-            skipped=stats["skipped"],
-            filtered=stats["filtered"],
-            exhausted=stats["exhausted"],
-            deferred=stats["deferred"],
-            unprocessed=stats["unprocessed"],
+        return collect_results_from_processing_results(
+            results,
+            agent_name,
+            storage_backend=storage_backend,
+            agent_config=agent_config,
         )
 
     @staticmethod

--- a/tests/unit/unification/test_phase8a_shared_collect_helper.py
+++ b/tests/unit/unification/test_phase8a_shared_collect_helper.py
@@ -1,0 +1,338 @@
+"""Phase 8a: Shared collect helper — extraction parity tests.
+
+Tests that the extracted ``collect_results_from_processing_results()``
+produces identical output to ``ResultCollector.collect_results()`` for
+all status paths: SUCCESS, FAILED, EXHAUSTED, SKIPPED, FILTERED,
+UNPROCESSED, DEFERRED.
+
+These tests exercise the shared helper directly and verify it against
+the batch retrieve scenario where ProcessingResult objects arrive
+with mixed statuses (as they do from BatchResultStrategy.process).
+"""
+
+from unittest.mock import MagicMock
+
+from agent_actions.processing.record_helpers import build_tombstone
+from agent_actions.processing.result_collector import (
+    ResultCollector,
+    collect_results_from_processing_results,
+)
+from agent_actions.processing.types import ProcessingResult
+from agent_actions.record.reasons import (
+    GUARD_SKIP,
+    UNPROCESSED,
+)
+from agent_actions.record.state import RecordState
+from agent_actions.storage.backend import (
+    DISPOSITION_EXHAUSTED,
+    DISPOSITION_FAILED,
+    DISPOSITION_PASSTHROUGH,
+    DISPOSITION_SUCCESS,
+    DISPOSITION_UNPROCESSED,
+)
+
+ACTION_NAME = "test_action"
+
+
+def _make_success_result(source_guid: str = "sg-001") -> ProcessingResult:
+    """Create a SUCCESS ProcessingResult mimicking batch retrieve output."""
+    return ProcessingResult.success(
+        data=[
+            {
+                "target_id": f"t-{source_guid}",
+                "source_guid": source_guid,
+                "content": {"ns": {"field": "value"}},
+            }
+        ],
+        source_guid=source_guid,
+    )
+
+
+def _make_failed_result(
+    source_guid: str = "sg-002", error: str = "LLM timeout"
+) -> ProcessingResult:
+    """Create a FAILED ProcessingResult."""
+    return ProcessingResult.failed(
+        error=error,
+        source_guid=source_guid,
+        input_record={"target_id": f"t-{source_guid}", "source_guid": source_guid},
+    )
+
+
+def _make_exhausted_result(source_guid: str = "sg-003") -> ProcessingResult:
+    """Create an EXHAUSTED ProcessingResult with retry metadata."""
+    return ProcessingResult.exhausted(
+        error="max retries exceeded",
+        data=[
+            {
+                "target_id": f"t-{source_guid}",
+                "source_guid": source_guid,
+                "content": {"ns": {"field": "partial"}},
+                "metadata": {"retry_exhausted": True},
+            }
+        ],
+        source_guid=source_guid,
+    )
+
+
+def _make_skipped_result(source_guid: str = "sg-004") -> ProcessingResult:
+    """Create a SKIPPED ProcessingResult (guard skip with tombstone)."""
+    tombstone = build_tombstone(
+        ACTION_NAME,
+        {"target_id": f"t-{source_guid}", "source_guid": source_guid},
+        GUARD_SKIP,
+        source_guid=source_guid,
+    )
+    return ProcessingResult.skipped(
+        passthrough_data=tombstone,
+        reason=GUARD_SKIP,
+        source_guid=source_guid,
+    )
+
+
+def _make_filtered_result() -> ProcessingResult:
+    """Create a FILTERED ProcessingResult (guard filter, no output)."""
+    return ProcessingResult.filtered(source_guid=None)
+
+
+def _make_unprocessed_result(source_guid: str = "sg-006") -> ProcessingResult:
+    """Create an UNPROCESSED ProcessingResult (upstream cascade)."""
+    tombstone = build_tombstone(
+        ACTION_NAME,
+        {"target_id": f"t-{source_guid}", "source_guid": source_guid},
+        UNPROCESSED,
+        source_guid=source_guid,
+    )
+    return ProcessingResult.unprocessed(
+        data=[tombstone],
+        reason=UNPROCESSED,
+        source_guid=source_guid,
+    )
+
+
+def _make_deferred_result(
+    source_guid: str = "sg-007", task_id: str = "batch-task-123"
+) -> ProcessingResult:
+    """Create a DEFERRED ProcessingResult."""
+    return ProcessingResult.deferred(
+        task_id=task_id,
+        source_guid=source_guid,
+    )
+
+
+def _mock_storage_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.set_disposition = MagicMock()
+    backend.clear_disposition = MagicMock()
+    return backend
+
+
+class TestSharedHelperParityWithCollectResults:
+    """Shared helper must produce identical (records, stats) to ResultCollector."""
+
+    def test_success_records(self):
+        """SUCCESS results produce PROCESSED state and SUCCESS disposition."""
+        results = [_make_success_result("sg-001")]
+        backend = _mock_storage_backend()
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=backend,
+        )
+
+        assert len(records) == 1
+        assert records[0]["_state"] == RecordState.PROCESSED.value
+        assert stats.success == 1
+        backend.set_disposition.assert_called_once()
+        call_args = backend.set_disposition.call_args
+        assert call_args[0][2] == DISPOSITION_SUCCESS
+
+    def test_failed_records(self):
+        """FAILED results produce tombstone with FAILED state and disposition."""
+        results = [_make_failed_result("sg-002")]
+        backend = _mock_storage_backend()
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=backend,
+        )
+
+        assert len(records) == 1
+        assert records[0]["_state"] == RecordState.FAILED.value
+        assert records[0].get("metadata", {}).get("agent_type") == "tombstone"
+        assert stats.failed == 1
+        backend.set_disposition.assert_called_once()
+        call_args = backend.set_disposition.call_args
+        assert call_args[0][2] == DISPOSITION_FAILED
+
+    def test_exhausted_records(self):
+        """EXHAUSTED results get EXHAUSTED state and disposition."""
+        results = [_make_exhausted_result("sg-003")]
+        backend = _mock_storage_backend()
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=backend,
+        )
+
+        assert len(records) == 1
+        assert records[0]["_state"] == RecordState.EXHAUSTED.value
+        assert stats.exhausted == 1
+        backend.set_disposition.assert_called_once()
+        call_args = backend.set_disposition.call_args
+        assert call_args[0][2] == DISPOSITION_EXHAUSTED
+
+    def test_skipped_records(self):
+        """SKIPPED results get GUARD_SKIPPED state and PASSTHROUGH disposition."""
+        results = [_make_skipped_result("sg-004")]
+        backend = _mock_storage_backend()
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=backend,
+        )
+
+        assert len(records) == 1
+        assert records[0]["_state"] == RecordState.GUARD_SKIPPED.value
+        assert stats.skipped == 1
+        backend.set_disposition.assert_called_once()
+        call_args = backend.set_disposition.call_args
+        assert call_args[0][2] == DISPOSITION_PASSTHROUGH
+
+    def test_filtered_records(self):
+        """FILTERED results produce no output records but count in stats."""
+        results = [_make_filtered_result()]
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+        )
+
+        assert len(records) == 0
+        assert stats.filtered == 1
+
+    def test_unprocessed_records(self):
+        """UNPROCESSED results get CASCADE_SKIPPED state and disposition."""
+        results = [_make_unprocessed_result("sg-006")]
+        backend = _mock_storage_backend()
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=backend,
+        )
+
+        assert len(records) == 1
+        assert records[0]["_state"] == RecordState.CASCADE_SKIPPED.value
+        assert stats.unprocessed == 1
+        backend.set_disposition.assert_called_once()
+        call_args = backend.set_disposition.call_args
+        assert call_args[0][2] == DISPOSITION_UNPROCESSED
+
+    def test_deferred_records(self):
+        """DEFERRED results produce no output but count in stats."""
+        results = [_make_deferred_result("sg-007")]
+        backend = _mock_storage_backend()
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=backend,
+        )
+
+        assert len(records) == 0
+        assert stats.deferred == 1
+
+    def test_mixed_batch_scenario(self):
+        """Batch retrieve scenario: mixed SUCCESS + FAILED + EXHAUSTED + UNPROCESSED.
+
+        This mimics the output of BatchResultStrategy.process() after enrichment,
+        where a batch of records produces various outcomes.
+        """
+        results = [
+            _make_success_result("sg-001"),
+            _make_success_result("sg-002"),
+            _make_failed_result("sg-003"),
+            _make_exhausted_result("sg-004"),
+            _make_unprocessed_result("sg-005"),
+        ]
+        backend = _mock_storage_backend()
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=backend,
+        )
+
+        # 2 success + 1 failed tombstone + 1 exhausted + 1 unprocessed = 5
+        assert len(records) == 5
+        assert stats.success == 2
+        assert stats.failed == 1
+        assert stats.exhausted == 1
+        assert stats.unprocessed == 1
+
+    def test_no_storage_backend(self):
+        """Helper works without a storage backend (no dispositions written)."""
+        results = [_make_success_result("sg-001"), _make_failed_result("sg-002")]
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            storage_backend=None,
+        )
+
+        assert len(records) == 2
+        assert stats.success == 1
+        assert stats.failed == 1
+
+
+class TestSharedHelperEquivalence:
+    """Shared helper and ResultCollector.collect_results produce identical output."""
+
+    def test_equivalent_output_for_mixed_results(self):
+        """Same input through both APIs produces same records and stats."""
+        results_a = [
+            _make_success_result("sg-001"),
+            _make_failed_result("sg-002"),
+            _make_skipped_result("sg-003"),
+        ]
+        results_b = [
+            _make_success_result("sg-001"),
+            _make_failed_result("sg-002"),
+            _make_skipped_result("sg-003"),
+        ]
+
+        agent_config = {"name": ACTION_NAME}
+
+        # Via shared helper
+        records_helper, stats_helper = collect_results_from_processing_results(
+            results_a,
+            ACTION_NAME,
+            agent_config=agent_config,
+        )
+
+        # Via ResultCollector
+        records_collector, stats_collector = ResultCollector.collect_results(
+            results_b,
+            agent_config,
+            ACTION_NAME,
+            is_first_stage=False,
+        )
+
+        # Same number of records
+        assert len(records_helper) == len(records_collector)
+
+        # Same stats
+        assert stats_helper.success == stats_collector.success
+        assert stats_helper.failed == stats_collector.failed
+        assert stats_helper.skipped == stats_collector.skipped
+        assert stats_helper.filtered == stats_collector.filtered
+        assert stats_helper.exhausted == stats_collector.exhausted
+
+        # Same _state on each record
+        for rh, rc in zip(records_helper, records_collector, strict=True):
+            assert rh["_state"] == rc["_state"]

--- a/tests/unit/unification/test_phase8a_shared_collect_helper.py
+++ b/tests/unit/unification/test_phase8a_shared_collect_helper.py
@@ -12,6 +12,9 @@ with mixed statuses (as they do from BatchResultStrategy.process).
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from agent_actions.errors import AgentActionsError
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import (
     ResultCollector,
@@ -121,10 +124,7 @@ def _make_deferred_result(
 
 
 def _mock_storage_backend() -> MagicMock:
-    backend = MagicMock()
-    backend.set_disposition = MagicMock()
-    backend.clear_disposition = MagicMock()
-    return backend
+    return MagicMock()
 
 
 class TestSharedHelperParityWithCollectResults:
@@ -268,7 +268,6 @@ class TestSharedHelperParityWithCollectResults:
             storage_backend=backend,
         )
 
-        # 2 success + 1 failed tombstone + 1 exhausted + 1 unprocessed = 5
         assert len(records) == 5
         assert stats.success == 2
         assert stats.failed == 1
@@ -333,6 +332,47 @@ class TestSharedHelperEquivalence:
         assert stats_helper.filtered == stats_collector.filtered
         assert stats_helper.exhausted == stats_collector.exhausted
 
-        # Same _state on each record
         for rh, rc in zip(records_helper, records_collector, strict=True):
             assert rh["_state"] == rc["_state"]
+
+
+class TestExhaustedRaiseGuard:
+    """The exhausted-raise check depends on agent_config presence."""
+
+    def test_exhausted_raise_with_config(self):
+        """on_exhausted=raise + agent_config raises AgentActionsError."""
+        results = [_make_exhausted_result("sg-001")]
+        config = {"retry": {"on_exhausted": "raise"}}
+
+        with pytest.raises(AgentActionsError, match="Retry exhausted"):
+            collect_results_from_processing_results(
+                results,
+                ACTION_NAME,
+                agent_config=config,
+            )
+
+    def test_exhausted_no_raise_without_config(self):
+        """agent_config=None skips exhausted-raise (batch retrieve path)."""
+        results = [_make_exhausted_result("sg-001")]
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            agent_config=None,
+        )
+
+        assert stats.exhausted == 1
+        assert len(records) == 1
+
+    def test_exhausted_raise_with_empty_config(self):
+        """agent_config={} still checks exhausted-raise (returns normally, no raise config)."""
+        results = [_make_exhausted_result("sg-001")]
+
+        records, stats = collect_results_from_processing_results(
+            results,
+            ACTION_NAME,
+            agent_config={},
+        )
+
+        assert stats.exhausted == 1
+        assert len(records) == 1


### PR DESCRIPTION
## Summary
- Extracted `collect_results_from_processing_results()` as a standalone module-level function in `result_collector.py`, with a simpler API (`action_name`, optional `storage_backend` and `agent_config`)
- `ResultCollector.collect_results()` now delegates to it — zero behavior change
- 10 new tests cover all 7 status paths (SUCCESS, FAILED, EXHAUSTED, SKIPPED, FILTERED, UNPROCESSED, DEFERRED), mixed batch scenario, no-backend mode, and equivalence with the original static method

## Verification
- 6966 passed, 2 skipped
- `ruff format --check` clean
- `ruff check` clean
- All 53 existing result_collector tests pass unchanged
- All 10 new Phase 8a tests pass