### PR TITLE
feat: add SQLite database maintenance operations (P4-2)

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260522-P42000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260522-P42000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add SQLite database maintenance: WAL checkpoint after workflow completion, stale disposition cleanup, configurable prompt trace retention, and optional source data TTL"
+time: 2026-05-22T04:20:00.000000Z

--- a/agent_actions/config/defaults.py
+++ b/agent_actions/config/defaults.py
@@ -5,6 +5,8 @@ class StorageDefaults:
     """Defaults for storage backends."""
 
     SQLITE_LOCK_TIMEOUT_SECONDS: float = 30.0
+    PROMPT_TRACE_RETENTION_RUNS: int = 10
+    SOURCE_DATA_TTL_DAYS: int | None = None  # None = keep forever
 
 
 class LockDefaults:

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -293,6 +293,17 @@ class StorageBackend(ABC):
         """
         raise NotImplementedError(f"{type(self).__name__} must implement delete_target()")
 
+    def perform_maintenance(  # noqa: B027
+        self,
+        prompt_trace_retention_runs: int = 10,
+        source_data_ttl_days: int | None = None,
+    ) -> None:
+        """Run post-workflow maintenance (WAL checkpoint, cleanup stale data).
+
+        Default is no-op. SQLiteBackend overrides with actual maintenance.
+        """
+        pass
+
     def close(self) -> None:  # noqa: B027
         """Close the storage backend and release resources."""
         pass

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -5,7 +5,11 @@ from enum import Enum
 from types import TracebackType
 from typing import Any
 
+from agent_actions.config.defaults import StorageDefaults
 from agent_actions.record.lifecycle_read import reset_for_downstream, validate_lifecycle_batch
+
+_MAINTENANCE_RETENTION_DEFAULT = StorageDefaults.PROMPT_TRACE_RETENTION_RUNS
+_MAINTENANCE_TTL_DEFAULT = StorageDefaults.SOURCE_DATA_TTL_DAYS
 
 NODE_LEVEL_RECORD_ID = "__node__"
 """Sentinel record_id for node-level disposition signals."""
@@ -295,8 +299,8 @@ class StorageBackend(ABC):
 
     def perform_maintenance(  # noqa: B027
         self,
-        prompt_trace_retention_runs: int = 10,
-        source_data_ttl_days: int | None = None,
+        prompt_trace_retention_runs: int = _MAINTENANCE_RETENTION_DEFAULT,
+        source_data_ttl_days: int | None = _MAINTENANCE_TTL_DEFAULT,
     ) -> None:
         """Run post-workflow maintenance (WAL checkpoint, cleanup stale data).
 

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -1221,6 +1221,172 @@ class SQLiteBackend(StorageBackend):
             size /= 1024
         return f"{size:.1f} TB"
 
