### PR TITLE
fix: guard prefilter writes DISPOSITION_FILTERED for filtered records

### DIFF
--- a/.changes/unreleased/Bug Fix-20260519-F01000.yaml
+++ b/.changes/unreleased/Bug Fix-20260519-F01000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Guard prefilter path now writes DISPOSITION_FILTERED for filtered records instead of silently dropping them"
+time: 2026-05-19T00:10:00.000000Z

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -126,7 +126,7 @@ class UnifiedProcessor:
         (SKIPPED or FILTERED). Records that pass are forwarded to the strategy.
         """
         config = cast(dict[str, Any], context.agent_config)
-        passing, skipped, _original_passing = prefilter_by_guard(
+        passing, skipped, _original_passing, filtered = prefilter_by_guard(
             records,
             config,
             context.agent_name,
@@ -156,9 +156,9 @@ class UnifiedProcessor:
                 )
             )
 
-        filtered_count = len(records) - len(passing) - len(skipped)
-        for _i in range(filtered_count):
-            guard_results.append(ProcessingResult.filtered(source_guid=None))
+        for item in filtered:
+            source_guid = item.get("source_guid") if isinstance(item, dict) else None
+            guard_results.append(ProcessingResult.filtered(source_guid=source_guid))
 
         return passing, guard_results
 
@@ -184,7 +184,7 @@ class UnifiedProcessor:
             (passing, guard_results, original_passing)
         """
         config = cast(dict[str, Any], context.agent_config)
-        passing, skipped, original_passing = prefilter_by_guard(
+        passing, skipped, original_passing, filtered = prefilter_by_guard(
             records,
             config,
             context.agent_name,
@@ -217,9 +217,9 @@ class UnifiedProcessor:
                 )
             )
 
-        filtered_count = len(records) - len(passing) - len(skipped)
-        for _i in range(filtered_count):
-            guard_results.append(ProcessingResult.filtered(source_guid=None))
+        for item in filtered:
+            source_guid = item.get("source_guid") if isinstance(item, dict) else None
+            guard_results.append(ProcessingResult.filtered(source_guid=source_guid))
 
         return passing, guard_results, original_passing
 

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -317,8 +317,8 @@ def prefilter_by_guard(
     version_context: dict[str, Any] | None = None,
     workflow_metadata: dict[str, Any] | None = None,
     dependency_configs: dict[str, Any] | None = None,
-) -> tuple[list[dict], list[dict], list[dict]]:
-    """Evaluate guard per-record and split into passing and skipped arrays.
+) -> tuple[list[dict], list[dict], list[dict], list[dict]]:
+    """Evaluate guard per-record and split into passing, skipped, and filtered arrays.
 
     Called before FILE-mode processing to apply per-record guard logic
     on the full array.  ``behavior: filter`` records are excluded from
