### PR TITLE
fix: reprompt metadata parity — counters, validation name, per-record attempts (spec 417)

### DIFF
--- a/.changes/unreleased/Bug Fix-20260521-417000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-417000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch reprompt metadata now matches online shape — failure-type counters populated, validation name is actual UDF name, per-record attempt counts used instead of global counter"
+time: 2026-05-21T04:17:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260521-418000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-418000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch parse errors now detected before UDF validation — classified as parse_error (not udf_fail), get JSON-specific feedback, and cannot accidentally pass loose UDFs"
+time: 2026-05-21T04:18:00.000000Z

--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -55,6 +55,10 @@ class RecoveryState:
     # Which evaluation strategy is active (e.g., "validation", "critique")
     evaluation_strategy_name: str | None = None
 
+    # Per-record failure type counts accumulated across recovery rounds.
+    # Maps custom_id → {"parse_error": N, "udf_fail": M, "schema_fail": K}
+    failure_type_counts: dict[str, dict[str, int]] = field(default_factory=dict)
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict without deep-copying already-serialized lists.
 
@@ -77,6 +81,7 @@ class RecoveryState:
             "accumulated_results": self.accumulated_results,
             "graduated_results": self.graduated_results,
             "evaluation_strategy_name": self.evaluation_strategy_name,
