### PR TITLE
docs(phase8c): batch-only preflight is intentional asymmetry

### DIFF
--- a/.changes/unreleased/Under the Hood-20260518-phase8c.yaml
+++ b/.changes/unreleased/Under the Hood-20260518-phase8c.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Phase 8c: Document batch-only preflight as intentional design — online path processes one record at a time, making preflight redundant"
+time: 2026-05-18T08:00:00.000000Z

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -343,10 +343,8 @@ class BatchTaskPreparator:
     ) -> None:
         """Run pre-flight validation on sample rows to catch template errors early.
 
-        Guard-aware: evaluates with ``skip_guard=False`` so guard-skipped rows
-        are advanced past rather than crashing on guard-conditional templates.
-        If all sampled rows are guard-skipped/filtered, preflight passes
-        silently — there are no prompts to validate.
+        Batch-only by design: online surfaces template errors on the first row;
+        batch submits thousands at once, so we sample first to fail fast.
         """
         if not data:
             return


### PR DESCRIPTION
## Summary
- **Phase 8c policy decision**: Preflight validation stays batch-only.
- Online processes one record at a time — template errors surface immediately, making preflight redundant.
- Batch submits thousands of rows — preflight samples 5 rows to catch Jinja/guard errors before the full submission.
- No dead preflight code exists in online/realtime path (verified via grep). Nothing to clean up.

## Verification
- 6929 tests passed, ruff clean
- Grep confirms no preflight references in `processing/unified.py` or `llm/realtime/`