### PR TITLE
Phase 8b: Route batch retrieve through UnifiedProcessor

### DIFF
--- a/.changes/unreleased/Under the Hood-20260518-008002.yaml
+++ b/.changes/unreleased/Under the Hood-20260518-008002.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Route batch retrieve through UnifiedProcessor shared enrich/collect pipeline, eliminating duplicate inline enrichment loop and batch-specific state stamping"
+time: 2026-05-18T00:80:02.000000Z

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -7,7 +7,10 @@ that can flow through the shared enrich/collect pipeline.
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agent_actions.processing.types import ProcessingContext
 
 from agent_actions.input.preprocessing.transformation.transformer import DataTransformer
 from agent_actions.llm.batch.core.batch_constants import FilterStatus
@@ -72,7 +75,58 @@ class BatchResultStrategy:
     caller (``BatchProcessingService``) uses to run enrichment through the
     shared enrichment pipeline.  Error results have ``processing_context``
     set to ``None`` and are intentionally not enriched.
+
+    Implements ``ProcessingStrategy`` (via structural typing) so it can
+    flow through ``UnifiedProcessor``.  Call ``prepare_invoke()`` to
+    pre-load batch data before ``invoke()`` is called by the processor.
     """
+
+    def __init__(self) -> None:
+        self._pending_batch_results: list[BatchResult] | None = None
+        self._pending_kwargs: dict[str, Any] = {}
+
+    def prepare_invoke(
+        self,
+        batch_results: list[BatchResult],
+        *,
+        context_map: dict[str, Any] | None = None,
+        output_directory: str | None = None,
+        agent_config: dict[str, Any] | None = None,
+        exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
+    ) -> None:
+        """Pre-load batch data for the next ``invoke()`` call.
+
+        Must be called before ``UnifiedProcessor.process()`` or
+        ``UnifiedProcessor.enrich_and_collect()`` invokes this strategy.
+        """
+        self._pending_batch_results = batch_results
+        self._pending_kwargs = {
+            "context_map": context_map,
+            "output_directory": output_directory,
+            "agent_config": agent_config,
+            "exhausted_recovery": exhausted_recovery,
+        }
+
+    def invoke(
+        self,
+        records: list[dict[str, Any]],
+        context: "ProcessingContext",
+    ) -> list[ProcessingResult]:
+        """ProcessingStrategy protocol: return results from pre-loaded batch data.
+
+        The ``records`` parameter is accepted for protocol compliance but
+        ignored — batch results are pre-loaded via ``prepare_invoke()``.
+        Guard filtering already happened at batch submit time.
+        """
+        if self._pending_batch_results is None:
+            raise RuntimeError(
+                "No batch data prepared. Call prepare_invoke() before invoke()."
+            )
+        try:
+            return self.process(self._pending_batch_results, **self._pending_kwargs)
+        finally:
+            self._pending_batch_results = None
+            self._pending_kwargs = {}
 
     def process(
         self,

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -119,9 +119,7 @@ class BatchResultStrategy:
         Guard filtering already happened at batch submit time.
         """
         if self._pending_batch_results is None:
-            raise RuntimeError(
-                "No batch data prepared. Call prepare_invoke() before invoke()."
-            )
+            raise RuntimeError("No batch data prepared. Call prepare_invoke() before invoke().")
         try:
             return self.process(self._pending_batch_results, **self._pending_kwargs)
         finally:

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
+from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.errors import ProcessingError
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
 from agent_actions.llm.batch.core.batch_models import BatchJobEntry
