### PR TITLE
fix: provider parity — remove Groq temperature default, raise Anthropic max_tokens

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-023000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-023000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix Groq injecting temperature=0.7 default and raise Anthropic max_tokens default from 1024 to 4096"
+time: 2026-05-22T02:30:00.000000Z

--- a/agent_actions/llm/providers/anthropic/client.py
+++ b/agent_actions/llm/providers/anthropic/client.py
@@ -77,8 +77,8 @@ class AnthropicClient(BaseClient):
             key_map={"stop": "stop_sequences"},
             stop_as_list=True,
         )
-        # max_tokens is always required for Anthropic; default 1024
-        params.setdefault("max_tokens", 1024)
+        # max_tokens is always required for Anthropic; default 4096
+        params.setdefault("max_tokens", 4096)
 
         api_args: dict[str, Any] = {
             "model": model_name,

--- a/agent_actions/llm/providers/groq/client.py
+++ b/agent_actions/llm/providers/groq/client.py
@@ -144,7 +144,6 @@ class GroqClient(BaseClient, JSONResponseMixin):
         model_name = agent_config[MODEL_NAME_KEY]
         envelope = MessageBuilder.build("groq", prompt_config, context_data, json_mode=False)
         params = extract_generation_params(agent_config)
-        params.setdefault("temperature", 0.7)
         params.setdefault("max_tokens", 1000)
         completion_kwargs = {
             "messages": envelope.to_dicts(),

--- a/tests/unit/llm/providers/test_provider_parity.py
+++ b/tests/unit/llm/providers/test_provider_parity.py
@@ -1,0 +1,103 @@
+"""Tests for provider parity fixes (P2-3).
+
+Issue 2: Groq should not inject temperature=0.7 default.
+Issue 3: Anthropic max_tokens default should be 4096 (not 1024).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from agent_actions.llm.providers.anthropic.client import AnthropicClient
+from agent_actions.llm.providers.groq.client import GroqClient
+
+
+def _setup_groq_mocks(mock_mb, mock_groq_cls):
+    """Wire Groq mocks and return mock_client for call_args inspection."""
+    mock_client = MagicMock()
+    mock_groq_cls.return_value = mock_client
+    mock_envelope = MagicMock()
+    mock_envelope.to_dicts.return_value = [{"role": "user", "content": "test"}]
+    mock_mb.build.return_value = mock_envelope
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = "plain text"
+    response.usage = MagicMock(prompt_tokens=5, completion_tokens=10, total_tokens=15)
+    response.model = "llama3-8b-8192"
+    mock_client.chat.completions.create.return_value = response
+    return mock_client
+
+
+def _call_groq_non_json(agent_config=None):
+    """Call GroqClient.call_non_json with default args."""
+    GroqClient.call_non_json(
+        api_key="test-key",
+        agent_config=agent_config or {"model_name": "llama3-8b-8192"},
+        prompt_config="test prompt",
+        context_data={"key": "val"},
+    )
+
+
+class TestGroqTemperatureDefault:
+    """Groq must not inject a temperature default — only max_tokens."""
+
+    @patch("agent_actions.llm.providers.groq.client.Groq")
+    @patch("agent_actions.llm.providers.groq.client.MessageBuilder")
+    def test_no_temperature_injected_when_absent(self, mock_mb, mock_groq_cls):
+        mock_client = _setup_groq_mocks(mock_mb, mock_groq_cls)
+        _call_groq_non_json()
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "temperature" not in call_kwargs
+
+    @patch("agent_actions.llm.providers.groq.client.Groq")
+    @patch("agent_actions.llm.providers.groq.client.MessageBuilder")
+    def test_user_temperature_preserved(self, mock_mb, mock_groq_cls):
+        mock_client = _setup_groq_mocks(mock_mb, mock_groq_cls)
+        _call_groq_non_json({"model_name": "llama3-8b-8192", "temperature": 0.3})
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["temperature"] == 0.3
+
+    @patch("agent_actions.llm.providers.groq.client.Groq")
+    @patch("agent_actions.llm.providers.groq.client.MessageBuilder")
+    def test_max_tokens_default_preserved(self, mock_mb, mock_groq_cls):
+        """max_tokens=1000 default must remain — required by Groq API."""
+        mock_client = _setup_groq_mocks(mock_mb, mock_groq_cls)
+        _call_groq_non_json()
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["max_tokens"] == 1000
+
+
+class TestAnthropicMaxTokensDefault:
+    """Anthropic max_tokens default should be 4096, not 1024."""
+
+    def test_default_max_tokens_is_4096(self):
+        api_args = AnthropicClient._build_api_args(
+            model_name="claude-3-sonnet-20240229",
+            messages=[{"role": "user", "content": "test"}],
+            schema=None,
+            agent_config={},
+        )
+        assert api_args["max_tokens"] == 4096
+
+    def test_user_max_tokens_not_overridden(self):
+        api_args = AnthropicClient._build_api_args(
+            model_name="claude-3-sonnet-20240229",
+            messages=[{"role": "user", "content": "test"}],
+            schema=None,
+            agent_config={"max_tokens": 8192},
+        )
+        assert api_args["max_tokens"] == 8192
+
+    def test_user_max_tokens_lower_than_default_preserved(self):
+        """setdefault respects user values even below the default."""
+        api_args = AnthropicClient._build_api_args(
+            model_name="claude-3-sonnet-20240229",
+            messages=[{"role": "user", "content": "test"}],
+            schema=None,
+            agent_config={"max_tokens": 512},
+        )
+        assert api_args["max_tokens"] == 512

--- a/tests/unit/llm_invocation/providers/test_non_json_standardization.py
+++ b/tests/unit/llm_invocation/providers/test_non_json_standardization.py
@@ -260,7 +260,11 @@ class TestGroqCallNonJson:
     @patch("agent_actions.llm.providers.groq.client.fire_event")
     @patch("agent_actions.llm.providers.groq.client.Groq")
     def test_none_temperature_and_max_tokens_use_defaults(self, mock_groq_cls, mock_fire):
-        """When config has temperature=None / max_tokens=None, fall back to defaults."""
+        """When config has temperature=None / max_tokens=None, fall back to defaults.
+
+        Groq does not inject a temperature default (parity with other providers).
+        Only max_tokens has a default (required by the Groq API).
+        """
         from agent_actions.llm.providers.groq.client import GroqClient
 
         config = {"model_name": "test-model", "temperature": None, "max_tokens": None}
@@ -273,7 +277,7 @@ class TestGroqCallNonJson:
         GroqClient.call_non_json("key", config, "prompt", "data")
 
         call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs["temperature"] == 0.7
+        assert "temperature" not in call_kwargs
         assert call_kwargs["max_tokens"] == 1000
 
 
@@ -479,8 +483,8 @@ class TestAnthropicSharedCallApi:
 
     @patch("agent_actions.llm.providers.anthropic.client.fire_event")
     @patch("agent_actions.llm.providers.anthropic.client.anthropic")
-    def test_default_max_tokens_is_1024(self, mock_anthropic_mod, mock_fire):
-        """When max_tokens is not in config, it should default to 1024."""
+    def test_default_max_tokens_is_4096(self, mock_anthropic_mod, mock_fire):
+        """When max_tokens is not in config, it should default to 4096."""
         from agent_actions.llm.providers.anthropic.client import AnthropicClient
 
         config = {"model_name": "claude-3"}
@@ -492,7 +496,7 @@ class TestAnthropicSharedCallApi:
         AnthropicClient.call_non_json("key", config, "prompt", "data")
 
         call_kwargs = mock_client.messages.create.call_args[1]
-        assert call_kwargs["max_tokens"] == 1024
+        assert call_kwargs["max_tokens"] == 4096
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Groq temperature default removed**: `call_non_json` no longer injects `temperature=0.7` via `setdefault`. No other provider sets a temperature default — Groq now uses the API's own default, matching parity with OpenAI/Anthropic/Cohere. `max_tokens=1000` default preserved (required by Groq API).
- **Anthropic max_tokens raised**: Default changed from 1024 to 4096. The old default was too low for most use cases. User-specified values still take precedence via `setdefault`.
- **Anthropic empty response (issue 1)**: Already fixed by PR #605 — `call_json` catches `VendorAPIError` from `_extract_response_content` and returns `_parse_error` sentinel matching OpenAI's behavior. No additional changes needed.

## Verification
- 6 new tests in `test_provider_parity.py`: Groq no-temperature-injected, user-temperature-preserved, max_tokens-default-preserved; Anthropic default-4096, user-override-preserved, user-lower-than-default
- 2 existing tests updated in `test_non_json_standardization.py` to match new defaults
- 7313 passed, 0 failed, ruff clean