### PR TITLE
fix: PassthroughEnricher no longer mutates shared namespace dicts

### DIFF
--- a/.changes/unreleased/Bug Fix-20260519-F11000.yaml
+++ b/.changes/unreleased/Bug Fix-20260519-F11000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix PassthroughEnricher mutating shared namespace dicts in-place, preventing cross-record data contamination when records share dict objects through shallow copies"
+time: 2026-05-19T00:11:00.000000Z

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -214,7 +214,7 @@ class PassthroughEnricher(Enricher):
                 continue
             ns = content.get(action_name)
             if isinstance(ns, dict):
-                ns.update(result.passthrough_fields)
+                content[action_name] = {**ns, **result.passthrough_fields}
             else:
                 content[action_name] = dict(result.passthrough_fields)
 

--- a/tests/unit/processing/test_enrichment_namespaced.py
+++ b/tests/unit/processing/test_enrichment_namespaced.py
@@ -172,6 +172,43 @@ class TestPassthroughEnricherNamespaced:
 
         assert enriched.data[0]["content"]["action_c"]["shared_key"] == "passthrough_value"
 
+    def test_shared_namespace_dict_not_mutated(self):
+        """PassthroughEnricher must not mutate shared namespace dict objects in-place."""
+        shared_ns = {"llm_field": "original"}
+        item_a = {"content": {"action_c": shared_ns}}
+
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[item_a],
+            passthrough_fields={"pt_from_a": "a_value"},
+        )
+        context = _make_context("action_c")
+        PassthroughEnricher().enrich(result, context)
+
+        assert item_a["content"]["action_c"]["pt_from_a"] == "a_value"
+        assert shared_ns == {"llm_field": "original"}
+
+    def test_shared_namespace_multiple_records_in_same_result(self):
+        """Multiple items in the same result sharing a namespace dict stay isolated."""
+        shared_ns = {"base": "value"}
+        items = [
+            {"content": {"action_c": shared_ns}},
+            {"content": {"action_c": shared_ns}},
+        ]
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=items,
+            passthrough_fields={"injected": "pt"},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        assert enriched.data[0]["content"]["action_c"]["injected"] == "pt"
+        assert enriched.data[1]["content"]["action_c"]["injected"] == "pt"
+        enriched.data[0]["content"]["action_c"]["extra"] = "only_in_0"
+        assert "extra" not in enriched.data[1]["content"]["action_c"]
+        assert shared_ns == {"base": "value"}
+
 
 # ---------------------------------------------------------------------------
 # Other enrichers — verify they don't touch content internals


### PR DESCRIPTION
## Summary
- **Root cause:** `PassthroughEnricher.enrich()` called `ns.update(result.passthrough_fields)` which mutates the namespace dict in-place. When multiple records share the same dict object through shallow copies (e.g., `RecordEnvelope.build_skipped`), passthrough fields from one record leak into another.
- **Fix:** Replace `ns.update(...)` with `content[action_name] = {**ns, **result.passthrough_fields}` — creates a new dict per record, eliminating cross-record contamination.
- 1 line changed in `enrichment.py`, 2 regression tests added.

## Verification
- 2 new tests: shared namespace isolation (cross-result and within-result)
- All 16 enrichment namespace tests pass
- Full suite: 6845 passed (same as baseline + 2 new tests)
- `ruff check` and `ruff format --check` clean