### PR TITLE
fix: rerun retries COMPLETED_WITH_FAILURES actions

### DIFF
--- a/.changes/unreleased/Bug Fix-20260519-F2000.yaml
+++ b/.changes/unreleased/Bug Fix-20260519-F2000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Rerun now retries actions with partial failures — COMPLETED_WITH_FAILURES is reset to PENDING on rerun instead of being skipped"
+time: 2026-05-19T00:20:00.000000Z

--- a/agent_actions/workflow/managers/state.py
+++ b/agent_actions/workflow/managers/state.py
@@ -41,6 +41,15 @@ TERMINAL_STATUSES: frozenset[ActionStatus] = frozenset(
         ActionStatus.COMPLETED_WITH_FAILURES,
     }
 )
+RETRYABLE_STATUSES: frozenset[ActionStatus] = frozenset(
+    {
+        ActionStatus.FAILED,
+        ActionStatus.SKIPPED,
+        ActionStatus.RUNNING,
+        ActionStatus.CHECKING_BATCH,
+        ActionStatus.COMPLETED_WITH_FAILURES,
+    }
+)
 
 
 class ActionStateManager:
@@ -166,21 +175,16 @@ class ActionStateManager:
         return marked
 
     def reset_retryable(self) -> list[str]:
-        """Reset non-completed terminal and in-progress actions to PENDING.
+        """Reset retryable actions to PENDING for re-run.
 
-        Called at workflow startup so that re-runs retry non-completed
-        actions while preserving completed results.  Callers should clear
-        storage dispositions for the returned action names.
+        Called at workflow startup so that re-runs retry failed, skipped,
+        in-progress, and partially-failed actions while preserving fully
+        completed results.  Callers should clear storage dispositions for
+        the returned action names.
         """
-        retryable = {
-            ActionStatus.FAILED,
-            ActionStatus.SKIPPED,
-            ActionStatus.RUNNING,
-            ActionStatus.CHECKING_BATCH,
-        }
         reset_names: list[str] = []
         for action_name, details in self.action_status.items():
-            if details.get("status") in retryable:
+            if details.get("status") in RETRYABLE_STATUSES:
                 reset_names.append(action_name)
         for action_name in reset_names:
             self.update_status(action_name, ActionStatus.PENDING)

--- a/tests/unit/workflow/managers/test_state_manager.py
+++ b/tests/unit/workflow/managers/test_state_manager.py
@@ -304,15 +304,16 @@ class TestResetRetryable:
         assert mgr.get_status("a") == ActionStatus.COMPLETED
         assert reset == []
 
-    def test_preserves_completed_with_failures(self, tmp_path):
+    def test_resets_completed_with_failures(self, tmp_path):
+        """COMPLETED_WITH_FAILURES must be retried on rerun — partial failures need reprocessing."""
         status_file = tmp_path / "status.json"
         mgr = ActionStateManager(status_file, ["a"])
         mgr.update_status("a", ActionStatus.COMPLETED_WITH_FAILURES)
 
         reset = mgr.reset_retryable()
 
-        assert mgr.get_status("a") == ActionStatus.COMPLETED_WITH_FAILURES
-        assert reset == []
+        assert mgr.get_status("a") == ActionStatus.PENDING
+        assert reset == ["a"]
 
     def test_resets_checking_batch_to_pending(self, tmp_path):
         """CHECKING_BATCH from a prior crash should be retried."""


### PR DESCRIPTION
## Summary
- Actions with partial failures (`COMPLETED_WITH_FAILURES`) were preserved on rerun, causing the entire action to be skipped — failed records were never reprocessed unless the user explicitly used the `retry` CLI command
- Added `COMPLETED_WITH_FAILURES` to the `retryable` set in `reset_retryable()` so plain reruns reset these actions to PENDING

## Verification
- Updated existing test `test_preserves_completed_with_failures` → `test_resets_completed_with_failures` to assert the new behavior
- 6846 passed, 0 failures
- `ruff check` + `ruff format --check` clean