### PR TITLE
fix: detect config changes and invalidate stale completed actions

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-014000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-014000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Detect prompt/model/schema/guard config changes and invalidate stale completed actions instead of requiring manual store deletion"
+time: 2026-05-22T01:40:00.000000Z

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -1,6 +1,8 @@
 """Single action execution with batch support."""
 
 import asyncio
+import hashlib
+import json as _json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -36,6 +38,32 @@ UPSTREAM_SKIP_PREFIX = "Upstream dependency"
 
 # Reason string for WHERE-clause skip (action skipped, record unchanged).
 WHERE_SKIP_REASON = "WHERE clause — action skipped"
+
+
+def _compute_action_config_hash(
+    action_config: ActionConfigDict,
+    prompt_content: str | None = None,
+) -> str:
+    """Compute a deterministic hash of semantically-meaningful action config.
+
+    Covers: prompt content (or reference), model, schema reference,
+    guard clause + behavior. Changes to these fields invalidate prior
+    results. Cosmetic fields (description, tags) are excluded.
+    """
+    guard = action_config.get("guard") or {}
+    if isinstance(guard, str):
+        guard = {"clause": guard, "behavior": "skip"}
+
+    hash_input = {
+        "prompt": prompt_content or action_config.get("prompt", ""),
+        "model": action_config.get("model", ""),
+        "schema": action_config.get("schema", ""),
+        "guard_clause": guard.get("clause", "") if isinstance(guard, dict) else "",
+        "guard_behavior": guard.get("behavior", "") if isinstance(guard, dict) else "",
+    }
+
+    serialized = _json.dumps(hash_input, sort_keys=True, ensure_ascii=True)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
 
 @dataclass
@@ -142,25 +170,36 @@ class ActionExecutor:
         return self.deps == other.deps
 
     @staticmethod
-    def _limit_metadata(action_config: ActionConfigDict) -> dict[str, int | None]:
-        """Extract limit fields for status metadata storage."""
+    def _completion_metadata(action_config: ActionConfigDict) -> dict[str, Any]:
+        """Build metadata dict for completed action status."""
         cfg: dict[str, Any] = action_config  # type: ignore[assignment]
         return {
             "record_limit": cfg.get("record_limit"),
             "file_limit": cfg.get("file_limit"),
+            "config_hash": _compute_action_config_hash(action_config),
         }
 
     def _maybe_invalidate_completed_status(
         self, action_name: str, action_config: ActionConfigDict, current_status: ActionStatus
     ) -> ActionStatus:
-        """Reset to pending if limit config changed since last completion."""
+        """Reset to pending if limit or semantic config changed since last completion."""
         if current_status not in COMPLETED_STATUSES:
             return current_status
         details = self.deps.state_manager.get_status_details(action_name)
-        if details.get("record_limit") != action_config.get("record_limit") or details.get(
-            "file_limit"
-        ) != action_config.get("file_limit"):
-            logger.info("Limit config changed for %s, resetting to pending", action_name)
+
+        limits_changed = details.get("record_limit") != action_config.get(
+            "record_limit"
+        ) or details.get("file_limit") != action_config.get("file_limit")
+
+        config_hash = _compute_action_config_hash(action_config)
+        stored_hash = details.get("config_hash")
+        config_changed = stored_hash is not None and stored_hash != config_hash
+
+        if limits_changed or config_changed:
+            reason = (
+                "limit config" if limits_changed else "action config (prompt/model/schema/guard)"
+            )
+            logger.info("%s changed for %s, resetting to pending", reason, action_name)
             self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
             storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
             if storage_backend is not None:
@@ -251,7 +290,7 @@ class ActionExecutor:
         # No disposition written: the record is unchanged, downstream
         # proceeds normally reading existing namespaces.
         self.deps.state_manager.update_status(
-            action_name, ActionStatus.COMPLETED, **self._limit_metadata(action_config)
+            action_name, ActionStatus.COMPLETED, **self._completion_metadata(action_config)
         )
 
         duration = (datetime.now() - start_time).total_seconds()
