### PR TITLE
refactor: centralize cascade filtering in UnifiedProcessor

### DIFF
--- a/.changes/unreleased/Under the Hood-20260521-423000.yaml
+++ b/.changes/unreleased/Under the Hood-20260521-423000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Move cascade filtering from individual strategies to UnifiedProcessor — strategies now only receive processable records"
+time: 2026-05-21T04:23:00.000000Z

--- a/agent_actions/processing/cascade_filter.py
+++ b/agent_actions/processing/cascade_filter.py
@@ -5,8 +5,8 @@ Partitions input records into processable (ACTIVE) and quarantined
 Quarantined records produce UNPROCESSED results immediately — no LLM
 call, no tool invocation, no compute wasted.
 
-Every processing strategy must call :func:`partition_cascade_records`
-at the top of its ``invoke()`` method.
+Called by :class:`~agent_actions.processing.unified.UnifiedProcessor`
+before ``strategy.invoke()`` — strategies never see cascade-blocked records.
 """
 
 from __future__ import annotations

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -7,13 +7,11 @@ import logging
 from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
-from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
 )
-from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -47,30 +45,19 @@ class FileToolStrategy:
     ) -> list[ProcessingResult]:
         """Invoke a FILE-mode tool and reconcile outputs.
 
-        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
-        upstream) are partitioned out before the tool runs — no tool
-        invocation for quarantined records.
+        Records are already cascade-filtered by UnifiedProcessor — only
+        processable records arrive here.
 
         ``context.source_data`` must contain the pre-context-scope records
-        that passed the guard filter (set by UnifiedProcessor before
-        invoking the strategy).  These are used for output reconciliation.
+        that passed the guard and cascade filters (set by UnifiedProcessor
+        before invoking the strategy).  These are used for output
+        reconciliation.
         """
-        processable, quarantined_results = partition_cascade_records(
-            records, action_name=context.agent_name
-        )
-
-        if not processable and quarantined_results:
-            return quarantined_results
-
-        # Filter original_data to exclude quarantined records so
-        # TrackedItem.source_index aligns with reconcile_outputs lookups.
-        original_data = [
-            r for r in (context.source_data or []) if r.get("_state") not in CASCADE_BLOCKING_VALUES
-        ]
+        original_data = context.source_data or []
         try:
             context_scope = context.agent_config.get("context_scope") or {}
             clean_input: list[TrackedItem] = []
-            for i, record in enumerate(processable):
+            for i, record in enumerate(records):
                 business = extract_tool_input(record, context_scope)
                 clean_input.append(TrackedItem(business, source_index=i))
 
@@ -84,18 +71,18 @@ class FileToolStrategy:
                 skip_guard_eval=True,
             )
 
-            if is_empty_response(raw_response) and processable:
+            if is_empty_response(raw_response) and records:
                 error_msg = (
                     f"Tool '{context.agent_name}' returned empty result "
-                    f"from {len(processable)} input record(s)"
+                    f"from {len(records)} input record(s)"
                 )
-                return quarantined_results + [
+                return [
                     ProcessingResult.failed(
                         error=error_msg,
                         source_guid=record.get("source_guid"),
                         source_snapshot=copy.deepcopy(record),
                     )
-                    for record in processable
+                    for record in records
                 ]
 
             structured_data, source_mapping = reconcile_outputs(
@@ -109,12 +96,12 @@ class FileToolStrategy:
                 data=structured_data,
                 source_guid=None,  # FILE mode has no single source
                 raw_response=raw_response,
-                is_expansion=len(structured_data) > len(processable),
+                is_expansion=len(structured_data) > len(records),
             )
             result.executed = executed
             result.source_mapping = source_mapping
 
-            return quarantined_results + [result]
+            return [result]
 
         except AgentActionsError:
             raise
@@ -124,7 +111,7 @@ class FileToolStrategy:
                 f"FILE mode tool '{context.agent_name}' failed: {e}",
                 context={
                     "agent_name": context.agent_name,
-                    "record_count": len(processable),
+                    "record_count": len(records),
                     "operation": "file_mode_tool",
                 },
                 cause=e,

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import AgentActionsError
-from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.record_helpers import carry_framework_fields
 from agent_actions.processing.types import (
@@ -17,7 +16,6 @@ from agent_actions.processing.types import (
     ProcessingStatus,
 )
 from agent_actions.record.envelope import RecordEnvelope
-from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.tools_resolver import resolve_tools_path
 from agent_actions.workflow.pipeline_file_mode import extract_tool_input
 
@@ -43,25 +41,15 @@ class HITLStrategy:
     ) -> list[ProcessingResult]:
         """Invoke a FILE-mode HITL action and broadcast the decision.
 
