### PR TITLE
fix: batch first-stage receives full pipeline context

### DIFF
--- a/.changes/unreleased/Bug Fix-20260521-422000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-422000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch first-stage now receives full pipeline context (agent_indices, dependency_configs, version_context, source_data, workflow_metadata) — matching downstream batch path for template resolution and guard filtering"
+time: 2026-05-21T04:22:00.000000Z

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -39,7 +39,7 @@ class InitialStageContext:
     output_directory: str
     idx: int = 0
     storage_backend: Any = None  # Optional StorageBackend for database persistence
-    action_configs: dict[str, Any] | None = None  # All action configs for pipeline context
+    action_configs: dict[str, Any] | None = None
 
 
 @dataclass
@@ -66,7 +66,7 @@ class BatchProcessingContext:
     output_directory: str
     idx: int = 0
     storage_backend: Any = None  # Optional StorageBackend for database persistence
-    action_configs: dict[str, Any] | None = None  # All action configs for pipeline context
+    action_configs: dict[str, Any] | None = None
 
 
 def _derive_workflow_root(primary_path: str | None, fallback_path: str) -> Path:

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -39,6 +39,7 @@ class InitialStageContext:
     output_directory: str
     idx: int = 0
     storage_backend: Any = None  # Optional StorageBackend for database persistence
+    action_configs: dict[str, Any] | None = None  # All action configs for pipeline context
 
 
 @dataclass
@@ -65,6 +66,7 @@ class BatchProcessingContext:
     output_directory: str
     idx: int = 0
     storage_backend: Any = None  # Optional StorageBackend for database persistence
+    action_configs: dict[str, Any] | None = None  # All action configs for pipeline context
 
 
 def _derive_workflow_root(primary_path: str | None, fallback_path: str) -> Path:
@@ -225,6 +227,7 @@ def process_initial_stage(ctx: InitialStageContext):
             output_directory=ctx.output_directory,
             idx=ctx.idx,
             storage_backend=ctx.storage_backend,
+            action_configs=ctx.action_configs,
         )
         return _process_batch_mode(batch_ctx)
 
@@ -608,13 +611,25 @@ def _process_batch_mode(ctx: BatchProcessingContext):
     from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
     from agent_actions.llm.batch.service import create_registry_manager_factory
     from agent_actions.llm.batch.services.submission import BatchSubmissionService
+    from agent_actions.processing.disposition_gate import DispositionGate
+    from agent_actions.workflow.pipeline import ProcessingPipeline
 
     local_batch_id = _get_batch_id_from_chunk(ctx.data_chunk)
-    task_preparator = BatchTaskPreparator(storage_backend=ctx.storage_backend)
+
+    agent_indices, dependency_configs, version_context = ProcessingPipeline._build_pipeline_context(
+        cast("ActionConfigDict", ctx.agent_config),
+        ctx.action_configs,
+    )
+
+    task_preparator = BatchTaskPreparator(
+        action_indices=agent_indices,
+        dependency_configs=dependency_configs,
+        storage_backend=ctx.storage_backend,
+        version_context=version_context,
+    )
     client_resolver = BatchClientResolver(client_cache={}, default_client=None)
     context_manager = BatchContextManager()
     registry_manager_factory = create_registry_manager_factory()
-    from agent_actions.processing.disposition_gate import DispositionGate
 
     disposition_gate = DispositionGate(storage_backend=ctx.storage_backend)
     submission_service = BatchSubmissionService(
@@ -627,7 +642,12 @@ def _process_batch_mode(ctx: BatchProcessingContext):
     )
     file_name = Path(ctx.file_path).name
     result = submission_service.submit_batch_job(
-        ctx.agent_config, file_name, ctx.data_chunk, ctx.output_directory
+        ctx.agent_config,
+        file_name,
+        ctx.data_chunk,
+        ctx.output_directory,
+        source_data=ctx.data_chunk,
+        workflow_metadata={"source_file": ctx.file_path},
     )
 
     relative_path = Path(ctx.file_path).relative_to(ctx.base_directory)

--- a/agent_actions/workflow/strategies.py
+++ b/agent_actions/workflow/strategies.py
@@ -91,6 +91,7 @@ class InitialStrategy(ActionStrategy):
                     output_directory=params.output_directory,
                     idx=params.idx,
                     storage_backend=params.storage_backend,
+                    action_configs=params.action_configs,
                 )
             ),
         )