@@ -45,7 +46,6 @@ from agent_actions.llm.batch.services.processing_recovery import (
 from agent_actions.llm.batch.services.retry import BatchRetryService
 from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
-from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.output.writer import FileWriter
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.result_collector import CollectionStats

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -45,12 +45,15 @@ from agent_actions.llm.batch.services.processing_recovery import (
 from agent_actions.llm.batch.services.retry import BatchRetryService
 from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
+from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.output.writer import FileWriter
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.result_collector import (
+    CollectionStats,
     write_record_dispositions as _write_record_dispositions_impl,
 )
-from agent_actions.processing.types import RecoveryMetadata
+from agent_actions.processing.types import ProcessingContext, RecoveryMetadata
+from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.utils.path_utils import ensure_directory_exists
 
 logger = logging.getLogger(__name__)
@@ -153,7 +156,7 @@ class BatchProcessingService:
                 record_count=entry.record_count if entry else None,
                 file_name=file_name,
             )
-            processed_data = self._convert_batch_results_to_workflow_format(
+            processed_data, _stats = self._convert_batch_results_to_workflow_format(
                 batch_results,
                 context_map=context_map,
                 output_directory=output_directory,
@@ -161,7 +164,7 @@ class BatchProcessingService:
             )
 
             if self._storage_backend and self._action_name:
-                self._write_record_dispositions(processed_data, self._action_name)
+                self._clear_deferred_dispositions(processed_data)
                 self._write_filtered_dispositions(context_map, self._action_name)
                 self._update_prompt_trace_responses(processed_data, self._action_name)
 
@@ -619,6 +622,35 @@ class BatchProcessingService:
         _cleanup_recovery_impl(self, manager, output_directory, file_name)
         return output_path
 
+    def _clear_deferred_dispositions(self, items: list[dict[str, Any]]) -> None:
+        """Clear DEFERRED dispositions for batch records entering output.
+
+        Batch records receive DEFERRED dispositions at submit time.
+        After retrieve, the shared collector writes final dispositions
+        (SUCCESS, FAILED, etc.), but DEFERRED entries remain unless
+        explicitly cleared.
+        """
+        if not self._storage_backend or not self._action_name:
+            return
+        from agent_actions.storage.backend import DISPOSITION_DEFERRED
+
+        for item in items:
+            source_guid = item.get("source_guid")
+            if not source_guid:
+                continue
+            try:
+                self._storage_backend.clear_disposition(
+                    self._action_name,
+                    disposition=DISPOSITION_DEFERRED,
+                    record_id=source_guid,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not clear DEFERRED disposition for %s (may not exist)",
+                    source_guid,
+                    exc_info=True,
+                )
+
     def _write_record_dispositions(self, items: list[dict[str, Any]], action_name: str) -> None:
         """Write dispositions for batch output records.
 
@@ -727,18 +759,21 @@ class BatchProcessingService:
         output_directory: str | None = None,
         agent_config: dict[str, Any] | None = None,
         exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
-    ) -> list[dict[str, Any]]:
-        """Convert batch results to workflow format.
+    ) -> tuple[list[dict[str, Any]], CollectionStats]:
+        """Convert batch results to workflow format via UnifiedProcessor.
+
+        Routes batch results through the shared enrich → collect pipeline
+        (same path online uses), eliminating the duplicate inline loop.
 
         Args:
             batch_results: Raw batch results
             context_map: Context map for processing
             output_directory: Output directory path
             agent_config: Agent configuration
-            exhausted_recovery: Per-record recovery metadata for exhausted records (custom_id -> RecoveryMetadata)
+            exhausted_recovery: Per-record recovery metadata for exhausted records
 
         Returns:
-            Processed results in workflow format
+            Tuple of (output_records, CollectionStats).
         """
         results = self._result_processor.process(
             batch_results=batch_results,
@@ -747,15 +782,17 @@ class BatchProcessingService:
             agent_config=agent_config,
             exhausted_recovery=exhausted_recovery,
         )
-        # Enrich results that carry a processing_context, then flatten to
-        # workflow-format dicts.  Error results (processing_context=None) are
-        # intentionally skipped — matching the original pipeline behaviour.
-        output: list[dict[str, Any]] = []
-        for result in results:
-            if result.processing_context is not None:
-                result = self._enrichment_pipeline.enrich(result, result.processing_context)
-            output.extend(result.data or [])
-        return output
+
+        effective_config = agent_config or {}
+        ctx = ProcessingContext(
+            agent_config=cast(ActionConfigDict, effective_config),
+            agent_name=effective_config.get("action_name", "batch"),
+            mode=RunMode.BATCH,
+            storage_backend=self._storage_backend,
+        )
+
+        processor = UnifiedProcessor(enrichment_pipeline=self._enrichment_pipeline)
+        return processor.enrich_and_collect(results, ctx)
 
     @staticmethod
     def _apply_workflow_session_id(

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -103,6 +103,7 @@ class BatchProcessingService:
             storage_backend=self._storage_backend,
         )
         self._enrichment_pipeline = EnrichmentPipeline()
+        self._unified_processor = UnifiedProcessor(enrichment_pipeline=self._enrichment_pipeline)
 
     def process_batch_results(
         self,
@@ -629,24 +630,10 @@ class BatchProcessingService:
         """
         if not self._storage_backend or not self._action_name:
             return
-        from agent_actions.storage.backend import DISPOSITION_DEFERRED
-
         for item in items:
             source_guid = item.get("source_guid")
-            if not source_guid:
-                continue
-            try:
-                self._storage_backend.clear_disposition(
-                    self._action_name,
-                    disposition=DISPOSITION_DEFERRED,
-                    record_id=source_guid,
-                )
-            except Exception:
-                logger.debug(
-                    "Could not clear DEFERRED disposition for %s (may not exist)",
-                    source_guid,
-                    exc_info=True,
-                )
+            if source_guid:
+                self._try_clear_deferred(self._action_name, source_guid)
 
     def _write_filtered_dispositions(self, context_map: dict[str, Any], action_name: str) -> None:
         """Write FILTERED dispositions for records excluded from output.
@@ -660,7 +647,7 @@ class BatchProcessingService:
         from agent_actions.llm.batch.core.batch_constants import FilterStatus
         from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
         from agent_actions.record.reasons import GUARD_FILTER
-        from agent_actions.storage.backend import DISPOSITION_DEFERRED, DISPOSITION_FILTERED
+        from agent_actions.storage.backend import DISPOSITION_FILTERED
 
         for _custom_id, entry in context_map.items():
             if BatchContextMetadata.get_filter_status(entry) != FilterStatus.FILTERED:
@@ -669,18 +656,7 @@ class BatchProcessingService:
             if not source_guid:
                 continue
             reason = BatchContextMetadata.get_skip_reason(entry) or GUARD_FILTER
-            try:
-                self._storage_backend.clear_disposition(
-                    action_name,
-                    disposition=DISPOSITION_DEFERRED,
-                    record_id=source_guid,
-                )
-            except Exception:
-                logger.debug(
-                    "Could not clear DEFERRED disposition for %s (may not exist)",
-                    source_guid,
-                    exc_info=True,
-                )
+            self._try_clear_deferred(action_name, source_guid)
             try:
                 self._storage_backend.set_disposition(
                     action_name, source_guid, DISPOSITION_FILTERED, reason=reason
@@ -689,6 +665,25 @@ class BatchProcessingService:
                 logger.debug(
                     "Failed to write FILTERED disposition for %s", source_guid, exc_info=True
                 )
+
+    def _try_clear_deferred(self, action_name: str, record_id: str) -> None:
+        """Clear a DEFERRED disposition for one record. Swallows errors."""
+        if not self._storage_backend:
+            return
+        from agent_actions.storage.backend import DISPOSITION_DEFERRED
+
+        try:
+            self._storage_backend.clear_disposition(
+                action_name,
+                disposition=DISPOSITION_DEFERRED,
+                record_id=record_id,
+            )
+        except Exception:
+            logger.debug(
+                "Could not clear DEFERRED disposition for %s (may not exist)",
+                record_id,
+                exc_info=True,
+            )
 
     def _update_prompt_trace_responses(self, items: list[dict[str, Any]], action_name: str) -> None:
         """Update prompt traces with batch responses for SUCCESS records only.
@@ -781,8 +776,7 @@ class BatchProcessingService:
             storage_backend=self._storage_backend,
         )
 
-        processor = UnifiedProcessor(enrichment_pipeline=self._enrichment_pipeline)
-        return processor.enrich_and_collect(results, ctx)
+        return self._unified_processor.enrich_and_collect(results, ctx)
 
     @staticmethod
     def _apply_workflow_session_id(

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -48,10 +48,7 @@ from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.output.writer import FileWriter
 from agent_actions.processing.enrichment import EnrichmentPipeline
-from agent_actions.processing.result_collector import (
-    CollectionStats,
-    write_record_dispositions as _write_record_dispositions_impl,
-)
+from agent_actions.processing.result_collector import CollectionStats
 from agent_actions.processing.types import ProcessingContext, RecoveryMetadata
 from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.utils.path_utils import ensure_directory_exists
@@ -650,13 +647,6 @@ class BatchProcessingService:
                     source_guid,
                     exc_info=True,
                 )
-
-    def _write_record_dispositions(self, items: list[dict[str, Any]], action_name: str) -> None:
-        """Write dispositions for batch output records.
-
-        Delegates to result_collector.write_record_dispositions.
-        """
-        _write_record_dispositions_impl(self._storage_backend, items, action_name)
 
     def _write_filtered_dispositions(self, context_map: dict[str, Any], action_name: str) -> None:
         """Write FILTERED dispositions for records excluded from output.

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -35,9 +35,7 @@ from agent_actions.logging.events.validation_events import (
     RepromptRecoveredEvent,
     RepromptRetryEvent,
 )
-from agent_actions.processing.result_collector import write_record_dispositions
 from agent_actions.processing.types import RecoveryMetadata
-from agent_actions.record.envelope import RecordEnvelope
 
 if TYPE_CHECKING:
     from agent_actions.llm.batch.services.processing import BatchProcessingService
@@ -633,24 +631,4 @@ def _remove_batch_placeholder(output_file: Path) -> None:
             pass  # Already removed by concurrent worker
 
 
-def _stamp_batch_records(records: list[dict[str, Any]], action_name: str) -> None:
-    """Stamp _state on batch output records that lack lifecycle fields.
 
-    Batch results bypass the online ResultCollector._stamp() path. This ensures
-    every record written to target has a valid _state for Phase 5 fail-closed reads.
-    """
-    from agent_actions.record.state import RecordState
-
-    for record in records:
-        if "_state" in record:
-            continue
-        # Determine state from record content
-        content = record.get("content")
-        metadata = record.get("metadata", {})
-        if metadata.get("retry_exhausted") or metadata.get("reason") == "exhausted":
-            state = RecordState.EXHAUSTED
-        elif content is None and metadata.get("reason"):
-            state = RecordState.FAILED
-        else:
-            state = RecordState.PROCESSED
-        RecordEnvelope.transition(record, state, action_name, "batch_completion")

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -629,6 +629,3 @@ def _remove_batch_placeholder(output_file: Path) -> None:
             logger.debug("Removed batch placeholder: %s", output_file)
         except OSError:
             pass  # Already removed by concurrent worker
-
-
-

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -493,7 +493,7 @@ def finalize_batch_output(
     start_time: float,
 ) -> str:
     """Finalize batch processing: convert, write output, fire events."""
-    processed_data = service._convert_batch_results_to_workflow_format(
+    processed_data, _stats = service._convert_batch_results_to_workflow_format(
         batch_results,
         context_map=context_map,
         output_directory=output_directory,
@@ -503,12 +503,11 @@ def finalize_batch_output(
 
     effective_action_name = action_name if action_name is not None else service._action_name
 
-    # Stamp _state on batch records before writing — batch results bypass the
-    # online ResultCollector._stamp() path and arrive without lifecycle fields.
-    _stamp_batch_records(processed_data, effective_action_name or file_name)
-
+    # State stamping and disposition writing are now handled by the shared
+    # collector inside _convert_batch_results_to_workflow_format.
+    # Only DEFERRED clearing and prompt trace updates remain batch-specific.
     if service._storage_backend and effective_action_name:
-        write_record_dispositions(service._storage_backend, processed_data, effective_action_name)
+        service._clear_deferred_dispositions(processed_data)
         service._update_prompt_trace_responses(processed_data, effective_action_name)
 
     output_file = service._determine_output_path(output_directory, file_name, batch_id)

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -460,12 +460,21 @@ def collect_results_from_processing_results(
                 result.error,
             )
 
-            # Build a tombstone so downstream actions see this record
-            # and can cascade-skip it (record-level error isolation).
-            tombstone = _build_failed_tombstone(
-                action_name, result.source_guid, result.input_record, result.error
-            )
-            output.append(tombstone)
+            if result.data:
+                # Batch FAILED results carry their own data (error items or
+                # tombstones from build_tombstone).  Preserve them as-is and
+                # stamp lifecycle state.
+                for d in result.data:
+                    _stamp(d, RecordState.FAILED, action_name, result.error or "processing_error")
+                output.extend(result.data)
+            else:
+                # Online FAILED results have data=[].  Build a tombstone so
+                # downstream actions see this record and can cascade-skip it
+                # (record-level error isolation).
+                tombstone = _build_failed_tombstone(
+                    action_name, result.source_guid, result.input_record, result.error
+                )
+                output.append(tombstone)
 
             fire_event(
                 ResultCollectedEvent(

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -10,6 +10,7 @@ import logging
 from dataclasses import replace
 from typing import Any, Protocol, cast, runtime_checkable
 
+from agent_actions.config.types import RunMode
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import CollectionStats, ResultCollector
@@ -222,6 +223,27 @@ class UnifiedProcessor:
 
         return passing, guard_results, original_passing
 
+    def enrich_and_collect(
+        self,
+        results: list[ProcessingResult],
+        context: ProcessingContext,
+    ) -> tuple[list[dict[str, Any]], CollectionStats]:
+        """Enrich and collect pre-computed results.
+
+        Used by batch retrieve where guard filtering and strategy invocation
+        happened separately (at batch submit and result processing time).
+        The results flow through the shared enrichment pipeline and collector.
+
+        Args:
+            results: ProcessingResult objects (from BatchResultStrategy.process).
+            context: Batch ProcessingContext for enrichment and collection.
+
+        Returns:
+            Tuple of (output_records, CollectionStats).
+        """
+        enriched = self._enrich(results, context)
+        return self._collect(enriched, context)
+
     def _enrich(
         self,
         results: list[ProcessingResult],
@@ -229,13 +251,24 @@ class UnifiedProcessor:
     ) -> list[ProcessingResult]:
         """Run enrichment pipeline on each result.
 
-        Each result gets a context with its positional record_index so that
-        VersionIdEnricher produces distinct version_correlation_ids per record.
+        Uses per-result ``processing_context`` when set (batch results carry
+        their own context with correct record_index and original_row).
+        Falls back to the shared context with positional record_index for
+        online results.  Batch results without ``processing_context`` (error
+        results) skip enrichment entirely.
         """
-        return [
-            self._enrichment_pipeline.enrich(r, replace(context, record_index=i))
-            for i, r in enumerate(results)
-        ]
+        enriched: list[ProcessingResult] = []
+        for i, r in enumerate(results):
+            if r.processing_context is not None:
+                enriched.append(self._enrichment_pipeline.enrich(r, r.processing_context))
+            elif context.mode == RunMode.ONLINE:
+                enriched.append(
+                    self._enrichment_pipeline.enrich(r, replace(context, record_index=i))
+                )
+            else:
+                # Batch error results without processing_context skip enrichment.
+                enriched.append(r)
+        return enriched
 
     def _collect(
         self,

--- a/tests/integration/test_batch_content_materialization.py
+++ b/tests/integration/test_batch_content_materialization.py
@@ -5,11 +5,9 @@ and persisted to both the storage backend and the filesystem.
 """
 
 import json
-from typing import Any
+from typing import Any, cast
 
 import pytest
-
-from typing import cast
 
 from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.llm.batch.processing.batch_result_strategy import BatchResultStrategy

--- a/tests/integration/test_batch_content_materialization.py
+++ b/tests/integration/test_batch_content_materialization.py
@@ -9,11 +9,14 @@ from typing import Any
 
 import pytest
 
+from typing import cast
+
+from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.llm.batch.processing.batch_result_strategy import BatchResultStrategy
-from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.writer import FileWriter
-from agent_actions.processing.enrichment import EnrichmentPipeline
+from agent_actions.processing.types import ProcessingContext
+from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
 
@@ -24,7 +27,7 @@ def _process_batch(
     output_directory: str,
     action_name: str = "verify_answer",
 ) -> list[dict[str, Any]]:
-    """Process batch results through strategy + enrichment + stamp (production path)."""
+    """Process batch results through strategy + UnifiedProcessor (production path)."""
     strategy = BatchResultStrategy()
     results = strategy.process(
         batch_results=batch_results,
@@ -32,13 +35,13 @@ def _process_batch(
         output_directory=output_directory,
         agent_config=action_config,
     )
-    enrichment = EnrichmentPipeline()
-    output: list[dict[str, Any]] = []
-    for result in results:
-        if result.processing_context is not None:
-            result = enrichment.enrich(result, result.processing_context)
-        output.extend(result.data or [])
-    _stamp_batch_records(output, action_name)
+    ctx = ProcessingContext(
+        agent_config=cast(ActionConfigDict, action_config),
+        agent_name=action_name,
+        mode=RunMode.BATCH,
+    )
+    processor = UnifiedProcessor()
+    output, _stats = processor.enrich_and_collect(results, ctx)
     return output
 
 

--- a/tests/unit/llm/batch/test_composed_recovery.py
+++ b/tests/unit/llm/batch/test_composed_recovery.py
@@ -86,10 +86,10 @@ class TestComposedRecoveryPaths:
     """End-to-end composed recovery scenarios."""
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-    @patch("agent_actions.llm.batch.services.processing_recovery.write_record_dispositions")
+
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
-    def test_retry_exhausted_then_reprompt_succeeds(self, mock_mgr, mock_build_loop, _disp, _event):
+    def test_retry_exhausted_then_reprompt_succeeds(self, mock_mgr, mock_build_loop, _event):
         """Happy composed: retry exhausts, reprompt evaluates all as passing → finalize."""
         service = _mock_service()
         state = _make_state(retry_attempt=3, retry_max_attempts=3)
@@ -133,11 +133,11 @@ class TestComposedRecoveryPaths:
         service._write_batch_output.assert_called_once()
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-    @patch("agent_actions.llm.batch.services.processing_recovery.write_record_dispositions")
+
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
     def test_retry_exhausted_then_reprompt_exhausted_return_last(
-        self, mock_mgr, mock_build_loop, _disp, _event
+        self, mock_mgr, mock_build_loop, _event
     ):
         """Both exhausted, graceful: reprompt exhausted with return_last → finalize with metadata."""
         service = _mock_service()
@@ -233,10 +233,10 @@ class TestComposedRecoveryPaths:
             )
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-    @patch("agent_actions.llm.batch.services.processing_recovery.write_record_dispositions")
+
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
-    def test_retry_exhausted_no_reprompt_configured(self, mock_mgr, mock_build_loop, _disp, _event):
+    def test_retry_exhausted_no_reprompt_configured(self, mock_mgr, mock_build_loop, _event):
         """Retry-only exhaustion: no reprompt configured → finalize with exhaustion metadata."""
         service = _mock_service()
         state = _make_state(retry_attempt=3, retry_max_attempts=3)
@@ -275,10 +275,10 @@ class TestComposedRecoveryPaths:
         mock_mgr.delete.assert_called_once()
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-    @patch("agent_actions.llm.batch.services.processing_recovery.write_record_dispositions")
+
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
-    def test_reprompt_only_all_graduated(self, mock_mgr, mock_build_loop, _disp, _event):
+    def test_reprompt_only_all_graduated(self, mock_mgr, mock_build_loop, _event):
         """Reprompt-only: no retry needed, all pass evaluation → finalize."""
         service = _mock_service()
         state = _make_state(phase="reprompt", retry_attempt=0, missing_ids=[])

--- a/tests/unit/llm/batch/test_composed_recovery.py
+++ b/tests/unit/llm/batch/test_composed_recovery.py
@@ -86,7 +86,6 @@ class TestComposedRecoveryPaths:
     """End-to-end composed recovery scenarios."""
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
     def test_retry_exhausted_then_reprompt_succeeds(self, mock_mgr, mock_build_loop, _event):
@@ -133,7 +132,6 @@ class TestComposedRecoveryPaths:
         service._write_batch_output.assert_called_once()
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
     def test_retry_exhausted_then_reprompt_exhausted_return_last(
@@ -233,7 +231,6 @@ class TestComposedRecoveryPaths:
             )
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
     def test_retry_exhausted_no_reprompt_configured(self, mock_mgr, mock_build_loop, _event):
@@ -275,7 +272,6 @@ class TestComposedRecoveryPaths:
         mock_mgr.delete.assert_called_once()
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
     def test_reprompt_only_all_graduated(self, mock_mgr, mock_build_loop, _event):

--- a/tests/unit/llm/batch/test_composed_recovery.py
+++ b/tests/unit/llm/batch/test_composed_recovery.py
@@ -69,7 +69,7 @@ def _mock_service():
     service._retry_service = MagicMock()
     service._storage_backend = MagicMock()
     service._action_name = "test_action"
-    service._convert_batch_results_to_workflow_format = MagicMock(return_value=[])
+    service._convert_batch_results_to_workflow_format = MagicMock(return_value=([], None))
     service._determine_output_path = MagicMock(return_value="/tmp/output.json")
     service._write_batch_output = MagicMock()
     service._cleanup_recovery_entries = MagicMock()

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -278,10 +278,9 @@ class TestHandleRetryRecovery:
         assert entry.status == BatchStatus.SUBMITTED
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-    @patch("agent_actions.llm.batch.services.processing_recovery.write_record_dispositions")
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     def test_retry_exhausted_transitions_to_reprompt_phase(
-        self, mock_build_loop, _disp, mock_fire_event
+        self, mock_build_loop, mock_fire_event
     ):
         """When retries exhausted, runs check_and_submit_reprompt for real (phase transition).
 
@@ -344,10 +343,9 @@ class TestHandleRetryRecovery:
         mock_mgr.delete.assert_called_once()
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
-    @patch("agent_actions.llm.batch.services.processing_recovery.write_record_dispositions")
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
     def test_all_recovered_finalizes_with_event_and_status(
-        self, mock_build_loop, _disp, mock_fire_event
+        self, mock_build_loop, mock_fire_event
     ):
         """All recovered + no reprompt: writes output, fires event with correct counts."""
         service = _mock_service()
@@ -567,7 +565,6 @@ class TestFinalizeBatchOutput:
 
         with (
             patch("agent_actions.llm.batch.services.processing_recovery.fire_event") as mock_event,
-            patch("agent_actions.llm.batch.services.processing_recovery.write_record_dispositions"),
         ):
             output_path = finalize_batch_output(
                 service,
@@ -774,77 +771,6 @@ class TestApplyExhaustedReprompt:
 
 # ---------------------------------------------------------------------------
 # TestStampBatchRecords (direct unit tests)
-# ---------------------------------------------------------------------------
-
-
-class TestStampBatchRecords:
-    """Direct tests for _stamp_batch_records."""
-
-    def test_stamps_processed_on_record_with_content(self):
-        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
-
-        record = {"content": {"action": {"field": "value"}}, "source_guid": "g1"}
-        _stamp_batch_records([record], "test_action")
-
-        assert record["_state"] == "processed"
-        assert "_state_history" in record
-
-    def test_stamps_exhausted_on_retry_exhausted(self):
-        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
-
-        record = {"content": {"a": {}}, "metadata": {"retry_exhausted": True}, "source_guid": "g1"}
-        _stamp_batch_records([record], "test_action")
-
-        assert record["_state"] == "exhausted"
-
-    def test_stamps_exhausted_on_reason_exhausted(self):
-        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
-
-        record = {"content": {"a": {}}, "metadata": {"reason": "exhausted"}, "source_guid": "g1"}
-        _stamp_batch_records([record], "test_action")
-
-        assert record["_state"] == "exhausted"
-
-    def test_stamps_failed_on_none_content_with_reason(self):
-        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
-
-        record = {"content": None, "metadata": {"reason": "api_error"}, "source_guid": "g1"}
-        _stamp_batch_records([record], "test_action")
-
-        assert record["_state"] == "failed"
-
-    def test_empty_dict_content_is_processed_not_failed(self):
-        """Empty dict {} is valid content — must NOT be classified as FAILED."""
-        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
-
-        record = {"content": {}, "metadata": {"reason": "something"}, "source_guid": "g1"}
-        _stamp_batch_records([record], "test_action")
-
-        assert record["_state"] == "processed"
-
-    def test_skips_record_with_existing_state(self):
-        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
-
-        record = {"_state": "committed", "content": {"a": {}}, "source_guid": "g1"}
-        _stamp_batch_records([record], "test_action")
-
-        assert record["_state"] == "committed"  # unchanged
-
-    def test_stamps_multiple_records(self):
-        from agent_actions.llm.batch.services.processing_recovery import _stamp_batch_records
-
-        records = [
-            {"content": {"a": {}}, "source_guid": "g1"},
-            {"content": None, "metadata": {"reason": "timeout"}, "source_guid": "g2"},
-        ]
-        _stamp_batch_records(records, "test_action")
-
-        assert records[0]["_state"] == "processed"
-        assert records[1]["_state"] == "failed"
-
-
-# ---------------------------------------------------------------------------
-# TestRemoveBatchPlaceholder (direct unit tests)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -88,7 +88,7 @@ def _mock_service():
     service._storage_backend = MagicMock()
     service._action_name = "test_action"
     service._apply_workflow_session_id = MagicMock(return_value={"kind": "llm"})
-    service._convert_batch_results_to_workflow_format = MagicMock(return_value=[])
+    service._convert_batch_results_to_workflow_format = MagicMock(return_value=([], None))
     service._determine_output_path = MagicMock(return_value=Path("/tmp/output.json"))
     service._write_batch_output = MagicMock()
     service._cleanup_recovery_entries = MagicMock()

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -279,9 +279,7 @@ class TestHandleRetryRecovery:
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
-    def test_retry_exhausted_transitions_to_reprompt_phase(
-        self, mock_build_loop, mock_fire_event
-    ):
+    def test_retry_exhausted_transitions_to_reprompt_phase(self, mock_build_loop, mock_fire_event):
         """When retries exhausted, runs check_and_submit_reprompt for real (phase transition).
 
         This exercises the actual transition — not a mock of it. We let
@@ -344,9 +342,7 @@ class TestHandleRetryRecovery:
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
     @patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop")
-    def test_all_recovered_finalizes_with_event_and_status(
-        self, mock_build_loop, mock_fire_event
-    ):
+    def test_all_recovered_finalizes_with_event_and_status(self, mock_build_loop, mock_fire_event):
         """All recovered + no reprompt: writes output, fires event with correct counts."""
         service = _mock_service()
         state = _make_state(phase="retry", retry_attempt=1, missing_ids=[])

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -218,7 +218,9 @@ class TestHandleRepromptRecoveryGraduatedPool:
         with (
             patch.object(RecoveryStateManager, "save"),
             patch.object(RecoveryStateManager, "delete"),
-            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=([], None)),
+            patch.object(
+                service, "_convert_batch_results_to_workflow_format", return_value=([], None)
+            ),
             patch.object(service, "_determine_output_path", return_value="/tmp/out.json"),
             patch.object(service, "_write_batch_output"),
             patch.object(service, "_cleanup_recovery_entries"),
@@ -243,7 +245,9 @@ class TestHandleRepromptRecoveryGraduatedPool:
         with (
             patch.object(RecoveryStateManager, "save"),
             patch.object(RecoveryStateManager, "delete"),
-            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=([], None)),
+            patch.object(
+                service, "_convert_batch_results_to_workflow_format", return_value=([], None)
+            ),
             patch.object(service, "_determine_output_path", return_value="/tmp/out.json"),
             patch.object(service, "_write_batch_output"),
             patch.object(service, "_cleanup_recovery_entries"),
@@ -270,7 +274,9 @@ class TestHandleRepromptRecoveryGraduatedPool:
         with (
             patch.object(RecoveryStateManager, "save"),
             patch.object(RecoveryStateManager, "delete"),
-            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=([], None)),
+            patch.object(
+                service, "_convert_batch_results_to_workflow_format", return_value=([], None)
+            ),
             patch.object(service, "_determine_output_path", return_value="/tmp/out.json"),
             patch.object(service, "_write_batch_output"),
             patch.object(service, "_cleanup_recovery_entries"),

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -218,7 +218,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
         with (
             patch.object(RecoveryStateManager, "save"),
             patch.object(RecoveryStateManager, "delete"),
-            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=[]),
+            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=([], None)),
             patch.object(service, "_determine_output_path", return_value="/tmp/out.json"),
             patch.object(service, "_write_batch_output"),
             patch.object(service, "_cleanup_recovery_entries"),
@@ -243,7 +243,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
         with (
             patch.object(RecoveryStateManager, "save"),
             patch.object(RecoveryStateManager, "delete"),
-            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=[]),
+            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=([], None)),
             patch.object(service, "_determine_output_path", return_value="/tmp/out.json"),
             patch.object(service, "_write_batch_output"),
             patch.object(service, "_cleanup_recovery_entries"),
@@ -270,7 +270,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
         with (
             patch.object(RecoveryStateManager, "save"),
             patch.object(RecoveryStateManager, "delete"),
-            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=[]),
+            patch.object(service, "_convert_batch_results_to_workflow_format", return_value=([], None)),
             patch.object(service, "_determine_output_path", return_value="/tmp/out.json"),
             patch.object(service, "_write_batch_output"),
             patch.object(service, "_cleanup_recovery_entries"),

--- a/tests/unit/unification/test_phase8b_unified_processor_retrieve.py
+++ b/tests/unit/unification/test_phase8b_unified_processor_retrieve.py
@@ -7,14 +7,9 @@ TDD tests verifying:
 4. Batch retrieve produces CollectionStats
 """
 
-from dataclasses import replace
 from typing import Any, cast
-from unittest.mock import MagicMock
-
-import pytest
 
 from agent_actions.config.types import ActionConfigDict, RunMode
-from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import (
     CollectionStats,
@@ -23,13 +18,10 @@ from agent_actions.processing.result_collector import (
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
-    ProcessingStatus,
 )
 from agent_actions.record.reasons import (
     BATCH_NOT_RETURNED,
-    GUARD_SKIP,
     PREP_FAILED,
-    UNPROCESSED,
 )
 from agent_actions.record.state import RecordState
 
@@ -62,9 +54,7 @@ def _make_batch_context(
     )
 
 
-def _make_success_result(
-    source_guid: str = "sg-001", record_index: int = 0
-) -> ProcessingResult:
+def _make_success_result(source_guid: str = "sg-001", record_index: int = 0) -> ProcessingResult:
     """SUCCESS result carrying per-result processing_context (batch style)."""
     result = ProcessingResult.success(
         data=[
@@ -129,9 +119,7 @@ def _make_failed_passthrough_result(
     return result
 
 
-def _make_exhausted_result(
-    source_guid: str = "sg-004", record_index: int = 0
-) -> ProcessingResult:
+def _make_exhausted_result(source_guid: str = "sg-004", record_index: int = 0) -> ProcessingResult:
     """EXHAUSTED result with processing_context."""
     result = ProcessingResult.exhausted(
         error="max retries exceeded",
@@ -287,9 +275,7 @@ class TestFailedResultDataPreservation:
         assert len(result.data) == 1
         assert result.data[0]["error"] == "LLM provider timeout"
 
-        records, stats = collect_results_from_processing_results(
-            [result], ACTION_NAME
-        )
+        records, stats = collect_results_from_processing_results([result], ACTION_NAME)
 
         assert stats.failed == 1
         assert len(records) == 1
@@ -305,9 +291,7 @@ class TestFailedResultDataPreservation:
         )
         assert result.data == []
 
-        records, stats = collect_results_from_processing_results(
-            [result], ACTION_NAME
-        )
+        records, stats = collect_results_from_processing_results([result], ACTION_NAME)
 
         assert stats.failed == 1
         assert len(records) == 1
@@ -319,9 +303,7 @@ class TestFailedResultDataPreservation:
         result = _make_failed_passthrough_result("sg-003")
         assert len(result.data) == 1
 
-        records, stats = collect_results_from_processing_results(
-            [result], ACTION_NAME
-        )
+        records, stats = collect_results_from_processing_results([result], ACTION_NAME)
 
         assert stats.failed == 1
         assert len(records) == 1
@@ -390,11 +372,13 @@ class TestCollectionStatsParity:
                 source_guid="sg-001",
             ),
             ProcessingResult.failed(
-                error="err", source_guid="sg-002",
+                error="err",
+                source_guid="sg-002",
                 input_record={"source_guid": "sg-002"},
             ),
             ProcessingResult.exhausted(
-                error="max", data=[{"source_guid": "sg-003", "content": {"ns": {"f": "p"}}}],
+                error="max",
+                data=[{"source_guid": "sg-003", "content": {"ns": {"f": "p"}}}],
                 source_guid="sg-003",
             ),
         ]
@@ -405,20 +389,26 @@ class TestCollectionStatsParity:
                 source_guid="sg-001",
             ),
             ProcessingResult.failed(
-                error="err", source_guid="sg-002",
+                error="err",
+                source_guid="sg-002",
                 input_record={"source_guid": "sg-002"},
             ),
             ProcessingResult.exhausted(
-                error="max", data=[{"source_guid": "sg-003", "content": {"ns": {"f": "p"}}}],
+                error="max",
+                data=[{"source_guid": "sg-003", "content": {"ns": {"f": "p"}}}],
                 source_guid="sg-003",
             ),
         ]
 
         _, online_stats = collect_results_from_processing_results(
-            online_results, ACTION_NAME, agent_config=_batch_agent_config(),
+            online_results,
+            ACTION_NAME,
+            agent_config=_batch_agent_config(),
         )
         _, batch_stats = collect_results_from_processing_results(
-            batch_results, ACTION_NAME, agent_config=None,
+            batch_results,
+            ACTION_NAME,
+            agent_config=None,
         )
 
         assert online_stats.success == batch_stats.success

--- a/tests/unit/unification/test_phase8b_unified_processor_retrieve.py
+++ b/tests/unit/unification/test_phase8b_unified_processor_retrieve.py
@@ -1,0 +1,428 @@
+"""Phase 8b: UnifiedProcessor retrieve — batch flows through shared pipeline.
+
+TDD tests verifying:
+1. BatchResultStrategy satisfies ProcessingStrategy protocol
+2. UnifiedProcessor.enrich_and_collect() handles batch results
+3. FAILED results with pre-existing data are preserved by collector
+4. Batch retrieve produces CollectionStats
+"""
+
+from dataclasses import replace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.config.types import ActionConfigDict, RunMode
+from agent_actions.processing.enrichment import EnrichmentPipeline
+from agent_actions.processing.record_helpers import build_tombstone
+from agent_actions.processing.result_collector import (
+    CollectionStats,
+    collect_results_from_processing_results,
+)
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+)
+from agent_actions.record.reasons import (
+    BATCH_NOT_RETURNED,
+    GUARD_SKIP,
+    PREP_FAILED,
+    UNPROCESSED,
+)
+from agent_actions.record.state import RecordState
+
+ACTION_NAME = "test_batch_action"
+
+
+def _batch_agent_config(**overrides: Any) -> dict[str, Any]:
+    """Minimal batch agent_config."""
+    config: dict[str, Any] = {
+        "action_name": ACTION_NAME,
+        "agent_type": ACTION_NAME,
+        "json_mode": True,
+        "output_field": "raw_response",
+    }
+    config.update(overrides)
+    return config
+
+
+def _make_batch_context(
+    agent_config: dict[str, Any] | None = None,
+    storage_backend: Any = None,
+) -> ProcessingContext:
+    """Build a batch ProcessingContext."""
+    config = agent_config or _batch_agent_config()
+    return ProcessingContext(
+        agent_config=cast(ActionConfigDict, config),
+        agent_name=config.get("action_name", ACTION_NAME),
+        mode=RunMode.BATCH,
+        storage_backend=storage_backend,
+    )
+
+
+def _make_success_result(
+    source_guid: str = "sg-001", record_index: int = 0
+) -> ProcessingResult:
+    """SUCCESS result carrying per-result processing_context (batch style)."""
+    result = ProcessingResult.success(
+        data=[
+            {
+                "target_id": f"t-{source_guid}",
+                "source_guid": source_guid,
+                "content": {ACTION_NAME: {"field": "value"}},
+            }
+        ],
+        source_guid=source_guid,
+    )
+    result.processing_context = ProcessingContext(
+        agent_config=cast(ActionConfigDict, _batch_agent_config()),
+        agent_name=ACTION_NAME,
+        mode=RunMode.BATCH,
+        record_index=record_index,
+    )
+    return result
+
+
+def _make_failed_error_result(source_guid: str = "sg-002") -> ProcessingResult:
+    """FAILED result from batch error (processing_context=None, data=[error_item]).
+
+    This is the batch-specific shape from BatchResultStrategy._build_error_result().
+    Error results carry data with error info and must NOT be enriched.
+    """
+    error_item: dict[str, Any] = {
+        "source_guid": source_guid,
+        "error": "LLM provider timeout",
+        "metadata": {"batch_id": "b-123"},
+    }
+    result = ProcessingResult.failed(
+        error="LLM provider timeout",
+        source_guid=source_guid,
+    )
+    result.data = [error_item]
+    result.processing_context = None  # Error results skip enrichment
+    return result
+
+
+def _make_failed_passthrough_result(
+    source_guid: str = "sg-003", record_index: int = 0
+) -> ProcessingResult:
+    """FAILED result from batch prep failure (has processing_context + tombstone)."""
+    tombstone = build_tombstone(
+        ACTION_NAME,
+        {"target_id": f"t-{source_guid}", "source_guid": source_guid},
+        PREP_FAILED,
+        source_guid=source_guid,
+    )
+    result = ProcessingResult.failed(
+        error=PREP_FAILED,
+        source_guid=source_guid,
+    )
+    result.data = [tombstone]
+    result.processing_context = ProcessingContext(
+        agent_config=cast(ActionConfigDict, _batch_agent_config()),
+        agent_name=ACTION_NAME,
+        mode=RunMode.BATCH,
+        record_index=record_index,
+    )
+    return result
+
+
+def _make_exhausted_result(
+    source_guid: str = "sg-004", record_index: int = 0
+) -> ProcessingResult:
+    """EXHAUSTED result with processing_context."""
+    result = ProcessingResult.exhausted(
+        error="max retries exceeded",
+        data=[
+            {
+                "target_id": f"t-{source_guid}",
+                "source_guid": source_guid,
+                "content": {ACTION_NAME: {"field": "partial"}},
+                "metadata": {"retry_exhausted": True},
+            }
+        ],
+        source_guid=source_guid,
+    )
+    result.processing_context = ProcessingContext(
+        agent_config=cast(ActionConfigDict, _batch_agent_config()),
+        agent_name=ACTION_NAME,
+        mode=RunMode.BATCH,
+        record_index=record_index,
+    )
+    return result
+
+
+def _make_unprocessed_result(
+    source_guid: str = "sg-005", record_index: int = 0
+) -> ProcessingResult:
+    """UNPROCESSED result (batch not returned)."""
+    tombstone = build_tombstone(
+        ACTION_NAME,
+        {"target_id": f"t-{source_guid}", "source_guid": source_guid},
+        BATCH_NOT_RETURNED,
+        source_guid=source_guid,
+    )
+    result = ProcessingResult.unprocessed(
+        data=[tombstone],
+        reason=BATCH_NOT_RETURNED,
+        source_guid=source_guid,
+    )
+    result.processing_context = ProcessingContext(
+        agent_config=cast(ActionConfigDict, _batch_agent_config()),
+        agent_name=ACTION_NAME,
+        mode=RunMode.BATCH,
+        record_index=record_index,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 1. ProcessingStrategy protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestBatchResultStrategyProtocol:
+    """BatchResultStrategy must satisfy ProcessingStrategy protocol."""
+
+    def test_satisfies_processing_strategy_protocol(self):
+        """BatchResultStrategy must be recognized as a ProcessingStrategy."""
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchResultStrategy,
+        )
+        from agent_actions.processing.unified import ProcessingStrategy
+
+        strategy = BatchResultStrategy()
+        assert isinstance(strategy, ProcessingStrategy)
+
+    def test_invoke_method_exists(self):
+        """BatchResultStrategy must have an invoke() method."""
+        from agent_actions.llm.batch.processing.batch_result_strategy import (
+            BatchResultStrategy,
+        )
+
+        strategy = BatchResultStrategy()
+        assert hasattr(strategy, "invoke")
+        assert callable(strategy.invoke)
+
+
+# ---------------------------------------------------------------------------
+# 2. UnifiedProcessor.enrich_and_collect
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedProcessorEnrichAndCollect:
+    """UnifiedProcessor must expose enrich_and_collect for batch retrieve."""
+
+    def test_enrich_and_collect_exists(self):
+        """enrich_and_collect method must exist on UnifiedProcessor."""
+        from agent_actions.processing.unified import UnifiedProcessor
+
+        processor = UnifiedProcessor()
+        assert hasattr(processor, "enrich_and_collect")
+        assert callable(processor.enrich_and_collect)
+
+    def test_returns_output_and_stats(self):
+        """enrich_and_collect returns (output_records, CollectionStats)."""
+        from agent_actions.processing.unified import UnifiedProcessor
+
+        processor = UnifiedProcessor()
+        ctx = _make_batch_context()
+        results = [_make_success_result("sg-001")]
+
+        output, stats = processor.enrich_and_collect(results, ctx)
+
+        assert isinstance(output, list)
+        assert isinstance(stats, CollectionStats)
+
+    def test_success_result_stamped_processed(self):
+        """SUCCESS results get _state=PROCESSED."""
+        from agent_actions.processing.unified import UnifiedProcessor
+
+        processor = UnifiedProcessor()
+        ctx = _make_batch_context()
+        results = [_make_success_result("sg-001")]
+
+        output, stats = processor.enrich_and_collect(results, ctx)
+
+        assert len(output) == 1
+        assert output[0]["_state"] == RecordState.PROCESSED.value
+        assert stats.success == 1
+
+    def test_mixed_batch_results(self):
+        """Mixed batch results produce correct CollectionStats."""
+        from agent_actions.processing.unified import UnifiedProcessor
+
+        processor = UnifiedProcessor()
+        ctx = _make_batch_context()
+        results = [
+            _make_success_result("sg-001", record_index=0),
+            _make_success_result("sg-002", record_index=1),
+            _make_failed_error_result("sg-003"),
+            _make_exhausted_result("sg-004", record_index=3),
+            _make_unprocessed_result("sg-005", record_index=4),
+        ]
+
+        output, stats = processor.enrich_and_collect(results, ctx)
+
+        assert stats.success == 2
+        assert stats.failed == 1
+        assert stats.exhausted == 1
+        assert stats.unprocessed == 1
+        assert len(output) == 5
+
+
+# ---------------------------------------------------------------------------
+# 3. FAILED result data preservation
+# ---------------------------------------------------------------------------
+
+
+class TestFailedResultDataPreservation:
+    """Collector must preserve pre-existing data on FAILED results."""
+
+    def test_failed_with_data_preserves_error_item(self):
+        """FAILED results with data=[error_item] preserve the error item."""
+        result = _make_failed_error_result("sg-002")
+        assert len(result.data) == 1
+        assert result.data[0]["error"] == "LLM provider timeout"
+
+        records, stats = collect_results_from_processing_results(
+            [result], ACTION_NAME
+        )
+
+        assert stats.failed == 1
+        assert len(records) == 1
+        # Error item must be preserved, not replaced by a fresh tombstone
+        assert records[0].get("error") == "LLM provider timeout"
+
+    def test_failed_without_data_builds_tombstone(self):
+        """FAILED results with data=[] still build a tombstone (online path)."""
+        result = ProcessingResult.failed(
+            error="some error",
+            source_guid="sg-010",
+            input_record={"source_guid": "sg-010", "target_id": "t-010"},
+        )
+        assert result.data == []
+
+        records, stats = collect_results_from_processing_results(
+            [result], ACTION_NAME
+        )
+
+        assert stats.failed == 1
+        assert len(records) == 1
+        # Tombstone built by collector
+        assert records[0].get("metadata", {}).get("agent_type") == "tombstone"
+
+    def test_failed_passthrough_with_tombstone_preserved(self):
+        """FAILED results from batch prep carry build_tombstone output — preserved."""
+        result = _make_failed_passthrough_result("sg-003")
+        assert len(result.data) == 1
+
+        records, stats = collect_results_from_processing_results(
+            [result], ACTION_NAME
+        )
+
+        assert stats.failed == 1
+        assert len(records) == 1
+        # Tombstone from build_tombstone must be preserved
+        assert records[0].get("metadata", {}).get("reason") == PREP_FAILED
+
+
+# ---------------------------------------------------------------------------
+# 4. Enrichment uses per-result processing_context
+# ---------------------------------------------------------------------------
+
+
+class TestPerResultEnrichmentContext:
+    """UnifiedProcessor._enrich must use per-result processing_context when set."""
+
+    def test_enrichment_uses_per_result_context(self):
+        """Results with processing_context use their own context for enrichment."""
+        from agent_actions.processing.unified import UnifiedProcessor
+
+        processor = UnifiedProcessor()
+        ctx = _make_batch_context()
+
+        # Two results at different record_index values
+        r1 = _make_success_result("sg-001", record_index=0)
+        r2 = _make_success_result("sg-002", record_index=1)
+
+        output, stats = processor.enrich_and_collect([r1, r2], ctx)
+
+        assert stats.success == 2
+        assert len(output) == 2
+        # Both records should have _state stamped
+        assert all(r["_state"] == RecordState.PROCESSED.value for r in output)
+
+    def test_error_results_skip_enrichment(self):
+        """Batch error results (processing_context=None) skip enrichment."""
+        from agent_actions.processing.unified import UnifiedProcessor
+
+        processor = UnifiedProcessor()
+        ctx = _make_batch_context()
+
+        error_result = _make_failed_error_result("sg-003")
+        assert error_result.processing_context is None
+
+        output, stats = processor.enrich_and_collect([error_result], ctx)
+
+        assert stats.failed == 1
+        assert len(output) == 1
+        # Error item should not have enrichment artifacts (no _lineage, no version_correlation_id)
+        record = output[0]
+        assert record.get("error") == "LLM provider timeout"
+
+
+# ---------------------------------------------------------------------------
+# 5. CollectionStats parity: online vs batch
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionStatsParity:
+    """Online and batch produce equivalent CollectionStats for same result mix."""
+
+    def test_equivalent_stats_for_same_input(self):
+        """Same ProcessingResult mix produces identical stats regardless of path."""
+        online_results = [
+            ProcessingResult.success(
+                data=[{"source_guid": "sg-001", "content": {"ns": {"f": "v"}}}],
+                source_guid="sg-001",
+            ),
+            ProcessingResult.failed(
+                error="err", source_guid="sg-002",
+                input_record={"source_guid": "sg-002"},
+            ),
+            ProcessingResult.exhausted(
+                error="max", data=[{"source_guid": "sg-003", "content": {"ns": {"f": "p"}}}],
+                source_guid="sg-003",
+            ),
+        ]
+
+        batch_results = [
+            ProcessingResult.success(
+                data=[{"source_guid": "sg-001", "content": {"ns": {"f": "v"}}}],
+                source_guid="sg-001",
+            ),
+            ProcessingResult.failed(
+                error="err", source_guid="sg-002",
+                input_record={"source_guid": "sg-002"},
+            ),
+            ProcessingResult.exhausted(
+                error="max", data=[{"source_guid": "sg-003", "content": {"ns": {"f": "p"}}}],
+                source_guid="sg-003",
+            ),
+        ]
+
+        _, online_stats = collect_results_from_processing_results(
+            online_results, ACTION_NAME, agent_config=_batch_agent_config(),
+        )
+        _, batch_stats = collect_results_from_processing_results(
+            batch_results, ACTION_NAME, agent_config=None,
+        )
+
+        assert online_stats.success == batch_stats.success
+        assert online_stats.failed == batch_stats.failed
+        assert online_stats.exhausted == batch_stats.exhausted
+        assert online_stats.skipped == batch_stats.skipped
+        assert online_stats.filtered == batch_stats.filtered


### PR DESCRIPTION
## Summary
- **BatchResultStrategy implements ProcessingStrategy** — adds `invoke()` / `prepare_invoke()` for protocol compliance via structural typing
- **UnifiedProcessor.enrich_and_collect()** — new entry point for pre-computed results (batch retrieve where guard filtering happened at submit time)
- **Shared enrichment** — `_enrich()` uses per-result `processing_context` when set (batch), falls back to shared context (online), skips batch error results (no processing_context)
- **Collector FAILED handler** — preserves pre-existing `result.data` (batch error items, tombstones) instead of always building fresh tombstones. Online path (data=[]) unchanged.
- **Deleted duplicate code** — inline enrich loop, `_stamp_batch_records`, `_write_record_dispositions` on BatchProcessingService, manual disposition writing in `finalize_batch_output`. State stamping and dispositions now handled by shared collector.
- 12 new TDD tests (red→green), 6972 total passed, ruff clean

## Verification
- `pytest` — 6972 passed, 2 skipped (2 pre-existing failures deselected: ollama trailing comma repair)
- `ruff format --check` — clean
- `ruff check` — clean
- TDD: 12 tests written first (9 failing), all green after implementation