-        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
-        upstream) are partitioned out before the HITL tool runs.
+        Records are already cascade-filtered by UnifiedProcessor — only
+        processable records arrive here.
 
         ``context.source_data`` must contain the pre-context-scope records
-        that passed the guard filter (set by UnifiedProcessor before
-        invoking the strategy).  These are used to build structured output.
+        that passed the guard and cascade filters (set by UnifiedProcessor
+        before invoking the strategy).  These are used to build structured
+        output.
         """
-        processable, quarantined_results = partition_cascade_records(
-            records, action_name=context.agent_name
-        )
-
-        if not processable and quarantined_results:
-            return quarantined_results
-
-        # Filter original_data to exclude quarantined records so positional
-        # indexing of record_reviews aligns with what the HITL tool received.
-        original_data = [
-            r for r in (context.source_data or []) if r.get("_state") not in CASCADE_BLOCKING_VALUES
-        ]
+        original_data = context.source_data or []
         try:
             # Inject HITL state persistence metadata into agent config
             hitl_agent_config = dict(context.agent_config)
@@ -78,7 +66,7 @@ class HITLStrategy:
                 hitl_agent_config["_hitl_file_stem"] = file_stem
 
             context_scope = context.agent_config.get("context_scope") or {}
-            filtered_records = [extract_tool_input(r, context_scope) for r in processable]
+            filtered_records = [extract_tool_input(r, context_scope) for r in records]
 
             empty_count = sum(1 for r in filtered_records if not r)
             if empty_count:
@@ -123,11 +111,11 @@ class HITLStrategy:
                     1 for r in (decision_payload.get("record_reviews") or []) if r is not None
                 )
                 raise AgentActionsError(
-                    f"HITL review timed out ({reviewed}/{len(processable)} records reviewed). "
+                    f"HITL review timed out ({reviewed}/{len(records)} records reviewed). "
                     "Partial reviews saved. Re-run workflow to resume.",
                     context={
                         "agent_name": context.agent_name,
-                        "record_count": len(processable),
+                        "record_count": len(records),
                     },
                 )
 
@@ -170,7 +158,7 @@ class HITLStrategy:
                 source_mapping={i: i for i in range(len(structured_data))},
             )
 
-            return quarantined_results + [result]
+            return [result]
         except AgentActionsError:
             raise
         except Exception:

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -25,7 +25,6 @@ from agent_actions.logging.events.data_pipeline_events import (
     RecordTransformedEvent,
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
-from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 from agent_actions.processing.invocation import InvocationStrategy, InvocationStrategyFactory
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
@@ -139,34 +138,29 @@ class OnlineLLMStrategy:
     ) -> list[ProcessingResult]:
         """Process records through the online LLM pipeline.
 
-        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
-        upstream) are partitioned out before processing — no LLM calls
-        are made for quarantined records.
+        Records are already cascade-filtered by UnifiedProcessor — only
+        processable records arrive here.
 
