### PR TITLE
fix: batch/online content assembly parity — 4 divergences

### DIFF
--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -21,7 +21,6 @@ from agent_actions.output.response.config_fields import get_default
 from agent_actions.processing.batch_context_adapter import BatchContextAdapter
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
 from agent_actions.processing.record_helpers import (
-    apply_version_merge,
     build_exhausted_tombstone,
     build_tombstone,
     carry_framework_fields,
@@ -32,12 +31,17 @@ from agent_actions.processing.types import (
     ProcessingStatus,
     RecoveryMetadata,
 )
-from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS
+from agent_actions.record.envelope import (
+    _PERSISTENT_FIELDS,
+    RECORD_FRAMEWORK_FIELDS,
+    RecordEnvelope,
+)
 from agent_actions.record.reasons import (
     BATCH_NOT_RETURNED,
     GUARD_SKIP,
     PREP_FAILED,
 )
+from agent_actions.utils.content import is_version_merge
 
 logger = logging.getLogger(__name__)
 
@@ -336,17 +340,35 @@ class BatchResultStrategy:
         is_first_stage = not ctx.agent_config.get("dependencies")
         existing_content = extract_existing_content(original_row, is_first_stage=is_first_stage)
 
+        action_name = ctx.agent_config["action_name"]
+        is_tool_version_merge = ctx.agent_config.get("kind") == "tool" and is_version_merge(
+            ctx.agent_config
+        )
+
+        # Precompute persistent fields and envelope input outside the loop
+        _vm_fields = tuple(f for f in _PERSISTENT_FIELDS if f != "source_guid")
+        if not is_tool_version_merge:
+            # Inject first-stage-aware content into the envelope input (matches online)
+            if existing_content and existing_content != original_row.get("content"):
+                envelope_input: dict[str, Any] = {**original_row, "content": existing_content}
+            else:
+                envelope_input = original_row
+
         structured_items = []
         for item in generated_list:
             item_dict = item if isinstance(item, dict) else {}
-            content = apply_version_merge(ctx.agent_config, item_dict, existing_content)
-            structured_items.append({"source_guid": original_source_guid, "content": content})
+            if is_tool_version_merge:
+                content = {**(existing_content or {}), **item_dict}
+                record: dict[str, Any] = {"source_guid": original_source_guid, "content": content}
+                carry_framework_fields(original_row, record, fields=_vm_fields)
+            else:
+                record = RecordEnvelope.build(action_name, item_dict, envelope_input)
+                record["source_guid"] = original_source_guid  # reconciler is authority for guid
+            structured_items.append(record)
 
-        # Batch items inherit target_id and version_correlation_id from the original input row.
+        # target_id is a per-stage field — not carried by RecordEnvelope.build()
         for item in structured_items:
-            carry_framework_fields(
-                original_row, item, fields=("target_id", "version_correlation_id")
-            )
+            carry_framework_fields(original_row, item, fields=("target_id",))
 
         record_index = ctx.reconciler.get_record_index(custom_id)
 
@@ -455,6 +477,7 @@ class BatchResultStrategy:
             error=error_message,
             source_guid=source_guid,
             source_snapshot=source_snapshot,
+            input_record=original_input,
         )
         result.data = [error_item]
         result.recovery_metadata = recovery_metadata

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -318,7 +318,7 @@ class BatchTaskPreparator:
         return PreparationContext(
             agent_config=agent_config,
             agent_name=agent_name,
-            is_first_stage=False,  # Batch is always subsequent-stage
+            is_first_stage=not agent_config.get("dependencies"),
             mode=RunMode.BATCH,
             source_data=source_data,
             agent_indices=self.action_indices,

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -757,7 +757,11 @@ class BatchProcessingService:
                 content = item.get("content")
                 if content is None:
                     continue
-                response_text = json.dumps(content, ensure_ascii=False, default=str)
+                # Extract only the action's output namespace — matches online prompt trace shape
+                action_output = (
+                    content.get(action_name, content) if isinstance(content, dict) else content
+                )
+                response_text = json.dumps(action_output, ensure_ascii=False, default=str)
                 self._storage_backend.update_prompt_trace_response(
                     action_name=action_name,
                     record_id=target_id,

--- a/agent_actions/processing/batch_context_adapter.py
+++ b/agent_actions/processing/batch_context_adapter.py
@@ -25,7 +25,7 @@ class BatchContextAdapter:
             agent_config=cast(ActionConfigDict, agent_config),
             agent_name=agent_config.get("agent_type", "unknown_action"),
             mode=RunMode.BATCH,
-            is_first_stage=False,
+            is_first_stage=not agent_config.get("dependencies"),
             current_item=original_row,
             record_index=record_index,
             output_directory=output_directory,


### PR DESCRIPTION
## Summary

- **RecordEnvelope.build()** now used for batch output records, carrying `_state_history`, `_state_schema_version`, and `version_correlation_id` that manual dict construction was dropping
- **Prompt trace** stores only the action's output namespace (e.g. `{"summary": ...}`) instead of the full content dict with all upstream namespaces — matches online shape
- **is_first_stage** derived from `not agent_config.get("dependencies")` in `BatchTaskPreparator` and `BatchContextAdapter` instead of hardcoded `False`
- **input_record** added to `ProcessingResult.failed()` in batch error path for `result_collector` serialization parity

## Test plan

- [x] All 7417 tests pass (0 failures, 2 skipped)
- [x] `ruff check` and `ruff format --check` clean
- [x] No hardcoded `is_first_stage=False` in preparator.py or batch_context_adapter.py
- [x] `RecordEnvelope.build` used in batch_result_strategy.py
- [x] Tool version-merge flat spread preserved (test_tool_version_merge_flat_spreads passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)