### PR TITLE
docs: fix 6 documentation issues (P3-3)

### DIFF
--- a/.changes/unreleased/Under the Hood-20260522-P33000.yaml
+++ b/.changes/unreleased/Under the Hood-20260522-P33000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Fix documentation: correct README quick-start syntax, remove deleted Mistral provider references, add support_resolution example, update RELEASING.md to use changie, reconcile CLI manifest with actual commands"
+time: 2026-05-22T03:30:00.000000Z

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You will, until you have 15 steps, 3 models, batch retry, and a teammate asks wh
 |----------|-------|----------|-------|
 | OpenAI | Yes | Groq | Yes |
 | Anthropic | Yes | Cohere | Online only |
-| Google Gemini | Yes | Ollama (local) | Online only |
+| Google Gemini | Yes | Ollama (local) | Yes |
 
 Switch providers per-action by changing `model_vendor`.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ pip install agent-actions
 ## Quick start
 
 ```bash
-agac init my-project && cd my-project                # scaffold a project
-agac init --example contract_reviewer my-project     # or start from an example
+agac init my_project && cd my_project                # scaffold a project
+agac init example contract_reviewer my_project       # or start from an example
 agac run -a my_workflow                              # execute
 ```
 
@@ -114,7 +114,7 @@ Switch providers per-action by changing `model_vendor`.
 
 ```bash
 git clone https://github.com/Muizzkolapo/agent-actions.git && cd agent-actions
-pip install -e ".[dev]"
+uv sync
 pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,8 @@ You will, until you have 15 steps, 3 models, batch retry, and a teammate asks wh
 | Provider | Batch | Provider | Batch |
 |----------|-------|----------|-------|
 | OpenAI | Yes | Groq | Yes |
-| Anthropic | Yes | Mistral | Yes |
-| Google Gemini | Yes | Cohere | Online only |
-| Ollama (local) | Online only | | |
+| Anthropic | Yes | Cohere | Online only |
+| Google Gemini | Yes | Ollama (local) | Online only |
 
 Switch providers per-action by changing `model_vendor`.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You will, until you have 15 steps, 3 models, batch retry, and a teammate asks wh
 | [Product Listing Enrichment](examples/product_listing_enrichment) | Tool + LLM hybrid | LLM generates copy, tool fetches pricing, LLM optimizes |
 | [Book Catalog Enrichment](examples/book_catalog_enrichment) | Multi-step enrichment | BISAC classification, marketing copy, SEO metadata, reading level |
 | [Incident Triage](examples/incident_triage) | Parallel consensus | Severity classification, impact assessment, team assignment, response plan |
+| [Support Resolution](examples/support_resolution) | Non-JSON pipeline | Classify, route, and draft responses using `output_field` — works with any model including local Ollama |
 
 ## Providers
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,18 +21,20 @@ ruff format --check .
 
 ### 2. Bump the version
 
-Update the version in `pyproject.toml`:
+Use `changie batch` to batch unreleased changelog entries and bump the version automatically:
 
-```toml
-[project]
-version = "X.Y.Z"
+```bash
+task changelog:batch -- X.Y.Z
+task changelog:merge
 ```
+
+This updates the version in both `pyproject.toml` and `agent_actions/__version__.py` (configured via `.changie.yaml` replacements), and merges entries into `CHANGELOG.md`.
 
 Commit and push:
 
 ```bash
-git add pyproject.toml
-git commit -m "chore: bump version to X.Y.Z"
+git add pyproject.toml agent_actions/__version__.py CHANGELOG.md .changes/
+git commit -m "chore: release vX.Y.Z"
 git push origin main
 ```
 

--- a/agent_actions/cli/_MANIFEST.md
+++ b/agent_actions/cli/_MANIFEST.md
@@ -65,13 +65,6 @@
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the CLI application with the provided arguments. | - |
 | `main_entrypoint` | Function | Main entry point for the CLI application. | - |
 | `main` | Function | Entry point for the CLI tool when run from the command line. | - |