-        Iterates remaining records, calling process_record() for each.
+        Iterates records, calling process_record() for each.
         Record-specific errors (RecordContextError, TemplateVariableError
         with missing vars) produce tombstones and continue. Action-fatal
         errors (ConfigurationError, TemplateSyntaxError, EmptyOutputError,
         SchemaValidationError) re-raise.
         """
-        processable, quarantined_results = partition_cascade_records(
-            records, action_name=context.agent_name
-        )
-
         start_time = datetime.now(UTC)
 
         fire_event(
             BatchProcessingStartedEvent(
                 action_name=context.agent_name,
-                batch_size=len(processable),
+                batch_size=len(records),
             )
         )
 
-        results: list[ProcessingResult] = list(quarantined_results)
+        results: list[ProcessingResult] = []
         successes = 0
         failures = 0
 
-        for idx, item in enumerate(processable):
+        for idx, item in enumerate(records):
             try:
                 item_context = _create_item_context(context, idx, item)
                 result = self.process_record(item, item_context)
@@ -177,12 +171,12 @@ class OnlineLLMStrategy:
                 elif result.status == ProcessingStatus.FAILED:
                     failures += 1
 
-                if (idx + 1) % 10 == 0 or (idx + 1) == len(processable):
+                if (idx + 1) % 10 == 0 or (idx + 1) == len(records):
                     fire_event(
                         BatchProcessingProgressEvent(
                             action_name=context.agent_name,
                             processed=idx + 1,
-                            total=len(processable),
+                            total=len(records),
                             successes=successes,
                             failures=failures,
                         )
@@ -256,7 +250,7 @@ class OnlineLLMStrategy:
         fire_event(
             BatchDataProcessingCompleteEvent(
                 action_name=context.agent_name,
-                total_records=len(processable),
+                total_records=len(records),
                 elapsed_time=elapsed_time,
             )
         )

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
+from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import CollectionStats, ResultCollector
@@ -43,7 +44,8 @@ class ProcessingStrategy(Protocol):
     - HITL state management and decision broadcast (FILE HITL)
     - Batch result reconciliation (batch)
 
-    The strategy receives only records that passed the guard filter.
+    The strategy receives only records that passed the guard filter and
+    cascade filter (upstream-failed records are quarantined by the processor).
     It returns one ProcessingResult per logical output (may be 1:1 or N:M
     depending on the strategy).
     """
@@ -60,7 +62,7 @@ class ProcessingStrategy(Protocol):
 class UnifiedProcessor:
     """Unified record processing pipeline.
 
-    Shared skeleton: guard -> invoke -> enrich -> collect.
+    Shared skeleton: guard -> cascade filter -> invoke -> enrich -> collect.
     The strategy controls only the invocation step.
     """
 
@@ -85,9 +87,10 @@ class UnifiedProcessor:
 
         Steps:
             1. Guard filter — split records into passing/skipped/filtered
-            2. Invoke strategy — process passing records
-            3. Enrich — add lineage, metadata, version IDs, passthrough fields
-            4. Collect — flatten results into output records with dispositions
+            2. Cascade filter — quarantine upstream-failed records
+            3. Invoke strategy — process remaining records
+            4. Enrich — add lineage, metadata, version IDs, passthrough fields
+            5. Collect — flatten results into output records with dispositions
 
         Args:
             records: Input records.  For FILE mode these are context-scope-
@@ -152,16 +155,34 @@ class UnifiedProcessor:
                     to_process = passing
             passing = to_process
 
-        invocation_results = strategy.invoke(passing, context) if passing else []
+        # Cascade filter — quarantine upstream-failed records before strategy
+        # sees them.  Strategies only receive processable records.
+        processable, quarantined_results = partition_cascade_records(
+            passing, action_name=context.agent_name
+        )
+
+        # FILE mode: filter context.source_data to maintain positional alignment
+        # with processable records (used by reconcile_outputs / HITL broadcast).
+        if raw_records is not None and quarantined_results:
+            quarantined_guids = {
+                r.source_guid for r in quarantined_results if r.source_guid is not None
+            }
+            context.source_data = [
+                s
+                for s in (context.source_data or [])
+                if s.get("source_guid") not in quarantined_guids
+            ]
+
+        invocation_results = strategy.invoke(processable, context) if processable else []
 
         # FILE mode: sequential processing — record N can reference record N-1's output.
         # RECORD mode: independent — merge order doesn't affect semantics.
         # This divergence is intentional. Do not unify without verifying FILE-mode
         # workflows that depend on sequential accumulation (e.g., multi-pass enrichment).
         if raw_records is not None:
-            all_results = invocation_results + guard_results
+            all_results = quarantined_results + invocation_results + guard_results
         else:
-            all_results = guard_results + invocation_results
+            all_results = guard_results + quarantined_results + invocation_results
 
         enriched = self._enrich(all_results, context)
 

--- a/tests/unit/processing/test_hitl_cascade_mixed.py
+++ b/tests/unit/processing/test_hitl_cascade_mixed.py
@@ -1,15 +1,21 @@
-"""Test HITL strategy with cascade-blocked records mixed in.
+"""Test HITL cascade filtering through UnifiedProcessor.
 
 Proves that when cascade-blocked records are present in input,
