### PR TITLE
fix: detect missing records in FILE-mode tool output

### DIFF
--- a/.changes/unreleased/Bug Fix-20260521-424000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-424000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "FILE-mode tools that return fewer records than received now produce tombstone results for missing records instead of silently dropping them"
+time: 2026-05-21T04:24:00.000000Z

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.processing.helpers import run_dynamic_agent
+from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
@@ -92,16 +93,53 @@ class FileToolStrategy:
                 version_merge=is_version_merge(context.agent_config),
             )
 
+            is_expansion = len(structured_data) > len(records)
+
+            # Detect missing records — tool dropped input without output.
+            # Skip for expansion tools (N→M, M>N) where output GUIDs
+            # legitimately differ from input GUIDs.
+            # Also skip when synthetic records exist (source_mapping contains
+            # None) — we can't determine which inputs a synthetic consumed.
+            has_synthetic = source_mapping and any(v is None for v in source_mapping.values())
+            missing_results: list[ProcessingResult] = []
+            if not is_expansion and not has_synthetic:
+                output_guids = {
+                    item.get("source_guid") for item in structured_data if isinstance(item, dict)
+                }
+                for input_record in records:
+                    rid = input_record.get("source_guid")
+                    if rid and rid not in output_guids:
+                        logger.warning(
+                            "Tool '%s' did not return record %s — producing passthrough tombstone",
+                            context.agent_name,
+                            rid,
+                        )
+                        missing_results.append(
+                            ProcessingResult.unprocessed(
+                                data=[
+                                    build_tombstone(
+                                        context.agent_name,
+                                        input_record,
+                                        "tool_missing_record",
+                                        source_guid=rid,
+                                    )
+                                ],
+                                reason="tool_missing_record",
+                                source_guid=rid,
+                                input_record=input_record,
+                            )
+                        )
+
             result = ProcessingResult.success(
                 data=structured_data,
                 source_guid=None,  # FILE mode has no single source
                 raw_response=raw_response,
-                is_expansion=len(structured_data) > len(records),
+                is_expansion=is_expansion,
             )
             result.executed = executed
             result.source_mapping = source_mapping
 
-            return [result]
+            return [result] + missing_results
 
         except AgentActionsError:
             raise

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -13,6 +13,7 @@ from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
 )
+from agent_actions.record.reasons import TOOL_MISSING_RECORD
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -103,9 +104,7 @@ class FileToolStrategy:
             has_synthetic = source_mapping and any(v is None for v in source_mapping.values())
             missing_results: list[ProcessingResult] = []
             if not is_expansion and not has_synthetic:
-                output_guids = {
-                    item.get("source_guid") for item in structured_data if isinstance(item, dict)
-                }
+                output_guids = {item.get("source_guid") for item in structured_data}
                 for input_record in records:
                     rid = input_record.get("source_guid")
                     if rid and rid not in output_guids:
@@ -120,11 +119,11 @@ class FileToolStrategy:
                                     build_tombstone(
                                         context.agent_name,
                                         input_record,
-                                        "tool_missing_record",
+                                        TOOL_MISSING_RECORD,
                                         source_guid=rid,
                                     )
                                 ],
-                                reason="tool_missing_record",
+                                reason=TOOL_MISSING_RECORD,
                                 source_guid=rid,
                                 input_record=input_record,
                             )

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -25,6 +25,9 @@ PREP_FAILED = "prep_failed"
 # -- Batch -------------------------------------------------------------------
 BATCH_NOT_RETURNED = "batch_not_returned"
 
+# -- Tool (FILE mode) -------------------------------------------------------
+TOOL_MISSING_RECORD = "tool_missing_record"
+
 # -- Empty output ------------------------------------------------------------
 EMPTY_OUTPUT = "empty_output"
 

--- a/tests/unit/processing/test_tool_missing_record_detection.py
+++ b/tests/unit/processing/test_tool_missing_record_detection.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from agent_actions.processing.strategies.file_tool import FileToolStrategy
 from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.reasons import TOOL_MISSING_RECORD
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.udf_management.registry import FileUDFResult
 
@@ -84,7 +85,7 @@ class TestToolMissingRecordDetection:
         assert missing_guids == {"r2", "r4"}
 
         for r in missing:
-            assert r.skip_reason == "tool_missing_record"
+            assert r.skip_reason == TOOL_MISSING_RECORD
             assert r.executed is False
             assert len(r.data) == 1
             assert r.data[0].get("_tombstone") is True

