### PR TITLE
perf: batch SQLite disposition commits

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260522-P11000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260522-P11000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Batch SQLite disposition commits — one transaction per action instead of N per-record commits during result collection"
+time: 2026-05-22T11:10:00.000000Z

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -363,6 +363,10 @@ def collect_results_from_processing_results(
 
     output: list[dict[str, Any]] = []
     stats: collections.Counter[str] = collections.Counter()
+    # Accumulate dispositions for a single batch flush instead of N per-record commits.
+    pending_dispositions: list[
+        tuple[str, str, str, str | None, str | None, str | None, str | None]
+    ] = []
 
     for idx, result in enumerate(results):
         status = result.status
@@ -405,12 +409,16 @@ def collect_results_from_processing_results(
                     )
                 )
                 if storage_backend and result.source_guid:
-                    _safe_set_disposition(
-                        storage_backend,
-                        action_name,
-                        result.source_guid,
-                        DISPOSITION_FAILED,
-                        reason=PARSE_ERROR,
+                    pending_dispositions.append(
+                        (
+                            action_name,
+                            result.source_guid,
+                            DISPOSITION_FAILED,
+                            PARSE_ERROR,
+                            None,
+                            None,
+                            None,
+                        )
                     )
                 continue
 
@@ -431,11 +439,16 @@ def collect_results_from_processing_results(
                 )
             )
             if storage_backend and result.source_guid:
