### PR TITLE
fix: isolate enrichment failures and enrich batch errors (F9+F6)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260519-F09F06.yaml
+++ b/.changes/unreleased/Bug Fix-20260519-F09F06.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Isolate per-record enrichment failures (F9) and enrich batch error results (F6) — a single enrichment failure no longer kills the entire action, and batch errors now go through the enrichment pipeline like online errors"
+time: 2026-05-19T09:06:00.000000Z

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -10,7 +10,6 @@ import logging
 from dataclasses import replace
 from typing import Any, Protocol, cast, runtime_checkable
 
-from agent_actions.config.types import RunMode
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import CollectionStats, ResultCollector
@@ -254,20 +253,30 @@ class UnifiedProcessor:
         Uses per-result ``processing_context`` when set (batch results carry
         their own context with correct record_index and original_row).
         Falls back to the shared context with positional record_index for
-        online results.  Batch results without ``processing_context`` (error
-        results) skip enrichment entirely.
+        results without their own context (online results and batch error
+        results alike).
+
+        Per-record enrichment failures are isolated: a failing record produces
+        a FAILED ProcessingResult instead of aborting the entire action.
         """
         enriched: list[ProcessingResult] = []
         for i, r in enumerate(results):
-            if r.processing_context is not None:
-                enriched.append(self._enrichment_pipeline.enrich(r, r.processing_context))
-            elif context.mode == RunMode.ONLINE:
+            enrich_ctx = (
+                r.processing_context
+                if r.processing_context is not None
+                else replace(context, record_index=i)
+            )
+            try:
+                enriched.append(self._enrichment_pipeline.enrich(r, enrich_ctx))
+            except Exception as e:
+                logger.warning("Enrichment failed for record %d: %s", i, e)
                 enriched.append(
-                    self._enrichment_pipeline.enrich(r, replace(context, record_index=i))
+                    ProcessingResult.failed(
+                        error=f"Enrichment failed: {e}",
+                        source_guid=r.source_guid,
+                        source_snapshot=r.input_record,
+                    )
                 )
-            else:
-                # Batch error results without processing_context skip enrichment.
-                enriched.append(r)
         return enriched
 
     def _collect(

--- a/tests/unit/processing/test_unified_processor.py
+++ b/tests/unit/processing/test_unified_processor.py
@@ -1,8 +1,11 @@
 """Tests for UnifiedProcessor skeleton and ProcessingStrategy protocol."""
 
+from dataclasses import replace
 from typing import Any
 from unittest.mock import patch
 
+from agent_actions.config.types import RunMode
+from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
@@ -241,7 +244,6 @@ class TestUnifiedProcessorEnrichment:
 
     def test_enrichment_pipeline_is_applied(self):
         """Verify enrichment is called for every result."""
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 
         class CountingEnricher(Enricher):
             def __init__(self):
@@ -264,7 +266,6 @@ class TestUnifiedProcessorEnrichment:
 
     def test_custom_enrichment_pipeline_used(self):
         """A custom pipeline replaces the default one."""
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 
         class TagEnricher(Enricher):
             def enrich(self, result, context):
@@ -425,7 +426,6 @@ class TestEnrichmentFailureIsolation:
 
     def test_enrichment_failure_isolates_to_single_record(self):
         """Record 1 of 3 fails enrichment — records 0 and 2 still succeed."""
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 
         class BombOnSecondEnricher(Enricher):
             def __init__(self):
@@ -452,7 +452,6 @@ class TestEnrichmentFailureIsolation:
 
     def test_enrichment_failure_records_error_message(self):
         """The failed record carries the enrichment error string."""
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 
         class AlwaysFailEnricher(Enricher):
             def enrich(self, result, context):
@@ -472,7 +471,6 @@ class TestEnrichmentFailureIsolation:
 
     def test_enrichment_failure_preserves_source_guid(self):
         """The failed result carries the original record's source_guid."""
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 
         class FailEnricher(Enricher):
             def enrich(self, result, context):
@@ -497,8 +495,6 @@ class TestBatchErrorEnrichment:
 
     def test_batch_error_result_is_enriched(self):
         """A batch FAILED result without processing_context gets enriched."""
-        from agent_actions.config.types import RunMode
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 
         class TagEnricher(Enricher):
             def enrich(self, result, context):
@@ -513,8 +509,6 @@ class TestBatchErrorEnrichment:
         batch_error = ProcessingResult.failed(error="provider timeout", source_guid="sg-batch-err")
         assert batch_error.processing_context is None
 
