### PR TITLE
fix: use uuid4 for source_guid to prevent silent collision

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-016000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-016000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Use uuid4 for source_guid to prevent silent data loss from deterministic GUID collisions on duplicate input rows and 1-to-N expansion children"
+time: 2026-05-22T01:60:00.000000Z

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -21,6 +21,7 @@ from agent_actions.prompt.formatter import PromptFormatter
 from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import CHUNK_CONFIG_KEY, MODEL_VENDOR_KEY
+from agent_actions.utils.id_generation import IDGenerator
 
 if TYPE_CHECKING:
     from agent_actions.config.types import ActionConfigDict
@@ -330,8 +331,6 @@ def _prepare_text_chunks_batch(
     content: str, agent_config: dict[str, Any], batch_id: str, node_id: str
 ) -> list[dict[str, Any]]:
     """Prepare text chunks for batch mode."""
-    from agent_actions.utils.id_generation import IDGenerator
-
     chunk_config = agent_config.get(CHUNK_CONFIG_KEY, {})
     chunk_size = chunk_config.get("chunk_size", get_default("chunk_size"))
     chunk_overlap = chunk_config.get("overlap", get_default("chunk_overlap"))
@@ -376,8 +375,6 @@ def _add_batch_metadata(
     rows: list[dict[str, Any]], batch_id: str, node_id: str
 ) -> list[dict[str, Any]]:
     """Add batch metadata to rows of data."""
-    from agent_actions.utils.id_generation import IDGenerator
-
     result = []
     for idx, row in enumerate(rows):
         target_id = str(uuid.uuid4())
@@ -503,8 +500,6 @@ def _prepare_online_data(ctx: DataPreparationContext):
         data_chunk = chunks
 
         # GUIDs must match what UnifiedProcessor/OnlineLLMStrategy will generate
-        from agent_actions.utils.id_generation import IDGenerator
-
         src_text = []
         for text in data_chunk:
             guid = IDGenerator.generate_source_guid()
@@ -517,8 +512,6 @@ def _prepare_online_data(ctx: DataPreparationContext):
             data_chunk = [data_chunk]
 
         # Do NOT mutate data_chunk: OnlineLLMStrategy hashes raw items for source_guid
