### PR TITLE
fix: initialize storage backend in CLI retry, dispositions, and preview

### DIFF
--- a/.changes/unreleased/Bug Fix-20260521-425000.yaml
+++ b/.changes/unreleased/Bug Fix-20260521-425000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix 'Backend not initialized' crash in agac retry, dispositions, and preview CLI commands"
+time: 2026-05-21T04:25:00.000000Z

--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -49,6 +49,7 @@ class DispositionsCommand:
             workflow_path=str(paths.io_dir.parent),
             workflow_name=self.agent_name,
         )
+        backend.initialize()
 
         workflow = load_workflow(self.agent_name, paths, project_root)
         execution_order = list(workflow.execution_order)

--- a/agent_actions/cli/preview.py
+++ b/agent_actions/cli/preview.py
@@ -67,6 +67,7 @@ class PreviewCommand:
             workflow_name=self.workflow_name,
             backend_type="sqlite",
         )
+        backend.initialize()
 
         try:
             if self.stats_only:

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -55,6 +55,7 @@ class RetryCommand:
             workflow_path=str(paths.io_dir.parent),
             workflow_name=self.agent_name,
         )
+        backend.initialize()
 
         workflow = load_workflow(self.agent_name, paths, project_root)
         execution_order = list(workflow.execution_order)


### PR DESCRIPTION
## Summary
- `agac retry`, `agac dispositions`, and `agac preview` all crash with `RuntimeError: Backend not initialized` because `get_storage_backend()` returns an uninitialized backend and none of the 3 CLI commands call `backend.initialize()`
- One-line fix in each: add `backend.initialize()` after `get_storage_backend()`

## Verification
- 80 CLI tests pass
- Changie entry included