### PR TITLE
fix: reclassify missing-field errors in action-level GuardStrategy

### DIFF
--- a/.changes/unreleased/Bug Fix-20260521-419001.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-419001.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Action-level GuardStrategy now reclassifies missing-field errors instead of silently passing through, matching per-record guard evaluation parity"
+time: 2026-05-21T04:19:01.000000Z

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -101,6 +101,63 @@ class GuardResult:
         return cls.passed()
 
 
+def reclassify_missing_field_error(filter_result: FilterResult, clause: str) -> FilterResult:
+    """Reclassify DATA errors for missing fields in namespaced content.
+
+    With namespaced content, guard conditions must use dotted paths
+    (e.g., ``validate.pass == false``).  Two cases are handled:
+
+    1. **Flat field with namespace match** — the field exists inside a
+       namespace but was referenced without the prefix.  Reclassified as
+       SEMANTIC so the guard behavior always applies (bypasses
+       ``passthrough_on_error``).
+    2. **Genuinely missing field** — the field does not exist anywhere.
+       Treated as *condition not matched* so the guard behavior applies
+       instead of silently passing.
+
+    This is a standalone function so it can be called from any guard
+    evaluation path (GuardEvaluator, GuardStrategy, etc.).
+    """
+    if (
+        filter_result.success
+        or filter_result.error_category != ErrorCategory.DATA
+        or not filter_result.error
+    ):
+        return filter_result
+
+    # Only reclassify MissingFieldError-originated errors
+    if "does not exist in the data" not in filter_result.error:
+        return filter_result
+
+    if "Did you mean:" in filter_result.error:
+        # Flat field reference that exists in a namespace → semantic error
+        logger.warning(
+            "Guard: flat field reference in condition '%s'. "
+            "Content is namespaced — use dotted paths (e.g., action_name.field). %s",
+            clause,
+            filter_result.error,
+        )
+        return FilterResult(
+            success=False,
+            error=filter_result.error,
+            error_category=ErrorCategory.SEMANTIC,
+            execution_time=filter_result.execution_time,
+        )
+
+    # Field genuinely missing → treat as condition not matched
+    logger.debug(
+        "Guard: field not found in condition '%s', treating as not matched: %s",
+        clause,
+        filter_result.error,
+    )
+    return FilterResult(
+        success=True,
+        matched=False,
+        error=filter_result.error,
+        execution_time=filter_result.execution_time,
+    )
+
+
 class GuardEvaluator:
     """Unified guard evaluation for batch and online modes."""
 
@@ -205,57 +262,8 @@ class GuardEvaluator:
     def _reclassify_missing_field_error(
         self, filter_result: FilterResult, clause: str
     ) -> FilterResult:
