### PR TITLE
fix: resolve mypy type errors in batch manager and submission

### DIFF
--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -287,6 +287,8 @@ class BatchSubmissionService:
         batch_id: str | None,
     ) -> None:
         """Stamp DISPOSITION_DEFERRED for all INCLUDED records after submission."""
+        if not self._storage_backend:
+            return
         for custom_id, entry in context_map.items():
             if BatchContextMetadata.get_filter_status(entry) != FilterStatus.INCLUDED:
                 continue

--- a/agent_actions/workflow/managers/batch.py
+++ b/agent_actions/workflow/managers/batch.py
@@ -202,8 +202,8 @@ class BatchLifecycleManager:
             for disp in _TERMINAL_DISPOSITIONS:
                 for r in self.storage_backend.get_disposition(agent_name, disposition=disp):
                     rid = r.get("record_id")
-                    if rid in deferred_ids:
-                        terminal_ids.add(rid)
+                    if rid and rid in deferred_ids:
+                        terminal_ids.add(str(rid))
                 if not (deferred_ids - terminal_ids):
                     return
 


### PR DESCRIPTION
## Summary

- `batch.py:206` — `rid` from `r.get("record_id")` is `Any | None`; guard None before `set.add(str)`
- `submission.py:295` — `self._storage_backend` is `Any | None`; early return when None before passing to `_safe_set_disposition`

Fixes CI mypy failures blocking the integration → main merge.

## Verification

- `uv run mypy` passes on both files