### PR TITLE
fix: break zero-output rerun cycle and scope workflow status to execution_order

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-012000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-012000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Break zero-output infinite rerun cycle by recognizing node-level terminal dispositions, and scope workflow status queries to execution_order to ignore orphan entries from removed actions"
+time: 2026-05-22T01:20:00.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -21,7 +21,11 @@ from agent_actions.logging.events import (
 from agent_actions.record.reasons import GUARD_FILTERED_ALL
 from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
+    DISPOSITION_FILTERED,
+    DISPOSITION_PASSTHROUGH,
     DISPOSITION_SKIPPED,
+    DISPOSITION_SUCCESS,
+    DISPOSITION_UNPROCESSED,
     NODE_LEVEL_RECORD_ID,
 )
 from agent_actions.tooling.docs.run_tracker import ActionCompleteConfig
@@ -222,17 +226,39 @@ class ActionExecutor:
                 self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
                 return (False, None)
 
-        if not storage_backend.list_target_files(action_name):
-            logger.info("Action %s completed but no output in storage — re-running", action_name)
-            self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
-            return (False, None)
-
-        return (
+        completed = (
             True,
             ActionExecutionResult(
-                success=True, status=ActionStatus.COMPLETED, metrics=ExecutionMetrics(duration=0.0)
+                success=True,
+                status=ActionStatus.COMPLETED,
+                metrics=ExecutionMetrics(duration=0.0),
             ),
         )
+
+        if storage_backend.list_target_files(action_name):
+            return completed
+
+        # No target files. Check if the action intentionally produced no
+        # output (guard-filtered all records, WHERE-skipped, etc.) by
+        # looking for a node-level terminal disposition that is NOT
+        # FAILED/SKIPPED (those were already handled above).
+        for disp in (
+            DISPOSITION_FILTERED,
+            DISPOSITION_PASSTHROUGH,
+            DISPOSITION_SUCCESS,
+            DISPOSITION_UNPROCESSED,
+        ):
+            if storage_backend.has_disposition(action_name, disp, record_id=NODE_LEVEL_RECORD_ID):
+                logger.info(
+                    "Action %s has no output but node-level %s — intentional, skipping re-run",
+                    action_name,
+                    disp,
+                )
+                return completed
+
+        logger.info("Action %s completed but no output in storage — re-running", action_name)
+        self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
+        return (False, None)
 
     def _handle_action_skip(
         self,

--- a/agent_actions/workflow/managers/state.py
+++ b/agent_actions/workflow/managers/state.py
@@ -188,27 +188,30 @@ class ActionStateManager:
         return reset_names
 
     def get_summary(self) -> dict[str, int]:
-        """Return summary counts of action statuses."""
+        """Return summary counts of action statuses (current actions only)."""
         summary: dict[str, int] = {}
-        for details in self.action_status.values():
-            status = details.get("status", ActionStatus.PENDING)
+        for name in self.execution_order:
+            status = self.action_status.get(name, {}).get("status", ActionStatus.PENDING)
             summary[status] = summary.get(status, 0) + 1
         return summary
 
     def is_workflow_complete(self) -> bool:
-        """Return True if all actions completed (including partial failures)."""
+        """Return True if all current actions completed (including partial failures)."""
         return all(
-            details.get("status") in COMPLETED_STATUSES for details in self.action_status.values()
+            self.action_status.get(name, {}).get("status") in COMPLETED_STATUSES
+            for name in self.execution_order
         )
 
     def is_workflow_done(self) -> bool:
-        """Return True if all actions are in a terminal state."""
+        """Return True if all current actions are in a terminal state."""
         return all(
-            details.get("status") in TERMINAL_STATUSES for details in self.action_status.values()
+            self.action_status.get(name, {}).get("status") in TERMINAL_STATUSES
+            for name in self.execution_order
         )
 
     def has_any_failed(self) -> bool:
-        """Return True if any action has 'failed' status."""
+        """Return True if any current action has 'failed' status."""
         return any(
-            details.get("status") == ActionStatus.FAILED for details in self.action_status.values()
+            self.action_status.get(name, {}).get("status") == ActionStatus.FAILED
+            for name in self.execution_order
         )

--- a/tests/unit/workflow/test_state_orphan_entries.py
+++ b/tests/unit/workflow/test_state_orphan_entries.py
@@ -1,0 +1,105 @@
+"""Tests for orphan status entry handling (P1-2 Bug B).
+
+Verifies that is_workflow_complete, is_workflow_done, has_any_failed,
+and get_summary iterate execution_order (current YAML actions) rather
+than action_status (which may contain stale orphan entries from removed
+actions).
+"""
+
+from agent_actions.workflow.managers.state import (
+    ActionStatus,
+    ActionStateManager,
+)
+
+
+def _make_state_manager(tmp_path, execution_order, extra_statuses=None):
+    """Build a StateManager and inject orphan entries into action_status."""
+    sm = ActionStateManager(
+        status_file_path=tmp_path / "status.json",
+        execution_order=execution_order,
+    )
+    if extra_statuses:
+        for name, status in extra_statuses.items():
+            sm.action_status[name] = {"status": status}
+    return sm
+
+
+class TestOrphanEntriesIgnored:
+    """Orphan entries in action_status must not affect workflow-level queries."""
+
+    def test_is_workflow_complete_ignores_orphan_failed(self, tmp_path):
+        sm = _make_state_manager(
+            tmp_path,
+            execution_order=["action_a"],
+            extra_statuses={"orphan_action": ActionStatus.FAILED},
+        )
+        sm.update_status("action_a", ActionStatus.COMPLETED)
+
+        assert sm.is_workflow_complete() is True
+
+    def test_is_workflow_complete_false_when_current_action_pending(self, tmp_path):
+        sm = _make_state_manager(tmp_path, execution_order=["action_a", "action_b"])
+        sm.update_status("action_a", ActionStatus.COMPLETED)
+        # action_b is still PENDING
+
+        assert sm.is_workflow_complete() is False
+
+    def test_is_workflow_done_ignores_orphan_pending(self, tmp_path):
+        sm = _make_state_manager(
+            tmp_path,
+            execution_order=["action_a"],
+            extra_statuses={"orphan_action": ActionStatus.PENDING},
+        )
+        sm.update_status("action_a", ActionStatus.COMPLETED)
+
+        assert sm.is_workflow_done() is True
+
+    def test_is_workflow_done_false_when_current_running(self, tmp_path):
+        sm = _make_state_manager(tmp_path, execution_order=["action_a"])
+        sm.update_status("action_a", ActionStatus.RUNNING)
+
+        assert sm.is_workflow_done() is False
+
+    def test_has_any_failed_ignores_orphan_failed(self, tmp_path):
+        sm = _make_state_manager(
+            tmp_path,
+            execution_order=["action_a"],
+            extra_statuses={"orphan_action": ActionStatus.FAILED},
+        )
+        sm.update_status("action_a", ActionStatus.COMPLETED)
+
+        assert sm.has_any_failed() is False
+
+    def test_has_any_failed_true_when_current_action_failed(self, tmp_path):
+        sm = _make_state_manager(tmp_path, execution_order=["action_a"])
+        sm.update_status("action_a", ActionStatus.FAILED)
+
+        assert sm.has_any_failed() is True
+
+    def test_get_summary_excludes_orphans(self, tmp_path):
+        sm = _make_state_manager(
+            tmp_path,
+            execution_order=["action_a", "action_b"],
+            extra_statuses={"orphan_action": ActionStatus.FAILED},
+        )
+        sm.update_status("action_a", ActionStatus.COMPLETED)
+        sm.update_status("action_b", ActionStatus.COMPLETED)
+
+        summary = sm.get_summary()
+
+        assert summary == {ActionStatus.COMPLETED: 2}
+        assert ActionStatus.FAILED not in summary
+
+    def test_get_summary_counts_only_current_actions(self, tmp_path):
+        sm = _make_state_manager(
+            tmp_path,
+            execution_order=["action_a", "action_b"],
+        )
+        sm.update_status("action_a", ActionStatus.COMPLETED)
+        # action_b stays PENDING
+
+        summary = sm.get_summary()
+
+        assert summary[ActionStatus.COMPLETED] == 1
+        assert summary[ActionStatus.PENDING] == 1
+        assert len(summary) == 2

--- a/tests/unit/workflow/test_zero_output_rerun.py
+++ b/tests/unit/workflow/test_zero_output_rerun.py
@@ -1,0 +1,127 @@
+"""Tests for zero-output infinite rerun fix (P1-2 Bug A).
+
+Verifies that _check_prior_output recognizes node-level terminal
+dispositions (FILTERED, PASSTHROUGH, SUCCESS, UNPROCESSED) as
+intentional no-output and does NOT reset the action to PENDING.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.storage.backend import (
+    DISPOSITION_FAILED,
+    DISPOSITION_FILTERED,
+    DISPOSITION_PASSTHROUGH,
+    DISPOSITION_SKIPPED,
+    DISPOSITION_SUCCESS,
+    DISPOSITION_UNPROCESSED,
+    NODE_LEVEL_RECORD_ID,
+)
+from agent_actions.workflow.executor import ActionExecutor
+from agent_actions.workflow.managers.state import ActionStatus
+
+
+def _make_executor():
+    """Build a minimal ActionExecutor with mocked deps."""
+    deps = MagicMock()
+    executor = object.__new__(ActionExecutor)
+    executor.deps = deps
+    return executor
+
+
+class TestCheckPriorOutputIntentionalNoOutput:
+    """Node-level terminal dispositions prevent rerun when no target files."""
+
+    @pytest.mark.parametrize(
+        "disposition",
+        [
+            DISPOSITION_FILTERED,
+            DISPOSITION_PASSTHROUGH,
+            DISPOSITION_SUCCESS,
+            DISPOSITION_UNPROCESSED,
+        ],
+        ids=["filtered", "passthrough", "success", "unprocessed"],
+    )
+    def test_node_level_disposition_skips_rerun(self, disposition):
+        executor = _make_executor()
+        backend = MagicMock()
+        backend.list_target_files.return_value = []
+
+        def has_disp(action, disp, record_id=None):
+            if disp in (DISPOSITION_FAILED, DISPOSITION_SKIPPED):
+                return False
+            return disp == disposition and record_id == NODE_LEVEL_RECORD_ID
+
+        backend.has_disposition.side_effect = has_disp
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is True
+        assert result is not None
+        assert result.status == ActionStatus.COMPLETED
+        # Must NOT reset to PENDING
+        executor.deps.state_manager.update_status.assert_not_called()
+
+    def test_no_disposition_no_files_resets_to_pending(self):
+        executor = _make_executor()
+        backend = MagicMock()
+        backend.list_target_files.return_value = []
+        backend.has_disposition.return_value = False
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is False
+        assert result is None
+        executor.deps.state_manager.update_status.assert_called_once_with(
+            "my_action", ActionStatus.PENDING
+        )
+
+    def test_target_files_exist_returns_completed(self):
+        executor = _make_executor()
+        backend = MagicMock()
+        backend.list_target_files.return_value = ["output.json"]
+        # No FAILED/SKIPPED disposition
+        backend.has_disposition.return_value = False
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is True
+        assert result.status == ActionStatus.COMPLETED
+
+    def test_failed_disposition_triggers_rerun(self):
+        executor = _make_executor()
+        backend = MagicMock()
+
+        def has_disp(action, disp, record_id=None):
+            return disp == DISPOSITION_FAILED and record_id == NODE_LEVEL_RECORD_ID
+
+        backend.has_disposition.side_effect = has_disp
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is False
+        assert result is None
+        backend.clear_disposition.assert_called_once_with(
+            "my_action", DISPOSITION_FAILED, record_id=NODE_LEVEL_RECORD_ID
+        )
+        executor.deps.state_manager.update_status.assert_called_once_with(
+            "my_action", ActionStatus.PENDING
+        )
+
+    def test_skipped_disposition_triggers_rerun(self):
+        executor = _make_executor()
+        backend = MagicMock()
+
+        def has_disp(action, disp, record_id=None):
+            return disp == DISPOSITION_SKIPPED and record_id == NODE_LEVEL_RECORD_ID
+
+        backend.has_disposition.side_effect = has_disp
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is False
+        assert result is None
+        backend.clear_disposition.assert_called_once_with(
+            "my_action", DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
+        )


### PR DESCRIPTION
## Summary
- `_check_prior_output` now recognizes node-level terminal dispositions (FILTERED, PASSTHROUGH, SUCCESS, UNPROCESSED) as intentional no-output, preventing infinite rerun cycles for guard-filtered actions
- `is_workflow_complete`, `is_workflow_done`, `has_any_failed`, and `get_summary` now iterate `execution_order` instead of `action_status.values()`, so orphan entries from removed actions no longer block workflow completion

## Verification
- 16 new tests (8 for zero-output rerun, 8 for orphan status entries) — all pass
- Full test suite: 7217 passed, 0 failures
- `ruff check` and `ruff format --check` clean
- Grep verification: `action_status.values()` removed from all 4 state methods, `execution_order` used instead