-                _safe_set_disposition(
-                    storage_backend,
-                    action_name,
-                    result.source_guid,
-                    DISPOSITION_SUCCESS,
+                pending_dispositions.append(
+                    (
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_SUCCESS,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
                 )
             elif storage_backend and result.source_guid is None and data:
                 # FILE-mode results have source_guid=None on the result level
@@ -445,11 +458,16 @@ def collect_results_from_processing_results(
                 for item in data:
                     item_guid = item.get("source_guid")
                     if item_guid:
-                        _safe_set_disposition(
-                            storage_backend,
-                            action_name,
-                            item_guid,
-                            DISPOSITION_SUCCESS,
+                        pending_dispositions.append(
+                            (
+                                action_name,
+                                item_guid,
+                                DISPOSITION_SUCCESS,
+                                None,
+                                None,
+                                None,
+                                None,
+                            )
                         )
 
         elif status == ProcessingStatus.SKIPPED:
@@ -476,12 +494,16 @@ def collect_results_from_processing_results(
                 )
             )
             if storage_backend and result.source_guid:
-                _safe_set_disposition(
-                    storage_backend,
-                    action_name,
-                    result.source_guid,
-                    DISPOSITION_PASSTHROUGH,
-                    reason=result.skip_reason or GUARD_SKIP,
+                pending_dispositions.append(
+                    (
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_PASSTHROUGH,
+                        result.skip_reason or GUARD_SKIP,
+                        None,
+                        None,
+                        None,
+                    )
                 )
 
         elif status == ProcessingStatus.EXHAUSTED:
@@ -508,14 +530,16 @@ def collect_results_from_processing_results(
                 input_snapshot_str = _serialize_snapshot(
                     result.source_snapshot or result.input_record
                 )
-                _safe_set_disposition(
-                    storage_backend,
-                    action_name,
-                    result.source_guid,
-                    DISPOSITION_EXHAUSTED,
-                    reason=f"exhausted_after_{attempts}_attempts",
-                    input_snapshot=input_snapshot_str,
-                    detail=result.error,
+                pending_dispositions.append(
+                    (
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_EXHAUSTED,
+                        f"exhausted_after_{attempts}_attempts",
+                        None,
+                        input_snapshot_str,
+                        result.error,
+                    )
                 )
 
         elif status == ProcessingStatus.FAILED:
@@ -553,14 +577,16 @@ def collect_results_from_processing_results(
                 input_snapshot_str = _serialize_snapshot(
                     result.source_snapshot or result.input_record
                 )
-                _safe_set_disposition(
-                    storage_backend,
-                    action_name,
-                    result.source_guid,
-                    DISPOSITION_FAILED,
-                    reason=result.error or "processing_error",
-                    input_snapshot=input_snapshot_str,
-                    detail=result.error,
+                pending_dispositions.append(
+                    (
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_FAILED,
+                        result.error or "processing_error",
+                        None,
+                        input_snapshot_str,
+                        result.error,
+                    )
                 )
 
         elif status == ProcessingStatus.FILTERED:
@@ -573,12 +599,16 @@ def collect_results_from_processing_results(
                 )
             )
             if storage_backend and result.source_guid:
-                _safe_set_disposition(
-                    storage_backend,
-                    action_name,
-                    result.source_guid,
-                    DISPOSITION_FILTERED,
-                    reason=result.skip_reason or GUARD_FILTER,
+                pending_dispositions.append(
+                    (
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_FILTERED,
+                        result.skip_reason or GUARD_FILTER,
+                        None,
+                        None,
+                        None,
+                    )
                 )
 
         elif status == ProcessingStatus.UNPROCESSED:
@@ -615,12 +645,16 @@ def collect_results_from_processing_results(
                 )
             )
             if storage_backend and result.source_guid:
-                _safe_set_disposition(
-                    storage_backend,
-                    action_name,
-                    result.source_guid,
-                    DISPOSITION_UNPROCESSED,
-                    reason=result.skip_reason or UNPROCESSED,
+                pending_dispositions.append(
+                    (
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_UNPROCESSED,
+                        result.skip_reason or UNPROCESSED,
+                        None,
+                        None,
+                        None,
+                    )
                 )
 
         elif status == ProcessingStatus.DEFERRED:
@@ -638,16 +672,31 @@ def collect_results_from_processing_results(
                 )
             )
             if storage_backend and result.source_guid:
-                _safe_set_disposition(
-                    storage_backend,
-                    action_name,
-                    result.source_guid,
-                    DISPOSITION_DEFERRED,
-                    reason=f"batch_queued:task_id={task_id}",
+                pending_dispositions.append(
+                    (
+                        action_name,
+                        result.source_guid,
+                        DISPOSITION_DEFERRED,
+                        f"batch_queued:task_id={task_id}",
+                        None,
+                        None,
+                        None,
+                    )
                 )
 
         else:
             logger.debug("Unhandled result status=%s", status)  # type: ignore[unreachable]
+
+    # Flush all accumulated dispositions in a single transaction.
+    if storage_backend and pending_dispositions:
+        try:
+            storage_backend.set_dispositions_batch(pending_dispositions)
+        except Exception:
+            logger.exception(
+                "Failed to batch-write %d dispositions for %s",
+                len(pending_dispositions),
+                action_name,
+            )
 
     guard_config = effective_config.get("guard", {})
     guard_condition = guard_config.get("clause", "") if isinstance(guard_config, dict) else ""

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -37,6 +37,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_SUCCESS,
     DISPOSITION_UNPROCESSED,
     NODE_LEVEL_RECORD_ID,
+    DispositionRow,
 )
 
 if TYPE_CHECKING:
@@ -363,10 +364,7 @@ def collect_results_from_processing_results(
 
     output: list[dict[str, Any]] = []
     stats: collections.Counter[str] = collections.Counter()
-    # Accumulate dispositions for a single batch flush instead of N per-record commits.
-    pending_dispositions: list[
-        tuple[str, str, str, str | None, str | None, str | None, str | None]
-    ] = []
+    pending_dispositions: list[DispositionRow] = []
 
     for idx, result in enumerate(results):
         status = result.status

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -34,6 +34,9 @@ class Disposition(str, Enum):
 
 VALID_DISPOSITIONS = frozenset(d.value for d in Disposition)
 
+DispositionRow = tuple[str, str, str, str | None, str | None, str | None, str | None]
+"""(action_name, record_id, disposition, reason, relative_path, input_snapshot, detail)."""
+
 
 class StorageBackend(ABC):
     """Abstract interface for pluggable storage backends (SQLite, S3, DuckDB, etc.)."""
@@ -149,12 +152,9 @@ class StorageBackend(ABC):
 
     def set_dispositions_batch(
         self,
-        dispositions: list[tuple[str, str, str, str | None, str | None, str | None, str | None]],
+        dispositions: list[DispositionRow],
     ) -> None:
         """Write multiple disposition records in a single transaction.
-
-        Each tuple: (action_name, record_id, disposition, reason, relative_path,
-                     input_snapshot, detail).
 
         Default implementation loops over set_disposition. Backends may
         override for batch-optimized writes.

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -147,6 +147,29 @@ class StorageBackend(ABC):
         """
         # No-op: subclass must override to persist dispositions.
 
+    def set_dispositions_batch(
+        self,
+        dispositions: list[tuple[str, str, str, str | None, str | None, str | None, str | None]],
+    ) -> None:
+        """Write multiple disposition records in a single transaction.
+
+        Each tuple: (action_name, record_id, disposition, reason, relative_path,
+                     input_snapshot, detail).
+
+        Default implementation loops over set_disposition. Backends may
+        override for batch-optimized writes.
+        """
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            self.set_disposition(
+                action_name,
+                record_id,
+                disposition,
+                reason=reason,
+                relative_path=rp,
+                input_snapshot=snapshot,
+                detail=detail,
+            )
+
     def get_disposition(
         self,
         action_name: str,

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -14,6 +14,7 @@ from agent_actions.storage.backend import (
     NODE_LEVEL_RECORD_ID,
     VALID_DISPOSITIONS,
     Disposition,
+    DispositionRow,
     StorageBackend,
 )
 
@@ -607,6 +608,33 @@ class SQLiteBackend(StorageBackend):
     # commit/rollback as well.
     # ------------------------------------------------------------------
 
+    def _validate_disposition_fields(
+        self,
+        action_name: str,
+        record_id: str,
+        disposition: str | Disposition,
+        relative_path: str | None,
+        input_snapshot: str | None,
+    ) -> tuple[str, str, str | None, str | None]:
+        """Validate and normalize fields shared by set_disposition and set_dispositions_batch.
+
+        Returns (action_name, record_id, relative_path, input_snapshot) after validation.
+        """
+        action_name = self._validate_identifier(action_name, "action_name")
+        record_id = self._validate_identifier(record_id, "record_id")
+        if relative_path is not None:
+            relative_path = self._validate_identifier(relative_path, "relative_path")
+        if disposition not in VALID_DISPOSITIONS:
+            raise ValueError(
+                f"Invalid disposition '{disposition}'. Valid: {sorted(VALID_DISPOSITIONS)}"
+            )
+        # Cap input_snapshot at 10KB to prevent storage bloat.
+        if input_snapshot and len(input_snapshot) > 10240:
+            input_snapshot = (
+                '{"__truncated__": true, "partial": ' + json.dumps(input_snapshot[:8192]) + "}"
+            )
+        return action_name, record_id, relative_path, input_snapshot
+
     def set_disposition(
         self,
         action_name: str,
@@ -618,20 +646,9 @@ class SQLiteBackend(StorageBackend):
         detail: str | None = None,
     ) -> None:
         """Write a disposition record, clearing any prior disposition for this (action, record)."""
-        action_name = self._validate_identifier(action_name, "action_name")
-        record_id = self._validate_identifier(record_id, "record_id")
-        if relative_path is not None:
-            relative_path = self._validate_identifier(relative_path, "relative_path")
-        if disposition not in VALID_DISPOSITIONS:
-            raise ValueError(
-                f"Invalid disposition '{disposition}'. Valid: {sorted(VALID_DISPOSITIONS)}"
-            )
-        # Cap input_snapshot at 10KB to prevent storage bloat.
-        # Wrap truncated content so consumers can detect and skip invalid JSON.
-        if input_snapshot and len(input_snapshot) > 10240:
-            input_snapshot = (
-                '{"__truncated__": true, "partial": ' + json.dumps(input_snapshot[:8192]) + "}"
-            )
+        action_name, record_id, relative_path, input_snapshot = self._validate_disposition_fields(
+            action_name, record_id, disposition, relative_path, input_snapshot
+        )
 
         with self._lock:
             cursor = self.connection.cursor()
@@ -682,7 +699,7 @@ class SQLiteBackend(StorageBackend):
 
     def set_dispositions_batch(
         self,
-        dispositions: list[tuple[str, str, str, str | None, str | None, str | None, str | None]],
+        dispositions: list[DispositionRow],
     ) -> None:
         """Batch-write dispositions in a single transaction.
 
@@ -694,18 +711,11 @@ class SQLiteBackend(StorageBackend):
         if not dispositions:
             return
 
-        rows: list[tuple[str, str, str, str | None, str | None, str | None, str | None]] = []
+        rows: list[DispositionRow] = []
         for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-            action_name = self._validate_identifier(action_name, "action_name")
-            record_id = self._validate_identifier(record_id, "record_id")
-            if rp is not None:
-                rp = self._validate_identifier(rp, "relative_path")
-            if disposition not in VALID_DISPOSITIONS:
-                raise ValueError(
-                    f"Invalid disposition '{disposition}'. Valid: {sorted(VALID_DISPOSITIONS)}"
-                )
-            if snapshot and len(snapshot) > 10240:
-                snapshot = '{"__truncated__": true, "partial": ' + json.dumps(snapshot[:8192]) + "}"
+            action_name, record_id, rp, snapshot = self._validate_disposition_fields(
+                action_name, record_id, disposition, rp, snapshot
+            )
             rows.append((action_name, record_id, disposition, reason, rp, snapshot, detail))
 
         with self._lock:

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -680,6 +680,68 @@ class SQLiteBackend(StorageBackend):
                 )
                 raise
 
+    def set_dispositions_batch(
+        self,
+        dispositions: list[tuple[str, str, str, str | None, str | None, str | None, str | None]],
+    ) -> None:
+        """Batch-write dispositions in a single transaction.
+
+        Validates every record before touching the DB — on first invalid
+        record the entire batch is rejected with no partial writes.  Uses
+        DELETE-then-INSERT (matching set_disposition) to prevent phantom
+        coexistence of conflicting dispositions for the same record.
+        """
+        if not dispositions:
+            return
+
+        rows: list[tuple[str, str, str, str | None, str | None, str | None, str | None]] = []
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            action_name = self._validate_identifier(action_name, "action_name")
+            record_id = self._validate_identifier(record_id, "record_id")
+            if rp is not None:
+                rp = self._validate_identifier(rp, "relative_path")
+            if disposition not in VALID_DISPOSITIONS:
+                raise ValueError(
+                    f"Invalid disposition '{disposition}'. Valid: {sorted(VALID_DISPOSITIONS)}"
+                )
+            if snapshot and len(snapshot) > 10240:
+                snapshot = '{"__truncated__": true, "partial": ' + json.dumps(snapshot[:8192]) + "}"
+            rows.append((action_name, record_id, disposition, reason, rp, snapshot, detail))
+
+        with self._lock:
+            cursor = self.connection.cursor()
+            try:
+                # DELETE prior dispositions for each (action_name, record_id) pair,
+                # matching set_disposition's DELETE-before-INSERT pattern (P0-5).
+                cursor.executemany(
+                    "DELETE FROM record_disposition WHERE action_name = ? AND record_id = ?",
+                    [(r[0], r[1]) for r in rows],
+                )
+                cursor.executemany(
+                    """
+                    INSERT INTO record_disposition
+                    (action_name, record_id, disposition, reason, relative_path,
+                     input_snapshot, detail, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                    """,
+                    rows,
+                )
+                self.connection.commit()
+                logger.debug(
+                    "Batch set %d dispositions",
+                    len(rows),
+                    extra={"workflow_name": self.workflow_name},
+                )
+            except sqlite3.Error as e:
+                self.connection.rollback()
+                logger.error(
+                    "Failed to batch set dispositions: %s (count=%d)",
+                    e,
+                    len(rows),
+                    extra={"workflow_name": self.workflow_name},
+                )
+                raise
+
     def get_disposition(
         self,
         action_name: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from click.testing import CliRunner
@@ -133,6 +133,29 @@ def make_mock_config_manager(upstream_refs: list[dict], agent_name: str = "downs
     manager.user_config = {"upstream": upstream_refs}
     manager.project_root = None
     return manager
+
+
+def wire_batch_disposition_delegate(backend: MagicMock) -> None:
+    """Wire ``set_dispositions_batch`` to forward calls to ``set_disposition``.
+
+    Use this on mock backends whose tests assert on per-record
+    ``set_disposition`` calls, since production code now batches
+    dispositions via ``set_dispositions_batch``.
+    """
+
+    def _delegate(dispositions: list) -> None:
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            kwargs: dict = {}
+            if reason is not None:
+                kwargs["reason"] = reason
+            if rp is not None:
+                kwargs["relative_path"] = rp
+            if snapshot is not None or detail is not None:
+                kwargs["input_snapshot"] = snapshot
+                kwargs["detail"] = detail
+            backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+    backend.set_dispositions_batch = MagicMock(side_effect=_delegate)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/processing/test_guard_skip_disposition.py
+++ b/tests/processing/test_guard_skip_disposition.py
@@ -15,6 +15,7 @@ from agent_actions.processing.prepared_task import GuardStatus, PreparedTask
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
 from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH
+from tests.conftest import wire_batch_disposition_delegate
 
 
 @pytest.fixture
@@ -95,21 +96,7 @@ class TestGuardSkipDisposition:
             source_guid="guid-1",
         )
         backend = MagicMock()
-
-        def _batch_delegate(dispositions):
-            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-                kwargs = {}
-                if reason is not None:
-                    kwargs["reason"] = reason
-                if rp is not None:
-                    kwargs["relative_path"] = rp
-                if snapshot is not None:
-                    kwargs["input_snapshot"] = snapshot
-                if detail is not None:
-                    kwargs["detail"] = detail
-                backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-        backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+        wire_batch_disposition_delegate(backend)
 
         ResultCollector.collect_results(
             [result],

--- a/tests/processing/test_guard_skip_disposition.py
+++ b/tests/processing/test_guard_skip_disposition.py
@@ -96,6 +96,21 @@ class TestGuardSkipDisposition:
         )
         backend = MagicMock()
 
+        def _batch_delegate(dispositions):
+            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+                kwargs = {}
+                if reason is not None:
+                    kwargs["reason"] = reason
+                if rp is not None:
+                    kwargs["relative_path"] = rp
+                if snapshot is not None:
+                    kwargs["input_snapshot"] = snapshot
+                if detail is not None:
+                    kwargs["detail"] = detail
+                backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+        backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+
         ResultCollector.collect_results(
             [result],
             {"kind": "llm"},

--- a/tests/unit/core/test_input_snapshot_forensics.py
+++ b/tests/unit/core/test_input_snapshot_forensics.py
@@ -42,6 +42,20 @@ def _retry_metadata(attempts: int = 2) -> RecoveryMetadata:
 def _make_backend() -> MagicMock:
     backend = MagicMock()
     backend.set_disposition = MagicMock()
+
+    def _batch_delegate(dispositions):
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            kwargs: dict = {}
+            if reason is not None:
+                kwargs["reason"] = reason
+            if rp is not None:
+                kwargs["relative_path"] = rp
+            if snapshot is not None or detail is not None:
+                kwargs["input_snapshot"] = snapshot
+                kwargs["detail"] = detail
+            backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+    backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
     return backend
 
 

--- a/tests/unit/core/test_input_snapshot_forensics.py
+++ b/tests/unit/core/test_input_snapshot_forensics.py
@@ -26,6 +26,7 @@ from agent_actions.processing.types import (
     RecoveryMetadata,
     RetryMetadata,
 )
+from tests.conftest import wire_batch_disposition_delegate
 
 
 def _retry_metadata(attempts: int = 2) -> RecoveryMetadata:
@@ -42,20 +43,7 @@ def _retry_metadata(attempts: int = 2) -> RecoveryMetadata:
 def _make_backend() -> MagicMock:
     backend = MagicMock()
     backend.set_disposition = MagicMock()
-
-    def _batch_delegate(dispositions):
-        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-            kwargs: dict = {}
-            if reason is not None:
-                kwargs["reason"] = reason
-            if rp is not None:
-                kwargs["relative_path"] = rp
-            if snapshot is not None or detail is not None:
-                kwargs["input_snapshot"] = snapshot
-                kwargs["detail"] = detail
-            backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-    backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+    wire_batch_disposition_delegate(backend)
     return backend
 
 

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -19,6 +19,7 @@ from agent_actions.processing.types import (
     RetryMetadata,
 )
 from agent_actions.utils.id_generation import IDGenerator
+from tests.conftest import wire_batch_disposition_delegate
 
 
 def _retry_metadata() -> RecoveryMetadata:
@@ -246,21 +247,7 @@ def test_result_collector_on_exhausted_raise_writes_disposition_before_raising()
 
     mock_backend = MagicMock()
     mock_backend.set_disposition = MagicMock()
-
-    def _batch_delegate(dispositions):
-        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-            kwargs = {}
-            if reason is not None:
-                kwargs["reason"] = reason
-            if rp is not None:
-                kwargs["relative_path"] = rp
-            if snapshot is not None:
-                kwargs["input_snapshot"] = snapshot
-            if detail is not None:
-                kwargs["detail"] = detail
-            mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-    mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+    wire_batch_disposition_delegate(mock_backend)
 
     with pytest.raises(AgentActionsError):
         ResultCollector.collect_results(
@@ -324,22 +311,7 @@ def _make_backend():
     """Create a mock StorageBackend with a mocked set_disposition method."""
     backend = MagicMock()
     backend.set_disposition = MagicMock()
-
-    def _batch_delegate(dispositions):
-        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-            kwargs: dict = {}
-            if reason is not None:
-                kwargs["reason"] = reason
-            if rp is not None:
-                kwargs["relative_path"] = rp
-            # Always pass input_snapshot and detail (even when None) — tests
-            # for FAILED/EXHAUSTED assert these are present in call kwargs.
-            if snapshot is not None or detail is not None:
-                kwargs["input_snapshot"] = snapshot
-                kwargs["detail"] = detail
-            backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-    backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+    wire_batch_disposition_delegate(backend)
     return backend
 
 

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -245,6 +245,22 @@ def test_result_collector_on_exhausted_raise_writes_disposition_before_raising()
     )
 
     mock_backend = MagicMock()
+    mock_backend.set_disposition = MagicMock()
+
+    def _batch_delegate(dispositions):
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            kwargs = {}
+            if reason is not None:
+                kwargs["reason"] = reason
+            if rp is not None:
+                kwargs["relative_path"] = rp
+            if snapshot is not None:
+                kwargs["input_snapshot"] = snapshot
+            if detail is not None:
+                kwargs["detail"] = detail
+            mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+    mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
 
     with pytest.raises(AgentActionsError):
         ResultCollector.collect_results(
@@ -308,6 +324,22 @@ def _make_backend():
     """Create a mock StorageBackend with a mocked set_disposition method."""
     backend = MagicMock()
     backend.set_disposition = MagicMock()
+
+    def _batch_delegate(dispositions):
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            kwargs: dict = {}
+            if reason is not None:
+                kwargs["reason"] = reason
+            if rp is not None:
+                kwargs["relative_path"] = rp
+            # Always pass input_snapshot and detail (even when None) — tests
+            # for FAILED/EXHAUSTED assert these are present in call kwargs.
+            if snapshot is not None or detail is not None:
+                kwargs["input_snapshot"] = snapshot
+                kwargs["detail"] = detail
+            backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+    backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
     return backend
 
 

--- a/tests/unit/core/test_result_collector_batch.py
+++ b/tests/unit/core/test_result_collector_batch.py
@@ -1,0 +1,166 @@
+"""Tests for batch disposition flush in collect_results_from_processing_results."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agent_actions.processing.result_collector import (
+    collect_results_from_processing_results,
+)
+from agent_actions.processing.types import ProcessingResult, ProcessingStatus
+from agent_actions.storage.backend import (
+    DISPOSITION_DEFERRED,
+    DISPOSITION_EXHAUSTED,
+    DISPOSITION_FAILED,
+    DISPOSITION_FILTERED,
+    DISPOSITION_PASSTHROUGH,
+    DISPOSITION_SUCCESS,
+    DISPOSITION_UNPROCESSED,
+)
+
+
+def _mock_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.set_dispositions_batch = MagicMock()
+    backend.set_disposition = MagicMock()
+    return backend
+
+
+class TestBatchDispositionFlush:
+    """Verify collect_results_from_processing_results flushes dispositions in a single batch."""
+
+    def test_success_results_batched(self):
+        """Multiple SUCCESS results should produce one set_dispositions_batch call."""
+        backend = _mock_backend()
+        results = [
+            ProcessingResult.success(data=[{"content": {"v": i}}], source_guid=f"rec_{i}")
+            for i in range(5)
+        ]
+        collect_results_from_processing_results(results, "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 5
+        assert all(t[2] == DISPOSITION_SUCCESS for t in batch_arg)
+
+    def test_mixed_statuses_batched_together(self):
+        """Different statuses should all land in a single batch call."""
+        backend = _mock_backend()
+        results = [
+            ProcessingResult.success(data=[{"content": {"v": 1}}], source_guid="s1"),
+            ProcessingResult.failed(error="boom", source_guid="s2"),
+            ProcessingResult.skipped(passthrough_data={"v": 3}, reason="guard", source_guid="s3"),
+            ProcessingResult(
+                status=ProcessingStatus.FILTERED,
+                data=[],
+                source_guid="s4",
+                skip_reason="filter",
+            ),
+            ProcessingResult(
+                status=ProcessingStatus.UNPROCESSED,
+                data=[{"source_guid": "s5"}],
+                source_guid="s5",
+                skip_reason="cascade",
+            ),
+            ProcessingResult.deferred(task_id="task-123", source_guid="s6"),
+        ]
+        collect_results_from_processing_results(results, "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 6
+        dispositions = [t[2] for t in batch_arg]
+        assert DISPOSITION_SUCCESS in dispositions
+        assert DISPOSITION_FAILED in dispositions
+        assert DISPOSITION_PASSTHROUGH in dispositions
+        assert DISPOSITION_FILTERED in dispositions
+        assert DISPOSITION_UNPROCESSED in dispositions
+        assert DISPOSITION_DEFERRED in dispositions
+
+    def test_no_backend_no_batch_call(self):
+        """Without a storage backend, no batch call should happen."""
+        results = [
+            ProcessingResult.success(data=[{"content": {"v": 1}}], source_guid="s1"),
+        ]
+        # Should not raise.
+        output, stats = collect_results_from_processing_results(
+            results, "action_A", storage_backend=None
+        )
+        assert stats.success == 1
+
+    def test_no_source_guid_no_disposition(self):
+        """Results without source_guid should not produce disposition entries."""
+        backend = _mock_backend()
+        results = [
+            ProcessingResult.success(data=[{"content": {"v": 1}}], source_guid=None),
+        ]
+        collect_results_from_processing_results(results, "action_A", storage_backend=backend)
+        # No dispositions accumulated (source_guid is None, no FILE-mode items).
+        backend.set_dispositions_batch.assert_not_called()
+
+    def test_batch_failure_logged_not_raised(self):
+        """If set_dispositions_batch raises, it should be caught and logged, not crash."""
+        backend = _mock_backend()
+        backend.set_dispositions_batch.side_effect = RuntimeError("DB gone")
+        results = [
+            ProcessingResult.success(data=[{"content": {"v": 1}}], source_guid="s1"),
+        ]
+        # Should not raise — disposition writes are telemetry.
+        output, stats = collect_results_from_processing_results(
+            results, "action_A", storage_backend=backend
+        )
+        assert stats.success == 1
+        assert len(output) == 1
+
+    def test_file_mode_per_item_dispositions(self):
+        """FILE-mode results (source_guid=None on result, per-item guids) should batch per-item."""
+        backend = _mock_backend()
+        results = [
+            ProcessingResult.success(
+                data=[
+                    {"content": {"v": 1}, "source_guid": "item_1"},
+                    {"content": {"v": 2}, "source_guid": "item_2"},
+                ],
+                source_guid=None,
+            ),
+        ]
+        collect_results_from_processing_results(results, "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 2
+        record_ids = {t[1] for t in batch_arg}
+        assert record_ids == {"item_1", "item_2"}
+
+    def test_exhausted_includes_snapshot_and_detail(self):
+        """EXHAUSTED disposition should carry input_snapshot and detail."""
+        backend = _mock_backend()
+        from agent_actions.processing.types import RecoveryMetadata, RetryMetadata
+
+        result = ProcessingResult.exhausted(
+            error="timeout",
+            source_guid="s1",
+            recovery_metadata=RecoveryMetadata(
+                retry=RetryMetadata(attempts=3, failures=3, succeeded=False, reason="timeout")
+            ),
+        )
+        result.data = [{"source_guid": "s1", "content": {}}]
+        result.source_snapshot = {"key": "value"}
+
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 1
+        t = batch_arg[0]
+        assert t[2] == DISPOSITION_EXHAUSTED
+        assert "exhausted_after_3_attempts" in t[3]  # reason
+        assert t[5] is not None  # input_snapshot
+        assert t[6] == "timeout"  # detail
+
+    def test_per_record_set_disposition_not_called(self):
+        """The per-record _safe_set_disposition path should NOT be used inside collect_results."""
+        backend = _mock_backend()
+        results = [
+            ProcessingResult.success(data=[{"content": {"v": 1}}], source_guid="s1"),
+            ProcessingResult.failed(error="err", source_guid="s2"),
+        ]
+        collect_results_from_processing_results(results, "action_A", storage_backend=backend)
+        # set_disposition (single-record) should NOT be called — only set_dispositions_batch.
+        backend.set_disposition.assert_not_called()

--- a/tests/unit/storage/test_sqlite_batch_dispositions.py
+++ b/tests/unit/storage/test_sqlite_batch_dispositions.py
@@ -1,0 +1,175 @@
+"""Tests for SQLiteBackend.set_dispositions_batch — single-transaction batch writes."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from agent_actions.storage.backend import (
+    DISPOSITION_FAILED,
+    VALID_DISPOSITIONS,
+    StorageBackend,
+)
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+@pytest.fixture
+def backend(tmp_path):
+    db_path = tmp_path / "agent_io" / "test.db"
+    b = SQLiteBackend(str(db_path), "test_workflow")
+    b.initialize()
+    yield b
+    b.close()
+
+
+class TestSetDispositionsBatch:
+    """Verify batch disposition writes in a single transaction."""
+
+    def test_batch_writes_1000_records(self, backend: SQLiteBackend):
+        """1000 records should all be written correctly by a single batch call."""
+        batch = [
+            ("action_A", f"record_{i}", "success", None, None, None, None) for i in range(1000)
+        ]
+        backend.set_dispositions_batch(batch)
+
+        rows = backend.get_disposition("action_A")
+        assert len(rows) == 1000
+
+    def test_batch_empty_list_is_noop(self, backend: SQLiteBackend):
+        """Empty batch should not touch the DB."""
+        # Write a record first, then batch-write an empty list.
+        backend.set_disposition("action_A", "rec_0", "success")
+        backend.set_dispositions_batch([])
+
+        # The pre-existing record should remain untouched.
+        rows = backend.get_disposition("action_A")
+        assert len(rows) == 1
+
+    def test_batch_validates_all_before_writing(self, backend: SQLiteBackend):
+        """Invalid disposition in batch should reject the entire batch — no partial writes."""
+        batch = [
+            ("action_A", "rec_1", "success", None, None, None, None),
+            ("action_A", "rec_2", "INVALID_DISP", None, None, None, None),
+            ("action_A", "rec_3", "failed", None, None, None, None),
+        ]
+        with pytest.raises(ValueError, match="Invalid disposition"):
+            backend.set_dispositions_batch(batch)
+
+        # No records should have been written.
+        rows = backend.get_disposition("action_A")
+        assert len(rows) == 0
+
+    def test_batch_truncates_large_snapshots(self, backend: SQLiteBackend):
+        """Snapshots > 10KB should be truncated with __truncated__ marker."""
+        large_snapshot = "x" * 20000
+        batch = [
+            ("action_A", "rec_1", "failed", "error", None, large_snapshot, None),
+        ]
+        backend.set_dispositions_batch(batch)
+
+        rows = backend.get_disposition("action_A", record_id="rec_1")
+        assert len(rows) == 1
+        snapshot = rows[0]["input_snapshot"]
+        assert '"__truncated__": true' in snapshot
+        assert len(snapshot) <= 10240 + 200  # truncated wrapper overhead
+
+    def test_batch_atomicity_on_error(self, backend: SQLiteBackend):
+        """If the DB write fails, no partial records should persist.
+
+        We verify atomicity by writing a valid batch first, then attempting
+        to write a second batch that will fail due to a constraint violation
+        (injecting a NULL into a NOT NULL column by corrupting the table).
+        """
+        # Write an initial record.
+        backend.set_disposition("action_A", "existing", "success")
+
+        # Temporarily break the table to cause an INSERT failure.
+        # Add a CHECK constraint that rejects a specific marker value.
+        backend.connection.execute(
+            "CREATE TRIGGER reject_marker BEFORE INSERT ON record_disposition "
+            "BEGIN "
+            "  SELECT RAISE(ABORT, 'marker rejected') "
+            "  WHERE NEW.record_id = '__FAIL__'; "
+            "END"
+        )
+        backend.connection.commit()
+
+        batch = [
+            ("action_A", "rec_ok", "success", None, None, None, None),
+            ("action_A", "__FAIL__", "success", None, None, None, None),
+        ]
+        with pytest.raises(sqlite3.Error):
+            backend.set_dispositions_batch(batch)
+
+        # The pre-existing "existing" record should survive; "rec_ok" should NOT persist.
+        rows = backend.get_disposition("action_A")
+        record_ids = {r["record_id"] for r in rows}
+        assert "rec_ok" not in record_ids
+        assert "existing" in record_ids
+
+    def test_batch_clears_prior_dispositions(self, backend: SQLiteBackend):
+        """Batch write should DELETE prior rows for each (action, record) — no phantom coexistence."""
+        # Write FAILED first via single-record method.
+        backend.set_disposition("action_A", "rec_1", DISPOSITION_FAILED, reason="error1")
+
+        # Batch write SUCCESS for the same record.
+        batch = [("action_A", "rec_1", "success", None, None, None, None)]
+        backend.set_dispositions_batch(batch)
+
+        rows = backend.get_disposition("action_A", record_id="rec_1")
+        assert len(rows) == 1
+        assert rows[0]["disposition"] == "success"
+
+    def test_batch_preserves_all_fields(self, backend: SQLiteBackend):
+        """All tuple fields should land in the correct columns."""
+        batch = [
+            (
+                "action_A",
+                "rec_1",
+                "failed",
+                "timeout_error",
+                "file.json",
+                '{"key": "val"}',
+                "detail text",
+            ),
+        ]
+        backend.set_dispositions_batch(batch)
+
+        rows = backend.get_disposition("action_A", record_id="rec_1")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["disposition"] == "failed"
+        assert row["reason"] == "timeout_error"
+        assert row["relative_path"] == "file.json"
+        assert row["input_snapshot"] == '{"key": "val"}'
+        assert row["detail"] == "detail text"
+
+    def test_batch_all_valid_dispositions(self, backend: SQLiteBackend):
+        """Every valid disposition value should be accepted in a batch."""
+        batch = [
+            (f"action_{d}", f"rec_{d}", d, None, None, None, None)
+            for d in sorted(VALID_DISPOSITIONS)
+        ]
+        backend.set_dispositions_batch(batch)
+
+        total = sum(len(backend.get_disposition(f"action_{d}")) for d in sorted(VALID_DISPOSITIONS))
+        assert total == len(VALID_DISPOSITIONS)
+
+
+class TestBaseClassDefault:
+    """Verify StorageBackend.set_dispositions_batch default loops over set_disposition."""
+
+    def test_default_delegates_to_set_disposition(self, backend: SQLiteBackend):
+        """The base class default should produce the same result as individual calls."""
+        # Call via the base class default (explicitly call super's impl).
+        batch = [
+            ("action_A", "rec_1", "success", None, None, None, None),
+            ("action_A", "rec_2", "failed", "err", None, None, None),
+        ]
+        StorageBackend.set_dispositions_batch(backend, batch)
+
+        rows = backend.get_disposition("action_A")
+        assert len(rows) == 2
+        disps = {r["record_id"]: r["disposition"] for r in rows}
+        assert disps == {"rec_1": "success", "rec_2": "failed"}

--- a/tests/unit/unification/test_filtered_disposition.py
+++ b/tests/unit/unification/test_filtered_disposition.py
@@ -23,6 +23,7 @@ from agent_actions.processing.types import (
 from agent_actions.processing.unified import UnifiedProcessor
 from agent_actions.storage.backend import DISPOSITION_FILTERED
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
+from tests.conftest import wire_batch_disposition_delegate
 
 
 def _make_evaluator(pass_fn):
@@ -259,21 +260,7 @@ class TestFilteredDispositionWritten:
             {"content": {"score": 40}, "source_guid": "sg-filter"},
         ]
         mock_backend = MagicMock()
-
-        def _batch_delegate(dispositions):
-            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-                kwargs = {}
-                if reason is not None:
-                    kwargs["reason"] = reason
-                if rp is not None:
-                    kwargs["relative_path"] = rp
-                if snapshot is not None:
-                    kwargs["input_snapshot"] = snapshot
-                if detail is not None:
-                    kwargs["detail"] = detail
-                mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-        mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+        wire_batch_disposition_delegate(mock_backend)
         context = _make_context(
             guard={"clause": "score >= 80", "behavior": "filter"},
             storage_backend=mock_backend,
@@ -316,21 +303,7 @@ class TestFilteredDispositionWritten:
         ]
         raw = records
         mock_backend = MagicMock()
-
-        def _batch_delegate(dispositions):
-            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-                kwargs = {}
-                if reason is not None:
-                    kwargs["reason"] = reason
-                if rp is not None:
-                    kwargs["relative_path"] = rp
-                if snapshot is not None:
-                    kwargs["input_snapshot"] = snapshot
-                if detail is not None:
-                    kwargs["detail"] = detail
-                mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-        mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+        wire_batch_disposition_delegate(mock_backend)
         context = _make_context(
             guard={"clause": "score >= 80", "behavior": "filter"},
             storage_backend=mock_backend,
@@ -369,21 +342,7 @@ class TestFilteredDispositionWritten:
         """Record without source_guid -> no disposition write (no crash)."""
         records = [{"content": {"score": 40}}]
         mock_backend = MagicMock()
-
-        def _batch_delegate(dispositions):
-            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-                kwargs = {}
-                if reason is not None:
-                    kwargs["reason"] = reason
-                if rp is not None:
-                    kwargs["relative_path"] = rp
-                if snapshot is not None:
-                    kwargs["input_snapshot"] = snapshot
-                if detail is not None:
-                    kwargs["detail"] = detail
-                mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-        mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+        wire_batch_disposition_delegate(mock_backend)
         context = _make_context(
             guard={"clause": "score >= 80", "behavior": "filter"},
             storage_backend=mock_backend,

--- a/tests/unit/unification/test_filtered_disposition.py
+++ b/tests/unit/unification/test_filtered_disposition.py
@@ -259,6 +259,21 @@ class TestFilteredDispositionWritten:
             {"content": {"score": 40}, "source_guid": "sg-filter"},
         ]
         mock_backend = MagicMock()
+
+        def _batch_delegate(dispositions):
+            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+                kwargs = {}
+                if reason is not None:
+                    kwargs["reason"] = reason
+                if rp is not None:
+                    kwargs["relative_path"] = rp
+                if snapshot is not None:
+                    kwargs["input_snapshot"] = snapshot
+                if detail is not None:
+                    kwargs["detail"] = detail
+                mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+        mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
         context = _make_context(
             guard={"clause": "score >= 80", "behavior": "filter"},
             storage_backend=mock_backend,
@@ -301,6 +316,21 @@ class TestFilteredDispositionWritten:
         ]
         raw = records
         mock_backend = MagicMock()
+
+        def _batch_delegate(dispositions):
+            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+                kwargs = {}
+                if reason is not None:
+                    kwargs["reason"] = reason
+                if rp is not None:
+                    kwargs["relative_path"] = rp
+                if snapshot is not None:
+                    kwargs["input_snapshot"] = snapshot
+                if detail is not None:
+                    kwargs["detail"] = detail
+                mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+        mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
         context = _make_context(
             guard={"clause": "score >= 80", "behavior": "filter"},
             storage_backend=mock_backend,
@@ -339,6 +369,21 @@ class TestFilteredDispositionWritten:
         """Record without source_guid -> no disposition write (no crash)."""
         records = [{"content": {"score": 40}}]
         mock_backend = MagicMock()
+
+        def _batch_delegate(dispositions):
+            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+                kwargs = {}
+                if reason is not None:
+                    kwargs["reason"] = reason
+                if rp is not None:
+                    kwargs["relative_path"] = rp
+                if snapshot is not None:
+                    kwargs["input_snapshot"] = snapshot
+                if detail is not None:
+                    kwargs["detail"] = detail
+                mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+        mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
         context = _make_context(
             guard={"clause": "score >= 80", "behavior": "filter"},
             storage_backend=mock_backend,

--- a/tests/unit/unification/test_phase8a_shared_collect_helper.py
+++ b/tests/unit/unification/test_phase8a_shared_collect_helper.py
@@ -33,6 +33,7 @@ from agent_actions.storage.backend import (
     DISPOSITION_SUCCESS,
     DISPOSITION_UNPROCESSED,
 )
+from tests.conftest import wire_batch_disposition_delegate
 
 ACTION_NAME = "test_action"
 
@@ -125,21 +126,7 @@ def _make_deferred_result(
 
 def _mock_storage_backend() -> MagicMock:
     backend = MagicMock()
-
-    def _batch_delegate(dispositions):
-        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-            kwargs = {}
-            if reason is not None:
-                kwargs["reason"] = reason
-            if rp is not None:
-                kwargs["relative_path"] = rp
-            if snapshot is not None:
-                kwargs["input_snapshot"] = snapshot
-            if detail is not None:
-                kwargs["detail"] = detail
-            backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-    backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+    wire_batch_disposition_delegate(backend)
     return backend
 
 

--- a/tests/unit/unification/test_phase8a_shared_collect_helper.py
+++ b/tests/unit/unification/test_phase8a_shared_collect_helper.py
@@ -124,7 +124,23 @@ def _make_deferred_result(
 
 
 def _mock_storage_backend() -> MagicMock:
-    return MagicMock()
+    backend = MagicMock()
+
+    def _batch_delegate(dispositions):
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            kwargs = {}
+            if reason is not None:
+                kwargs["reason"] = reason
+            if rp is not None:
+                kwargs["relative_path"] = rp
+            if snapshot is not None:
+                kwargs["input_snapshot"] = snapshot
+            if detail is not None:
+                kwargs["detail"] = detail
+            backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+    backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+    return backend
 
 
 class TestSharedHelperParityWithCollectResults:

--- a/tests/unit/wave3/test_enrichment_complete_event.py
+++ b/tests/unit/wave3/test_enrichment_complete_event.py
@@ -190,6 +190,21 @@ class TestDeferredStatusHandling:
         )
         backend = MagicMock()
 
+        def _batch_delegate(dispositions):
+            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+                kwargs = {}
+                if reason is not None:
+                    kwargs["reason"] = reason
+                if rp is not None:
+                    kwargs["relative_path"] = rp
+                if snapshot is not None:
+                    kwargs["input_snapshot"] = snapshot
+                if detail is not None:
+                    kwargs["detail"] = detail
+                backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+        backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+
         ResultCollector.collect_results(
             [deferred],
             {},

--- a/tests/unit/wave3/test_enrichment_complete_event.py
+++ b/tests/unit/wave3/test_enrichment_complete_event.py
@@ -10,6 +10,7 @@ from agent_actions.output.response.expander_action_types import process_tool_act
 from agent_actions.processing.enrichment import EnrichmentPipeline
 from agent_actions.processing.result_collector import ProcessingStatus
 from agent_actions.utils.correlation.version_id import VersionIdGenerator
+from tests.conftest import wire_batch_disposition_delegate
 
 
 class TestEnrichmentCompleteEventOnFailure:
@@ -189,21 +190,7 @@ class TestDeferredStatusHandling:
             source_guid="test-guid",
         )
         backend = MagicMock()
-
-        def _batch_delegate(dispositions):
-            for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-                kwargs = {}
-                if reason is not None:
-                    kwargs["reason"] = reason
-                if rp is not None:
-                    kwargs["relative_path"] = rp
-                if snapshot is not None:
-                    kwargs["input_snapshot"] = snapshot
-                if detail is not None:
-                    kwargs["detail"] = detail
-                backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-        backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+        wire_batch_disposition_delegate(backend)
 
         ResultCollector.collect_results(
             [deferred],

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -509,6 +509,21 @@ def test_file_tool_empty_response_writes_disposition_per_record():
         assert result.source_guid == f"sg-{i + 1}"
 
     mock_backend = MagicMock()
+
+    def _batch_delegate(dispositions):
+        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
+            kwargs = {}
+            if reason is not None:
+                kwargs["reason"] = reason
+            if rp is not None:
+                kwargs["relative_path"] = rp
+            if snapshot is not None:
+                kwargs["input_snapshot"] = snapshot
+            if detail is not None:
+                kwargs["detail"] = detail
+            mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
+
+    mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
     output, stats = ResultCollector.collect_results(
         results,
         {"kind": "tool"},

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -486,6 +486,7 @@ def test_file_tool_empty_response_writes_disposition_per_record():
     from unittest.mock import MagicMock
 
     from agent_actions.processing.result_collector import ResultCollector
+    from tests.conftest import wire_batch_disposition_delegate
 
     context = _make_context()
     input_data = [
@@ -509,21 +510,7 @@ def test_file_tool_empty_response_writes_disposition_per_record():
         assert result.source_guid == f"sg-{i + 1}"
 
     mock_backend = MagicMock()
-
-    def _batch_delegate(dispositions):
-        for action_name, record_id, disposition, reason, rp, snapshot, detail in dispositions:
-            kwargs = {}
-            if reason is not None:
-                kwargs["reason"] = reason
-            if rp is not None:
-                kwargs["relative_path"] = rp
-            if snapshot is not None:
-                kwargs["input_snapshot"] = snapshot
-            if detail is not None:
-                kwargs["detail"] = detail
-            mock_backend.set_disposition(action_name, record_id, disposition, **kwargs)
-
-    mock_backend.set_dispositions_batch = MagicMock(side_effect=_batch_delegate)
+    wire_batch_disposition_delegate(mock_backend)
     output, stats = ResultCollector.collect_results(
         results,
         {"kind": "tool"},


### PR DESCRIPTION
## Summary
- Add `set_dispositions_batch()` to `StorageBackend` base class (default loops over `set_disposition`) and optimized override in `SQLiteBackend` using `executemany` + single COMMIT
- Update `collect_results_from_processing_results` to accumulate dispositions into a list and flush once per action instead of N per-record INSERT+COMMIT calls
- For a 1000-record action, reduces disposition writes from 1000 fsyncs to 1

## Design
- Validates all records before opening transaction — invalid disposition rejects the entire batch with no partial writes
- DELETE-before-INSERT in batch (matching P0-5 phantom prevention pattern)
- Rollback on `sqlite3.Error` (atomic batch)
- Disposition flush errors caught and logged (telemetry, not authoritative)
- Base class default loops for non-SQLite backend compatibility
- Existing per-record `set_disposition` unchanged for retry, node-level signals, and other single-record paths

## Verification
- `ruff check` + `ruff format --check`: clean
- `pytest`: 7218 passed, 0 failed
- 17 new tests across 2 test files (batch writes, validation, rollback, flush behavior)
- Grep verification: `set_dispositions_batch` in base class, `executemany` in SQLiteBackend, `pending_dispositions` accumulation in result_collector