### PR TITLE
fix: schema migration uses ALTER TABLE, not DROP TABLE

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-P02000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-P02000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Schema migration now uses ALTER TABLE ADD COLUMN instead of DROP TABLE, preserving user data across framework upgrades"
+time: 2026-05-22T00:20:00.000000Z

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -270,8 +270,9 @@ class SQLiteBackend(StorageBackend):
             existing = {row[1] for row in rows}
             missing = required - existing
             if missing:
-                for column in sorted(missing):
-                    logger.info(
+                columns_to_add = sorted(missing)
+                for column in columns_to_add:
+                    logger.debug(
                         "Table '%s' missing column '%s' — adding via ALTER TABLE",
                         table_name,
                         column,
@@ -285,8 +286,8 @@ class SQLiteBackend(StorageBackend):
                 logger.info(
                     "Schema migration complete for '%s': added %d column(s): %s",
                     table_name,
-                    len(missing),
-                    sorted(missing),
+                    len(columns_to_add),
+                    columns_to_add,
                 )
 
     def write_target(self, action_name: str, relative_path: str, data: list[dict[str, Any]]) -> str:

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -251,21 +251,43 @@ class SQLiteBackend(StorageBackend):
                 raise
 
     def _enforce_schema(self, cursor: sqlite3.Cursor) -> None:
-        """Drop tables whose columns don't match _REQUIRED_COLUMNS."""
+        """Add missing columns to existing tables via ALTER TABLE.
+
+        Never drops tables — user data must survive framework upgrades.
+        Only adds columns; does not remove or rename existing columns.
+        """
         for table_name, required in self._REQUIRED_COLUMNS.items():
+            # Quote identifier to prevent SQL injection (table_name is from
+            # hardcoded _REQUIRED_COLUMNS keys, but defense-in-depth)
+            quoted_table = f'"{table_name}"'
+            # PRAGMA does not support quoted identifiers — but table_name
+            # is safe (from hardcoded _REQUIRED_COLUMNS keys, not user input)
             cursor.execute(f"PRAGMA table_info({table_name})")
             rows = cursor.fetchall()
             if not rows:
-                continue  # table doesn't exist yet — CREATE will handle it
+                continue  # table doesn't exist yet — CREATE TABLE handles it
+
             existing = {row[1] for row in rows}
             missing = required - existing
             if missing:
-                logger.warning(
-                    "Table '%s' schema outdated (missing: %s) — dropping and recreating",
+                for column in sorted(missing):
+                    logger.info(
+                        "Table '%s' missing column '%s' — adding via ALTER TABLE",
+                        table_name,
+                        column,
+                    )
+                    # Quote column name for safety; TEXT DEFAULT NULL is
+                    # the most permissive — application code handles types
+                    quoted_col = f'"{column}"'
+                    cursor.execute(
+                        f"ALTER TABLE {quoted_table} ADD COLUMN {quoted_col} TEXT DEFAULT NULL"
+                    )
+                logger.info(
+                    "Schema migration complete for '%s': added %d column(s): %s",
                     table_name,
+                    len(missing),
                     sorted(missing),
                 )
-                cursor.execute(f"DROP TABLE {table_name}")
 
     def write_target(self, action_name: str, relative_path: str, data: list[dict[str, Any]]) -> str:
         """Write target data for a specific node."""

--- a/tests/unit/storage/test_schema_migration.py
+++ b/tests/unit/storage/test_schema_migration.py
@@ -2,11 +2,22 @@
 
 import json
 import sqlite3
-from unittest.mock import patch
+from contextlib import contextmanager
 
 import pytest
 
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+@contextmanager
+def extra_required_columns(backend, table_name, columns):
+    """Temporarily add columns to _REQUIRED_COLUMNS, restoring on exit."""
+    original = backend._REQUIRED_COLUMNS[table_name].copy()
+    backend._REQUIRED_COLUMNS[table_name] = original | set(columns)
+    try:
+        yield
+    finally:
+        backend._REQUIRED_COLUMNS[table_name] = original
 
 
 class TestSchemaMigrationPreservesData:
@@ -14,21 +25,18 @@ class TestSchemaMigrationPreservesData:
 
     @pytest.fixture
     def backend_with_records(self, tmp_path):
-        """Create a backend with 100 target records and 100 dispositions."""
+        """Create a backend with 3 target records and 3 dispositions."""
         db_path = tmp_path / "agent_io" / "test.db"
         backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
 
         cursor = backend.connection.cursor()
-        # Insert 100 target records
-        for i in range(100):
+        for i in range(3):
             cursor.execute(
                 "INSERT INTO target_data (action_name, relative_path, data, record_count) "
                 "VALUES (?, ?, ?, ?)",
                 (f"action_{i}", f"file_{i}.json", json.dumps([{"id": i}]), 1),
             )
-        # Insert 100 dispositions
-        for i in range(100):
             cursor.execute(
                 "INSERT INTO record_disposition (action_name, record_id, disposition, reason, relative_path) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -42,69 +50,44 @@ class TestSchemaMigrationPreservesData:
     def test_alter_table_preserves_target_records(self, backend_with_records):
         """Adding a missing column must not destroy existing target records."""
         backend = backend_with_records
-
-        # Verify records exist before migration
         cursor = backend.connection.cursor()
-        cursor.execute("SELECT COUNT(*) FROM target_data")
-        assert cursor.fetchone()[0] == 100
 
-        # Add a new required column that doesn't exist yet
-        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
-        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"updated_at"}
-
-        try:
-            # Re-run _enforce_schema (simulating re-initialize)
+        with extra_required_columns(backend, "target_data", {"updated_at"}):
             backend._enforce_schema(cursor)
             backend.connection.commit()
 
-            # All 100 records must still exist
             cursor.execute("SELECT COUNT(*) FROM target_data")
-            assert cursor.fetchone()[0] == 100
+            assert cursor.fetchone()[0] == 3
 
-            # New column must be present
             cursor.execute("PRAGMA table_info(target_data)")
             columns = {row[1] for row in cursor.fetchall()}
             assert "updated_at" in columns
 
-            # New column must default to NULL for existing rows
             cursor.execute("SELECT updated_at FROM target_data LIMIT 1")
             assert cursor.fetchone()[0] is None
-        finally:
-            backend._REQUIRED_COLUMNS["target_data"] = original_required
 
     def test_alter_table_preserves_dispositions(self, backend_with_records):
         """Adding a missing column must not destroy existing dispositions."""
         backend = backend_with_records
-
         cursor = backend.connection.cursor()
-        cursor.execute("SELECT COUNT(*) FROM record_disposition")
-        assert cursor.fetchone()[0] == 100
 
-        original_required = backend._REQUIRED_COLUMNS["record_disposition"].copy()
-        backend._REQUIRED_COLUMNS["record_disposition"] = original_required | {"updated_at"}
-
-        try:
+        with extra_required_columns(backend, "record_disposition", {"updated_at"}):
             backend._enforce_schema(cursor)
             backend.connection.commit()
 
             cursor.execute("SELECT COUNT(*) FROM record_disposition")
-            assert cursor.fetchone()[0] == 100
+            assert cursor.fetchone()[0] == 3
 
             cursor.execute("PRAGMA table_info(record_disposition)")
             columns = {row[1] for row in cursor.fetchall()}
             assert "updated_at" in columns
-        finally:
-            backend._REQUIRED_COLUMNS["record_disposition"] = original_required
 
     def test_multiple_missing_columns(self, backend_with_records):
         """Multiple missing columns are each added individually."""
         backend = backend_with_records
         cursor = backend.connection.cursor()
 
-        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
-        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"col_a", "col_b", "col_c"}
-
-        try:
+        with extra_required_columns(backend, "target_data", {"col_a", "col_b", "col_c"}):
             backend._enforce_schema(cursor)
             backend.connection.commit()
 
@@ -112,23 +95,22 @@ class TestSchemaMigrationPreservesData:
             columns = {row[1] for row in cursor.fetchall()}
             assert {"col_a", "col_b", "col_c"}.issubset(columns)
 
-            # Data preserved
             cursor.execute("SELECT COUNT(*) FROM target_data")
-            assert cursor.fetchone()[0] == 100
-        finally:
-            backend._REQUIRED_COLUMNS["target_data"] = original_required
+            assert cursor.fetchone()[0] == 3
 
     def test_no_change_when_schema_matches(self, backend_with_records):
         """No ALTER when existing columns already match required columns."""
         backend = backend_with_records
         cursor = backend.connection.cursor()
 
-        # _enforce_schema should be a no-op when schema matches
-        with patch("agent_actions.storage.backends.sqlite_backend.logger") as mock_logger:
-            backend._enforce_schema(cursor)
-            # No info logs about migration
-            for call in mock_logger.info.call_args_list:
-                assert "ALTER TABLE" not in str(call)
+        cursor.execute("PRAGMA table_info(target_data)")
+        columns_before = {row[1] for row in cursor.fetchall()}
+
+        backend._enforce_schema(cursor)
+
+        cursor.execute("PRAGMA table_info(target_data)")
+        columns_after = {row[1] for row in cursor.fetchall()}
+        assert columns_before == columns_after
 
     def test_nonexistent_table_skipped(self, tmp_path):
         """Tables not yet created are skipped (CREATE TABLE handles them)."""
@@ -142,7 +124,6 @@ class TestSchemaMigrationPreservesData:
         backend._connection = conn
 
         cursor = conn.cursor()
-        # Should not raise — just skips nonexistent tables
         backend._enforce_schema(cursor)
         conn.close()
 
@@ -151,22 +132,15 @@ class TestSchemaMigrationPreservesData:
         backend = backend_with_records
         cursor = backend.connection.cursor()
 
-        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
-        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"new_col"}
-
-        try:
-            # First run adds the column
+        with extra_required_columns(backend, "target_data", {"new_col"}):
             backend._enforce_schema(cursor)
             backend.connection.commit()
 
-            # Second run — column already exists, should be a no-op
             backend._enforce_schema(cursor)
             backend.connection.commit()
 
             cursor.execute("SELECT COUNT(*) FROM target_data")
-            assert cursor.fetchone()[0] == 100
-        finally:
-            backend._REQUIRED_COLUMNS["target_data"] = original_required
+            assert cursor.fetchone()[0] == 3
 
     def test_full_reinitialize_preserves_data(self, tmp_path):
         """Full initialize() cycle with a new column preserves all records."""
@@ -174,9 +148,8 @@ class TestSchemaMigrationPreservesData:
         backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
 
-        # Insert records
         cursor = backend.connection.cursor()
-        for i in range(50):
+        for i in range(3):
             cursor.execute(
                 "INSERT INTO target_data (action_name, relative_path, data, record_count) "
                 "VALUES (?, ?, ?, ?)",
@@ -184,21 +157,15 @@ class TestSchemaMigrationPreservesData:
             )
         backend.connection.commit()
 
-        # Add new required column
-        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
-        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"migrated_col"}
-
-        try:
-            # Re-initialize (as would happen on framework upgrade)
+        with extra_required_columns(backend, "target_data", {"migrated_col"}):
             backend.initialize()
 
             cursor = backend.connection.cursor()
             cursor.execute("SELECT COUNT(*) FROM target_data")
