### PR TITLE
fix: propagate storage errors in completion status and version correlation

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-P01000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-P01000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Propagate storage errors (DB locked, corrupt, disk full) instead of silently swallowing them in completion status resolution and version correlation"
+time: 2026-05-22T00:10:00.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -511,47 +511,44 @@ class ActionExecutor:
         storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
         if storage_backend is None:
             return ActionStatus.COMPLETED
-        try:
-            if storage_backend.has_disposition(
-                action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
-            ):
-                target_files = storage_backend.list_target_files(action_name)
-                if not target_files:
-                    logger.info(
-                        "Action '%s' had all records guard-filtered — marking as skipped",
-                        action_name,
-                    )
-                    return ActionStatus.SKIPPED
-                storage_backend.clear_disposition(
-                    action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
-                )
-                logger.warning(
-                    "Stale guard-skip disposition on '%s' — action has %d target file(s). "
-                    "A write path set SKIPPED despite output existing. "
-                    "Clearing disposition and proceeding as COMPLETED.",
+        if storage_backend.has_disposition(
+            action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+        ):
+            target_files = storage_backend.list_target_files(action_name)
+            if not target_files:
+                logger.info(
+                    "Action '%s' had all records guard-filtered — marking as skipped",
                     action_name,
-                    len(target_files),
                 )
-            item_failures = storage_backend.get_failed_items(action_name)
-            if item_failures:
-                if not storage_backend.has_successful_items(action_name):
-                    logger.error(
-                        "Action '%s' failed: 0 successful outputs out of %d records. "
-                        "Halting workflow — all downstream actions will be skipped.",
-                        action_name,
-                        len(item_failures),
-                    )
-                    self._log_failure_details(item_failures)
-                    return ActionStatus.FAILED
-                logger.warning(
-                    "Action '%s' completed with %d item-level failure(s)",
+                return ActionStatus.SKIPPED
+            storage_backend.clear_disposition(
+                action_name, DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+            )
+            logger.warning(
+                "Stale guard-skip disposition on '%s' — action has %d target file(s). "
+                "A write path set SKIPPED despite output existing. "
+                "Clearing disposition and proceeding as COMPLETED.",
+                action_name,
+                len(target_files),
+            )
+        item_failures = storage_backend.get_failed_items(action_name)
+        if item_failures:
+            if not storage_backend.has_successful_items(action_name):
+                logger.error(
+                    "Action '%s' failed: 0 successful outputs out of %d records. "
+                    "Halting workflow — all downstream actions will be skipped.",
                     action_name,
                     len(item_failures),
                 )
                 self._log_failure_details(item_failures)
-                return ActionStatus.COMPLETED_WITH_FAILURES
-        except Exception as e:
-            logger.warning("Could not check partial failures for %s: %s", action_name, e)
+                return ActionStatus.FAILED
+            logger.warning(
+                "Action '%s' completed with %d item-level failure(s)",
+                action_name,
+                len(item_failures),
+            )
+            self._log_failure_details(item_failures)
+            return ActionStatus.COMPLETED_WITH_FAILURES
         return ActionStatus.COMPLETED
 
     def _log_failure_details(self, item_failures: list[dict]) -> None:

--- a/agent_actions/workflow/managers/loop.py
+++ b/agent_actions/workflow/managers/loop.py
@@ -115,51 +115,39 @@ class VersionOutputCorrelator:
         outputs = []
         filenames = set()
 
-        try:
-            target_files = self.storage_backend.list_target_files(version_agent)
-            if not target_files:
-                logger.debug(
-                    "No target files found in storage backend for %s",
-                    version_agent,
-                )
-                return [], set()
-
-            for relative_path in target_files:
-                try:
-                    data = self.storage_backend.read_target(version_agent, relative_path)
-                    if isinstance(data, list):
-                        for record in data:
-                            record["_source_file"] = relative_path
-                        outputs.extend(data)
-                    else:
-                        data["_source_file"] = relative_path  # type: ignore[unreachable]
-                        outputs.append(data)
-                    filenames.add(relative_path)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to read target %s/%s from storage backend: %s",
-                        version_agent,
-                        relative_path,
-                        e,
-                        exc_info=True,
-                    )
-
+        target_files = self.storage_backend.list_target_files(version_agent)
+        if not target_files:
             logger.debug(
-                "Loaded %d records from storage backend for %s (files: %s)",
-                len(outputs),
+                "No target files found in storage backend for %s",
                 version_agent,
-                list(filenames),
-            )
-            return outputs, filenames
-
-        except Exception as e:
-            logger.warning(
-                "Failed to list target files from storage backend for %s: %s",
-                version_agent,
-                e,
-                exc_info=True,
             )
             return [], set()
+
+        for relative_path in target_files:
+            try:
+                data = self.storage_backend.read_target(version_agent, relative_path)
+                if isinstance(data, list):
+                    for record in data:
+                        record["_source_file"] = relative_path
+                    outputs.extend(data)
+                else:
+                    data["_source_file"] = relative_path  # type: ignore[unreachable]
+                    outputs.append(data)
+                filenames.add(relative_path)
+            except FileNotFoundError:
+                logger.warning(
+                    "Target %s/%s listed but not found (possible TOCTOU race) — skipping",
+                    version_agent,
+                    relative_path,
+                )
+
+        logger.debug(
+            "Loaded %d records from storage backend for %s (files: %s)",
+            len(outputs),
+            version_agent,
+            list(filenames),
+        )
+        return outputs, filenames
 
     def _process_version_files(
         self,

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -598,11 +598,13 @@ class TestResolveCompletionStatus:
         assert executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED
 
     @patch("agent_actions.workflow.executor.fire_event")
-    def test_returns_completed_on_storage_error(self, mock_fire, executor, mock_deps):
+    def test_storage_error_propagates(self, mock_fire, executor, mock_deps):
+        """Storage errors must propagate instead of being silently swallowed."""
         mock_deps.action_runner.storage_backend.has_disposition.side_effect = RuntimeError(
             "DB error"
         )
-        assert executor._resolve_completion_status("agent_a") == ActionStatus.COMPLETED
+        with pytest.raises(RuntimeError, match="DB error"):
+            executor._resolve_completion_status("agent_a")
 
     @patch("agent_actions.workflow.executor.fire_event")
     def test_returns_skipped_when_all_records_guard_skipped(self, mock_fire, executor, mock_deps):

--- a/tests/unit/workflow/test_executor_storage_errors.py
+++ b/tests/unit/workflow/test_executor_storage_errors.py
@@ -1,0 +1,84 @@
+"""Tests for storage error propagation in _resolve_completion_status.
+
+Verifies that storage errors (sqlite3.OperationalError, etc.) propagate
+instead of being silently caught and returning COMPLETED.
+"""
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.workflow.executor import (
+    ActionExecutor,
+    ExecutorDependencies,
+)
+from agent_actions.workflow.managers.batch import BatchLifecycleManager
+from agent_actions.workflow.managers.output import ActionOutputManager
+from agent_actions.workflow.managers.skip import SkipEvaluator
+from agent_actions.workflow.managers.state import ActionStateManager, ActionStatus
+
+
+@pytest.fixture
+def mock_deps():
+    deps = MagicMock(spec=ExecutorDependencies)
+    deps.state_manager = MagicMock(spec=ActionStateManager)
+    deps.batch_manager = MagicMock(spec=BatchLifecycleManager)
+    deps.action_runner = MagicMock()
+    deps.skip_evaluator = MagicMock(spec=SkipEvaluator)
+    deps.output_manager = MagicMock(spec=ActionOutputManager)
+    deps.action_runner.workflow_name = "test_workflow"
+    deps.action_runner.get_action_folder.return_value = "/tmp/agent_io"
+    deps.action_runner.execution_order = ["agent_a"]
+    deps.state_manager.get_status_details.return_value = {"status": ActionStatus.COMPLETED}
+    return deps
+
+
+@pytest.fixture
+def executor(mock_deps):
+    return ActionExecutor(mock_deps)
+
+
+class TestResolveCompletionStatusStorageErrors:
+    def test_operational_error_from_has_disposition_propagates(self, executor, mock_deps):
+        mock_deps.action_runner.storage_backend.has_disposition.side_effect = (
+            sqlite3.OperationalError("database is locked")
+        )
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            executor._resolve_completion_status("agent_a")
+
+    def test_operational_error_from_get_failed_items_propagates(self, executor, mock_deps):
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.side_effect = (
+            sqlite3.OperationalError("database is locked")
+        )
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            executor._resolve_completion_status("agent_a")
+
+    def test_database_error_from_list_target_files_propagates(self, executor, mock_deps):
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = True
+        mock_deps.action_runner.storage_backend.list_target_files.side_effect = (
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+        with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+            executor._resolve_completion_status("agent_a")
+
+    def test_no_storage_backend_returns_completed(self, executor, mock_deps):
+        mock_deps.action_runner.storage_backend = None
+        result = executor._resolve_completion_status("agent_a")
+        assert result == ActionStatus.COMPLETED
+
+    def test_normal_completed_still_works(self, executor, mock_deps):
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = []
+        result = executor._resolve_completion_status("agent_a")
+        assert result == ActionStatus.COMPLETED
+
+    def test_completed_with_failures_still_works(self, executor, mock_deps):
+        mock_deps.action_runner.storage_backend.has_disposition.return_value = False
+        mock_deps.action_runner.storage_backend.get_failed_items.return_value = [
+            {"record_id": "abc123", "reason": "LLM error"}
+        ]
+        mock_deps.action_runner.storage_backend.has_successful_items.return_value = True
+        result = executor._resolve_completion_status("agent_a")
+        assert result == ActionStatus.COMPLETED_WITH_FAILURES

--- a/tests/unit/workflow/test_loop_storage_errors.py
+++ b/tests/unit/workflow/test_loop_storage_errors.py
@@ -1,0 +1,73 @@
+"""Tests for storage error propagation in _load_from_storage_backend.
+
+Verifies that:
+- DB errors from list_target_files propagate (not return empty)
+- Per-file FileNotFoundError is caught and file skipped
+- DB errors from read_target propagate (not silently skipped)
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.workflow.managers.loop import VersionOutputCorrelator
+
+
+@pytest.fixture
+def loop_manager():
+    mgr = VersionOutputCorrelator.__new__(VersionOutputCorrelator)
+    mgr.storage_backend = MagicMock()
+    mgr.agent_folder = Path("/tmp/agent_io")
+    return mgr
+
+
+class TestLoadFromStorageBackendErrors:
+    def test_operational_error_from_list_target_files_propagates(self, loop_manager):
+        loop_manager.storage_backend.list_target_files.side_effect = sqlite3.OperationalError(
+            "database is locked"
+        )
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            loop_manager._load_from_storage_backend("version_agent_1")
+
+    def test_file_not_found_for_single_file_skips_and_continues(self, loop_manager):
+        loop_manager.storage_backend.list_target_files.return_value = ["file_a.json", "file_b.json"]
+        loop_manager.storage_backend.read_target.side_effect = [
+            FileNotFoundError("file_a.json not found"),
+            [{"id": "rec1", "data": "ok"}],
+        ]
+        outputs, filenames = loop_manager._load_from_storage_backend("version_agent_1")
+        assert len(outputs) == 1
+        assert outputs[0]["id"] == "rec1"
+        assert "file_b.json" in filenames
+        assert "file_a.json" not in filenames
+
+    def test_operational_error_from_read_target_propagates(self, loop_manager):
+        loop_manager.storage_backend.list_target_files.return_value = ["file_a.json"]
+        loop_manager.storage_backend.read_target.side_effect = sqlite3.OperationalError(
+            "database is locked"
+        )
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            loop_manager._load_from_storage_backend("version_agent_1")
+
+    def test_json_decode_error_from_read_target_propagates(self, loop_manager):
+        loop_manager.storage_backend.list_target_files.return_value = ["file_a.json"]
+        loop_manager.storage_backend.read_target.side_effect = json.JSONDecodeError(
+            "Expecting value", "", 0
+        )
+        with pytest.raises(json.JSONDecodeError):
+            loop_manager._load_from_storage_backend("version_agent_1")
+
+    def test_no_storage_backend_returns_empty(self, loop_manager):
+        loop_manager.storage_backend = None
+        outputs, filenames = loop_manager._load_from_storage_backend("version_agent_1")
+        assert outputs == []
+        assert filenames == set()
+
+    def test_empty_target_files_returns_empty(self, loop_manager):
+        loop_manager.storage_backend.list_target_files.return_value = []
+        outputs, filenames = loop_manager._load_from_storage_backend("version_agent_1")
+        assert outputs == []
+        assert filenames == set()


### PR DESCRIPTION
## Summary
- Remove broad `except Exception` blocks in `_resolve_completion_status` (executor.py) and `_load_from_storage_backend` (loop.py) that silently swallowed storage errors (DB locked, corrupt, disk full) and returned COMPLETED / empty data
- Narrow per-file exception handling in loop.py to `FileNotFoundError` only (TOCTOU race between list and read)
- Storage errors now propagate to `_execute_action_run` which correctly marks the action as FAILED

## Changes
- **executor.py**: Removed try/except — storage backend calls are not expected to raise `FileNotFoundError`, so all exceptions are genuine storage failures
- **loop.py**: Removed outer except block (list_target_files errors propagate), narrowed inner except from `Exception` to `FileNotFoundError`
- **test_circuit_breaker.py**: Updated existing test from asserting COMPLETED on error → asserting error propagates
- **test_executor_storage_errors.py**: 6 new tests (3 propagation + 3 happy-path)
- **test_loop_storage_errors.py**: 6 new tests (propagation for OperationalError/JSONDecodeError, FileNotFoundError skip, happy paths)

## Verification
- 7155 tests pass, 0 failures
- `ruff check` clean
- `ruff format --check` clean
- Verified: `sqlite3.OperationalError("database is locked")` on `has_disposition` → raises (not COMPLETED)
- Verified: `sqlite3.OperationalError("database is locked")` on `list_target_files` → raises (not empty list)
- Verified: `FileNotFoundError` on single `read_target` → warning logged, other files loaded