-| `project_paths_factory.py` | Shim | Re-export shim → `config.project_paths`. | `config` |
-| `find_config_file` | Function | Find a workflow configuration file with optional alternative-location lookup. Accepts `project_root: Path \| None`. | - |
-| `ProjectPaths` | Class | Container for project directory paths. | - |
-| &nbsp;&nbsp;&nbsp;&nbsp;└─ `to_dict` | Method | Convert paths to a dictionary of strings. | - |
-| `ProjectPathsFactory` | Class | Factory for creating project paths. | - |
-| &nbsp;&nbsp;&nbsp;&nbsp;└─ `get_agent_paths` | Method | Get the agent paths using the FileHandler. | - |
-| &nbsp;&nbsp;&nbsp;&nbsp;└─ `create_project_paths` | Method | Create project paths for the given agent. Accepts `project_root: Path \| None`. | - |
 | `run.py` | Module | Run command for the Agent Actions CLI. | `cli`, `docs`, `errors`, `orchestration`, `prompt_generation`, `validation` |
 | `RunCommand` | Class | Implementation of the run command. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute_validation_only` | Method | Execute pre-flight validation only, without running the workflow. | - |

--- a/agent_actions/cli/_MANIFEST.md
+++ b/agent_actions/cli/_MANIFEST.md
@@ -22,26 +22,39 @@
 | `RenderCommand` | Class | Implementation of the render command. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the render command. | - |
 | `render` | Function | Render Jinja2 templates in agent configuration files. | - |
+| `compile` | Function | Alias for render — compile workflow configuration. | - |
+| `dispositions.py` | Module | Inspect record-level processing dispositions per action. | `cli`, `storage`, `validation` |
+| `DispositionsCommand` | Class | Implementation of the dispositions command. | - |
+| &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the dispositions command. | - |
+| `dispositions` | Function | Inspect record-level processing dispositions per action. | - |
 | `docs.py` | Module | Documentation commands for agent-actions CLI. | `cli`, `docs` |
 | `docs` | Function | Generate and serve workflow documentation. | - |
 | `generate` | Function | Generate documentation data files. Accepts `project_root: Path \| None` (injected by `@requires_project`). | - |
 | `serve` | Function | Start HTTP server to view documentation. Accepts `project_root: Path \| None` (injected by `@requires_project`). | - |
 | `run_tests` | Function | Run Playwright tests to verify documentation site. Accepts `project_root: Path \| None` (injected by `@requires_project`). | - |
 | `dev` | Function | Start development environment. | - |
+| `example.py` | Module | Browse and install example projects. | `cli`, `configuration` |
+| `example` | Function | Example command group. | - |
+| `example_list` | Function | List available example projects from GitHub. | - |
+| `example_install` | Function | Install an example project. | - |
 | `init.py` | Module | Initialize command for the Agent Actions CLI. | `cli`, `configuration`, `errors`, `validation` |
 | `InitCommand` | Class | Implementation of the init command. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the init command. | - |
 | `init` | Function | Initialize a new Agent Actions project. | - |
-| `inspect.py` | Module | Inspect commands for the Agent Actions CLI. | `cli`, `errors`, `orchestration`, `prompt_generation`, `response_processing`, `services`, `utilities`, `validation` |
-| `BaseInspectCommand` | Class | Base class for inspect commands with common functionality. | - |
-| `DependenciesCommand` | Class | Show dependency analysis in table format. | - |
-| `GraphCommand` | Class | Show workflow structure as a visual dependency graph. | - |
-| `ActionCommand` | Class | Show detailed information about a single action. | - |
-| `ContextCommand` | Class | Show context debug information for a specific action. | - |
+| `inspect.py` | Module | Inspect command group for the Agent Actions CLI. | `cli` |
 | `inspect` | Function | Inspect workflow structure and data flow (command group). | - |
+| `inspect_base.py` | Module | Shared base class for all inspect subcommands. | `cli`, `orchestration`, `validation` |
+| `BaseInspectCommand` | Class | Base class for inspect commands with common functionality. | - |
+| `inspect_deps.py` | Module | Dependencies inspect subcommand. | `cli`, `orchestration` |
+| `DependenciesCommand` | Class | Show dependency analysis in table format. | - |
 | `dependencies` | Function | Analyze workflow dependencies and auto-inferred context. | - |
+| `inspect_graph.py` | Module | Graph inspect subcommand. | `cli`, `orchestration` |
+| `GraphCommand` | Class | Show workflow structure as a visual dependency graph. | - |
 | `graph` | Function | Show workflow structure as a dependency graph. | - |
+| `inspect_action.py` | Module | Action and context inspect subcommands. | `cli`, `orchestration`, `prompt_generation` |
+| `ActionCommand` | Class | Show detailed information about a single action. | - |
 | `action` | Function | Show details for a specific action. | - |
+| `ContextCommand` | Class | Show context debug information for a specific action. | - |
 | `context` | Function | Show context debug information for a specific action. | - |
 | `list_udfs.py` | Module | list-udfs command for the Agent Actions CLI. | `cli`, `input_loading`, `utilities` |
 | `ListUDFsCommand` | Class | Implementation of the list-udfs command. | - |
@@ -64,6 +77,12 @@
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute_validation_only` | Method | Execute pre-flight validation only, without running the workflow. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the run command. | - |
 | `run` | Function | Run agents with a specified agent configuration. | - |
