### PR TITLE
FILE/staging/cascade parity + tool missing record detection

### DIFF
--- a/.changes/unreleased/Bug Fix-20260521-421000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-421000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "FILE-mode tool/HITL actions now write per-record SUCCESS dispositions, enabling DispositionGate carry-forward on retry"
+time: 2026-05-21T04:21:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260521-422000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-422000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Batch first-stage now receives full pipeline context (agent_indices, dependency_configs, version_context, source_data, workflow_metadata) — matching downstream batch path for template resolution and guard filtering"
+time: 2026-05-21T04:22:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260521-424000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-424000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "FILE-mode tools that return fewer records than received now produce tombstone results for missing records instead of silently dropping them"
+time: 2026-05-21T04:24:00.000000Z

--- a/.changes/unreleased/Under the Hood-20260521-423000.yaml
+++ b/.changes/unreleased/Under the Hood-20260521-423000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Move cascade filtering from individual strategies to UnifiedProcessor — strategies now only receive processable records"
+time: 2026-05-21T04:23:00.000000Z

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -39,6 +39,7 @@ class InitialStageContext:
     output_directory: str
     idx: int = 0
     storage_backend: Any = None  # Optional StorageBackend for database persistence
+    action_configs: dict[str, Any] | None = None
 
 
 @dataclass
@@ -65,6 +66,7 @@ class BatchProcessingContext:
     output_directory: str
     idx: int = 0
     storage_backend: Any = None  # Optional StorageBackend for database persistence
+    action_configs: dict[str, Any] | None = None
 
 
 def _derive_workflow_root(primary_path: str | None, fallback_path: str) -> Path:
@@ -225,6 +227,7 @@ def process_initial_stage(ctx: InitialStageContext):
             output_directory=ctx.output_directory,
             idx=ctx.idx,
             storage_backend=ctx.storage_backend,
+            action_configs=ctx.action_configs,
         )
         return _process_batch_mode(batch_ctx)
 
@@ -608,13 +611,25 @@ def _process_batch_mode(ctx: BatchProcessingContext):
     from agent_actions.llm.batch.processing.preparator import BatchTaskPreparator
     from agent_actions.llm.batch.service import create_registry_manager_factory
     from agent_actions.llm.batch.services.submission import BatchSubmissionService
+    from agent_actions.processing.disposition_gate import DispositionGate
+    from agent_actions.workflow.pipeline import ProcessingPipeline
 
     local_batch_id = _get_batch_id_from_chunk(ctx.data_chunk)
-    task_preparator = BatchTaskPreparator(storage_backend=ctx.storage_backend)
+
+    agent_indices, dependency_configs, version_context = ProcessingPipeline._build_pipeline_context(
+        cast("ActionConfigDict", ctx.agent_config),
+        ctx.action_configs,
+    )
+
+    task_preparator = BatchTaskPreparator(
+        action_indices=agent_indices,
+        dependency_configs=dependency_configs,
+        storage_backend=ctx.storage_backend,
+        version_context=version_context,
+    )
     client_resolver = BatchClientResolver(client_cache={}, default_client=None)
     context_manager = BatchContextManager()
     registry_manager_factory = create_registry_manager_factory()
-    from agent_actions.processing.disposition_gate import DispositionGate
 
     disposition_gate = DispositionGate(storage_backend=ctx.storage_backend)
     submission_service = BatchSubmissionService(
@@ -627,7 +642,12 @@ def _process_batch_mode(ctx: BatchProcessingContext):
     )
     file_name = Path(ctx.file_path).name
     result = submission_service.submit_batch_job(
-        ctx.agent_config, file_name, ctx.data_chunk, ctx.output_directory
+        ctx.agent_config,
+        file_name,
+        ctx.data_chunk,
+        ctx.output_directory,
+        source_data=ctx.data_chunk,
+        workflow_metadata={"source_file": ctx.file_path},
     )
 
     relative_path = Path(ctx.file_path).relative_to(ctx.base_directory)

--- a/agent_actions/processing/cascade_filter.py
+++ b/agent_actions/processing/cascade_filter.py
@@ -5,8 +5,8 @@ Partitions input records into processable (ACTIVE) and quarantined
 Quarantined records produce UNPROCESSED results immediately — no LLM
 call, no tool invocation, no compute wasted.
 
-Every processing strategy must call :func:`partition_cascade_records`
-at the top of its ``invoke()`` method.
+Called by :class:`~agent_actions.processing.unified.UnifiedProcessor`
+before ``strategy.invoke()`` — strategies never see cascade-blocked records.
 """
 
 from __future__ import annotations

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -437,6 +437,20 @@ def collect_results_from_processing_results(
                     result.source_guid,
                     DISPOSITION_SUCCESS,
                 )
+            elif storage_backend and result.source_guid is None and data:
+                # FILE-mode results have source_guid=None on the result level
+                # but individual items carry their own source_guid.  Write
+                # per-item dispositions so DispositionGate can carry them
+                # forward on retry.
+                for item in data:
+                    item_guid = item.get("source_guid")
+                    if item_guid:
+                        _safe_set_disposition(
+                            storage_backend,
+                            action_name,
+                            item_guid,
+                            DISPOSITION_SUCCESS,
+                        )
 
         elif status == ProcessingStatus.SKIPPED:
             data = result.data or []

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -8,10 +8,12 @@ from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.processing.helpers import run_dynamic_agent
+from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
 )
+from agent_actions.record.reasons import TOOL_MISSING_RECORD
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -92,16 +94,51 @@ class FileToolStrategy:
                 version_merge=is_version_merge(context.agent_config),
             )
 
+            is_expansion = len(structured_data) > len(records)
+
+            # Detect missing records — tool dropped input without output.
+            # Skip for expansion tools (N→M, M>N) where output GUIDs
+            # legitimately differ from input GUIDs.
+            # Also skip when synthetic records exist (source_mapping contains
+            # None) — we can't determine which inputs a synthetic consumed.
+            has_synthetic = source_mapping and any(v is None for v in source_mapping.values())
+            missing_results: list[ProcessingResult] = []
+            if not is_expansion and not has_synthetic:
+                output_guids = {item.get("source_guid") for item in structured_data}
+                for input_record in records:
+                    rid = input_record.get("source_guid")
+                    if rid and rid not in output_guids:
+                        logger.warning(
+                            "Tool '%s' did not return record %s — producing passthrough tombstone",
+                            context.agent_name,
+                            rid,
+                        )
+                        missing_results.append(
+                            ProcessingResult.unprocessed(
+                                data=[
+                                    build_tombstone(
+                                        context.agent_name,
+                                        input_record,
+                                        TOOL_MISSING_RECORD,
+                                        source_guid=rid,
+                                    )
+                                ],
+                                reason=TOOL_MISSING_RECORD,
+                                source_guid=rid,
+                                input_record=input_record,
+                            )
+                        )
+
             result = ProcessingResult.success(
                 data=structured_data,
                 source_guid=None,  # FILE mode has no single source
                 raw_response=raw_response,
-                is_expansion=len(structured_data) > len(records),
+                is_expansion=is_expansion,
             )
             result.executed = executed
             result.source_mapping = source_mapping
 
-            return [result]
+            return [result] + missing_results
 
         except AgentActionsError:
             raise

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -7,13 +7,11 @@ import logging
 from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
-from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
 )
-from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -47,30 +45,19 @@ class FileToolStrategy:
     ) -> list[ProcessingResult]:
         """Invoke a FILE-mode tool and reconcile outputs.
 