-        """Reclassify DATA errors for missing fields in namespaced content.
-
-        With namespaced content, guard conditions must use dotted paths
-        (e.g., ``validate.pass == false``).  Two cases are handled:
-
-        1. **Flat field with namespace match** — the field exists inside a
-           namespace but was referenced without the prefix.  Reclassified as
-           SEMANTIC so the guard behavior always applies (bypasses
-           ``passthrough_on_error``).
-        2. **Genuinely missing field** — the field does not exist anywhere.
-           Treated as *condition not matched* so the guard behavior applies
-           instead of silently passing.
-        """
-        if (
-            filter_result.success
-            or filter_result.error_category != ErrorCategory.DATA
-            or not filter_result.error
-        ):
-            return filter_result
-
-        # Only reclassify MissingFieldError-originated errors
-        if "does not exist in the data" not in filter_result.error:
-            return filter_result
-
-        if "Did you mean:" in filter_result.error:
-            # Flat field reference that exists in a namespace → semantic error
-            logger.warning(
-                "Guard: flat field reference in condition '%s'. "
-                "Content is namespaced — use dotted paths (e.g., action_name.field). %s",
-                clause,
-                filter_result.error,
-            )
-            return FilterResult(
-                success=False,
-                error=filter_result.error,
-                error_category=ErrorCategory.SEMANTIC,
-                execution_time=filter_result.execution_time,
-            )
-
-        # Field genuinely missing → treat as condition not matched
-        logger.debug(
-            "Guard: field not found in condition '%s', treating as not matched: %s",
-            clause,
-            filter_result.error,
-        )
-        return FilterResult(
-            success=True,
-            matched=False,
-            error=filter_result.error,
-            execution_time=filter_result.execution_time,
-        )
+        """Delegate to module-level reclassify_missing_field_error."""
+        return reclassify_missing_field_error(filter_result, clause)
 
     def _prepare_eval_context(self, context: Any) -> dict[str, Any]:
         """Promote content namespaces to top-level keys for guard evaluation.

--- a/agent_actions/input/preprocessing/filtering/evaluator.py
+++ b/agent_actions/input/preprocessing/filtering/evaluator.py
@@ -238,7 +238,7 @@ class GuardEvaluator:
             request = FilterItemRequest(data=eval_context, condition=clause)
             filter_result = self._filter.filter_item(request)
 
-            filter_result = self._reclassify_missing_field_error(filter_result, clause)
+            filter_result = reclassify_missing_field_error(filter_result, clause)
 
             return GuardResult.from_filter_result(filter_result, behavior, passthrough_on_error)
 
@@ -258,12 +258,6 @@ class GuardEvaluator:
             if behavior == GuardBehavior.SKIP:
                 return GuardResult.skipped(error=str(e))
             return GuardResult.filtered(error=str(e))
-
-    def _reclassify_missing_field_error(
-        self, filter_result: FilterResult, clause: str
-    ) -> FilterResult:
-        """Delegate to module-level reclassify_missing_field_error."""
-        return reclassify_missing_field_error(filter_result, clause)
 
     def _prepare_eval_context(self, context: Any) -> dict[str, Any]:
         """Promote content namespaces to top-level keys for guard evaluation.

--- a/agent_actions/workflow/managers/skip.py
+++ b/agent_actions/workflow/managers/skip.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from rich.console import Console
 
+from agent_actions.input.preprocessing.filtering.evaluator import (
+    reclassify_missing_field_error,
+)
 from agent_actions.input.preprocessing.filtering.guard_filter import (
+    ErrorCategory,
     FilterItemRequest,
     get_global_guard_filter,
 )
@@ -194,7 +198,22 @@ class GuardStrategy(SkipStrategy):
                 )
             )
 
+            # Reclassify missing-field DATA errors so they apply guard
+            # behavior instead of silently passing via passthrough_on_error.
+            filter_result = reclassify_missing_field_error(filter_result, guard_clause)
+
             if not filter_result.success:
+                # SEMANTIC errors (e.g. flat field reference in namespaced
+                # content) always apply guard behavior — they bypass
+                # passthrough_on_error, matching GuardEvaluator parity.
+                if filter_result.error_category == ErrorCategory.SEMANTIC:
+                    fire_event(
+                        ActionSkipEvent(
+                            action_name=agent_name,
+                            skip_reason=f"guard semantic error: {filter_result.error}",
+                        )
+                    )
+                    return True
                 error_msg = filter_result.error or "Unknown filter error"
                 return self._handle_filter_error(agent_name, error_msg, passthrough_on_error)
 

--- a/agent_actions/workflow/managers/skip.py
+++ b/agent_actions/workflow/managers/skip.py
@@ -204,8 +204,9 @@ class GuardStrategy(SkipStrategy):
 
             if not filter_result.success:
                 # SEMANTIC errors (e.g. flat field reference in namespaced