+    # ------------------------------------------------------------------
+    # Maintenance operations
+    # ------------------------------------------------------------------
+
+    def perform_maintenance(
+        self,
+        prompt_trace_retention_runs: int = 10,
+        source_data_ttl_days: int | None = None,
+    ) -> None:
+        """Run post-workflow maintenance: WAL checkpoint, disposition cleanup,
+        prompt trace retention, and source data TTL.
+
+        All operations are idempotent and safe to run concurrently.
+        """
+        self._checkpoint_wal()
+        self._cleanup_stale_dispositions()
+        self._enforce_prompt_trace_retention(prompt_trace_retention_runs)
+        if source_data_ttl_days is not None:
+            self._enforce_source_data_ttl(source_data_ttl_days)
+
+    def _checkpoint_wal(self) -> None:
+        """Checkpoint and truncate the WAL file to reclaim disk space."""
+        with self._lock:
+            try:
+                result = self.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+                busy, log_pages, checkpointed = result if result else (0, 0, 0)
+                if log_pages > 0 or checkpointed > 0:
+                    logger.info(
+                        "WAL checkpoint: %d pages checkpointed, %d busy",
+                        checkpointed,
+                        busy,
+                        extra={"workflow_name": self.workflow_name},
+                    )
+                else:
+                    logger.debug(
+                        "WAL checkpoint: nothing to checkpoint",
+                        extra={"workflow_name": self.workflow_name},
+                    )
+            except sqlite3.Error as e:
+                logger.warning(
+                    "WAL checkpoint failed (non-fatal): %s",
+                    e,
+                    extra={"workflow_name": self.workflow_name},
+                )
+
+    def _cleanup_stale_dispositions(self) -> None:
+        """Remove disposition records for items that completed successfully on re-run.
+
+        When a workflow re-runs, records that previously FAILED may now succeed.
+        This removes the old FAILED/EXHAUSTED dispositions for records that have
+        a newer SUCCESS disposition, preventing stale data from accumulating.
+        """
+        with self._lock:
+            cursor = self.connection.cursor()
+            try:
+                cursor.execute("""
+                    DELETE FROM record_disposition
+                    WHERE id IN (
+                        SELECT old.id
+                        FROM record_disposition old
+                        INNER JOIN record_disposition success
+                            ON old.action_name = success.action_name
+                            AND old.record_id = success.record_id
+                        WHERE success.disposition = 'success'
+                          AND old.disposition IN ('failed', 'exhausted')
+                          AND old.id < success.id
+                    )
+                """)
+                self.connection.commit()
+                deleted = cursor.rowcount
+                if deleted > 0:
+                    logger.info(
+                        "Cleaned up %d stale disposition records",
+                        deleted,
+                        extra={"workflow_name": self.workflow_name},
+                    )
+            except sqlite3.Error as e:
+                self.connection.rollback()
+                logger.warning(
+                    "Disposition cleanup failed (non-fatal): %s",
+                    e,
+                    extra={"workflow_name": self.workflow_name},
+                )
+
+    def _enforce_prompt_trace_retention(self, retention_runs: int) -> None:
+        """Delete prompt traces older than the N most recent workflow runs.
+
+        Uses created_at timestamps to identify run boundaries. Traces from the
+        most recent ``retention_runs`` distinct runs are kept.
+        """
+        if retention_runs < 1:
+            return
+        with self._lock:
+            cursor = self.connection.cursor()
+            try:
+                # Find the Nth most recent distinct run timestamp boundary.
+                # Each workflow run writes traces with created_at within the same
+                # second range, so we use DATE(created_at) as a run boundary.
+                cursor.execute(
+                    """
+                    SELECT DISTINCT DATE(created_at) as run_date
+                    FROM prompt_trace
+                    ORDER BY run_date DESC
+                    LIMIT 1 OFFSET ?
+                    """,
+                    (retention_runs - 1,),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    # Fewer runs than retention window — nothing to delete
+                    return
+
+                cutoff_date = row[0]
+                cursor.execute(
+                    "DELETE FROM prompt_trace WHERE DATE(created_at) < ?",
+                    (cutoff_date,),
+                )
+                self.connection.commit()
+                deleted = cursor.rowcount
+                if deleted > 0:
+                    logger.info(
+                        "Pruned %d prompt traces older than %s (keeping %d runs)",
+                        deleted,
+                        cutoff_date,
+                        retention_runs,
+                        extra={"workflow_name": self.workflow_name},
+                    )
+            except sqlite3.Error as e:
+                self.connection.rollback()
+                logger.warning(
+                    "Prompt trace retention enforcement failed (non-fatal): %s",
+                    e,
+                    extra={"workflow_name": self.workflow_name},
+                )
+
+    def _enforce_source_data_ttl(self, ttl_days: int) -> None:
+        """Delete source_data rows older than ``ttl_days`` days."""
+        if ttl_days < 1:
+            return
+        with self._lock:
+            cursor = self.connection.cursor()
+            try:
+                cursor.execute(
+                    """
+                    DELETE FROM source_data
+                    WHERE created_at < datetime('now', '-' || ? || ' days')
+                    """,
+                    (ttl_days,),
+                )
+                self.connection.commit()
+                deleted = cursor.rowcount
+                if deleted > 0:
+                    logger.info(
+                        "Deleted %d source_data rows older than %d days",
+                        deleted,
+                        ttl_days,
+                        extra={"workflow_name": self.workflow_name},
+                    )
+            except sqlite3.Error as e:
+                self.connection.rollback()
+                logger.warning(
+                    "Source data TTL enforcement failed (non-fatal): %s",
+                    e,
+                    extra={"workflow_name": self.workflow_name},
+                )
+
     def close(self) -> None:
         """Close the database connection."""
         with self._lock:

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -11,6 +11,9 @@ from typing import Any
 from agent_actions.config.defaults import StorageDefaults
 from agent_actions.errors.configuration import ConfigValidationError
 from agent_actions.storage.backend import (
+    DISPOSITION_EXHAUSTED,
+    DISPOSITION_FAILED,
+    DISPOSITION_SUCCESS,
     NODE_LEVEL_RECORD_ID,
     VALID_DISPOSITIONS,
     Disposition,
@@ -1227,8 +1230,8 @@ class SQLiteBackend(StorageBackend):
 
     def perform_maintenance(
         self,
-        prompt_trace_retention_runs: int = 10,
-        source_data_ttl_days: int | None = None,
+        prompt_trace_retention_runs: int = StorageDefaults.PROMPT_TRACE_RETENTION_RUNS,
+        source_data_ttl_days: int | None = StorageDefaults.SOURCE_DATA_TTL_DAYS,
     ) -> None:
         """Run post-workflow maintenance: WAL checkpoint, disposition cleanup,
         prompt trace retention, and source data TTL.
@@ -1276,7 +1279,8 @@ class SQLiteBackend(StorageBackend):
         with self._lock:
             cursor = self.connection.cursor()
             try:
-                cursor.execute("""
+                cursor.execute(
+                    """
                     DELETE FROM record_disposition
                     WHERE id IN (
                         SELECT old.id
@@ -1284,11 +1288,13 @@ class SQLiteBackend(StorageBackend):
                         INNER JOIN record_disposition success
                             ON old.action_name = success.action_name
                             AND old.record_id = success.record_id
-                        WHERE success.disposition = 'success'
-                          AND old.disposition IN ('failed', 'exhausted')
+                        WHERE success.disposition = ?
+                          AND old.disposition IN (?, ?)
                           AND old.id < success.id
                     )
-                """)
+                    """,
+                    (DISPOSITION_SUCCESS, DISPOSITION_FAILED, DISPOSITION_EXHAUSTED),
+                )
                 self.connection.commit()
                 deleted = cursor.rowcount
                 if deleted > 0:
@@ -1334,8 +1340,10 @@ class SQLiteBackend(StorageBackend):
                     return
 
                 cutoff_date = row[0]
+                # Compare created_at directly (not via DATE()) so indexes can be used.
+                # cutoff_date is "YYYY-MM-DD"; all timestamps before that date sort lower.
                 cursor.execute(
-                    "DELETE FROM prompt_trace WHERE DATE(created_at) < ?",
+                    "DELETE FROM prompt_trace WHERE created_at < ?",
                     (cutoff_date,),
                 )
                 self.connection.commit()

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 from rich.console import Console
 
+from agent_actions.config.defaults import StorageDefaults
 from agent_actions.errors import ConfigurationError, enrich_exception_context
 from agent_actions.errors.preflight import PreFlightValidationError
 from agent_actions.input.preprocessing.parsing.parser import WhereClauseParser
@@ -443,11 +444,13 @@ class AgentWorkflow:
 
                 if state_mgr.is_workflow_complete():
                     self.event_logger.finalize_workflow(elapsed_time=duration)
+                    self._run_storage_maintenance()
                     return ("success", {})
 
                 if state_mgr.is_workflow_done():
                     self.state.failed = True
                     self.event_logger.finalize_workflow(elapsed_time=duration)
+                    self._run_storage_maintenance()
                     failed = state_mgr.get_failed_actions(self.execution_order)
                     return ("completed_with_failures", {"failed": failed})
 
@@ -534,12 +537,14 @@ class AgentWorkflow:
 
                 if state_mgr.is_workflow_complete():
                     self.event_logger.finalize_workflow(elapsed_time=duration)
+                    self._run_storage_maintenance()
                     return ("success", {})
 
                 if state_mgr.is_workflow_done():
                     # All actions reached a terminal state but some failed
                     self.state.failed = True
                     self.event_logger.finalize_workflow(elapsed_time=duration)
+                    self._run_storage_maintenance()
                     failed = state_mgr.get_failed_actions(self.execution_order)
                     return ("completed_with_failures", {"failed": failed})
 
@@ -557,6 +562,30 @@ class AgentWorkflow:
                 )
                 self.event_logger.handle_workflow_error(e, elapsed_time=duration)
                 raise
+
+    def _run_storage_maintenance(self) -> None:
+        """Run post-workflow storage maintenance (WAL checkpoint, cleanup)."""
+        backend = getattr(self, "storage_backend", None)
+        if backend is None:
+            return
+
+        storage_config: dict = {}
+        config_mgr = getattr(self.config, "manager", None)
+        if config_mgr is not None:
+            user_cfg = getattr(config_mgr, "user_config", None)
+            if isinstance(user_cfg, dict):
+                storage_config = user_cfg.get("storage", {})
+
+        backend.perform_maintenance(
+            prompt_trace_retention_runs=storage_config.get(
+                "prompt_trace_retention_runs",
+                StorageDefaults.PROMPT_TRACE_RETENTION_RUNS,
+            ),
+            source_data_ttl_days=storage_config.get(
+                "source_data_ttl_days",
+                StorageDefaults.SOURCE_DATA_TTL_DAYS,
+            ),
+        )
 
     def _run_single_action(self, idx: int, action_name: str, total_actions: int) -> bool:
         """Run a single action in sequential mode. Return True if workflow should stop."""

--- a/tests/unit/storage/test_sqlite_maintenance.py
+++ b/tests/unit/storage/test_sqlite_maintenance.py
@@ -1,0 +1,295 @@
+"""Tests for SQLite storage backend maintenance operations (P4-2)."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+@pytest.fixture()
+def backend(tmp_path):
+    """Create and initialize a SQLiteBackend for testing."""
+    db_path = str(tmp_path / "test.db")
+    b = SQLiteBackend(db_path, "test_workflow")
+    b.initialize()
+    return b
+
+
+class TestWalCheckpoint:
+    """Tests for WAL checkpoint after workflow completion."""
+
+    def test_checkpoint_succeeds_on_clean_db(self, backend):
+        """WAL checkpoint runs without error on a clean database."""
+        backend._checkpoint_wal()
+
+    def test_checkpoint_after_writes(self, backend):
+        """WAL checkpoint runs after data has been written."""
+        backend.write_source("file1.json", [{"source_guid": "g1", "data": "test"}])
+        backend._checkpoint_wal()
+
+    def test_checkpoint_is_idempotent(self, backend):
+        """Multiple WAL checkpoints in sequence are safe."""
+        backend._checkpoint_wal()
+        backend._checkpoint_wal()
+
+
+class TestDispositionCleanup:
+    """Tests for stale disposition cleanup on successful re-run."""
+
+    def _insert_disposition(self, backend, action, record_id, disposition, reason=None):
+        """Insert a disposition row directly (bypassing DELETE-before-INSERT)."""
+        with backend._lock:
+            backend.connection.execute(
+                """
+                INSERT INTO record_disposition
+                (action_name, record_id, disposition, reason, created_at)
+                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                """,
+                (action, record_id, disposition, reason),
+            )
+            backend.connection.commit()
+
+    def test_removes_old_failed_when_success_exists(self, backend):
+        """Old FAILED disposition removed when newer SUCCESS exists for same record."""
+        # Insert directly to simulate dispositions accumulated across runs
+        self._insert_disposition(backend, "action_a", "record_1", "failed", "error")
+        self._insert_disposition(backend, "action_a", "record_1", "success")
+
+        backend._cleanup_stale_dispositions()
+
+        rows = backend.get_disposition("action_a", record_id="record_1")
+        dispositions = [r["disposition"] for r in rows]
+        assert "success" in dispositions
+        assert "failed" not in dispositions
+
+    def test_removes_old_exhausted_when_success_exists(self, backend):
+        """Old EXHAUSTED disposition removed when newer SUCCESS exists."""
+        self._insert_disposition(backend, "action_a", "record_1", "exhausted", "retries")
+        self._insert_disposition(backend, "action_a", "record_1", "success")
+
+        backend._cleanup_stale_dispositions()
+
+        rows = backend.get_disposition("action_a", record_id="record_1")
+        dispositions = [r["disposition"] for r in rows]
+        assert "success" in dispositions
+        assert "exhausted" not in dispositions
+
+    def test_preserves_failed_without_success(self, backend):
+        """FAILED disposition kept when no SUCCESS exists for that record."""
+        self._insert_disposition(backend, "action_a", "record_1", "failed", "error")
+
+        backend._cleanup_stale_dispositions()
+
+        rows = backend.get_disposition("action_a", record_id="record_1")
+        assert len(rows) == 1
+        assert rows[0]["disposition"] == "failed"
+
+    def test_preserves_other_dispositions(self, backend):
+        """Non-failed/exhausted dispositions are never removed by cleanup."""
+        self._insert_disposition(backend, "action_a", "record_1", "filtered", "guard")
+        self._insert_disposition(backend, "action_a", "record_1", "success")
+
+        backend._cleanup_stale_dispositions()
+
+        rows = backend.get_disposition("action_a", record_id="record_1")
+        dispositions = [r["disposition"] for r in rows]
+        assert "filtered" in dispositions
+        assert "success" in dispositions
+
+    def test_does_not_remove_across_actions(self, backend):
+        """SUCCESS in action_b does not affect FAILED in action_a."""
+        self._insert_disposition(backend, "action_a", "record_1", "failed", "error")
+        self._insert_disposition(backend, "action_b", "record_1", "success")
+
+        backend._cleanup_stale_dispositions()
+
+        rows = backend.get_disposition("action_a", record_id="record_1")
+        assert len(rows) == 1
+        assert rows[0]["disposition"] == "failed"
+
+    def test_cleanup_is_idempotent(self, backend):
+        """Running cleanup twice produces the same result."""
+        self._insert_disposition(backend, "action_a", "record_1", "failed", "error")
+        self._insert_disposition(backend, "action_a", "record_1", "success")
+
+        backend._cleanup_stale_dispositions()
+        backend._cleanup_stale_dispositions()
+
+        rows = backend.get_disposition("action_a", record_id="record_1")
+        dispositions = [r["disposition"] for r in rows]
+        assert dispositions == ["success"]
+
+
+class TestPromptTraceRetention:
+    """Tests for prompt trace retention policy."""
+
+    def _insert_trace(self, backend, action, record_id, created_at):
+        """Insert a prompt trace with a specific created_at timestamp."""
+        with backend._lock:
+            backend.connection.execute(
+                """
+                INSERT OR REPLACE INTO prompt_trace
+                (action_name, record_id, attempt, compiled_prompt, created_at)
+                VALUES (?, ?, 1, 'test prompt', ?)
+                """,
+                (action, record_id, created_at),
+            )
+            backend.connection.commit()
+
+    def test_retains_recent_runs(self, backend):
+        """Traces from recent runs within retention window are kept."""
+        today = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self._insert_trace(backend, "act", "r1", today)
+        self._insert_trace(backend, "act", "r2", today)
+
+        backend._enforce_prompt_trace_retention(retention_runs=10)
+
+        traces = backend.get_prompt_traces("act")
+        assert len(traces) == 2
+
+    def test_deletes_old_runs_beyond_retention(self, backend):
+        """Traces from runs older than retention window are deleted."""
+        old_date = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+        mid_date = (datetime.now() - timedelta(days=15)).strftime("%Y-%m-%d %H:%M:%S")
+        today = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        self._insert_trace(backend, "act", "r_old", old_date)
+        self._insert_trace(backend, "act", "r_mid", mid_date)
+        self._insert_trace(backend, "act", "r_new", today)
+
+        # Keep last 2 run-days — old should be deleted
+        backend._enforce_prompt_trace_retention(retention_runs=2)
+
+        traces = backend.get_prompt_traces("act")
+        record_ids = [t["record_id"] for t in traces]
+        assert "r_old" not in record_ids
+        assert "r_mid" in record_ids
+        assert "r_new" in record_ids
+
+    def test_noop_when_fewer_runs_than_retention(self, backend):
+        """No deletion when there are fewer runs than the retention window."""
+        today = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self._insert_trace(backend, "act", "r1", today)
+
+        backend._enforce_prompt_trace_retention(retention_runs=10)
+
+        traces = backend.get_prompt_traces("act")
+        assert len(traces) == 1
+
+    def test_retention_zero_is_noop(self, backend):
+        """retention_runs < 1 does nothing."""
+        today = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self._insert_trace(backend, "act", "r1", today)
+
+        backend._enforce_prompt_trace_retention(retention_runs=0)
+
+        traces = backend.get_prompt_traces("act")
+        assert len(traces) == 1
+
+
+class TestSourceDataTtl:
+    """Tests for source data TTL enforcement."""
+
+    def _insert_source_with_age(self, backend, path, guid, days_old):
+        """Insert source data with a specific age."""
+        created = (datetime.now() - timedelta(days=days_old)).strftime("%Y-%m-%d %H:%M:%S")
+        with backend._lock:
+            backend.connection.execute(
+                """
+                INSERT OR REPLACE INTO source_data
+                (relative_path, source_guid, data, created_at)
+                VALUES (?, ?, '{}', ?)
+                """,
+                (path, guid, created),
+            )
+            backend.connection.commit()
+
+    def _count_source_rows(self, backend):
+        """Count total rows in source_data table."""
+        cursor = backend.connection.execute("SELECT COUNT(*) FROM source_data")
+        return cursor.fetchone()[0]
+
+    def _get_source_guids(self, backend):
+        """Get all source_guids from source_data table."""
+        cursor = backend.connection.execute("SELECT source_guid FROM source_data")
+        return [row[0] for row in cursor.fetchall()]
+
+    def test_deletes_old_source_data(self, backend):
+        """Source data older than TTL is deleted."""
+        self._insert_source_with_age(backend, "old.json", "guid_old", days_old=60)
+        self._insert_source_with_age(backend, "new.json", "guid_new", days_old=1)
+
+        backend._enforce_source_data_ttl(ttl_days=30)
+
+        guids = self._get_source_guids(backend)
+        assert "guid_old" not in guids
+        assert "guid_new" in guids
+
+    def test_keeps_data_within_ttl(self, backend):
+        """Source data within TTL is preserved."""
+        self._insert_source_with_age(backend, "recent.json", "guid_recent", days_old=5)
+
+        backend._enforce_source_data_ttl(ttl_days=30)
+
+        assert self._count_source_rows(backend) == 1
+
+    def test_ttl_zero_is_noop(self, backend):
+        """ttl_days < 1 does nothing."""
+        self._insert_source_with_age(backend, "old.json", "guid_old", days_old=60)
+
+        backend._enforce_source_data_ttl(ttl_days=0)
+
+        assert self._count_source_rows(backend) == 1
+
+    def test_ttl_none_skipped_in_perform_maintenance(self, backend):
+        """perform_maintenance with source_data_ttl_days=None skips TTL enforcement."""
+        self._insert_source_with_age(backend, "old.json", "guid_old", days_old=365)
+
+        backend.perform_maintenance(
+            prompt_trace_retention_runs=10,
+            source_data_ttl_days=None,
+        )
+
+        assert self._count_source_rows(backend) == 1
+
+
+class TestPerformMaintenance:
+    """Tests for the orchestrator method that runs all maintenance operations."""
+
+    def test_runs_without_error_on_empty_db(self, backend):
+        """perform_maintenance is safe on an empty database."""
+        backend.perform_maintenance()
+
+    def test_runs_all_operations(self, backend):
+        """perform_maintenance executes WAL checkpoint + disposition cleanup + trace retention."""
+        # Write some data to exercise all paths
+        backend.write_source("file.json", [{"source_guid": "g1", "data": "test"}])
+        # Insert dispositions directly to simulate accumulated records
+        with backend._lock:
+            backend.connection.execute(
+                "INSERT INTO record_disposition (action_name, record_id, disposition, reason, created_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                ("act", "r1", "failed", "error"),
+            )
+            backend.connection.execute(
+                "INSERT INTO record_disposition (action_name, record_id, disposition, reason, created_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                ("act", "r1", "success", None),
+            )
+            backend.connection.commit()
+
+        backend.perform_maintenance(
+            prompt_trace_retention_runs=10,
+            source_data_ttl_days=None,
+        )
+
+        # Stale disposition should be cleaned up
+        rows = backend.get_disposition("act", record_id="r1")
+        dispositions = [r["disposition"] for r in rows]
+        assert "failed" not in dispositions
+        assert "success" in dispositions
+
+    def test_is_idempotent(self, backend):
+        """Running maintenance multiple times is safe."""
+        backend.perform_maintenance()
+        backend.perform_maintenance()
+        backend.perform_maintenance()


### PR DESCRIPTION
## Summary
- **WAL checkpoint**: `PRAGMA wal_checkpoint(TRUNCATE)` after every workflow completion to reclaim disk space
- **Stale disposition cleanup**: removes old FAILED/EXHAUSTED records when a newer SUCCESS exists for the same (action, record) pair
- **Prompt trace retention**: configurable N-run retention window (default: 10), deletes traces from older runs
- **Source data TTL**: optional age-based cleanup via `storage.source_data_ttl_days` (default: null = keep forever)

All operations are idempotent, non-fatal on error, and wired into both sequential and async coordinator completion paths.

Config keys (in workflow YAML under `storage.*`):
- `prompt_trace_retention_runs` (default: 10)
- `source_data_ttl_days` (default: null)

## Verification
- 20 new tests in `tests/unit/storage/test_sqlite_maintenance.py`
- 7309 tests pass, 2 skipped
- `ruff check` and `ruff format --check` clean
- Pre-existing failures: `test_batch_timeout.py` (StopIteration in mock), `test_retry_reprompt_audit.py` (circular import) — unrelated