-            assert cursor.fetchone()[0] == 50
+            assert cursor.fetchone()[0] == 3
 
             cursor.execute("PRAGMA table_info(target_data)")
             columns = {row[1] for row in cursor.fetchall()}
             assert "migrated_col" in columns
-        finally:
-            backend._REQUIRED_COLUMNS["target_data"] = original_required
-            backend.close()
+
+        backend.close()

--- a/tests/unit/storage/test_schema_migration.py
+++ b/tests/unit/storage/test_schema_migration.py
@@ -1,0 +1,204 @@
+"""Tests for _enforce_schema: ALTER TABLE ADD COLUMN instead of DROP TABLE."""
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+class TestSchemaMigrationPreservesData:
+    """Verify _enforce_schema uses ALTER TABLE, never DROP TABLE."""
+
+    @pytest.fixture
+    def backend_with_records(self, tmp_path):
+        """Create a backend with 100 target records and 100 dispositions."""
+        db_path = tmp_path / "agent_io" / "test.db"
+        backend = SQLiteBackend(str(db_path), "test_workflow")
+        backend.initialize()
+
+        cursor = backend.connection.cursor()
+        # Insert 100 target records
+        for i in range(100):
+            cursor.execute(
+                "INSERT INTO target_data (action_name, relative_path, data, record_count) "
+                "VALUES (?, ?, ?, ?)",
+                (f"action_{i}", f"file_{i}.json", json.dumps([{"id": i}]), 1),
+            )
+        # Insert 100 dispositions
+        for i in range(100):
+            cursor.execute(
+                "INSERT INTO record_disposition (action_name, record_id, disposition, reason, relative_path) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (f"action_{i}", f"record_{i}", "SUCCESS", "completed", f"file_{i}.json"),
+            )
+        backend.connection.commit()
+
+        yield backend
+        backend.close()
+
+    def test_alter_table_preserves_target_records(self, backend_with_records):
+        """Adding a missing column must not destroy existing target records."""
+        backend = backend_with_records
+
+        # Verify records exist before migration
+        cursor = backend.connection.cursor()
+        cursor.execute("SELECT COUNT(*) FROM target_data")
+        assert cursor.fetchone()[0] == 100
+
+        # Add a new required column that doesn't exist yet
+        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
+        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"updated_at"}
+
+        try:
+            # Re-run _enforce_schema (simulating re-initialize)
+            backend._enforce_schema(cursor)
+            backend.connection.commit()
+
+            # All 100 records must still exist
+            cursor.execute("SELECT COUNT(*) FROM target_data")
+            assert cursor.fetchone()[0] == 100
+
+            # New column must be present
+            cursor.execute("PRAGMA table_info(target_data)")
+            columns = {row[1] for row in cursor.fetchall()}
+            assert "updated_at" in columns
+
+            # New column must default to NULL for existing rows
+            cursor.execute("SELECT updated_at FROM target_data LIMIT 1")
+            assert cursor.fetchone()[0] is None
+        finally:
+            backend._REQUIRED_COLUMNS["target_data"] = original_required
+
+    def test_alter_table_preserves_dispositions(self, backend_with_records):
+        """Adding a missing column must not destroy existing dispositions."""
+        backend = backend_with_records
+
+        cursor = backend.connection.cursor()
+        cursor.execute("SELECT COUNT(*) FROM record_disposition")
+        assert cursor.fetchone()[0] == 100
+
+        original_required = backend._REQUIRED_COLUMNS["record_disposition"].copy()
+        backend._REQUIRED_COLUMNS["record_disposition"] = original_required | {"updated_at"}
+
+        try:
+            backend._enforce_schema(cursor)
+            backend.connection.commit()
+
+            cursor.execute("SELECT COUNT(*) FROM record_disposition")
+            assert cursor.fetchone()[0] == 100
+
+            cursor.execute("PRAGMA table_info(record_disposition)")
+            columns = {row[1] for row in cursor.fetchall()}
+            assert "updated_at" in columns
+        finally:
+            backend._REQUIRED_COLUMNS["record_disposition"] = original_required
+
+    def test_multiple_missing_columns(self, backend_with_records):
+        """Multiple missing columns are each added individually."""
+        backend = backend_with_records
+        cursor = backend.connection.cursor()
+
+        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
+        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"col_a", "col_b", "col_c"}
+
+        try:
+            backend._enforce_schema(cursor)
+            backend.connection.commit()
+
+            cursor.execute("PRAGMA table_info(target_data)")
+            columns = {row[1] for row in cursor.fetchall()}
+            assert {"col_a", "col_b", "col_c"}.issubset(columns)
+
+            # Data preserved
+            cursor.execute("SELECT COUNT(*) FROM target_data")
+            assert cursor.fetchone()[0] == 100
+        finally:
+            backend._REQUIRED_COLUMNS["target_data"] = original_required
+
+    def test_no_change_when_schema_matches(self, backend_with_records):
+        """No ALTER when existing columns already match required columns."""
+        backend = backend_with_records
+        cursor = backend.connection.cursor()
+
+        # _enforce_schema should be a no-op when schema matches
+        with patch("agent_actions.storage.backends.sqlite_backend.logger") as mock_logger:
+            backend._enforce_schema(cursor)
+            # No info logs about migration
+            for call in mock_logger.info.call_args_list:
+                assert "ALTER TABLE" not in str(call)
+
+    def test_nonexistent_table_skipped(self, tmp_path):
+        """Tables not yet created are skipped (CREATE TABLE handles them)."""
+        db_path = tmp_path / "agent_io" / "test.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+
+        backend = SQLiteBackend(str(db_path), "test_workflow")
+        backend._connection = conn
+
+        cursor = conn.cursor()
+        # Should not raise — just skips nonexistent tables
+        backend._enforce_schema(cursor)
+        conn.close()
+
+    def test_idempotent_migration(self, backend_with_records):
+        """Running _enforce_schema twice with the same missing column is safe."""
+        backend = backend_with_records
+        cursor = backend.connection.cursor()
+
+        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
+        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"new_col"}
+
+        try:
+            # First run adds the column
+            backend._enforce_schema(cursor)
+            backend.connection.commit()
+
+            # Second run — column already exists, should be a no-op
+            backend._enforce_schema(cursor)
+            backend.connection.commit()
+
+            cursor.execute("SELECT COUNT(*) FROM target_data")
+            assert cursor.fetchone()[0] == 100
+        finally:
+            backend._REQUIRED_COLUMNS["target_data"] = original_required
+
+    def test_full_reinitialize_preserves_data(self, tmp_path):
+        """Full initialize() cycle with a new column preserves all records."""
+        db_path = tmp_path / "agent_io" / "test.db"
+        backend = SQLiteBackend(str(db_path), "test_workflow")
+        backend.initialize()
+
+        # Insert records
+        cursor = backend.connection.cursor()
+        for i in range(50):
+            cursor.execute(
+                "INSERT INTO target_data (action_name, relative_path, data, record_count) "
+                "VALUES (?, ?, ?, ?)",
+                (f"action_{i}", f"file_{i}.json", json.dumps([{"id": i}]), 1),
+            )
+        backend.connection.commit()
+
+        # Add new required column
+        original_required = backend._REQUIRED_COLUMNS["target_data"].copy()
+        backend._REQUIRED_COLUMNS["target_data"] = original_required | {"migrated_col"}
+
+        try:
+            # Re-initialize (as would happen on framework upgrade)
+            backend.initialize()
+
+            cursor = backend.connection.cursor()
+            cursor.execute("SELECT COUNT(*) FROM target_data")
+            assert cursor.fetchone()[0] == 50
+
+            cursor.execute("PRAGMA table_info(target_data)")
+            columns = {row[1] for row in cursor.fetchall()}
+            assert "migrated_col" in columns
+        finally:
+            backend._REQUIRED_COLUMNS["target_data"] = original_required
+            backend.close()

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -611,12 +611,12 @@ class TestServiceInitSqliteError:
 class TestSchemaEnforcement:
     """Tests for _enforce_schema dropping stale tables."""
 