-                # content) always apply guard behavior — they bypass
-                # passthrough_on_error, matching GuardEvaluator parity.
+                # content) always skip — unlike GuardResult.from_filter_result
+                # which dispatches on behavior (skip/filter/warn), action-level
+                # guards only have a binary outcome (skip or don't skip).
                 if filter_result.error_category == ErrorCategory.SEMANTIC:
                     fire_event(
                         ActionSkipEvent(

--- a/tests/preprocessing/test_guard_evaluator.py
+++ b/tests/preprocessing/test_guard_evaluator.py
@@ -11,6 +11,7 @@ import pytest
 from agent_actions.input.preprocessing.filtering.evaluator import (
     GuardEvaluator,
     GuardResult,
+    reclassify_missing_field_error,
 )
 from agent_actions.input.preprocessing.filtering.guard_filter import (
     FilterResult,
@@ -711,15 +712,15 @@ class TestNamespacedContentGuardEvaluation:
         semantic = FilterResult(
             success=False, error="broken condition", error_category=ErrorCategory.SEMANTIC
         )
-        assert evaluator._reclassify_missing_field_error(semantic, "x == y") is semantic
+        assert reclassify_missing_field_error(semantic, "x == y") is semantic
 
         timeout = FilterResult(
             success=False, error="timed out", error_category=ErrorCategory.TIMEOUT
         )
-        assert evaluator._reclassify_missing_field_error(timeout, "x == y") is timeout
+        assert reclassify_missing_field_error(timeout, "x == y") is timeout
 
         success = FilterResult(success=True, matched=True)
-        assert evaluator._reclassify_missing_field_error(success, "x == y") is success
+        assert reclassify_missing_field_error(success, "x == y") is success
 
     def test_reclassify_ignores_parse_errors(self, evaluator):
         """_reclassify_missing_field_error does not reclassify parse errors."""
@@ -733,7 +734,7 @@ class TestNamespacedContentGuardEvaluation:
             error="Error evaluating guard condition: Parse error: unexpected token",
             error_category=ErrorCategory.DATA,
         )
-        result = evaluator._reclassify_missing_field_error(parse_err, "bad syntax")
+        result = reclassify_missing_field_error(parse_err, "bad syntax")
 
         # Should return the same object — not reclassified
         assert result is parse_err
@@ -746,7 +747,7 @@ class TestNamespacedContentGuardEvaluation:
         )
 
         no_msg = FilterResult(success=False, error=None, error_category=ErrorCategory.DATA)
-        result = evaluator._reclassify_missing_field_error(no_msg, "x == y")
+        result = reclassify_missing_field_error(no_msg, "x == y")
 
         assert result is no_msg
 
@@ -849,7 +850,7 @@ class TestGuardMissingFieldLogNoise:
             error="Error evaluating guard condition: cannot compare types",
             error_category=ErrorCategory.DATA,
         )
-        result = evaluator._reclassify_missing_field_error(raw, "x > y")
+        result = reclassify_missing_field_error(raw, "x > y")
 
         assert result.error_category == ErrorCategory.DATA
         assert not result.success

--- a/tests/unit/workflow/managers/test_skip_strategies.py
+++ b/tests/unit/workflow/managers/test_skip_strategies.py
@@ -23,6 +23,8 @@ class FakeFilterResult:
     success: bool
     matched: bool = False
     error: str | None = None
+    error_category: object | None = None
+    execution_time: float = 0.0
 
 
 def _make_filter(result: FakeFilterResult):
@@ -315,6 +317,107 @@ class TestGuardStrategy:
         call_args = filt.filter_item.call_args[0][0]
         # Multi-item list should remain as-is
         assert call_args.data["extract"] == [{"id": 1}, {"id": 2}]
