### PR TITLE
fix: empty LLM response records no longer vanish from output (F10)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260519-F10000.yaml
+++ b/.changes/unreleased/Bug Fix-20260519-F10000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix SUCCESS records with empty LLM response vanishing from output — on_empty=warn now returns FAILED, on_empty=skip returns SKIPPED with tombstone"
+time: 2026-05-19T10:00:00.000000Z

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -459,6 +459,35 @@ class OnlineLLMStrategy:
                     },
                 )
 
+            if on_empty == "warn":
+                logger.warning(
+                    "Action '%s' produced empty output for record '%s' — "
+                    "marking as failed (on_empty=warn)",
+                    context.agent_name,
+                    source_guid,
+                )
+                return ProcessingResult.failed(
+                    error=f"Empty LLM response for record '{source_guid}'",
+                    source_guid=source_guid,
+                    source_snapshot=source_snapshot,
+                    input_record=input_record,
+                )
+
+            # on_empty == "skip": silently skip the record
+            tombstone = build_tombstone(
+                context.action_name,
+                input_record,
+                "empty_output",
+                source_guid=source_guid,
+            )
+            return ProcessingResult.skipped(
+                passthrough_data=tombstone,
+                reason="empty_output",
+                source_guid=source_guid,
+                source_snapshot=source_snapshot,
+                input_record=input_record,
+            )
+
         # Transform response
         item_existing_content = (
             extract_existing_content(item, is_first_stage=context.is_first_stage)

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -44,6 +44,7 @@ from agent_actions.processing.types import (
 )
 from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.record.reasons import (
+    EMPTY_OUTPUT,
     GUARD_FILTER,
     GUARD_SKIP,
     LLM_LAYER_GUARD_FILTER,
@@ -460,12 +461,6 @@ class OnlineLLMStrategy:
                 )
 
             if on_empty == "warn":
-                logger.warning(
-                    "Action '%s' produced empty output for record '%s' — "
-                    "marking as failed (on_empty=warn)",
-                    context.agent_name,
-                    source_guid,
-                )
                 return ProcessingResult.failed(
                     error=f"Empty LLM response for record '{source_guid}'",
                     source_guid=source_guid,
@@ -473,16 +468,16 @@ class OnlineLLMStrategy:
                     input_record=input_record,
                 )
 
-            # on_empty == "skip": silently skip the record
+            # on_empty == "skip": produce tombstone so record is visible in output
             tombstone = build_tombstone(
                 context.action_name,
                 input_record,
-                "empty_output",
+                EMPTY_OUTPUT,
                 source_guid=source_guid,
             )
             return ProcessingResult.skipped(
                 passthrough_data=tombstone,
-                reason="empty_output",
+                reason=EMPTY_OUTPUT,
                 source_guid=source_guid,
                 source_snapshot=source_snapshot,
                 input_record=input_record,

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -25,6 +25,9 @@ PREP_FAILED = "prep_failed"
 # -- Batch -------------------------------------------------------------------
 BATCH_NOT_RETURNED = "batch_not_returned"
 
+# -- Empty output ------------------------------------------------------------
+EMPTY_OUTPUT = "empty_output"
+
 # -- Exhaustion --------------------------------------------------------------
 RETRY_EXHAUSTED = "retry_exhausted"
 

--- a/tests/unit/processing/test_online_llm_strategy.py
+++ b/tests/unit/processing/test_online_llm_strategy.py
@@ -344,6 +344,115 @@ class TestProcessRecordEmptyOutput:
         with pytest.raises(EmptyOutputError, match="on_empty=error"):
             strategy.process_record({"field": "value"}, context)
 
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_empty_output_warn_returns_failed(self, mock_fire, mock_get_preparer):
+        """on_empty=warn must return FAILED, not SUCCESS with empty data (F10 regression)."""
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(response={}, executed=True)
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test", "on_empty": "warn"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = ProcessingContext(
+            agent_config={"agent_type": "test", "on_empty": "warn"},
+            agent_name="test",
+        )
+
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.FAILED
+        assert "Empty LLM response" in result.error
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_empty_output_warn_default_returns_failed(self, mock_fire, mock_get_preparer):
+        """Default on_empty (warn) must return FAILED for empty responses (F10 regression)."""
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response=None, executed=True
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = ProcessingContext(
+            agent_config={"agent_type": "test"},
+            agent_name="test",
+        )
+
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.FAILED
+        assert "Empty LLM response" in result.error
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_empty_output_skip_returns_skipped(self, mock_fire, mock_get_preparer):
+        """on_empty=skip must return SKIPPED with tombstone, not SUCCESS with empty data."""
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(response=[], executed=True)
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test", "on_empty": "skip"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = ProcessingContext(
+            agent_config={"agent_type": "test", "on_empty": "skip"},
+            agent_name="test",
+        )
+
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.SKIPPED
+        assert result.skip_reason == "empty_output"
+        assert len(result.data) == 1  # tombstone record
+
+    @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
+    @patch("agent_actions.processing.strategies.online_llm.fire_event")
+    def test_nonempty_output_still_succeeds(self, mock_fire, mock_get_preparer):
+        """Non-empty LLM responses must still produce SUCCESS (F10 guard)."""
+        prepared = _make_prepared()
+        mock_get_preparer.return_value.prepare.return_value = prepared
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response={"result": "data"}, executed=True
+        )
+
+        strategy = OnlineLLMStrategy(
+            agent_config={"agent_type": "test", "on_empty": "warn"},
+            agent_name="test",
+            invocation_strategy=mock_invocation,
+        )
+
+        context = ProcessingContext(
+            agent_config={"agent_type": "test", "on_empty": "warn"},
+            agent_name="test",
+        )
+
+        result = strategy.process_record({"field": "value"}, context)
+
+        assert result.status == ProcessingStatus.SUCCESS
+        assert len(result.data) > 0
+
 
 # ---------------------------------------------------------------------------
 # invoke — batch loop

--- a/tests/unit/processing/test_online_llm_strategy.py
+++ b/tests/unit/processing/test_online_llm_strategy.py
@@ -18,6 +18,7 @@ from agent_actions.processing.types import (
     RetryMetadata,
 )
 from agent_actions.processing.unified import ProcessingStrategy
+from agent_actions.record.reasons import EMPTY_OUTPUT
 from agent_actions.record.state import RecordState
 
 
@@ -422,7 +423,7 @@ class TestProcessRecordEmptyOutput:
         result = strategy.process_record({"field": "value"}, context)
 
         assert result.status == ProcessingStatus.SKIPPED
-        assert result.skip_reason == "empty_output"
+        assert result.skip_reason == EMPTY_OUTPUT
         assert len(result.data) == 1  # tombstone record
 
     @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")


### PR DESCRIPTION
## Summary
- **Bug**: When `on_empty=warn` (the default), an empty LLM response produced `ProcessingResult.success()` with `data=[]`. The result collector wrote `DISPOSITION_SUCCESS` but added zero rows to output — the record silently vanished.
- **Fix**: `on_empty=warn` now returns `ProcessingResult.failed()` so the record gets `DISPOSITION_FAILED` and surfaces in error reporting. `on_empty=skip` now returns `ProcessingResult.skipped()` with a tombstone record so it appears in output with a skip reason.
- No changes to `on_empty=error` behavior (still raises `EmptyOutputError`).

## Verification
- 4 new regression tests covering warn (explicit + default), skip, and a guard test confirming non-empty responses still succeed
- Full test suite: 7013 passed, 2 skipped
- `ruff check` and `ruff format --check` clean