+UnifiedProcessor filters them before the strategy sees them, and
 HITL review decisions are applied to the correct active records
 by position (not misattributed to quarantined records).
+
+After the cascade-filter-enforcement refactor, cascade filtering
+happens in UnifiedProcessor.process(), not inside each strategy.
 """
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from agent_actions.processing.disposition_gate import DispositionGate
 from agent_actions.processing.strategies.hitl import HITLStrategy
-from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.processing.unified import UnifiedProcessor
 from tests.helpers.cascade_helpers import make_record as _record
 
 
@@ -26,22 +32,38 @@ def _make_context(agent_name: str = "hitl_review", **kwargs) -> ProcessingContex
     )
 
 
+class _SpyStrategy:
+    """Test strategy that records received records and returns success for each."""
+
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+
+    def invoke(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+    ) -> list[ProcessingResult]:
+        self.received.extend(records)
+        return [
+            ProcessingResult.success(data=[r], source_guid=r.get("source_guid")) for r in records
+        ]
+
+
 class TestHITLCascadeMixed:
-    """HITL with mixed active + cascade-blocked records."""
+    """HITL with mixed active + cascade-blocked records via UnifiedProcessor."""
 
     def test_reviews_applied_to_correct_records(self):
         """Input: [R1 active, R2 failed, R3 active].
         HITL sees [R1, R3] (processable only).
         Returns record_reviews for [R1, R3].
         R1 gets review_for_R1, R3 gets review_for_R3.
-        R2 appears only as a quarantined tombstone.
+        R2 appears as a quarantined tombstone in output.
         """
         r1 = _record("r1", "active")
         r2 = _record("r2", "failed")
         r3 = _record("r3", "active")
 
         context = _make_context()
-        # source_data is set by UnifiedProcessor — includes all passing records
         context.source_data = [r1, r2, r3]
 
         hitl_response = {
@@ -56,28 +78,28 @@ class TestHITLCascadeMixed:
             "agent_actions.processing.strategies.hitl.run_dynamic_agent",
             return_value=([hitl_response], True),
         ):
-            results = HITLStrategy().invoke([r1, r2, r3], context)
+            processor = UnifiedProcessor()
+            strategy = HITLStrategy()
+            # FILE mode: pass raw_records to trigger FILE-mode guard path
+            output, stats = processor.process(
+                [r1, r2, r3], context, strategy, raw_records=[r1, r2, r3]
+            )
 
-        # Should have quarantined results + 1 SUCCESS result
-        unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
-        successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
-        assert len(unprocessed) == 1  # R2 quarantined
-        assert unprocessed[0].source_guid == "r2"
+        # R2 should appear as unprocessed in output
+        r2_out = [r for r in output if r.get("source_guid") == "r2"]
+        assert len(r2_out) == 1
 
-        assert len(successes) == 1
-        success_data = successes[0].data
-        # Should have exactly 2 records (R1 and R3), not 3
-        assert len(success_data) == 2
+        # R1 and R3 should have HITL review data
+        r1_out = [r for r in output if r.get("source_guid") == "r1"]
+        r3_out = [r for r in output if r.get("source_guid") == "r3"]
+        assert len(r1_out) == 1
+        assert len(r3_out) == 1
 
-        # R1 should have "R1 looks good" comment
-        r1_out = success_data[0]
-        r1_content = r1_out.get("content", {})
+        r1_content = r1_out[0].get("content", {})
         hitl_ns = r1_content.get("hitl_review", {})
         assert hitl_ns.get("user_comment") == "R1 looks good"
 
-        # R3 should have "R3 needs work" comment (not misattributed to R2)
-        r3_out = success_data[1]
-        r3_content = r3_out.get("content", {})
+        r3_content = r3_out[0].get("content", {})
         hitl_ns_r3 = r3_content.get("hitl_review", {})
         assert hitl_ns_r3.get("user_comment") == "R3 needs work"
 
@@ -89,15 +111,16 @@ class TestHITLCascadeMixed:
         context = _make_context()
         context.source_data = [r1, r2]
 
-        # run_dynamic_agent should NOT be called
+        # run_dynamic_agent should NOT be called — all quarantined
         with patch(
             "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         ) as mock_agent:
-            results = HITLStrategy().invoke([r1, r2], context)
+            processor = UnifiedProcessor()
+            strategy = HITLStrategy()
+            output, stats = processor.process([r1, r2], context, strategy, raw_records=[r1, r2])
 
         mock_agent.assert_not_called()
-        assert len(results) == 2
-        assert all(r.status == ProcessingStatus.UNPROCESSED for r in results)
+        assert stats.unprocessed == 2
 
     def test_interleaved_cascade_blocked_at_start_and_end(self):
         """Input: [R1 failed, R2 active, R3 failed, R4 active, R5 failed].