@@ -329,7 +368,7 @@ class ActionExecutor:
             self.deps.state_manager.update_status(
                 params.action_name,
                 ActionStatus.COMPLETED,
-                **self._limit_metadata(params.action_config),
+                **self._completion_metadata(params.action_config),
             )
             logger.info(
                 "Action completed (passthrough)",
@@ -354,7 +393,7 @@ class ActionExecutor:
             params.action_name,
             final_status,
             execution_time=duration,
-            **self._limit_metadata(params.action_config),
+            **self._completion_metadata(params.action_config),
         )
         tokens = get_last_usage()
         self._track_action_complete(params.action_name, duration, final_status, tokens=tokens)
@@ -928,7 +967,7 @@ class ActionExecutor:
                 final_status,
                 execution_time=wall_clock,
                 execution_mode="batch",
-                **self._limit_metadata(action_config),
+                **self._completion_metadata(action_config),
             )
             fire_event(
                 BatchCompleteEvent(

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import hashlib
-import json as _json
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -62,7 +62,7 @@ def _compute_action_config_hash(
         "guard_behavior": guard.get("behavior", "") if isinstance(guard, dict) else "",
     }
 
-    serialized = _json.dumps(hash_input, sort_keys=True, ensure_ascii=True)
+    serialized = json.dumps(hash_input, sort_keys=True)
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
 

--- a/tests/unit/workflow/test_config_change_detection.py
+++ b/tests/unit/workflow/test_config_change_detection.py
@@ -1,0 +1,207 @@
+"""Tests for config change detection via action hash."""
+
+from unittest.mock import MagicMock
+
+from agent_actions.workflow.executor import (
+    ActionExecutor,
+    ExecutorDependencies,
+    _compute_action_config_hash,
+)
+from agent_actions.workflow.managers.state import ActionStateManager, ActionStatus
+
+
+class TestComputeActionConfigHash:
+    """_compute_action_config_hash must produce stable, deterministic hashes."""
+
+    def test_same_config_produces_same_hash(self):
+        config = {"prompt": "Summarize", "model": "gpt-4", "schema": "s.yml"}
+        assert _compute_action_config_hash(config) == _compute_action_config_hash(config)
+
+    def test_different_model_produces_different_hash(self):
+        base = {"prompt": "Summarize", "model": "gpt-4", "schema": "s.yml"}
+        changed = {**base, "model": "gpt-4o"}
+        assert _compute_action_config_hash(base) != _compute_action_config_hash(changed)
+
+    def test_different_prompt_produces_different_hash(self):
+        base = {"prompt": "Summarize", "model": "gpt-4"}
+        changed = {**base, "prompt": "Analyze"}
+        assert _compute_action_config_hash(base) != _compute_action_config_hash(changed)
+
+    def test_different_schema_produces_different_hash(self):
+        base = {"prompt": "Summarize", "model": "gpt-4", "schema": "old.yml"}
+        changed = {**base, "schema": "new.yml"}
+        assert _compute_action_config_hash(base) != _compute_action_config_hash(changed)
+
+    def test_different_guard_clause_produces_different_hash(self):
+        base = {"prompt": "X", "guard": {"clause": "a > 1", "behavior": "skip"}}
+        changed = {"prompt": "X", "guard": {"clause": "a > 2", "behavior": "skip"}}
+        assert _compute_action_config_hash(base) != _compute_action_config_hash(changed)
+
+    def test_different_guard_behavior_produces_different_hash(self):
+        base = {"prompt": "X", "guard": {"clause": "a > 1", "behavior": "skip"}}
+        changed = {"prompt": "X", "guard": {"clause": "a > 1", "behavior": "warn"}}
+        assert _compute_action_config_hash(base) != _compute_action_config_hash(changed)
+
+    def test_cosmetic_description_change_does_not_change_hash(self):
+        base = {"prompt": "X", "model": "m", "description": "Old desc"}
+        changed = {**base, "description": "New desc"}
+        assert _compute_action_config_hash(base) == _compute_action_config_hash(changed)
+
+    def test_limit_change_does_not_change_hash(self):
+        base = {"prompt": "X", "model": "m", "record_limit": 10}
+        changed = {**base, "record_limit": 20}
+        assert _compute_action_config_hash(base) == _compute_action_config_hash(changed)
+
+    def test_guard_string_normalized_to_dict(self):
+        """Guard as string should produce same hash as equivalent dict."""
+        string_guard = {"prompt": "X", "guard": "a > 1"}
+        dict_guard = {"prompt": "X", "guard": {"clause": "a > 1", "behavior": "skip"}}
+        assert _compute_action_config_hash(string_guard) == _compute_action_config_hash(dict_guard)
+
+    def test_guard_none_handled(self):
+        """guard: null should not crash."""
+        config = {"prompt": "X", "guard": None}
+        h = _compute_action_config_hash(config)
+        assert isinstance(h, str) and len(h) == 16
+
+    def test_missing_fields_produce_stable_hash(self):
+        """Config with no prompt/model/schema/guard should still hash."""
+        config = {}
+        h = _compute_action_config_hash(config)
+        assert isinstance(h, str) and len(h) == 16
+
+    def test_prompt_content_override(self):
+        """Resolved prompt content should override the config reference."""
+        config = {"prompt": "file_ref.md", "model": "m"}
+        h_ref = _compute_action_config_hash(config)
+        h_content = _compute_action_config_hash(config, prompt_content="Actual content")
+        assert h_ref != h_content
+
+    def test_hash_is_16_hex_chars(self):
+        config = {"prompt": "X", "model": "m"}
+        h = _compute_action_config_hash(config)
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+class TestConfigChangeInvalidation:
+    """_maybe_invalidate_completed_status must detect config hash changes."""
+
+    def _make_executor(self, state_mgr):
+        action_runner = MagicMock()
+        action_runner.storage_backend = MagicMock()
+        deps = ExecutorDependencies(
+            action_runner=action_runner,
+            state_manager=state_mgr,
+            skip_evaluator=MagicMock(),
+            batch_manager=MagicMock(),
+            output_manager=MagicMock(),
+        )
+        return ActionExecutor(deps)
+
+    def test_config_change_resets_to_pending(self, tmp_path):
+        """Changed model triggers invalidation when stored hash exists."""
+        status_file = tmp_path / "status.json"
+        state_mgr = ActionStateManager(status_file, ["action_a"])
+
+        old_config = {"prompt": "X", "model": "gpt-4", "record_limit": 10}
+        old_hash = _compute_action_config_hash(old_config)
+        state_mgr.update_status(
+            "action_a", ActionStatus.COMPLETED, record_limit=10, config_hash=old_hash
+        )
+
+        new_config = {"prompt": "X", "model": "gpt-4o", "record_limit": 10}
+        executor = self._make_executor(state_mgr)
+        result = executor._maybe_invalidate_completed_status(
+            "action_a", new_config, ActionStatus.COMPLETED
+        )
+        assert result == ActionStatus.PENDING
+
+    def test_same_config_stays_completed(self, tmp_path):
+        """Identical config should not invalidate."""
+        status_file = tmp_path / "status.json"
+        state_mgr = ActionStateManager(status_file, ["action_a"])
+
+        config = {"prompt": "X", "model": "gpt-4", "record_limit": 10}
+        config_hash = _compute_action_config_hash(config)
+        state_mgr.update_status(
+            "action_a", ActionStatus.COMPLETED, record_limit=10, config_hash=config_hash
+        )
+
+        executor = self._make_executor(state_mgr)
+        result = executor._maybe_invalidate_completed_status(
+            "action_a", config, ActionStatus.COMPLETED
+        )
+        assert result == ActionStatus.COMPLETED
+
+    def test_missing_stored_hash_does_not_invalidate(self, tmp_path):
+        """First run or upgrade -- no stored hash means no invalidation."""
+        status_file = tmp_path / "status.json"
+        state_mgr = ActionStateManager(status_file, ["action_a"])
+        state_mgr.update_status("action_a", ActionStatus.COMPLETED, record_limit=10)
+
+        config = {"prompt": "X", "model": "gpt-4", "record_limit": 10}
+        executor = self._make_executor(state_mgr)
+        result = executor._maybe_invalidate_completed_status(
+            "action_a", config, ActionStatus.COMPLETED
+        )
+        assert result == ActionStatus.COMPLETED
+
+    def test_limit_change_still_invalidates(self, tmp_path):
+        """Limit changes should still trigger invalidation (existing behavior)."""
+        status_file = tmp_path / "status.json"
+        state_mgr = ActionStateManager(status_file, ["action_a"])
+
+        config_hash = _compute_action_config_hash({"prompt": "X", "model": "m"})
+        state_mgr.update_status(
+            "action_a", ActionStatus.COMPLETED, record_limit=10, config_hash=config_hash
+        )
+
+        new_config = {"prompt": "X", "model": "m", "record_limit": 20}
+        executor = self._make_executor(state_mgr)
+        result = executor._maybe_invalidate_completed_status(
+            "action_a", new_config, ActionStatus.COMPLETED
+        )
+        assert result == ActionStatus.PENDING
+
+    def test_non_completed_status_not_checked(self, tmp_path):
+        """PENDING/RUNNING actions should be returned as-is."""
+        status_file = tmp_path / "status.json"
+        state_mgr = ActionStateManager(status_file, ["action_a"])
+
+        executor = self._make_executor(state_mgr)
+        result = executor._maybe_invalidate_completed_status(
+            "action_a", {"prompt": "X"}, ActionStatus.PENDING
+        )
+        assert result == ActionStatus.PENDING
+
+    def test_clear_disposition_called_on_config_invalidation(self, tmp_path):
+        """Dispositions must be cleared when config change triggers reset."""
+        status_file = tmp_path / "status.json"
+        state_mgr = ActionStateManager(status_file, ["action_a"])
+
+        old_config = {"prompt": "X", "model": "gpt-4"}
+        old_hash = _compute_action_config_hash(old_config)
+        state_mgr.update_status(
+            "action_a", ActionStatus.COMPLETED, record_limit=10, config_hash=old_hash
+        )
+
+        new_config = {"prompt": "X", "model": "gpt-4o", "record_limit": 10}
+        executor = self._make_executor(state_mgr)
+        executor._maybe_invalidate_completed_status("action_a", new_config, ActionStatus.COMPLETED)
+
+        executor.deps.action_runner.storage_backend.clear_disposition.assert_called_once_with(
+            "action_a"
+        )
+
+
+class TestCompletionMetadata:
+    """_completion_metadata must include config_hash alongside limits."""
+
+    def test_includes_config_hash(self):
+        config = {"prompt": "X", "model": "m", "record_limit": 5, "file_limit": 10}
+        meta = ActionExecutor._completion_metadata(config)
+        assert "config_hash" in meta
+        assert meta["config_hash"] == _compute_action_config_hash(config)
+        assert meta["record_limit"] == 5
+        assert meta["file_limit"] == 10

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -1,7 +1,7 @@
 """Tests for ActionExecutor lifecycle: execute_action_sync and helper methods."""
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -286,7 +286,7 @@ class TestHandleRunSuccess:
         assert result.status == ActionStatus.COMPLETED
         assert result.output_folder == "/out"
         mock_deps.state_manager.update_status.assert_called_with(
-            "agent_a", ActionStatus.COMPLETED, record_limit=None, file_limit=None
+            "agent_a", ActionStatus.COMPLETED, record_limit=None, file_limit=None, config_hash=ANY
         )
 
     def test_normal_completion_with_tokens(self, executor, mock_deps):
@@ -548,7 +548,7 @@ class TestHandleAgentSkip:
         assert result.success is True
         assert result.status == ActionStatus.COMPLETED
         mock_deps.state_manager.update_status.assert_called_with(
-            "agent_a", ActionStatus.COMPLETED, record_limit=None, file_limit=None
+            "agent_a", ActionStatus.COMPLETED, record_limit=None, file_limit=None, config_hash=ANY
         )
         mock_fire.assert_called_once()
 


### PR DESCRIPTION
## Summary
- `_maybe_invalidate_completed_status` only checked `record_limit` and `file_limit` — changing prompt, model, schema, or guard left actions COMPLETED with stale config, requiring manual store deletion
- Added `_compute_action_config_hash()` producing a stable SHA-256 fingerprint of semantic config fields (prompt, model, schema, guard clause+behavior)
- Hash stored in status metadata on completion; compared on re-run — mismatch resets to PENDING
- Guard normalization handles string/dict/None; missing stored hash (upgrade path) does not invalidate; cosmetic fields excluded

## Verification
- 20 new tests in `test_config_change_detection.py` (hash stability, change detection, upgrade path, guard normalization, cosmetic exclusion, disposition clearing)
- 2 existing `test_executor_lifecycle.py` tests updated for new `config_hash` kwarg
- 7219 passed, ruff clean
- Pre-existing failures in `test_trailing_comma_repair` (2 tests) unrelated to this change