-        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
-        upstream) are partitioned out before the tool runs — no tool
-        invocation for quarantined records.
+        Records are already cascade-filtered by UnifiedProcessor — only
+        processable records arrive here.
 
         ``context.source_data`` must contain the pre-context-scope records
-        that passed the guard filter (set by UnifiedProcessor before
-        invoking the strategy).  These are used for output reconciliation.
+        that passed the guard and cascade filters (set by UnifiedProcessor
+        before invoking the strategy).  These are used for output
+        reconciliation.
         """
-        processable, quarantined_results = partition_cascade_records(
-            records, action_name=context.agent_name
-        )
-
-        if not processable and quarantined_results:
-            return quarantined_results
-
-        # Filter original_data to exclude quarantined records so
-        # TrackedItem.source_index aligns with reconcile_outputs lookups.
-        original_data = [
-            r for r in (context.source_data or []) if r.get("_state") not in CASCADE_BLOCKING_VALUES
-        ]
+        original_data = context.source_data or []
         try:
             context_scope = context.agent_config.get("context_scope") or {}
             clean_input: list[TrackedItem] = []
-            for i, record in enumerate(processable):
+            for i, record in enumerate(records):
                 business = extract_tool_input(record, context_scope)
                 clean_input.append(TrackedItem(business, source_index=i))
 
@@ -84,18 +71,18 @@ class FileToolStrategy:
                 skip_guard_eval=True,
             )
 
-            if is_empty_response(raw_response) and processable:
+            if is_empty_response(raw_response) and records:
                 error_msg = (
                     f"Tool '{context.agent_name}' returned empty result "
-                    f"from {len(processable)} input record(s)"
+                    f"from {len(records)} input record(s)"
                 )
-                return quarantined_results + [
+                return [
                     ProcessingResult.failed(
                         error=error_msg,
                         source_guid=record.get("source_guid"),
                         source_snapshot=copy.deepcopy(record),
                     )
-                    for record in processable
+                    for record in records
                 ]
 
             structured_data, source_mapping = reconcile_outputs(
@@ -109,12 +96,12 @@ class FileToolStrategy:
                 data=structured_data,
                 source_guid=None,  # FILE mode has no single source
                 raw_response=raw_response,
-                is_expansion=len(structured_data) > len(processable),
+                is_expansion=len(structured_data) > len(records),
             )
             result.executed = executed
             result.source_mapping = source_mapping
 
-            return quarantined_results + [result]
+            return [result]
 
         except AgentActionsError:
             raise
@@ -124,7 +111,7 @@ class FileToolStrategy:
                 f"FILE mode tool '{context.agent_name}' failed: {e}",
                 context={
                     "agent_name": context.agent_name,
-                    "record_count": len(processable),
+                    "record_count": len(records),
                     "operation": "file_mode_tool",
                 },
                 cause=e,

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import AgentActionsError
-from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.record_helpers import carry_framework_fields
 from agent_actions.processing.types import (
@@ -17,7 +16,6 @@ from agent_actions.processing.types import (
     ProcessingStatus,
 )
 from agent_actions.record.envelope import RecordEnvelope
-from agent_actions.record.state import CASCADE_BLOCKING_VALUES
 from agent_actions.utils.tools_resolver import resolve_tools_path
 from agent_actions.workflow.pipeline_file_mode import extract_tool_input
 
@@ -43,25 +41,15 @@ class HITLStrategy:
     ) -> list[ProcessingResult]:
         """Invoke a FILE-mode HITL action and broadcast the decision.
 
-        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
-        upstream) are partitioned out before the HITL tool runs.
+        Records are already cascade-filtered by UnifiedProcessor — only
+        processable records arrive here.
 
         ``context.source_data`` must contain the pre-context-scope records
-        that passed the guard filter (set by UnifiedProcessor before
-        invoking the strategy).  These are used to build structured output.
+        that passed the guard and cascade filters (set by UnifiedProcessor
+        before invoking the strategy).  These are used to build structured
+        output.
         """
-        processable, quarantined_results = partition_cascade_records(
-            records, action_name=context.agent_name
-        )
-
-        if not processable and quarantined_results:
-            return quarantined_results
-
-        # Filter original_data to exclude quarantined records so positional
-        # indexing of record_reviews aligns with what the HITL tool received.
-        original_data = [
-            r for r in (context.source_data or []) if r.get("_state") not in CASCADE_BLOCKING_VALUES
-        ]
+        original_data = context.source_data or []
         try:
             # Inject HITL state persistence metadata into agent config
             hitl_agent_config = dict(context.agent_config)
@@ -78,7 +66,7 @@ class HITLStrategy:
                 hitl_agent_config["_hitl_file_stem"] = file_stem
 
             context_scope = context.agent_config.get("context_scope") or {}
-            filtered_records = [extract_tool_input(r, context_scope) for r in processable]
+            filtered_records = [extract_tool_input(r, context_scope) for r in records]
 
             empty_count = sum(1 for r in filtered_records if not r)
             if empty_count:
@@ -123,11 +111,11 @@ class HITLStrategy:
                     1 for r in (decision_payload.get("record_reviews") or []) if r is not None
                 )
                 raise AgentActionsError(
-                    f"HITL review timed out ({reviewed}/{len(processable)} records reviewed). "
+                    f"HITL review timed out ({reviewed}/{len(records)} records reviewed). "
                     "Partial reviews saved. Re-run workflow to resume.",
                     context={
                         "agent_name": context.agent_name,
-                        "record_count": len(processable),
+                        "record_count": len(records),
                     },
                 )
 
@@ -170,7 +158,7 @@ class HITLStrategy:
                 source_mapping={i: i for i in range(len(structured_data))},
             )
 
-            return quarantined_results + [result]
+            return [result]
         except AgentActionsError:
             raise
         except Exception:

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -25,7 +25,6 @@ from agent_actions.logging.events.data_pipeline_events import (
     RecordTransformedEvent,
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
-from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 from agent_actions.processing.invocation import InvocationStrategy, InvocationStrategyFactory
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
@@ -139,34 +138,29 @@ class OnlineLLMStrategy:
     ) -> list[ProcessingResult]:
         """Process records through the online LLM pipeline.
 