-        from dataclasses import replace
-
         context = replace(_make_context(), mode=RunMode.BATCH)
         enriched = processor._enrich([batch_error], context)
 
@@ -525,9 +519,6 @@ class TestBatchErrorEnrichment:
 
     def test_batch_and_online_errors_both_enriched(self):
         """Both batch and online error results go through the same path."""
-        from agent_actions.config.types import RunMode
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
-
         enrich_calls = []
 
         class TrackingEnricher(Enricher):
@@ -539,8 +530,6 @@ class TestBatchErrorEnrichment:
         processor = UnifiedProcessor(enrichment_pipeline=pipeline)
 
         error_result = ProcessingResult.failed(error="timeout", source_guid="sg-err")
-
-        from dataclasses import replace
 
         # Online mode
         ctx_online = replace(_make_context(), mode=RunMode.ONLINE)
@@ -564,8 +553,6 @@ class TestBatchErrorEnrichmentFailure:
 
     def test_batch_error_enrichment_failure_isolated(self):
         """Batch error result that fails enrichment doesn't kill other records."""
-        from agent_actions.config.types import RunMode
-        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
 
         class FailOnErrorResultEnricher(Enricher):
             def enrich(self, result, context):
@@ -580,8 +567,6 @@ class TestBatchErrorEnrichmentFailure:
             ProcessingResult.success(data=[{"ok": True}], source_guid="sg-ok"),
             ProcessingResult.failed(error="provider error", source_guid="sg-bad"),
         ]
-
-        from dataclasses import replace
 
         context = replace(_make_context(), mode=RunMode.BATCH)
         enriched = processor._enrich(results, context)

--- a/tests/unit/processing/test_unified_processor.py
+++ b/tests/unit/processing/test_unified_processor.py
@@ -413,3 +413,182 @@ class TestProcessingStrategyProtocol:
     def test_lambda_does_not_satisfy_protocol(self):
         # A plain function object does not satisfy a Protocol with invoke method
         assert not isinstance(lambda r, c: [], ProcessingStrategy)
