### PR TITLE
feat: close observability gaps across enrichment, LLM, batch, and storage

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260522-P41000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260522-P41000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add observability improvements: record identity in enrichment error logs, LLM call duration logging, batch timeout progress context, disposition clearing events, and action_name in warning logs"
+time: 2026-05-22T04:10:00.000000Z

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -788,9 +788,10 @@ class BatchProcessingService:
             )
         except Exception:
             logger.warning(
-                "Could not load context_map for failed batch %s — "
+                "Could not load context_map for failed batch %s (action=%s) — "
                 "records may remain with stale DEFERRED dispositions",
                 file_name,
+                action_name,
                 exc_info=True,
             )
             return
@@ -827,10 +828,12 @@ class BatchProcessingService:
             failed_count += 1
 
         if failed_count:
-            logger.info(
-                "Wrote FAILED disposition for %d records in failed batch %s",
+            logger.warning(
+                "Wrote FAILED disposition for %d abandoned records in batch %s (action=%s): %s",
                 failed_count,
                 file_name,
+                action_name,
+                str(error)[:200],
             )
 
     @staticmethod

--- a/agent_actions/llm/batch/services/retry_polling.py
+++ b/agent_actions/llm/batch/services/retry_polling.py
@@ -83,7 +83,16 @@ def wait_for_batch_completion(
         logger.debug("Retry batch %s status: %s, waiting...", batch_id, status)
         time.sleep(poll_interval)
 
-    logger.warning("Retry batch %s timed out after %d seconds", batch_id, timeout_seconds)
+    elapsed = time.time() - start_time
+    logger.warning(
+        "Retry batch %s timed out after %.0fs (limit=%ds, completed=%d, failed=%d, total=%d)",
+        batch_id,
+        elapsed,
+        timeout_seconds,
+        completed,
+        failed,
+        total_items,
+    )
     return provider.check_status(batch_id)  # type: ignore[return-value]
 
 

--- a/agent_actions/llm/realtime/services/invocation.py
+++ b/agent_actions/llm/realtime/services/invocation.py
@@ -5,6 +5,7 @@ Handles client routing and invocation for different LLM providers.
 
 import importlib
 import logging
+import time
 from typing import Any
 
 from agent_actions.llm.providers.agac.client import AgacClient
@@ -117,24 +118,33 @@ class ClientInvocationService:
 
         client = _resolve_client(model_vendor)
 
+        start = time.perf_counter()
+
         # Tool client has different parameters
         if model_vendor == "tool":
-            return client.invoke(  # type: ignore[no-any-return]
-                agent_config, context_data, tool_args=tool_args, source_content=source_content
-            )
-
-        # HITL client has same signature as tool client; wrap for List consistency
-        if model_vendor == "hitl":
             result = client.invoke(
                 agent_config, context_data, tool_args=tool_args, source_content=source_content
             )
-            return [result]
+        elif model_vendor == "hitl":
+            # HITL client has same signature as tool client; wrap for List consistency
+            result = [
+                client.invoke(
+                    agent_config, context_data, tool_args=tool_args, source_content=source_content
+                )
+            ]
+        else:
+            # Standard client invocation (all providers, including Groq)
+            result = client.invoke(agent_config, prompt_config, context_data, schema)
+            # Single-response clients return single item, wrap in list for consistency
+            if model_vendor in SINGLE_RESPONSE_CLIENTS:
+                result = [result]
 
-        # Standard client invocation (all providers, including Groq)
-        result = client.invoke(agent_config, prompt_config, context_data, schema)
-
-        # Single-response clients return single item, wrap in list for consistency
-        if model_vendor in SINGLE_RESPONSE_CLIENTS:
-            result = [result]
+        elapsed = time.perf_counter() - start
+        logger.info(
+            "LLM call completed: vendor=%s action=%s elapsed=%.3fs",
+            model_vendor,
+            action_name,
+            elapsed,
+        )
 
         return result  # type: ignore[no-any-return]

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -80,11 +80,13 @@ class LineageEnricher(Enricher):
                     skipped = len(source_idx) - len(source_items)
                     if skipped:
                         logger.warning(
-                            "source_mapping[%d]: %d of %d indices out of bounds (source_data has %d items)",
+                            "source_mapping[%d]: %d of %d indices out of bounds "
+                            "(source_data has %d items, action=%s)",
                             i,
                             skipped,
                             len(source_idx),
                             source_data_len,
+                            context.action_name,
                         )
                     result.data[i] = LineageBuilder.add_lineage_tracking_from_sources(
                         obj=item,
@@ -101,10 +103,12 @@ class LineageEnricher(Enricher):
                         parent_item = context.source_data[source_idx]
                     else:
                         logger.warning(
-                            "source_mapping[%d] -> %d is out of bounds (source_data has %d items)",
+                            "source_mapping[%d] -> %d is out of bounds "
+                            "(source_data has %d items, action=%s)",
                             i,
                             source_idx,
                             source_data_len,
+                            context.action_name,
                         )
                         parent_item = None
             elif use_per_item_parent_lookup:
@@ -324,7 +328,12 @@ class EnrichmentPipeline:
                         )
                     )
                 except Exception:
-                    logger.exception("Enricher %s failed", enricher_name)
+                    logger.exception(
+                        "Enricher %s failed for action=%s source_guid=%s",
+                        enricher_name,
+                        context.action_name,
+                        result.source_guid,
+                    )
                     fire_event(
                         EnricherExecutedEvent(
                             enricher_name=enricher_name,

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -850,13 +850,23 @@ class SQLiteBackend(StorageBackend):
                 cursor.execute(query, params)
                 self.connection.commit()
                 deleted = cursor.rowcount
-                logger.debug(
-                    "Cleared %d dispositions: action=%s disp=%s",
-                    deleted,
-                    action_name,
-                    disposition,
-                    extra={"workflow_name": self.workflow_name},
-                )
+                if deleted > 0:
+                    logger.info(
+                        "Cleared %d dispositions: action=%s disp=%s record_id=%s",
+                        deleted,
+                        action_name,
+                        disposition,
+                        record_id,
+                        extra={"workflow_name": self.workflow_name},
+                    )
+                else:
+                    logger.debug(
+                        "Cleared %d dispositions: action=%s disp=%s",
+                        deleted,
+                        action_name,
+                        disposition,
+                        extra={"workflow_name": self.workflow_name},
+                    )
                 return deleted
             except sqlite3.Error as e:
                 self.connection.rollback()


### PR DESCRIPTION
## Summary
- Add record identity (action_name, source_guid) to enrichment pipeline exception handler
- Add LLM call duration logging via `time.perf_counter` to all ClientInvocationService paths
- Add progress context (completed/failed/total) to batch timeout warning
- Upgrade abandoned-records log from INFO to WARNING with error context
- Add action_name to batch context_map failure and enrichment source_mapping warnings
- Upgrade disposition clearing log to INFO when records are actually deleted

## Verification
- `ruff format --check` clean (937 files)
- `ruff check` clean (1 pre-existing import sort in unrelated test file)
- `pytest`: 7353 passed, 2 pre-existing failures (trailing comma repair — unrelated)
- No behavioral changes — logging only
- All changes verified with AFTER grep checks from VERIFICATION-CHECKS.md