### PR TITLE
fix(batch): write FAILED dispositions when batch file processing throws

### DIFF
--- a/.changes/unreleased/Bug Fix-20260519-004000.yaml
+++ b/.changes/unreleased/Bug Fix-20260519-004000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch processing exceptions now write FAILED dispositions for all INCLUDED records instead of leaving them stuck with stale DEFERRED dispositions"
+time: 2026-05-19T00:40:00.000000Z

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.errors import ProcessingError
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.core.batch_models import BatchJobEntry
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
     BatchClientResolver,
@@ -51,6 +52,7 @@ from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.result_collector import CollectionStats
 from agent_actions.processing.types import ProcessingContext, RecoveryMetadata
 from agent_actions.processing.unified import UnifiedProcessor
+from agent_actions.storage.backend import DISPOSITION_DEFERRED, DISPOSITION_FAILED
 from agent_actions.utils.path_utils import ensure_directory_exists
 
 logger = logging.getLogger(__name__)
@@ -263,6 +265,12 @@ class BatchProcessingService:
                         "total_processed": len(processed_files),
                         "registry_size": len(all_jobs),
                     },
+                )
+                self._fail_abandoned_records(
+                    file_name=file_name,
+                    output_directory=output_directory,
+                    action_name=effective_action_name,
+                    error=e,
                 )
                 continue
 
@@ -721,6 +729,78 @@ class BatchProcessingService:
     # =========================================================================
     # HELPERS (kept in this module)
     # =========================================================================
+
+    def _fail_abandoned_records(
+        self,
+        file_name: str,
+        output_directory: str,
+        action_name: str | None,
+        error: Exception,
+    ) -> None:
+        """Write FAILED dispositions for INCLUDED records in a batch file that threw an exception.
+
+        Without this, records remain stuck with stale DEFERRED dispositions —
+        the retry command won't find them and subsequent reruns won't know they failed.
+        """
+        if not self._storage_backend or not action_name:
+            return
+
+        try:
+            context_map = self._context_manager.load_batch_context_map(
+                output_directory, file_name or "default"
+            )
+        except Exception:
+            logger.warning(
+                "Could not load context_map for failed batch %s — "
+                "records may remain with stale DEFERRED dispositions",
+                file_name,
+                exc_info=True,
+            )
+            return
+
+        reason = f"batch_processing_exception: {str(error)[:500]}"
+        failed_count = 0
+        for _custom_id, record in context_map.items():
+            if not BatchContextMetadata.is_included(record):
+                continue
+            source_guid = record.get("source_guid")
+            if not source_guid:
+                continue
+
+            try:
+                self._storage_backend.clear_disposition(
+                    action_name,
+                    disposition=DISPOSITION_DEFERRED,
+                    record_id=source_guid,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not clear DEFERRED disposition for %s (may not exist)",
+                    source_guid,
+                    exc_info=True,
+                )
+
+            try:
+                self._storage_backend.set_disposition(
+                    action_name,
+                    source_guid,
+                    DISPOSITION_FAILED,
+                    reason=reason,
+                )
+                failed_count += 1
+            except Exception:
+                logger.exception(
+                    "Failed to write FAILED disposition for record %s in batch %s",
+                    source_guid,
+                    file_name,
+                )
+
+        if failed_count:
+            logger.info(
+                "Wrote FAILED disposition for %d records in failed batch %s",
+                failed_count,
+                file_name,
+            )
 
     @staticmethod
     def _cleanup_recovery_entries(manager: BatchRegistryManager, parent_file_name: str) -> None:

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -49,7 +49,7 @@ from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.writer import FileWriter
 from agent_actions.processing.enrichment import EnrichmentPipeline
-from agent_actions.processing.result_collector import CollectionStats
+from agent_actions.processing.result_collector import CollectionStats, _safe_set_disposition
 from agent_actions.processing.types import ProcessingContext, RecoveryMetadata
 from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.storage.backend import DISPOSITION_DEFERRED, DISPOSITION_FAILED