-        from agent_actions.utils.id_generation import IDGenerator
-
         src_text = []
         for item in data_chunk:
             if isinstance(item, dict):

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -350,7 +350,7 @@ def _prepare_text_chunks_batch(
                 "content": chunk,
                 "batch_id": batch_id,
                 "batch_uuid": f"{batch_id}_{idx}",
-                "source_guid": str(uuid.uuid5(uuid.NAMESPACE_OID, str(chunk))),
+                "source_guid": str(uuid.uuid4()),
                 "target_id": target_id,
                 # Ancestry Chain: first-stage records are their own root
                 "parent_target_id": None,
@@ -382,7 +382,7 @@ def _add_batch_metadata(
                 **row,
                 "batch_id": batch_id,
                 "batch_uuid": f"{batch_id}_{idx}",
-                "source_guid": str(uuid.uuid5(uuid.NAMESPACE_OID, json.dumps(row, sort_keys=True))),
+                "source_guid": str(uuid.uuid4()),
                 "target_id": target_id,
                 # Ancestry Chain: first-stage records are their own root
                 "parent_target_id": None,
@@ -503,7 +503,7 @@ def _prepare_online_data(ctx: DataPreparationContext):
 
         src_text = []
         for text in data_chunk:
-            guid = IDGenerator.generate_deterministic_source_guid(text)
+            guid = IDGenerator.generate_source_guid()
             src_text.append({"source_guid": guid, "content": text})
 
     elif ctx.file_type == ".json":
@@ -520,9 +520,7 @@ def _prepare_online_data(ctx: DataPreparationContext):
             if isinstance(item, dict):
                 source_item = item.copy()
                 if "source_guid" not in source_item:
-                    source_item["source_guid"] = IDGenerator.generate_deterministic_source_guid(
-                        item
-                    )
+                    source_item["source_guid"] = IDGenerator.generate_source_guid()
                 src_text.append(source_item)
             else:
                 src_text.append(item)

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -330,6 +330,8 @@ def _prepare_text_chunks_batch(
     content: str, agent_config: dict[str, Any], batch_id: str, node_id: str
 ) -> list[dict[str, Any]]:
     """Prepare text chunks for batch mode."""
+    from agent_actions.utils.id_generation import IDGenerator
+
     chunk_config = agent_config.get(CHUNK_CONFIG_KEY, {})
     chunk_size = chunk_config.get("chunk_size", get_default("chunk_size"))
     chunk_overlap = chunk_config.get("overlap", get_default("chunk_overlap"))
@@ -350,7 +352,7 @@ def _prepare_text_chunks_batch(
                 "content": chunk,
                 "batch_id": batch_id,
                 "batch_uuid": f"{batch_id}_{idx}",
-                "source_guid": str(uuid.uuid4()),
+                "source_guid": IDGenerator.generate_source_guid(),
                 "target_id": target_id,
                 # Ancestry Chain: first-stage records are their own root
                 "parent_target_id": None,
@@ -374,6 +376,8 @@ def _add_batch_metadata(
     rows: list[dict[str, Any]], batch_id: str, node_id: str
 ) -> list[dict[str, Any]]:
     """Add batch metadata to rows of data."""
+    from agent_actions.utils.id_generation import IDGenerator
+
     result = []
     for idx, row in enumerate(rows):
         target_id = str(uuid.uuid4())
@@ -382,7 +386,7 @@ def _add_batch_metadata(
                 **row,
                 "batch_id": batch_id,
                 "batch_uuid": f"{batch_id}_{idx}",
-                "source_guid": str(uuid.uuid4()),
+                "source_guid": IDGenerator.generate_source_guid(),
                 "target_id": target_id,
                 # Ancestry Chain: first-stage records are their own root
                 "parent_target_id": None,

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -58,6 +58,12 @@ class LineageEnricher(Enricher):
                 item["target_id"] = IDGenerator.generate_target_id()
                 if old_target_id:
                     item["parent_target_id"] = old_target_id
+                # Each expansion child gets its own source_guid to prevent
+                # UNIQUE constraint collisions when written to source_data.
+                old_source_guid = item.get("source_guid")
+                item["source_guid"] = IDGenerator.generate_source_guid()
+                if old_source_guid:
+                    item["parent_source_guid"] = old_source_guid
 
             if (
                 result.source_mapping is not None

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -233,7 +233,7 @@ class OnlineLLMStrategy:
                 if context.is_first_stage:
                     from agent_actions.utils.id_generation import IDGenerator
 
-                    source_guid = IDGenerator.generate_deterministic_source_guid(item)
+                    source_guid = IDGenerator.generate_source_guid()
                     source_snapshot = TaskPreparer._prepare_source_snapshot(item)
                 else:
                     source_guid = item.get("source_guid") if isinstance(item, dict) else None

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -137,7 +137,7 @@ class TaskPreparer:
             if self._id_generator:
                 source_guid = self._id_generator(item)
             else:
-                source_guid = IDGenerator.generate_deterministic_source_guid(item)
+                source_guid = IDGenerator.generate_source_guid()
 
             snapshot = self._prepare_source_snapshot(item)
             return item, source_guid, snapshot
@@ -149,7 +149,7 @@ class TaskPreparer:
                     # treat them like first-stage by extracting raw fields
                     source_guid = item.get("source_guid")
                     if not source_guid:
-                        source_guid = IDGenerator.generate_deterministic_source_guid(item)
+                        source_guid = IDGenerator.generate_source_guid()
                     snapshot = self._prepare_source_snapshot(item)
                     return item, source_guid, snapshot
                 source_guid = item.get("source_guid")

--- a/agent_actions/utils/id_generation/generator.py
+++ b/agent_actions/utils/id_generation/generator.py
@@ -19,10 +19,24 @@ class IDGenerator:
         return f"{action_name}_{uuid.uuid4()}"
 
     @staticmethod
-    def generate_deterministic_source_guid(content: Any) -> str:
-        """Generate a deterministic UUID5 source GUID based on content."""
+    def generate_source_guid() -> str:
+        """Generate a unique UUID4 source GUID for a record instance."""
+        return str(uuid.uuid4())
+
+    @staticmethod
+    def generate_content_hash(content: Any) -> str:
+        """Generate a deterministic UUID5 content hash for dedup comparison.
+
+        This is NOT a source_guid — it is a content fingerprint.
+        Use generate_source_guid() for record identity.
+        """
         if isinstance(content, dict):
             content_for_hash = json.dumps(content, sort_keys=True)
         else:
             content_for_hash = str(content)
         return str(uuid.uuid5(uuid.NAMESPACE_OID, content_for_hash))
+
+    @staticmethod
+    def generate_deterministic_source_guid(content: Any) -> str:
+        """Deprecated: use generate_content_hash() instead."""
+        return IDGenerator.generate_content_hash(content)

--- a/tests/unit/processing/test_enrichment_expansion_guid.py
+++ b/tests/unit/processing/test_enrichment_expansion_guid.py
@@ -1,0 +1,80 @@
+"""Tests for LineageEnricher: expansion children get unique source_guids."""
+
+from unittest.mock import MagicMock
+
+from agent_actions.processing.enrichment import LineageEnricher
+from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
+
+
+def _make_context(action_name: str = "test_action") -> ProcessingContext:
+    """Create a minimal ProcessingContext for testing."""
+    ctx = MagicMock(spec=ProcessingContext)
+    ctx.action_name = action_name
+    ctx.agent_name = action_name
+    ctx.is_first_stage = True
+    ctx.source_data = None
+    ctx.record_index = 0
+    ctx.agent_config = {}
+    return ctx
+
+
+class TestExpansionSourceGuidUniqueness:
+    """Expansion children each get their own source_guid."""
+
+    def test_expansion_children_get_unique_source_guids(self):
+        parent_guid = "parent-guid-123"
+        items = [
+            {"source_guid": parent_guid, "target_id": "tid-1", "content": "a"},
+            {"source_guid": parent_guid, "target_id": "tid-1", "content": "b"},
+            {"source_guid": parent_guid, "target_id": "tid-1", "content": "c"},
+        ]
+        result = ProcessingResult(
+            data=items,
+            status=ProcessingStatus.SUCCESS,
+            is_expansion=True,
+        )
+        context = _make_context()
+
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        source_guids = [item["source_guid"] for item in enriched.data]
+        # All children should have unique source_guids
+        assert len(set(source_guids)) == 3
+        # None should be the parent's guid
+        assert parent_guid not in source_guids
+
+    def test_expansion_children_preserve_parent_source_guid(self):
+        parent_guid = "parent-guid-456"
+        items = [
+            {"source_guid": parent_guid, "target_id": "tid-1", "content": "x"},
+            {"source_guid": parent_guid, "target_id": "tid-1", "content": "y"},
+        ]
+        result = ProcessingResult(
+            data=items,
+            status=ProcessingStatus.SUCCESS,
+            is_expansion=True,
+        )
+        context = _make_context()
+
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        for item in enriched.data:
+            assert item["parent_source_guid"] == parent_guid
+
+    def test_non_expansion_keeps_original_source_guid(self):
+        original_guid = "keep-this-guid"
+        items = [{"source_guid": original_guid, "content": "data"}]
+        result = ProcessingResult(
+            data=items,
+            status=ProcessingStatus.SUCCESS,
+            is_expansion=False,
+        )
+        context = _make_context()
+
+        enricher = LineageEnricher()
+        enriched = enricher.enrich(result, context)
+
+        assert enriched.data[0]["source_guid"] == original_guid
+        assert "parent_source_guid" not in enriched.data[0]

--- a/tests/unit/utils/test_id_generation.py
+++ b/tests/unit/utils/test_id_generation.py
@@ -1,0 +1,56 @@
+"""Tests for IDGenerator: uuid4 uniqueness and content_hash determinism."""
+
+from agent_actions.utils.id_generation.generator import IDGenerator
+
+
+class TestGenerateSourceGuid:
+    """generate_source_guid() returns unique uuid4 values."""
+
+    def test_returns_unique_values(self):
+        guids = {IDGenerator.generate_source_guid() for _ in range(100)}
+        assert len(guids) == 100
+
+    def test_returns_valid_uuid_string(self):
+        import uuid
+
+        guid = IDGenerator.generate_source_guid()
+        parsed = uuid.UUID(guid)
+        assert parsed.version == 4
+
+
+class TestGenerateContentHash:
+    """generate_content_hash() is deterministic for same content."""
+
+    def test_deterministic_for_same_dict(self):
+        content = {"amount": 100, "date": "2024-01-01"}
+        hash_a = IDGenerator.generate_content_hash(content)
+        hash_b = IDGenerator.generate_content_hash(content)
+        assert hash_a == hash_b
+
+    def test_deterministic_for_same_string(self):
+        content = "hello world"
+        hash_a = IDGenerator.generate_content_hash(content)
+        hash_b = IDGenerator.generate_content_hash(content)
+        assert hash_a == hash_b
+
+    def test_different_content_different_hash(self):
+        hash_a = IDGenerator.generate_content_hash({"a": 1})
+        hash_b = IDGenerator.generate_content_hash({"a": 2})
+        assert hash_a != hash_b
+
+    def test_returns_valid_uuid5(self):
+        import uuid
+
+        h = IDGenerator.generate_content_hash("test")
+        parsed = uuid.UUID(h)
+        assert parsed.version == 5
+
+
+class TestDeprecatedWrapper:
+    """generate_deterministic_source_guid() still works as deprecated wrapper."""
+
+    def test_matches_content_hash(self):
+        content = {"key": "value"}
+        old = IDGenerator.generate_deterministic_source_guid(content)
+        new = IDGenerator.generate_content_hash(content)
+        assert old == new


### PR DESCRIPTION
## Summary
- `source_guid` was generated as `uuid5(content_hash)`, causing identical input rows to silently collapse via the `UNIQUE(relative_path, source_guid)` constraint, and 1-to-N expansion children to overwrite each other in storage
- Added `generate_source_guid()` (uuid4) for unique record identity; renamed old method to `generate_content_hash()` for explicit dedup use
- Updated all callers in `initial_pipeline.py` (4 sites), `task_preparer.py` (2 sites), `online_llm.py` (1 site)
- `LineageEnricher` now gives each expansion child its own `source_guid` with parent's guid stored as `parent_source_guid`

## Verification
- All grep checks from VERIFICATION-CHECKS.md pass (no uuid5 in source_guid paths, no `generate_deterministic_source_guid` in callers)
- 10 new tests covering uuid4 uniqueness, content_hash determinism, deprecated wrapper, expansion guid uniqueness, and non-expansion preservation
- Full test suite: 7317 passed, 0 failures
- `ruff check` and `ruff format --check` clean on all modified files