-        Cascade-blocking records (FAILED/EXHAUSTED/CASCADE_SKIPPED from
-        upstream) are partitioned out before processing — no LLM calls
-        are made for quarantined records.
+        Records are already cascade-filtered by UnifiedProcessor — only
+        processable records arrive here.
 
-        Iterates remaining records, calling process_record() for each.
+        Iterates records, calling process_record() for each.
         Record-specific errors (RecordContextError, TemplateVariableError
         with missing vars) produce tombstones and continue. Action-fatal
         errors (ConfigurationError, TemplateSyntaxError, EmptyOutputError,
         SchemaValidationError) re-raise.
         """
-        processable, quarantined_results = partition_cascade_records(
-            records, action_name=context.agent_name
-        )
-
         start_time = datetime.now(UTC)
 
         fire_event(
             BatchProcessingStartedEvent(
                 action_name=context.agent_name,
-                batch_size=len(processable),
+                batch_size=len(records),
             )
         )
 
-        results: list[ProcessingResult] = list(quarantined_results)
+        results: list[ProcessingResult] = []
         successes = 0
         failures = 0
 
-        for idx, item in enumerate(processable):
+        for idx, item in enumerate(records):
             try:
                 item_context = _create_item_context(context, idx, item)
                 result = self.process_record(item, item_context)
@@ -177,12 +171,12 @@ class OnlineLLMStrategy:
                 elif result.status == ProcessingStatus.FAILED:
                     failures += 1
 
-                if (idx + 1) % 10 == 0 or (idx + 1) == len(processable):
+                if (idx + 1) % 10 == 0 or (idx + 1) == len(records):
                     fire_event(
                         BatchProcessingProgressEvent(
                             action_name=context.agent_name,
                             processed=idx + 1,
-                            total=len(processable),
+                            total=len(records),
                             successes=successes,
                             failures=failures,
                         )
@@ -256,7 +250,7 @@ class OnlineLLMStrategy:
         fire_event(
             BatchDataProcessingCompleteEvent(
                 action_name=context.agent_name,
-                total_records=len(processable),
+                total_records=len(records),
                 elapsed_time=elapsed_time,
             )
         )

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
+from agent_actions.processing.cascade_filter import partition_cascade_records
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.result_collector import CollectionStats, ResultCollector
@@ -43,7 +44,8 @@ class ProcessingStrategy(Protocol):
     - HITL state management and decision broadcast (FILE HITL)
     - Batch result reconciliation (batch)
 
-    The strategy receives only records that passed the guard filter.
+    The strategy receives only records that passed the guard filter and
+    cascade filter (upstream-failed records are quarantined by the processor).
     It returns one ProcessingResult per logical output (may be 1:1 or N:M
     depending on the strategy).
     """
@@ -60,7 +62,7 @@ class ProcessingStrategy(Protocol):
 class UnifiedProcessor:
     """Unified record processing pipeline.
 
-    Shared skeleton: guard -> invoke -> enrich -> collect.
+    Shared skeleton: guard -> cascade filter -> invoke -> enrich -> collect.
     The strategy controls only the invocation step.
     """
 
@@ -85,9 +87,10 @@ class UnifiedProcessor:
 
         Steps:
             1. Guard filter — split records into passing/skipped/filtered
-            2. Invoke strategy — process passing records
-            3. Enrich — add lineage, metadata, version IDs, passthrough fields
-            4. Collect — flatten results into output records with dispositions
+            2. Cascade filter — quarantine upstream-failed records
+            3. Invoke strategy — process remaining records
+            4. Enrich — add lineage, metadata, version IDs, passthrough fields
+            5. Collect — flatten results into output records with dispositions
 
         Args:
             records: Input records.  For FILE mode these are context-scope-
@@ -152,16 +155,34 @@ class UnifiedProcessor:
                     to_process = passing
             passing = to_process
 
-        invocation_results = strategy.invoke(passing, context) if passing else []
+        # Cascade filter — quarantine upstream-failed records before strategy
+        # sees them.  Strategies only receive processable records.
+        processable, quarantined_results = partition_cascade_records(
+            passing, action_name=context.agent_name
+        )
+
+        # FILE mode: filter context.source_data to maintain positional alignment
+        # with processable records (used by reconcile_outputs / HITL broadcast).
+        if raw_records is not None and quarantined_results:
+            quarantined_guids = {
+                r.source_guid for r in quarantined_results if r.source_guid is not None
+            }
+            context.source_data = [
+                s
+                for s in (context.source_data or [])
+                if s.get("source_guid") not in quarantined_guids
+            ]
+
+        invocation_results = strategy.invoke(processable, context) if processable else []
 
         # FILE mode: sequential processing — record N can reference record N-1's output.
         # RECORD mode: independent — merge order doesn't affect semantics.
         # This divergence is intentional. Do not unify without verifying FILE-mode
         # workflows that depend on sequential accumulation (e.g., multi-pass enrichment).
         if raw_records is not None:
-            all_results = invocation_results + guard_results
+            all_results = quarantined_results + invocation_results + guard_results
         else:
-            all_results = guard_results + invocation_results
+            all_results = guard_results + quarantined_results + invocation_results
 
         enriched = self._enrich(all_results, context)
 

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -25,6 +25,9 @@ PREP_FAILED = "prep_failed"
 # -- Batch -------------------------------------------------------------------
 BATCH_NOT_RETURNED = "batch_not_returned"
 
+# -- Tool (FILE mode) -------------------------------------------------------
+TOOL_MISSING_RECORD = "tool_missing_record"
+
 # -- Empty output ------------------------------------------------------------
 EMPTY_OUTPUT = "empty_output"
 

--- a/agent_actions/workflow/strategies.py
+++ b/agent_actions/workflow/strategies.py
@@ -91,6 +91,7 @@ class InitialStrategy(ActionStrategy):
                     output_directory=params.output_directory,
                     idx=params.idx,
                     storage_backend=params.storage_backend,
+                    action_configs=params.action_configs,
                 )
             ),
         )

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -637,6 +637,120 @@ class TestResultCollectorDispositions:
         assert calls[1] == (("agent", "src-f", "filtered"), {"reason": "guard_filter"})
 
 
+class TestFileModeDispositionWrites:
+    """Tests for per-item disposition fallback when result.source_guid is None (FILE mode)."""
+
+    def test_file_mode_success_writes_per_item_dispositions(self):
+        """FILE-mode SUCCESS with source_guid=None writes per-item dispositions."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "rec-1", "content": {"a": 1}},
+                {"source_guid": "rec-2", "content": {"b": 2}},
+                {"source_guid": "rec-3", "content": {"c": 3}},
+            ],
+            source_guid=None,
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        assert backend.set_disposition.call_count == 3
+        calls = backend.set_disposition.call_args_list
+        assert calls[0] == (("agent", "rec-1", "success"), {})
+        assert calls[1] == (("agent", "rec-2", "success"), {})
+        assert calls[2] == (("agent", "rec-3", "success"), {})
+
+    def test_record_mode_still_uses_result_level_disposition(self):
+        """RECORD-mode SUCCESS with source_guid set uses the fast result-level path."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[{"source_guid": "rec-1", "content": {"a": 1}}],
+            source_guid="rec-1",
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        backend.set_disposition.assert_called_once_with(
+            "agent",
+            "rec-1",
+            "success",
+        )
+
+    def test_file_mode_items_without_source_guid_silently_skipped(self):
+        """FILE-mode items lacking source_guid are skipped without crashing."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "rec-1", "content": {"a": 1}},
+                {"content": {"b": 2}},  # no source_guid
+                {"source_guid": "rec-3", "content": {"c": 3}},
+            ],
+            source_guid=None,
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        assert backend.set_disposition.call_count == 2
+        calls = backend.set_disposition.call_args_list
+        assert calls[0] == (("agent", "rec-1", "success"), {})
+        assert calls[1] == (("agent", "rec-3", "success"), {})
+
+    def test_file_mode_empty_data_no_disposition(self):
+        """FILE-mode SUCCESS with empty data writes no dispositions."""
+        backend = _make_backend()
+        result = ProcessingResult.success(
+            data=[],
+            source_guid=None,
+        )
+
+        ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=backend,
+        )
+
+        backend.set_disposition.assert_not_called()
+
+    def test_file_mode_no_backend_no_crash(self):
+        """FILE-mode without storage backend does not crash."""
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "rec-1", "content": {"a": 1}},
+            ],
+            source_guid=None,
+        )
+
+        output, _ = ResultCollector.collect_results(
+            [result],
+            {},
+            "agent",
+            is_first_stage=False,
+            storage_backend=None,
+        )
+
+        assert len(output) == 1
+
+
 class TestCollectionStatsOnlyGuardOutcomes:
     """Tests for CollectionStats.only_guard_outcomes property.
 

