### PR TITLE
refactor: extract zero-success check into CollectionStats.raise_if_terminal_failure()

### DIFF
--- a/.changes/unreleased/Under the Hood-20260521-420000.yaml
+++ b/.changes/unreleased/Under the Hood-20260521-420000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Extract duplicated zero-success / only-guard-outcomes check into CollectionStats.raise_if_terminal_failure(), called from both pipeline.py and initial_pipeline.py"
+time: 2026-05-21T04:20:00.000000Z

--- a/agent_actions/input/preprocessing/staging/_MANIFEST.md
+++ b/agent_actions/input/preprocessing/staging/_MANIFEST.md
@@ -43,5 +43,6 @@ The reserved names come from `SPECIAL_NAMESPACES` in `utils/constants.py`.
 
 ### Zero-success failure check (`initial_pipeline.py`)
 
-Mirrors the check in `workflow/pipeline.py`. See `workflow/_MANIFEST.md` design note for
+Delegates to `CollectionStats.raise_if_terminal_failure()` (in
+`processing/result_collector.py`). See `workflow/_MANIFEST.md` design note for
 full rationale on why `stats.success == 0` is used instead of `not output`.

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -18,7 +18,7 @@ from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
 from agent_actions.processing.types import ProcessingContext
 from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.prompt.formatter import PromptFormatter
-from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
+from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import CHUNK_CONFIG_KEY, MODEL_VENDOR_KEY
 