+            "failure_type_counts": self.failure_type_counts,
         }
 
 

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -402,7 +402,10 @@ def check_and_submit_reprompt(
 
     current_attempt = recovery_state.reprompt_attempt if recovery_state else 0
 
-    ftc: dict[str, dict[str, int]] = {}
+    # Seed from prior-round counts (if resuming from persisted state)
+    ftc: dict[str, dict[str, int]] = (
+        dict(recovery_state.failure_type_counts) if recovery_state else {}
+    )
     accumulate_failure_types(ftc, failure_types)
 
     if current_attempt >= max_attempts:
@@ -454,6 +457,7 @@ def check_and_submit_reprompt(
         retry_attempt=recovery_state.retry_attempt if recovery_state else 0,
         retry_max_attempts=recovery_state.retry_max_attempts if recovery_state else 3,
         accumulated_results=list(recovery_state.accumulated_results) if recovery_state else [],
+        failure_type_counts=ftc,
     )
     for fr in repromptable:
         state.reprompt_attempts_per_record[fr.custom_id] = (

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -268,7 +268,7 @@ def handle_reprompt_recovery(
         )
 
     loop, strategy, _ = setup
-    graduated, still_failing = loop.split(recovery_results)
+    graduated, still_failing, _failure_types = loop.split(recovery_results)
     loop.tag_graduated(graduated)
     state.graduated_results.extend(BatchRetryService.serialize_results(graduated))
     state.evaluation_strategy_name = strategy.name
@@ -386,7 +386,7 @@ def check_and_submit_reprompt(
     max_attempts = strategy.max_attempts
     on_exhausted = strategy.on_exhausted
 
-    graduated, still_failing = loop.split(batch_results)
+    graduated, still_failing, _failure_types = loop.split(batch_results)
     loop.tag_graduated(graduated)
 
     # Filter out records with None content (provider failures, not content quality issues)

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -35,6 +35,7 @@ from agent_actions.logging.events.validation_events import (
     RepromptRecoveredEvent,
     RepromptRetryEvent,
 )
+from agent_actions.processing.evaluation.loop import accumulate_failure_types
 from agent_actions.processing.types import RecoveryMetadata
 
 if TYPE_CHECKING:
@@ -273,10 +274,7 @@ def handle_reprompt_recovery(
     state.graduated_results.extend(BatchRetryService.serialize_results(graduated))
     state.evaluation_strategy_name = validation_name
 
-    # Accumulate failure type counts per record across rounds
-    for cid, ftype in failure_types.items():
-        per_record = state.failure_type_counts.setdefault(cid, {})
-        per_record[ftype] = per_record.get(ftype, 0) + 1
+    accumulate_failure_types(state.failure_type_counts, failure_types)
 
     if still_failing and state.reprompt_attempt < state.reprompt_max_attempts:
         next_attempt = state.reprompt_attempt + 1
@@ -404,11 +402,8 @@ def check_and_submit_reprompt(
 
     current_attempt = recovery_state.reprompt_attempt if recovery_state else 0
 
-    # Build per-record failure type counts from this split
     ftc: dict[str, dict[str, int]] = {}
-    for cid, ftype in failure_types.items():
-        per_record = ftc.setdefault(cid, {})
-        per_record[ftype] = per_record.get(ftype, 0) + 1
+    accumulate_failure_types(ftc, failure_types)
 
     if current_attempt >= max_attempts:
         failed_ids = {r.custom_id for r in still_failing}

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -267,11 +267,16 @@ def handle_reprompt_recovery(
             start_time,
         )
 
-    loop, strategy, _ = setup
-    graduated, still_failing, _failure_types = loop.split(recovery_results)
+    loop, strategy, validation_name = setup
+    graduated, still_failing, failure_types = loop.split(recovery_results)
     loop.tag_graduated(graduated)
     state.graduated_results.extend(BatchRetryService.serialize_results(graduated))
-    state.evaluation_strategy_name = strategy.name
+    state.evaluation_strategy_name = validation_name
+
+    # Accumulate failure type counts per record across rounds
+    for cid, ftype in failure_types.items():
+        per_record = state.failure_type_counts.setdefault(cid, {})
+        per_record[ftype] = per_record.get(ftype, 0) + 1
 
     if still_failing and state.reprompt_attempt < state.reprompt_max_attempts:
         next_attempt = state.reprompt_attempt + 1
@@ -311,9 +316,11 @@ def handle_reprompt_recovery(
         service._retry_service.apply_exhausted_reprompt_metadata(
             results=still_failing,
             failed_ids=failed_ids,
-            validation_name=strategy.name,
+            validation_name=validation_name,
             attempt=state.reprompt_attempt,
             on_exhausted=state.on_exhausted,
+            per_record_attempts=state.reprompt_attempts_per_record or None,
+            failure_type_counts=state.failure_type_counts or None,
         )
 
     final_results = BatchRetryService.deserialize_results(state.graduated_results)
@@ -326,7 +333,7 @@ def handle_reprompt_recovery(
                 action_name=parent_file_name or "batch",
                 attempt=state.reprompt_attempt,
                 max_attempts=state.reprompt_max_attempts,
-                validation_name=strategy.name,
+                validation_name=validation_name,
             )
         )
 
@@ -382,11 +389,11 @@ def check_and_submit_reprompt(
     if setup is None:
         return True
 
-    loop, strategy, _ = setup
+    loop, strategy, validation_name = setup
     max_attempts = strategy.max_attempts
     on_exhausted = strategy.on_exhausted
 
-    graduated, still_failing, _failure_types = loop.split(batch_results)
+    graduated, still_failing, failure_types = loop.split(batch_results)
     loop.tag_graduated(graduated)
 
     # Filter out records with None content (provider failures, not content quality issues)
@@ -397,14 +404,25 @@ def check_and_submit_reprompt(
 
     current_attempt = recovery_state.reprompt_attempt if recovery_state else 0
 
+    # Build per-record failure type counts from this split
+    ftc: dict[str, dict[str, int]] = {}
+    for cid, ftype in failure_types.items():
+        per_record = ftc.setdefault(cid, {})
+        per_record[ftype] = per_record.get(ftype, 0) + 1
+
     if current_attempt >= max_attempts:
         failed_ids = {r.custom_id for r in still_failing}
+        per_record_attempts = (
+            recovery_state.reprompt_attempts_per_record if recovery_state else None
+        )
         service._retry_service.apply_exhausted_reprompt_metadata(
             results=still_failing,
             failed_ids=failed_ids,
-            validation_name=strategy.name,
+            validation_name=validation_name,
             attempt=current_attempt,
             on_exhausted=on_exhausted,
+            per_record_attempts=per_record_attempts,
+            failure_type_counts=ftc or None,
         )
         return True
 

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -131,6 +131,7 @@ def build_evaluation_loop(
         max_attempts=max_attempts if max_attempts is not None else parsed.max_attempts,
         on_exhausted=on_exhausted if on_exhausted is not None else parsed.on_exhausted,
         json_mode=bool(json_mode),
+        validation_name=parsed.validation_name,
     )
     return EvaluationLoop(strategy), strategy, parsed.validation_name
 
@@ -177,10 +178,16 @@ def validate_and_reprompt(
     all_graduated: list[BatchResult] = []
     active_results = results
     reprompted_ids: dict[str, int] = {}
+    failure_type_counts: dict[str, dict[str, int]] = {}
 
     for attempt in range(max_attempts):
-        graduated, still_failing, _failure_types = loop.split(active_results)
+        graduated, still_failing, round_failure_types = loop.split(active_results)
         all_graduated.extend(graduated)
+
+        # Accumulate failure type counts across rounds
+        for cid, ftype in round_failure_types.items():
+            per_record = failure_type_counts.setdefault(cid, {})
+            per_record[ftype] = per_record.get(ftype, 0) + 1
 
         if not still_failing:
             logger.info("All records passed validation after %d attempts", attempt + 1)
@@ -209,6 +216,7 @@ def validate_and_reprompt(
                 attempt=attempt + 1,
                 on_exhausted=on_exhausted,
                 per_record_attempts=reprompted_ids,
+                failure_type_counts=failure_type_counts or None,
             )
             all_graduated.extend(still_failing)
             break

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -16,6 +16,7 @@ from agent_actions.logging.events.validation_events import (
     RepromptRetryEvent,
 )
 from agent_actions.output.response.config_fields import get_default
+from agent_actions.processing.evaluation.loop import accumulate_failure_types
 from agent_actions.processing.types import RecoveryMetadata
 
 if TYPE_CHECKING:
@@ -184,10 +185,7 @@ def validate_and_reprompt(
         graduated, still_failing, round_failure_types = loop.split(active_results)
         all_graduated.extend(graduated)
 
-        # Accumulate failure type counts across rounds
-        for cid, ftype in round_failure_types.items():
-            per_record = failure_type_counts.setdefault(cid, {})
-            per_record[ftype] = per_record.get(ftype, 0) + 1
+        accumulate_failure_types(failure_type_counts, round_failure_types)
 
         if not still_failing:
             logger.info("All records passed validation after %d attempts", attempt + 1)

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -15,6 +15,7 @@ from agent_actions.logging.events.validation_events import (
     RepromptRecoveredEvent,
     RepromptRetryEvent,
 )
+from agent_actions.output.response.config_fields import get_default
 from agent_actions.processing.types import RecoveryMetadata
 
 if TYPE_CHECKING:
@@ -121,12 +122,15 @@ def build_evaluation_loop(
 
     strategies = resolve_feedback_strategies(raw_reprompt_config)
 
+    json_mode = (agent_config or {}).get("json_mode", get_default("json_mode"))
+
     strategy = ValidationStrategy(
         validation_func=validation_func,
         feedback_message=feedback_message,
         strategies=strategies,
         max_attempts=max_attempts if max_attempts is not None else parsed.max_attempts,
         on_exhausted=on_exhausted if on_exhausted is not None else parsed.on_exhausted,
+        json_mode=bool(json_mode),
     )
     return EvaluationLoop(strategy), strategy, parsed.validation_name
 
@@ -175,7 +179,7 @@ def validate_and_reprompt(
     reprompted_ids: dict[str, int] = {}
 
     for attempt in range(max_attempts):
-        graduated, still_failing = loop.split(active_results)
+        graduated, still_failing, _failure_types = loop.split(active_results)
         all_graduated.extend(graduated)
 
         if not still_failing:
@@ -434,6 +438,12 @@ def validate_results(
         logger.error("Failed to get validation function: %s", e)
         return [], None
 
+    from agent_actions.processing.evaluation.strategies.validation import (
+        _detect_parse_error,
+    )
+
+    json_mode = bool((agent_config or {}).get("json_mode", get_default("json_mode")))
+
     failed_results = []
     for result in results:
         if not result.success:
@@ -444,6 +454,11 @@ def validate_results(
             and result.recovery_metadata.reprompt
             and result.recovery_metadata.reprompt.passed
         ):
+            continue
+
+        # Check parse error before UDF — matching online path
+        if _detect_parse_error(result.content, json_mode=json_mode):
+            failed_results.append(result)
             continue
 
         is_valid = safe_validate(

--- a/agent_actions/llm/batch/services/retry.py
+++ b/agent_actions/llm/batch/services/retry.py
@@ -313,6 +313,8 @@ class BatchRetryService:
         validation_name: str,
         attempt: int,
         on_exhausted: str,
+        per_record_attempts: dict[str, int] | None = None,
+        failure_type_counts: dict[str, dict[str, int]] | None = None,
     ) -> list[BatchResult]:
         """Apply reprompt exhaustion metadata to failed records."""
         from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
@@ -323,6 +325,8 @@ class BatchRetryService:
             validation_name=validation_name,
             attempt=attempt,
             on_exhausted=on_exhausted,
+            per_record_attempts=per_record_attempts,
+            failure_type_counts=failure_type_counts,
         )
 
     # =========================================================================

--- a/agent_actions/processing/evaluation/exhaustion.py
+++ b/agent_actions/processing/evaluation/exhaustion.py
@@ -27,6 +27,7 @@ def apply_exhausted_reprompt(
     attempt: int,
     on_exhausted: str,
     per_record_attempts: dict[str, int] | None = None,
+    failure_type_counts: dict[str, dict[str, int]] | None = None,
 ) -> list[BatchResult]:
     """Apply reprompt exhaustion metadata to records that failed validation.
 
@@ -43,6 +44,10 @@ def apply_exhausted_reprompt(
         per_record_attempts: Optional per-record attempt counts. When
             provided, each record's metadata uses its own count instead
             of the scalar ``attempt``. Used by the sync reprompt path.
+        failure_type_counts: Optional per-record failure type counts.
+            Maps custom_id → ``{"parse_error": N, "udf_fail": M, ...}``.
+            When provided, populates ``parse_error_count``,
+            ``schema_fail_count``, ``udf_fail_count`` on RepromptMetadata.
 
     Returns:
         The same results list with exhaustion metadata applied.
@@ -73,6 +78,8 @@ def apply_exhausted_reprompt(
             per_record_attempts.get(result.custom_id, attempt) if per_record_attempts else attempt
         )
 
+        counts = (failure_type_counts or {}).get(result.custom_id, {})
+
         if not result.recovery_metadata:
             result.recovery_metadata = RecoveryMetadata()
 
@@ -80,6 +87,9 @@ def apply_exhausted_reprompt(
             attempts=record_attempts,
             passed=False,
             validation=validation_name,
+            parse_error_count=counts.get("parse_error", 0),
+            schema_fail_count=counts.get("schema_fail", 0),
+            udf_fail_count=counts.get("udf_fail", 0),
         )
 
     return results

--- a/agent_actions/processing/evaluation/loop.py
+++ b/agent_actions/processing/evaluation/loop.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from agent_actions.processing.types import EvaluationMetadata, RecoveryMetadata
+from agent_actions.processing.types import (
+    EvaluationMetadata,
+    EvaluationOutcome,
+    RecoveryMetadata,
+)
 
 if TYPE_CHECKING:
     from agent_actions.llm.providers.batch_base import BatchResult
@@ -22,7 +26,7 @@ logger = logging.getLogger(__name__)
 class EvaluationStrategy(Protocol):
     """What changes between reprompt, critique, etc."""
 
-    def evaluate(self, result: BatchResult) -> bool: ...
+    def evaluate(self, result: BatchResult) -> EvaluationOutcome: ...
 
     def build_feedback(self, result: BatchResult) -> str: ...
 
@@ -52,20 +56,30 @@ class EvaluationLoop:
             return False
         return getattr(eval_meta, "passed", False) is True
 
-    def split(self, results: list[BatchResult]) -> tuple[list[BatchResult], list[BatchResult]]:
-        """→ (graduated, still_failing). Skips already-graduated."""
+    def split(
+        self, results: list[BatchResult]
+    ) -> tuple[list[BatchResult], list[BatchResult], dict[str, str]]:
+        """→ (graduated, still_failing, failure_types).
+
+        Skips already-graduated. ``failure_types`` maps custom_id to
+        failure classification (e.g. ``"parse_error"``, ``"udf_fail"``).
+        """
         graduated: list[BatchResult] = []
         still_failing: list[BatchResult] = []
+        failure_types: dict[str, str] = {}
 
         for result in results:
             if self._is_already_graduated(result):
                 graduated.append(result)
                 continue
 
-            if self.strategy.evaluate(result):
+            outcome = self.strategy.evaluate(result)
+            if outcome.passed:
                 graduated.append(result)
             else:
                 still_failing.append(result)
+                if outcome.failure_type:
+                    failure_types[result.custom_id] = outcome.failure_type
 
         logger.info(
             "EvaluationLoop[%s].split: %d graduated, %d still failing (of %d total)",
@@ -74,7 +88,7 @@ class EvaluationLoop:
             len(still_failing),
             len(results),
         )
-        return graduated, still_failing
+        return graduated, still_failing, failure_types
 
     def tag_graduated(self, results: list[BatchResult]) -> None:
         """Mark as done. Never evaluated again."""

--- a/agent_actions/processing/evaluation/loop.py
+++ b/agent_actions/processing/evaluation/loop.py
@@ -125,3 +125,18 @@ class EvaluationLoop:
             len(submissions),
         )
         return submissions
+
+
+def accumulate_failure_types(
+    target: dict[str, dict[str, int]],
+    failure_types: dict[str, str],
+) -> None:
+    """Merge per-record failure classifications into cumulative counts.
+
+    ``failure_types`` maps ``custom_id → failure_type`` (one entry per
+    failing record from a single ``split()`` call).  ``target`` accumulates
+    counts across rounds: ``custom_id → {failure_type: count}``.
+    """
+    for cid, ftype in failure_types.items():
+        per_record = target.setdefault(cid, {})
+        per_record[ftype] = per_record.get(ftype, 0) + 1

--- a/agent_actions/processing/evaluation/strategies/validation.py
+++ b/agent_actions/processing/evaluation/strategies/validation.py
@@ -56,6 +56,7 @@ class ValidationStrategy:
         max_attempts: int = 3,
         on_exhausted: str = "return_last",
         json_mode: bool = False,
+        validation_name: str = "validation",
     ) -> None:
         self._validation_func = validation_func
         self._feedback_message = feedback_message
@@ -63,10 +64,11 @@ class ValidationStrategy:
         self._max_attempts = max_attempts
         self._on_exhausted = on_exhausted
         self._json_mode = json_mode
+        self._validation_name = validation_name
 
     @property
     def name(self) -> str:
-        return "validation"
+        return self._validation_name
 
     @property
     def max_attempts(self) -> int:

--- a/agent_actions/processing/evaluation/strategies/validation.py
+++ b/agent_actions/processing/evaluation/strategies/validation.py
@@ -9,6 +9,7 @@ from agent_actions.processing.recovery.response_validator import (
     build_validation_feedback,
     safe_validate,
 )
+from agent_actions.processing.types import EvaluationOutcome
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -17,6 +18,31 @@ if TYPE_CHECKING:
     from agent_actions.processing.recovery.response_validator import FeedbackStrategy
 
 logger = logging.getLogger(__name__)
+
+_PARSE_ERROR_FEEDBACK = (
+    "---\n"
+    "Your previous response was not valid JSON and could not be parsed.\n"
+    "Please respond with a valid JSON object only — no preamble, no markdown fences."
+)
+
+
+def _detect_parse_error(content: Any, *, json_mode: bool) -> str | None:
+    """Detect a parse error in batch result content.
+
+    Batch providers return content as a raw string when JSON parsing fails.
+    Online providers wrap as ``{"_parse_error": "..."}``.  This helper checks
+    both patterns.
+    """
+    # String content in json_mode = provider couldn't parse JSON
+    if json_mode and isinstance(content, str):
+        return "Failed to parse JSON from LLM response"
+    # Dict with _parse_error = pre-wrapped parse error (online convention)
+    if isinstance(content, dict) and "_parse_error" in content:
+        return content["_parse_error"] or None
+    # List with _parse_error at index 0 = online list-wrapped format
+    if isinstance(content, list) and content and isinstance(content[0], dict):
+        return content[0].get("_parse_error") or None
+    return None
 
 
 class ValidationStrategy:
@@ -29,12 +55,14 @@ class ValidationStrategy:
         strategies: list[FeedbackStrategy] | None = None,
         max_attempts: int = 3,
         on_exhausted: str = "return_last",
+        json_mode: bool = False,
     ) -> None:
         self._validation_func = validation_func
         self._feedback_message = feedback_message
         self._strategies = strategies
         self._max_attempts = max_attempts
         self._on_exhausted = on_exhausted
+        self._json_mode = json_mode
 
     @property
     def name(self) -> str:
@@ -48,24 +76,37 @@ class ValidationStrategy:
     def on_exhausted(self) -> str:
         return self._on_exhausted
 
-    def evaluate(self, result: BatchResult) -> bool:
-        """Return True if the result passes validation."""
+    def evaluate(self, result: BatchResult) -> EvaluationOutcome:
+        """Return evaluation outcome with failure classification."""
         if not result.success:
-            return False
+            return EvaluationOutcome(passed=False, failure_type="api_error", error=result.error)
 
         if (
             result.recovery_metadata
             and result.recovery_metadata.reprompt
             and result.recovery_metadata.reprompt.passed
         ):
-            return True
+            return EvaluationOutcome(passed=True)
 
-        return safe_validate(
+        # Explicit parse error detection — before UDF, matching online path
+        parse_error = _detect_parse_error(result.content, json_mode=self._json_mode)
+        if parse_error:
+            logger.warning(
+                "Parse error detected for %s before UDF: %s",
+                result.custom_id,
+                parse_error,
+            )
+            return EvaluationOutcome(passed=False, failure_type="parse_error", error=parse_error)
+
+        if safe_validate(
             self._validation_func,
             result.content,
             context=result.custom_id,
             catch=(Exception,),
-        )
+        ):
+            return EvaluationOutcome(passed=True)
+
+        return EvaluationOutcome(passed=False, failure_type="udf_fail")
 
     def build_feedback(self, result: BatchResult) -> str:
         """Build validation feedback for a failing result."""
@@ -75,6 +116,11 @@ class ValidationStrategy:
                 "The previous attempt failed due to an API error and produced no response.\n"
                 "Please respond again."
             )
+
+        # Parse error → JSON-specific feedback (not generic UDF feedback)
+        if _detect_parse_error(result.content, json_mode=self._json_mode):
+            return _PARSE_ERROR_FEEDBACK
+
         return build_validation_feedback(
             failed_response=result.content,
             feedback_message=self._feedback_message,

--- a/agent_actions/processing/evaluation/strategies/validation.py
+++ b/agent_actions/processing/evaluation/strategies/validation.py
@@ -90,7 +90,6 @@ class ValidationStrategy:
         ):
             return EvaluationOutcome(passed=True)
 
-        # Explicit parse error detection — before UDF, matching online path
         parse_error = _detect_parse_error(result.content, json_mode=self._json_mode)
         if parse_error:
             logger.warning(

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -60,9 +60,10 @@ class RepromptMetadata:
     """Metadata for reprompt recovery, stored in output _recovery.reprompt field.
 
     Failure-type counters (``parse_error_count``, ``schema_fail_count``,
-    ``udf_fail_count``) are populated by the **online** reprompt path only.
-    Batch paths default to 0 because ``EvaluationLoop.split()`` returns
-    pass/fail without failure-type classification.
+    ``udf_fail_count``) are populated by the **online** reprompt path.
+    Batch paths return failure-type classification via
+    ``EvaluationOutcome.failure_type`` in ``EvaluationLoop.split()``,
+    but counter wiring into ``RepromptMetadata`` is deferred to spec 417.
     """
 
     attempts: int
@@ -86,6 +87,15 @@ class RepromptMetadata:
         if self.udf_fail_count:
             result["udf_fail_count"] = self.udf_fail_count
         return result
+
+
+@dataclass
+class EvaluationOutcome:
+    """Result of a single evaluation — pass/fail with failure classification."""
+
+    passed: bool
+    failure_type: str | None = None  # "parse_error", "udf_fail", "api_error", None
+    error: str | None = None
 
 
 @dataclass

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -60,10 +60,11 @@ class RepromptMetadata:
     """Metadata for reprompt recovery, stored in output _recovery.reprompt field.
 
     Failure-type counters (``parse_error_count``, ``schema_fail_count``,
-    ``udf_fail_count``) are populated by the **online** reprompt path.
-    Batch paths return failure-type classification via
-    ``EvaluationOutcome.failure_type`` in ``EvaluationLoop.split()``,
-    but counter wiring into ``RepromptMetadata`` is deferred to spec 417.
+    ``udf_fail_count``) are populated by both online and batch paths.
+    Online: ``RepromptService.execute()`` increments counters per attempt.
+    Batch: ``EvaluationLoop.split()`` returns failure classifications via
+    ``EvaluationOutcome.failure_type``, accumulated across rounds and
+    wired into counters by ``apply_exhausted_reprompt()``.
     """
 
     attempts: int

--- a/tests/integration/test_evaluation_loop_batch.py
+++ b/tests/integration/test_evaluation_loop_batch.py
@@ -15,7 +15,7 @@ import pytest
 
 from agent_actions.llm.batch.infrastructure.recovery_state import RecoveryState
 from agent_actions.llm.providers.batch_base import BatchResult
-from agent_actions.processing.types import EvaluationMetadata, RecoveryMetadata
+from agent_actions.processing.types import EvaluationMetadata, EvaluationOutcome, RecoveryMetadata
 
 # Skip entire module if evaluation loop code is not yet available.
 # Created by specs 062 (PR #295) and 063 (PR #297).
@@ -63,7 +63,7 @@ def deterministic_strategy():
         strategy.name = "test_validation"
         strategy.max_attempts = max_attempts
         strategy.on_exhausted = "keep_last"
-        strategy.evaluate = lambda r: r.custom_id in passing_ids
+        strategy.evaluate = lambda r: EvaluationOutcome(passed=r.custom_id in passing_ids)
         strategy.build_feedback.return_value = "Please fix the output."
         return strategy
 
@@ -88,9 +88,9 @@ def make_strategy():
         strategy.max_attempts = max_attempts
         strategy.on_exhausted = on_exhausted
         if evaluate_fn is not None:
-            strategy.evaluate.side_effect = evaluate_fn
+            strategy.evaluate.side_effect = lambda r: EvaluationOutcome(passed=evaluate_fn(r))
         elif evaluate_return is not None:
-            strategy.evaluate.return_value = evaluate_return
+            strategy.evaluate.return_value = EvaluationOutcome(passed=evaluate_return)
         strategy.build_feedback.return_value = feedback
         return strategy
 
@@ -107,7 +107,7 @@ def nondeterministic_strategy():
         strategy.name = "nondeterministic"
         strategy.max_attempts = 5
         strategy.on_exhausted = "keep_last"
-        strategy.evaluate = lambda r: rng.random() < pass_probability
+        strategy.evaluate = lambda r: EvaluationOutcome(passed=rng.random() < pass_probability)
         strategy.build_feedback.return_value = "Try again."
         return strategy
 
@@ -128,7 +128,7 @@ class TestGraduatedPoolWorks:
         strategy = deterministic_strategy(passing)
         loop = EvaluationLoop(strategy)
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
         assert len(graduated) == 7
         assert len(failing) == 3
         loop.tag_graduated(graduated)
@@ -137,7 +137,7 @@ class TestGraduatedPoolWorks:
         passing.add("record_7")
         strategy_2 = deterministic_strategy(passing)
         loop_2 = EvaluationLoop(strategy_2)
-        graduated_2, failing_2 = loop_2.split(failing)
+        graduated_2, failing_2, _ = loop_2.split(failing)
         assert len(graduated_2) == 1  # record_7
         assert len(failing_2) == 2  # record_8, record_9
 
@@ -150,7 +150,7 @@ class TestGraduatedPoolWorks:
         strategy = make_strategy(evaluate_fn=lambda r: r.custom_id in passing)
         loop = EvaluationLoop(strategy)
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
         assert len(graduated) == 7
         loop.tag_graduated(graduated)
         graduated_ids = {r.custom_id for r in graduated}
@@ -158,7 +158,7 @@ class TestGraduatedPoolWorks:
         strategy.evaluate.reset_mock()
 
         # Pass ALL results (including graduated) back to split
-        graduated_2, failing_2 = loop.split(results)
+        graduated_2, failing_2, _ = loop.split(results)
 
         # Graduated records must NOT appear in the failing set
         failing_2_ids = {r.custom_id for r in failing_2}
@@ -196,7 +196,7 @@ class TestFailureSetShrinksDeterministic:
                 evaluate_fn=lambda r, p=passing: r.custom_id in p,
             )
             loop = EvaluationLoop(strategy)
-            graduated, failing = loop.split(active)
+            graduated, failing, _ = loop.split(active)
             loop.tag_graduated(graduated)
             failure_counts.append(len(failing))
             active = failing
@@ -224,7 +224,7 @@ class TestFailureSetShrinksDeterministic:
                 evaluate_fn=lambda r, p=passing: r.custom_id in p,
             )
             loop = EvaluationLoop(strategy)
-            graduated, failing = loop.split(active)
+            graduated, failing, _ = loop.split(active)
             loop.tag_graduated(graduated)
             all_graduated.extend(graduated)
             active = failing
@@ -257,7 +257,7 @@ class TestNonDeterministicConvergence:
 
         for _cycle in range(5):
             pre_call_count = strategy.evaluate.call_count
-            graduated, failing = loop.split(active)
+            graduated, failing, _ = loop.split(active)
 
             # evaluate() called exactly once per active record — never for graduated
             assert strategy.evaluate.call_count - pre_call_count == len(active)
@@ -280,7 +280,7 @@ class TestNonDeterministicConvergence:
         failure_counts = []
 
         for _cycle in range(5):
-            graduated, failing = loop.split(active)
+            graduated, failing, _ = loop.split(active)
             loop.tag_graduated(graduated)
             failure_counts.append(len(failing))
             active = failing
@@ -308,7 +308,7 @@ class TestDispositionCorrect:
         active = results
 
         for _attempt in range(strategy.max_attempts):
-            graduated, failing = loop.split(active)
+            graduated, failing, _ = loop.split(active)
             loop.tag_graduated(graduated)
             if not failing:
                 break
@@ -328,7 +328,7 @@ class TestDispositionCorrect:
         )
 
         loop = EvaluationLoop(strategy)
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert len(graduated) == 0
         assert len(failing) == 3
@@ -358,7 +358,7 @@ class TestRetryEvaluationInteraction:
 
         complete_results = initial_results + retry_results
         loop = EvaluationLoop(strategy)
-        graduated, failing = loop.split(complete_results)
+        graduated, failing, _ = loop.split(complete_results)
 
         assert len(graduated) == 10
         assert len(failing) == 0
@@ -373,7 +373,7 @@ class TestRetryEvaluationInteraction:
 
         complete_results = make_batch_results(10)
         loop = EvaluationLoop(strategy)
-        graduated, failing = loop.split(complete_results)
+        graduated, failing, _ = loop.split(complete_results)
 
         assert len(graduated) == 5
         assert len(failing) == 5
@@ -399,14 +399,14 @@ class TestStrategyPluggable:
             on_exhausted = "drop"
 
             def evaluate(self, result):
-                return False
+                return EvaluationOutcome(passed=False, failure_type="udf_fail")
 
             def build_feedback(self, result):
                 return "This will never pass."
 
         results = make_batch_results(5)
         loop = EvaluationLoop(AlwaysFailStrategy())
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
         assert len(graduated) == 0
         assert len(failing) == 5
 
@@ -419,14 +419,14 @@ class TestStrategyPluggable:
             on_exhausted = "keep_last"
 
             def evaluate(self, result):
-                return True
+                return EvaluationOutcome(passed=True)
 
             def build_feedback(self, result):
                 return "Should not be called."
 
         results = make_batch_results(10)
         loop = EvaluationLoop(AlwaysPassStrategy())
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
         assert len(graduated) == 10
         assert len(failing) == 0
 
@@ -450,7 +450,7 @@ class TestBackwardCompat:
         strategy = make_strategy(name="validation", evaluate_return=True)
 
         loop = EvaluationLoop(strategy)
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert len(graduated) == 5
         assert len(failing) == 0
@@ -466,10 +466,10 @@ class TestBackwardCompat:
 
         strategy = MagicMock(spec=EvaluationStrategy)
         strategy.name = "validation"
-        strategy.evaluate = lambda r: True  # All new ones would pass
+        strategy.evaluate = lambda r: EvaluationOutcome(passed=True)
         loop = EvaluationLoop(strategy)
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
         # 5 already-graduated (skipped) + 5 newly evaluated (all pass) = 10 graduated
         assert len(graduated) == 10
         assert len(failing) == 0

--- a/tests/simulation/simulate_reprompt_additional_bugs.py
+++ b/tests/simulation/simulate_reprompt_additional_bugs.py
@@ -135,7 +135,7 @@ def run_bug8_no_state_mutation():
         patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager"),
     ):
         loop, strategy = _make_eval_loop_mocks(max_attempts=2)
-        loop.split.return_value = ([], [_make_result("id-1", success=False)])
+        loop.split.return_value = ([], [_make_result("id-1", success=False)], {})
         mock_build.return_value = (loop, strategy, None)
 
         check_and_submit_reprompt(
@@ -193,7 +193,7 @@ def run_bug10_none_content_filtered():
         patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager"),
     ):
         loop, strategy = _make_eval_loop_mocks(max_attempts=3)
-        loop.split.return_value = ([], results)
+        loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy, None)
 
         check_and_submit_reprompt(

--- a/tests/simulation/simulate_reprompt_rerun_loop.py
+++ b/tests/simulation/simulate_reprompt_rerun_loop.py
@@ -152,7 +152,7 @@ def run_max_attempts_enforced(work_dir):
         patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager") as mgr,
     ):
         loop, strategy = _make_eval_loop_mocks(max_attempts=2)
-        loop.split.return_value = ([], results)
+        loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy, None)
 
         should_continue = check_and_submit_reprompt(
@@ -183,7 +183,7 @@ def run_max_attempts_enforced(work_dir):
         patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager") as mgr,
     ):
         loop, strategy = _make_eval_loop_mocks(max_attempts=2)
-        loop.split.return_value = ([], results)
+        loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy, None)
 
         should_continue = check_and_submit_reprompt(
@@ -211,7 +211,7 @@ def run_max_attempts_enforced(work_dir):
     state_run3 = RecoveryState(phase="reprompt", reprompt_attempt=2, reprompt_max_attempts=2)
     with patch("agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop") as mock_build:
         loop, strategy = _make_eval_loop_mocks(max_attempts=2)
-        loop.split.return_value = ([], results)
+        loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy, None)
 
         should_continue = check_and_submit_reprompt(
@@ -295,7 +295,7 @@ def run_graduated_pool_persists(work_dir):
         patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager") as mgr,
     ):
         loop, strategy = _make_eval_loop_mocks(max_attempts=3)
-        loop.split.return_value = ([], results)
+        loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy, None)
 
         check_and_submit_reprompt(

--- a/tests/unit/llm/batch/test_composed_recovery.py
+++ b/tests/unit/llm/batch/test_composed_recovery.py
@@ -108,7 +108,7 @@ class TestComposedRecoveryPaths:
         strategy.name = "schema_check"
         strategy.max_attempts = 2
         strategy.on_exhausted = "return_last"
-        loop.split.return_value = ([_make_result("id-1")], [])
+        loop.split.return_value = ([_make_result("id-1")], [], {})
         mock_build_loop.return_value = (loop, strategy, None)
 
         result = handle_retry_recovery(
@@ -156,7 +156,7 @@ class TestComposedRecoveryPaths:
         strategy.max_attempts = 0  # Already at max (current_attempt >= max)
         strategy.on_exhausted = "return_last"
         failing_result = _make_result("id-1", success=False)
-        loop.split.return_value = ([], [failing_result])
+        loop.split.return_value = ([], [failing_result], {})
         mock_build_loop.return_value = (loop, strategy, None)
 
         result = handle_retry_recovery(
@@ -203,7 +203,7 @@ class TestComposedRecoveryPaths:
         strategy.max_attempts = 0
         strategy.on_exhausted = "raise"
         failing_result = _make_result("id-1", success=False)
-        loop.split.return_value = ([], [failing_result])
+        loop.split.return_value = ([], [failing_result], {})
         mock_build_loop.return_value = (loop, strategy, None)
 
         # Wire the real exhaustion function to get the raise
@@ -282,7 +282,7 @@ class TestComposedRecoveryPaths:
         loop = MagicMock()
         strategy = MagicMock()
         strategy.name = "validation"
-        loop.split.return_value = ([_make_result("id-1"), _make_result("id-2")], [])
+        loop.split.return_value = ([_make_result("id-1"), _make_result("id-2")], [], {})
         mock_build_loop.return_value = (loop, strategy, None)
 
         result = handle_reprompt_recovery(
@@ -388,7 +388,7 @@ class TestGraduatedPoolMonotonicity:
         strategy.name = "validation"
 
         # Split returns: id-new graduated, id-still-bad failing
-        loop.split.return_value = ([_make_result("id-new")], [_make_result("id-still-bad")])
+        loop.split.return_value = ([_make_result("id-new")], [_make_result("id-still-bad")], {})
         mock_build_loop.return_value = (loop, strategy, None)
 
         service = _mock_service()
@@ -434,7 +434,7 @@ class TestGraduatedPoolMonotonicity:
         strategy = MagicMock()
         strategy.name = "validation"
         # This cycle: id-2 graduates, id-3 still fails
-        loop.split.return_value = ([_make_result("id-2")], [_make_result("id-3")])
+        loop.split.return_value = ([_make_result("id-2")], [_make_result("id-3")], {})
         mock_build_loop.return_value = (loop, strategy, None)
 
         service = _mock_service()

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -308,7 +308,7 @@ class TestHandleRetryRecovery:
         strategy.name = "validation"
         strategy.max_attempts = 2
         strategy.on_exhausted = "return_last"
-        loop.split.return_value = ([_make_result("id-1")], [])  # all pass
+        loop.split.return_value = ([_make_result("id-1")], [], {})  # all pass
         mock_build_loop.return_value = (loop, strategy, None)
 
         with patch(
@@ -405,7 +405,7 @@ class TestHandleRepromptRecovery:
 
         graduated = [_make_result(cid) for cid in graduated_ids]
         failing = [_make_result(cid, success=False) for cid in failing_ids]
-        loop.split.return_value = (graduated, failing)
+        loop.split.return_value = (graduated, failing, {})
 
         return loop, strategy
 
@@ -716,7 +716,7 @@ class TestRecoveryStatePersistence:
         loop = MagicMock()
         strategy = MagicMock()
         strategy.name = "validation"
-        loop.split.return_value = ([], [_make_result("id-1")])  # all failing
+        loop.split.return_value = ([], [_make_result("id-1")], {})  # all failing
         mock_build_loop.return_value = (loop, strategy, None)
 
         service = _mock_service()
@@ -1035,7 +1035,7 @@ class TestRecoveryLoopRootCauses:
             ) as mock_state_mgr,
         ):
             loop, strategy = _make_eval_loop_mocks(max_attempts=2)
-            loop.split.return_value = ([], results)
+            loop.split.return_value = ([], results, {})
             mock_build_loop.return_value = (loop, strategy, None)
             service._retry_service.submit_reprompt_batch.return_value = ("reprompt-batch-2", 1)
 
@@ -1066,7 +1066,7 @@ class TestRecoveryLoopRootCauses:
             "agent_actions.llm.batch.services.reprompt_ops.build_evaluation_loop"
         ) as mock_build_loop:
             loop, strategy = _make_eval_loop_mocks(max_attempts=2)
-            loop.split.return_value = ([], results)
+            loop.split.return_value = ([], results, {})
             mock_build_loop.return_value = (loop, strategy, None)
 
             should_continue = check_and_submit_reprompt(
@@ -1120,7 +1120,7 @@ class TestDownstreamBugs:
     @patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager")
     def test_retry_to_reprompt_does_not_mutate_retry_state(self, mock_mgr, mock_build_loop):
         loop, strategy = _make_eval_loop_mocks(max_attempts=2)
-        loop.split.return_value = ([], [_make_result("id-1", success=False)])
+        loop.split.return_value = ([], [_make_result("id-1", success=False)], {})
         mock_build_loop.return_value = (loop, strategy, None)
 
         service = _mock_service()
@@ -1162,7 +1162,7 @@ class TestDownstreamBugs:
             patch("agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager"),
         ):
             loop, strategy = _make_eval_loop_mocks(max_attempts=3)
-            loop.split.return_value = ([], results)
+            loop.split.return_value = ([], results, {})
             mock_build_loop.return_value = (loop, strategy, None)
             service._retry_service.submit_reprompt_batch.return_value = ("reprompt-batch", 1)
 

--- a/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
+++ b/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
@@ -25,9 +25,7 @@ def _make_results(n: int, fail_ids: set[str] | None = None) -> list[BatchResult]
     return [
         BatchResult(
             custom_id=f"rec_{i:03d}",
-            content='{"answer": "bad"}'
-            if f"rec_{i:03d}" in fail_ids
-            else f'{{"answer": "ok_{i}"}}',
+            content={"answer": "bad"} if f"rec_{i:03d}" in fail_ids else {"answer": f"ok_{i}"},
             success=True,
         )
         for i in range(n)
@@ -121,7 +119,7 @@ class TestSelectiveRepromptResubmission:
         provider = MagicMock()
         provider.submit_batch.return_value = ("batch_reprompt_1", "submitted")
         provider.retrieve_results.return_value = [
-            BatchResult(custom_id=cid, content='{"answer": "fixed"}', success=True)
+            BatchResult(custom_id=cid, content={"answer": "fixed"}, success=True)
             for cid in FAIL_IDS
         ]
 
@@ -159,8 +157,7 @@ class TestSelectiveRepromptResubmission:
         from agent_actions.llm.batch.services.reprompt_ops import submit_reprompt_batch
 
         failed_results = [
-            BatchResult(custom_id=cid, content='{"answer": "bad"}', success=True)
-            for cid in FAIL_IDS
+            BatchResult(custom_id=cid, content={"answer": "bad"}, success=True) for cid in FAIL_IDS
         ]
         context_map = _make_context_map(10)
 
@@ -217,7 +214,7 @@ class TestSelectiveRepromptResubmission:
         provider = MagicMock()
         provider.submit_batch.return_value = ("batch_rp", "submitted")
         provider.retrieve_results.return_value = [
-            BatchResult(custom_id=cid, content='{"answer": "bad"}', success=True)
+            BatchResult(custom_id=cid, content={"answer": "bad"}, success=True)
             for cid in persistent_fail
         ]
 
@@ -267,9 +264,9 @@ class TestSelectiveRepromptResubmission:
         from agent_actions.llm.batch.services.retry import BatchRetryService
 
         accumulated = _make_results(10, fail_ids=set())
-        rec_003_ok = BatchResult(custom_id="rec_003", content='{"answer": "now_ok"}', success=True)
+        rec_003_ok = BatchResult(custom_id="rec_003", content={"answer": "now_ok"}, success=True)
         rec_007_bad = BatchResult(
-            custom_id="rec_007", content='{"answer": "still_bad"}', success=True
+            custom_id="rec_007", content={"answer": "still_bad"}, success=True
         )
         recovery_results = [rec_003_ok, rec_007_bad]
 
@@ -285,7 +282,7 @@ class TestSelectiveRepromptResubmission:
 
         # Mock the evaluation loop: rec_003 graduates, rec_007 still fails
         mock_loop = MagicMock()
-        mock_loop.split.return_value = ([rec_003_ok], [rec_007_bad])
+        mock_loop.split.return_value = ([rec_003_ok], [rec_007_bad], {})
         mock_strategy = MagicMock()
         mock_strategy.name = "check_it"
         mock_strategy.max_attempts = 3
@@ -337,8 +334,7 @@ class TestSelectiveRepromptResubmission:
         from agent_actions.llm.batch.services.reprompt_ops import submit_reprompt_batch
 
         failed_results = [
-            BatchResult(custom_id=cid, content='{"answer": "bad"}', success=True)
-            for cid in FAIL_IDS
+            BatchResult(custom_id=cid, content={"answer": "bad"}, success=True) for cid in FAIL_IDS
         ]
 
         # 6 entries: 3 that match FAIL_IDS + 3 that don't
@@ -406,7 +402,7 @@ class TestRepromptDroppedRecordReconciliation:
         provider = MagicMock()
         provider.submit_batch.return_value = ("batch_rp_1", "submitted")
         provider.retrieve_results.return_value = [
-            BatchResult(custom_id="rec_003", content='{"answer": "fixed"}', success=True),
+            BatchResult(custom_id="rec_003", content={"answer": "fixed"}, success=True),
         ]
 
         with (
@@ -472,7 +468,7 @@ class TestRepromptDroppedRecordReconciliation:
         provider = MagicMock()
         provider.submit_batch.return_value = ("batch_rp_1", "submitted")
         provider.retrieve_results.return_value = [
-            BatchResult(custom_id=cid, content='{"answer": "fixed"}', success=True)
+            BatchResult(custom_id=cid, content={"answer": "fixed"}, success=True)
             for cid in FAIL_IDS
         ]
 
@@ -599,13 +595,13 @@ class TestRepromptDroppedRecordReconciliation:
         provider_retrieve_side_effects = [
             # Attempt 1: drop rec_002
             [
-                BatchResult(custom_id="rec_001", content='{"answer": "bad"}', success=True),
-                BatchResult(custom_id="rec_003", content='{"answer": "bad"}', success=True),
+                BatchResult(custom_id="rec_001", content={"answer": "bad"}, success=True),
+                BatchResult(custom_id="rec_003", content={"answer": "bad"}, success=True),
             ],
             # Attempt 2: both pass
             [
-                BatchResult(custom_id="rec_001", content='{"answer": "fixed"}', success=True),
-                BatchResult(custom_id="rec_003", content='{"answer": "fixed"}', success=True),
+                BatchResult(custom_id="rec_001", content={"answer": "fixed"}, success=True),
+                BatchResult(custom_id="rec_003", content={"answer": "fixed"}, success=True),
             ],
         ]
 
@@ -670,14 +666,13 @@ class TestCheckAndSubmitRepromptSelectivity:
         all_results = _make_results(10, fail_ids=set())
         fail_ids = {"rec_003", "rec_007"}
         still_failing = [
-            BatchResult(custom_id=cid, content='{"answer": "bad"}', success=True)
-            for cid in fail_ids
+            BatchResult(custom_id=cid, content={"answer": "bad"}, success=True) for cid in fail_ids
         ]
         graduated = [r for r in all_results if r.custom_id not in fail_ids]
 
         # Mock evaluation loop: 8 graduate, 2 still fail
         mock_loop = MagicMock()
-        mock_loop.split.return_value = (graduated, still_failing)
+        mock_loop.split.return_value = (graduated, still_failing, {})
         mock_strategy = MagicMock()
         mock_strategy.name = "check_it"
         mock_strategy.max_attempts = 3

--- a/tests/unit/processing/test_batch_parse_error_detection.py
+++ b/tests/unit/processing/test_batch_parse_error_detection.py
@@ -1,0 +1,301 @@
+"""Tests for batch parse error detection in ValidationStrategy.
+
+Spec 418: Batch parse error reprompt detection (R4).
+
+When a batch LLM response fails JSON parsing (_parse_error present or
+content is a string in json_mode), the record must be explicitly classified
+as a parse error before the UDF runs.
+"""
+
+from unittest.mock import MagicMock
+
+from agent_actions.processing.evaluation.loop import EvaluationLoop
+from agent_actions.processing.evaluation.strategies.validation import (
+    ValidationStrategy,
+    _detect_parse_error,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    custom_id: str,
+    content=None,
+    success: bool = True,
+    recovery_metadata=None,
+) -> MagicMock:
+    result = MagicMock()
+    result.custom_id = custom_id
+    result.content = content
+    result.success = success
+    result.recovery_metadata = recovery_metadata
+    result.error = None if success else "API error"
+    return result
+
+
+def _always_pass(response):
+    """UDF that accepts everything — a 'loose' validator."""
+    return True
+
+
+def _always_fail(response):
+    return False
+
+
+# ---------------------------------------------------------------------------
+# _detect_parse_error helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectParseError:
+    def test_string_content_json_mode(self):
+        """String content in json_mode → parse error."""
+        assert _detect_parse_error("not json", json_mode=True) is not None
+
+    def test_string_content_non_json_mode(self):
+        """String content in non-json_mode → NOT a parse error (legitimate text)."""
+        assert _detect_parse_error("plain text response", json_mode=False) is None
+
+    def test_dict_with_parse_error_key(self):
+        """Dict containing _parse_error → always a parse error regardless of json_mode."""
+        content = {"raw_response": "bad", "_parse_error": "Failed to parse JSON"}
+        assert _detect_parse_error(content, json_mode=False) == "Failed to parse JSON"
+        assert _detect_parse_error(content, json_mode=True) == "Failed to parse JSON"
+
+    def test_dict_without_parse_error_key(self):
+        """Normal dict content → not a parse error."""
+        assert _detect_parse_error({"answer": "ok"}, json_mode=True) is None
+        assert _detect_parse_error({"answer": "ok"}, json_mode=False) is None
+
+    def test_list_with_parse_error_at_index_0(self):
+        """Online-path format: list with _parse_error at index 0."""
+        content = [{"_parse_error": "bad json", "raw_response": ""}]
+        assert _detect_parse_error(content, json_mode=False) == "bad json"
+
+    def test_list_without_parse_error(self):
+        """Normal list content → not a parse error."""
+        assert _detect_parse_error([{"value": 10}], json_mode=True) is None
+
+    def test_empty_parse_error_string_returns_none(self):
+        """Empty _parse_error value is not treated as a parse error."""
+        assert _detect_parse_error({"_parse_error": ""}, json_mode=True) is None
+
+    def test_none_content(self):
+        """None content → not a parse error."""
+        assert _detect_parse_error(None, json_mode=True) is None
+
+
+# ---------------------------------------------------------------------------
+# ValidationStrategy.evaluate() parse error detection
+# ---------------------------------------------------------------------------
+
+
+class TestParseErrorDetectionInEvaluate:
+    """Spec verification test 1: Parse error detected before UDF."""
+
+    def test_batch_parse_error_detected_before_udf(self):
+        """String content in json_mode fails with failure_type='parse_error', UDF never called."""
+        call_log = []
+
+        def tracking_validate(response):
+            call_log.append(response)
+            return True
+
+        strategy = ValidationStrategy(
+            validation_func=tracking_validate,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        result = _make_result("r1", content="not valid json")
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is False
+        assert outcome.failure_type == "parse_error"
+        assert call_log == [], "UDF should NOT have been called"
+
+    def test_parse_error_dict_detected_before_udf(self):
+        """Pre-wrapped _parse_error dict fails with failure_type='parse_error'."""
+        call_log = []
+
+        def tracking_validate(response):
+            call_log.append(response)
+            return True
+
+        strategy = ValidationStrategy(
+            validation_func=tracking_validate,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        content = {"raw_response": "bad", "_parse_error": "Failed to parse JSON"}
+        result = _make_result("r1", content=content)
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is False
+        assert outcome.failure_type == "parse_error"
+        assert call_log == []
+
+    def test_loose_udf_does_not_pass_parse_error(self):
+        """Spec test 3: UDF that always returns True still fails on parse error."""
+        strategy = ValidationStrategy(
+            validation_func=_always_pass,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        result = _make_result("r1", content="unparsed string response")
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is False
+        assert outcome.failure_type == "parse_error"
+
+    def test_normal_dict_passes_to_udf(self):
+        """Spec test 4: Valid dict content without _parse_error calls UDF normally."""
+        received = []
+
+        def capture_validate(response):
+            received.append(response)
+            return True
+
+        strategy = ValidationStrategy(
+            validation_func=capture_validate,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        content = {"answer": "correct"}
+        result = _make_result("r1", content=content)
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is True
+        assert received == [content]
+
+    def test_udf_failure_classified_as_udf_fail(self):
+        """UDF rejection returns failure_type='udf_fail'."""
+        strategy = ValidationStrategy(
+            validation_func=_always_fail,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        result = _make_result("r1", content={"answer": "wrong"})
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is False
+        assert outcome.failure_type == "udf_fail"
+
+    def test_api_error_classified_as_api_error(self):
+        """API failure returns failure_type='api_error'."""
+        strategy = ValidationStrategy(
+            validation_func=_always_pass,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        result = _make_result("r1", success=False)
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is False
+        assert outcome.failure_type == "api_error"
+
+    def test_non_json_mode_string_content_reaches_udf(self):
+        """In non-json-mode, string content is NOT a parse error — UDF is called."""
+        received = []
+
+        def capture_validate(response):
+            received.append(response)
+            return True
+
+        strategy = ValidationStrategy(
+            validation_func=capture_validate,
+            feedback_message="fix",
+            json_mode=False,
+        )
+        result = _make_result("r1", content="plain text response")
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is True
+        assert received == ["plain text response"]
+
+
+# ---------------------------------------------------------------------------
+# build_feedback parse-error-specific feedback
+# ---------------------------------------------------------------------------
+
+
+class TestParseErrorFeedback:
+    def test_parse_error_gets_json_feedback(self):
+        """Parse error should get JSON-specific feedback, not generic UDF feedback."""
+        strategy = ValidationStrategy(
+            validation_func=_always_fail,
+            feedback_message="Field 'name' is required",
+            json_mode=True,
+        )
+        result = _make_result("r1", content="not valid json")
+        feedback = strategy.build_feedback(result)
+
+        assert "valid JSON" in feedback
+        assert "Field 'name' is required" not in feedback
+
+    def test_udf_failure_gets_normal_feedback(self):
+        """UDF failure should get the normal validation feedback."""
+        strategy = ValidationStrategy(
+            validation_func=_always_fail,
+            feedback_message="Field 'name' is required",
+            json_mode=True,
+        )
+        result = _make_result("r1", content={"incomplete": True})
+        feedback = strategy.build_feedback(result)
+
+        assert "Field 'name' is required" in feedback
+
+
+# ---------------------------------------------------------------------------
+# EvaluationLoop.split() failure_types dict
+# ---------------------------------------------------------------------------
+
+
+class TestSplitFailureTypes:
+    def test_failure_types_returned(self):
+        """split() returns failure_types dict classifying each failure."""
+        strategy = ValidationStrategy(
+            validation_func=_always_fail,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        loop = EvaluationLoop(strategy)
+
+        results = [
+            _make_result("parse_err", content="not json"),
+            _make_result("udf_fail", content={"answer": "wrong"}),
+            _make_result("pass_ok", content={"answer": "right"}),
+        ]
+        # Override UDF to pass the "right" answer
+        strategy._validation_func = lambda r: r.get("answer") == "right"
+
+        graduated, failing, failure_types = loop.split(results)
+
+        assert len(graduated) == 1
+        assert graduated[0].custom_id == "pass_ok"
+        assert len(failing) == 2
+        assert failure_types["parse_err"] == "parse_error"
+        assert failure_types["udf_fail"] == "udf_fail"
+
+    def test_parse_error_and_udf_fail_counted_separately(self):
+        """Spec test 2: parse errors and UDF failures have distinct types."""
+        strategy = ValidationStrategy(
+            validation_func=lambda r: r.get("valid", False),
+            feedback_message="fix",
+            json_mode=True,
+        )
+        loop = EvaluationLoop(strategy)
+
+        results = [
+            _make_result("pe1", content="unparsed string"),
+            _make_result("uf1", content={"valid": False}),
+        ]
+
+        _, failing, failure_types = loop.split(results)
+
+        parse_errors = [cid for cid, ft in failure_types.items() if ft == "parse_error"]
+        udf_fails = [cid for cid, ft in failure_types.items() if ft == "udf_fail"]
+
+        assert parse_errors == ["pe1"]
+        assert udf_fails == ["uf1"]

--- a/tests/unit/processing/test_reprompt_metadata_parity.py
+++ b/tests/unit/processing/test_reprompt_metadata_parity.py
@@ -1,0 +1,222 @@
+"""Tests for reprompt metadata parity between online and batch paths.
+
+Spec 417: Reprompt metadata parity (R2 + NEW1 + NEW2).
+
+Ensures batch _recovery.reprompt output matches online shape:
+- failure-type counters populated
+- validation_name is the actual UDF name
+- per-record attempt counts (not global counter)
+"""
+
+from unittest.mock import MagicMock
+
+from agent_actions.llm.providers.batch_base import BatchResult
+from agent_actions.processing.evaluation.exhaustion import apply_exhausted_reprompt
+from agent_actions.processing.evaluation.strategies.validation import ValidationStrategy
+from agent_actions.processing.types import RepromptMetadata
+
+
+def _make_result(custom_id, success=True, content=None, recovery_metadata=None):
+    r = MagicMock(spec=BatchResult)
+    r.custom_id = custom_id
+    r.success = success
+    r.content = content
+    r.error = None if success else "API error"
+    r.recovery_metadata = recovery_metadata
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: failure-type counters
+# ---------------------------------------------------------------------------
+
+
+class TestFailureTypeCounters:
+    def test_exhaustion_populates_parse_error_count(self):
+        """parse_error_count populated from failure_type_counts."""
+        results = [_make_result("r1")]
+        ftc = {"r1": {"parse_error": 2, "udf_fail": 0}}
+
+        apply_exhausted_reprompt(
+            results=results,
+            failed_ids={"r1"},
+            validation_name="check_output",
+            attempt=3,
+            on_exhausted="return_last",
+            failure_type_counts=ftc,
+        )
+
+        meta = results[0].recovery_metadata.reprompt
+        assert meta.parse_error_count == 2
+        assert meta.udf_fail_count == 0
+        assert meta.schema_fail_count == 0
+
+    def test_exhaustion_populates_udf_fail_count(self):
+        """udf_fail_count populated from failure_type_counts."""
+        results = [_make_result("r1")]
+        ftc = {"r1": {"udf_fail": 3}}
+
+        apply_exhausted_reprompt(
+            results=results,
+            failed_ids={"r1"},
+            validation_name="check_output",
+            attempt=3,
+            on_exhausted="return_last",
+            failure_type_counts=ftc,
+        )
+
+        assert results[0].recovery_metadata.reprompt.udf_fail_count == 3
+
+    def test_mixed_failure_types_per_record(self):
+        """Each record gets its own failure type counts."""
+        results = [_make_result("r1"), _make_result("r2")]
+        ftc = {
+            "r1": {"parse_error": 1, "udf_fail": 1},
+            "r2": {"udf_fail": 2},
+        }
+
+        apply_exhausted_reprompt(
+            results=results,
+            failed_ids={"r1", "r2"},
+            validation_name="check",
+            attempt=3,
+            on_exhausted="return_last",
+            failure_type_counts=ftc,
+        )
+
+        r1_meta = results[0].recovery_metadata.reprompt
+        r2_meta = results[1].recovery_metadata.reprompt
+        assert r1_meta.parse_error_count == 1
+        assert r1_meta.udf_fail_count == 1
+        assert r2_meta.parse_error_count == 0
+        assert r2_meta.udf_fail_count == 2
+
+    def test_counters_present_in_to_dict_when_nonzero(self):
+        """RepromptMetadata.to_dict() includes counter keys when non-zero."""
+        meta = RepromptMetadata(
+            attempts=3,
+            passed=False,
+            validation="check_output",
+            parse_error_count=1,
+            udf_fail_count=2,
+        )
+        d = meta.to_dict()
+
+        assert "parse_error_count" in d
+        assert d["parse_error_count"] == 1
+        assert "udf_fail_count" in d
+        assert d["udf_fail_count"] == 2
+        assert "schema_fail_count" not in d  # 0, so omitted
+
+    def test_no_failure_type_counts_defaults_to_zero(self):
+        """Without failure_type_counts, all counters default to 0."""
+        results = [_make_result("r1")]
+
+        apply_exhausted_reprompt(
+            results=results,
+            failed_ids={"r1"},
+            validation_name="check",
+            attempt=2,
+            on_exhausted="return_last",
+        )
+
+        meta = results[0].recovery_metadata.reprompt
+        assert meta.parse_error_count == 0
+        assert meta.udf_fail_count == 0
+        assert meta.schema_fail_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: validation_name
+# ---------------------------------------------------------------------------
+
+
+class TestValidationName:
+    def test_strategy_name_is_actual_udf_name(self):
+        """ValidationStrategy.name returns the configured UDF name, not 'validation'."""
+        strategy = ValidationStrategy(
+            validation_func=lambda r: True,
+            feedback_message="fix",
+            validation_name="check_output_quality",
+        )
+        assert strategy.name == "check_output_quality"
+
+    def test_strategy_name_defaults_to_validation(self):
+        """Without explicit name, falls back to 'validation' for backward compat."""
+        strategy = ValidationStrategy(
+            validation_func=lambda r: True,
+            feedback_message="fix",
+        )
+        assert strategy.name == "validation"
+
+    def test_exhaustion_metadata_uses_actual_validation_name(self):
+        """apply_exhausted_reprompt writes the actual validation name."""
+        results = [_make_result("r1")]
+
+        apply_exhausted_reprompt(
+            results=results,
+            failed_ids={"r1"},
+            validation_name="check_output_quality",
+            attempt=3,
+            on_exhausted="return_last",
+        )
+
+        assert results[0].recovery_metadata.reprompt.validation == "check_output_quality"
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: per-record attempt counts
+# ---------------------------------------------------------------------------
+
+
+class TestPerRecordAttempts:
+    def test_per_record_attempts_used_over_global(self):
+        """Per-record attempt counts override the global attempt counter."""
+        results = [_make_result("r1"), _make_result("r2")]
+        per_record = {"r1": 1, "r2": 3}
+
+        apply_exhausted_reprompt(
+            results=results,
+            failed_ids={"r1", "r2"},
+            validation_name="check",
+            attempt=5,  # global counter — should NOT be used
+            on_exhausted="return_last",
+            per_record_attempts=per_record,
+        )
+
+        assert results[0].recovery_metadata.reprompt.attempts == 1
+        assert results[1].recovery_metadata.reprompt.attempts == 3
+
+    def test_global_attempt_used_when_per_record_missing(self):
+        """Falls back to global attempt when per_record_attempts not provided."""
+        results = [_make_result("r1")]
+
+        apply_exhausted_reprompt(
+            results=results,
+            failed_ids={"r1"},
+            validation_name="check",
+            attempt=2,
+            on_exhausted="return_last",
+        )
+
+        assert results[0].recovery_metadata.reprompt.attempts == 2
+
+
+# ---------------------------------------------------------------------------
+# RecoveryState serialization of failure_type_counts
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryStateFailureTypeCounts:
+    def test_failure_type_counts_serialized(self):
+        """failure_type_counts round-trips through to_dict / from_dict."""
+        from agent_actions.llm.batch.infrastructure.recovery_state import RecoveryState
+
+        state = RecoveryState(phase="reprompt")
+        state.failure_type_counts = {"r1": {"parse_error": 1, "udf_fail": 2}}
+
+        d = state.to_dict()
+        assert d["failure_type_counts"] == {"r1": {"parse_error": 1, "udf_fail": 2}}
+
+        restored = RecoveryState(**d)
+        assert restored.failure_type_counts == {"r1": {"parse_error": 1, "udf_fail": 2}}

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -111,7 +111,7 @@ def _mock_validation_setup():
 def mock_loop():
     """A controllable EvaluationLoop instance with patched constructor."""
     loop = MagicMock()
-    loop.split.return_value = ([], [])
+    loop.split.return_value = ([], [], {})
     loop.tag_graduated = MagicMock()
     with patch("agent_actions.processing.evaluation.EvaluationLoop", return_value=loop):
         yield loop
@@ -151,7 +151,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
         """loop.split() receives recovery_results, NOT merged accumulated."""
         recovery = [_result("r1"), _result("r2")]
         accumulated = [_result("old1"), _result("old2"), _result("old3")]
-        mock_loop.split.return_value = ([_result("r1")], [_result("r2")])
+        mock_loop.split.return_value = ([_result("r1")], [_result("r2")], {})
 
         service = _make_service()
         with (
@@ -170,7 +170,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
     def test_graduated_results_grow_after_each_cycle(self, mock_loop):
         """state.graduated_results accumulates graduated records across cycles."""
         r1, r2 = _result("r1", "pass"), _result("r2", "fail")
-        mock_loop.split.return_value = ([r1], [r2])
+        mock_loop.split.return_value = ([r1], [r2], {})
 
         prior_graduated = [{"custom_id": "r0", "content": "prior", "success": True}]
         state = _make_state(
@@ -189,7 +189,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
     def test_record_count_invariant(self, mock_loop):
         """Only still_failing records are submitted for reprompt."""
         recovery = [_result("r1"), _result("r2"), _result("r3")]
-        mock_loop.split.return_value = ([_result("r1"), _result("r3")], [_result("r2")])
+        mock_loop.split.return_value = ([_result("r1"), _result("r3")], [_result("r2")], {})
 
         service = _make_service()
         with (
@@ -210,7 +210,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
     def test_exhaustion_marks_still_failing_and_adds_to_graduated(self, mock_loop):
         """When max_attempts reached, still_failing get exhaustion metadata and join graduated."""
         r1, r2 = _result("r1", "pass"), _result("r2", "fail")
-        mock_loop.split.return_value = ([r1], [r2])
+        mock_loop.split.return_value = ([r1], [r2], {})
 
         state = _make_state(reprompt_attempt=2, reprompt_max_attempts=2, graduated_results=[])
         service = _make_service()
@@ -239,7 +239,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
     def test_all_graduated_no_submission(self, mock_loop):
         """When all recovery_results pass, no reprompt batch is submitted."""
         recovery = [_result("r1"), _result("r2")]
-        mock_loop.split.return_value = (recovery, [])
+        mock_loop.split.return_value = (recovery, [], {})
 
         service = _make_service()
         with (
@@ -265,7 +265,7 @@ class TestHandleRepromptRecoveryGraduatedPool:
     def test_submission_failure_falls_through_to_exhaustion(self, mock_loop):
         """When submit_reprompt_batch returns None under max attempts, treat as exhausted."""
         r1, r2 = _result("r1", "pass"), _result("r2", "fail")
-        mock_loop.split.return_value = ([r1], [r2])
+        mock_loop.split.return_value = ([r1], [r2], {})
 
         state = _make_state(reprompt_attempt=0, reprompt_max_attempts=2, graduated_results=[])
         service = _make_service()
@@ -317,7 +317,7 @@ class TestCheckAndSubmitRepromptGraduatedPool:
     def test_uses_evaluation_loop_split(self, mock_loop):
         """EvaluationLoop.split() is used instead of validate_results()."""
         batch = [_result("r1"), _result("r2")]
-        mock_loop.split.return_value = ([_result("r1")], [_result("r2")])
+        mock_loop.split.return_value = ([_result("r1")], [_result("r2")], {})
 
         service = _make_service()
         with patch.object(RecoveryStateManager, "save"):
@@ -330,7 +330,7 @@ class TestCheckAndSubmitRepromptGraduatedPool:
     def test_all_pass_returns_true(self, mock_loop):
         """When all results pass evaluation, returns True (no reprompt needed)."""
         batch = [_result("r1"), _result("r2")]
-        mock_loop.split.return_value = (batch, [])
+        mock_loop.split.return_value = (batch, [], {})
 
         result = self._call(_make_service(), batch_results=batch)
         assert result is True
@@ -338,7 +338,7 @@ class TestCheckAndSubmitRepromptGraduatedPool:
     def test_exhausted_returns_true_and_applies_metadata(self, mock_loop):
         """When current_attempt >= max_attempts, applies exhaustion metadata and returns True."""
         batch = [_result("r1"), _result("r2")]
-        mock_loop.split.return_value = ([_result("r1")], [_result("r2")])
+        mock_loop.split.return_value = ([_result("r1")], [_result("r2")], {})
 
         service = _make_service()
         recovery_state = _make_state(reprompt_attempt=2)
@@ -357,7 +357,7 @@ class TestCheckAndSubmitRepromptGraduatedPool:
     def test_graduated_saved_to_state(self, mock_loop):
         """Graduated results are persisted to state.graduated_results."""
         r1, r2 = _result("r1", "pass"), _result("r2", "fail")
-        mock_loop.split.return_value = ([r1], [r2])
+        mock_loop.split.return_value = ([r1], [r2], {})
 
         service = _make_service()
         saved_state = {}

--- a/tests/unit/test_evaluation_loop.py
+++ b/tests/unit/test_evaluation_loop.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from agent_actions.processing.evaluation.loop import EvaluationLoop
 from agent_actions.processing.types import (
     EvaluationMetadata,
+    EvaluationOutcome,
     RecoveryMetadata,
     RepromptMetadata,
     RetryMetadata,
@@ -25,7 +26,8 @@ def _make_strategy(evaluate_fn=None, name="test", max_attempts=3, on_exhausted="
     strategy.name = name
     strategy.max_attempts = max_attempts
     strategy.on_exhausted = on_exhausted
-    strategy.evaluate = evaluate_fn or (lambda r: True)
+    raw_fn = evaluate_fn or (lambda r: True)
+    strategy.evaluate = lambda r: EvaluationOutcome(passed=raw_fn(r))
     strategy.build_feedback.return_value = "Please fix this."
     return strategy
 
@@ -36,7 +38,7 @@ class TestSplit:
         loop = EvaluationLoop(strategy)
         results = [_make_result("r1"), _make_result("r2")]
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert len(graduated) == 2
         assert len(failing) == 0
@@ -48,7 +50,7 @@ class TestSplit:
         loop = EvaluationLoop(strategy)
         results = [_make_result("r1"), _make_result("r2")]
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert len(graduated) == 0
         assert len(failing) == 2
@@ -63,7 +65,7 @@ class TestSplit:
         loop = EvaluationLoop(strategy)
         results = [_make_result("r1"), _make_result("r2"), _make_result("r3")]
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert [r.custom_id for r in graduated] == ["r1"]
         assert [r.custom_id for r in failing] == ["r2", "r3"]
@@ -79,7 +81,7 @@ class TestSplit:
         )
         fresh = _make_result("r2")
 
-        graduated, failing = loop.split([already_done, fresh])
+        graduated, failing, _ = loop.split([already_done, fresh])
 
         assert len(graduated) == 2
         assert graduated[0].custom_id == "r1"
@@ -89,7 +91,7 @@ class TestSplit:
         strategy = _make_strategy()
         loop = EvaluationLoop(strategy)
 
-        graduated, failing = loop.split([])
+        graduated, failing, _ = loop.split([])
 
         assert graduated == []
         assert failing == []
@@ -101,7 +103,7 @@ class TestSplit:
         result = MagicMock(spec=[])
         result.custom_id = "r1"
 
-        _, failing = loop.split([result])
+        _, failing, _ = loop.split([result])
 
         assert len(failing) == 1
         assert failing[0].custom_id == "r1"
@@ -134,7 +136,7 @@ class TestSplit:
         result = _make_result("r1", recovery_metadata=None)
         result.recovery_metadata = None
 
-        graduated, _ = loop.split([result])
+        graduated, _, _ = loop.split([result])
 
         assert len(graduated) == 1
 
@@ -155,7 +157,7 @@ class TestSplit:
             ),
         )
 
-        _, failing = loop.split([result])
+        _, failing, _ = loop.split([result])
 
         assert "r1" in call_log
         assert len(failing) == 1
@@ -342,12 +344,12 @@ class TestSplitThenTagRoundtrip:
         loop = EvaluationLoop(strategy)
         results = [_make_result("r1"), _make_result("r2")]
 
-        graduated, _ = loop.split(results)
+        graduated, _, _ = loop.split(results)
         loop.tag_graduated(graduated)
 
         # Second cycle: make strategy reject everything — graduated should still pass
-        loop.strategy.evaluate = lambda r: False
-        graduated2, failing2 = loop.split(results)
+        loop.strategy.evaluate = lambda r: EvaluationOutcome(passed=False)
+        graduated2, failing2, _ = loop.split(results)
 
         assert [r.custom_id for r in graduated2] == ["r1", "r2"]
         assert failing2 == []
@@ -364,10 +366,10 @@ class TestSplitThenTagRoundtrip:
         loop = EvaluationLoop(strategy)
         result = _make_result("r1")
 
-        _, failing = loop.split([result])
+        _, failing, _ = loop.split([result])
         assert len(failing) == 1
 
-        graduated, _ = loop.split([result])
+        graduated, _, _ = loop.split([result])
         assert len(graduated) == 1
 
 
@@ -432,12 +434,12 @@ class TestTypedMetadataRoundtrip:
         retry = RetryMetadata(attempts=1, failures=0, succeeded=True, reason="timeout")
         result = _make_result("r1", recovery_metadata=RecoveryMetadata(retry=retry))
 
-        graduated, _ = loop.split([result])
+        graduated, _, _ = loop.split([result])
         loop.tag_graduated(graduated)
 
         # Change strategy to reject everything — graduated should still be detected
-        loop.strategy.evaluate = lambda r: False
-        graduated2, failing2 = loop.split([result])
+        loop.strategy.evaluate = lambda r: EvaluationOutcome(passed=False)
+        graduated2, failing2, _ = loop.split([result])
 
         assert len(graduated2) == 1
         assert len(failing2) == 0

--- a/tests/unit/test_validation_strategy.py
+++ b/tests/unit/test_validation_strategy.py
@@ -75,12 +75,12 @@ class TestValidationStrategyEvaluate:
     def test_passing_result(self):
         strategy = ValidationStrategy(validation_func=_always_pass, feedback_message="fix")
         result = _make_result("r1", content={"valid": True})
-        assert strategy.evaluate(result) is True
+        assert strategy.evaluate(result).passed is True
 
     def test_failing_result(self):
         strategy = ValidationStrategy(validation_func=_always_fail, feedback_message="fix")
         result = _make_result("r1", content={"valid": False})
-        assert strategy.evaluate(result) is False
+        assert strategy.evaluate(result).passed is False
 
     def test_success_false_fails_validation(self):
         """API-failed results fail validation without calling the UDF."""
@@ -92,7 +92,7 @@ class TestValidationStrategyEvaluate:
 
         strategy = ValidationStrategy(validation_func=tracking_validate, feedback_message="fix")
         result = _make_result("r1", success=False)
-        assert strategy.evaluate(result) is False
+        assert strategy.evaluate(result).passed is False
         assert call_log == []
 
     def test_success_false_with_content_still_fails(self):
@@ -105,7 +105,7 @@ class TestValidationStrategyEvaluate:
 
         strategy = ValidationStrategy(validation_func=tracking_validate, feedback_message="fix")
         result = _make_result("r1", content={"partial": "data"}, success=False)
-        assert strategy.evaluate(result) is False
+        assert strategy.evaluate(result).passed is False
         assert call_log == []
 
     def test_already_passed_skips_validation(self):
@@ -123,7 +123,7 @@ class TestValidationStrategyEvaluate:
 
         strategy = ValidationStrategy(validation_func=tracking_validate, feedback_message="fix")
         result = _make_result("r1", recovery_metadata=recovery)
-        assert strategy.evaluate(result) is True
+        assert strategy.evaluate(result).passed is True
         assert call_log == []
 
     def test_exception_in_validation_returns_false(self):
@@ -134,7 +134,7 @@ class TestValidationStrategyEvaluate:
 
         strategy = ValidationStrategy(validation_func=raising_validate, feedback_message="fix")
         result = _make_result("r1")
-        assert strategy.evaluate(result) is False
+        assert strategy.evaluate(result).passed is False
 
     def test_uses_result_content(self):
         """Validation function receives result.content."""
@@ -190,7 +190,7 @@ class TestGraduatedPoolIntegration:
         loop = EvaluationLoop(strategy)
         results = [_make_result("r1"), _make_result("r2")]
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert len(graduated) == 2
         assert len(failing) == 0
@@ -207,7 +207,7 @@ class TestGraduatedPoolIntegration:
             _make_result("r3", content={"valid": True}),
         ]
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert [r.custom_id for r in graduated] == ["r1", "r3"]
         assert [r.custom_id for r in failing] == ["r2"]
@@ -232,19 +232,19 @@ class TestGraduatedPoolIntegration:
 
         # Cycle 0
         attempt_counter[0] = 0
-        graduated_0, failing_0 = loop.split(results)
+        graduated_0, failing_0, _ = loop.split(results)
         assert len(graduated_0) == 1
         assert len(failing_0) == 2
 
         # Cycle 1 — only failing records re-evaluated
         attempt_counter[0] = 1
-        graduated_1, failing_1 = loop.split(failing_0)
+        graduated_1, failing_1, _ = loop.split(failing_0)
         assert len(graduated_1) == 1
         assert len(failing_1) == 1
 
         # Cycle 2
         attempt_counter[0] = 2
-        graduated_2, failing_2 = loop.split(failing_1)
+        graduated_2, failing_2, _ = loop.split(failing_1)
         assert len(graduated_2) == 1
         assert len(failing_2) == 0
 
@@ -272,14 +272,14 @@ class TestGraduatedPoolIntegration:
         results = [_make_result("r1"), _make_result("r2")]
 
         # Cycle 0 — both evaluated, both graduate
-        graduated_0, _ = loop.split(results)
+        graduated_0, _, _ = loop.split(results)
         assert set(evaluated_ids) == {"r1", "r2"}
 
         # Cycle 1 — pass same results, but since we're using the graduated pool
         # pattern correctly, only new active_results go into split.
         # Simulating: active_results would be reprompt results (empty in this case)
         evaluated_ids.clear()
-        graduated_1, _ = loop.split([])
+        graduated_1, _, _ = loop.split([])
         assert evaluated_ids == []
 
     def test_api_failures_are_not_graduated(self):
@@ -292,7 +292,7 @@ class TestGraduatedPoolIntegration:
             _make_result("r2", success=False),  # API failure
         ]
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert [r.custom_id for r in graduated] == []
         assert [r.custom_id for r in failing] == ["r1", "r2"]
@@ -312,7 +312,7 @@ class TestGraduatedPoolIntegration:
             _make_result("pass-2", content={"valid": True}, success=True),
         ]
 
-        graduated, failing = loop.split(results)
+        graduated, failing, _ = loop.split(results)
 
         assert [r.custom_id for r in graduated] == ["pass-1", "pass-2"]
         assert [r.custom_id for r in failing] == ["api-fail", "val-fail"]


### PR DESCRIPTION
## Summary
- Failure-type counters (`parse_error_count`, `udf_fail_count`, `schema_fail_count`) were always 0 in batch output — now populated from `EvaluationOutcome.failure_type` accumulated across recovery rounds
- `validation` field in `_recovery.reprompt` was hardcoded to `"validation"` — now uses the actual UDF name (e.g. `"check_output_quality"`)
- Async exhaustion path used global attempt counter instead of per-record counts — now forwards `state.reprompt_attempts_per_record`
- Depends on spec 418 (PR #584) which introduced `EvaluationOutcome` and `failure_types` in `split()`

## Changes
- `apply_exhausted_reprompt()` accepts `failure_type_counts` param and wires into `RepromptMetadata`
- `ValidationStrategy` accepts `validation_name` param; `.name` returns actual UDF name
- `build_evaluation_loop()` passes `parsed.validation_name` to strategy
- `handle_reprompt_recovery` + `check_and_submit_reprompt` use `validation_name` (not `strategy.name`) and pass `per_record_attempts` + `failure_type_counts`
- `BatchRetryService.apply_exhausted_reprompt_metadata` forwards new params
- `RecoveryState` gains `failure_type_counts` field for cross-round persistence
- 11 new tests

## Verification
- 7101 tests pass (2 pre-existing failures from circular import in `test_async_evaluation_wiring.py`)
- `ruff format --check` clean
- `ruff check` clean