--- a/tests/unit/input/test_staging_batch_pipeline_parity.py
+++ b/tests/unit/input/test_staging_batch_pipeline_parity.py
@@ -1,0 +1,187 @@
+"""Tests for staging batch pipeline parity (spec 422).
+
+Verifies that batch first-stage processing receives the same pipeline context
+as downstream batch: agent_indices, dependency_configs, version_context,
+source_data, and workflow_metadata.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.input.preprocessing.staging.initial_pipeline import (
+    BatchProcessingContext,
+    _process_batch_mode,
+)
+from agent_actions.llm.batch.core.batch_models import SubmissionResult
+
+_PREP_MODULE = "agent_actions.llm.batch.processing.preparator"
+_SUBMISSION_MODULE = "agent_actions.llm.batch.services.submission"
+
+
+@pytest.fixture
+def tmp_dirs(tmp_path):
+    """Create base and output directories with a sample input file."""
+    base = tmp_path / "base"
+    output = tmp_path / "output"
+    base.mkdir()
+    output.mkdir()
+    input_file = base / "sample.json"
+    input_file.write_text(json.dumps([{"text": "hello"}]))
+    return base, output, input_file
+
+
+@pytest.fixture
+def action_configs():
+    """Multi-action pipeline configs with idx ordering."""
+    return {
+        "extract": {"idx": 0, "model_vendor": "openai"},
+        "classify": {"idx": 1, "model_vendor": "openai"},
+        "summarize": {"idx": 2, "model_vendor": "openai"},
+    }
+
+
+def _make_ctx(tmp_dirs, *, action_configs=None, agent_config=None, data_chunk=None):
+    """Build a BatchProcessingContext for testing."""
+    base, output, input_file = tmp_dirs
+    return BatchProcessingContext(
+        agent_config=agent_config or {"run_mode": "batch"},
+        agent_name="extract",
+        data_chunk=data_chunk or [{"batch_id": "b1", "batch_uuid": "b1_0", "content": "x"}],
+        file_path=str(input_file),
+        base_directory=str(base),
+        output_directory=str(output),
+        action_configs=action_configs,
+    )
+
+
+def _run_batch_and_get_prep_kwargs(ctx):
+    """Run _process_batch_mode and return the kwargs passed to BatchTaskPreparator."""
+    with (
+        patch(f"{_PREP_MODULE}.BatchTaskPreparator") as MockPrep,
+        patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc,
+    ):
+        MockSvc.return_value.submit_batch_job.return_value = SubmissionResult(batch_id="vid_123")
+        _process_batch_mode(ctx)
+    return MockPrep.call_args[1]
+
+
+class TestBatchFirstStagePipelineContext:
+    """BatchTaskPreparator receives full pipeline context from _build_pipeline_context."""
+
+    def test_preparator_receives_agent_indices_and_dependency_configs(
+        self, tmp_dirs, action_configs
+    ):
+        """When action_configs is provided, BatchTaskPreparator gets agent_indices
+        and dependency_configs — matching the downstream batch path."""
+        ctx = _make_ctx(tmp_dirs, action_configs=action_configs)
+        prep_kwargs = _run_batch_and_get_prep_kwargs(ctx)
+
+        assert prep_kwargs["action_indices"] == {"extract": 0, "classify": 1, "summarize": 2}
+        assert prep_kwargs["dependency_configs"] is action_configs
+
+    def test_preparator_receives_version_context_for_versioned_agent(
+        self, tmp_dirs, action_configs
+    ):
+        """Versioned agents get version_context threaded to BatchTaskPreparator."""
+        version_ctx = {"version_id": "v42", "base_version": "v41"}
+        ctx = _make_ctx(
+            tmp_dirs,
+            action_configs=action_configs,
+            agent_config={
+                "run_mode": "batch",
+                "is_versioned_agent": True,
+                "_version_context": version_ctx,
+            },
+        )
+        prep_kwargs = _run_batch_and_get_prep_kwargs(ctx)
+
+        assert prep_kwargs["version_context"] == version_ctx
+        # Must be a copy, not the same object (mutation safety from _build_pipeline_context)
+        assert prep_kwargs["version_context"] is not version_ctx
+
+    def test_preparator_accepts_none_action_configs(self, tmp_dirs):
+        """When action_configs is None (single-action workflow), preparator gets
+        None for indices/configs — matches _build_pipeline_context contract."""
+        ctx = _make_ctx(tmp_dirs)
+        prep_kwargs = _run_batch_and_get_prep_kwargs(ctx)
+
+        assert prep_kwargs["action_indices"] is None
+        assert prep_kwargs["dependency_configs"] is None
+        assert prep_kwargs["version_context"] is None
+
+
+class TestBatchFirstStageTemplateContext:
+    """submit_batch_job receives source_data and workflow_metadata for template rendering."""
+
+    def test_submit_receives_source_data_and_workflow_metadata(self, tmp_dirs):
+        """source_data and workflow_metadata are passed to submit_batch_job so
+        {{ source.* }} and {{ workflow.* }} templates resolve."""
+        data_chunk = [{"batch_id": "b1", "batch_uuid": "b1_0", "name": "Alice"}]
+        _, _, input_file = tmp_dirs
+        ctx = _make_ctx(tmp_dirs, data_chunk=data_chunk)
+
+        with patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc:
+            mock_submit = MockSvc.return_value.submit_batch_job
+            mock_submit.return_value = SubmissionResult(batch_id="vid_123")
+            _process_batch_mode(ctx)
+
+        _, kwargs = mock_submit.call_args
+        assert kwargs["source_data"] is data_chunk
+        assert kwargs["workflow_metadata"] == {"source_file": str(input_file)}
+
+    def test_submit_positional_args_unchanged(self, tmp_dirs):
+        """Positional args (agent_config, batch_name, data, output_directory)
+        remain in the same order — no regression."""
+        _, output, _ = tmp_dirs
+        data_chunk = [{"batch_id": "b1", "batch_uuid": "b1_0", "content": "x"}]
+        ctx = _make_ctx(tmp_dirs, data_chunk=data_chunk)
+
+        with patch(f"{_SUBMISSION_MODULE}.BatchSubmissionService") as MockSvc:
+            mock_submit = MockSvc.return_value.submit_batch_job
+            mock_submit.return_value = SubmissionResult(batch_id="vid_123")
+            _process_batch_mode(ctx)
+
+        args, _ = mock_submit.call_args
+        assert args[0] == {"run_mode": "batch"}  # agent_config
+        assert args[1] == "sample.json"  # batch_name (file_name)
+        assert args[2] is data_chunk  # data
+        assert args[3] == str(output)  # output_directory
+
+
+class TestInitialStrategyThreadsActionConfigs:
+    """InitialStrategy passes action_configs from StrategyExecutionParams
+    to InitialStageContext, which threads to BatchProcessingContext."""
+
+    def test_action_configs_threaded_to_initial_stage_context(self):
+        """StrategyExecutionParams.action_configs reaches InitialStageContext."""
+        from agent_actions.workflow.strategies import InitialStrategy, StrategyExecutionParams
+
+        action_configs = {"a": {"idx": 0}, "b": {"idx": 1}}
+
+        captured_ctx = {}
+
+        # Patch where strategies.py imported the function (its own namespace)
+        with patch("agent_actions.workflow.strategies.process_initial_stage") as mock_process:
+
+            def capture(ctx):
+                captured_ctx["action_configs"] = ctx.action_configs
+                return "/fake/path.json"
+
+            mock_process.side_effect = capture
+
+            strategy = InitialStrategy()
+            strategy.execute(
+                StrategyExecutionParams(
+                    action_config={"run_mode": "batch"},
+                    action_name="test",
+                    file_path="/fake/input.json",
+                    base_directory="/fake/base",
+                    output_directory="/fake/output",
+                    idx=0,
+                    action_configs=action_configs,
+                )
+            )
+
+        assert captured_ctx["action_configs"] is action_configs

--- a/tests/unit/processing/test_hitl_cascade_mixed.py
+++ b/tests/unit/processing/test_hitl_cascade_mixed.py
@@ -1,15 +1,21 @@
-"""Test HITL strategy with cascade-blocked records mixed in.
+"""Test HITL cascade filtering through UnifiedProcessor.
 
 Proves that when cascade-blocked records are present in input,
+UnifiedProcessor filters them before the strategy sees them, and
 HITL review decisions are applied to the correct active records
 by position (not misattributed to quarantined records).
+
+After the cascade-filter-enforcement refactor, cascade filtering
+happens in UnifiedProcessor.process(), not inside each strategy.
 """
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from agent_actions.processing.disposition_gate import DispositionGate
 from agent_actions.processing.strategies.hitl import HITLStrategy
-from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.processing.unified import UnifiedProcessor
 from tests.helpers.cascade_helpers import make_record as _record
 
 