+| `retry.py` | Module | Retry failed/exhausted records from a specific action forward. | `cli`, `storage`, `validation` |
+| `RetryCommand` | Class | Implementation of the retry command. | - |
+| &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the retry command. | - |
+| `retry` | Function | Retry failed/exhausted records from a specific action. | - |
+| `workflow_loader.py` | Module | Shared workflow loading helper for CLI commands. | `cli`, `validation` |
+| `load_workflow` | Function | Load and validate a workflow configuration. | - |
 | `schema.py` | Module | Schema command for the Agent Actions CLI. | `cli`, `errors`, `orchestration`, `prompt_generation`, `response_processing`, `services`, `utilities` |
 | `SchemaCommand` | Class | Implementation of the schema command. | - |
 | &nbsp;&nbsp;&nbsp;&nbsp;└─ `execute` | Method | Execute the schema command. | - |

--- a/agent_actions/skills/agac-agent-skills/references/cli-reference.md
+++ b/agent_actions/skills/agac-agent-skills/references/cli-reference.md
@@ -227,7 +227,7 @@ Run actions asynchronously via vendor batch APIs for up to 50% cost savings:
   model_name: gpt-4o-mini
 ```
 
-**Supported vendors:** OpenAI, Anthropic, Google (Gemini), Groq, Mistral, Ollama
+**Supported vendors:** OpenAI, Anthropic, Google (Gemini), Groq, Ollama
 
 **How it works:**
 1. Framework submits all records as a batch job to the vendor

--- a/agent_actions/skills/agac-agent-skills/references/yaml-schema.md
+++ b/agent_actions/skills/agac-agent-skills/references/yaml-schema.md
@@ -309,7 +309,6 @@ guard:
 | Anthropic | `anthropic` | claude-3-5-sonnet, claude-3-5-haiku |
 | Google | `google` | gemini-1.5-pro, gemini-1.5-flash |
 | Groq | `groq` | mixtral-8x7b, llama-3.1-70b |
-| Mistral | `mistral` | mistral-large, mistral-medium |
 | Cohere | `cohere` | command-r-plus |
 | Ollama | `ollama` | llama3, mistral |
 
@@ -347,7 +346,7 @@ actions:
 **Batch:** Asynchronous batch API processing
 - Up to 50% cost savings
 - 24-hour processing window
-- Supported: OpenAI, Anthropic, Google, Groq, Mistral
+- Supported: OpenAI, Anthropic, Google, Groq
 
 ## Environment Variables
 
@@ -358,7 +357,6 @@ actions:
 | `ANTHROPIC_API_KEY` | Alternative Anthropic key |
 | `GOOGLE_API_KEY` | Google Gemini API key |
 | `GROQ_API_KEY` | Groq API key |
-| `MISTRAL_API_KEY` | Mistral API key |
 | `OLLAMA_HOST` | Ollama server URL |
 | `AGENT_ACTIONS_DEBUG` | Enable debug mode (0/1) |
 | `AGENT_ACTIONS_LOG_LEVEL` | Log level (DEBUG, INFO, WARNING, ERROR) |

--- a/docs.agent-actions/docs/index.md
+++ b/docs.agent-actions/docs/index.md
@@ -11,7 +11,7 @@ An agentic workflow engine that runs in your terminal. Define LLM pipelines in Y
 
 ## Get started in 30 seconds
 
-**Prerequisites:** Python 3.11+ and an API key from any supported provider (OpenAI, Anthropic, Gemini, Groq, Mistral, Ollama).
+**Prerequisites:** Python 3.11+ and an API key from any supported provider (OpenAI, Anthropic, Gemini, Groq, Ollama).
 
 **Install Agent Actions:**
 
@@ -53,7 +53,7 @@ See [Installation](./installation.md) for configuration options or [Troubleshoot
 
 **Validate every output:** Every LLM response is validated against JSON Schema. Invalid outputs trigger automatic reprompting until they conform.
 
-**Mix and match providers:** Chain OpenAI, Anthropic, Gemini, Groq, Mistral, and Ollama in the same workflow. Switch models per-action.
+**Mix and match providers:** Chain OpenAI, Anthropic, Gemini, Groq, and Ollama in the same workflow. Switch models per-action.
 
 **Catch errors before they cost you:** Pre-flight validation checks your config, variables, and dependency wiring before any API calls are made.
 

--- a/docs.agent-actions/docs/installation.md
+++ b/docs.agent-actions/docs/installation.md
@@ -81,7 +81,6 @@ Agent Actions automatically loads `.env` files from the current directory.
 | Anthropic | `ANTHROPIC_API_KEY` | Any model supported by the Anthropic API |
 | Google | `GEMINI_API_KEY` | Any model supported by the Gemini API |
 | Groq | `GROQ_API_KEY` | Any model supported by the Groq API |
-| Mistral | `MISTRAL_API_KEY` | Any model supported by the Mistral API |
 | Cohere | `COHERE_API_KEY` | Any model supported by the Cohere API |
 | Ollama | (local) | Any model you've pulled locally |
 

--- a/docs.agent-actions/docs/reference/cli/troubleshooting.md
+++ b/docs.agent-actions/docs/reference/cli/troubleshooting.md
@@ -41,7 +41,6 @@ Redirect debug output to a file for complex issues: `AGENT_ACTIONS_LOG_LEVEL=DEB
 | `OPENAI_API_KEY` | OpenAI API key |
 | `GEMINI_API_KEY` | Google Gemini API key |
 | `GROQ_API_KEY` | Groq API key |
