### PR TITLE
fix: propagate status save and disposition clear errors

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-P03000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-P03000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Propagate status save and disposition clear errors instead of swallowing them, preventing silent state inconsistencies"
+time: 2026-05-22T00:30:00.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -164,10 +164,7 @@ class ActionExecutor:
             self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
             storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
             if storage_backend is not None:
-                try:
-                    storage_backend.clear_disposition(action_name)
-                except Exception as e:
-                    logger.warning("Failed to clear dispositions for %s: %s", action_name, e)
+                storage_backend.clear_disposition(action_name)
             return ActionStatus.PENDING
         return current_status
 

--- a/agent_actions/workflow/managers/state.py
+++ b/agent_actions/workflow/managers/state.py
@@ -87,12 +87,9 @@ class ActionStateManager:
         }
 
     def _save_status(self):
-        """Persist current status to file."""
-        try:
-            self.status_file.parent.mkdir(parents=True, exist_ok=True)
-            atomic_json_write(self.status_file, self.action_status, indent=4)
-        except (OSError, ValueError, TypeError) as e:
-            logger.error("Error saving status: %s", e)
+        """Persist current status to file. Raises on I/O failure."""
+        self.status_file.parent.mkdir(parents=True, exist_ok=True)
+        atomic_json_write(self.status_file, self.action_status, indent=4)
 
     def update_status(self, action_name: str, status: ActionStatus, **metadata):
         """Update action status and persist to file."""

--- a/tests/unit/workflow/managers/test_state_save_errors.py
+++ b/tests/unit/workflow/managers/test_state_save_errors.py
@@ -1,0 +1,93 @@
+"""Tests that status save and disposition clear failures propagate as exceptions."""
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.workflow.executor import ActionExecutor, ExecutorDependencies
+from agent_actions.workflow.managers.state import ActionStateManager, ActionStatus
+
+
+class TestSaveStatusErrorPropagation:
+    """_save_status must raise on I/O failure, not swallow exceptions."""
+
+    def test_oserror_propagates_through_update_status(self, tmp_path):
+        """OSError from atomic_json_write must propagate through update_status."""
+        status_file = tmp_path / "status.json"
+        mgr = ActionStateManager(status_file, ["action_a"])
+
+        with patch(
+            "agent_actions.workflow.managers.state.atomic_json_write",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                mgr.update_status("action_a", ActionStatus.COMPLETED)
+
+    def test_value_error_propagates_through_save_status(self, tmp_path):
+        """ValueError from atomic_json_write (serialization bug) must propagate."""
+        status_file = tmp_path / "status.json"
+        mgr = ActionStateManager(status_file, ["action_a"])
+
+        with patch(
+            "agent_actions.workflow.managers.state.atomic_json_write",
+            side_effect=ValueError("not serializable"),
+        ):
+            with pytest.raises(ValueError, match="not serializable"):
+                mgr._save_status()
+
+    def test_mkdir_failure_propagates(self, tmp_path):
+        """If the status directory can't be created, the error must propagate."""
+        status_file = tmp_path / "status.json"
+        mgr = ActionStateManager(status_file, ["action_a"])
+
+        with patch.object(
+            type(mgr.status_file.parent),
+            "mkdir",
+            side_effect=OSError("permission denied"),
+        ):
+            with pytest.raises(OSError, match="permission denied"):
+                mgr._save_status()
+
+    def test_reset_save_failure_propagates(self, tmp_path):
+        """If save fails during reset(), the error must propagate."""
+        status_file = tmp_path / "status.json"
+        mgr = ActionStateManager(status_file, ["action_a"])
+
+        with patch(
+            "agent_actions.workflow.managers.state.atomic_json_write",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                mgr.reset()
+
+
+class TestClearDispositionErrorPropagation:
+    """clear_disposition failure in _maybe_invalidate must propagate."""
+
+    def test_clear_disposition_error_propagates(self, tmp_path):
+        """sqlite3.OperationalError from clear_disposition must propagate."""
+        status_file = tmp_path / "status.json"
+        state_mgr = ActionStateManager(status_file, ["action_a"])
+        state_mgr.update_status("action_a", ActionStatus.COMPLETED, record_limit=10)
+
+        storage = MagicMock()
+        storage.clear_disposition.side_effect = sqlite3.OperationalError("database is locked")
+
+        action_runner = MagicMock()
+        action_runner.storage_backend = storage
+        deps = ExecutorDependencies(
+            action_runner=action_runner,
+            state_manager=state_mgr,
+            skip_evaluator=MagicMock(),
+            batch_manager=MagicMock(),
+            output_manager=MagicMock(),
+        )
+        executor = ActionExecutor(deps)
+
+        action_config = {"record_limit": 20}  # changed from 10 to trigger invalidation
+
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            executor._maybe_invalidate_completed_status(
+                "action_a", action_config, ActionStatus.COMPLETED
+            )


### PR DESCRIPTION
## Summary
- Remove try/except in `_save_status` (state.py:89-95) that swallowed OSError/ValueError/TypeError — disk-full and serialization errors now propagate, preventing silent in-memory vs disk inconsistency
- Remove try/except in `_maybe_invalidate_completed_status` (executor.py:167-170) that swallowed clear_disposition failures — stale dispositions no longer silently persist when the DB is locked or corrupt
- 5 regression tests covering OSError, ValueError, mkdir failure, reset failure, and clear_disposition failure propagation

## Verification
- All 5 new tests pass
- All 61 existing state manager tests pass
- 7146 tests pass, ruff clean
- 2 pre-existing failures unrelated (JSON trailing comma repair)