### PR TITLE
fix: eliminate false-positive tests (P3-4)

### DIFF
--- a/.changes/unreleased/Under the Hood-20260522-P34000.yaml
+++ b/.changes/unreleased/Under the Hood-20260522-P34000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Fix false-positive tests: strengthen weak assertions, add argument checks to assert_called_once, remove flaky sleeps from thread tests, remove vestigial /tmp cleanup fixture"
+time: 2026-05-22T03:40:00.000000Z

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import os
-import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -94,16 +92,6 @@ def sample_agent_config_no_json_mode() -> dict[str, Any]:
         "json_mode": False,
         "prompt": "You are helpful",
     }
-
-
-@pytest.fixture(autouse=True)
-def cleanup_temp_files():
-    """Automatically cleanup temporary files after each test."""
-    yield
-    temp_dirs = ["/tmp/agent_actions_test", "/tmp/test_output", "/tmp/test_config"]
-    for temp_dir in temp_dirs:
-        if os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/parser/test_schema_array_conversion.py
+++ b/tests/core/parser/test_schema_array_conversion.py
@@ -286,9 +286,12 @@ class TestEdgeCases:
             "items": {"type": "string"},
         }
 
-        # Should not crash
+        # Should not crash and should wrap array in an object property
         result = compile_unified_schema(schema, "openai")
-        assert result is not None, "Should compile successfully"
+        assert isinstance(result, dict)
+        props = result["schema"]["properties"]
+        assert "bounded_array" in props
+        assert props["bounded_array"]["type"] == "array"
 
     def test_empty_string_items_type(self):
         """Items with empty string type should be handled."""
@@ -298,6 +301,10 @@ class TestEdgeCases:
             "items": {"type": ""},  # Empty type string
         }
 
-        # Should default to object handling
+        # Should default to object handling and wrap array in object property
         result = compile_unified_schema(schema, "anthropic")
-        assert result is not None, "Should handle gracefully"
+        assert isinstance(result, list)
+        assert len(result) == 1
+        props = result[0]["input_schema"]["properties"]
+        assert "test" in props
+        assert props["test"]["type"] == "array"

--- a/tests/core/utils/test_processor_utils_integration.py
+++ b/tests/core/utils/test_processor_utils_integration.py
@@ -43,7 +43,6 @@ class TestProcessorUtilsIntegration:
                 correlation_id = VersionIdGenerator.get_or_create_version_correlation_id(
                     source_guid, version_base_name, self.get_test_session_id()
                 )
-                time.sleep(0.001)
                 with results_lock:
                     if source_guid not in results:
                         results[source_guid] = []
@@ -86,7 +85,6 @@ class TestProcessorUtilsIntegration:
                         position, version_base_name, self.get_test_session_id(), file_context
                     )
                 )
-                time.sleep(0.002)
                 with results_lock:
                     if position not in results:
                         results[position] = []

--- a/tests/core/utils/test_processor_utils_thread_safety.py
+++ b/tests/core/utils/test_processor_utils_thread_safety.py
@@ -3,7 +3,6 @@ Tests for ProcessorUtils thread safety, specifically the loop correlation ID rac
 """
 
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
@@ -44,7 +43,6 @@ class TestProcessorUtilsThreadSafety:
                     source_guid, version_base_name, self.get_test_session_id()
                 )
                 local_ids.append(correlation_id)
-                time.sleep(0.001)
             with correlation_ids_lock:
                 correlation_ids.extend(local_ids)
 
@@ -147,8 +145,8 @@ class TestProcessorUtilsThreadSafety:
             clear_completed.set()
 
         def access_worker():
-            """Worker that tries to access the registry during clearing."""
-            time.sleep(0.01)
+            """Worker that accesses the registry after clearing."""
+            clear_completed.wait()
             return VersionIdGenerator.get_or_create_version_correlation_id(
                 source_guid, version_base_name, self.get_test_session_id()
             )

--- a/tests/integration/test_retry_reprompt_audit.py
+++ b/tests/integration/test_retry_reprompt_audit.py
@@ -570,7 +570,9 @@ class TestRepromptServiceFactory:
 
     def test_none_config_with_validator_returns_service(self):
         svc = create_reprompt_service_from_config(None, validator=_StubValidator([True]))
-        assert svc is not None
+        assert isinstance(svc, RepromptService)
+        assert svc.max_attempts == 2
+        assert svc.on_exhausted == "return_last"
 
     def test_config_missing_validation_no_validator_raises(self):
         with pytest.raises(ValueError, match="Reprompt requires a validator"):

--- a/tests/logging/events/test_factory.py
+++ b/tests/logging/events/test_factory.py
@@ -111,8 +111,8 @@ class TestLoggerFactoryConfig:
         with patch.dict("os.environ", {"AGENT_ACTIONS_LOG_LEVEL": "WARNING"}):
             LoggerFactory.initialize()
             config = LoggerFactory.get_config()
-            # Config should exist
-            assert config is not None
+            assert isinstance(config, LoggingConfig)
+            assert config.default_level == "WARNING"
 
 
 class TestLoggerFactoryLoggingBridge:

--- a/tests/workflow/test_runner.py
+++ b/tests/workflow/test_runner.py
@@ -135,7 +135,7 @@ class TestResolveStartNodeDirectories:
         mock_resolve.return_value = mock_result
         result = runner._resolve_start_node_directories(tmp_path, "agent")
         assert result == [staging]
-        mock_resolve.assert_called_once()
+        mock_resolve.assert_called_once_with(tmp_path, None, "agent")
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +222,7 @@ class TestSetupDirectories:
         config = {"agent_type": "analyzer", "dependencies": ["dep1"]}
         dirs, output = runner.setup_directories(str(tmp_path), config, None)
         assert dirs == [str(dep_dir)]
-        mock_dep.assert_called_once()
+        mock_dep.assert_called_once_with(tmp_path, ["dep1"], "analyzer")
 
     def test_has_previous_agent_type(self, runner, tmp_path):
         config = {"agent_type": "analyzer"}

--- a/tests/workflow/test_stale_completion_verification.py
+++ b/tests/workflow/test_stale_completion_verification.py
@@ -510,5 +510,10 @@ class TestCoordinatorSequentialVerification:
         )
 
         assert result is False
-        mock.services.core.action_executor.execute_action_sync.assert_called_once()
+        mock.services.core.action_executor.execute_action_sync.assert_called_once_with(
+            "write_description",
+            action_idx=0,
+            action_config={"agent_type": "write_description"},
+            is_last_action=True,
+        )
         mock.event_logger.log_action_skip.assert_not_called()


### PR DESCRIPTION
## Summary
- Remove vestigial `/tmp` cleanup fixture from conftest.py — these hardcoded paths are never created by any test
- Strengthen 3 bare `assert_called_once()` calls to `assert_called_once_with(expected_args)` in test_runner.py and test_stale_completion_verification.py
- Replace 4 weak `is not None`-only assertions with actual value checks in test_schema_array_conversion.py, test_factory.py, test_retry_reprompt_audit.py
- Remove 3 unnecessary `time.sleep()` calls from thread safety tests; replace sleep-based race with `Event.wait()` in test_processor_utils_thread_safety.py

## Verification
- `ruff check` and `ruff format --check` pass on all changed files
- All 7248 tests pass (2 skipped, 0 failures)
- Pre-existing circular import in test_retry_reprompt_audit.py is unrelated