### PR TITLE
feat: config UX improvements (P2-4)

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260522-P24000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260522-P24000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Surface unknown defaults keys with warning, add fuzzy-match suggestions for action key typos, and expose Pydantic field errors in ConfigurationError context"
+time: 2026-05-22T024000.000000Z

--- a/agent_actions/config/manager.py
+++ b/agent_actions/config/manager.py
@@ -16,7 +16,7 @@ from agent_actions.config.path_config import (
     resolve_project_root,
 )
 from agent_actions.config.paths import PathManager, ProjectRootNotFoundError
-from agent_actions.config.schema import WorkflowConfig
+from agent_actions.config.schema import DefaultsConfig, WorkflowConfig
 from agent_actions.errors import ConfigurationError, ConfigValidationError, TemplateRenderingError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import ConfigLoadEvent, ConfigLoadStartEvent
@@ -193,14 +193,34 @@ class ConfigManager:
             try:
                 workflow = WorkflowConfig.model_validate(self.user_config)
             except ValidationError as e:
+                field_errors = [
+                    {
+                        "field": ".".join(str(x) for x in err["loc"]),
+                        "message": err["msg"],
+                        "type": err["type"],
+                    }
+                    for err in e.errors()
+                ][:10]
                 raise ConfigurationError(
                     "Workflow configuration is invalid",
                     context={
                         "config_path": str(self.constructor_path),
                         "workflow_name": self.user_config.get("name", "unknown"),
+                        "validation_errors": field_errors,
                     },
                     cause=e,
                 ) from e