@@ -780,20 +780,14 @@ class BatchProcessingService:
                     exc_info=True,
                 )
 
-            try:
-                self._storage_backend.set_disposition(
-                    action_name,
-                    source_guid,
-                    DISPOSITION_FAILED,
-                    reason=reason,
-                )
-                failed_count += 1
-            except Exception:
-                logger.exception(
-                    "Failed to write FAILED disposition for record %s in batch %s",
-                    source_guid,
-                    file_name,
-                )
+            _safe_set_disposition(
+                self._storage_backend,
+                action_name,
+                source_guid,
+                DISPOSITION_FAILED,
+                reason=reason,
+            )
+            failed_count += 1
 
         if failed_count:
             logger.info(

--- a/tests/unit/llm/batch/test_batch_exception_disposition.py
+++ b/tests/unit/llm/batch/test_batch_exception_disposition.py
@@ -21,6 +21,8 @@ from agent_actions.storage.backend import DISPOSITION_FAILED
 # Helpers
 # ---------------------------------------------------------------------------
 
+_EMPTY_STATS = BatchRegistryStats(total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0)
+
 
 def _make_entry(
     batch_id: str = "batch-1",
@@ -67,6 +69,42 @@ def _build_service(
     return svc
 
 
+def _setup_single_file_failure(
+    svc: BatchProcessingService,
+    *,
+    file_name: str = "file_a",
+    batch_id: str = "batch-1",
+) -> MagicMock:
+    """Wire up a single-file registry where _process_single_batch_file raises."""
+    entry = _make_entry(batch_id=batch_id, file_name=file_name)
+    manager = MagicMock()
+    manager.get_all_jobs.return_value = {file_name: entry}
+    manager.get_registry_stats.return_value = _EMPTY_STATS
+    svc._registry_manager_factory.return_value = manager
+    return manager
+
+
+def _failed_disposition_record_ids(backend: MagicMock) -> set[str]:
+    """Extract record_ids from set_disposition calls that wrote DISPOSITION_FAILED."""
+    ids = set()
+    for c in backend.set_disposition.call_args_list:
+        # Handles both positional and keyword calling conventions
+        disposition = c[0][2] if len(c[0]) > 2 else c.kwargs.get("disposition")
+        if disposition == DISPOSITION_FAILED:
+            ids.add(c[0][1])
+    return ids
+
+
+def _run_with_failure(svc, side_effect):
+    """Patch _is_batch_ready + _process_single_batch_file, call process_all_batch_results."""
+    with (
+        patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+        patch.object(svc, "_process_single_batch_file", side_effect=side_effect),
+    ):
+        with pytest.raises(ProcessingError):
+            svc.process_all_batch_results("/output")
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -86,47 +124,16 @@ class TestBatchExceptionDisposition:
             ("t3", "sg-3", FilterStatus.SKIPPED),
         )
         svc._context_manager.load_batch_context_map.return_value = context_map
+        _setup_single_file_failure(svc)
+        _run_with_failure(svc, ValueError("simulated error"))
 
-        entry_a = _make_entry(batch_id="batch-a", file_name="file_a")
-        manager = MagicMock()
-        manager.get_all_jobs.return_value = {"file_a": entry_a}
-        manager.get_registry_stats.return_value = BatchRegistryStats(
-            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
-        )
-        svc._registry_manager_factory.return_value = manager
-
-        # Simulate _is_batch_ready_for_processing returning True, then
-        # _process_single_batch_file raising a ValueError
-        with (
-            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
-            patch.object(
-                svc,
-                "_process_single_batch_file",
-                side_effect=ValueError("simulated error"),
-            ),
-        ):
-            # Should raise ProcessingError because no files were processed
-            with pytest.raises(ProcessingError):
-                svc.process_all_batch_results("/output")
-
-        # INCLUDED records get FAILED
-        failed_calls = [
-            c
-            for c in backend.set_disposition.call_args_list
-            if c[0][2] == DISPOSITION_FAILED or c.kwargs.get("disposition") == DISPOSITION_FAILED
-        ]
-        assert len(failed_calls) == 2
-        failed_ids = {c[0][1] for c in failed_calls}
+        failed_ids = _failed_disposition_record_ids(backend)
         assert failed_ids == {"sg-1", "sg-2"}
 
-        # DEFERRED cleared for INCLUDED records
-        clear_calls = backend.clear_disposition.call_args_list
-        cleared_ids = {c.kwargs.get("record_id") or c[0][1] for c in clear_calls}
+        cleared_ids = {c.kwargs.get("record_id") for c in backend.clear_disposition.call_args_list}
         assert "sg-1" in cleared_ids
         assert "sg-2" in cleared_ids
-        # SKIPPED record sg-3 must NOT appear
         assert "sg-3" not in cleared_ids
-        assert "sg-3" not in failed_ids
 
     def test_failed_batch_reason_contains_exception_message(self):
         """FAILED disposition reason includes the exception message."""
@@ -135,36 +142,17 @@ class TestBatchExceptionDisposition:
 
         context_map = _make_context_map(("t1", "sg-1", FilterStatus.INCLUDED))
         svc._context_manager.load_batch_context_map.return_value = context_map
+        _setup_single_file_failure(svc, file_name="file_x", batch_id="batch-x")
+        _run_with_failure(svc, TypeError("unexpected None"))
 
-        entry = _make_entry(batch_id="batch-x", file_name="file_x")
-        manager = MagicMock()
-        manager.get_all_jobs.return_value = {"file_x": entry}
-        manager.get_registry_stats.return_value = BatchRegistryStats(
-            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
-        )
-        svc._registry_manager_factory.return_value = manager
-
-        with (
-            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
-            patch.object(
-                svc,
-                "_process_single_batch_file",
-                side_effect=TypeError("unexpected None"),
-            ),
-        ):
-            with pytest.raises(ProcessingError):
-                svc.process_all_batch_results("/output")
-
-        # Check reason
         set_call = backend.set_disposition.call_args
-        assert "unexpected None" in set_call.kwargs.get("reason", set_call[1].get("reason", ""))
+        assert "unexpected None" in set_call.kwargs.get("reason", "")
 
     def test_other_files_unaffected_by_single_file_failure(self):
         """When one batch file fails, other files still process normally."""
         backend = MagicMock()
         svc = _build_service(storage_backend=backend)
 
-        # file_a will fail, file_b will succeed
         ctx_a = _make_context_map(("t1", "sg-1", FilterStatus.INCLUDED))
         ctx_b = _make_context_map(("t2", "sg-2", FilterStatus.INCLUDED))
 
@@ -179,108 +167,48 @@ class TestBatchExceptionDisposition:
         manager.get_all_jobs.return_value = {"file_a": entry_a, "file_b": entry_b}
         svc._registry_manager_factory.return_value = manager
 
-        call_count = 0
-
         def process_side_effect(**kwargs):
-            nonlocal call_count
-            call_count += 1
             if kwargs["file_name"] == "file_a":
                 raise ValueError("file_a broke")
             return "/output/file_b.json"
 
         with (
             patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
-            patch.object(
-                svc,
-                "_process_single_batch_file",
-                side_effect=process_side_effect,
-            ),
+            patch.object(svc, "_process_single_batch_file", side_effect=process_side_effect),
         ):
             result = svc.process_all_batch_results("/output")
 
-        # file_b processed successfully
         assert result == ["/output/file_b.json"]
 
-        # Only file_a's records got FAILED dispositions
-        failed_calls = [
-            c
-            for c in backend.set_disposition.call_args_list
-            if len(c[0]) > 2 and c[0][2] == DISPOSITION_FAILED
-        ]
-        assert len(failed_calls) == 1
-        assert failed_calls[0][0][1] == "sg-1"
+        failed_ids = _failed_disposition_record_ids(backend)
+        assert failed_ids == {"sg-1"}
 
     def test_no_disposition_when_no_storage_backend(self):
         """Without a storage backend, exception path doesn't crash."""
         svc = _build_service(storage_backend=None)
+        _setup_single_file_failure(svc)
+        _run_with_failure(svc, ValueError("boom"))
 
-        entry = _make_entry(batch_id="batch-1", file_name="file_a")
-        manager = MagicMock()
-        manager.get_all_jobs.return_value = {"file_a": entry}
-        manager.get_registry_stats.return_value = BatchRegistryStats(
-            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
-        )
-        svc._registry_manager_factory.return_value = manager
-
-        with (
-            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
-            patch.object(
-                svc,
-                "_process_single_batch_file",
-                side_effect=ValueError("boom"),
-            ),
-        ):
-            with pytest.raises(ProcessingError):
-                svc.process_all_batch_results("/output")
-
-        # No crash — context_manager should not even be called for context_map
         svc._context_manager.load_batch_context_map.assert_not_called()
 
     def test_context_map_load_failure_does_not_crash(self):
         """If loading the context_map itself fails, we log and continue."""
         backend = MagicMock()
         svc = _build_service(storage_backend=backend)
-
         svc._context_manager.load_batch_context_map.side_effect = OSError("disk error")
+        _setup_single_file_failure(svc)
+        _run_with_failure(svc, ValueError("processing failed"))
 
-        entry = _make_entry(batch_id="batch-1", file_name="file_a")
-        manager = MagicMock()
-        manager.get_all_jobs.return_value = {"file_a": entry}
-        manager.get_registry_stats.return_value = BatchRegistryStats(
-            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
-        )
-        svc._registry_manager_factory.return_value = manager
-
-        with (
-            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
-            patch.object(
-                svc,
-                "_process_single_batch_file",
-                side_effect=ValueError("processing failed"),
-            ),
-        ):
-            with pytest.raises(ProcessingError):
-                svc.process_all_batch_results("/output")
-
-        # No disposition writes since context_map couldn't be loaded
         backend.set_disposition.assert_not_called()
 
     def test_runtime_error_still_propagates(self):
         """RuntimeError must propagate (not be caught by the exception handler)."""
         svc = _build_service(storage_backend=MagicMock())
-
-        entry = _make_entry(batch_id="batch-1", file_name="file_a")
-        manager = MagicMock()
-        manager.get_all_jobs.return_value = {"file_a": entry}
-        svc._registry_manager_factory.return_value = manager
+        _setup_single_file_failure(svc)
 
         with (
             patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
-            patch.object(
-                svc,
-                "_process_single_batch_file",
-                side_effect=RuntimeError("fatal"),
-            ),
+            patch.object(svc, "_process_single_batch_file", side_effect=RuntimeError("fatal")),
         ):
             with pytest.raises(RuntimeError, match="fatal"):
                 svc.process_all_batch_results("/output")
@@ -290,33 +218,14 @@ class TestBatchExceptionDisposition:
         backend = MagicMock()
         svc = _build_service(storage_backend=backend)
 
-        # Record with no source_guid
         ctx = {}
         record: dict = {}
         BatchContextMetadata.set_filter_status(record, FilterStatus.INCLUDED)
         ctx["t1"] = record
-
         svc._context_manager.load_batch_context_map.return_value = ctx
 
-        entry = _make_entry(batch_id="batch-1", file_name="file_a")
-        manager = MagicMock()
-        manager.get_all_jobs.return_value = {"file_a": entry}
-        manager.get_registry_stats.return_value = BatchRegistryStats(
-            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
-        )
-        svc._registry_manager_factory.return_value = manager
+        _setup_single_file_failure(svc)
+        _run_with_failure(svc, ValueError("boom"))
 
-        with (
-            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
-            patch.object(
-                svc,
-                "_process_single_batch_file",
-                side_effect=ValueError("boom"),
-            ),
-        ):
-            with pytest.raises(ProcessingError):
-                svc.process_all_batch_results("/output")
-
-        # No disposition writes for records without source_guid
         backend.set_disposition.assert_not_called()
         backend.clear_disposition.assert_not_called()

--- a/tests/unit/llm/batch/test_batch_exception_disposition.py
+++ b/tests/unit/llm/batch/test_batch_exception_disposition.py
@@ -1,0 +1,322 @@
+"""Tests for F4: batch exception writes FAILED dispositions for abandoned records.
+
+When _process_single_batch_file raises a non-RuntimeError exception,
+process_all_batch_results must write DISPOSITION_FAILED for every INCLUDED
+record in the failed batch file's context_map, clearing any stale DEFERRED
+dispositions. Records in other files must be unaffected.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.errors import ProcessingError
+from agent_actions.llm.batch.core.batch_constants import BatchStatus, FilterStatus
+from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
+from agent_actions.llm.batch.core.batch_models import BatchJobEntry, BatchRegistryStats
+from agent_actions.llm.batch.services.processing import BatchProcessingService
+from agent_actions.storage.backend import DISPOSITION_FAILED
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    batch_id: str = "batch-1",
+    file_name: str = "file_a",
+    record_count: int = 3,
+) -> BatchJobEntry:
+    return BatchJobEntry(
+        batch_id=batch_id,
+        status=BatchStatus.COMPLETED,
+        timestamp="2026-05-19T00:00:00Z",
+        provider="openai",
+        record_count=record_count,
+        file_name=file_name,
+    )
+
+
+def _make_context_map(*records: tuple[str, str, FilterStatus]) -> dict:
+    """Build a context_map from (custom_id, source_guid, status) tuples."""
+    ctx = {}
+    for custom_id, source_guid, status in records:
+        record: dict = {"source_guid": source_guid}
+        BatchContextMetadata.set_filter_status(record, status)
+        ctx[custom_id] = record
+    return ctx
+
+
+def _build_service(
+    storage_backend: MagicMock | None = None,
+    action_name: str = "test_action",
+) -> BatchProcessingService:
+    """Construct a BatchProcessingService with mocked dependencies."""
+    svc = BatchProcessingService.__new__(BatchProcessingService)
+    svc._client_resolver = MagicMock()
+    svc._context_manager = MagicMock()
+    svc._result_processor = MagicMock()
+    svc._registry_manager_factory = MagicMock()
+    svc._source_handler = None
+    svc._action_indices = {}
+    svc._dependency_configs = {}
+    svc._storage_backend = storage_backend
+    svc._action_name = action_name
+    svc._retry_service = MagicMock()
+    svc._enrichment_pipeline = MagicMock()
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchExceptionDisposition:
+    """process_all_batch_results writes FAILED dispositions on exception."""
+
+    def test_failed_batch_writes_failed_disposition_for_included_records(self):
+        """INCLUDED records in a failed batch get DISPOSITION_FAILED."""
+        backend = MagicMock()
+        svc = _build_service(storage_backend=backend)
+
+        context_map = _make_context_map(
+            ("t1", "sg-1", FilterStatus.INCLUDED),
+            ("t2", "sg-2", FilterStatus.INCLUDED),
+            ("t3", "sg-3", FilterStatus.SKIPPED),
+        )
+        svc._context_manager.load_batch_context_map.return_value = context_map
+
+        entry_a = _make_entry(batch_id="batch-a", file_name="file_a")
+        manager = MagicMock()
+        manager.get_all_jobs.return_value = {"file_a": entry_a}
+        manager.get_registry_stats.return_value = BatchRegistryStats(
+            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
+        )
+        svc._registry_manager_factory.return_value = manager
+
+        # Simulate _is_batch_ready_for_processing returning True, then
+        # _process_single_batch_file raising a ValueError
+        with (
+            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+            patch.object(
+                svc,
+                "_process_single_batch_file",
+                side_effect=ValueError("simulated error"),
+            ),
+        ):
+            # Should raise ProcessingError because no files were processed
+            with pytest.raises(ProcessingError):
+                svc.process_all_batch_results("/output")
+
+        # INCLUDED records get FAILED
+        failed_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if c[0][2] == DISPOSITION_FAILED or c.kwargs.get("disposition") == DISPOSITION_FAILED
+        ]
+        assert len(failed_calls) == 2
+        failed_ids = {c[0][1] for c in failed_calls}
+        assert failed_ids == {"sg-1", "sg-2"}
+
+        # DEFERRED cleared for INCLUDED records
+        clear_calls = backend.clear_disposition.call_args_list
+        cleared_ids = {c.kwargs.get("record_id") or c[0][1] for c in clear_calls}
+        assert "sg-1" in cleared_ids
+        assert "sg-2" in cleared_ids
+        # SKIPPED record sg-3 must NOT appear
+        assert "sg-3" not in cleared_ids
+        assert "sg-3" not in failed_ids
+
+    def test_failed_batch_reason_contains_exception_message(self):
+        """FAILED disposition reason includes the exception message."""
+        backend = MagicMock()
+        svc = _build_service(storage_backend=backend)
+
+        context_map = _make_context_map(("t1", "sg-1", FilterStatus.INCLUDED))
+        svc._context_manager.load_batch_context_map.return_value = context_map
+
+        entry = _make_entry(batch_id="batch-x", file_name="file_x")
+        manager = MagicMock()
+        manager.get_all_jobs.return_value = {"file_x": entry}
+        manager.get_registry_stats.return_value = BatchRegistryStats(
+            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
+        )
+        svc._registry_manager_factory.return_value = manager
+
+        with (
+            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+            patch.object(
+                svc,
+                "_process_single_batch_file",
+                side_effect=TypeError("unexpected None"),
+            ),
+        ):
+            with pytest.raises(ProcessingError):
+                svc.process_all_batch_results("/output")
+
+        # Check reason
+        set_call = backend.set_disposition.call_args
+        assert "unexpected None" in set_call.kwargs.get("reason", set_call[1].get("reason", ""))
+
+    def test_other_files_unaffected_by_single_file_failure(self):
+        """When one batch file fails, other files still process normally."""
+        backend = MagicMock()
+        svc = _build_service(storage_backend=backend)
+
+        # file_a will fail, file_b will succeed
+        ctx_a = _make_context_map(("t1", "sg-1", FilterStatus.INCLUDED))
+        ctx_b = _make_context_map(("t2", "sg-2", FilterStatus.INCLUDED))
+
+        def load_context(output_dir, file_name):
+            return ctx_a if file_name == "file_a" else ctx_b
+
+        svc._context_manager.load_batch_context_map.side_effect = load_context
+
+        entry_a = _make_entry(batch_id="batch-a", file_name="file_a")
+        entry_b = _make_entry(batch_id="batch-b", file_name="file_b")
+        manager = MagicMock()
+        manager.get_all_jobs.return_value = {"file_a": entry_a, "file_b": entry_b}
+        svc._registry_manager_factory.return_value = manager
+
+        call_count = 0
+
+        def process_side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if kwargs["file_name"] == "file_a":
+                raise ValueError("file_a broke")
+            return "/output/file_b.json"
+
+        with (
+            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+            patch.object(
+                svc,
+                "_process_single_batch_file",
+                side_effect=process_side_effect,
+            ),
+        ):
+            result = svc.process_all_batch_results("/output")
+
+        # file_b processed successfully
+        assert result == ["/output/file_b.json"]
+
+        # Only file_a's records got FAILED dispositions
+        failed_calls = [
+            c
+            for c in backend.set_disposition.call_args_list
+            if len(c[0]) > 2 and c[0][2] == DISPOSITION_FAILED
+        ]
+        assert len(failed_calls) == 1
+        assert failed_calls[0][0][1] == "sg-1"
+
+    def test_no_disposition_when_no_storage_backend(self):
+        """Without a storage backend, exception path doesn't crash."""
+        svc = _build_service(storage_backend=None)
+
+        entry = _make_entry(batch_id="batch-1", file_name="file_a")
+        manager = MagicMock()
+        manager.get_all_jobs.return_value = {"file_a": entry}
+        manager.get_registry_stats.return_value = BatchRegistryStats(
+            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
+        )
+        svc._registry_manager_factory.return_value = manager
+
+        with (
+            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+            patch.object(
+                svc,
+                "_process_single_batch_file",
+                side_effect=ValueError("boom"),
+            ),
+        ):
+            with pytest.raises(ProcessingError):
+                svc.process_all_batch_results("/output")
+
+        # No crash — context_manager should not even be called for context_map
+        svc._context_manager.load_batch_context_map.assert_not_called()
+
+    def test_context_map_load_failure_does_not_crash(self):
+        """If loading the context_map itself fails, we log and continue."""
+        backend = MagicMock()
+        svc = _build_service(storage_backend=backend)
+
+        svc._context_manager.load_batch_context_map.side_effect = OSError("disk error")
+
+        entry = _make_entry(batch_id="batch-1", file_name="file_a")
+        manager = MagicMock()
+        manager.get_all_jobs.return_value = {"file_a": entry}
+        manager.get_registry_stats.return_value = BatchRegistryStats(
+            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
+        )
+        svc._registry_manager_factory.return_value = manager
+
+        with (
+            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+            patch.object(
+                svc,
+                "_process_single_batch_file",
+                side_effect=ValueError("processing failed"),
+            ),
+        ):
+            with pytest.raises(ProcessingError):
+                svc.process_all_batch_results("/output")
+
+        # No disposition writes since context_map couldn't be loaded
+        backend.set_disposition.assert_not_called()
+
+    def test_runtime_error_still_propagates(self):
+        """RuntimeError must propagate (not be caught by the exception handler)."""
+        svc = _build_service(storage_backend=MagicMock())
+
+        entry = _make_entry(batch_id="batch-1", file_name="file_a")
+        manager = MagicMock()
+        manager.get_all_jobs.return_value = {"file_a": entry}
+        svc._registry_manager_factory.return_value = manager
+
+        with (
+            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+            patch.object(
+                svc,
+                "_process_single_batch_file",
+                side_effect=RuntimeError("fatal"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="fatal"):
+                svc.process_all_batch_results("/output")
+
+    def test_records_without_source_guid_skipped(self):
+        """Records missing source_guid don't get dispositions (no crash)."""
+        backend = MagicMock()
+        svc = _build_service(storage_backend=backend)
+
+        # Record with no source_guid
+        ctx = {}
+        record: dict = {}
+        BatchContextMetadata.set_filter_status(record, FilterStatus.INCLUDED)
+        ctx["t1"] = record
+
+        svc._context_manager.load_batch_context_map.return_value = ctx
+
+        entry = _make_entry(batch_id="batch-1", file_name="file_a")
+        manager = MagicMock()
+        manager.get_all_jobs.return_value = {"file_a": entry}
+        manager.get_registry_stats.return_value = BatchRegistryStats(
+            total_jobs=1, completed=1, in_progress=0, failed=0, cancelled=0
+        )
+        svc._registry_manager_factory.return_value = manager
+
+        with (
+            patch.object(svc, "_is_batch_ready_for_processing", return_value=True),
+            patch.object(
+                svc,
+                "_process_single_batch_file",
+                side_effect=ValueError("boom"),
+            ),
+        ):
+            with pytest.raises(ProcessingError):
+                svc.process_all_batch_results("/output")
+
+        # No disposition writes for records without source_guid
+        backend.set_disposition.assert_not_called()
+        backend.clear_disposition.assert_not_called()


### PR DESCRIPTION
## Summary
- When `_process_single_batch_file` raises a non-RuntimeError exception, the `except/continue` block in `process_all_batch_results` silently abandoned records — they stayed DEFERRED forever, invisible to retry and rerun
- Now loads the context_map for the failed batch file, iterates INCLUDED records, clears DEFERRED, and writes DISPOSITION_FAILED with the exception message as reason
- Records in other batch files are unaffected

## Verification
- 7 regression tests: INCLUDED vs SKIPPED filtering, reason propagation, multi-file isolation, no-backend safety, context_map load failure, RuntimeError propagation, missing source_guid
- `ruff check` + `ruff format --check` clean
- 6851 tests pass (same 2 pre-existing JSON parsing failures)