@@ -675,27 +675,9 @@ def _process_online_mode_with_record_processor(
 
     processed_items, stats = processor.process(data_chunk, processing_context, strategy)
 
-    # Signal node-level SKIP only when output is truly empty and the
-    # only outcomes were guard-skip / guard-filter.  Guard-skipped
-    # records with passthrough data ARE in `processed_items`, so
-    # `not processed_items` prevents cascade-blocking when passthrough
-    # data exists.
-    if data_chunk and stats.only_guard_outcomes and not processed_items:
-        write_node_level_disposition(
-            ctx.storage_backend,
-            ctx.agent_name,
-            DISPOSITION_SKIPPED,
-            "All records filtered — no output produced",
-        )
-
-    # Zero-success failure: raise so executor marks FAILED and circuit
-    # breaker skips downstream.  See _MANIFEST.md design note for rationale.
-    if data_chunk and stats.success == 0 and (stats.failed + stats.exhausted) > 0:
-        raise RuntimeError(
-            f"Action '{ctx.agent_name}' produced 0 successful records — "
-            f"all {len(data_chunk)} input item(s) failed or exhausted "
-            f"({stats.failed} failed, {stats.exhausted} exhausted)"
-        )
+    stats.raise_if_terminal_failure(
+        ctx.agent_name, data_chunk, processed_items, ctx.storage_backend
+    )
 
     # Tool actions that return empty output should be treated as failures
     # rather than silently succeeding (mirrors pipeline.py check).

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -33,6 +33,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
     DISPOSITION_PASSTHROUGH,
+    DISPOSITION_SKIPPED,
     DISPOSITION_SUCCESS,
     DISPOSITION_UNPROCESSED,
     NODE_LEVEL_RECORD_ID,
@@ -87,6 +88,47 @@ class CollectionStats:
         """
         total: int = sum(getattr(self, f.name) for f in fields(self))
         return bool((self.skipped + self.filtered) == total)
+
+    def raise_if_terminal_failure(
+        self,
+        action_name: str,
+        data: list,
+        output: list,
+        storage_backend: Optional["StorageBackend"] = None,
+    ) -> None:
+        """Raise RuntimeError if all active records failed.
+
+        Handles two cases:
+
+        1. **only_guard_outcomes** with no output — write a node-level
+           SKIPPED disposition so the executor can cascade-skip downstream.
+        2. **zero successes** among active (non-unprocessed) input records
+           with at least one failure — raise ``RuntimeError`` for the
+           circuit breaker.
+        """
+        # Guard-only outcome: signal node-level SKIP when output is truly
+        # empty.  Guard-skipped records with passthrough data ARE in
+        # ``output``, so ``not output`` prevents cascade-blocking when
+        # passthrough data exists.
+        if data and self.only_guard_outcomes and not output:
+            write_node_level_disposition(
+                storage_backend,
+                action_name,
+                DISPOSITION_SKIPPED,
+                "All records filtered — no output produced",
+            )
+            return
+
+        # Exclude cascade-quarantined records from the denominator: if all
+        # ACTIVE input records failed but some records were quarantined
+        # pass-throughs, the action should not be marked FAILED.
+        active_input_count = len(data) - self.unprocessed
+        if active_input_count > 0 and self.success == 0 and (self.failed + self.exhausted) > 0:
+            raise RuntimeError(
+                f"Action '{action_name}' produced 0 successful records — "
+                f"all {active_input_count} active input item(s) failed or exhausted "
+                f"({self.failed} failed, {self.exhausted} exhausted)"
+            )
 
 
 def _build_failed_tombstone(

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -102,14 +102,15 @@ class CollectionStats:
 
         1. **only_guard_outcomes** with no output — write a node-level
            SKIPPED disposition so the executor can cascade-skip downstream.
+           Guard-skipped records with passthrough data ARE in ``output``,
+           so ``not output`` prevents cascade-blocking when passthrough
+           data exists.
         2. **zero successes** among active (non-unprocessed) input records
            with at least one failure — raise ``RuntimeError`` for the
-           circuit breaker.
+           circuit breaker.  Unprocessed (cascade-quarantined) records are
+           excluded from the denominator so pass-through-only actions
+           don't erroneously trip the breaker.
         """
-        # Guard-only outcome: signal node-level SKIP when output is truly
-        # empty.  Guard-skipped records with passthrough data ARE in
-        # ``output``, so ``not output`` prevents cascade-blocking when
-        # passthrough data exists.
         if data and self.only_guard_outcomes and not output:
             write_node_level_disposition(
                 storage_backend,
@@ -119,9 +120,6 @@ class CollectionStats:
             )
             return
 
-        # Exclude cascade-quarantined records from the denominator: if all
-        # ACTIVE input records failed but some records were quarantined
-        # pass-throughs, the action should not be marked FAILED.
         active_input_count = len(data) - self.unprocessed
         if active_input_count > 0 and self.success == 0 and (self.failed + self.exhausted) > 0:
             raise RuntimeError(

--- a/agent_actions/workflow/_MANIFEST.md
+++ b/agent_actions/workflow/_MANIFEST.md
@@ -32,12 +32,13 @@ Agent Actions.
 
 ## Design Notes
 
-### Zero-success failure check (`pipeline.py`)
+### Zero-success failure check
 
-Both `pipeline.py` and `initial_pipeline.py` raise `RuntimeError` when `stats.success == 0`
-and `stats.failed + stats.exhausted > 0`. This uses `stats.success` rather than `not output`
-because EXHAUSTED records produce tombstone data that inflates the output list despite
-representing zero real successes.
+Both `pipeline.py` and `initial_pipeline.py` delegate to
+`CollectionStats.raise_if_terminal_failure()` (in `processing/result_collector.py`).
+The method uses `stats.success` rather than `not output` because EXHAUSTED records
+produce tombstone data that inflates the output list despite representing zero real
+successes.
 
 This intentionally overrides `on_exhausted="return_last"` when ALL records exhaust.
 `return_last` is designed for partial failures where some records succeed alongside exhausted

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -22,7 +22,7 @@ from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
 from agent_actions.processing.types import ProcessingContext
 from agent_actions.processing.unified import ProcessingStrategy, UnifiedProcessor
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
-from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
+from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 from agent_actions.utils.safe_format import safe_format_error
@@ -582,33 +582,9 @@ class ProcessingPipeline:
             # RECORD mode — UnifiedProcessor handles guard + invoke + enrich + collect
             output, stats = self._unified_processor.process(data, context, strategy)
 
-        # Signal node-level SKIP only when output is truly empty and the
-        # only outcomes were guard-skip / guard-filter.  Guard-skipped
-        # records with passthrough data ARE in `output`, so `not output`
-        # prevents cascade-blocking when passthrough data exists.
-        if data and stats.only_guard_outcomes and not output:
-            write_node_level_disposition(
-                self.config.storage_backend,
-                self.config.action_name,
-                DISPOSITION_SKIPPED,
-                "All records filtered — no output produced",
-            )
-
-        # Zero-success failure: raise so executor marks FAILED and circuit
-        # breaker skips downstream.  Uses stats.success (not `not output`)
-        # because EXHAUSTED tombstones inflate the output list.
-        #
-        # Exclude cascade-quarantined records from the denominator: if all
-        # ACTIVE input records failed but some records were quarantined
-        # pass-throughs, the action should not be marked FAILED (the
-        # quarantined records flow through untouched).
-        active_input_count = len(data) - stats.unprocessed
-        if active_input_count > 0 and stats.success == 0 and (stats.failed + stats.exhausted) > 0:
-            raise RuntimeError(
-                f"Action '{self.config.action_name}' produced 0 successful records — "
-                f"all {active_input_count} active input item(s) failed or exhausted "
-                f"({stats.failed} failed, {stats.exhausted} exhausted)"
-            )
+        stats.raise_if_terminal_failure(
+            self.config.action_name, data, output, self.config.storage_backend
+        )
 
         self.output_handler.save_main_output(output, file_path, base_directory, output_directory)
 

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -682,6 +682,91 @@ class TestCollectionStatsOnlyGuardOutcomes:
 
 
 # ---------------------------------------------------------------------------
+# raise_if_terminal_failure tests
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseIfTerminalFailure:
+    """Tests for CollectionStats.raise_if_terminal_failure.
+
+    Covers the guard-only disposition path, the zero-success circuit breaker,
+    and the unprocessed-exclusion edge case that was previously inconsistent
+    between pipeline.py and initial_pipeline.py.
+    """
+
+    def test_guard_only_writes_skipped_disposition(self):
+        """All guard outcomes + empty output → write SKIPPED, no raise."""
+        stats = CollectionStats(skipped=3)
+        backend = MagicMock()
+        # Should not raise
+        stats.raise_if_terminal_failure("act", [1, 2, 3], [], backend)
+        backend.set_disposition.assert_called_once()
+        call_args = backend.set_disposition.call_args
+        assert call_args[0][2] == "skipped"
+
+    def test_guard_only_with_output_does_not_write(self):
+        """Guard outcomes but output exists (passthrough) → no disposition, no raise."""
+        stats = CollectionStats(skipped=2)
+        backend = MagicMock()
+        stats.raise_if_terminal_failure("act", [1, 2], [{"data": 1}], backend)
+        backend.set_disposition.assert_not_called()
+
+    def test_zero_success_all_failed_raises(self):
+        """All records failed → RuntimeError."""
+        stats = CollectionStats(failed=3)
+        with pytest.raises(RuntimeError, match="0 successful records"):
+            stats.raise_if_terminal_failure("act", [1, 2, 3], [])
+
+    def test_zero_success_all_exhausted_raises(self):
+        """All records exhausted → RuntimeError."""
+        stats = CollectionStats(exhausted=2)
+        with pytest.raises(RuntimeError, match="0 successful records"):
+            stats.raise_if_terminal_failure("act", [1, 2], [])
+
+    def test_zero_success_mixed_failed_exhausted_raises(self):
+        """Mixed failed + exhausted → RuntimeError."""
+        stats = CollectionStats(failed=2, exhausted=1)
+        with pytest.raises(RuntimeError, match="3 active input"):
+            stats.raise_if_terminal_failure("act", [1, 2, 3], [])
+
+    def test_some_success_does_not_raise(self):
+        """At least one success → no raise."""
+        stats = CollectionStats(success=1, failed=2)
+        stats.raise_if_terminal_failure("act", [1, 2, 3], [{"ok": True}])
+
+    def test_unprocessed_excluded_from_denominator(self):
+        """Unprocessed (cascade-quarantined) records don't count as active input.
+
+        3 input records, all 3 unprocessed (0 active) → no raise even though
+        success == 0 and the input list is non-empty.
+        """
+        stats = CollectionStats(unprocessed=3)
+        # Should not raise — active_input_count is 0
+        stats.raise_if_terminal_failure("act", [1, 2, 3], [])
+
+    def test_unprocessed_with_failures_raises_for_active(self):
+        """2 unprocessed + 1 failed → active_input_count is 1, raises."""
+        stats = CollectionStats(unprocessed=2, failed=1)
+        with pytest.raises(RuntimeError, match="1 active input"):
+            stats.raise_if_terminal_failure("act", [1, 2, 3], [])
+
+    def test_empty_data_does_not_raise(self):
+        """Empty input → no raise regardless of stats."""
+        stats = CollectionStats(failed=5)
+        stats.raise_if_terminal_failure("act", [], [])
+
+    def test_no_backend_guard_only_does_not_crash(self):
+        """Guard-only with no storage backend → no crash, no disposition write."""
+        stats = CollectionStats(filtered=2)
+        stats.raise_if_terminal_failure("act", [1, 2], [])
+
+    def test_deferred_only_does_not_raise(self):
+        """All deferred, zero success → no raise (no failed/exhausted)."""
+        stats = CollectionStats(deferred=3)
+        stats.raise_if_terminal_failure("act", [1, 2, 3], [])
+
+
+# ---------------------------------------------------------------------------
 # _data_has_parse_error helper tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Extracted the duplicated zero-success / only-guard-outcomes check from `pipeline.py` and `initial_pipeline.py` into `CollectionStats.raise_if_terminal_failure()` in `result_collector.py`
- The `initial_pipeline.py` copy previously did not subtract `stats.unprocessed` from the active input denominator — now consistent with `pipeline.py`'s refined logic
- Removed unused `DISPOSITION_SKIPPED` imports from both call sites

## Verification
- `ruff format --check` + `ruff check`: clean
- `pytest`: 7071 passed, 2 skipped (2 pre-existing failures in ollama vendor split and JSON parsing deselected — unrelated)
- `grep -r 'stats.success == 0' agent_actions/` returns only `_MANIFEST.md` references, not inline code