@@ -124,18 +147,111 @@ class TestHITLCascadeMixed:
             "agent_actions.processing.strategies.hitl.run_dynamic_agent",
             return_value=([hitl_response], True),
         ):
-            results = HITLStrategy().invoke([r1, r2, r3, r4, r5], context)
+            processor = UnifiedProcessor()
+            strategy = HITLStrategy()
+            output, stats = processor.process(
+                [r1, r2, r3, r4, r5], context, strategy, raw_records=[r1, r2, r3, r4, r5]
+            )
 
-        unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
-        successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
-        assert len(unprocessed) == 3  # R1, R3, R5 quarantined
-        assert len(successes) == 1
+        # R1, R3, R5 quarantined
+        assert stats.unprocessed == 3
 
-        success_data = successes[0].data
-        assert len(success_data) == 2  # R2 and R4 only
+        # R2 and R4 should have correct reviews
+        r2_out = next(r for r in output if r.get("source_guid") == "r2")
+        r4_out = next(r for r in output if r.get("source_guid") == "r4")
 
-        r2_content = success_data[0].get("content", {}).get("hitl_review", {})
+        r2_content = r2_out.get("content", {}).get("hitl_review", {})
         assert r2_content.get("user_comment") == "R2 approved"
 
-        r4_content = success_data[1].get("content", {}).get("hitl_review", {})
+        r4_content = r4_out.get("content", {}).get("hitl_review", {})
         assert r4_content.get("user_comment") == "R4 rejected"
+
+
+class TestStrategyReceivesOnlyProcessable:
+    """Verify strategies never see cascade-blocked records."""
+
+    def test_cascade_blocked_never_reach_strategy(self):
+        """Mock strategy records what it receives. Assert no cascade-blocked records."""
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "failed")
+        r3 = _record("r3", "cascade_skipped")
+        r4 = _record("r4", "active")
+
+        spy = _SpyStrategy()
+        context = _make_context()
+        processor = UnifiedProcessor()
+        output, stats = processor.process([r1, r2, r3, r4], context, spy)
+
+        # Strategy should only see R1 and R4
+        assert len(spy.received) == 2
+        guids = {r.get("source_guid") for r in spy.received}
+        assert guids == {"r1", "r4"}
+
+        # R2 and R3 should appear as unprocessed in output
+        assert stats.unprocessed == 2
+
+    def test_new_strategy_without_cascade_call_still_works(self):
+        """A bare ProcessingStrategy with no cascade logic still works —
+        UnifiedProcessor handles cascade filtering."""
+
+        class BareStrategy:
+            def invoke(
+                self,
+                records: list[dict[str, Any]],
+                context: ProcessingContext,
+            ) -> list[ProcessingResult]:
+                return [
+                    ProcessingResult.success(data=[r], source_guid=r.get("source_guid"))
+                    for r in records
+                ]
+
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "failed")
+
+        context = _make_context()
+        processor = UnifiedProcessor()
+        output, stats = processor.process([r1, r2], context, BareStrategy())
+
+        assert stats.success == 1
+        assert stats.unprocessed == 1
+
+
+class TestGateCascadeInteraction:
+    """Verify disposition gate + cascade filter interact correctly.
+
+    Gate runs first (carries forward already-terminal records), then
+    cascade filter quarantines upstream-failed records. Both reduce
+    what the strategy sees.
+    """
+
+    def test_gate_carry_forward_plus_cascade_quarantine(self):
+        """R1 active (process), R2 failed (cascade), R3 active but terminal (gate).
+
+        Strategy should only see R1. R2 quarantined by cascade filter.
+        R3 carried forward by disposition gate.
+        """
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "failed")
+        r3 = _record("r3", "active")
+
+        # Mock storage backend: R3 has terminal disposition
+        mock_backend = MagicMock()
+        mock_backend.get_terminal_record_ids.return_value = {"r3"}
+        mock_backend.read_target.return_value = [
+            {"source_guid": "r3", "content": {"hitl_review": {"prior": True}}}
+        ]
+
+        gate = DispositionGate(storage_backend=mock_backend)
+        context = _make_context()
+        context.storage_backend = mock_backend
+        context.file_path = "test.json"
+
+        spy = _SpyStrategy()
+        processor = UnifiedProcessor(disposition_gate=gate)
+        output, stats = processor.process([r1, r2, r3], context, spy)
+
+        # Strategy should only see R1 (R2 cascade-quarantined, R3 gate-carried)
+        assert len(spy.received) == 1
+        assert spy.received[0].get("source_guid") == "r1"
+
+        assert stats.unprocessed == 1

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -1824,7 +1824,12 @@ def test_file_tool_cascade_blocked_source_index_alignment():
     Input: [R1 active, R2 failed, R3 active]. Processable = [R1, R3].
     Tool returns TrackedItem results indexed 0→R1, 1→R3.
     reconcile_outputs must map source_index=1 to R3 (not R2).
