### PR TITLE
fix: file I/O hardening (P2-5)

### DIFF
--- a/.changes/unreleased/Security-20260522-025000.yaml
+++ b/.changes/unreleased/Security-20260522-025000.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: "Add output path containment check, filesystem name sanitization, and fix json.dumps on binary data"
+time: 2026-05-22T02:50:00.000000Z

--- a/agent_actions/output/saver.py
+++ b/agent_actions/output/saver.py
@@ -72,7 +72,7 @@ class UnifiedSourceDataSaver:
         self.storage_backend.write_source(
             relative_path, items, enable_deduplication=self.enable_deduplication
         )
-        bytes_written = sum(len(json.dumps(item).encode()) for item in items)
+        bytes_written = sum(len(json.dumps(item, default=str).encode()) for item in items)
 
         fire_event(
             SourceDataSavedEvent(

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -15,6 +15,7 @@ from agent_actions.logging.events import (
 )
 from agent_actions.processing.error_handling import ProcessorErrorHandlerMixin
 from agent_actions.utils.atomic_write import atomic_json_write
+from agent_actions.utils.path_safety import assert_path_contained
 from agent_actions.utils.path_utils import ensure_directory_exists
 
 if TYPE_CHECKING:
@@ -125,6 +126,9 @@ class FileWriter(ProcessorErrorHandlerMixin):
                     relative_path = file_path.name
             else:
                 relative_path = file_path.name
+
+            if self.output_directory:
+                assert_path_contained(file_path, Path(self.output_directory))
 
             self.storage_backend.write_target(self.action_name, relative_path, data)
 

--- a/agent_actions/utils/path_safety.py
+++ b/agent_actions/utils/path_safety.py
@@ -1,0 +1,52 @@
+"""Path safety utilities for output containment and filesystem name sanitization."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def assert_path_contained(child: Path, parent: Path) -> Path:
+    """Resolve both paths and raise ValueError if child escapes parent.
+
+    Resolves symlinks before comparison to prevent symlink traversal.
+
+    Args:
+        child: The path to validate.
+        parent: The containment boundary.
+
+    Returns:
+        The resolved child path.
+
+    Raises:
+        ValueError: If the resolved child is not under the resolved parent.
+    """
+    resolved_child = child.resolve()
+    resolved_parent = parent.resolve()
+    if not resolved_child.is_relative_to(resolved_parent):
+        raise ValueError(
+            f"Path escapes containment: {resolved_child} is not under {resolved_parent}"
+        )
+    return resolved_child
+
+
+def sanitize_path_component(name: str, max_bytes: int = 200) -> str:
+    """Sanitize a string for use as a filesystem path component.
+
+    Replaces path separators and null bytes. If the encoded name exceeds
+    *max_bytes*, truncates and appends a short hash to avoid collisions.
+
+    Args:
+        name: Raw name (e.g., action name).
+        max_bytes: Maximum byte length before truncation (default 200).
+
+    Returns:
+        A filesystem-safe, deterministic string.
+    """
+    safe = name.replace("/", "_").replace("\\", "_").replace("\0", "_")
+    encoded = safe.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return safe
+    truncated = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    suffix = hashlib.sha256(name.encode()).hexdigest()[:8]
+    return f"{truncated}_{suffix}"

--- a/tests/unit/core/test_file_writer.py
+++ b/tests/unit/core/test_file_writer.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from agent_actions.errors import ProcessingError
 from agent_actions.output.writer import FileWriter
 
 
@@ -52,8 +55,8 @@ class TestFileWriterRelativePath:
         call_args = mock_backend.write_target.call_args
         assert call_args[0][1] == "data.json"
 
-    def test_handles_file_not_under_output_directory(self, tmp_path):
-        """Should fall back to filename when file is not under output_directory."""
+    def test_rejects_file_not_under_output_directory(self, tmp_path):
+        """Should reject writes when file path escapes output_directory."""
         mock_backend = MagicMock()
 
         output_dir = tmp_path / "output"
@@ -66,11 +69,11 @@ class TestFileWriterRelativePath:
             output_directory=str(output_dir),
         )
 
-        writer.write_target([{"key": "value"}])
+        with pytest.raises(ProcessingError, match="Path escapes containment"):
+            writer.write_target([{"key": "value"}])
 
-        # Verify falls back to filename only
-        call_args = mock_backend.write_target.call_args
-        assert call_args[0][1] == "data.json"
+        # Backend should NOT have been called
+        mock_backend.write_target.assert_not_called()
 
     def test_prevents_collision_for_same_filename_different_dirs(self, tmp_path):
         """Should prevent collision when same filename exists in different subdirs."""

--- a/tests/unit/output/test_saver.py
+++ b/tests/unit/output/test_saver.py
@@ -196,6 +196,21 @@ class TestSaverErrors:
             saver.save_source_items([{"x": 1}], "path")
 
     @patch("agent_actions.output.saver.fire_event")
+    def test_binary_data_does_not_crash(self, mock_fire, tmp_path):
+        """Items containing bytes values must not crash json.dumps."""
+        backend = MagicMock()
+        saver = UnifiedSourceDataSaver(
+            base_directory=str(tmp_path),
+            storage_backend=backend,
+        )
+        items = [{"key": b"binary data from UDF", "normal": "text"}]
+        # Should not raise TypeError
+        saver.save_source_items(items, "binary_path")
+        backend.write_source.assert_called_once()
+        saved_event = mock_fire.call_args_list[1][0][0]
+        assert saved_event.bytes_written > 0
+
+    @patch("agent_actions.output.saver.fire_event")
     def test_saving_event_fired_before_backend_error(self, mock_fire, tmp_path):
         """Even if backend raises, the 'saving' event should have been fired."""
         backend = MagicMock()

--- a/tests/unit/output/test_writer.py
+++ b/tests/unit/output/test_writer.py
@@ -264,6 +264,41 @@ class TestWriteTarget:
         with pytest.raises(ProcessingError):
             writer.write_target([{"x": 1}])
 
+    @patch("agent_actions.output.writer.fire_event")
+    def test_rejects_path_traversal(self, mock_fire, tmp_path):
+        """write_target must reject paths that escape output_directory."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        # Crafted path escaping via ../
+        fp = str(output_dir / ".." / "escaped.json")
+        backend = MagicMock()
+        writer = FileWriter(
+            fp,
+            storage_backend=backend,
+            action_name="node_a",
+            output_directory=str(output_dir),
+        )
+        with pytest.raises(ProcessingError):
+            writer.write_target([{"x": 1}])
+        # Backend should NOT have been called
+        backend.write_target.assert_not_called()
+
+    @patch("agent_actions.output.writer.fire_event")
+    def test_accepts_valid_subdirectory_path(self, mock_fire, tmp_path):
+        """write_target must accept paths within output_directory."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        fp = str(output_dir / "subdir" / "data.json")
+        backend = MagicMock()
+        writer = FileWriter(
+            fp,
+            storage_backend=backend,
+            action_name="node_a",
+            output_directory=str(output_dir),
+        )
+        writer.write_target([{"x": 1}])
+        backend.write_target.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # write_source

--- a/tests/unit/utils/test_path_safety.py
+++ b/tests/unit/utils/test_path_safety.py
@@ -1,0 +1,106 @@
+"""Tests for path safety utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_actions.utils.path_safety import assert_path_contained, sanitize_path_component
+
+
+class TestAssertPathContained:
+    """Tests for assert_path_contained."""
+
+    def test_valid_child_path(self, tmp_path: Path) -> None:
+        child = tmp_path / "subdir" / "file.json"
+        child.parent.mkdir(parents=True, exist_ok=True)
+        child.touch()
+        result = assert_path_contained(child, tmp_path)
+        assert result == child.resolve()
+
+    def test_rejects_parent_traversal(self, tmp_path: Path) -> None:
+        child = tmp_path / ".." / ".." / "etc" / "passwd"
+        with pytest.raises(ValueError, match="Path escapes containment"):
+            assert_path_contained(child, tmp_path)
+
+    def test_rejects_dot_slash_traversal(self, tmp_path: Path) -> None:
+        child = tmp_path / "foo" / "." / ".." / ".." / "bar"
+        with pytest.raises(ValueError, match="Path escapes containment"):
+            assert_path_contained(child, tmp_path)
+
+    def test_accepts_nested_subdirectory(self, tmp_path: Path) -> None:
+        child = tmp_path / "a" / "b" / "c" / "file.json"
+        child.parent.mkdir(parents=True, exist_ok=True)
+        child.touch()
+        result = assert_path_contained(child, tmp_path)
+        assert result.is_relative_to(tmp_path.resolve())
+
+    def test_rejects_symlink_traversal(self, tmp_path: Path) -> None:
+        """Symlink pointing outside parent must be rejected."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret = outside / "secret.txt"
+        secret.touch()
+
+        inside = tmp_path / "safe"
+        inside.mkdir()
+        link = inside / "escape"
+        link.symlink_to(outside)
+
+        child = link / "secret.txt"
+        with pytest.raises(ValueError, match="Path escapes containment"):
+            assert_path_contained(child, inside)
+
+    def test_same_directory(self, tmp_path: Path) -> None:
+        """Child equal to parent should be accepted."""
+        result = assert_path_contained(tmp_path, tmp_path)
+        assert result == tmp_path.resolve()
+
+
+class TestSanitizePathComponent:
+    """Tests for sanitize_path_component."""
+
+    def test_short_name_unchanged(self) -> None:
+        assert sanitize_path_component("my_action") == "my_action"
+
+    def test_replaces_slashes(self) -> None:
+        assert sanitize_path_component("foo/bar\\baz") == "foo_bar_baz"
+
+    def test_replaces_null_bytes(self) -> None:
+        assert sanitize_path_component("foo\0bar") == "foo_bar"
+
+    def test_long_name_truncated_with_hash(self) -> None:
+        long_name = "a" * 300
+        result = sanitize_path_component(long_name)
+        encoded = result.encode("utf-8")
+        # 200 truncated + 1 underscore + 8 hex chars = 209 max
+        assert len(encoded) <= 209
+        # Must end with _<8 hex chars>
+        assert result[-9] == "_"
+        assert len(result[-8:]) == 8
+        # Hash is hex
+        int(result[-8:], 16)
+
+    def test_deterministic(self) -> None:
+        name = "x" * 300
+        assert sanitize_path_component(name) == sanitize_path_component(name)
+
+    def test_different_long_names_different_results(self) -> None:
+        """Two long names sharing a prefix produce different sanitized names."""
+        name_a = "a" * 250 + "_suffix_a"
+        name_b = "a" * 250 + "_suffix_b"
+        assert sanitize_path_component(name_a) != sanitize_path_component(name_b)
+
+    def test_exact_boundary(self) -> None:
+        """Name exactly at max_bytes is not truncated."""
+        name = "b" * 200
+        result = sanitize_path_component(name)
+        assert result == name  # no hash appended
+
+    def test_one_over_boundary(self) -> None:
+        """Name one byte over max_bytes IS truncated with hash."""
+        name = "c" * 201
+        result = sanitize_path_component(name)
+        assert len(result.encode("utf-8")) <= 209
+        assert "_" in result[-9:]


### PR DESCRIPTION
## Summary
- Add `assert_path_contained()` utility — resolves symlinks before checking containment, preventing path traversal via `../../` or symlinks in crafted `source_guid` values
- Add `sanitize_path_component()` utility — truncates long action names to 200 bytes + appends SHA-256 hash suffix to avoid filesystem limit crashes and collisions
- Wire containment check into `FileWriter.write_target()` — rejects writes outside the output directory
- Fix `json.dumps(item)` crash in `saver.py:75` when items contain `bytes` values (from tool UDFs) — uses `default=str` since the byte count is for logging only

## Verification
- 17 new tests across 3 test files (path traversal, symlink traversal, long names, binary data, boundary conditions)
- 1 existing test updated to expect the new security behavior (file outside output_dir now blocked instead of silently falling back)
- All verification grep checks from spec pass
- 7324 passed, 2 skipped, ruff clean