@@ -26,22 +32,38 @@ def _make_context(agent_name: str = "hitl_review", **kwargs) -> ProcessingContex
     )
 
 
+class _SpyStrategy:
+    """Test strategy that records received records and returns success for each."""
+
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+
+    def invoke(
+        self,
+        records: list[dict[str, Any]],
+        context: ProcessingContext,
+    ) -> list[ProcessingResult]:
+        self.received.extend(records)
+        return [
+            ProcessingResult.success(data=[r], source_guid=r.get("source_guid")) for r in records
+        ]
+
+
 class TestHITLCascadeMixed:
-    """HITL with mixed active + cascade-blocked records."""
+    """HITL with mixed active + cascade-blocked records via UnifiedProcessor."""
 
     def test_reviews_applied_to_correct_records(self):
         """Input: [R1 active, R2 failed, R3 active].
         HITL sees [R1, R3] (processable only).
         Returns record_reviews for [R1, R3].
         R1 gets review_for_R1, R3 gets review_for_R3.
-        R2 appears only as a quarantined tombstone.
+        R2 appears as a quarantined tombstone in output.
         """
         r1 = _record("r1", "active")
         r2 = _record("r2", "failed")
         r3 = _record("r3", "active")
 
         context = _make_context()
-        # source_data is set by UnifiedProcessor — includes all passing records
         context.source_data = [r1, r2, r3]
 
         hitl_response = {
@@ -56,28 +78,28 @@ class TestHITLCascadeMixed:
             "agent_actions.processing.strategies.hitl.run_dynamic_agent",
             return_value=([hitl_response], True),
         ):
-            results = HITLStrategy().invoke([r1, r2, r3], context)
+            processor = UnifiedProcessor()
+            strategy = HITLStrategy()
+            # FILE mode: pass raw_records to trigger FILE-mode guard path
+            output, stats = processor.process(
+                [r1, r2, r3], context, strategy, raw_records=[r1, r2, r3]
+            )
 
-        # Should have quarantined results + 1 SUCCESS result
-        unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
-        successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
-        assert len(unprocessed) == 1  # R2 quarantined
-        assert unprocessed[0].source_guid == "r2"
+        # R2 should appear as unprocessed in output
+        r2_out = [r for r in output if r.get("source_guid") == "r2"]
+        assert len(r2_out) == 1
 
-        assert len(successes) == 1
-        success_data = successes[0].data
-        # Should have exactly 2 records (R1 and R3), not 3
-        assert len(success_data) == 2
+        # R1 and R3 should have HITL review data
+        r1_out = [r for r in output if r.get("source_guid") == "r1"]
+        r3_out = [r for r in output if r.get("source_guid") == "r3"]
+        assert len(r1_out) == 1
+        assert len(r3_out) == 1
 
-        # R1 should have "R1 looks good" comment
-        r1_out = success_data[0]
-        r1_content = r1_out.get("content", {})
+        r1_content = r1_out[0].get("content", {})
         hitl_ns = r1_content.get("hitl_review", {})
         assert hitl_ns.get("user_comment") == "R1 looks good"
 
-        # R3 should have "R3 needs work" comment (not misattributed to R2)
-        r3_out = success_data[1]
-        r3_content = r3_out.get("content", {})
+        r3_content = r3_out[0].get("content", {})
         hitl_ns_r3 = r3_content.get("hitl_review", {})
         assert hitl_ns_r3.get("user_comment") == "R3 needs work"
 
@@ -89,15 +111,16 @@ class TestHITLCascadeMixed:
         context = _make_context()
         context.source_data = [r1, r2]
 
-        # run_dynamic_agent should NOT be called
+        # run_dynamic_agent should NOT be called — all quarantined
         with patch(
             "agent_actions.processing.strategies.hitl.run_dynamic_agent",
         ) as mock_agent:
-            results = HITLStrategy().invoke([r1, r2], context)
+            processor = UnifiedProcessor()
+            strategy = HITLStrategy()
+            output, stats = processor.process([r1, r2], context, strategy, raw_records=[r1, r2])
 
         mock_agent.assert_not_called()