@@ -335,10 +335,10 @@ def prefilter_by_guard(
     TaskPreparer.prepare() — so guards referencing source, version, workflow,
     or promoted output_fields produce correct decisions.
 
-    When no guard is configured, returns ``(data, [], original_data or data)``.
+    When no guard is configured, returns ``(data, [], original_data or data, [])``.
 
     Returns:
-        (passing, skipped, original_passing)
+        (passing, skipped, original_passing, filtered)
     """
     originals = original_data if original_data is not None else data
 
@@ -350,7 +350,7 @@ def prefilter_by_guard(
 
     guard_config = agent_config.get("guard")
     if not guard_config:
-        return data, [], originals
+        return data, [], originals, []
 
     from agent_actions.guards import GuardBehavior
     from agent_actions.input.preprocessing.filtering.evaluator import (
@@ -394,6 +394,7 @@ def prefilter_by_guard(
     passing: list[dict] = []
     skipped: list[dict] = []
     original_passing: list[dict] = []
+    filtered: list[dict] = []
     for idx, item in enumerate(data):
         eval_item = get_existing_content(item)
 
@@ -424,7 +425,9 @@ def prefilter_by_guard(
         elif behavior == GuardBehavior.SKIP:
             # Use pre-observe original so skipped tombstones keep namespaced content.
             skipped.append(originals[idx])
-        # behavior == GuardBehavior.FILTER: record excluded from both lists
+        else:
+            # behavior == GuardBehavior.FILTER: use original for source_guid access.
+            filtered.append(originals[idx])
 
     logger.info(
         "Guard pre-filter for '%s': %d passed, %d skipped, %d filtered of %d total",
@@ -435,4 +438,4 @@ def prefilter_by_guard(
         len(data),
     )
 
-    return passing, skipped, original_passing
+    return passing, skipped, original_passing, filtered

--- a/tests/unit/llm/batch/test_batch_online_guard_unification.py
+++ b/tests/unit/llm/batch/test_batch_online_guard_unification.py
@@ -450,7 +450,7 @@ class TestOnlineGuardContextParity:
             mock_evaluator.evaluate.side_effect = evaluate_fn
             mock_get_eval.return_value = mock_evaluator
 
-            passing_out, skipped_out, _ = prefilter_by_guard(
+            passing_out, skipped_out, _, _filtered = prefilter_by_guard(
                 [passing_item, skipping_item], agent_config, "test_action"
             )
 

--- a/tests/unit/processing/test_unified_processor.py
+++ b/tests/unit/processing/test_unified_processor.py
@@ -158,10 +158,10 @@ class TestUnifiedProcessorNoGuard:
         context = _make_context(guard={"clause": "item.impossible == true", "behavior": "filter"})
         records = [_make_record("sg-1")]
 
-        # Guard will filter all records
+        # Guard will filter all records — 4th value is the filtered records
         with patch(
             "agent_actions.processing.unified.prefilter_by_guard",
-            return_value=([], [], []),
+            return_value=([], [], [], [_make_record("sg-1")]),
         ):
             processor.process(records, context, tracking)
 
@@ -185,7 +185,7 @@ class TestUnifiedProcessorGuardFilter:
 
         with patch(
             "agent_actions.processing.unified.prefilter_by_guard",
-            return_value=([], [skipped_record], []),
+            return_value=([], [skipped_record], [], []),
         ):
             output, stats = processor.process([skipped_record], context, strategy)
 
@@ -201,7 +201,7 @@ class TestUnifiedProcessorGuardFilter:
 
         with patch(
             "agent_actions.processing.unified.prefilter_by_guard",
-            return_value=([], [], []),
+            return_value=([], [], [], [record]),
         ):
             output, stats = processor.process([record], context, strategy)
 
@@ -216,12 +216,13 @@ class TestUnifiedProcessorGuardFilter:
 
         passing = _make_record("sg-pass")
         skipped = _make_record("sg-skip")
+        filtered_rec = _make_record("sg-filter")
         # 3 total records: 1 passes, 1 skipped, 1 filtered
-        all_records = [passing, skipped, _make_record("sg-filter")]
+        all_records = [passing, skipped, filtered_rec]
 
         with patch(
             "agent_actions.processing.unified.prefilter_by_guard",
-            return_value=([passing], [skipped], [passing]),
+            return_value=([passing], [skipped], [passing], [filtered_rec]),
         ):
             output, stats = processor.process(all_records, context, strategy)
 

--- a/tests/unit/unification/test_filtered_disposition.py
+++ b/tests/unit/unification/test_filtered_disposition.py
@@ -1,0 +1,363 @@
+"""Regression tests for F1: prefilter guard-filtered records must write DISPOSITION_FILTERED.
+
+The bug: prefilter_by_guard() dropped filtered records entirely. The caller
+(_guard_filter / _guard_filter_file_mode) could only count them by subtraction
+and created ProcessingResult.filtered(source_guid=None). result_collector.py
+skips disposition writes when source_guid is None, so filtered records vanished
+from the DB.
+
+The fix: prefilter_by_guard() now returns filtered records as a 4th return
+value. The callers iterate them to create ProcessingResult.filtered() with
+each record's actual source_guid, enabling proper disposition writes.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from agent_actions.input.preprocessing.filtering.evaluator import GuardResult
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingResult,
+    ProcessingStatus,
+)
+from agent_actions.processing.unified import UnifiedProcessor
+from agent_actions.storage.backend import DISPOSITION_FILTERED
+from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+
+
+def _make_evaluator(pass_fn):
+    """Create a mock evaluator whose evaluate delegates to pass_fn."""
+    evaluator = MagicMock()
+
+    def side_effect(*, item, guard_config, context=None, conditional_clause=None):
+        if pass_fn(item):
+            return GuardResult.passed()
+        return GuardResult.filtered()
+
+    evaluator.evaluate.side_effect = side_effect
+    return evaluator
+
+
+def _make_context(
+    agent_name: str = "test_action",
+    *,
+    guard: dict | None = None,
+    storage_backend: Any = None,
+) -> ProcessingContext:
+    config: dict[str, Any] = {"agent_type": agent_name, "name": agent_name}
+    if guard is not None:
+        config["guard"] = guard
+    return ProcessingContext(
+        agent_config=config,
+        agent_name=agent_name,
+        storage_backend=storage_backend,
+    )
+
+
+# ---------------------------------------------------------------------------
+# prefilter_by_guard returns filtered records with identity
+# ---------------------------------------------------------------------------
+
+
+class TestPrefilterReturnsFilteredRecords:
+    """prefilter_by_guard must return filtered records so callers can
+    create ProcessingResult.filtered() with proper source_guid."""
+
+    def test_filtered_records_returned_with_source_guid(self):
+        """Filtered records appear in the 4th return value."""
+        data = [
+            {"content": {"score": 90}, "source_guid": "sg-pass"},
+            {"content": {"score": 40}, "source_guid": "sg-filter-1"},
+            {"content": {"score": 30}, "source_guid": "sg-filter-2"},
+        ]
+        config = {"guard": {"clause": "score >= 80", "behavior": "filter"}}
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
+
+        assert len(passing) == 1
+        assert len(filtered) == 2
+        assert filtered[0]["source_guid"] == "sg-filter-1"
+        assert filtered[1]["source_guid"] == "sg-filter-2"
+
+    def test_no_guard_returns_empty_filtered(self):
+        """No guard config -> filtered list is empty."""
+        data = [{"content": {"x": 1}}]
+        _, _, _, filtered = prefilter_by_guard(data, {}, "test")
+        assert filtered == []
+
+    def test_all_pass_returns_empty_filtered(self):
+        """All records pass -> filtered list is empty."""
+        data = [{"content": {"score": 90}}, {"content": {"score": 95}}]
+        config = {"guard": {"clause": "score >= 80", "behavior": "filter"}}
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            _, _, _, filtered = prefilter_by_guard(data, config, "test")
+
+        assert filtered == []
+
+    def test_all_filtered_returns_all(self):
+        """All records fail filter -> all in filtered list."""
+        data = [
+            {"content": {"score": 10}, "source_guid": "sg-1"},
+            {"content": {"score": 20}, "source_guid": "sg-2"},
+        ]
+        config = {"guard": {"clause": "score >= 80", "behavior": "filter"}}
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            passing, _, _, filtered = prefilter_by_guard(data, config, "test")
+
+        assert passing == []
+        assert len(filtered) == 2
+
+    def test_filtered_uses_original_data_when_provided(self):
+        """With original_data, filtered list contains originals (not observe-filtered)."""
+        data = [{"content": {"score": 40}}]
+        raw = [{"content": {"score": 40, "name": "Bob"}, "source_guid": "sg-2"}]
+        config = {"guard": {"clause": "score >= 80", "behavior": "filter"}}
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            _, _, _, filtered = prefilter_by_guard(data, config, "test", original_data=raw)
+
+        assert len(filtered) == 1
+        assert filtered[0]["source_guid"] == "sg-2"
+        assert filtered[0]["content"]["name"] == "Bob"
+
+
+# ---------------------------------------------------------------------------
+# _guard_filter produces FILTERED results with source_guid
+# ---------------------------------------------------------------------------
+
+
+class TestGuardFilterDisposition:
+    """_guard_filter must produce ProcessingResult.filtered() with the
+    record's actual source_guid so result_collector writes DISPOSITION_FILTERED."""
+
+    def test_filtered_result_has_source_guid(self):
+        """RECORD-mode: filtered ProcessingResult carries the record's source_guid."""
+        records = [
+            {"content": {"score": 90}, "source_guid": "sg-pass"},
+            {"content": {"score": 40}, "source_guid": "sg-filter"},
+        ]
+        context = _make_context(guard={"clause": "score >= 80", "behavior": "filter"})
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            processor = UnifiedProcessor()
+            passing, guard_results = processor._guard_filter(records, context)
+
+        assert len(passing) == 1
+        assert len(guard_results) == 1
+        assert guard_results[0].status == ProcessingStatus.FILTERED
+        assert guard_results[0].source_guid == "sg-filter"
+
+    def test_multiple_filtered_records_have_distinct_guids(self):
+        """Each filtered record gets its own source_guid on the result."""
+        records = [
+            {"content": {"score": 10}, "source_guid": "sg-1"},
+            {"content": {"score": 20}, "source_guid": "sg-2"},
+            {"content": {"score": 30}, "source_guid": "sg-3"},
+        ]
+        context = _make_context(guard={"clause": "score >= 80", "behavior": "filter"})
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            processor = UnifiedProcessor()
+            passing, guard_results = processor._guard_filter(records, context)
+
+        assert passing == []
+        assert len(guard_results) == 3
+        guids = [r.source_guid for r in guard_results]
+        assert guids == ["sg-1", "sg-2", "sg-3"]
+
+    def test_filtered_without_source_guid_gets_none(self):
+        """Record without source_guid -> result.source_guid is None (no crash)."""
+        records = [{"content": {"score": 40}}]
+        context = _make_context(guard={"clause": "score >= 80", "behavior": "filter"})
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            processor = UnifiedProcessor()
+            _, guard_results = processor._guard_filter(records, context)
+
+        assert len(guard_results) == 1
+        assert guard_results[0].source_guid is None
+
+
+# ---------------------------------------------------------------------------
+# _guard_filter_file_mode produces FILTERED results with source_guid
+# ---------------------------------------------------------------------------
+
+
+class TestGuardFilterFileModeDisposition:
+    """FILE-mode: _guard_filter_file_mode must also produce FILTERED results
+    with proper source_guid."""
+
+    def test_filtered_result_has_source_guid_file_mode(self):
+        """FILE-mode: filtered result carries source_guid from original_data."""
+        data = [{"content": {"score": 40}}]
+        raw = [{"content": {"score": 40, "name": "Bob"}, "source_guid": "sg-filter"}]
+        context = ProcessingContext(
+            agent_config={"guard": {"clause": "score >= 80", "behavior": "filter"}},
+            agent_name="test",
+        )
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            processor = UnifiedProcessor()
+            passing, guard_results, original_passing = processor._guard_filter_file_mode(
+                data, context, raw
+            )
+
+        assert passing == []
+        assert len(guard_results) == 1
+        assert guard_results[0].status == ProcessingStatus.FILTERED
+        assert guard_results[0].source_guid == "sg-filter"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: DISPOSITION_FILTERED written to storage backend
+# ---------------------------------------------------------------------------
+
+
+class TestFilteredDispositionWritten:
+    """Integration: when a prefilter-filtered record has source_guid,
+    result_collector must call set_disposition(DISPOSITION_FILTERED)."""
+
+    def test_record_mode_filtered_writes_disposition(self):
+        """RECORD mode: filtered record -> DISPOSITION_FILTERED in DB."""
+        records = [
+            {"content": {"score": 90}, "source_guid": "sg-pass"},
+            {"content": {"score": 40}, "source_guid": "sg-filter"},
+        ]
+        mock_backend = MagicMock()
+        context = _make_context(
+            guard={"clause": "score >= 80", "behavior": "filter"},
+            storage_backend=mock_backend,
+        )
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        class PassthroughStrategy:
+            def invoke(self, recs, ctx):
+                return [
+                    ProcessingResult.success(
+                        data=[{"content": {"test_action": {"out": 1}}}],
+                        source_guid=r["source_guid"],
+                    )
+                    for r in recs
+                ]
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            output, stats = UnifiedProcessor().process(records, context, PassthroughStrategy())
+
+        assert stats.filtered == 1
+        assert stats.success == 1
+
+        # Verify DISPOSITION_FILTERED was written with the correct source_guid
+        disposition_calls = [
+            c for c in mock_backend.set_disposition.call_args_list if DISPOSITION_FILTERED in str(c)
+        ]
+        assert len(disposition_calls) == 1
+
+    def test_file_mode_filtered_writes_disposition(self):
+        """FILE mode: filtered record -> DISPOSITION_FILTERED in DB."""
+        records = [
+            {"content": {"score": 90}, "source_guid": "sg-pass"},
+            {"content": {"score": 40}, "source_guid": "sg-filter"},
+        ]
+        raw = records
+        mock_backend = MagicMock()
+        context = _make_context(
+            guard={"clause": "score >= 80", "behavior": "filter"},
+            storage_backend=mock_backend,
+        )
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        class PassthroughStrategy:
+            def invoke(self, recs, ctx):
+                return [
+                    ProcessingResult.success(
+                        data=[{"content": {"test_action": {"out": 1}}}],
+                        source_guid=r["source_guid"],
+                    )
+                    for r in recs
+                ]
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            output, stats = UnifiedProcessor().process(
+                records, context, PassthroughStrategy(), raw_records=raw
+            )
+
+        assert stats.filtered == 1
+
+        disposition_calls = [
+            c
+            for c in mock_backend.set_disposition.call_args_list
+            if len(c.args) >= 3 and c.args[2] == DISPOSITION_FILTERED
+        ]
+        assert len(disposition_calls) == 1
+        assert disposition_calls[0].args[1] == "sg-filter"
+
+    def test_no_source_guid_no_disposition_write(self):
+        """Record without source_guid -> no disposition write (no crash)."""
+        records = [{"content": {"score": 40}}]
+        mock_backend = MagicMock()
+        context = _make_context(
+            guard={"clause": "score >= 80", "behavior": "filter"},
+            storage_backend=mock_backend,
+        )
+        evaluator = _make_evaluator(lambda item: item.get("score", 0) >= 80)
+
+        class NoOpStrategy:
+            def invoke(self, recs, ctx):
+                return []
+
+        with patch(
+            "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
+            return_value=evaluator,
+        ):
+            output, stats = UnifiedProcessor().process(records, context, NoOpStrategy())
+
+        assert stats.filtered == 1
+        # No disposition write because source_guid is missing
+        disposition_calls = [
+            c
+            for c in mock_backend.set_disposition.call_args_list
+            if c.kwargs.get("disposition") == DISPOSITION_FILTERED
+            or (len(c.args) >= 4 and c.args[3] == DISPOSITION_FILTERED)
+        ]
+        assert len(disposition_calls) == 0