+
+    # ── Missing field reclassification tests ──
+
+    def test_missing_upstream_skips_action(self, strategy):
+        """Guard on missing upstream action skips instead of passing through.
+
+        Before the fix, a missing field produced a DATA error that
+        passthrough_on_error=True (default) let through silently.
+        After reclassification, the missing field is treated as
+        matched=False → action is skipped.
+        """
+        from agent_actions.input.preprocessing.filtering.guard_filter import (
+            ErrorCategory,
+            FilterResult,
+        )
+
+        # Simulate GuardFilter response for a field that doesn't exist
+        result = FilterResult(
+            success=False,
+            error="Field 'classify.category' does not exist in the data",
+            error_category=ErrorCategory.DATA,
+        )
+        filt = _make_filter(result)
+        cfg = {
+            "guard": {
+                "scope": "action",
+                "clause": 'classify.category == "urgent"',
+                "passthrough_on_error": True,
+            },
+            "agent_type": "triage",
+        }
+        # previous_outputs does NOT contain 'classify'
+        with patch(GUARD_FILTER_PATH, return_value=filt), patch(FIRE_EVENT_PATH) as mock_fire:
+            should_skip = strategy.should_skip(cfg, {})
+
+        assert should_skip is True
+        mock_fire.assert_called_once()
+        event = mock_fire.call_args[0][0]
+        assert event.action_name == "triage"
+
+    def test_present_upstream_matching_does_not_skip(self, strategy):
+        """Guard on present upstream with matching value → action runs."""
+        filt = _make_filter(FakeFilterResult(success=True, matched=True))
+        cfg = {
+            "guard": {
+                "scope": "action",
+                "clause": 'classify.category == "urgent"',
+            },
+            "agent_type": "triage",
+        }
+        previous_outputs = {"classify": [{"category": "urgent"}]}
+        with patch(GUARD_FILTER_PATH, return_value=filt):
+            assert strategy.should_skip(cfg, previous_outputs) is False
+
+    def test_present_upstream_non_matching_skips(self, strategy):
+        """Guard on present upstream with non-matching value → action skipped."""
+        filt = _make_filter(FakeFilterResult(success=True, matched=False))
+        cfg = {
+            "guard": {
+                "scope": "action",
+                "clause": 'classify.category == "urgent"',
+            },
+            "agent_type": "triage",
+        }
+        previous_outputs = {"classify": [{"category": "low"}]}
+        with patch(GUARD_FILTER_PATH, return_value=filt), patch(FIRE_EVENT_PATH):
+            assert strategy.should_skip(cfg, previous_outputs) is True
+
+    def test_semantic_error_always_skips_regardless_of_passthrough(self, strategy):
+        """SEMANTIC errors bypass passthrough_on_error and always skip.
+
+        This matches GuardEvaluator parity: semantic errors (e.g. flat
+        field reference in namespaced content) are structural config
+        mistakes that should not be silently passed through.
+        """
+        from agent_actions.input.preprocessing.filtering.guard_filter import (
+            ErrorCategory,
+            FilterResult,
+        )
+
+        # After reclassification, a flat-field-in-namespace error becomes SEMANTIC
+        result = FilterResult(
+            success=False,
+            error="Field 'category' does not exist in the data. Did you mean: classify.category?",
+            error_category=ErrorCategory.DATA,
+        )
+        filt = _make_filter(result)
+        cfg = {
+            "guard": {
+                "scope": "action",
+                "clause": 'category == "urgent"',
+                "passthrough_on_error": True,
+            },
+            "agent_type": "triage",
+        }
+        with patch(GUARD_FILTER_PATH, return_value=filt), patch(FIRE_EVENT_PATH) as mock_fire:
+            should_skip = strategy.should_skip(cfg, {})
+
+        # Should skip despite passthrough_on_error=True
+        assert should_skip is True
+        mock_fire.assert_called_once()
 
 
 # ── LegacySkipIfStrategy ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `GuardStrategy.should_skip()` was calling `GuardFilter.filter_item()` directly, bypassing `_reclassify_missing_field_error` — missing upstream fields silently passed through instead of skipping the action
- Extracted `_reclassify_missing_field_error` from `GuardEvaluator` into a standalone `reclassify_missing_field_error()` function and wired it into `GuardStrategy.should_skip()`
- Added SEMANTIC error handling that bypasses `passthrough_on_error`, matching `GuardEvaluator` parity

## Verification
- 4 new tests: missing upstream skips, present upstream matching/non-matching, SEMANTIC error bypasses passthrough
- All 37 skip strategy tests pass (33 existing + 4 new)
- Full suite: 7077 passed, 0 failures
- ruff check + format clean