### PR TITLE
fix: narrow preflight key verifier to fail on infrastructure errors

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-004000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-004000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Narrow preflight key verifier exception handling: infrastructure errors (SSL, DNS, proxy) now fail preflight instead of silently passing; ImportError fails with install hint; transient errors (rate limit, timeout, connection) still pass"
+time: 2026-05-22T00:40:00.000000Z

--- a/agent_actions/validation/preflight/key_verifier.py
+++ b/agent_actions/validation/preflight/key_verifier.py
@@ -28,21 +28,46 @@ class ProbeResult:
 # a ProbeResult.  SDK imports are lazy (inside the function body) to
 # avoid loading unused vendor SDKs.
 
+_INFRA_ERROR_PREFIX = "Infrastructure error during key verification"
+
+
+def _classify_sdk_exception(
+    vendor: str,
+    exc: Exception,
+    auth_types: tuple[type, ...],
+    transient_types: tuple[type, ...],
+) -> ProbeResult:
+    """Classify an SDK exception into auth failure, transient, or infrastructure error."""
+    if isinstance(exc, auth_types):
+        return ProbeResult(vendor=vendor, ok=False, error=str(exc))
+    if isinstance(exc, transient_types):
+        logger.warning("Could not verify %s key: %s (proceeding — transient)", vendor, exc)
+        return ProbeResult(vendor=vendor, ok=True)
+    return ProbeResult(vendor=vendor, ok=False, error=f"{_INFRA_ERROR_PREFIX}: {exc}")
+
 
 def _probe_openai(api_key: str) -> ProbeResult:
     try:
         from openai import AuthenticationError, OpenAI
 
         client = OpenAI(api_key=api_key, timeout=_PROBE_TIMEOUT_SECONDS)
-        # models.list() consumes no tokens.
         client.models.list()
         return ProbeResult(vendor="openai", ok=True)
-    except AuthenticationError as e:
-        return ProbeResult(vendor="openai", ok=False, error=str(e))
+    except ImportError:
+        return ProbeResult(
+            vendor="openai",
+            ok=False,
+            error="openai package not installed — run: pip install openai",
+        )
     except Exception as e:
-        # Network / timeout / rate-limit — not an auth issue.
-        logger.warning("Could not verify openai key: %s (proceeding)", e)
-        return ProbeResult(vendor="openai", ok=True)
+        from openai import APIConnectionError, APITimeoutError, AuthenticationError, RateLimitError
+
+        return _classify_sdk_exception(
+            "openai",
+            e,
+            (AuthenticationError,),
+            (APIConnectionError, APITimeoutError, RateLimitError),
+        )
 
 
 def _probe_anthropic(api_key: str) -> ProbeResult:
@@ -52,11 +77,21 @@ def _probe_anthropic(api_key: str) -> ProbeResult:
         client = anthropic.Anthropic(api_key=api_key, timeout=_PROBE_TIMEOUT_SECONDS)
         client.models.list(limit=1)
         return ProbeResult(vendor="anthropic", ok=True)
-    except anthropic.AuthenticationError as e:
-        return ProbeResult(vendor="anthropic", ok=False, error=str(e))
+    except ImportError:
+        return ProbeResult(
+            vendor="anthropic",
+            ok=False,
+            error="anthropic package not installed — run: pip install anthropic",
+        )
     except Exception as e:
-        logger.warning("Could not verify anthropic key: %s (proceeding)", e)
-        return ProbeResult(vendor="anthropic", ok=True)
+        import anthropic
+
+        return _classify_sdk_exception(
+            "anthropic",
+            e,
+            (anthropic.AuthenticationError,),
+            (anthropic.APIConnectionError, anthropic.APITimeoutError, anthropic.RateLimitError),
+        )
 
 
 def _probe_groq(api_key: str) -> ProbeResult:
@@ -66,11 +101,18 @@ def _probe_groq(api_key: str) -> ProbeResult:
         client = Groq(api_key=api_key, timeout=_PROBE_TIMEOUT_SECONDS)
         client.models.list()
         return ProbeResult(vendor="groq", ok=True)