-| `MISTRAL_API_KEY` | Mistral API key |
 | `COHERE_API_KEY` | Cohere API key |
 
 ## Exit Codes

--- a/docs.agent-actions/docs/reference/configuration/index.md
+++ b/docs.agent-actions/docs/reference/configuration/index.md
@@ -125,7 +125,7 @@ actions:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `model_vendor` | string | Provider: openai, anthropic, google, groq, mistral, cohere, ollama_local, ollama_cloud |
+| `model_vendor` | string | Provider: openai, anthropic, google, groq, cohere, ollama_local, ollama_cloud |
 | `model_name` | string | Model identifier (e.g., gpt-4o-mini) |
 | `api_key` | string | Environment variable name for API key |
 | `temperature` | float | LLM temperature (0.0-2.0) |
@@ -135,7 +135,7 @@ actions:
 
 :::note Vendor-Specific Parameter Mapping
 Generation parameters (`temperature`, `max_tokens`, `top_p`, `stop`) are mapped to vendor-specific API keys automatically:
-- **OpenAI / Groq / Mistral**: Parameters passed through as-is. OpenAI and Groq also support `frequency_penalty` and `presence_penalty`.
+- **OpenAI / Groq**: Parameters passed through as-is. OpenAI and Groq also support `frequency_penalty` and `presence_penalty`.
 - **Anthropic**: `stop` → `stop_sequences` (string values are wrapped in a list)
 - **Gemini**: `max_tokens` → `max_output_tokens`, `stop` → `stop_sequences`
 - **Cohere**: `top_p` → `p`, `stop` → `stop_sequences`
@@ -195,7 +195,6 @@ Tool actions support both `Record` and `File` granularity. File granularity allo
 | Anthropic | `anthropic` | ✅ | claude-sonnet-4-20250514 |
 | Google | `google` | ✅ | gemini-2.0-flash |
 | Groq | `groq` | ✅ | llama-3.3-70b-versatile |
-| Mistral | `mistral` | ✅ | mistral-large-latest |
 | Cohere | `cohere` | ❌ | command-r-plus |
 | Ollama | `ollama` | ✅ | llama3, mistral |
 
@@ -215,7 +214,6 @@ api_key: OPENAI_API_KEY  # Uses $OPENAI_API_KEY from environment
 | `ANTHROPIC_API_KEY` | Anthropic |
 | `GOOGLE_API_KEY` | Google Gemini |
 | `GROQ_API_KEY` | Groq |
-| `MISTRAL_API_KEY` | Mistral |
 | `OLLAMA_HOST` | Ollama (default: `http://localhost:11434`) |
 
 ### Runtime Variables

