### PR TITLE
unify: post-merge integration fixes (filtered dispositions, changie timestamps, prefilter warning)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260518-integfix-1.yaml
+++ b/.changes/unreleased/Bug Fix-20260518-integfix-1.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix FILTERED disposition write gap on the production batch retrieve path — finalize_batch_output now writes DISPOSITION_FILTERED for records the reconciler strips, completing Phase 7b parity"
+time: 2026-05-18T11:00:00.000000Z

--- a/.changes/unreleased/Enhancement or New Feature-20260517-007000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260517-007000.yaml
@@ -1,3 +1,3 @@
 kind: Enhancement or New Feature
 body: "Stamp DISPOSITION_DEFERRED on batch submit for all records sent to the provider, enabling operators to track in-flight batch records via the disposition table"
-time: 2026-05-17T00:70:00.000000Z
+time: 2026-05-17T00:07:00.000000Z

--- a/.changes/unreleased/Enhancement or New Feature-20260517-009000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260517-009000.yaml
@@ -1,3 +1,3 @@
 kind: Enhancement or New Feature
 body: "Phase 9a: observe resolves missing fields to None matching guard semantics — eliminates guard/observe null asymmetry (U-4.2)"
-time: 2026-05-17T00:90:00.000000Z
+time: 2026-05-17T00:09:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260517-009002.yaml
+++ b/.changes/unreleased/Under the Hood-20260517-009002.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
 body: "Introduce NullNamespace sentinel for skipped upstream namespaces so observe/passthrough resolve fields to None with reason introspection instead of crashing"
-time: 2026-05-17T00:90:02.000000Z
+time: 2026-05-17T00:09:02.000000Z

--- a/.changes/unreleased/Under the Hood-20260518-008002.yaml
+++ b/.changes/unreleased/Under the Hood-20260518-008002.yaml
@@ -1,3 +1,3 @@
 kind: Under the Hood
 body: "Route batch retrieve through UnifiedProcessor shared enrich/collect pipeline, eliminating duplicate inline enrichment loop and batch-specific state stamping"
-time: 2026-05-18T00:80:02.000000Z
+time: 2026-05-18T00:08:02.000000Z

--- a/.changes/unreleased/Under the Hood-20260518-integfix-2.yaml
+++ b/.changes/unreleased/Under the Hood-20260518-integfix-2.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "prefilter_by_guard logs a WARNING when called without pipeline context kwargs — surfaces accidental regressions to the pre-Phase-5 online/batch guard divergence"
+time: 2026-05-18T11:00:01.000000Z

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -501,11 +501,14 @@ def finalize_batch_output(
 
     effective_action_name = action_name if action_name is not None else service._action_name
 
-    # State stamping and disposition writing are now handled by the shared
-    # collector inside _convert_batch_results_to_workflow_format.
-    # Only DEFERRED clearing and prompt trace updates remain batch-specific.
+    # SUCCESS/FAILED/EXHAUSTED dispositions and state stamping are handled by the
+    # shared collector inside _convert_batch_results_to_workflow_format. FILTERED
+    # records are stripped by the reconciler before collection, so they require
+    # an explicit write here to match online ResultCollector parity (Phase 7b /
+    # U-3.2a). DEFERRED clearing and prompt trace updates also remain batch-specific.
     if service._storage_backend and effective_action_name:
         service._clear_deferred_dispositions(processed_data)
+        service._write_filtered_dispositions(context_map, effective_action_name)
         service._update_prompt_trace_responses(processed_data, effective_action_name)
 
     output_file = service._determine_output_path(output_directory, file_name, batch_id)

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -375,6 +375,22 @@ def prefilter_by_guard(
         )
     )
 
+    # Phase 5 unification: all production callers (UnifiedProcessor._guard_filter
+    # and _guard_filter_file_mode) pass full pipeline context. The eval_item-only
+    # fallback exists for test convenience and would reintroduce the pre-Phase-5
+    # online/batch guard divergence if a production caller ever omitted the
+    # context kwargs. Log once per call so the regression is visible in ops logs
+    # — quiet enough not to spam test runs (one log line, not per-record).
+    if not has_pipeline_context:
+        logger.warning(
+            "prefilter_by_guard called for agent=%s without pipeline context "
+            "(agent_indices/source_data/version_context/workflow_metadata/dependency_configs); "
+            "falling back to eval_item-only guard context. This diverges from "
+            "TaskPreparer.prepare() and breaks online/batch guard parity. "
+            "Production callers must pass pipeline context kwargs.",
+            agent_name,
+        )
+
     passing: list[dict] = []
     skipped: list[dict] = []
     original_passing: list[dict] = []

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -603,6 +603,68 @@ class TestFinalizeBatchOutput:
         service, _, _, _ = self._run_finalize()
         service._cleanup_recovery_entries.assert_not_called()
 