+
+            raw_defaults = self.user_config.get("defaults") or {}
+            if raw_defaults:
+                known_fields = set(DefaultsConfig.model_fields.keys())
+                unknown = sorted(set(raw_defaults.keys()) - known_fields)
+                if unknown:
+                    logger.warning(
+                        "Unknown keys in defaults config: %s. Known keys: %s",
+                        ", ".join(unknown),
+                        ", ".join(sorted(known_fields)),
+                    )
 
             validated_actions = [
                 action.model_dump(mode="python", exclude_unset=True, by_alias=True)

--- a/agent_actions/validation/action_validators/unknown_keys_detector.py
+++ b/agent_actions/validation/action_validators/unknown_keys_detector.py
@@ -1,5 +1,7 @@
 """Detector for unknown/unexpected keys in action configuration."""
 
+import difflib
+
 from agent_actions.validation.action_validators.base_action_validator import (
     ActionEntryValidationResult,
     BaseActionEntryValidator,
@@ -25,8 +27,23 @@ class UnknownKeysDetector(BaseActionEntryValidator):
 
         if unknown_keys:
             sorted_unknown = sorted(unknown_keys)
+            all_known_list = sorted(all_known_keys)
+            suggestions = {}
+            for key in sorted_unknown:
+                matches = difflib.get_close_matches(key, all_known_list, n=1, cutoff=0.6)
+                if matches:
+                    suggestions[key] = matches[0]
+
+            hint = ""
+            if suggestions:
+                hint = (
+                    " Did you mean: "
+                    + ", ".join(f"{k} -> {v}" for k, v in suggestions.items())
+                    + "?"
+                )
+
             warning_msg = (
-                f"{desc} has unknown key(s): {', '.join(sorted_unknown)}. "
+                f"{desc} has unknown key(s): {', '.join(sorted_unknown)}.{hint} "
                 f"Ensure these are intended or correct typos."
             )
             return ActionEntryValidationResult.with_warnings([warning_msg])

--- a/tests/unit/config/test_config_ux.py
+++ b/tests/unit/config/test_config_ux.py
@@ -1,0 +1,255 @@
+"""Tests for config UX improvements: unknown defaults warning, fuzzy match, validation errors."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.config.manager import ConfigManager
+from agent_actions.errors import ConfigurationError
+from agent_actions.validation.action_validators.unknown_keys_detector import UnknownKeysDetector
+
+_WORKFLOW_HEADER = "name: test_workflow\ndescription: test workflow\nversion: '1.0'\n"
+
+_ACTIONS_BLOCK = "actions:\n  - name: extract\n    intent: extract data\n    kind: llm\n"
+
+
+def _make_manager(tmp_path, workflow_yaml):
+    cfg = tmp_path / "workflow.yml"
+    cfg.write_text(workflow_yaml)
+    default = tmp_path / "default.yml"
+    default.write_text("{}")
+    (tmp_path / "templates").mkdir()
+    cm = ConfigManager(str(cfg), str(default), project_root=tmp_path)
+    cm.load_configs()
+    return cm
+
+
+def _call_get_user_agents(cm, tmp_path):
+    with (
+        patch("agent_actions.config.manager.PathManager") as mock_pm_cls,
+        patch("agent_actions.config.manager.load_project_config", return_value={}),
+        patch(
+            "agent_actions.output.response.expander.ActionExpander.expand_actions_to_agents",
+            return_value={"test_workflow": [{"agent_type": "extract"}]},
+        ),
+    ):
+        mock_pm_cls.return_value.get_project_root.return_value = tmp_path
+        return cm.get_user_agents()
+
+
+@pytest.fixture
+def _enable_propagation():
+    """Temporarily enable propagation on agent_actions logger so caplog captures records."""
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = original
+
+
+class TestUnknownDefaultsKeysWarning:
+    """Issue 1: Unknown keys in defaults config should produce a warning."""
+
+    @pytest.mark.usefixtures("_enable_propagation")
+    def test_unknown_defaults_key_logs_warning(self, tmp_path, caplog):
+        """Typo like 'modle_name' in defaults triggers a warning."""
+        cm = _make_manager(
+            tmp_path,
+            _WORKFLOW_HEADER
+            + _ACTIONS_BLOCK
+            + "defaults:\n  modle_name: gpt-4\n  model_vendor: openai\n",
+        )
+        with caplog.at_level(logging.WARNING):
+            _call_get_user_agents(cm, tmp_path)
+
+        assert any("Unknown keys in defaults config" in r.message for r in caplog.records)
+        assert any("modle_name" in r.message for r in caplog.records)
+
+    @pytest.mark.usefixtures("_enable_propagation")
+    def test_no_warning_when_no_unknown_keys(self, tmp_path, caplog):
+        """Valid defaults keys produce no warning."""
+        cm = _make_manager(
+            tmp_path,
+            _WORKFLOW_HEADER
+            + _ACTIONS_BLOCK
+            + "defaults:\n  model_vendor: openai\n  model_name: gpt-4\n",
+        )
+        with caplog.at_level(logging.WARNING):
+            _call_get_user_agents(cm, tmp_path)
+
+        assert not any("Unknown keys in defaults config" in r.message for r in caplog.records)
+
+    @pytest.mark.usefixtures("_enable_propagation")
+    def test_no_warning_when_no_defaults(self, tmp_path, caplog):
+        """No defaults section produces no warning."""
+        cm = _make_manager(tmp_path, _WORKFLOW_HEADER + _ACTIONS_BLOCK)
+        with caplog.at_level(logging.WARNING):
+            _call_get_user_agents(cm, tmp_path)
+
+        assert not any("Unknown keys in defaults config" in r.message for r in caplog.records)
+
+    @pytest.mark.usefixtures("_enable_propagation")
+    def test_warning_lists_known_keys(self, tmp_path, caplog):
+        """Warning message includes the list of known keys for reference."""
+        cm = _make_manager(
+            tmp_path,
+            _WORKFLOW_HEADER + _ACTIONS_BLOCK + "defaults:\n  bogus_key: value\n",
+        )
+        with caplog.at_level(logging.WARNING):
+            _call_get_user_agents(cm, tmp_path)
+
+        warning_msgs = [r.message for r in caplog.records if "Unknown keys" in r.message]
+        assert len(warning_msgs) == 1
+        assert "model_name" in warning_msgs[0]
+        assert "model_vendor" in warning_msgs[0]
+
+
+class TestFuzzyMatchSuggestions:
+    """Issue 2: Unknown keys detector should suggest closest valid key."""
+
+    def _make_context(self, entry):
+        return SimpleNamespace(
+            entry=entry,
+            normalized_entry=entry,
+            description="Action 'extract'",
+        )
+
+    def test_typo_gets_suggestion(self):
+        """'modle_name' should suggest 'model_name'."""
+        detector = UnknownKeysDetector()
+        ctx = self._make_context({"agent_type": "llm", "modle_name": "gpt-4"})
+
+        with patch(
+            "agent_actions.validation.utils.action_config_validation_utilities."
+            "ActionConfigValidationUtilities.get_all_known_action_keys",
+            return_value={"agent_type", "model_name", "model_vendor", "kind", "intent", "name"},
+        ):
+            result = detector.validate(ctx)
+
+        assert result.warnings
+        assert "Did you mean" in result.warnings[0]
+        assert "modle_name -> model_name" in result.warnings[0]
+
+    def test_no_suggestion_for_distant_key(self):
+        """A completely unrelated key should not get a suggestion."""
+        detector = UnknownKeysDetector()
+        ctx = self._make_context({"agent_type": "llm", "zzzzzzz": "value"})
+
+        with patch(
+            "agent_actions.validation.utils.action_config_validation_utilities."
+            "ActionConfigValidationUtilities.get_all_known_action_keys",
+            return_value={"agent_type", "model_name", "model_vendor", "kind"},
+        ):
+            result = detector.validate(ctx)
+
+        assert result.warnings
+        assert "Did you mean" not in result.warnings[0]
+        assert "zzzzzzz" in result.warnings[0]
+
+    def test_no_warnings_for_known_keys(self):
+        """Known keys produce no warnings."""
+        detector = UnknownKeysDetector()
+        ctx = self._make_context({"agent_type": "llm", "model_name": "gpt-4"})
+
+        with patch(
+            "agent_actions.validation.utils.action_config_validation_utilities."
+            "ActionConfigValidationUtilities.get_all_known_action_keys",
+            return_value={"agent_type", "model_name", "model_vendor"},
+        ):
+            result = detector.validate(ctx)
+
+        assert not result.warnings
+
+    def test_multiple_typos_get_individual_suggestions(self):
+        """Each typo key gets its own suggestion if close enough."""
+        detector = UnknownKeysDetector()
+        ctx = self._make_context(
+            {
+                "agent_type": "llm",
+                "modle_name": "gpt-4",
+                "modle_vendor": "openai",
+            }
+        )
+
+        with patch(
+            "agent_actions.validation.utils.action_config_validation_utilities."
+            "ActionConfigValidationUtilities.get_all_known_action_keys",
+            return_value={"agent_type", "model_name", "model_vendor", "kind"},
+        ):
+            result = detector.validate(ctx)
+
+        assert result.warnings
+        warning = result.warnings[0]
+        assert "modle_name -> model_name" in warning
+        assert "modle_vendor -> model_vendor" in warning
+
+
+class TestValidationErrorSurfacing:
+    """Issue 3: Pydantic field errors should be surfaced in ConfigurationError context."""
+
+    def test_validation_error_includes_field_details(self, tmp_path):
+        """ConfigurationError context should include structured validation_errors."""
+        cm = _make_manager(
+            tmp_path,
+            _WORKFLOW_HEADER + "actions:\n  - invalid_entry: true\n",
+        )
+
+        with (
+            patch("agent_actions.config.manager.PathManager") as mock_pm_cls,
+            patch("agent_actions.config.manager.load_project_config", return_value={}),
+            pytest.raises(ConfigurationError) as exc_info,
+        ):
+            mock_pm_cls.return_value.get_project_root.return_value = tmp_path
+            cm.get_user_agents()
+
+        err = exc_info.value
+        assert "validation_errors" in err.context
+        field_errors = err.context["validation_errors"]
+        assert isinstance(field_errors, list)
+        assert len(field_errors) > 0
+        first = field_errors[0]
+        assert "field" in first
+        assert "message" in first
+        assert "type" in first
+
+    def test_validation_error_capped_at_10(self, tmp_path):
+        """At most 10 validation errors are included in context."""
+        cm = _make_manager(
+            tmp_path,
+            _WORKFLOW_HEADER
+            + "actions:\n  - name: extract\n    intent: extract data\n    kind: llm\n    dependencies: not_a_list\n",
+        )
+
+        with (
+            patch("agent_actions.config.manager.PathManager") as mock_pm_cls,
+            patch("agent_actions.config.manager.load_project_config", return_value={}),
+            pytest.raises(ConfigurationError) as exc_info,
+        ):
+            mock_pm_cls.return_value.get_project_root.return_value = tmp_path
+            cm.get_user_agents()
+
+        err = exc_info.value
+        assert "validation_errors" in err.context
+        assert len(err.context["validation_errors"]) <= 10
+
+    def test_validation_error_preserves_config_path_and_workflow_name(self, tmp_path):
+        """config_path and workflow_name are still in context alongside validation_errors."""
+        cm = _make_manager(
+            tmp_path,
+            "name: my_workflow\ndescription: test\nversion: '1.0'\nactions:\n  - invalid_entry: true\n",
+        )
+
+        with (
+            patch("agent_actions.config.manager.PathManager") as mock_pm_cls,
+            patch("agent_actions.config.manager.load_project_config", return_value={}),
+            pytest.raises(ConfigurationError) as exc_info,
+        ):
+            mock_pm_cls.return_value.get_project_root.return_value = tmp_path
+            cm.get_user_agents()
+
+        err = exc_info.value
+        assert "config_path" in err.context
+        assert "workflow_name" in err.context
+        assert err.context["workflow_name"] == "my_workflow"


### PR DESCRIPTION
## Summary
- Warn when defaults config contains unknown keys (e.g., `modle_name` typo) by comparing raw input keys against `DefaultsConfig.model_fields`; keeps `extra="ignore"` unchanged so vendor-specific passthrough params still work
- Add `difflib.get_close_matches` to `UnknownKeysDetector` for "did you mean: modle_name -> model_name?" suggestions on action key typos
- Surface Pydantic field-level errors in `ConfigurationError.context` as structured `validation_errors` list (capped at 10 entries)

## Verification
- 11 new tests covering all three issues (happy path + negative cases)
- 7318 passed, 2 skipped, ruff clean
- `extra="ignore"` on `DefaultsConfig` unchanged (verified via grep)
- BEFORE/AFTER verification checks from spec all pass