-    except AuthenticationError as e:
-        return ProbeResult(vendor="groq", ok=False, error=str(e))
+    except ImportError:
+        return ProbeResult(
+            vendor="groq",
+            ok=False,
+            error="groq package not installed — run: pip install groq",
+        )
     except Exception as e:
-        logger.warning("Could not verify groq key: %s (proceeding)", e)
-        return ProbeResult(vendor="groq", ok=True)
+        from groq import APIConnectionError, APITimeoutError, AuthenticationError, RateLimitError
+
+        return _classify_sdk_exception(
+            "groq", e, (AuthenticationError,), (APIConnectionError, APITimeoutError, RateLimitError)
+        )
 
 
 def _probe_gemini(api_key: str) -> ProbeResult:
@@ -78,15 +120,33 @@ def _probe_gemini(api_key: str) -> ProbeResult:
         from google import genai
 
         client = genai.Client(api_key=api_key)
-        # Fetch one model to validate the key.
         next(iter(client.models.list(config={"page_size": 1})))
         return ProbeResult(vendor="gemini", ok=True)
+    except ImportError:
+        return ProbeResult(
+            vendor="gemini",
+            ok=False,
+            error="google-genai package not installed — run: pip install google-genai",
+        )
     except Exception as e:
         err_str = str(e).lower()
         if "401" in err_str or "403" in err_str or "api key" in err_str:
             return ProbeResult(vendor="gemini", ok=False, error=str(e))
-        logger.warning("Could not verify gemini key: %s (proceeding)", e)
-        return ProbeResult(vendor="gemini", ok=True)
+        # Build transient type tuple from optional Google SDK exceptions
+        transient_types: list[type] = []
+        try:
+            from google.api_core.exceptions import ServiceUnavailable
+            from google.auth.exceptions import TransportError
+
+            transient_types.extend([ServiceUnavailable, TransportError])
+        except ImportError:
+            pass
+        if (transient_types and isinstance(e, tuple(transient_types))) or (
+            "timeout" in err_str or "connection" in err_str
+        ):
+            logger.warning("Could not verify gemini key: %s (proceeding — transient)", e)
+            return ProbeResult(vendor="gemini", ok=True)
+        return ProbeResult(vendor="gemini", ok=False, error=f"{_INFRA_ERROR_PREFIX}: {e}")
 
 
 # ── Registry ──────────────────────────────────────────────────────────

--- a/tests/unit/validation/test_key_verifier.py
+++ b/tests/unit/validation/test_key_verifier.py
@@ -1,9 +1,12 @@
 """Tests for key_verifier.py — lightweight API key probing."""
 
+import ssl
 from unittest.mock import MagicMock, patch
 
 from agent_actions.validation.preflight.key_verifier import (
     ProbeResult,
+    _probe_anthropic,
+    _probe_groq,
     _probe_openai,
     verify_keys,
 )
@@ -34,10 +37,22 @@ class TestProbeOpenai:
         assert result.ok is False
         assert "Invalid API Key" in result.error
 
-    def test_network_error_treated_as_ok(self):
-        """Timeout/network errors are not auth failures — proceed anyway."""
+    def test_api_timeout_treated_as_ok(self):
+        """SDK APITimeoutError is transient — proceed anyway."""
+        from openai import APITimeoutError
+
         mock_client = MagicMock()
-        mock_client.models.list.side_effect = TimeoutError("connect timeout")
+        mock_client.models.list.side_effect = APITimeoutError(request=MagicMock())
+        with patch("openai.OpenAI", return_value=mock_client):
+            result = _probe_openai("sk-validkey12345678901234567890")
+        assert result.ok is True
+
+    def test_api_connection_error_treated_as_ok(self):
+        """SDK APIConnectionError is transient — proceed anyway."""
+        from openai import APIConnectionError
+
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = APIConnectionError(request=MagicMock())
         with patch("openai.OpenAI", return_value=mock_client):
             result = _probe_openai("sk-validkey12345678901234567890")
         assert result.ok is True
@@ -55,6 +70,114 @@ class TestProbeOpenai:
         with patch("openai.OpenAI", return_value=mock_client):
             result = _probe_openai("sk-validkey12345678901234567890")
         assert result.ok is True