+    def test_finalize_writes_filtered_dispositions(self):
+        """Phase 7b parity: FILTERED records in context_map must reach DISPOSITION_FILTERED.
+
+        finalize_batch_output is the production retrieve entry point (called via
+        process_all_batch_results → _process_single_batch_file → _process_original_batch
+        → _finalize_batch_output). The reconciler strips FILTERED rows from
+        processed_data before this function runs, so the collector path never sees
+        them. Without an explicit _write_filtered_dispositions call here, FILTERED
+        records stay stuck at DISPOSITION_DEFERRED (stamped at submit by Phase 7a)
+        and never transition to DISPOSITION_FILTERED — silently breaking the
+        Phase 7b parity contract for every real batch run.
+        """
+        service = _mock_service()
+        manager = MagicMock()
+        context_map = {"custom-filtered-1": {"source_guid": "sg-001"}}
+
+        with patch("agent_actions.llm.batch.services.processing_recovery.fire_event"):
+            finalize_batch_output(
+                service,
+                batch_results=[_make_result("id-1")],
+                exhausted_recovery=None,
+                context_map=context_map,
+                output_directory="/tmp",
+                file_name="test_file",
+                batch_id="batch-123",
+                agent_config={"kind": "llm"},
+                manager=manager,
+                action_name="test_action",
+                start_time=0.0,
+            )
+
+        service._write_filtered_dispositions.assert_called_once_with(context_map, "test_action")
+
+    def test_finalize_uses_service_action_name_when_action_name_none(self):
+        """When action_name=None, _write_filtered_dispositions still uses service._action_name.
+
+        Mirrors how _clear_deferred_dispositions and _update_prompt_trace_responses
+        fall back to effective_action_name. A None action_name must not silently
+        skip filtered-disposition writes — the service knows its own name.
+        """
+        service = _mock_service()
+        service._action_name = "fallback_action"
+        manager = MagicMock()
+        context_map = {"custom-filtered-1": {"source_guid": "sg-001"}}
+
+        with patch("agent_actions.llm.batch.services.processing_recovery.fire_event"):
+            finalize_batch_output(
+                service,
+                batch_results=[_make_result("id-1")],
+                exhausted_recovery=None,
+                context_map=context_map,
+                output_directory="/tmp",
+                file_name="test_file",
+                batch_id="batch-123",
+                agent_config={"kind": "llm"},
+                manager=manager,
+                action_name=None,
+                start_time=0.0,
+            )
+
+        service._write_filtered_dispositions.assert_called_once_with(context_map, "fallback_action")
+
 
 # ---------------------------------------------------------------------------
 # TestRecoveryStatePersistence

--- a/tests/unit/unification/test_phase5_guard_context.py
+++ b/tests/unit/unification/test_phase5_guard_context.py
@@ -369,3 +369,96 @@ class TestPrefilterByGuardContextAlignment:
         assert passing[0]["target_id"] == "t-001"
         assert len(skipped) == 1
         assert skipped[0]["target_id"] == "t-002"