--- a/tests/unit/input/test_staging_batch_pipeline_parity.py
+++ b/tests/unit/input/test_staging_batch_pipeline_parity.py
@@ -1,0 +1,203 @@
+"""Tests for staging batch pipeline parity (spec 422).
+
+Verifies that batch first-stage processing receives the same pipeline context
+as downstream batch: agent_indices, dependency_configs, version_context,
+source_data, and workflow_metadata.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.input.preprocessing.staging.initial_pipeline import (
+    BatchProcessingContext,
+    _process_batch_mode,
+)
+from agent_actions.llm.batch.core.batch_models import SubmissionResult
+
+_PREP_MODULE = "agent_actions.llm.batch.processing.preparator"
+_SUBMISSION_MODULE = "agent_actions.llm.batch.services.submission"
+
+
+@pytest.fixture
+def tmp_dirs(tmp_path):
+    """Create base and output directories with a sample input file."""
+    base = tmp_path / "base"
+    output = tmp_path / "output"
+    base.mkdir()
+    output.mkdir()
+    input_file = base / "sample.json"
+    input_file.write_text(json.dumps([{"text": "hello"}]))
+    return base, output, input_file
+
+
+@pytest.fixture
+def action_configs():
+    """Multi-action pipeline configs with idx ordering."""
+    return {
+        "extract": {"idx": 0, "model_vendor": "openai"},
+        "classify": {"idx": 1, "model_vendor": "openai"},
+        "summarize": {"idx": 2, "model_vendor": "openai"},
+    }
+
+
+def _make_ctx(tmp_dirs, *, action_configs=None, agent_config=None, data_chunk=None):
+    """Build a BatchProcessingContext for testing."""
+    base, output, input_file = tmp_dirs
+    return BatchProcessingContext(
+        agent_config=agent_config or {"run_mode": "batch"},
+        agent_name="extract",
+        data_chunk=data_chunk or [{"batch_id": "b1", "batch_uuid": "b1_0", "content": "x"}],
+        file_path=str(input_file),
+        base_directory=str(base),
+        output_directory=str(output),
+        action_configs=action_configs,
+    )
+
+
+class TestBatchFirstStagePipelineContext:
+    """BatchTaskPreparator receives full pipeline context from _build_pipeline_context."""
+
+    def test_preparator_receives_agent_indices_and_dependency_configs(
+        self, tmp_dirs, action_configs
+    ):
+        """When action_configs is provided, BatchTaskPreparator gets agent_indices
+        and dependency_configs — matching the downstream batch path."""
+        ctx = _make_ctx(tmp_dirs, action_configs=action_configs)
+
+        with (
+            patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
+            patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
+        ):
+            MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(
+                batch_id="vid_123"
+            )
+            _process_batch_mode(ctx)
+
+        prep_kwargs = MockPrep.call_args[1]
+        assert prep_kwargs["action_indices"] == {"extract": 0, "classify": 1, "summarize": 2}
+        assert prep_kwargs["dependency_configs"] is action_configs
+
+    def test_preparator_receives_version_context_for_versioned_agent(
+        self, tmp_dirs, action_configs
+    ):
+        """Versioned agents get version_context threaded to BatchTaskPreparator."""
+        version_ctx = {"version_id": "v42", "base_version": "v41"}
+        ctx = _make_ctx(
+            tmp_dirs,
+            action_configs=action_configs,
+            agent_config={
+                "run_mode": "batch",
+                "is_versioned_agent": True,
+                "_version_context": version_ctx,
+            },
+        )
+
+        with (
+            patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
+            patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
+        ):
+            MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(
+                batch_id="vid_123"
+            )
+            _process_batch_mode(ctx)
+
+        prep_kwargs = MockPrep.call_args[1]
+        assert prep_kwargs["version_context"] == version_ctx
+        # Must be a copy, not the same object (mutation safety from _build_pipeline_context)
+        assert prep_kwargs["version_context"] is not version_ctx
+
+    def test_preparator_accepts_none_action_configs(self, tmp_dirs):
+        """When action_configs is None (single-action workflow), preparator gets
+        None for indices/configs — matches _build_pipeline_context contract."""
+        ctx = _make_ctx(tmp_dirs)  # action_configs defaults to None
+
+        with (
+            patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
+            patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
+        ):
+            MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(
+                batch_id="vid_123"
+            )
+            _process_batch_mode(ctx)
+
+        prep_kwargs = MockPrep.call_args[1]
+        assert prep_kwargs["action_indices"] is None
+        assert prep_kwargs["dependency_configs"] is None
+        assert prep_kwargs["version_context"] is None
+
+
+class TestBatchFirstStageTemplateContext:
+    """submit_batch_job receives source_data and workflow_metadata for template rendering."""
+
+    def test_submit_receives_source_data_and_workflow_metadata(self, tmp_dirs):
+        """source_data and workflow_metadata are passed to submit_batch_job so
+        {{ source.* }} and {{ workflow.* }} templates resolve."""
+        data_chunk = [{"batch_id": "b1", "batch_uuid": "b1_0", "name": "Alice"}]
+        base, output, input_file = tmp_dirs
+        ctx = _make_ctx(tmp_dirs, data_chunk=data_chunk)
+
+        with patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc:
+            mock_submit = MockSvc.return_value.submit_batch_job
+            mock_submit.return_value = SubmissionResult(batch_id="vid_123")
+            _process_batch_mode(ctx)
+
+        _, kwargs = mock_submit.call_args
+        assert kwargs["source_data"] is data_chunk
+        assert kwargs["workflow_metadata"] == {"source_file": str(input_file)}
+
+    def test_submit_positional_args_unchanged(self, tmp_dirs):
+        """Positional args (agent_config, batch_name, data, output_directory)
+        remain in the same order — no regression."""
+        base, output, input_file = tmp_dirs
+        data_chunk = [{"batch_id": "b1", "batch_uuid": "b1_0", "content": "x"}]
+        ctx = _make_ctx(tmp_dirs, data_chunk=data_chunk)
+
+        with patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc:
+            mock_submit = MockSvc.return_value.submit_batch_job
+            mock_submit.return_value = SubmissionResult(batch_id="vid_123")
+            _process_batch_mode(ctx)
+
+        args, _ = mock_submit.call_args
+        assert args[0] == {"run_mode": "batch"}  # agent_config
+        assert args[1] == "sample.json"  # batch_name (file_name)
+        assert args[2] is data_chunk  # data
+        assert args[3] == str(output)  # output_directory
+
+
+class TestInitialStrategyThreadsActionConfigs:
+    """InitialStrategy passes action_configs from StrategyExecutionParams
+    to InitialStageContext, which threads to BatchProcessingContext."""
+
+    def test_action_configs_threaded_to_initial_stage_context(self):
+        """StrategyExecutionParams.action_configs reaches InitialStageContext."""
+        from agent_actions.workflow.strategies import InitialStrategy, StrategyExecutionParams
+
+        action_configs = {"a": {"idx": 0}, "b": {"idx": 1}}
+
+        captured_ctx = {}
+
+        # Patch where strategies.py imported the function (its own namespace)
+        with patch("agent_actions.workflow.strategies.process_initial_stage") as mock_process:
+
+            def capture(ctx):
+                captured_ctx["action_configs"] = ctx.action_configs
+                return "/fake/path.json"
+
+            mock_process.side_effect = capture
+
+            strategy = InitialStrategy()
+            strategy.execute(
+                StrategyExecutionParams(
+                    action_config={"run_mode": "batch"},
+                    action_name="test",
+                    file_path="/fake/input.json",
+                    base_directory="/fake/base",
+                    output_directory="/fake/output",
+                    idx=0,
+                    action_configs=action_configs,
+                )
+            )
+
+        assert captured_ctx["action_configs"] is action_configs

--- a/tests/unit/input/test_staging_batch_pipeline_parity.py
+++ b/tests/unit/input/test_staging_batch_pipeline_parity.py
@@ -56,6 +56,17 @@ def _make_ctx(tmp_dirs, *, action_configs=None, agent_config=None, data_chunk=No
     )
 
 
+def _run_batch_and_get_prep_kwargs(ctx):
+    """Run _process_batch_mode and return the kwargs passed to BatchTaskPreparator."""
+    with (
+        patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
+        patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
+    ):
+        MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(batch_id="vid_123")
+        _process_batch_mode(ctx)
+    return MockPrep.call_args[1]
+
+
 class TestBatchFirstStagePipelineContext:
     """BatchTaskPreparator receives full pipeline context from _build_pipeline_context."""
 
@@ -65,17 +76,8 @@ class TestBatchFirstStagePipelineContext:
         """When action_configs is provided, BatchTaskPreparator gets agent_indices
         and dependency_configs — matching the downstream batch path."""
         ctx = _make_ctx(tmp_dirs, action_configs=action_configs)
+        prep_kwargs = _run_batch_and_get_prep_kwargs(ctx)
 
-        with (
-            patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
-            patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
-        ):
-            MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(
-                batch_id="vid_123"
-            )
-            _process_batch_mode(ctx)
-
-        prep_kwargs = MockPrep.call_args[1]
         assert prep_kwargs["action_indices"] == {"extract": 0, "classify": 1, "summarize": 2}
         assert prep_kwargs["dependency_configs"] is action_configs
 
@@ -93,17 +95,8 @@ class TestBatchFirstStagePipelineContext:
                 "_version_context": version_ctx,
             },
         )
+        prep_kwargs = _run_batch_and_get_prep_kwargs(ctx)
 
-        with (
-            patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
-            patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
-        ):
-            MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(
-                batch_id="vid_123"
-            )
-            _process_batch_mode(ctx)
-
-        prep_kwargs = MockPrep.call_args[1]
         assert prep_kwargs["version_context"] == version_ctx
         # Must be a copy, not the same object (mutation safety from _build_pipeline_context)
         assert prep_kwargs["version_context"] is not version_ctx
@@ -111,18 +104,9 @@ class TestBatchFirstStagePipelineContext:
     def test_preparator_accepts_none_action_configs(self, tmp_dirs):
         """When action_configs is None (single-action workflow), preparator gets
         None for indices/configs — matches _build_pipeline_context contract."""
-        ctx = _make_ctx(tmp_dirs)  # action_configs defaults to None
+        ctx = _make_ctx(tmp_dirs)
+        prep_kwargs = _run_batch_and_get_prep_kwargs(ctx)
 
-        with (
-            patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
-            patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
-        ):
-            MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(
-                batch_id="vid_123"
-            )
-            _process_batch_mode(ctx)
-
-        prep_kwargs = MockPrep.call_args[1]
         assert prep_kwargs["action_indices"] is None
         assert prep_kwargs["dependency_configs"] is None
         assert prep_kwargs["version_context"] is None
@@ -135,7 +119,7 @@ class TestBatchFirstStageTemplateContext:
         """source_data and workflow_metadata are passed to submit_batch_job so
         {{ source.* }} and {{ workflow.* }} templates resolve."""
         data_chunk = [{"batch_id": "b1", "batch_uuid": "b1_0", "name": "Alice"}]
-        base, output, input_file = tmp_dirs
+        _, _, input_file = tmp_dirs
         ctx = _make_ctx(tmp_dirs, data_chunk=data_chunk)
 
         with patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc:
@@ -150,7 +134,7 @@ class TestBatchFirstStageTemplateContext:
     def test_submit_positional_args_unchanged(self, tmp_dirs):
         """Positional args (agent_config, batch_name, data, output_directory)
         remain in the same order — no regression."""
-        base, output, input_file = tmp_dirs
+        _, output, _ = tmp_dirs
         data_chunk = [{"batch_id": "b1", "batch_uuid": "b1_0", "content": "x"}]
         ctx = _make_ctx(tmp_dirs, data_chunk=data_chunk)
 


### PR DESCRIPTION
## Summary
- Batch first-stage (`_process_batch_mode`) was constructing `BatchTaskPreparator` with only `storage_backend`, missing `agent_indices`, `dependency_configs`, and `version_context`. It also called `submit_batch_job` without `source_data` or `workflow_metadata`.
- Thread `action_configs` from `StrategyExecutionParams` → `InitialStageContext` → `BatchProcessingContext`. Call `_build_pipeline_context()` to compute full context. Pass all to `BatchTaskPreparator` and `submit_batch_job` — matching the downstream batch path in `pipeline.py`.
- This fixes `{{ source.* }}` and `{{ workflow.* }}` template resolution and enables dependency context in batch first-stage prompts.

## Verification
- 6 new tests in `test_staging_batch_pipeline_parity.py`:
  - `BatchTaskPreparator` receives `agent_indices`, `dependency_configs`, `version_context` when `action_configs` provided
  - Version context is a defensive copy (mutation safety)
  - `None` action_configs (single-action workflow) propagates cleanly
  - `submit_batch_job` receives `source_data` and `workflow_metadata`
  - Positional args to `submit_batch_job` unchanged (regression)
  - `InitialStrategy` threads `action_configs` to `InitialStageContext`
- 7127 passed, 2 skipped, ruff clean