### PR TITLE
fix: clear prior conflicting dispositions before writing terminal

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-P05000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-P05000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Clear prior conflicting dispositions before writing terminal — prevents SUCCESS + FAILED coexistence in disposition table"
+time: 2026-05-22T05:00:00.000000Z

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -594,7 +594,7 @@ class SQLiteBackend(StorageBackend):
         input_snapshot: str | None = None,
         detail: str | None = None,
     ) -> None:
-        """Write a disposition record (INSERT OR REPLACE)."""
+        """Write a disposition record, clearing any prior disposition for this (action, record)."""
         action_name = self._validate_identifier(action_name, "action_name")
         record_id = self._validate_identifier(record_id, "record_id")
         if relative_path is not None:
@@ -613,9 +613,14 @@ class SQLiteBackend(StorageBackend):
         with self._lock:
             cursor = self.connection.cursor()
             try:
+                # UNIQUE is on (action_name, record_id, disposition), so DELETE first to prevent coexistence.
+                cursor.execute(
+                    "DELETE FROM record_disposition WHERE action_name = ? AND record_id = ?",
+                    (action_name, record_id),
+                )
                 cursor.execute(
                     """
-                    INSERT OR REPLACE INTO record_disposition
+                    INSERT INTO record_disposition
                     (action_name, record_id, disposition, reason, relative_path,
                      input_snapshot, detail, created_at)
                     VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)

--- a/tests/unit/storage/test_disposition_conflict.py
+++ b/tests/unit/storage/test_disposition_conflict.py
@@ -1,0 +1,141 @@
+"""Tests for P0-5: Clear conflicting dispositions before writing terminal.
+
+The disposition table's UNIQUE constraint is (action_name, record_id, disposition),
+not (action_name, record_id). Without the DELETE-before-INSERT fix, writing SUCCESS
+for a record that previously had FAILED results in BOTH rows coexisting — phantom
+failures that _resolve_completion_status would report.
+"""
+
+import pytest
+
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+@pytest.fixture
+def backend(tmp_path):
+    """Create a fresh SQLiteBackend for each test."""
+    db_path = tmp_path / "test.db"
+    b = SQLiteBackend(str(db_path), workflow_name="test_workflow")
+    b.initialize()
+    return b
+
+
+class TestDispositionConflictClearing:
+    """Verify that set_disposition clears prior conflicting dispositions."""
+
+    def test_success_replaces_failed(self, backend):
+        """Writing SUCCESS after FAILED leaves only SUCCESS — no phantom FAILED."""
+        backend.set_disposition("action_A", "rec1", "failed", reason="llm error")
+        backend.set_disposition("action_A", "rec1", "success")
+
+        rows = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = 'rec1'"
+        ).fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "success"
+
+    def test_no_phantom_failures_in_get_failed_items(self, backend):
+        """After SUCCESS overwrites FAILED, get_failed_items returns empty."""
+        backend.set_disposition("action_A", "rec1", "failed", reason="timeout")
+        backend.set_disposition("action_A", "rec1", "success")
+
+        failed = backend.get_failed_items("action_A")
+        assert failed == []
+
+    def test_failed_replaces_success(self, backend):
+        """Writing FAILED after SUCCESS leaves only FAILED."""
+        backend.set_disposition("action_A", "rec1", "success")
+        backend.set_disposition("action_A", "rec1", "failed", reason="retry failed")
+
+        rows = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = 'rec1'"
+        ).fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "failed"
+
+    def test_terminal_replaces_any_prior(self, backend):
+        """Any terminal disposition clears all prior dispositions for that record."""
+        backend.set_disposition("action_A", "rec1", "failed", reason="first")
+        backend.set_disposition("action_A", "rec1", "skipped", reason="second")
+        backend.set_disposition("action_A", "rec1", "success")
+
+        rows = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = 'rec1'"
+        ).fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "success"
+
+    def test_node_level_sentinel_also_cleared(self, backend):
+        """__node__ sentinel records also get cleared on overwrite."""
+        backend.set_disposition("action_A", "__node__", "failed", reason="node fail")
+        backend.set_disposition("action_A", "__node__", "success")
+
+        rows = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = '__node__'"
+        ).fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "success"
+
+    def test_different_records_unaffected(self, backend):
+        """Clearing for rec1 does not affect rec2 at the same action."""
+        backend.set_disposition("action_A", "rec1", "failed", reason="err")
+        backend.set_disposition("action_A", "rec2", "failed", reason="err")
+        backend.set_disposition("action_A", "rec1", "success")
+
+        rec1_rows = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = 'rec1'"
+        ).fetchall()
+        rec2_rows = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = 'rec2'"
+        ).fetchall()
+
+        assert len(rec1_rows) == 1
+        assert rec1_rows[0][0] == "success"
+        assert len(rec2_rows) == 1
+        assert rec2_rows[0][0] == "failed"
+
+    def test_different_actions_unaffected(self, backend):
+        """Clearing for action_A does not affect action_B for the same record."""
+        backend.set_disposition("action_A", "rec1", "failed", reason="err")
+        backend.set_disposition("action_B", "rec1", "failed", reason="err")
+        backend.set_disposition("action_A", "rec1", "success")
+
+        action_a = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = 'rec1'"
+        ).fetchall()
+        action_b = backend.connection.execute(
+            "SELECT disposition FROM record_disposition "
+            "WHERE action_name = 'action_B' AND record_id = 'rec1'"
+        ).fetchall()
+
+        assert len(action_a) == 1
+        assert action_a[0][0] == "success"
+        assert len(action_b) == 1
+        assert action_b[0][0] == "failed"
+
+    def test_reason_and_detail_preserved_on_overwrite(self, backend):
+        """The new disposition's reason and detail are preserved after clearing."""
+        backend.set_disposition("action_A", "rec1", "failed", reason="old reason")
+        backend.set_disposition(
+            "action_A", "rec1", "success", reason="new reason", detail="detail info"
+        )
+
+        row = backend.connection.execute(
+            "SELECT disposition, reason, detail FROM record_disposition "
+            "WHERE action_name = 'action_A' AND record_id = 'rec1'"
+        ).fetchone()
+
+        assert row[0] == "success"
+        assert row[1] == "new reason"
+        assert row[2] == "detail info"


### PR DESCRIPTION
## Summary
- The disposition table's UNIQUE constraint is `(action_name, record_id, disposition)`, not `(action_name, record_id)`. Writing SUCCESS for a record that previously had FAILED resulted in both rows coexisting — phantom failures that `_resolve_completion_status` reports.
- Added `DELETE FROM record_disposition WHERE action_name = ? AND record_id = ?` before the INSERT in `set_disposition`, both in the same transaction. Ensures only one disposition per record per action.

## Verification
- 8 new tests in `tests/unit/storage/test_disposition_conflict.py` covering: SUCCESS replaces FAILED, FAILED replaces SUCCESS, multi-disposition clearing, `__node__` sentinels, record/action isolation, reason/detail preservation
- `ruff format --check` and `ruff check`: clean
- `pytest`: 7151 passed, 2 skipped

**Spec:** P0-5