+
+
+# ---------------------------------------------------------------------------
+# F9: Enrichment failure isolation
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentFailureIsolation:
+    """F9: An enrichment failure for one record must not kill the action."""
+
+    def test_enrichment_failure_isolates_to_single_record(self):
+        """Record 1 of 3 fails enrichment — records 0 and 2 still succeed."""
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        class BombOnSecondEnricher(Enricher):
+            def __init__(self):
+                self.call_count = 0
+
+            def enrich(self, result, context):
+                self.call_count += 1
+                if self.call_count == 2:
+                    raise RuntimeError("enrichment explosion")
+                return result
+
+        enricher = BombOnSecondEnricher()
+        pipeline = EnrichmentPipeline(enrichers=[enricher])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+        strategy = NoOpStrategy()
+        records = [_make_record("sg-1"), _make_record("sg-2"), _make_record("sg-3")]
+        context = _make_context()
+
+        output, stats = processor.process(records, context, strategy)
+
+        # Record 1 (index 1) failed enrichment — becomes FAILED
+        assert stats.success == 2
+        assert stats.failed == 1
+
+    def test_enrichment_failure_records_error_message(self):
+        """The failed record carries the enrichment error string."""
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        class AlwaysFailEnricher(Enricher):
+            def enrich(self, result, context):
+                raise ValueError("bad lineage data")
+
+        pipeline = EnrichmentPipeline(enrichers=[AlwaysFailEnricher()])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+
+        # Feed a single result directly through _enrich
+        result = ProcessingResult.success(data=[{"x": 1}], source_guid="sg-fail")
+        context = _make_context()
+        enriched = processor._enrich([result], context)
+
+        assert len(enriched) == 1
+        assert enriched[0].status == ProcessingStatus.FAILED
+        assert "bad lineage data" in enriched[0].error
+
+    def test_enrichment_failure_preserves_source_guid(self):
+        """The failed result carries the original record's source_guid."""
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        class FailEnricher(Enricher):
+            def enrich(self, result, context):
+                raise RuntimeError("boom")
+
+        pipeline = EnrichmentPipeline(enrichers=[FailEnricher()])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+        result = ProcessingResult.success(data=[{"x": 1}], source_guid="sg-preserve-me")
+        context = _make_context()
+        enriched = processor._enrich([result], context)
+
+        assert enriched[0].source_guid == "sg-preserve-me"
+
+
+# ---------------------------------------------------------------------------
+# F6: Batch error results go through enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestBatchErrorEnrichment:
+    """F6: Batch error results (no processing_context) must be enriched."""
+
+    def test_batch_error_result_is_enriched(self):
+        """A batch FAILED result without processing_context gets enriched."""
+        from agent_actions.config.types import RunMode
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        class TagEnricher(Enricher):
+            def enrich(self, result, context):
+                for item in result.data:
+                    item["_enriched"] = True
+                return result
+
+        pipeline = EnrichmentPipeline(enrichers=[TagEnricher()])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+
+        # Simulate a batch error result: FAILED, no processing_context
+        batch_error = ProcessingResult.failed(error="provider timeout", source_guid="sg-batch-err")
+        assert batch_error.processing_context is None
+
+        from dataclasses import replace
+
+        context = replace(_make_context(), mode=RunMode.BATCH)
+        enriched = processor._enrich([batch_error], context)
+
+        # Must have been passed through enrichment (not skipped)
+        assert len(enriched) == 1
+        # The enricher ran — it should not have been skipped
+        assert enriched[0].status == ProcessingStatus.FAILED
+
+    def test_batch_and_online_errors_both_enriched(self):
+        """Both batch and online error results go through the same path."""
+        from agent_actions.config.types import RunMode
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        enrich_calls = []
+
+        class TrackingEnricher(Enricher):
+            def enrich(self, result, context):
+                enrich_calls.append(result.source_guid)
+                return result
+
+        pipeline = EnrichmentPipeline(enrichers=[TrackingEnricher()])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+
+        error_result = ProcessingResult.failed(error="timeout", source_guid="sg-err")
+
+        from dataclasses import replace
+
+        # Online mode
+        ctx_online = replace(_make_context(), mode=RunMode.ONLINE)
+        processor._enrich([error_result], ctx_online)
+
+        # Batch mode
+        ctx_batch = replace(_make_context(), mode=RunMode.BATCH)
+        processor._enrich([error_result], ctx_batch)
+
+        # Both should have been enriched
+        assert enrich_calls == ["sg-err", "sg-err"]
+
+
+# ---------------------------------------------------------------------------
+# F9+F6 interaction: batch error + enrichment failure
+# ---------------------------------------------------------------------------
+
+
+class TestBatchErrorEnrichmentFailure:
+    """Combined: batch error result where enrichment itself throws."""
+
+    def test_batch_error_enrichment_failure_isolated(self):
+        """Batch error result that fails enrichment doesn't kill other records."""
+        from agent_actions.config.types import RunMode
+        from agent_actions.processing.enrichment import Enricher, EnrichmentPipeline
+
+        class FailOnErrorResultEnricher(Enricher):
+            def enrich(self, result, context):
+                if result.status == ProcessingStatus.FAILED:
+                    raise RuntimeError("cannot enrich error result")
+                return result
+
+        pipeline = EnrichmentPipeline(enrichers=[FailOnErrorResultEnricher()])
+        processor = UnifiedProcessor(enrichment_pipeline=pipeline)
+
+        results = [
+            ProcessingResult.success(data=[{"ok": True}], source_guid="sg-ok"),
+            ProcessingResult.failed(error="provider error", source_guid="sg-bad"),
+        ]
+
+        from dataclasses import replace
+
+        context = replace(_make_context(), mode=RunMode.BATCH)
+        enriched = processor._enrich(results, context)
+
+        assert len(enriched) == 2
+        # First record enriched successfully
+        assert enriched[0].status == ProcessingStatus.SUCCESS
+        # Second record: enrichment failed, still gets a FAILED result
+        assert enriched[1].status == ProcessingStatus.FAILED
+        assert "cannot enrich error result" in enriched[1].error


### PR DESCRIPTION
## Summary
- **F9**: Wrap per-record enrichment in try/except — a single enrichment failure now produces a `ProcessingResult.failed()` instead of aborting the entire action
- **F6**: Remove the `RunMode.ONLINE` guard in `_enrich()` so batch error results go through the enrichment pipeline (previously skipped, producing hollow tombstones)

Both fixes land in `unified.py:_enrich()`. The three-way branch (`processing_context` / online fallback / batch skip) is simplified to two paths (own context vs shared fallback) with per-record isolation.

## Verification
- 6 new regression tests: enrichment failure isolation (3), batch error enrichment (2), combined F9+F6 interaction (1)
- 7015 tests pass, 0 failures
- `ruff check` and `ruff format --check` clean