+
+
+class TestPrefilterFallbackWarning:
+    """Phase 5 hardening: log a warning when the eval_item-only fallback path runs.
+
+    The fallback exists for test convenience but breaks online/batch guard parity
+    if a production caller ever omits pipeline context kwargs. The warning makes
+    the regression visible in ops logs instead of silently diverging.
+    """
+
+    def test_fallback_path_emits_warning(self, caplog):
+        """When no pipeline context kwargs are passed, a single warning fires.
+
+        Asserts: warning fires once per call (not per record), names the agent,
+        mentions the diverging behavior so operators can act on the signal.
+        """
+        records = [
+            {"target_id": "t-001", "source_guid": "sg-001", "content": {"x": 1}},
+            {"target_id": "t-002", "source_guid": "sg-002", "content": {"x": 2}},
+            {"target_id": "t-003", "source_guid": "sg-003", "content": {"x": 3}},
+        ]
+        agent_config = {
+            "name": "test_action",
+            "guard": {"clause": "x == 1", "behavior": "skip"},
+        }
+
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="agent_actions.workflow.pipeline_file_mode"):
+            prefilter_by_guard(records, agent_config, "test_action")
+
+        fallback_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == _logging.WARNING
+            and "prefilter_by_guard" in r.message
+            and "without pipeline context" in r.message
+        ]
+        assert len(fallback_warnings) == 1, (
+            "Expected exactly one fallback warning per call (not per record); "
+            f"got {len(fallback_warnings)} for 3 input records"
+        )
+        assert "test_action" in fallback_warnings[0].message
+
+    def test_pipeline_context_path_silent(self, caplog):
+        """When pipeline context is supplied, no fallback warning fires.
+
+        Confirms the warning only triggers on the fallback path — production
+        callers (UnifiedProcessor._guard_filter*) that pass full context kwargs
+        don't generate noise.
+        """
+        records = [{"target_id": "t-001", "source_guid": "sg-001", "content": {"x": 1}}]
+        agent_config = {
+            "name": "test_action",
+            "guard": {"clause": "x == 1", "behavior": "skip"},
+        }
+
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="agent_actions.workflow.pipeline_file_mode"):
+            prefilter_by_guard(
+                records,
+                agent_config,
+                "test_action",
+                source_data=[{"source_guid": "sg-001"}],
+            )
+
+        fallback_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == _logging.WARNING and "without pipeline context" in r.message
+        ]
+        assert fallback_warnings == [], (
+            "Pipeline-context path must not emit fallback warning; "
+            f"unexpected warnings: {[r.message for r in fallback_warnings]}"
+        )
+
+    def test_no_guard_configured_silent(self, caplog):
+        """When no guard is configured, the function returns early — no warning.
+
+        The fallback warning is about guard *evaluation* divergence; if there's
+        no guard to evaluate, the warning is irrelevant and would be noise.
+        """
+        records = [{"target_id": "t-001", "source_guid": "sg-001", "content": {"x": 1}}]
+        agent_config = {"name": "test_action"}  # no guard key
+
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="agent_actions.workflow.pipeline_file_mode"):
+            prefilter_by_guard(records, agent_config, "test_action")
+
+        fallback_warnings = [r for r in caplog.records if "without pipeline context" in r.message]
+        assert fallback_warnings == [], "No guard configured → no fallback warning"


### PR DESCRIPTION
## Summary

Three small post-merge fixes for issues surfaced by a holistic review of `integration/batch-online-unification` (see `unification/batch-online-integration-review.md`). All three close gaps relative to the unification plan in `unification/batch-vs-online.md` — none change architectural verdict, but each fixes a real defect:

1. **`fix(batch)`** — Production batch retrieve path (`process_all_batch_results` → `BatchLifecycleManager`) now writes `DISPOSITION_FILTERED` for records the reconciler strips. Without this, Phase 7b parity (#557, U-3.2a) was a no-op in production; FILTERED records stayed stuck at `DISPOSITION_DEFERRED` from Phase 7a submit-stamp.
2. **`fix(changie)`** — Four entries used invalid minute values (`00:70/80/90`). Go's strict `time.Parse` would fail or silently drop these from CHANGELOG on the next release, hiding Phase 7a / 9a / 9b / 8b user-visible work.
3. **`chore(prefilter)`** — `prefilter_by_guard` now logs a WARNING when the eval_item-only fallback runs with a guard configured. Production never hits this path post-Phase-5; the warning makes any future regression visible in ops logs.

## Commits

| Commit | What | Test |
|---|---|---|
| `f805c66` | Repair 4 changie timestamps | n/a (data; verified via `datetime.fromisoformat`) |
| `7d6b3f1` | Write FILTERED dispositions on production retrieve path | `test_finalize_writes_filtered_dispositions` + `test_finalize_uses_service_action_name_when_action_name_none` (red→green) |
| `088741f` | Warn on prefilter fallback path | `test_fallback_path_emits_warning` (3 records → exactly 1 warning), `test_pipeline_context_path_silent`, `test_no_guard_configured_silent` |

## Verification

- `pytest` — **6979 passed, 2 skipped** (full suite; excludes 1 untracked local file `tests/manual/test_seed_override_flow.py`)
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- Unification suite specifically: **197 / 197 green**

## Why not fold Fix 3 into making kwargs required?

The eval_item fallback in `prefilter_by_guard` has 54 test call sites. Migrating them is a separate, larger PR. The warning-only approach surfaces any production regression immediately without forcing test churn. Follow-up branch: `unify/phase-5-cleanup-prefilter-kwargs-required` once we've confirmed the warning truly never fires in production.

## Targets `integration/batch-online-unification`, not main

These fixes are scoped to the unification work and should land on the integration branch before the eventual `integration → main` merge.