+
+    Cascade filtering is done by UnifiedProcessor, so this test runs
+    through the full processor pipeline (FILE mode with raw_records).
     """
+    from agent_actions.processing.unified import UnifiedProcessor
+
     r1 = {"source_guid": "sg-1", "_state": "active", "content": {"prev": {"id": 1}}}
     r2 = {"source_guid": "sg-2", "_state": "failed", "content": {"prev": {"id": 2}}}
     r3 = {"source_guid": "sg-3", "_state": "active", "content": {"prev": {"id": 3}}}
@@ -1841,19 +1846,16 @@ def test_file_tool_cascade_blocked_source_index_alignment():
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(tool_output, True),
     ):
-        results = FileToolStrategy().invoke([r1, r2, r3], context)
+        processor = UnifiedProcessor()
+        strategy = FileToolStrategy()
+        output, stats = processor.process([r1, r2, r3], context, strategy, raw_records=[r1, r2, r3])
 
-    # R2 should be quarantined (UNPROCESSED), R1 and R3 processed
-    unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
-    successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
-    assert len(unprocessed) == 1
-    assert unprocessed[0].source_guid == "sg-2"
+    # R2 should be quarantined (unprocessed), R1 and R3 processed
+    assert stats.unprocessed == 1
 
-    assert len(successes) == 1
-    success_data = successes[0].data
-    assert len(success_data) == 2
-
-    # R1's output should carry R1's source_guid (not R2's)
-    assert success_data[0].get("source_guid") == "sg-1"
-    # R3's output should carry R3's source_guid (not R2's — the bug)
-    assert success_data[1].get("source_guid") == "sg-3"
+    r1_out = [r for r in output if r.get("source_guid") == "sg-1"]
+    r3_out = [r for r in output if r.get("source_guid") == "sg-3"]
+    r2_out = [r for r in output if r.get("source_guid") == "sg-2"]
+    assert len(r1_out) == 1
+    assert len(r3_out) == 1
+    assert len(r2_out) == 1  # quarantined tombstone


### PR DESCRIPTION
## Summary
- Moved `partition_cascade_records` from inside each strategy's `invoke()` to `UnifiedProcessor.process()`, so strategies only ever receive processable records
- Removed duplicate cascade filtering from `OnlineLLMStrategy`, `FileToolStrategy`, and `HITLStrategy`
- FILE-mode `context.source_data` is filtered by quarantined source_guids to maintain positional alignment for `reconcile_outputs` and HITL broadcast
- Updated `ProcessingStrategy` protocol docstring to reflect new cascade contract

## Verification
- 7122 tests pass (2 pre-existing failures in unrelated Ollama/JSON parsing excluded)
- `ruff check` and `ruff format --check` clean
- Tests rewritten to go through `UnifiedProcessor` (new enforcement point) instead of calling strategies directly with cascade-blocked records
- Added: gate+cascade interaction test, bare-strategy-without-cascade test, spy-strategy-receives-only-processable test