### PR TITLE
fix: VS Code/LSP fixes — 6 independent editor issues

### DIFF
--- a/.changes/unreleased/Bug Fix-20260522-032000.yaml
+++ b/.changes/unreleased/Bug Fix-20260522-032000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fix 6 VS Code/LSP issues: missing grammar file, disposed flag surviving reload, context_scope completions limited to current file, missing didChange handler, no crash recovery, and unescaped Mermaid labels"
+time: 2026-05-22T03:20:00.000000Z

--- a/agent_actions/tooling/lsp/completions.py
+++ b/agent_actions/tooling/lsp/completions.py
@@ -40,7 +40,7 @@ def is_in_versions_block(lines: list[str], line_number: int) -> bool:
 
 
 def build_context_scope_completions(
-    file_path: Path, index: ProjectIndex
+    index: ProjectIndex,
 ) -> list[lsp.CompletionItem]:
     """Build completions for context_scope observe/drop blocks.
 

--- a/agent_actions/tooling/lsp/completions.py
+++ b/agent_actions/tooling/lsp/completions.py
@@ -42,28 +42,36 @@ def is_in_versions_block(lines: list[str], line_number: int) -> bool:
 def build_context_scope_completions(
     file_path: Path, index: ProjectIndex
 ) -> list[lsp.CompletionItem]:
-    """Build completions for context_scope observe/drop blocks."""
+    """Build completions for context_scope observe/drop blocks.
+
+    Searches all indexed files in the workspace so that cross-file action
+    references are available, not just actions defined in the current file.
+    """
     items = []
-    actions = index.file_actions.get(file_path, {})
-    for action in actions.values():
-        if action.schema_ref:
-            schema = index.get_schema_definition(action.schema_ref)
-            if schema and schema.fields:
-                for field in schema.fields:
-                    items.append(
-                        lsp.CompletionItem(
-                            label=f"{action.name}.{field}",
-                            kind=lsp.CompletionItemKind.Field,
-                            detail=f"Output field from {action.name}",
+    seen_actions: set[str] = set()
+    for actions in index.file_actions.values():
+        for action in actions.values():
+            if action.name in seen_actions:
+                continue
+            seen_actions.add(action.name)
+            if action.schema_ref:
+                schema = index.get_schema_definition(action.schema_ref)
+                if schema and schema.fields:
+                    for field in schema.fields:
+                        items.append(
+                            lsp.CompletionItem(
+                                label=f"{action.name}.{field}",
+                                kind=lsp.CompletionItemKind.Field,
+                                detail=f"Output field from {action.name}",
+                            )
                         )
-                    )
-        items.append(
-            lsp.CompletionItem(
-                label=action.name,
-                kind=lsp.CompletionItemKind.Module,
-                detail="Action output",
+            items.append(
+                lsp.CompletionItem(
+                    label=action.name,
+                    kind=lsp.CompletionItemKind.Module,
+                    detail="Action output",
+                )
             )
-        )
     return items
 
 

--- a/agent_actions/tooling/lsp/server.py
+++ b/agent_actions/tooling/lsp/server.py
@@ -379,6 +379,12 @@ def did_save(params: lsp.DidSaveTextDocumentParams):
     _publish_diagnostics(params.text_document.uri)
 
 
+@server.feature(lsp.TEXT_DOCUMENT_DID_CHANGE)
+def did_change(params: lsp.DidChangeTextDocumentParams):
+    """Handle document change — update in-memory content and republish diagnostics."""
+    _publish_diagnostics(params.text_document.uri)
+
+
 @server.feature(lsp.TEXT_DOCUMENT_DID_OPEN)
 def did_open(params: lsp.DidOpenTextDocumentParams):
     """Handle file open - publish diagnostics."""

--- a/agent_actions/tooling/lsp/server.py
+++ b/agent_actions/tooling/lsp/server.py
@@ -289,7 +289,7 @@ def completions(params: lsp.CompletionParams) -> lsp.CompletionList:
 
     # Context scope completions
     elif is_in_context_scope_block(lines, params.position.line):
-        items.extend(build_context_scope_completions(current_file, index))
+        items.extend(build_context_scope_completions(index))
 
     # Guard/reprompt completions
     elif "condition:" in line_before_cursor or "validation:" in line_before_cursor:

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,6 +7,8 @@
 
 import * as vscode from 'vscode';
 import {
+    CloseAction,
+    ErrorAction,
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
@@ -46,6 +48,7 @@ let disposed = false;
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 const DEBOUNCE_MS = 300;
 const ACTIVATION_TIMEOUT_MS = 10_000;
+const MAX_RESTART_COUNT = 3;
 const MODULE_ARGS = ['-m', 'agent_actions.tooling.lsp.server', '--stdio'];
 
 // File watchers for LSP synchronization — created once in activate(), reused across restarts
@@ -114,6 +117,18 @@ async function startClient(context: vscode.ExtensionContext): Promise<void> {
         ],
         synchronize: { fileEvents: lspFileWatchers },
         outputChannel,
+        errorHandler: {
+            error: () => ({ action: ErrorAction.Continue }),
+            closed: () => {
+                if (disposed) {
+                    return { action: CloseAction.DoNotRestart };
+                }
+                return { action: CloseAction.Restart, message: 'LSP server crashed, restarting...' };
+            },
+        },
+        connectionOptions: {
+            maxRestartCount: MAX_RESTART_COUNT,
+        },
     };
 
     client = new LanguageClient('agentActionsLsp', 'Agent Actions LSP', serverOptions, clientOptions);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -174,6 +174,7 @@ function restartServer(context: vscode.ExtensionContext): Promise<void> {
 // ── Activation ───────────────────────────────────────────────────────
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    disposed = false;
     initializeLogger(context);
     outputChannel = vscode.window.createOutputChannel('Agent Actions');
     context.subscriptions.push(outputChannel);

--- a/vscode-extension/src/views/dagWebview.ts
+++ b/vscode-extension/src/views/dagWebview.ts
@@ -159,7 +159,7 @@ export class DagWebview implements vscode.Disposable {
         // Define nodes with status styling
         for (const action of actions) {
             const nodeId = this.sanitizeId(action.name);
-            const label = action.name.replace(/["\]\\]/g, '_');
+            const label = this.escapeMermaidLabel(action.name);
             const statusClass = this.getStatusClass(action.status);
 
             lines.push(`  ${nodeId}["[${action.index}] ${label}"]:::${statusClass}`);
@@ -195,6 +195,14 @@ export class DagWebview implements vscode.Disposable {
 
     private sanitizeId(name: string): string {
         return name.replace(/[^a-zA-Z0-9_]/g, '_');
+    }
+
+    /**
+     * Escape special Mermaid characters in node labels to prevent syntax breaks.
+     * Handles quotes, brackets, braces, parens, pipes, and other Mermaid-significant chars.
+     */
+    private escapeMermaidLabel(label: string): string {
+        return label.replace(/["\\[\]{}()<>|#&;]/g, '_');
     }
 
     /**

--- a/vscode-extension/src/views/dagWebview.ts
+++ b/vscode-extension/src/views/dagWebview.ts
@@ -197,10 +197,7 @@ export class DagWebview implements vscode.Disposable {
         return name.replace(/[^a-zA-Z0-9_]/g, '_');
     }
 
-    /**
-     * Escape special Mermaid characters in node labels to prevent syntax breaks.
-     * Handles quotes, brackets, braces, parens, pipes, and other Mermaid-significant chars.
-     */
+    /** Escape Mermaid-significant characters in node labels. */
     private escapeMermaidLabel(label: string): string {
         return label.replace(/["\\[\]{}()<>|#&;]/g, '_');
     }

--- a/vscode-extension/syntaxes/prompt-blocks.tmLanguage.json
+++ b/vscode-extension/syntaxes/prompt-blocks.tmLanguage.json
@@ -1,0 +1,25 @@
+{
+  "scopeName": "markdown.prompt-blocks.injection",
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "begin": "(^|\\G)(\\s*)(\\{\\{)",
+      "end": "(\\}\\})",
+      "beginCaptures": {
+        "3": { "name": "punctuation.definition.template.begin.prompt" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.template.end.prompt" }
+      },
+      "name": "meta.embedded.block.prompt",
+      "contentName": "variable.other.prompt-template"
+    },
+    {
+      "match": "\\$\\{([^}]+)\\}",
+      "name": "variable.other.prompt-variable",
+      "captures": {
+        "1": { "name": "variable.other.readwrite.prompt" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- **Grammar file**: Created missing `syntaxes/prompt-blocks.tmLanguage.json` referenced by `package.json` (was causing VS Code activation warning)
- **Disposed flag**: Reset `disposed = false` in `activate()` so LSP server restarts after deactivate/reactivate cycle
- **Context scope completions**: `build_context_scope_completions` now searches all indexed files, not just the current file, so cross-file action references appear
- **didChange handler**: Added `textDocument/didChange` handler to LSP server so in-memory document store stays current while typing
- **Crash recovery**: Added `ErrorAction`/`CloseAction` handlers + `maxRestartCount: 3` so the LSP auto-restarts if the server process crashes
- **Mermaid label escaping**: Replaced incomplete inline regex with `escapeMermaidLabel()` that handles all Mermaid-significant characters (`[]{}()<>|#&;"\\`)

## Verification
- All 6 BEFORE checks confirmed bugs exist, all 6 AFTER checks pass
- `ruff check` / `ruff format --check` clean on changed files (pre-existing lint issue in unrelated test file)
- 7355 tests passed, 2 skipped
- One commit per fix for clean bisect