### PR TITLE
fix: add thread safety to ActionStateManager and atomic_json_write

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-P21000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-P21000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix race condition in ActionStateManager concurrent updates and atomic_json_write temp file collisions"
+time: 2026-05-22T02:10:00.000000Z

--- a/agent_actions/utils/atomic_write.py
+++ b/agent_actions/utils/atomic_write.py
@@ -6,6 +6,7 @@ is either the old content or the new content, never a partial write.
 
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -35,10 +36,18 @@ def atomic_json_write(
         OSError: If the write or rename fails. The original exception is
                  chained via ``from``.
     """
-    tmp_path = path.with_suffix(".json.tmp")
+    fd, tmp_path_str = tempfile.mkstemp(dir=path.parent, suffix=".tmp", prefix=path.stem + "_")
+    tmp_path = Path(tmp_path_str)
 
     try:
-        with open(tmp_path, "w", encoding="utf-8") as f:
+        f = os.fdopen(fd, "w", encoding="utf-8")
+    except Exception:
+        os.close(fd)
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    try:
+        with f:
             json.dump(data, f, **json_kwargs)
             if fsync:
                 f.flush()

--- a/agent_actions/workflow/managers/state.py
+++ b/agent_actions/workflow/managers/state.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import threading
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -60,6 +61,7 @@ class ActionStateManager:
         self.status_file = status_file_path
         self.execution_order = execution_order
         self.action_status: dict[str, dict[str, Any]] = {}
+        self._lock = threading.Lock()
         self._load_status()
 
     def _load_status(self):
@@ -77,8 +79,9 @@ class ActionStateManager:
 
     def reset(self) -> None:
         """Reset all actions to 'pending' status and persist."""
-        self._initialize_default_status()
-        self._save_status()
+        with self._lock:
+            self._initialize_default_status()
+            self._save_status()
 
     def _initialize_default_status(self):
         """Initialize all actions with 'pending' status."""
@@ -93,16 +96,16 @@ class ActionStateManager:
 
     def update_status(self, action_name: str, status: ActionStatus, **metadata):
         """Update action status and persist to file."""
-        if action_name not in self.action_status:
-            self.action_status[action_name] = {}
+        with self._lock:
+            if action_name not in self.action_status:
+                self.action_status[action_name] = {}
 
-        self.action_status[action_name]["status"] = status
+            self.action_status[action_name]["status"] = status
 
-        # Add any additional metadata
-        for key, value in metadata.items():
-            self.action_status[action_name][key] = value
+            for key, value in metadata.items():
+                self.action_status[action_name][key] = value
 
-        self._save_status()
+            self._save_status()
 
     def get_status(self, action_name: str) -> ActionStatus:
         """Return current status of an action, defaulting to PENDING."""
@@ -158,18 +161,34 @@ class ActionStateManager:
         """Return actions that were skipped."""
         return [agent for agent in agents if self.is_skipped(agent)]
 
+    def _bulk_transition(
+        self, from_statuses: frozenset[ActionStatus] | set[ActionStatus], to_status: ActionStatus
+    ) -> list[str]:
+        """Transition all actions matching *from_statuses* to *to_status*.
+
+        Holds the lock for the entire scan-mutate-save cycle and persists
+        at most once.  Returns the names of affected actions.
+        """
+        with self._lock:
+            affected = [
+                name
+                for name, details in self.action_status.items()
+                if details.get("status") in from_statuses
+            ]
+            for name in affected:
+                self.action_status[name]["status"] = to_status
+            if affected:
+                self._save_status()
+        return affected
+
     def mark_running_as_failed(self) -> list[str]:
         """Mark all actions in 'running' or 'checking_batch' status as failed.
 
         Returns list of action names that were marked failed.
         """
-        marked: list[str] = []
-        for action_name, details in self.action_status.items():
-            if details.get("status") in (ActionStatus.RUNNING, ActionStatus.CHECKING_BATCH):
-                marked.append(action_name)
-        for action_name in marked:
-            self.update_status(action_name, ActionStatus.FAILED)
-        return marked
+        return self._bulk_transition(
+            {ActionStatus.RUNNING, ActionStatus.CHECKING_BATCH}, ActionStatus.FAILED
+        )
 
     def reset_retryable(self) -> list[str]:
         """Reset retryable actions to PENDING for re-run.
@@ -179,13 +198,7 @@ class ActionStateManager:
         completed results.  Callers should clear storage dispositions for
         the returned action names.
         """
-        reset_names: list[str] = []
-        for action_name, details in self.action_status.items():
-            if details.get("status") in RETRYABLE_STATUSES:
-                reset_names.append(action_name)
-        for action_name in reset_names:
-            self.update_status(action_name, ActionStatus.PENDING)
-        return reset_names
+        return self._bulk_transition(RETRYABLE_STATUSES, ActionStatus.PENDING)
 
     def get_summary(self) -> dict[str, int]:
         """Return summary counts of action statuses (current actions only)."""

--- a/tests/unit/llm/test_recovery_state_graduated.py
+++ b/tests/unit/llm/test_recovery_state_graduated.py
@@ -225,7 +225,7 @@ class TestRecoveryStateAtomicWrite:
         # Temp file was observed with valid data before rename
         assert captured_tmp["existed"] is True
         assert captured_tmp["content"]["phase"] == "retry"
-        assert str(captured_tmp["path"]).endswith(".json.tmp")
+        assert str(captured_tmp["path"]).endswith(".tmp")
 
         # Final file is correct, temp file gone
         assert path.exists()
@@ -267,8 +267,7 @@ class TestRecoveryStateAtomicWrite:
         assert len(loaded.graduated_results) == 1
 
         # No leftover temp file
-        tmp_file = path.with_suffix(".json.tmp")
-        assert not tmp_file.exists()
+        assert list(path.parent.glob("*.tmp")) == []
 
     def test_save_error_cleans_up_temp_file(self, tmp_path):
         """On write failure, the temp file is removed — no disk litter."""
@@ -314,7 +313,7 @@ class TestRecoveryStateAtomicWrite:
         assert loaded.phase == "retry"
 
         # Temp file cleaned up
-        assert not path.with_suffix(".json.tmp").exists()
+        assert list(path.parent.glob("*.tmp")) == []
 
     def test_save_error_raises_oserror(self, tmp_path):
         """save() propagates write failures as OSError."""

--- a/tests/unit/logging/test_atomic_write.py
+++ b/tests/unit/logging/test_atomic_write.py
@@ -61,7 +61,7 @@ class TestRunResultsAtomicWrite:
         _orig = Path.replace
 
         def failing_replace(self_path, target):
-            if str(self_path).endswith(".json.tmp"):
+            if str(self_path).endswith(".tmp"):
                 raise OSError("disk full")
             return _orig(self_path, target)
 

--- a/tests/unit/utils/test_atomic_write.py
+++ b/tests/unit/utils/test_atomic_write.py
@@ -1,6 +1,7 @@
 """Tests for atomic_json_write utility."""
 
 import json
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -24,7 +25,7 @@ class TestAtomicJsonWrite:
         """Temp file is removed after successful write."""
         target = tmp_path / "out.json"
         atomic_json_write(target, {"a": 1})
-        assert not target.with_suffix(".json.tmp").exists()
+        assert list(tmp_path.glob("*.tmp")) == []
 
     def test_json_kwargs_forwarded(self, tmp_path):
         """indent and other json.dump kwargs are respected."""
@@ -65,7 +66,7 @@ class TestAtomicJsonWriteAtomicity:
         with patch.object(Path, "replace", spy):
             atomic_json_write(target, {"spied": True}, ensure_ascii=False)
 
-        assert str(captured["tmp_path"]).endswith(".json.tmp")
+        assert str(captured["tmp_path"]).endswith(".tmp")
         assert captured["tmp_content"] == {"spied": True}
 
     def test_original_survives_write_failure(self, tmp_path):
@@ -96,7 +97,7 @@ class TestAtomicJsonWriteAtomicity:
             atomic_json_write(target, {"v": 2})
 
         assert target.read_text() == original
-        assert not target.with_suffix(".json.tmp").exists()
+        assert list(tmp_path.glob("*.tmp")) == []
 
 
 class TestAtomicJsonWriteErrorHandling:
@@ -143,3 +144,53 @@ class TestAtomicJsonWriteErrorHandling:
             atomic_json_write(target, {"fast": True}, fsync=False)
         mock_fsync.assert_not_called()
         assert json.loads(target.read_text()) == {"fast": True}
+
+
+class TestAtomicJsonWriteConcurrency:
+    """Verify concurrent writes to the same file don't corrupt data."""
+
+    def test_concurrent_writes_no_corruption(self, tmp_path):
+        """N threads writing to the same file never produce corrupt JSON."""
+        target = tmp_path / "shared.json"
+        atomic_json_write(target, {"init": True})
+
+        num_threads = 20
+        errors: list[Exception] = []
+        barrier = threading.Barrier(num_threads)
+
+        def writer(i: int):
+            try:
+                barrier.wait(timeout=5)
+                atomic_json_write(target, {"thread": i, "data": list(range(100))})
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert errors == [], f"Errors during concurrent writes: {errors}"
+        # File must contain valid JSON from one of the writers
+        result = json.loads(target.read_text())
+        assert "thread" in result
+        assert "data" in result
+
+    def test_unique_temp_paths_per_call(self, tmp_path):
+        """Each call to atomic_json_write uses a unique temp path."""
+        target = tmp_path / "out.json"
+        observed_temps: list[Path] = []
+        original_replace = Path.replace
+
+        def spy(self_path, dest):
+            observed_temps.append(self_path)
+            return original_replace(self_path, dest)
+
+        with patch.object(Path, "replace", spy):
+            for i in range(5):
+                atomic_json_write(target, {"i": i})
+
+        # All temp paths must be unique (mkstemp guarantees this)
+        assert len(observed_temps) == 5
+        assert len(set(observed_temps)) == 5

--- a/tests/unit/workflow/managers/test_state_manager.py
+++ b/tests/unit/workflow/managers/test_state_manager.py
@@ -1,6 +1,7 @@
 """Tests for ActionStateManager state persistence and queries."""
 
 import json
+import threading
 
 import pytest
 
@@ -373,3 +374,78 @@ class TestResetRetryable:
         reset = mgr.reset_retryable()
 
         assert reset == []
+
+
+class TestConcurrentUpdateStatus:
+    """Verify thread safety of ActionStateManager under concurrent access."""
+
+    def test_no_lost_updates_under_contention(self, tmp_path):
+        """N threads updating different actions must not lose any updates."""
+        num_actions = 20
+        action_names = [f"action_{i}" for i in range(num_actions)]
+        status_file = tmp_path / "status.json"
+        mgr = ActionStateManager(status_file, action_names)
+
+        errors: list[Exception] = []
+        barrier = threading.Barrier(num_actions)
+
+        def updater(name: str):
+            try:
+                barrier.wait(timeout=5)
+                mgr.update_status(name, ActionStatus.COMPLETED, thread=name)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=updater, args=(n,)) for n in action_names]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert errors == [], f"Errors during concurrent updates: {errors}"
+
+        # Every action must be COMPLETED with its metadata
+        for name in action_names:
+            assert mgr.get_status(name) == ActionStatus.COMPLETED, f"{name} status lost"
+            assert mgr.get_status_details(name)["thread"] == name
+
+        # Verify persistence: reload and check
+        saved = json.loads(status_file.read_text())
+        for name in action_names:
+            assert saved[name]["status"] == "completed"
+            assert saved[name]["thread"] == name
+
+    def test_concurrent_update_and_reset(self, tmp_path):
+        """Concurrent update_status and reset must not corrupt state."""
+        status_file = tmp_path / "status.json"
+        actions = ["a", "b", "c"]
+        mgr = ActionStateManager(status_file, actions)
+
+        errors: list[Exception] = []
+
+        def do_updates():
+            try:
+                for _ in range(50):
+                    mgr.update_status("a", ActionStatus.RUNNING)
+                    mgr.update_status("a", ActionStatus.COMPLETED)
+            except Exception as e:
+                errors.append(e)
+
+        def do_resets():
+            try:
+                for _ in range(50):
+                    mgr.reset()
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=do_updates)
+        t2 = threading.Thread(target=do_resets)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert errors == [], f"Errors during concurrent update/reset: {errors}"
+        # State must be valid JSON on disk
+        saved = json.loads(status_file.read_text())
+        assert isinstance(saved, dict)


### PR DESCRIPTION
## Summary
- Add `threading.Lock` to `ActionStateManager` protecting all mutating methods (`update_status`, `reset`, `mark_running_as_failed`, `reset_retryable`) against concurrent executor threads losing metadata
- Replace deterministic temp path in `atomic_json_write` (`path.with_suffix(".json.tmp")`) with `tempfile.mkstemp` for unique temp paths per call, preventing concurrent write collisions
- Update existing tests asserting on old `.json.tmp` suffix pattern
- Add concurrency tests: 20-thread contention on state manager, concurrent update+reset, concurrent atomic writes, unique temp path verification

## Verification
- All BEFORE checks confirmed bugs exist (no lock, deterministic tmp path)
- All AFTER grep checks pass (lock present, mkstemp used, no `.json.tmp` pattern)
- `ruff check` and `ruff format --check` pass on all changed files
- `pytest` passes 7309 tests (2 pre-existing failures in trailing comma repair unrelated to this change)