-        assert len(results) == 2
-        assert all(r.status == ProcessingStatus.UNPROCESSED for r in results)
+        assert stats.unprocessed == 2
 
     def test_interleaved_cascade_blocked_at_start_and_end(self):
         """Input: [R1 failed, R2 active, R3 failed, R4 active, R5 failed].
@@ -124,18 +147,111 @@ class TestHITLCascadeMixed:
             "agent_actions.processing.strategies.hitl.run_dynamic_agent",
             return_value=([hitl_response], True),
         ):
-            results = HITLStrategy().invoke([r1, r2, r3, r4, r5], context)
+            processor = UnifiedProcessor()
+            strategy = HITLStrategy()
+            output, stats = processor.process(
+                [r1, r2, r3, r4, r5], context, strategy, raw_records=[r1, r2, r3, r4, r5]
+            )
 
-        unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
-        successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
-        assert len(unprocessed) == 3  # R1, R3, R5 quarantined
-        assert len(successes) == 1
+        # R1, R3, R5 quarantined
+        assert stats.unprocessed == 3
 
-        success_data = successes[0].data
-        assert len(success_data) == 2  # R2 and R4 only
+        # R2 and R4 should have correct reviews
+        r2_out = next(r for r in output if r.get("source_guid") == "r2")
+        r4_out = next(r for r in output if r.get("source_guid") == "r4")
 
-        r2_content = success_data[0].get("content", {}).get("hitl_review", {})
+        r2_content = r2_out.get("content", {}).get("hitl_review", {})
         assert r2_content.get("user_comment") == "R2 approved"
 
-        r4_content = success_data[1].get("content", {}).get("hitl_review", {})
+        r4_content = r4_out.get("content", {}).get("hitl_review", {})
         assert r4_content.get("user_comment") == "R4 rejected"
+
+
+class TestStrategyReceivesOnlyProcessable:
+    """Verify strategies never see cascade-blocked records."""
+
+    def test_cascade_blocked_never_reach_strategy(self):
+        """Mock strategy records what it receives. Assert no cascade-blocked records."""
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "failed")
+        r3 = _record("r3", "cascade_skipped")
+        r4 = _record("r4", "active")
+
+        spy = _SpyStrategy()
+        context = _make_context()
+        processor = UnifiedProcessor()
+        output, stats = processor.process([r1, r2, r3, r4], context, spy)
+
+        # Strategy should only see R1 and R4
+        assert len(spy.received) == 2
+        guids = {r.get("source_guid") for r in spy.received}
+        assert guids == {"r1", "r4"}
+
+        # R2 and R3 should appear as unprocessed in output
+        assert stats.unprocessed == 2
+
+    def test_new_strategy_without_cascade_call_still_works(self):
+        """A bare ProcessingStrategy with no cascade logic still works —
+        UnifiedProcessor handles cascade filtering."""
+
+        class BareStrategy:
+            def invoke(
+                self,
+                records: list[dict[str, Any]],
+                context: ProcessingContext,
+            ) -> list[ProcessingResult]:
+                return [
+                    ProcessingResult.success(data=[r], source_guid=r.get("source_guid"))
+                    for r in records
+                ]
+
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "failed")
+
+        context = _make_context()
+        processor = UnifiedProcessor()
+        output, stats = processor.process([r1, r2], context, BareStrategy())
+
+        assert stats.success == 1
+        assert stats.unprocessed == 1
+
+
+class TestGateCascadeInteraction:
+    """Verify disposition gate + cascade filter interact correctly.
+
+    Gate runs first (carries forward already-terminal records), then
+    cascade filter quarantines upstream-failed records. Both reduce
+    what the strategy sees.
+    """
+
+    def test_gate_carry_forward_plus_cascade_quarantine(self):
+        """R1 active (process), R2 failed (cascade), R3 active but terminal (gate).
+
+        Strategy should only see R1. R2 quarantined by cascade filter.
+        R3 carried forward by disposition gate.
+        """
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "failed")
+        r3 = _record("r3", "active")
+
+        # Mock storage backend: R3 has terminal disposition
+        mock_backend = MagicMock()
+        mock_backend.get_terminal_record_ids.return_value = {"r3"}
+        mock_backend.read_target.return_value = [
+            {"source_guid": "r3", "content": {"hitl_review": {"prior": True}}}
+        ]
+
+        gate = DispositionGate(storage_backend=mock_backend)
+        context = _make_context()
+        context.storage_backend = mock_backend
+        context.file_path = "test.json"
+
+        spy = _SpyStrategy()
+        processor = UnifiedProcessor(disposition_gate=gate)
+        output, stats = processor.process([r1, r2, r3], context, spy)
+
+        # Strategy should only see R1 (R2 cascade-quarantined, R3 gate-carried)
+        assert len(spy.received) == 1
+        assert spy.received[0].get("source_guid") == "r1"
+
+        assert stats.unprocessed == 1

--- a/tests/unit/processing/test_tool_missing_record_detection.py
+++ b/tests/unit/processing/test_tool_missing_record_detection.py
@@ -1,0 +1,219 @@
+"""Tests for FILE-mode tool missing record detection.
+
+When a tool returns fewer records than it received, the missing records
+should be detected and tombstoned — not silently lost.
+"""
+
+from unittest.mock import patch
+
+from agent_actions.processing.strategies.file_tool import FileToolStrategy
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.reasons import TOOL_MISSING_RECORD
+from agent_actions.record.tracking import TrackedItem
+from agent_actions.utils.udf_management.registry import FileUDFResult
+
+
+def _make_context(agent_name="my_tool"):
+    ctx = ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file"},
+        agent_name=agent_name,
+    )
+    return ctx
+
+
+def _make_records(*guids):
+    """Build input records with source_guid and minimal content."""
+    return [{"source_guid": g, "content": {"prev": {"id": i}}} for i, g in enumerate(guids)]
+
+
+class TestToolMissingRecordDetection:
+    """Missing record detection after tool invocation."""
+
+    def test_all_records_returned_no_tombstones(self):
+        """Tool returns all records — no warnings, no tombstones."""
+        records = _make_records("r1", "r2", "r3")
+        context = _make_context()
+        context.source_data = records
+
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"v": 1}, source_index=0),
+                    TrackedItem({"v": 2}, source_index=1),
+                    TrackedItem({"v": 3}, source_index=2),
+                ],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # Single success result, no missing tombstones
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS
+        assert len(results[0].data) == 3
+
+    def test_tool_drops_records_produces_tombstones(self):
+        """Tool drops 2 of 5 records — 2 unprocessed results with tombstones."""
+        records = _make_records("r1", "r2", "r3", "r4", "r5")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool only returns r1, r3, r5 — drops r2 and r4
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"v": 1}, source_index=0),
+                    TrackedItem({"v": 3}, source_index=2),
+                    TrackedItem({"v": 5}, source_index=4),
+                ],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # 1 success + 2 unprocessed
+        assert len(results) == 3
+        assert results[0].status == ProcessingStatus.SUCCESS
+        assert len(results[0].data) == 3
+
+        missing = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        assert len(missing) == 2
+
+        missing_guids = {r.source_guid for r in missing}
+        assert missing_guids == {"r2", "r4"}
+
+        for r in missing:
+            assert r.skip_reason == TOOL_MISSING_RECORD
+            assert r.executed is False
+            assert len(r.data) == 1
+            assert r.data[0].get("_tombstone") is True
+
+    def test_tool_returns_empty_all_records_tombstoned(self):
+        """Tool returns empty for non-empty input — all fail via empty-response path."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        # Empty response triggers the is_empty_response branch, not missing detection
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=([], True),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # Empty-response path produces FAILED results, not unprocessed
+        assert len(results) == 2
+        for r in results:
+            assert r.status == ProcessingStatus.FAILED
+
+    def test_expansion_tool_no_false_positives(self):
+        """Tool with expansion (1→3) — no false tombstones for new output GUIDs."""
+        records = _make_records("r1")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool expands 1 record into 3 — output GUIDs differ from input
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"child": 1}, source_index=0),
+                    TrackedItem({"child": 2}, source_index=0),
+                    TrackedItem({"child": 3}, source_index=0),
+                ],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # Expansion: only the success result, no missing tombstones
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS
+        assert results[0].is_expansion is True
+
+    def test_missing_record_tombstone_has_source_guid(self):
+        """Tombstone for missing record carries source_guid for disposition writes."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool only returns r1
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [TrackedItem({"v": 1}, source_index=0)],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        missing = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        assert len(missing) == 1
+        assert missing[0].source_guid == "r2"
+        # Tombstone data also carries the guid
+        assert missing[0].data[0].get("source_guid") == "r2"
+
+    def test_missing_record_has_input_record(self):
+        """Unprocessed result for missing record carries the original input_record."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [TrackedItem({"v": 1}, source_index=0)],
+                True,
+            ),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        missing = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
+        assert len(missing) == 1
+        assert missing[0].input_record == records[1]
+
+    def test_warning_logged_for_missing_records(self, capsys):
+        """Missing records produce a warning log for each."""
+        records = _make_records("r1", "r2", "r3")
+        context = _make_context("dropper_tool")
+        context.source_data = records
+
+        # Tool drops r2
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"v": 1}, source_index=0),
+                    TrackedItem({"v": 3}, source_index=2),
+                ],
+                True,
+            ),
+        ):
+            FileToolStrategy().invoke(records, context)
+
+        stderr = capsys.readouterr().err
+        assert "dropper_tool" in stderr
+        assert "r2" in stderr
+
+    def test_synthetic_record_no_false_positives(self):
+        """Tool merging N inputs into synthetic output — no false tombstones."""
+        records = _make_records("r1", "r2")
+        context = _make_context()
+        context.source_data = records
+
+        # Tool merges 2 inputs into 1 synthetic record (source_index=None)
+        udf_result = FileUDFResult(
+            outputs=[{"source_index": None, "data": {"merged": True}}],
+        )
+
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(udf_result, True),
+        ):
+            results = FileToolStrategy().invoke(records, context)
+
+        # No false tombstones — synthetic record can't be mapped to input GUIDs
+        assert len(results) == 1
+        assert results[0].status == ProcessingStatus.SUCCESS

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -1824,7 +1824,12 @@ def test_file_tool_cascade_blocked_source_index_alignment():
     Input: [R1 active, R2 failed, R3 active]. Processable = [R1, R3].
     Tool returns TrackedItem results indexed 0→R1, 1→R3.
     reconcile_outputs must map source_index=1 to R3 (not R2).
