### PR TITLE
fix: retry manifest checkpoint prevents Ctrl+C disposition loss

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-P13000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-P13000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Add retry manifest checkpoint to prevent Ctrl+C disposition loss during retry re-runs"
+time: 2026-05-22T01:30:00.000000Z

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -5,6 +5,8 @@ Uses the disposition table to identify what failed and delegates to
 the existing workflow execution engine for re-processing.
 """
 
+import datetime
+import json
 import logging
 from pathlib import Path
 
@@ -21,6 +23,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     NODE_LEVEL_RECORD_ID,
 )
+from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.validation.retry_validator import RetryCommandArgs
 
 logger = logging.getLogger(__name__)
@@ -36,6 +39,51 @@ logger = logging.getLogger(__name__)
 #   filtered    — removed by predicate; not a failure
 #   deferred    — pending HITL/batch; retrying would clobber in-flight state
 _FAILURE_DISPOSITIONS = (DISPOSITION_FAILED, DISPOSITION_EXHAUSTED)
+
+_RETRY_MANIFEST_NAME = "_retry_manifest.json"
+
+
+def _manifest_path(store_dir: Path) -> Path:
+    """Return the retry manifest file path within the workflow store directory."""
+    return store_dir / _RETRY_MANIFEST_NAME
+
+
+def _write_manifest(
+    path: Path,
+    from_action: str,
+    record_ids: list[str],
+    downstream_actions: list[str],
+    dispositions: list[dict],
+) -> None:
+    """Write a retry manifest before clearing dispositions."""
+    manifest = {
+        "from_action": from_action,
+        "record_ids": sorted(record_ids),
+        "downstream_actions": downstream_actions,
+        "dispositions": dispositions,
+        "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_json_write(path, manifest, indent=2)
+
+
+def _read_manifest(path: Path) -> dict | None:
+    """Read and return the retry manifest, or None if absent/corrupt."""
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Corrupt retry manifest at %s: %s — ignoring", path, e)
+        return None
+
+
+def _delete_manifest(path: Path) -> None:
+    """Delete the retry manifest after successful completion."""
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as e:
+        logger.warning("Could not delete retry manifest %s: %s", path, e)
 
 
 class RetryCommand:
@@ -56,6 +104,31 @@ class RetryCommand:
             workflow_name=self.agent_name,
         )
         backend.initialize()
+
+        store_dir = paths.io_dir / "store" / self.agent_name
+        manifest_file = _manifest_path(store_dir)
+        prior_manifest = _read_manifest(manifest_file)
+
+        if prior_manifest:
+            self.console.print(
+                "[yellow]Found incomplete retry manifest — "
+                "prior retry was interrupted. Restoring dispositions...[/yellow]"
+            )
+            disposition_rows = prior_manifest.get("dispositions", [])
+            for row in disposition_rows:
+                backend.set_disposition(
+                    row["action_name"],
+                    row["record_id"],
+                    row["disposition"],
+                    reason=row.get("reason"),
+                    detail=row.get("detail"),
+                    input_snapshot=row.get("input_snapshot"),
+                )
+            _delete_manifest(manifest_file)
+            self.console.print(
+                f"[cyan]Restored {len(disposition_rows)} disposition(s). "
+                f"Proceeding with retry.[/cyan]"
+            )
 
         workflow = load_workflow(self.agent_name, paths, project_root)
         execution_order = list(workflow.execution_order)
@@ -115,6 +188,21 @@ class RetryCommand:
             downstream_actions,
         )
 
+        # Snapshot dispositions BEFORE clearing — this is the crash-recovery payload.
+        snapshot_dispositions: list[dict] = []
+        for action in downstream_actions:
+            rows = backend.get_disposition(action)
+            snapshot_dispositions.extend(r for r in rows if r.get("record_id") in record_ids)
+
+        # Write manifest — if this fails, we abort (no dispositions cleared).
+        _write_manifest(
+            manifest_file,
+            from_action,
+            list(record_ids),
+            downstream_actions,
+            snapshot_dispositions,
+        )
+
         cleared = 0
         for action in downstream_actions:
             for record_id in record_ids:
@@ -143,6 +231,10 @@ class RetryCommand:
             state_mgr.update_status(action, ActionStatus.PENDING)
 
         workflow.run()
+
+        # Retry completed successfully — delete the manifest.
+        _delete_manifest(manifest_file)
+
         self.console.print("\n[green]Retry complete.[/green]")
 
     @staticmethod

--- a/tests/unit/cli/test_retry_manifest.py
+++ b/tests/unit/cli/test_retry_manifest.py
@@ -1,0 +1,440 @@
+"""Tests for the retry manifest checkpoint (crash-safe disposition clearing)."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.cli.retry import (
+    RetryCommand,
+    _delete_manifest,
+    _manifest_path,
+    _read_manifest,
+    _write_manifest,
+)
+from agent_actions.validation.retry_validator import RetryCommandArgs
+from tests.unit.cli.conftest import make_mock_backend
+
+
+class TestManifestHelpers:
+    """Unit tests for _manifest_path, _write_manifest, _read_manifest, _delete_manifest."""
+
+    def test_manifest_path(self, tmp_path: Path):
+        result = _manifest_path(tmp_path / "store" / "my_wf")
+        assert result == tmp_path / "store" / "my_wf" / "_retry_manifest.json"
+
+    def test_write_manifest_creates_file(self, tmp_path: Path):
+        path = tmp_path / "store" / "my_wf" / "_retry_manifest.json"
+        _write_manifest(
+            path,
+            from_action="classify",
+            record_ids=["r1", "r2"],
+            downstream_actions=["classify", "enrich"],
+            dispositions=[
+                {
+                    "action_name": "classify",
+                    "record_id": "r1",
+                    "disposition": "failed",
+                    "reason": "API error",
+                },
+            ],
+        )
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["from_action"] == "classify"
+        assert data["record_ids"] == ["r1", "r2"]
+        assert data["downstream_actions"] == ["classify", "enrich"]
+        assert len(data["dispositions"]) == 1
+        assert "created_at" in data
+
+    def test_write_manifest_sorts_record_ids(self, tmp_path: Path):
+        path = tmp_path / "_retry_manifest.json"
+        _write_manifest(path, "act", ["z", "a", "m"], ["act"], [])
+        data = json.loads(path.read_text())
+        assert data["record_ids"] == ["a", "m", "z"]
+
+    def test_write_manifest_creates_parent_dirs(self, tmp_path: Path):
+        path = tmp_path / "deep" / "nested" / "_retry_manifest.json"
+        _write_manifest(path, "act", [], [], [])
+        assert path.exists()
+
+    def test_read_manifest_returns_none_when_absent(self, tmp_path: Path):
+        result = _read_manifest(tmp_path / "nonexistent.json")
+        assert result is None
+
+    def test_read_manifest_returns_dict(self, tmp_path: Path):
+        path = tmp_path / "_retry_manifest.json"
+        _write_manifest(path, "act", ["r1"], ["act"], [{"x": 1}])
+        result = _read_manifest(path)
+        assert result is not None
+        assert result["from_action"] == "act"
+
+    def test_read_manifest_returns_none_for_corrupt_json(self, tmp_path: Path):
+        path = tmp_path / "_retry_manifest.json"
+        path.write_text("not valid json {{{", encoding="utf-8")
+        result = _read_manifest(path)
+        assert result is None
+
+    def test_delete_manifest_removes_file(self, tmp_path: Path):
+        path = tmp_path / "_retry_manifest.json"
+        path.write_text("{}", encoding="utf-8")
+        _delete_manifest(path)
+        assert not path.exists()
+
+    def test_delete_manifest_noop_when_absent(self, tmp_path: Path):
+        path = tmp_path / "nonexistent.json"
+        _delete_manifest(path)  # should not raise
+
+
+class TestManifestWriteBeforeClear:
+    """Manifest must be written BEFORE dispositions are cleared."""
+
+    def test_manifest_written_before_clear(self, tmp_path: Path):
+        """The manifest file must exist before clear_disposition is called."""
+        store_dir = tmp_path / "agent_io" / "store" / "test_wf"
+        store_dir.mkdir(parents=True)
+        manifest_file = _manifest_path(store_dir)
+
+        call_order: list[str] = []
+
+        def track_write_manifest(*_args, **_kwargs):
+            call_order.append("write_manifest")
+            # Actually write the file so the assertion can check it
+            _write_manifest(
+                manifest_file,
+                "classify",
+                ["r1"],
+                ["classify"],
+                [
+                    {
+                        "action_name": "classify",
+                        "record_id": "r1",
+                        "disposition": "failed",
+                        "reason": "err",
+                    }
+                ],
+            )
+
+        def track_clear(*_args, **_kwargs):
+            call_order.append("clear_disposition")
+            return 1
+
+        backend = make_mock_backend(
+            {
+                "classify": [
+                    {
+                        "action_name": "classify",
+                        "record_id": "r1",
+                        "disposition": "failed",
+                        "reason": "API error",
+                    },
+                ],
+            }
+        )
+        backend.clear_disposition = MagicMock(side_effect=track_clear)
+
+        with (
+            patch("agent_actions.cli.retry._write_manifest", side_effect=track_write_manifest),
+            patch("agent_actions.cli.retry.get_storage_backend", return_value=backend),
+            patch("agent_actions.cli.retry.ProjectPathsFactory") as mock_paths_factory,
+            patch("agent_actions.cli.retry.load_workflow") as mock_load_wf,
+        ):
+            mock_paths = MagicMock()
+            mock_paths.io_dir = tmp_path / "agent_io"
+            mock_paths_factory.create_project_paths.return_value = mock_paths
+
+            mock_wf = MagicMock()
+            mock_wf.execution_order = ["classify"]
+            mock_load_wf.return_value = mock_wf
+
+            args = RetryCommandArgs(agent="test_wf")
+            cmd = RetryCommand(args)
+            cmd.console = MagicMock()
+            cmd.execute()
+
+        assert call_order.index("write_manifest") < call_order.index("clear_disposition")
+
+
+class TestManifestDeletedAfterSuccess:
+    """Manifest is deleted after workflow.run() completes successfully."""
+
+    def test_manifest_deleted_after_successful_run(self, tmp_path: Path):
+        store_dir = tmp_path / "agent_io" / "store" / "test_wf"
+        store_dir.mkdir(parents=True)
+        manifest_file = _manifest_path(store_dir)
+
+        backend = make_mock_backend(
+            {
+                "classify": [
+                    {
+                        "action_name": "classify",
+                        "record_id": "r1",
+                        "disposition": "failed",
+                        "reason": "err",
+                    },
+                ],
+            }
+        )
+
+        with (
+            patch("agent_actions.cli.retry.get_storage_backend", return_value=backend),
+            patch("agent_actions.cli.retry.ProjectPathsFactory") as mock_paths_factory,
+            patch("agent_actions.cli.retry.load_workflow") as mock_load_wf,
+        ):
+            mock_paths = MagicMock()
+            mock_paths.io_dir = tmp_path / "agent_io"
+            mock_paths_factory.create_project_paths.return_value = mock_paths
+
+            mock_wf = MagicMock()
+            mock_wf.execution_order = ["classify"]
+            mock_load_wf.return_value = mock_wf
+
+            args = RetryCommandArgs(agent="test_wf")
+            cmd = RetryCommand(args)
+            cmd.console = MagicMock()
+            cmd.execute()
+
+        # Manifest should NOT exist after successful completion
+        assert not manifest_file.exists()
+
+
+class TestManifestSurvivesInterruption:
+    """If workflow.run() raises, the manifest remains for recovery."""
+
+    def test_manifest_survives_keyboard_interrupt(self, tmp_path: Path):
+        store_dir = tmp_path / "agent_io" / "store" / "test_wf"
+        store_dir.mkdir(parents=True)
+        manifest_file = _manifest_path(store_dir)
+
+        backend = make_mock_backend(
+            {
+                "classify": [
+                    {
+                        "action_name": "classify",
+                        "record_id": "r1",
+                        "disposition": "failed",
+                        "reason": "API error",
+                    },
+                ],
+            }
+        )
+
+        with (
+            patch("agent_actions.cli.retry.get_storage_backend", return_value=backend),
+            patch("agent_actions.cli.retry.ProjectPathsFactory") as mock_paths_factory,
+            patch("agent_actions.cli.retry.load_workflow") as mock_load_wf,
+        ):
+            mock_paths = MagicMock()
+            mock_paths.io_dir = tmp_path / "agent_io"
+            mock_paths_factory.create_project_paths.return_value = mock_paths
+
+            mock_wf = MagicMock()
+            mock_wf.execution_order = ["classify"]
+            mock_wf.run.side_effect = KeyboardInterrupt
+            mock_load_wf.return_value = mock_wf
+
+            args = RetryCommandArgs(agent="test_wf")
+            cmd = RetryCommand(args)
+            cmd.console = MagicMock()
+
+            with pytest.raises(KeyboardInterrupt):
+                cmd.execute()
+
+        # Manifest must survive — it's the recovery checkpoint
+        assert manifest_file.exists()
+        data = json.loads(manifest_file.read_text())
+        assert data["from_action"] == "classify"
+        assert "r1" in data["record_ids"]
+        assert len(data["dispositions"]) == 1
+
+    def test_manifest_survives_runtime_error(self, tmp_path: Path):
+        store_dir = tmp_path / "agent_io" / "store" / "test_wf"
+        store_dir.mkdir(parents=True)
+        manifest_file = _manifest_path(store_dir)
+
+        backend = make_mock_backend(
+            {
+                "classify": [
+                    {
+                        "action_name": "classify",
+                        "record_id": "r1",
+                        "disposition": "failed",
+                        "reason": "err",
+                    },
+                ],
+            }
+        )
+
+        with (
+            patch("agent_actions.cli.retry.get_storage_backend", return_value=backend),
+            patch("agent_actions.cli.retry.ProjectPathsFactory") as mock_paths_factory,
+            patch("agent_actions.cli.retry.load_workflow") as mock_load_wf,
+        ):
+            mock_paths = MagicMock()
+            mock_paths.io_dir = tmp_path / "agent_io"
+            mock_paths_factory.create_project_paths.return_value = mock_paths
+
+            mock_wf = MagicMock()
+            mock_wf.execution_order = ["classify"]
+            mock_wf.run.side_effect = RuntimeError("crash during workflow")
+            mock_load_wf.return_value = mock_wf
+
+            args = RetryCommandArgs(agent="test_wf")
+            cmd = RetryCommand(args)
+            cmd.console = MagicMock()
+
+            with pytest.raises(RuntimeError, match="crash during workflow"):
+                cmd.execute()
+
+        assert manifest_file.exists()
+
+
+class TestManifestRestoreOnNextInvocation:
+    """Next retry detects manifest and restores dispositions."""
+
+    def test_restores_dispositions_from_manifest(self, tmp_path: Path):
+        store_dir = tmp_path / "agent_io" / "store" / "test_wf"
+        store_dir.mkdir(parents=True)
+
+        # Write a manifest as if a prior retry was interrupted
+        manifest_file = _manifest_path(store_dir)
+        _write_manifest(
+            manifest_file,
+            from_action="classify",
+            record_ids=["r1"],
+            downstream_actions=["classify", "enrich"],
+            dispositions=[
+                {
+                    "action_name": "classify",
+                    "record_id": "r1",
+                    "disposition": "failed",
+                    "reason": "API error",
+                    "detail": "timeout",
+                    "input_snapshot": '{"field": "val"}',
+                },
+                {
+                    "action_name": "enrich",
+                    "record_id": "r1",
+                    "disposition": "exhausted",
+                    "reason": "retry_exhausted",
+                    "detail": None,
+                    "input_snapshot": None,
+                },
+            ],
+        )
+
+        backend = make_mock_backend(
+            {
+                # After restore, failures are visible again
+                "classify": [
+                    {
+                        "action_name": "classify",
+                        "record_id": "r1",
+                        "disposition": "failed",
+                        "reason": "API error",
+                    },
+                ],
+            }
+        )
+        set_calls: list[tuple] = []
+
+        def track_set(*args, **kwargs):
+            set_calls.append((args, kwargs))
+
+        backend.set_disposition = MagicMock(side_effect=track_set)
+
+        with (
+            patch("agent_actions.cli.retry.get_storage_backend", return_value=backend),
+            patch("agent_actions.cli.retry.ProjectPathsFactory") as mock_paths_factory,
+            patch("agent_actions.cli.retry.load_workflow") as mock_load_wf,
+        ):
+            mock_paths = MagicMock()
+            mock_paths.io_dir = tmp_path / "agent_io"
+            mock_paths_factory.create_project_paths.return_value = mock_paths
+
+            mock_wf = MagicMock()
+            mock_wf.execution_order = ["classify", "enrich"]
+            mock_load_wf.return_value = mock_wf
+
+            args = RetryCommandArgs(agent="test_wf")
+            cmd = RetryCommand(args)
+            cmd.console = MagicMock()
+            cmd.execute()
+
+        # 2 dispositions should have been restored
+        assert len(set_calls) == 2
+
+        # First restore: classify/r1/failed
+        call_args, call_kwargs = set_calls[0]
+        assert call_args == ("classify", "r1", "failed")
+        assert call_kwargs["reason"] == "API error"
+        assert call_kwargs["detail"] == "timeout"
+        assert call_kwargs["input_snapshot"] == '{"field": "val"}'
+
+        # Second restore: enrich/r1/exhausted
+        call_args, call_kwargs = set_calls[1]
+        assert call_args == ("enrich", "r1", "exhausted")
+        assert call_kwargs["reason"] == "retry_exhausted"
+
+        # Manifest deleted after restore
+        assert not manifest_file.exists()
+
+
+class TestManifestWriteFailureAborts:
+    """If manifest write fails, dispositions must NOT be cleared."""
+
+    def test_io_error_on_manifest_write_aborts(self, tmp_path: Path):
+        store_dir = tmp_path / "agent_io" / "store" / "test_wf"
+        store_dir.mkdir(parents=True)
+
+        backend = make_mock_backend(
+            {
+                "classify": [
+                    {
+                        "action_name": "classify",
+                        "record_id": "r1",
+                        "disposition": "failed",
+                        "reason": "err",
+                    },
+                ],
+            }
+        )
+
+        with (
+            patch("agent_actions.cli.retry.get_storage_backend", return_value=backend),
+            patch("agent_actions.cli.retry.ProjectPathsFactory") as mock_paths_factory,
+            patch("agent_actions.cli.retry.load_workflow") as mock_load_wf,
+            patch("agent_actions.cli.retry._write_manifest", side_effect=OSError("disk full")),
+        ):
+            mock_paths = MagicMock()
+            mock_paths.io_dir = tmp_path / "agent_io"
+            mock_paths_factory.create_project_paths.return_value = mock_paths
+
+            mock_wf = MagicMock()
+            mock_wf.execution_order = ["classify"]
+            mock_load_wf.return_value = mock_wf
+
+            args = RetryCommandArgs(agent="test_wf")
+            cmd = RetryCommand(args)
+            cmd.console = MagicMock()
+
+            with pytest.raises(OSError, match="disk full"):
+                cmd.execute()
+
+        # clear_disposition must NOT have been called
+        backend.clear_disposition.assert_not_called()
+
+
+class TestNoSignalHandler:
+    """The manifest approach does not use SIGINT signal handlers."""
+
+    def test_no_signal_import(self):
+        import inspect
+
+        from agent_actions.cli import retry
+
+        source = inspect.getsource(retry)
+        assert "signal.signal" not in source
+        assert "SIGINT" not in source
+        assert "signal_handler" not in source


### PR DESCRIPTION
## Summary
- Ctrl+C (or any crash) between disposition clearing and workflow.run() completion would silently lose failed records — next retry sees "Nothing to retry"
- Added a JSON manifest checkpoint written BEFORE clearing dispositions, deleted AFTER successful completion
- On next retry invocation, manifest is detected → dispositions restored → retry proceeds normally

## Changes
- `agent_actions/cli/retry.py`: Added `_write_manifest`, `_read_manifest`, `_delete_manifest` helpers. Manifest written before clear, checked on startup, deleted after success.
- `tests/unit/cli/test_retry_manifest.py`: 16 new tests covering ordering, interrupt survival, restore, write-failure abort, no-signal-handler.

## Verification
- `ruff check` clean
- `ruff format --check` clean  
- `pytest`: 7217 passed, 2 skipped
- Grep verification: `_write_manifest` (L198) < `clear_disposition` (L209) < `workflow.run()` (L233) < `_delete_manifest` (L236)
- No signal handlers: `grep -c "signal.signal|SIGINT" retry.py` → 0