--- a/docs.agent-actions/docs/reference/execution/retry.md
+++ b/docs.agent-actions/docs/reference/execution/retry.md
@@ -54,7 +54,7 @@ For invalid LLM outputs, Agent Actions uses [reprompting](../validation/reprompt
 
 ## Provider Support
 
-All provider-specific errors are normalized into unified `RateLimitError` and `NetworkError` types, ensuring consistent retry behavior across OpenAI, Anthropic, Gemini, Cohere, Mistral, Groq, and Ollama.
+All provider-specific errors are normalized into unified `RateLimitError` and `NetworkError` types, ensuring consistent retry behavior across OpenAI, Anthropic, Gemini, Cohere, Groq, and Ollama.
 
 ## Best Practices
 

--- a/docs.agent-actions/docs/reference/execution/run-modes.md
+++ b/docs.agent-actions/docs/reference/execution/run-modes.md
@@ -67,7 +67,6 @@ defaults:
 | Anthropic | Yes | ~50% |
 | Google Gemini | Yes | Varies |
 | Groq | Yes | Varies |
-| Mistral | Yes | Varies |
 | Ollama | Yes (local) | N/A |
 
 ### Batch Commands

--- a/docs.agent-actions/docs/reference/index.md
+++ b/docs.agent-actions/docs/reference/index.md
@@ -93,4 +93,4 @@ Consider what happens when `extract_facts` returns an empty list. The guard on `
 
 ## Supported Providers
 
-Agent Actions supports OpenAI, Anthropic, Google, Groq, Mistral, Cohere, and Ollama. You can mix providers in the same agentic workflow—use different models for different actions based on cost or capability. See [Configuration](./configuration/) for setup details.
+Agent Actions supports OpenAI, Anthropic, Google, Groq, Cohere, and Ollama. You can mix providers in the same agentic workflow—use different models for different actions based on cost or capability. See [Configuration](./configuration/) for setup details.

--- a/docs.agent-actions/docs/reference/validation/index.md
+++ b/docs.agent-actions/docs/reference/validation/index.md
@@ -60,7 +60,6 @@ Feature support varies by vendor:
 | Anthropic | ✅ | ✅ | ✅ | ✅ |
 | Google | ✅ | ✅ | ✅ | ✅ |
 | Groq | ✅ | ✅ | ✅ | ❌ |
-| Mistral | ✅ | ✅ | ✅ | ❌ |
 | Ollama | ✅ | ✅ | ✅ | ✅ |
 
 ## Schema Validation

--- a/docs.agent-actions/docs/tutorials/index.md
+++ b/docs.agent-actions/docs/tutorials/index.md
@@ -171,7 +171,7 @@ actions:
 ```yaml
 default_agent_config:
   api_key: OPENAI_API_KEY        # Environment variable name for your API key
-  model_vendor: openai           # openai, anthropic, google, groq, mistral, ollama_local, ollama_cloud
+  model_vendor: openai           # openai, anthropic, google, groq, ollama_local, ollama_cloud
   model_name: gpt-4o-mini        # Any model supported by your provider
 
 schema_path: schema

--- a/docs.agent-actions/docs/tutorials/index.md
+++ b/docs.agent-actions/docs/tutorials/index.md
@@ -171,7 +171,7 @@ actions:
 ```yaml
 default_agent_config:
   api_key: OPENAI_API_KEY        # Environment variable name for your API key
-  model_vendor: openai           # openai, anthropic, google, groq, ollama_local, ollama_cloud
+  model_vendor: openai           # openai, anthropic, google, groq, cohere, ollama_local, ollama_cloud
   model_name: gpt-4o-mini        # Any model supported by your provider
 
 schema_path: schema


### PR DESCRIPTION
## Summary

Fixes 6 documentation issues that mislead users or contradict the codebase:

1. **README quick-start syntax** — `agac init --example` is actually a subcommand (`agac init example`); Contributing section used `pip install` but project uses `uv`
2. **Mistral listed but deleted** — Removed all standalone Mistral provider references from README, docs site (8 files), and skills references. The provider code was deleted in P3-1 but docs still listed it. Ollama references to running Mistral models are preserved.
3. **Missing support_resolution from README** — Added to examples table (existed in examples/ and docs site but was missing from README)
4. **CONTRIBUTING.md pip** — Already correct (`task dev`); the actual pip reference was in the README Contributing section, fixed in issue 1
5. **CHANGELOG unreleased entries** — Skipped: the 108 entries in `.changes/unreleased/` are managed by changie and will be batched on release via `changie batch`. Manually grouping them would conflict with changie's workflow.
6. **RELEASING.md version dual-source** — Updated to use `changie batch` which updates both `pyproject.toml` and `agent_actions/__version__.py` via `.changie.yaml` replacements
7. **CLI manifest stale** — Added missing modules (dispositions, example, retry, workflow_loader) and split monolithic inspect entry into actual source files (inspect_base, inspect_deps, inspect_graph, inspect_action)

## Verification

- `ruff check` / `ruff format --check` — clean (1 pre-existing error in unrelated test file)
- `pytest` — 7353 passed, 2 pre-existing failures (trailing comma JSON repair, unrelated)
- `grep -ri "mistral" README.md docs.agent-actions/docs/installation.md | grep -v ollama` — 0 matches
- All changes are docs-only (.md and .yaml files) — no code changes