--- a/tests/unit/unification/test_phase1_observability.py
+++ b/tests/unit/unification/test_phase1_observability.py
@@ -154,7 +154,7 @@ class TestPrefilterLengthGuard:
         data = [{"content": {"x": 1}}, {"content": {"x": 2}}]
         original_data = [{"content": {"x": 1, "extra": "a"}}, {"content": {"x": 2, "extra": "b"}}]
 
-        passing, skipped, original_passing = prefilter_by_guard(
+        passing, skipped, original_passing, _filtered = prefilter_by_guard(
             data, {}, "test_agent", original_data=original_data
         )
         assert len(passing) == 2

--- a/tests/unit/unification/test_phase5_guard_context.py
+++ b/tests/unit/unification/test_phase5_guard_context.py
@@ -85,7 +85,7 @@ class TestGuardContextParity:
         }
         agent_config = {"name": "test_action", "guard": guard_config}
 
-        passing, skipped, _ = prefilter_by_guard(
+        passing, skipped, _, _filtered = prefilter_by_guard(
             records,
             agent_config,
             "test_action",
@@ -113,7 +113,7 @@ class TestGuardContextParity:
         }
         agent_config = {"name": "test_action", "guard": guard_config}
 
-        passing, skipped, _ = prefilter_by_guard(
+        passing, skipped, _, _filtered = prefilter_by_guard(
             records,
             agent_config,
             "test_action",
@@ -152,7 +152,7 @@ class TestGuardContextParity:
         }
         dependency_configs = {"assess": {"output_field": "severity"}}
 
-        passing, skipped, _ = prefilter_by_guard(
+        passing, skipped, _, _filtered = prefilter_by_guard(
             records,
             agent_config,
             "test_action",
@@ -181,7 +181,7 @@ class TestGuardContextParity:
         agent_config = {"name": "test_action", "guard": guard_config}
 
         # Online path: prefilter_by_guard with pipeline context
-        passing, _skipped, _ = prefilter_by_guard(
+        passing, _skipped, _, _filtered = prefilter_by_guard(
             [record],
             agent_config,
             "test_action",
@@ -227,7 +227,7 @@ class TestCodeCenteredQuizGuard:
         }
         dependency_configs = {"code_quiz": {"output_field": "has_failures"}}
 
-        passing, skipped, _ = prefilter_by_guard(
+        passing, skipped, _, _filtered = prefilter_by_guard(
             records,
             agent_config,
             "test_action",
@@ -265,7 +265,7 @@ class TestCodeCenteredQuizGuard:
         }
         dependency_configs = {"code_quiz": {"output_field": "has_failures"}}
 
-        passing, skipped, _ = prefilter_by_guard(
+        passing, skipped, _, _filtered = prefilter_by_guard(
             records,
             agent_config,
             "test_action",
@@ -299,7 +299,7 @@ class TestPrefilterByGuardContextAlignment:
         agent_config = {"name": "test_action", "guard": guard_config}
 
         # No pipeline context → uses eval_item (record content has upstream_ns)
-        passing, skipped, _ = prefilter_by_guard(records, agent_config, "test_action")
+        passing, skipped, _, _filtered = prefilter_by_guard(records, agent_config, "test_action")
 
         assert len(passing) == 1, "Should pass — field is in record content"
 
@@ -319,7 +319,7 @@ class TestPrefilterByGuardContextAlignment:
         }
         agent_config = {"name": "test_action", "guard": guard_config}
 
-        passing, skipped, _ = prefilter_by_guard(
+        passing, skipped, _, _filtered = prefilter_by_guard(
             records,
             agent_config,
             "test_action",
@@ -357,7 +357,7 @@ class TestPrefilterByGuardContextAlignment:
         }
         dependency_configs = {"assess": {"output_field": "severity"}}
 
-        passing, skipped, _ = prefilter_by_guard(
+        passing, skipped, _, _filtered = prefilter_by_guard(
             records,
             agent_config,
             "test_action",

--- a/tests/unit/workflow/test_file_mode_guard_prefilter.py
+++ b/tests/unit/workflow/test_file_mode_guard_prefilter.py
@@ -30,7 +30,7 @@ class TestPrefilterByGuard:
     def test_no_guard_returns_all(self):
         """No guard config -> all records pass, no skipped."""
         data = [{"content": {"x": 1}}, {"content": {"x": 2}}]
-        passing, skipped, original_passing = prefilter_by_guard(data, {}, "test")
+        passing, skipped, original_passing, filtered = prefilter_by_guard(data, {}, "test")
         assert passing == data
         assert skipped == []
         assert original_passing == data
@@ -39,7 +39,9 @@ class TestPrefilterByGuard:
         """No guard config with original_data -> original_passing is original_data."""
         data = [{"content": {"x": 1}}]
         raw = [{"content": {"x": 1}, "extra_field": "preserved"}]
-        passing, skipped, original_passing = prefilter_by_guard(data, {}, "test", original_data=raw)
+        passing, skipped, original_passing, filtered = prefilter_by_guard(
+            data, {}, "test", original_data=raw
+        )
         assert passing == data
         assert original_passing == raw
 
@@ -57,7 +59,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert len(passing) == 2
         assert passing[0]["content"]["score"] == 90
@@ -79,7 +81,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert len(passing) == 2
         assert len(skipped) == 1
@@ -95,7 +97,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert len(passing) == 2
         assert skipped == []
@@ -110,7 +112,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert passing == []
         assert skipped == []
@@ -126,7 +128,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert passing == []
         assert len(skipped) == 2
@@ -163,7 +165,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert len(passing) == 1
         assert skipped == []
@@ -190,7 +192,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(
+            passing, skipped, original_passing, filt = prefilter_by_guard(
                 filtered, config, "test", original_data=raw
             )
 
@@ -222,7 +224,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(
+            passing, skipped, original_passing, filt = prefilter_by_guard(
                 filtered, config, "test", original_data=raw
             )
 
@@ -242,7 +244,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard([], config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard([], config, "test")
 
         assert passing == []
         assert skipped == []
@@ -258,7 +260,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert len(passing) == 0
 
@@ -272,7 +274,7 @@ class TestPrefilterByGuard:
             "agent_actions.input.preprocessing.filtering.evaluator.get_guard_evaluator",
             return_value=evaluator,
         ):
-            passing, skipped, original_passing = prefilter_by_guard(data, config, "test")
+            passing, skipped, original_passing, filtered = prefilter_by_guard(data, config, "test")
 
         assert len(passing) == 0
 


### PR DESCRIPTION
## Summary
- **Bug:** `prefilter_by_guard()` dropped filtered records entirely — they appeared in neither the `passing` nor `skipped` return lists. Callers created `ProcessingResult.filtered(source_guid=None)`, and `result_collector` skips disposition writes when `source_guid` is None. Result: filtered records vanished from the DB (confirmed in review_analyzer: 13 filtered, 0 DB rows).
- **Fix:** `prefilter_by_guard()` now returns filtered records as a 4th return value. Both `_guard_filter()` and `_guard_filter_file_mode()` iterate them to create `ProcessingResult.filtered()` with each record's actual `source_guid`, enabling proper `DISPOSITION_FILTERED` writes.
- Both RECORD mode and FILE mode paths are fixed (same bug pattern in both).

## Verification
- 6858 tests pass (6846 baseline + 12 new regression tests)
- `ruff check` clean, `ruff format --check` clean
- New test file: `tests/unit/unification/test_filtered_disposition.py` — covers prefilter return values, `_guard_filter` source_guid propagation, `_guard_filter_file_mode` source_guid propagation, and end-to-end disposition writes for both RECORD and FILE modes