+
+    Cascade filtering is done by UnifiedProcessor, so this test runs
+    through the full processor pipeline (FILE mode with raw_records).
     """
+    from agent_actions.processing.unified import UnifiedProcessor
+
     r1 = {"source_guid": "sg-1", "_state": "active", "content": {"prev": {"id": 1}}}
     r2 = {"source_guid": "sg-2", "_state": "failed", "content": {"prev": {"id": 2}}}
     r3 = {"source_guid": "sg-3", "_state": "active", "content": {"prev": {"id": 3}}}
@@ -1841,19 +1846,16 @@ def test_file_tool_cascade_blocked_source_index_alignment():
         "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
         return_value=(tool_output, True),
     ):
-        results = FileToolStrategy().invoke([r1, r2, r3], context)
+        processor = UnifiedProcessor()
+        strategy = FileToolStrategy()
+        output, stats = processor.process([r1, r2, r3], context, strategy, raw_records=[r1, r2, r3])
 
-    # R2 should be quarantined (UNPROCESSED), R1 and R3 processed
-    unprocessed = [r for r in results if r.status == ProcessingStatus.UNPROCESSED]
-    successes = [r for r in results if r.status == ProcessingStatus.SUCCESS]
-    assert len(unprocessed) == 1
-    assert unprocessed[0].source_guid == "sg-2"
+    # R2 should be quarantined (unprocessed), R1 and R3 processed
+    assert stats.unprocessed == 1
 
-    assert len(successes) == 1
-    success_data = successes[0].data
-    assert len(success_data) == 2
-
-    # R1's output should carry R1's source_guid (not R2's)
-    assert success_data[0].get("source_guid") == "sg-1"
-    # R3's output should carry R3's source_guid (not R2's — the bug)
-    assert success_data[1].get("source_guid") == "sg-3"
+    r1_out = [r for r in output if r.get("source_guid") == "sg-1"]
+    r3_out = [r for r in output if r.get("source_guid") == "sg-3"]
+    r2_out = [r for r in output if r.get("source_guid") == "sg-2"]
+    assert len(r1_out) == 1
+    assert len(r3_out) == 1
+    assert len(r2_out) == 1  # quarantined tombstone


### PR DESCRIPTION
## Summary

4 PRs from the FILE/staging/cascade unification wave — all audit-confirmed bugs with adversarial review and 4th-degree dependency analysis.

### What changed

- **FILE-mode disposition writes (421)**: Per-record dispositions now written for FILE-mode tool/HITL results. Previously `result.source_guid=None` skipped all 8 disposition write sites. Enables `DispositionGate` carry-forward for FILE-mode actions on retry.
- **Staging batch pipeline parity (422)**: Batch first-stage now receives full pipeline context (`agent_indices`, `dependency_configs`, `version_context`, `source_data`, `workflow_metadata`). Previously went straight to `submit_batch_job` with empty context — `{{ source.* }}` templates and guards silently broken.
- **Cascade filter enforcement (423)**: `partition_cascade_records` moved from inside each strategy's `invoke()` to `UnifiedProcessor.process()`. Strategies only receive processable records. No new strategy can accidentally skip cascade filtering.
- **Tool missing record detection (424)**: FILE-mode tools that return fewer records than received now produce UNPROCESSED tombstones with warnings. Previously missing records vanished silently. Expansion tools (1→N) correctly exempt via `is_expansion` guard.

### PRs included

| PR | What |
|----|------|
| #588 | fix: FILE-mode per-record disposition writes |
| #589 | fix: batch first-stage receives full pipeline context |
| #590 | refactor: move cascade filtering from strategies to UnifiedProcessor |
| #591 | fix: detect missing records in FILE-mode tool output |

### Verification

- 7093 tests pass, 0 regressions (6 pre-existing async failures unchanged from main)
- Each spec underwent adversarial review (20 attack scenarios total, 4 bugs caught and fixed pre-implementation)
- 4th-degree dependency chains traced for all 4 specs — 7 pitfalls identified and documented

## Test plan

- [x] Full test suite: 7093 passed
- [x] Pre-existing failures confirmed identical on main
- [x] Adversarial review: 20 scenarios tested across 4 specs
- [x] Cross-spec interaction matrix verified (5 interaction pairs documented)