+
+    def test_ssl_error_fails(self):
+        """SSL certificate error is an infrastructure problem — must fail."""
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = ssl.SSLError("certificate verify failed")
+        with patch("openai.OpenAI", return_value=mock_client):
+            result = _probe_openai("sk-validkey12345678901234567890")
+        assert result.ok is False
+        assert "Infrastructure error" in result.error
+
+    def test_import_error_fails(self):
+        """Missing openai package must fail with install hint."""
+        with patch.dict("sys.modules", {"openai": None}):
+            result = _probe_openai("sk-validkey12345678901234567890")
+        assert result.ok is False
+        assert "not installed" in result.error
+        assert "pip install openai" in result.error
+
+
+class TestProbeAnthropic:
+    """Unit tests for the Anthropic probe function."""
+
+    def test_successful_probe(self):
+        mock_client = MagicMock()
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = _probe_anthropic("sk-ant-validkey")
+        assert result.ok is True
+        assert result.vendor == "anthropic"
+
+    def test_auth_failure(self):
+        import anthropic
+
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = anthropic.AuthenticationError(
+            message="Invalid API Key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = _probe_anthropic("sk-ant-expired")
+        assert result.ok is False
+        assert "Invalid API Key" in result.error
+
+    def test_rate_limit_treated_as_ok(self):
+        import anthropic
+
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = anthropic.RateLimitError(
+            message="Rate limited",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = _probe_anthropic("sk-ant-validkey")
+        assert result.ok is True
+
+    def test_ssl_error_fails(self):
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = ssl.SSLError("certificate verify failed")
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = _probe_anthropic("sk-ant-validkey")
+        assert result.ok is False
+        assert "Infrastructure error" in result.error
+
+    def test_import_error_fails(self):
+        with patch.dict("sys.modules", {"anthropic": None}):
+            result = _probe_anthropic("sk-ant-validkey")
+        assert result.ok is False
+        assert "pip install anthropic" in result.error
+
+
+class TestProbeGroq:
+    """Unit tests for the Groq probe function."""
+
+    def test_successful_probe(self):
+        mock_client = MagicMock()
+        with patch("groq.Groq", return_value=mock_client):
+            result = _probe_groq("gsk_validkey")
+        assert result.ok is True
+        assert result.vendor == "groq"
+
+    def test_auth_failure(self):
+        from groq import AuthenticationError
+
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = AuthenticationError(
+            message="Invalid API Key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+        with patch("groq.Groq", return_value=mock_client):
+            result = _probe_groq("gsk_expired")
+        assert result.ok is False
+        assert "Invalid API Key" in result.error
+
+    def test_ssl_error_fails(self):
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = ssl.SSLError("certificate verify failed")
+        with patch("groq.Groq", return_value=mock_client):
+            result = _probe_groq("gsk_validkey")
+        assert result.ok is False
+        assert "Infrastructure error" in result.error
+
+    def test_import_error_fails(self):
+        with patch.dict("sys.modules", {"groq": None}):
+            result = _probe_groq("gsk_validkey")
+        assert result.ok is False
+        assert "pip install groq" in result.error
 
 
 class TestVerifyKeys:


### PR DESCRIPTION
## Summary
- All 4 `_probe_*` functions previously caught `except Exception` and returned `ok=True`, causing SSL errors, DNS failures, proxy misconfigs, and missing packages to silently pass preflight
- Now each probe classifies exceptions into 3 buckets: ImportError (fail with install hint), SDK transient errors like rate limits/timeouts (pass — unchanged), and infrastructure errors like SSL/DNS/proxy (fail with clear message)
- Pattern applied identically to all 4 probes (openai, anthropic, groq, gemini)
- Fixed exception handler ordering: `except ImportError` before SDK-specific handlers to avoid `NameError` when the SDK package is not installed

## Verification
- 13 new tests: SSL errors → `ok=False`, ImportError → `ok=False` with install hint, rate limits → `ok=True`, API timeouts → `ok=True`, connection errors → `ok=True`
- All 25 key_verifier tests pass
- Full suite: 7155 passed, 0 failures
- `ruff check` and `ruff format --check` clean