### PR TITLE
fix: FILE-mode per-record disposition writes

### DIFF
--- a/.changes/unreleased/Bug Fix-20260521-421000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-421000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "FILE-mode tool/HITL actions now write per-record SUCCESS dispositions, enabling DispositionGate carry-forward on retry"
+time: 2026-05-21T04:21:00.000000Z

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -437,6 +437,20 @@ def collect_results_from_processing_results(
                     result.source_guid,
                     DISPOSITION_SUCCESS,
                 )
+            elif storage_backend and result.source_guid is None and data:
+                # FILE-mode results have source_guid=None on the result level
+                # but individual items carry their own source_guid.  Write
+                # per-item dispositions so DispositionGate can carry them
+                # forward on retry.
+                for item in data:
+                    item_guid = item.get("source_guid")
+                    if item_guid:
+                        _safe_set_disposition(
+                            storage_backend,
+                            action_name,
+                            item_guid,
+                            DISPOSITION_SUCCESS,
+                        )
 
         elif status == ProcessingStatus.SKIPPED:
             data = result.data or []

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -637,6 +637,120 @@ class TestResultCollectorDispositions:
         assert calls[1] == (("agent", "src-f", "filtered"), {"reason": "guard_filter"})
 
 
+class TestFileModeDispositionWrites:
+    """Tests for per-item disposition fallback when result.source_guid is None (FILE mode)."""
+
+    def test_file_mode_success_writes_per_item_dispositions(self):
+        """FILE-mode SUCCESS with source_guid=None writes per-item dispositions."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "rec-1", "content": {"a": 1}},
+                {"source_guid": "rec-2", "content": {"b": 2}},
+                {"source_guid": "rec-3", "content": {"c": 3}},
+            ],
+            source_guid=None,
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        assert backend.set_disposition.call_count == 3
+        calls = backend.set_disposition.call_args_list
+        assert calls[0] == (("agent", "rec-1", "success"), {})
+        assert calls[1] == (("agent", "rec-2", "success"), {})
+        assert calls[2] == (("agent", "rec-3", "success"), {})
+
+    def test_record_mode_still_uses_result_level_disposition(self):
+        """RECORD-mode SUCCESS with source_guid set uses the fast result-level path."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[{"source_guid": "rec-1", "content": {"a": 1}}],
+            source_guid="rec-1",
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        backend.set_disposition.assert_called_once_with(
+            "agent",
+            "rec-1",
+            "success",
+        )
+
+    def test_file_mode_items_without_source_guid_silently_skipped(self):
+        """FILE-mode items lacking source_guid are skipped without crashing."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "rec-1", "content": {"a": 1}},
+                {"content": {"b": 2}},  # no source_guid
+                {"source_guid": "rec-3", "content": {"c": 3}},
+            ],
+            source_guid=None,
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        assert backend.set_disposition.call_count == 2
+        calls = backend.set_disposition.call_args_list
+        assert calls[0] == (("agent", "rec-1", "success"), {})
+        assert calls[1] == (("agent", "rec-3", "success"), {})
+
+    def test_file_mode_empty_data_no_disposition(self):
+        """FILE-mode SUCCESS with empty data writes no dispositions."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[],
+            source_guid=None,
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        backend.set_disposition.assert_not_called()
+
+    def test_file_mode_no_backend_no_crash(self):
+        """FILE-mode without storage backend does not crash."""
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "rec-1", "content": {"a": 1}},
+            ],
+            source_guid=None,
+        )
+
+        output, _ = ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=None,
+        )
+
+        assert len(output) == 1
+
+
 class TestCollectionStatsOnlyGuardOutcomes:
     """Tests for CollectionStats.only_guard_outcomes property.
 


### PR DESCRIPTION
## Summary
- FILE-mode tool/HITL actions set `source_guid=None` on result-level `ProcessingResult`, so the collector's `if storage_backend and result.source_guid:` check was always False — no SUCCESS dispositions ever written for FILE-mode records
- Added per-item disposition fallback in `collect_results`: when `result.source_guid is None` and `result.data` is non-empty, iterate items and write dispositions using each item's `source_guid`
- RECORD-mode still uses the fast result-level path (no behavior change)
- Fixes DispositionGate carry-forward for FILE-mode actions on retry

## Verification
- 5 new tests in `TestFileModeDispositionWrites`: per-item writes, record-mode unchanged, items without source_guid skipped, empty data, no-backend safety
- 7126 passed, ruff clean, format clean