### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.changes/unreleased/Breaking Change-20260523-627000.yaml
+++ b/.changes/unreleased/Breaking Change-20260523-627000.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Change
+body: |
+  Removed cross-workflow chaining: upstream: config key, --upstream/--downstream CLI flags,
+  WorkflowOrchestrator, and VirtualAction injection. Workflows are self-contained.
+  Users with upstream: in config will see an unknown-key warning.
+time: 2026-05-23T06:27:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260523-625000.yaml
+++ b/.changes/unreleased/Bug Fix-20260523-625000.yaml
@@ -1,0 +1,5 @@
+kind: Bug Fix
+body: |
+  Batch/online content parity: first-stage batch actions now synthesize the source namespace,
+  matching online mode. Fixes source.page_content resolving as null in batch workflows.
+time: 2026-05-23T06:25:00.000000Z

--- a/.changes/unreleased/Bug Fix-20260523-626000.yaml
+++ b/.changes/unreleased/Bug Fix-20260523-626000.yaml
@@ -1,0 +1,6 @@
+kind: Bug Fix
+body: |
+  Batch disposition dedup prevents UNIQUE constraint violations on resume.
+  Deferred dispositions now cleared using per-action name instead of workflow name.
+  Prep failure logs show source_guid instead of array index.
+time: 2026-05-23T06:26:00.000000Z

--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.1.17"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.1.17"
+version = "0.2.0"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},


### PR DESCRIPTION
## Summary

Bump version to 0.2.0 and add changie entries for post-merge fixes.

### Version changes
- `pyproject.toml`: 0.1.17 → 0.2.0
- `agent_actions/__version__.py`: 0.1.17 → 0.2.0

### Changie entries added
- **#625** — Remove dead source_data guid lookup
- **#626** — Batch/online content assembly parity (source namespace synthesis)
- **#627** — Remove cross-workflow upstream/downstream chaining (BREAKING)

After merge, run `changie batch v0.2.0` to generate the release changelog.