-    def test_old_schema_dropped_and_recreated(self, tmp_path):
-        """Table with missing columns is dropped and recreated on initialize()."""
+    def test_old_schema_migrated_with_alter_table(self, tmp_path):
+        """Table with missing columns gets them added via ALTER TABLE, preserving data."""
         import sqlite3
 
         db_path = tmp_path / "test.db"
-        # Create a DB with old schema missing 'detail' column
+        # Create a DB with old schema missing 'detail' and 'input_snapshot' columns
         conn = sqlite3.connect(str(db_path))
         conn.execute("""
             CREATE TABLE record_disposition (
@@ -643,9 +643,16 @@ class TestSchemaEnforcement:
         assert "detail" in columns
         assert "input_snapshot" in columns
 
-        # Old data should be gone (table was dropped)
+        # Old data must be preserved (ALTER TABLE, not DROP TABLE)
         cursor.execute("SELECT COUNT(*) FROM record_disposition")
-        assert cursor.fetchone()[0] == 0
+        assert cursor.fetchone()[0] == 1
+
+        # Verify the existing row is intact
+        cursor.execute("SELECT action_name, record_id, disposition FROM record_disposition")
+        row = cursor.fetchone()
+        assert row["action_name"] == "a"
+        assert row["record_id"] == "r"
+        assert row["disposition"] == "d"
         backend.close()
 
     def test_correct_schema_not_dropped(self, tmp_path):


### PR DESCRIPTION
## Summary
- `_enforce_schema` now uses `ALTER TABLE ADD COLUMN` instead of `DROP TABLE` when columns are missing from existing tables
- User data (target records, dispositions, prompt traces, source data) survives framework upgrades that add new columns to `_REQUIRED_COLUMNS`
- Quoted identifiers for SQL injection defense-in-depth (audit finding)
- Idempotent: re-running after migration is a safe no-op

## Verification
- 7 new tests in `test_schema_migration.py`: data preservation (target + dispositions), multi-column migration, no-change no-op, nonexistent table skip, idempotency, full reinitialize cycle
- Updated existing `test_old_schema_dropped_and_recreated` → `test_old_schema_migrated_with_alter_table` to assert data preservation
- `grep -n "DROP TABLE" sqlite_backend.py` → 0 matches
- `grep -n "ALTER TABLE" sqlite_backend.py` → confirmed in `_enforce_schema`
- 7150 tests passed, ruff clean