--- a/tests/unit/processing/test_tool_missing_record_detection.py
+++ b/tests/unit/processing/test_tool_missing_record_detection.py
@@ -1,0 +1,218 @@
+"""Tests for FILE-mode tool missing record detection.
+
+When a tool returns fewer records than it received, the missing records
+should be detected and tombstoned — not silently lost.
+"""
+
+from unittest.mock import patch
+
+from agent_actions.processing.strategies.file_tool import FileToolStrategy
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.tracking import TrackedItem
+from agent_actions.utils.udf_management.registry import FileUDFResult
+
+
+def _make_context(agent_name="my_tool"):
+    ctx = ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file"},
+        agent_name=agent_name,
+    )
+    return ctx
+
+
+def _make_records(*guids):
+    """Build input records with source_guid and minimal content."""
+    return [{"source_guid": g, "content": {"prev": {"id": i}}} for i, g in enumerate(guids)]
+
+
+class TestToolMissingRecordDetection:
+    """Missing record detection after tool invocation."""
+
+    def test_all_records_returned_no_tombstones(self):
+        """Tool returns all records — no warnings, no tombstones."""
+        records = _make_records("r1", "r2", "r3")
+        context = _make_context()
+        context.source_data = records
+
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"v": 1}, source_index=0),
+                    TrackedItem({"v": 2}, source_index=1),
+                    TrackedItem({"v": 3}, source_index=2),
+                ],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # Single success result, no missing tombstones
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS
+        assert len(results[0].data) == 3
+
+    def test_tool_drops_records_produces_tombstones(self):
+        """Tool drops 2 of 5 records — 2 unprocessed results with tombstones."""
+        records = _make_records("r1", "r2", "r3", "r4", "r5")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool only returns r1, r3, r5 — drops r2 and r4
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"v": 1}, source_index=0),
+                    TrackedItem({"v": 3}, source_index=2),
+                    TrackedItem({"v": 5}, source_index=4),
+                ],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # 1 success + 2 unprocessed
+        assert len(results) == 3
+        assert results[0].status == ProcessingStatus.SUCCESS
+        assert len(results[0].data) == 3
+
+        missing = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        assert len(missing) == 2
+
+        missing_guids = {r.source_guid for r in missing}
+        assert missing_guids == {"r2", "r4"}
+
+        for r in missing:
+            assert r.skip_reason == "tool_missing_record"
+            assert r.executed is False
+            assert len(r.data) == 1
+            assert r.data[0].get("_tombstone") is True
+
+    def test_tool_returns_empty_all_records_tombstoned(self):
+        """Tool returns empty for non-empty input — all fail via empty-response path."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        # Empty response triggers the is_empty_response branch, not missing detection
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=([], True),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # Empty-response path produces FAILED results, not unprocessed
+        assert len(results) == 2
+        for r in results:
+            assert r.status == ProcessingStatus.FAILED
+
+    def test_expansion_tool_no_false_positives(self):
+        """Tool with expansion (1→3) — no false tombstones for new output GUIDs."""
+        records = _make_records("r1")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool expands 1 record into 3 — output GUIDs differ from input
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"child": 1}, source_index=0),
+                    TrackedItem({"child": 2}, source_index=0),
+                    TrackedItem({"child": 3}, source_index=0),
+                ],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # Expansion: only the success result, no missing tombstones
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS
+        assert results[0].is_expansion is True
+
+    def test_missing_record_tombstone_has_source_guid(self):
+        """Tombstone for missing record carries source_guid for disposition writes."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool only returns r1
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [TrackedItem({"v": 1}, source_index=0)],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        missing = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        assert len(missing) == 1
+        assert missing[0].source_guid == "r2"
+        # Tombstone data also carries the guid
+        assert missing[0].data[0].get("source_guid") == "r2"
+
+    def test_missing_record_has_input_record(self):
+        """Unprocessed result for missing record carries the original input_record."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [TrackedItem({"v": 1}, source_index=0)],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        missing = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        assert len(missing) == 1
+        assert missing[0].input_record == records[1]
+
+    def test_warning_logged_for_missing_records(self, capsys):
+        """Missing records produce a warning log for each."""
+        records = _make_records("r1", "r2", "r3")
+        context = _make_context("dropper_tool")
+        context.source_data = records
+
+        # Tool drops r2
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"v": 1}, source_index=0),
+                    TrackedItem({"v": 3}, source_index=2),
+                ],
+                True,
+            ),
+        ):
+            FileToolStrategy().invoke(records, context)
+
+        stderr = capsys.readouterr().err
+        assert "dropper_tool" in stderr
+        assert "r2" in stderr
+
+    def test_synthetic_record_no_false_positives(self):
+        """Tool merging N inputs into synthetic output — no false tombstones."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool merges 2 inputs into 1 synthetic record (source_index=None)
+        udf_result = FileUDFResult(
+            outputs=[{"source_index": None, "data": {"merged": True}}],
+        )
+
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(udf_result, True),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # No false tombstones — synthetic record can't be mapped to input GUIDs
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS


### PR DESCRIPTION
## Summary
- FILE-mode tools that silently drop records now produce tombstone results for the missing records
- Detection runs after `reconcile_outputs` (source_guids reattached) and is skipped for expansion tools and synthetic records to avoid false positives
- Matches batch reconciler behavior where missing records are logged and carried forward with dispositions

## Verification
- 8 new tests covering: all records returned, records dropped, empty return, expansion tools, synthetic records, source_guid propagation, input_record propagation, warning logging
- 86 FILE-mode tool tests pass (78 existing + 8 new)
- 7141 total tests pass, ruff clean
- 2 pre-existing failures in JSON parsing tests (unrelated)