### PR TITLE
refactor: batch recovery enums, registry index, and parameter cleanup

### DIFF
--- a/agent_actions/llm/batch/core/batch_constants.py
+++ b/agent_actions/llm/batch/core/batch_constants.py
@@ -50,6 +50,29 @@ class FilterStatus(str, Enum):
         return self.value
 
 
+class RecoveryType(str, Enum):
+    """Type of recovery operation for async batch processing."""
+
+    RETRY = "retry"
+    REPROMPT = "reprompt"
+
+    def __str__(self) -> str:
+        """Return the string value for str() conversion."""
+        return self.value
+
+
+class RecoveryPhase(str, Enum):
+    """Current phase in the recovery state machine."""
+
+    RETRY = "retry"
+    REPROMPT = "reprompt"
+    DONE = "done"
+
+    def __str__(self) -> str:
+        """Return the string value for str() conversion."""
+        return self.value
+
+
 class ContextMetaKeys:
     """Internal underscore-prefixed metadata keys used in batch context maps."""
 

--- a/agent_actions/llm/batch/core/batch_models.py
+++ b/agent_actions/llm/batch/core/batch_models.py
@@ -159,6 +159,28 @@ class PreparedBatchTasks:
 
 
 @dataclass
+class RecoveryContext:
+    """Execution context shared across all recovery operations."""
+
+    service: Any  # BatchProcessingService (avoid circular import)
+    manager: Any  # BatchRegistryManager
+    provider: Any
+    agent_config: dict[str, Any]
+    output_directory: str
+    action_name: str | None
+    start_time: float
+
+
+@dataclass
+class BatchIdentity:
+    """Identifies a specific batch job."""
+
+    batch_id: str
+    file_name: str
+    entry: BatchJobEntry
+
+
+@dataclass
 class SubmissionResult:
     """Result of a batch submission."""
 

--- a/agent_actions/llm/batch/core/batch_models.py
+++ b/agent_actions/llm/batch/core/batch_models.py
@@ -2,9 +2,9 @@
 
 import dataclasses
 from dataclasses import asdict, dataclass, field
-from typing import Any, Literal
+from typing import Any
 
-from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_constants import BatchStatus, RecoveryType
 
 
 @dataclass
@@ -23,7 +23,7 @@ class BatchJobEntry:
     version_base_name: str | None = None
     # Recovery fields for async retry/reprompt batches
     parent_file_name: str | None = None  # links to original batch's file_name key
-    recovery_type: Literal["retry", "reprompt"] | None = None
+    recovery_type: RecoveryType | None = None
     recovery_attempt: int | None = None  # attempt number (1, 2, 3...)
 
     def __post_init__(self):
@@ -43,6 +43,10 @@ class BatchJobEntry:
         """Create BatchJobEntry from dictionary (JSON deserialization)."""
         known_fields = {f.name for f in dataclasses.fields(cls)}
         filtered = {k: v for k, v in data.items() if k in known_fields}
+        # Coerce recovery_type string to enum (JSON stores "retry"/"reprompt")
+        rt = filtered.get("recovery_type")
+        if rt is not None and isinstance(rt, str):
+            filtered["recovery_type"] = RecoveryType(rt)
         return cls(**filtered)
 
     def to_dict(self) -> dict:

--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -6,13 +6,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from agent_actions.llm.batch.core.batch_constants import RecoveryPhase
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.path_utils import ensure_directory_exists
 
 logger = logging.getLogger(__name__)
-
-
-_VALID_PHASES = {"retry", "reprompt", "done"}
 
 
 @dataclass
@@ -23,14 +21,12 @@ class RecoveryState:
     service can track progress across multiple async batch submissions.
     """
 
-    phase: str  # "retry" | "reprompt" | "done"
+    phase: RecoveryPhase = RecoveryPhase.RETRY
 
     def __post_init__(self):
-        if self.phase not in _VALID_PHASES:
-            raise ValueError(
-                f"Invalid recovery phase '{self.phase}'. "
-                f"Expected one of: {', '.join(sorted(_VALID_PHASES))}"
-            )
+        # Coerce raw strings from JSON deserialization
+        if isinstance(self.phase, str):
+            self.phase = RecoveryPhase(self.phase)
 
     # Retry state
     retry_attempt: int = 0

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -57,7 +57,7 @@ class BatchRegistryManager:
                     "cache initialization failed"
                 )
             self._cache[file_name] = entry
-            self._rebuild_batch_id_index()
+            self._batch_id_index = None
             self._persist_registry(self._cache)
             logger.info("Saved batch job %s for file %s", entry.batch_id, file_name)
 
@@ -75,7 +75,7 @@ class BatchRegistryManager:
             if file_name not in self._cache:
                 return False
             del self._cache[file_name]
-            self._rebuild_batch_id_index()
+            self._batch_id_index = None
             self._persist_registry(self._cache)
             logger.info("Removed batch job entry for %s", file_name)
             return True
@@ -111,6 +111,8 @@ class BatchRegistryManager:
                     "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
                     "cache initialization failed"
                 )
+            if self._batch_id_index is None:
+                self._rebuild_batch_id_index()
             file_name = (self._batch_id_index or {}).get(batch_id)
             if file_name and file_name in self._cache:
                 fire_event(CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}"))
@@ -135,6 +137,8 @@ class BatchRegistryManager:
                     "cache initialization failed"
                 )
 
+            if self._batch_id_index is None:
+                self._rebuild_batch_id_index()
             file_name = (self._batch_id_index or {}).get(batch_id)
             if file_name and file_name in self._cache:
                 updated_entry = dataclasses.replace(self._cache[file_name], status=new_status)

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -113,9 +113,7 @@ class BatchRegistryManager:
                 )
             file_name = (self._batch_id_index or {}).get(batch_id)
             if file_name and file_name in self._cache:
-                fire_event(
-                    CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}")
-                )
+                fire_event(CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}"))
                 return self._cache[file_name]
 
             fire_event(
@@ -278,8 +276,7 @@ class BatchRegistryManager:
     def _rebuild_batch_id_index(self) -> None:
         """Rebuild secondary index from cache. Must be called under lock."""
         self._batch_id_index = {
-            entry.batch_id: file_name
-            for file_name, entry in (self._cache or {}).items()
+            entry.batch_id: file_name for file_name, entry in (self._cache or {}).items()
         }
 
     def _ensure_cache_loaded(self) -> None:

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -35,6 +35,7 @@ class BatchRegistryManager:
         """
         self._registry_path = Path(registry_path)
         self._cache: dict[str, BatchJobEntry] | None = None
+        self._batch_id_index: dict[str, str] | None = None  # batch_id → file_name
         self._lock = threading.Lock()
         logger.debug("Initialized BatchRegistryManager for %s", registry_path)
 
@@ -56,6 +57,7 @@ class BatchRegistryManager:
                     "cache initialization failed"
                 )
             self._cache[file_name] = entry
+            self._rebuild_batch_id_index()
             self._persist_registry(self._cache)
             logger.info("Saved batch job %s for file %s", entry.batch_id, file_name)
 
@@ -73,6 +75,7 @@ class BatchRegistryManager:
             if file_name not in self._cache:
                 return False
             del self._cache[file_name]
+            self._rebuild_batch_id_index()
             self._persist_registry(self._cache)
             logger.info("Removed batch job entry for %s", file_name)
             return True
@@ -108,12 +111,12 @@ class BatchRegistryManager:
                     "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
                     "cache initialization failed"
                 )
-            for entry in self._cache.values():
-                if entry.batch_id == batch_id:
-                    fire_event(
-                        CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}")
-                    )
-                    return entry
+            file_name = (self._batch_id_index or {}).get(batch_id)
+            if file_name and file_name in self._cache:
+                fire_event(
+                    CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}")
+                )
+                return self._cache[file_name]
 
             fire_event(
                 CacheMissEvent(
@@ -134,13 +137,13 @@ class BatchRegistryManager:
                     "cache initialization failed"
                 )
 
-            for file_name, entry in self._cache.items():
-                if entry.batch_id == batch_id:
-                    updated_entry = dataclasses.replace(entry, status=new_status)
-                    self._cache[file_name] = updated_entry
-                    self._persist_registry(self._cache)
-                    logger.info("Updated batch %s status to %s", batch_id, new_status)
-                    return True
+            file_name = (self._batch_id_index or {}).get(batch_id)
+            if file_name and file_name in self._cache:
+                updated_entry = dataclasses.replace(self._cache[file_name], status=new_status)
+                self._cache[file_name] = updated_entry
+                self._persist_registry(self._cache)
+                logger.info("Updated batch %s status to %s", batch_id, new_status)
+                return True
 
             logger.warning("Batch ID %s not found in registry", batch_id)
             return False
@@ -257,6 +260,7 @@ class BatchRegistryManager:
         with self._lock:
             entries_removed = len(self._cache) if self._cache is not None else 0
             self._cache = None
+            self._batch_id_index = None
             logger.debug("Registry cache invalidated")
 
             fire_event(
@@ -271,10 +275,18 @@ class BatchRegistryManager:
     # PRIVATE METHODS - Internal implementation
     # ============================================================
 
+    def _rebuild_batch_id_index(self) -> None:
+        """Rebuild secondary index from cache. Must be called under lock."""
+        self._batch_id_index = {
+            entry.batch_id: file_name
+            for file_name, entry in (self._cache or {}).items()
+        }
+
     def _ensure_cache_loaded(self) -> None:
         """Lazy load cache if not already loaded."""
         if self._cache is None:
             self._cache = self._load_registry()
+            self._rebuild_batch_id_index()
 
     def _load_registry(self) -> dict[str, BatchJobEntry]:
         """

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -542,6 +542,21 @@ class BatchResultStrategy:
 
         return results
 
+    def _attach_passthrough_context(
+        self,
+        result: ProcessingResult,
+        ctx: BatchProcessingContext,
+        original_row: dict[str, Any],
+        record_index: int,
+    ) -> None:
+        """Attach processing context to a passthrough result."""
+        result.processing_context = BatchContextAdapter.to_processing_context(
+            agent_config=ctx.agent_config or {},
+            original_row=original_row,
+            record_index=record_index,
+            output_directory=ctx.output_directory,
+        )
+
     def _build_exhausted_passthrough(
         self,
         ctx: BatchProcessingContext,
@@ -583,12 +598,6 @@ class BatchResultStrategy:
             source_guid=source_guid,
         )
 
-        processing_context = BatchContextAdapter.to_processing_context(
-            agent_config=ctx.agent_config or {},
-            original_row=original_row,
-            record_index=record_index,
-            output_directory=ctx.output_directory,
-        )
         processing_result = ProcessingResult.exhausted(
             error=f"Retry exhausted after {recovery_meta.retry.attempts} attempts",
             data=[exhausted_item],
@@ -596,7 +605,7 @@ class BatchResultStrategy:
             recovery_metadata=recovery_meta,
             source_snapshot=copy.deepcopy(original_row) if original_row else None,
         )
-        processing_result.processing_context = processing_context
+        self._attach_passthrough_context(processing_result, ctx, original_row, record_index)
         return processing_result
 
     def _build_unprocessed_passthrough(
@@ -624,19 +633,13 @@ class BatchResultStrategy:
             source_guid=source_guid,
         )
 
-        processing_context = BatchContextAdapter.to_processing_context(
-            agent_config=ctx.agent_config or {},
-            original_row=original_row,
-            record_index=record_index,
-            output_directory=ctx.output_directory,
-        )
         processing_result = ProcessingResult.unprocessed(
             data=[passthrough_item],
             reason=reason,
             source_guid=source_guid,
             source_snapshot=copy.deepcopy(original_row) if original_row else None,
         )
-        processing_result.processing_context = processing_context
+        self._attach_passthrough_context(processing_result, ctx, original_row, record_index)
         return processing_result
 
     def _build_failed_passthrough(
@@ -662,18 +665,12 @@ class BatchResultStrategy:
             source_guid=source_guid,
         )
 
-        processing_context = BatchContextAdapter.to_processing_context(
-            agent_config=ctx.agent_config or {},
-            original_row=original_row,
-            record_index=record_index,
-            output_directory=ctx.output_directory,
-        )
         processing_result = ProcessingResult.failed(
             error=reason,
             source_guid=source_guid,
             source_snapshot=copy.deepcopy(original_row) if original_row else None,
         )
         processing_result.data = [passthrough_item]
-        processing_result.processing_context = processing_context
+        self._attach_passthrough_context(processing_result, ctx, original_row, record_index)
         processing_result.skip_reason = reason
         return processing_result

--- a/agent_actions/llm/batch/processing/preparator.py
+++ b/agent_actions/llm/batch/processing/preparator.py
@@ -70,8 +70,8 @@ class BatchTaskPreparator:
                 },
             )
 
-        # Validate configuration
-        self._validate_config(agent_config, provider)
+        # Validate configuration and get compiled schema
+        schema = self._validate_config(agent_config, provider)
 
         from agent_actions.prompt.formatter import PromptFormatter
 
@@ -89,8 +89,6 @@ class BatchTaskPreparator:
 
         tools_path = resolve_tools_path(agent_config)
         self._add_tools_to_path(tools_path)
-
-        schema = self._prepare_schema(agent_config, provider)
 
         context_map_builder: dict[str, Any] = {}
         tasks_builder: list[dict[str, Any]] = []
@@ -265,8 +263,8 @@ class BatchTaskPreparator:
                     reason=error_str[:500],
                 )
 
-    def _validate_config(self, agent_config: dict[str, Any], provider) -> None:
-        """Validate agent configuration."""
+    def _validate_config(self, agent_config: dict[str, Any], provider) -> dict[str, Any] | None:
+        """Validate agent configuration. Returns compiled schema."""
         schema = self._prepare_schema(agent_config, provider)
         json_mode = agent_config.get(JSON_MODE_KEY, True)
 
@@ -279,6 +277,7 @@ class BatchTaskPreparator:
                     "hint": "Either provide a schema or set json_mode: false",
                 },
             )
+        return schema
 
     def _prepare_schema(self, agent_config: dict[str, Any], provider) -> dict[str, Any] | None:
         """Prepare and compile schema for provider."""

--- a/agent_actions/llm/batch/processing/reconciler.py
+++ b/agent_actions/llm/batch/processing/reconciler.py
@@ -26,9 +26,7 @@ class BatchResultReconciler:
         """Initialize reconciler with context map."""
         self.context_map = context_map or {}
         self._processed_ids: set[str] = set()
-        self._key_index: dict[str, int] = {
-            str(k): i for i, k in enumerate(self.context_map)
-        }
+        self._key_index: dict[str, int] = {str(k): i for i, k in enumerate(self.context_map)}
 
     def mark_processed(self, custom_id: Any) -> None:
         """Mark a custom_id as processed."""

--- a/agent_actions/llm/batch/processing/reconciler.py
+++ b/agent_actions/llm/batch/processing/reconciler.py
@@ -26,6 +26,9 @@ class BatchResultReconciler:
         """Initialize reconciler with context map."""
         self.context_map = context_map or {}
         self._processed_ids: set[str] = set()
+        self._key_index: dict[str, int] = {
+            str(k): i for i, k in enumerate(self.context_map)
+        }
 
     def mark_processed(self, custom_id: Any) -> None:
         """Mark a custom_id as processed."""
@@ -95,11 +98,7 @@ class BatchResultReconciler:
 
     def get_record_index(self, custom_id: str) -> int:
         """Get the index of a custom_id in context_map order, or -1 if not found."""
-        context_keys = list(self.context_map.keys())
-        try:
-            return context_keys.index(str(custom_id))
-        except ValueError:
-            return -1
+        return self._key_index.get(str(custom_id), -1)
 
     @staticmethod
     def collect_expected_custom_ids(context_map: dict[str, Any]) -> set:

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -14,7 +14,7 @@ from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.errors import ProcessingError
 from agent_actions.llm.batch.core.batch_constants import BatchStatus, RecoveryPhase, RecoveryType
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.core.batch_models import BatchIdentity, BatchJobEntry, RecoveryContext
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
     BatchClientResolver,
 )
@@ -534,36 +534,42 @@ class BatchProcessingService:
                     )
                     return None  # Recovery pending
 
+        # Build context objects for recovery functions
+        context = RecoveryContext(
+            service=self,
+            manager=manager,
+            provider=provider,
+            agent_config=agent_config or {},
+            output_directory=output_directory,
+            action_name=action_name,
+            start_time=start_time,
+        )
+        identity = BatchIdentity(
+            batch_id=batch_id,
+            file_name=file_name,
+            entry=entry,
+        )
+
         # Do NOT load recovery state here. The original batch path processes
         # from scratch — any existing recovery_state file is stale (left by a
         # crashed run). Passing it would poison the reprompt check with a stale
         # reprompt_attempt counter, causing it to think attempts are exhausted.
         # Stale files are cleaned up in _finalize_batch_output.
         should_continue = self._check_and_submit_reprompt(
+            context=context,
+            identity=identity,
             batch_results=batch_results,
             context_map=context_map,
-            output_directory=output_directory,
-            file_name=file_name,
-            entry=entry,
-            agent_config=agent_config,
-            manager=manager,
-            provider=provider,
             recovery_state=None,
         )
         if not should_continue:
             return None  # Reprompt submitted, processing paused
 
         return self._finalize_batch_output(
+            context=context,
+            identity=identity,
             batch_results=batch_results,
-            exhausted_recovery=None,
             context_map=context_map,
-            output_directory=output_directory,
-            file_name=file_name,
-            batch_id=batch_id,
-            agent_config=agent_config,
-            manager=manager,
-            action_name=action_name,
-            start_time=start_time,
         )
 
     # =========================================================================
@@ -597,14 +603,10 @@ class BatchProcessingService:
 
     def _check_and_submit_reprompt(
         self,
+        context: RecoveryContext,
+        identity: BatchIdentity,
         batch_results: list[BatchResult],
         context_map: dict[str, Any],
-        output_directory: str,
-        file_name: str,
-        entry: BatchJobEntry,
-        agent_config: dict[str, Any] | None,
-        manager: BatchRegistryManager,
-        provider: Any,
         recovery_state: RecoveryState | None = None,
         exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
     ) -> bool:
@@ -613,31 +615,21 @@ class BatchProcessingService:
         Delegates to processing_recovery.check_and_submit_reprompt.
         """
         return _check_and_submit_reprompt_impl(
-            self,
+            context,
+            identity,
             batch_results=batch_results,
             context_map=context_map,
-            output_directory=output_directory,
-            file_name=file_name,
-            entry=entry,
-            agent_config=agent_config,
-            manager=manager,
-            provider=provider,
             recovery_state=recovery_state,
             exhausted_recovery=exhausted_recovery,
         )
 
     def _finalize_batch_output(
         self,
+        context: RecoveryContext,
+        identity: BatchIdentity,
         batch_results: list[BatchResult],
-        exhausted_recovery: dict[str, RecoveryMetadata] | None,
         context_map: dict[str, Any],
-        output_directory: str,
-        file_name: str,
-        batch_id: str,
-        agent_config: dict[str, Any] | None,
-        manager: BatchRegistryManager,
-        action_name: str | None,
-        start_time: float,
+        exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
     ) -> str:
         """Finalize batch processing: convert, write output, fire events, cleanup.
 
@@ -647,21 +639,15 @@ class BatchProcessingService:
         # Clean up stale recovery state (e.g. from a crashed previous run).
         # The recovery path already does this in _finalize_and_cleanup, but the
         # original batch path goes through this method instead and must also clean up.
-        RecoveryStateManager.delete(output_directory, file_name)
+        RecoveryStateManager.delete(context.output_directory, identity.file_name)
         output_path = _finalize_batch_output_impl(
-            self,
+            context,
+            identity,
             batch_results=batch_results,
-            exhausted_recovery=exhausted_recovery,
             context_map=context_map,
-            output_directory=output_directory,
-            file_name=file_name,
-            batch_id=batch_id,
-            agent_config=agent_config,
-            manager=manager,
-            action_name=action_name,
-            start_time=start_time,
+            exhausted_recovery=exhausted_recovery,
         )
-        _cleanup_recovery_impl(self, manager, output_directory, file_name)
+        _cleanup_recovery_impl(context, identity)
         return output_path
 
     def _clear_deferred_dispositions(

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
 from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.errors import ProcessingError
-from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_constants import BatchStatus, RecoveryPhase, RecoveryType
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.core.batch_models import BatchJobEntry
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
@@ -503,14 +503,14 @@ class BatchProcessingService:
                         record_count=record_count,
                         file_name=recovery_file_name,
                         parent_file_name=file_name,
-                        recovery_type="retry",
+                        recovery_type=RecoveryType.RETRY,
                         recovery_attempt=1,
                     )
                     manager.save_batch_job(recovery_file_name, recovery_entry)
 
                     record_failure_counts = {rid: 1 for rid in missing_ids}
                     state = RecoveryState(
-                        phase="retry",
+                        phase=RecoveryPhase.RETRY,
                         retry_attempt=1,
                         retry_max_attempts=max_attempts,
                         missing_ids=list(missing_ids),

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -336,12 +336,11 @@ class BatchProcessingService:
         )
 
         carry_path = Path(output_directory) / "batch" / BATCH_CARRY_FORWARD_FILENAME
-        if not carry_path.exists():
-            return batch_output
-
         try:
             carry_data = json.loads(carry_path.read_text())
             carry_guids = set(carry_data.get("guids", []))
+        except FileNotFoundError:
+            return batch_output
         except (json.JSONDecodeError, KeyError):
             logger.warning("Malformed .batch_carry_forward.json — skipping merge")
             return batch_output

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus, RecoveryPhase, RecoveryType
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.core.batch_models import BatchIdentity, BatchJobEntry, RecoveryContext
 from agent_actions.llm.batch.infrastructure.recovery_state import (
     RecoveryState,
     RecoveryStateManager,
@@ -63,7 +63,6 @@ def process_recovery_batch(
 
     Returns output file path if complete, None if more recovery is needed.
     """
-    start_time = time.time()
     parent_file_name = entry.parent_file_name
     if not parent_file_name:
         logger.error("Recovery entry %s has no parent_file_name", file_name)
@@ -74,12 +73,28 @@ def process_recovery_batch(
         logger.error("No recovery state found for %s", parent_file_name)
         return None
 
-    context_map = service._context_manager.load_batch_context_map(
-        output_directory, parent_file_name
-    )
     agent_config = service._apply_workflow_session_id(agent_config, entry)
     provider = service._client_resolver.get_for_batch_id(
         batch_id, manager, output_directory, agent_config=agent_config
+    )
+
+    context = RecoveryContext(
+        service=service,
+        manager=manager,
+        provider=provider,
+        agent_config=agent_config or {},
+        output_directory=output_directory,
+        action_name=action_name,
+        start_time=time.time(),
+    )
+    identity = BatchIdentity(
+        batch_id=batch_id,
+        file_name=parent_file_name,
+        entry=entry,
+    )
+
+    context_map = service._context_manager.load_batch_context_map(
+        output_directory, parent_file_name
     )
 
     recovery_results = retrieve_and_reconcile(
@@ -95,35 +110,21 @@ def process_recovery_batch(
 
     if entry.recovery_type == RecoveryType.RETRY:
         return handle_retry_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=recovery_results,
             accumulated=accumulated,
             context_map=context_map,
-            output_directory=output_directory,
-            parent_file_name=parent_file_name,
-            entry=entry,
-            agent_config=agent_config,
-            manager=manager,
-            provider=provider,
-            action_name=action_name,
-            start_time=start_time,
         )
     elif entry.recovery_type == RecoveryType.REPROMPT:
         return handle_reprompt_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=recovery_results,
             accumulated=accumulated,
             context_map=context_map,
-            output_directory=output_directory,
-            parent_file_name=parent_file_name,
-            entry=entry,
-            agent_config=agent_config,
-            manager=manager,
-            provider=provider,
-            action_name=action_name,
-            start_time=start_time,
         )
 
     logger.error("Unknown recovery_type: %s", entry.recovery_type)
@@ -136,22 +137,15 @@ def process_recovery_batch(
 
 
 def handle_retry_recovery(
-    service: "BatchProcessingService",
+    context: RecoveryContext,
+    identity: BatchIdentity,
     state: RecoveryState,
     recovery_results: list[BatchResult],
     accumulated: list[BatchResult],
     context_map: dict[str, Any],
-    output_directory: str,
-    parent_file_name: str,
-    entry: BatchJobEntry,
-    agent_config: dict[str, Any] | None,
-    manager: BatchRegistryManager,
-    provider: Any,
-    action_name: str | None,
-    start_time: float,
 ) -> str | None:
     """Handle retry recovery batch completion."""
-    merged, still_missing, updated_counts, _ = service._retry_service.process_retry_results(
+    merged, still_missing, updated_counts, _ = context.service._retry_service.process_retry_results(
         results=recovery_results,
         accumulated_results=accumulated,
         context_map=context_map,
@@ -161,41 +155,36 @@ def handle_retry_recovery(
 
     if still_missing and state.retry_attempt < state.retry_max_attempts:
         next_attempt = state.retry_attempt + 1
-        submission = service._retry_service.submit_retry_batch(
-            provider=provider,
+        submission = context.service._retry_service.submit_retry_batch(
+            provider=context.provider,
             missing_ids=still_missing,
             context_map=context_map,
-            output_directory=output_directory,
-            file_name=parent_file_name,
-            agent_config=agent_config,
+            output_directory=context.output_directory,
+            file_name=identity.file_name,
+            agent_config=context.agent_config,
         )
         if submission:
             _register_recovery_batch(
-                manager, submission, parent_file_name, entry.provider, RecoveryType.RETRY, next_attempt
+                context.manager, submission, identity.file_name, identity.entry.provider, RecoveryType.RETRY, next_attempt
             )
             state.retry_attempt = next_attempt
             state.missing_ids = list(still_missing)
             state.record_failure_counts = updated_counts
             state.accumulated_results = BatchRetryService.serialize_results(merged)
-            RecoveryStateManager.save(output_directory, parent_file_name, state)
+            RecoveryStateManager.save(context.output_directory, identity.file_name, state)
             return None
 
     exhausted_recovery = None
     if still_missing:
-        exhausted_recovery = service._retry_service.build_exhausted_recovery(
+        exhausted_recovery = context.service._retry_service.build_exhausted_recovery(
             still_missing, updated_counts
         )
 
     should_continue = check_and_submit_reprompt(
-        service,
+        context,
+        identity,
         batch_results=merged,
         context_map=context_map,
-        output_directory=output_directory,
-        file_name=parent_file_name,
-        entry=entry,
-        agent_config=agent_config,
-        manager=manager,
-        provider=provider,
         recovery_state=state,
         exhausted_recovery=exhausted_recovery,
     )
@@ -203,17 +192,11 @@ def handle_retry_recovery(
         return None
 
     return _finalize_and_cleanup(
-        service,
-        merged,
-        exhausted_recovery,
-        context_map,
-        output_directory,
-        parent_file_name,
-        entry.batch_id,
-        agent_config,
-        manager,
-        action_name,
-        start_time,
+        context,
+        identity,
+        batch_results=merged,
+        context_map=context_map,
+        exhausted_recovery=exhausted_recovery,
     )
 
 
@@ -223,19 +206,12 @@ def handle_retry_recovery(
 
 
 def handle_reprompt_recovery(
-    service: "BatchProcessingService",
+    context: RecoveryContext,
+    identity: BatchIdentity,
     state: RecoveryState,
     recovery_results: list[BatchResult],
     accumulated: list[BatchResult],
     context_map: dict[str, Any],
-    output_directory: str,
-    parent_file_name: str,
-    entry: BatchJobEntry,
-    agent_config: dict[str, Any] | None,
-    manager: BatchRegistryManager,
-    provider: Any,
-    action_name: str | None,
-    start_time: float,
 ) -> str | None:
     """Handle reprompt recovery batch completion.
 
@@ -246,7 +222,7 @@ def handle_reprompt_recovery(
     from agent_actions.llm.batch.services.reprompt_ops import build_evaluation_loop
 
     setup = build_evaluation_loop(
-        agent_config,
+        context.agent_config,
         max_attempts=state.reprompt_max_attempts,
         on_exhausted=state.on_exhausted,
     )
@@ -255,17 +231,11 @@ def handle_reprompt_recovery(
         final_results = BatchRetryService.deserialize_results(state.graduated_results)
         final_results.extend(recovery_results)
         return _finalize_and_cleanup(
-            service,
-            final_results,
-            None,
-            context_map,
-            output_directory,
-            parent_file_name,
-            entry.batch_id,
-            agent_config,
-            manager,
-            action_name,
-            start_time,
+            context,
+            identity,
+            batch_results=final_results,
+            context_map=context_map,
+            exhausted_recovery=None,
         )
 
     loop, strategy = setup
@@ -279,22 +249,22 @@ def handle_reprompt_recovery(
 
     if still_failing and state.reprompt_attempt < state.reprompt_max_attempts:
         next_attempt = state.reprompt_attempt + 1
-        submission = service._retry_service.submit_reprompt_batch(
-            provider=provider,
+        submission = context.service._retry_service.submit_reprompt_batch(
+            provider=context.provider,
             failed_results=still_failing,
             context_map=context_map,
-            output_directory=output_directory,
-            file_name=parent_file_name,
-            agent_config=agent_config,
+            output_directory=context.output_directory,
+            file_name=identity.file_name,
+            agent_config=context.agent_config,
             attempt=next_attempt,
         )
         if submission:
             _register_recovery_batch(
-                manager, submission, parent_file_name, entry.provider, RecoveryType.REPROMPT, next_attempt
+                context.manager, submission, identity.file_name, identity.entry.provider, RecoveryType.REPROMPT, next_attempt
             )
             fire_event(
                 RepromptRetryEvent(
-                    action_name=parent_file_name or "batch",
+                    action_name=identity.file_name or "batch",
                     attempt=next_attempt,
                     max_attempts=state.reprompt_max_attempts,
                     error=f"{len(still_failing)} records failed validation",
@@ -306,13 +276,13 @@ def handle_reprompt_recovery(
                     state.reprompt_attempts_per_record.get(fr.custom_id, 0) + 1
                 )
             state.reprompt_attempt = next_attempt
-            RecoveryStateManager.save(output_directory, parent_file_name, state)
+            RecoveryStateManager.save(context.output_directory, identity.file_name, state)
             return None
 
     # Exhausted or all graduated — finalize.
     if still_failing:
         failed_ids = {r.custom_id for r in still_failing}
-        service._retry_service.apply_exhausted_reprompt_metadata(
+        context.service._retry_service.apply_exhausted_reprompt_metadata(
             results=still_failing,
             failed_ids=failed_ids,
             validation_name=validation_name,
@@ -329,7 +299,7 @@ def handle_reprompt_recovery(
     if state.graduated_results:
         fire_event(
             RepromptRecoveredEvent(
-                action_name=parent_file_name or "batch",
+                action_name=identity.file_name or "batch",
                 attempt=state.reprompt_attempt,
                 max_attempts=state.reprompt_max_attempts,
                 validation_name=validation_name,
@@ -339,22 +309,16 @@ def handle_reprompt_recovery(
     # Rebuild exhausted_recovery from retry phase state (frozen at phase transition).
     exhausted_recovery = None
     if state.missing_ids:
-        exhausted_recovery = service._retry_service.build_exhausted_recovery(
+        exhausted_recovery = context.service._retry_service.build_exhausted_recovery(
             set(state.missing_ids), state.record_failure_counts
         )
 
     return _finalize_and_cleanup(
-        service,
-        final_results,
-        exhausted_recovery,
-        context_map,
-        output_directory,
-        parent_file_name,
-        entry.batch_id,
-        agent_config,
-        manager,
-        action_name,
-        start_time,
+        context,
+        identity,
+        batch_results=final_results,
+        context_map=context_map,
+        exhausted_recovery=exhausted_recovery,
     )
 
 
@@ -364,15 +328,10 @@ def handle_reprompt_recovery(
 
 
 def check_and_submit_reprompt(
-    service: "BatchProcessingService",
+    context: RecoveryContext,
+    identity: BatchIdentity,
     batch_results: list[BatchResult],
     context_map: dict[str, Any],
-    output_directory: str,
-    file_name: str,
-    entry: BatchJobEntry,
-    agent_config: dict[str, Any] | None,
-    manager: BatchRegistryManager,
-    provider: Any,
     recovery_state: RecoveryState | None = None,
     exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
 ) -> bool:
@@ -384,7 +343,7 @@ def check_and_submit_reprompt(
     """
     from agent_actions.llm.batch.services.reprompt_ops import build_evaluation_loop
 
-    setup = build_evaluation_loop(agent_config)
+    setup = build_evaluation_loop(context.agent_config)
     if setup is None:
         return True
 
@@ -415,7 +374,7 @@ def check_and_submit_reprompt(
         per_record_attempts = (
             recovery_state.reprompt_attempts_per_record if recovery_state else None
         )
-        service._retry_service.apply_exhausted_reprompt_metadata(
+        context.service._retry_service.apply_exhausted_reprompt_metadata(
             results=still_failing,
             failed_ids=failed_ids,
             validation_name=validation_name,
@@ -427,13 +386,13 @@ def check_and_submit_reprompt(
         return True
 
     next_attempt = current_attempt + 1
-    submission = service._retry_service.submit_reprompt_batch(
-        provider=provider,
+    submission = context.service._retry_service.submit_reprompt_batch(
+        provider=context.provider,
         failed_results=repromptable,
         context_map=context_map,
-        output_directory=output_directory,
-        file_name=file_name,
-        agent_config=agent_config,
+        output_directory=context.output_directory,
+        file_name=identity.file_name,
+        agent_config=context.agent_config,
         attempt=next_attempt,
     )
 
@@ -441,7 +400,7 @@ def check_and_submit_reprompt(
         return True
 
     _register_recovery_batch(
-        manager, submission, file_name, entry.provider, RecoveryType.REPROMPT, next_attempt
+        context.manager, submission, identity.file_name, identity.entry.provider, RecoveryType.REPROMPT, next_attempt
     )
 
     state = RecoveryState(
@@ -472,10 +431,10 @@ def check_and_submit_reprompt(
             rid: meta.retry.failures for rid, meta in exhausted_recovery.items() if meta.retry
         }
 
-    RecoveryStateManager.save(output_directory, file_name, state)
+    RecoveryStateManager.save(context.output_directory, identity.file_name, state)
     fire_event(
         RepromptRetryEvent(
-            action_name=file_name or "batch",
+            action_name=identity.file_name or "batch",
             attempt=next_attempt,
             max_attempts=max_attempts,
             error=f"{len(still_failing)} records failed validation",
@@ -484,7 +443,7 @@ def check_and_submit_reprompt(
     )
     logger.info(
         "Async reprompt submitted for %s: %d failed records, batch %s",
-        file_name,
+        identity.file_name,
         len(repromptable),
         submission[0],
     )
@@ -497,28 +456,23 @@ def check_and_submit_reprompt(
 
 
 def finalize_batch_output(
-    service: "BatchProcessingService",
+    context: RecoveryContext,
+    identity: BatchIdentity,
     batch_results: list[BatchResult],
-    exhausted_recovery: dict[str, RecoveryMetadata] | None,
     context_map: dict[str, Any],
-    output_directory: str,
-    file_name: str,
-    batch_id: str,
-    agent_config: dict[str, Any] | None,
-    manager: BatchRegistryManager,
-    action_name: str | None,
-    start_time: float,
+    exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
 ) -> str:
     """Finalize batch processing: convert, write output, fire events."""
+    service = context.service
     processed_data, _stats = service._convert_batch_results_to_workflow_format(
         batch_results,
         context_map=context_map,
-        output_directory=output_directory,
-        agent_config=agent_config,
+        output_directory=context.output_directory,
+        agent_config=context.agent_config,
         exhausted_recovery=exhausted_recovery,
     )
 
-    effective_action_name = action_name if action_name is not None else service._action_name
+    effective_action_name = context.action_name if context.action_name is not None else service._action_name
 
     # SUCCESS/FAILED/EXHAUSTED dispositions and state stamping are handled by the
     # shared collector inside _convert_batch_results_to_workflow_format. FILTERED
@@ -530,8 +484,8 @@ def finalize_batch_output(
         service._write_filtered_dispositions(context_map, effective_action_name)
         service._update_prompt_trace_responses(processed_data, effective_action_name)
 
-    output_file = service._determine_output_path(output_directory, file_name, batch_id)
-    service._write_batch_output(output_file, processed_data, output_directory, action_name)
+    output_file = service._determine_output_path(context.output_directory, identity.file_name, identity.batch_id)
+    service._write_batch_output(output_file, processed_data, context.output_directory, context.action_name)
 
     # Remove batch placeholder file if storage backend wrote to SQLite instead.
     # The placeholder (written at batch submission) persists on disk when
@@ -540,14 +494,14 @@ def finalize_batch_output(
     if service._storage_backend and output_path.exists():
         _remove_batch_placeholder(output_path)
 
-    elapsed_time = time.time() - start_time
+    elapsed_time = time.time() - context.start_time
     total_count = len(batch_results)
     successful_count = sum(1 for r in batch_results if r.success)
 
     fire_event(
         BatchCompleteEvent(
-            batch_id=batch_id,
-            action_name=file_name or "default",
+            batch_id=identity.batch_id,
+            action_name=identity.file_name or "default",
             total=total_count,
             completed=successful_count,
             failed=total_count - successful_count,
@@ -555,18 +509,16 @@ def finalize_batch_output(
         )
     )
 
-    manager.update_status(batch_id, BatchStatus.COMPLETED)
+    context.manager.update_status(identity.batch_id, BatchStatus.COMPLETED)
     return str(output_file)
 
 
 def cleanup_recovery(
-    service: "BatchProcessingService",
-    manager: BatchRegistryManager,
-    output_directory: str,
-    parent_file_name: str,
+    context: RecoveryContext,
+    identity: BatchIdentity,
 ) -> None:
     """Remove recovery batch entries from registry after finalization."""
-    service._cleanup_recovery_entries(manager, parent_file_name)
+    context.service._cleanup_recovery_entries(context.manager, identity.file_name)
 
 
 # ---------------------------------------------------------------------------
@@ -575,34 +527,22 @@ def cleanup_recovery(
 
 
 def _finalize_and_cleanup(
-    service: "BatchProcessingService",
+    context: RecoveryContext,
+    identity: BatchIdentity,
     batch_results: list[BatchResult],
-    exhausted_recovery: dict[str, RecoveryMetadata] | None,
     context_map: dict[str, Any],
-    output_directory: str,
-    parent_file_name: str,
-    batch_id: str,
-    agent_config: dict[str, Any] | None,
-    manager: BatchRegistryManager,
-    action_name: str | None,
-    start_time: float,
+    exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
 ) -> str:
     """Delete recovery state, finalize output, then clean up registry entries."""
-    RecoveryStateManager.delete(output_directory, parent_file_name)
+    RecoveryStateManager.delete(context.output_directory, identity.file_name)
     output_path = finalize_batch_output(
-        service,
+        context,
+        identity,
         batch_results=batch_results,
-        exhausted_recovery=exhausted_recovery,
         context_map=context_map,
-        output_directory=output_directory,
-        file_name=parent_file_name,
-        batch_id=batch_id,
-        agent_config=agent_config,
-        manager=manager,
-        action_name=action_name,
-        start_time=start_time,
+        exhausted_recovery=exhausted_recovery,
     )
-    cleanup_recovery(service, manager, output_directory, parent_file_name)
+    cleanup_recovery(context, identity)
     return output_path
 
 

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -606,7 +606,11 @@ def _remove_batch_placeholder(output_file: Path) -> None:
         logger.warning("Malformed JSON at %s during placeholder cleanup", output_file)
         return
 
-    if isinstance(data, dict) and "batch_job_id" in data and data.get("status") == BatchStatus.SUBMITTED:
+    if (
+        isinstance(data, dict)
+        and "batch_job_id" in data
+        and data.get("status") == BatchStatus.SUBMITTED
+    ):
         try:
             output_file.unlink()
             logger.debug("Removed batch placeholder: %s", output_file)

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -165,7 +165,12 @@ def handle_retry_recovery(
         )
         if submission:
             _register_recovery_batch(
-                context.manager, submission, identity.file_name, identity.entry.provider, RecoveryType.RETRY, next_attempt
+                context.manager,
+                submission,
+                identity.file_name,
+                identity.entry.provider,
+                RecoveryType.RETRY,
+                next_attempt,
             )
             state.retry_attempt = next_attempt
             state.missing_ids = list(still_missing)
@@ -260,7 +265,12 @@ def handle_reprompt_recovery(
         )
         if submission:
             _register_recovery_batch(
-                context.manager, submission, identity.file_name, identity.entry.provider, RecoveryType.REPROMPT, next_attempt
+                context.manager,
+                submission,
+                identity.file_name,
+                identity.entry.provider,
+                RecoveryType.REPROMPT,
+                next_attempt,
             )
             fire_event(
                 RepromptRetryEvent(
@@ -400,7 +410,12 @@ def check_and_submit_reprompt(
         return True
 
     _register_recovery_batch(
-        context.manager, submission, identity.file_name, identity.entry.provider, RecoveryType.REPROMPT, next_attempt
+        context.manager,
+        submission,
+        identity.file_name,
+        identity.entry.provider,
+        RecoveryType.REPROMPT,
+        next_attempt,
     )
 
     state = RecoveryState(
@@ -472,7 +487,9 @@ def finalize_batch_output(
         exhausted_recovery=exhausted_recovery,
     )
 
-    effective_action_name = context.action_name if context.action_name is not None else service._action_name
+    effective_action_name = (
+        context.action_name if context.action_name is not None else service._action_name
+    )
 
     # SUCCESS/FAILED/EXHAUSTED dispositions and state stamping are handled by the
     # shared collector inside _convert_batch_results_to_workflow_format. FILTERED
@@ -484,8 +501,12 @@ def finalize_batch_output(
         service._write_filtered_dispositions(context_map, effective_action_name)
         service._update_prompt_trace_responses(processed_data, effective_action_name)
 
-    output_file = service._determine_output_path(context.output_directory, identity.file_name, identity.batch_id)
-    service._write_batch_output(output_file, processed_data, context.output_directory, context.action_name)
+    output_file = service._determine_output_path(
+        context.output_directory, identity.file_name, identity.batch_id
+    )
+    service._write_batch_output(
+        output_file, processed_data, context.output_directory, context.action_name
+    )
 
     # Remove batch placeholder file if storage backend wrote to SQLite instead.
     # The placeholder (written at batch submission) persists on disk when

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -606,7 +606,7 @@ def _remove_batch_placeholder(output_file: Path) -> None:
         logger.warning("Malformed JSON at %s during placeholder cleanup", output_file)
         return
 
-    if isinstance(data, dict) and "batch_job_id" in data and data.get("status") == "submitted":
+    if isinstance(data, dict) and "batch_job_id" in data and data.get("status") == BatchStatus.SUBMITTED:
         try:
             output_file.unlink()
             logger.debug("Removed batch placeholder: %s", output_file)

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -15,9 +15,9 @@ import logging
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
-from agent_actions.llm.batch.core.batch_constants import BatchStatus
+from agent_actions.llm.batch.core.batch_constants import BatchStatus, RecoveryPhase, RecoveryType
 from agent_actions.llm.batch.core.batch_models import BatchJobEntry
 from agent_actions.llm.batch.infrastructure.recovery_state import (
     RecoveryState,
@@ -93,7 +93,7 @@ def process_recovery_batch(
 
     accumulated = BatchRetryService.deserialize_results(state.accumulated_results)
 
-    if entry.recovery_type == "retry":
+    if entry.recovery_type == RecoveryType.RETRY:
         return handle_retry_recovery(
             service,
             state=state,
@@ -109,7 +109,7 @@ def process_recovery_batch(
             action_name=action_name,
             start_time=start_time,
         )
-    elif entry.recovery_type == "reprompt":
+    elif entry.recovery_type == RecoveryType.REPROMPT:
         return handle_reprompt_recovery(
             service,
             state=state,
@@ -171,7 +171,7 @@ def handle_retry_recovery(
         )
         if submission:
             _register_recovery_batch(
-                manager, submission, parent_file_name, entry.provider, "retry", next_attempt
+                manager, submission, parent_file_name, entry.provider, RecoveryType.RETRY, next_attempt
             )
             state.retry_attempt = next_attempt
             state.missing_ids = list(still_missing)
@@ -290,7 +290,7 @@ def handle_reprompt_recovery(
         )
         if submission:
             _register_recovery_batch(
-                manager, submission, parent_file_name, entry.provider, "reprompt", next_attempt
+                manager, submission, parent_file_name, entry.provider, RecoveryType.REPROMPT, next_attempt
             )
             fire_event(
                 RepromptRetryEvent(
@@ -441,11 +441,11 @@ def check_and_submit_reprompt(
         return True
 
     _register_recovery_batch(
-        manager, submission, file_name, entry.provider, "reprompt", next_attempt
+        manager, submission, file_name, entry.provider, RecoveryType.REPROMPT, next_attempt
     )
 
     state = RecoveryState(
-        phase="reprompt",
+        phase=RecoveryPhase.REPROMPT,
         reprompt_attempt=next_attempt,
         reprompt_max_attempts=max_attempts,
         validation_name=strategy.name,
@@ -611,7 +611,7 @@ def _register_recovery_batch(
     submission: tuple[str, int],
     parent_file_name: str,
     provider: str,
-    recovery_type: Literal["retry", "reprompt"],
+    recovery_type: RecoveryType,
     attempt: int,
 ) -> None:
     """Register a new recovery batch entry in the manager."""

--- a/tests/simulation/simulate_reprompt_additional_bugs.py
+++ b/tests/simulation/simulate_reprompt_additional_bugs.py
@@ -17,7 +17,12 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
-from agent_actions.llm.batch.core.batch_models import BatchIdentity, BatchJobEntry, BatchRegistryStats, RecoveryContext
+from agent_actions.llm.batch.core.batch_models import (
+    BatchIdentity,
+    BatchJobEntry,
+    BatchRegistryStats,
+    RecoveryContext,
+)
 from agent_actions.llm.batch.infrastructure.recovery_state import RecoveryState
 from agent_actions.llm.batch.services.processing import BatchProcessingService
 from agent_actions.llm.batch.services.processing_recovery import check_and_submit_reprompt

--- a/tests/simulation/simulate_reprompt_additional_bugs.py
+++ b/tests/simulation/simulate_reprompt_additional_bugs.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry, BatchRegistryStats
+from agent_actions.llm.batch.core.batch_models import BatchIdentity, BatchJobEntry, BatchRegistryStats, RecoveryContext
 from agent_actions.llm.batch.infrastructure.recovery_state import RecoveryState
 from agent_actions.llm.batch.services.processing import BatchProcessingService
 from agent_actions.llm.batch.services.processing_recovery import check_and_submit_reprompt
@@ -138,16 +138,27 @@ def run_bug8_no_state_mutation():
         loop.split.return_value = ([], [_make_result("id-1", success=False)], {})
         mock_build.return_value = (loop, strategy)
 
-        check_and_submit_reprompt(
-            service,
-            batch_results=[_make_result("id-1", success=False)],
-            context_map={},
-            output_directory="/tmp",
-            file_name="my_action",
-            entry=_make_parent_entry(),
-            agent_config={"kind": "llm"},
+        entry = _make_parent_entry()
+        ctx = RecoveryContext(
+            service=service,
             manager=MagicMock(),
             provider=MagicMock(),
+            agent_config={"kind": "llm"},
+            output_directory="/tmp",
+            action_name=None,
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name="my_action",
+            entry=entry,
+        )
+
+        check_and_submit_reprompt(
+            context=ctx,
+            identity=identity,
+            batch_results=[_make_result("id-1", success=False)],
+            context_map={},
             recovery_state=state,
         )
 
@@ -196,16 +207,27 @@ def run_bug10_none_content_filtered():
         loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy)
 
-        check_and_submit_reprompt(
-            service,
-            batch_results=results,
-            context_map={"id-real-fail": {}, "id-none": {}},
-            output_directory="/tmp",
-            file_name="my_action",
-            entry=_make_parent_entry(),
-            agent_config={"kind": "llm"},
+        entry = _make_parent_entry()
+        ctx = RecoveryContext(
+            service=service,
             manager=MagicMock(),
             provider=MagicMock(),
+            agent_config={"kind": "llm"},
+            output_directory="/tmp",
+            action_name=None,
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name="my_action",
+            entry=entry,
+        )
+
+        check_and_submit_reprompt(
+            context=ctx,
+            identity=identity,
+            batch_results=results,
+            context_map={"id-real-fail": {}, "id-none": {}},
         )
 
     call_kwargs = service._retry_service.submit_reprompt_batch.call_args.kwargs

--- a/tests/simulation/simulate_reprompt_rerun_loop.py
+++ b/tests/simulation/simulate_reprompt_rerun_loop.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.core.batch_models import BatchIdentity, BatchJobEntry, RecoveryContext
 from agent_actions.llm.batch.infrastructure.recovery_state import (
     RecoveryState,
 )
@@ -155,16 +155,26 @@ def run_max_attempts_enforced(work_dir):
         loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy)
 
-        should_continue = check_and_submit_reprompt(
-            service,
-            batch_results=results,
-            context_map={"id-fail": {}},
-            output_directory=str(work_dir),
-            file_name="my_action",
-            entry=entry,
-            agent_config={"kind": "llm"},
+        ctx = RecoveryContext(
+            service=service,
             manager=MagicMock(),
             provider=MagicMock(),
+            agent_config={"kind": "llm"},
+            output_directory=str(work_dir),
+            action_name=None,
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name="my_action",
+            entry=entry,
+        )
+
+        should_continue = check_and_submit_reprompt(
+            context=ctx,
+            identity=identity,
+            batch_results=results,
+            context_map={"id-fail": {}},
             recovery_state=None,
         )
 
@@ -186,16 +196,26 @@ def run_max_attempts_enforced(work_dir):
         loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy)
 
-        should_continue = check_and_submit_reprompt(
-            service,
-            batch_results=results,
-            context_map={"id-fail": {}},
-            output_directory=str(work_dir),
-            file_name="my_action",
-            entry=entry,
-            agent_config={"kind": "llm"},
+        ctx = RecoveryContext(
+            service=service,
             manager=MagicMock(),
             provider=MagicMock(),
+            agent_config={"kind": "llm"},
+            output_directory=str(work_dir),
+            action_name=None,
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name="my_action",
+            entry=entry,
+        )
+
+        should_continue = check_and_submit_reprompt(
+            context=ctx,
+            identity=identity,
+            batch_results=results,
+            context_map={"id-fail": {}},
             recovery_state=state_run2,
         )
 
@@ -214,16 +234,26 @@ def run_max_attempts_enforced(work_dir):
         loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy)
 
-        should_continue = check_and_submit_reprompt(
-            service,
-            batch_results=results,
-            context_map={},
-            output_directory=str(work_dir),
-            file_name="my_action",
-            entry=entry,
-            agent_config={"kind": "llm"},
+        ctx = RecoveryContext(
+            service=service,
             manager=MagicMock(),
             provider=MagicMock(),
+            agent_config={"kind": "llm"},
+            output_directory=str(work_dir),
+            action_name=None,
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name="my_action",
+            entry=entry,
+        )
+
+        should_continue = check_and_submit_reprompt(
+            context=ctx,
+            identity=identity,
+            batch_results=results,
+            context_map={},
             recovery_state=state_run3,
         )
 
@@ -298,16 +328,26 @@ def run_graduated_pool_persists(work_dir):
         loop.split.return_value = ([], results, {})
         mock_build.return_value = (loop, strategy)
 
-        check_and_submit_reprompt(
-            service,
-            batch_results=results,
-            context_map={"id-still-bad": {}},
-            output_directory=str(work_dir),
-            file_name="my_action",
-            entry=entry,
-            agent_config={"kind": "llm"},
+        ctx = RecoveryContext(
+            service=service,
             manager=MagicMock(),
             provider=MagicMock(),
+            agent_config={"kind": "llm"},
+            output_directory=str(work_dir),
+            action_name=None,
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name="my_action",
+            entry=entry,
+        )
+
+        check_and_submit_reprompt(
+            context=ctx,
+            identity=identity,
+            batch_results=results,
+            context_map={"id-still-bad": {}},
             recovery_state=prior_state,
         )
 

--- a/tests/unit/llm/batch/test_composed_recovery.py
+++ b/tests/unit/llm/batch/test_composed_recovery.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.core.batch_models import BatchIdentity, BatchJobEntry, RecoveryContext
 from agent_actions.llm.batch.infrastructure.recovery_state import (
     RecoveryState,
 )
@@ -77,6 +77,37 @@ def _mock_service():
     return service
 
 
+def _make_context_and_identity(
+    service=None,
+    entry=None,
+    manager=None,
+    provider=None,
+    agent_config=None,
+    output_directory="/tmp",
+    action_name="test_action",
+    start_time=0.0,
+    parent_file_name="test_file",
+):
+    """Build RecoveryContext + BatchIdentity for tests."""
+    service = service or _mock_service()
+    entry = entry or _make_entry()
+    context = RecoveryContext(
+        service=service,
+        manager=manager or MagicMock(),
+        provider=provider or MagicMock(),
+        agent_config=agent_config or {"kind": "llm"},
+        output_directory=output_directory,
+        action_name=action_name,
+        start_time=start_time,
+    )
+    identity = BatchIdentity(
+        batch_id=entry.batch_id,
+        file_name=parent_file_name,
+        entry=entry,
+    )
+    return context, identity
+
+
 # ---------------------------------------------------------------------------
 # TestComposedRecoveryPaths
 # ---------------------------------------------------------------------------
@@ -111,20 +142,15 @@ class TestComposedRecoveryPaths:
         loop.split.return_value = ([_make_result("id-1")], [], {})
         mock_build_loop.return_value = (loop, strategy)
 
+        context, identity = _make_context_and_identity(service=service)
+
         result = handle_retry_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=[_make_result("id-1")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         # Composed path completed: output written
@@ -159,20 +185,15 @@ class TestComposedRecoveryPaths:
         loop.split.return_value = ([], [failing_result], {})
         mock_build_loop.return_value = (loop, strategy)
 
+        context, identity = _make_context_and_identity(service=service)
+
         result = handle_retry_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=[_make_result("id-1")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         # Exhaustion metadata applied (return_last path — no raise)
@@ -213,21 +234,16 @@ class TestComposedRecoveryPaths:
             lambda **kwargs: apply_exhausted_reprompt(**kwargs)
         )
 
+        context, identity = _make_context_and_identity(service=service)
+
         with pytest.raises(RuntimeError, match="Reprompt validation exhausted"):
             handle_retry_recovery(
-                service,
+                context,
+                identity,
                 state=state,
                 recovery_results=[_make_result("id-1")],
                 accumulated=[],
                 context_map={},
-                output_directory="/tmp",
-                parent_file_name="test_file",
-                entry=_make_entry(),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
-                action_name="test_action",
-                start_time=0.0,
             )
 
     @patch("agent_actions.llm.batch.services.processing_recovery.fire_event")
@@ -248,20 +264,15 @@ class TestComposedRecoveryPaths:
         # No reprompt configured
         mock_build_loop.return_value = None
 
+        context, identity = _make_context_and_identity(service=service)
+
         result = handle_retry_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=[_make_result("id-1")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         # Finalizes directly without reprompt
@@ -285,20 +296,17 @@ class TestComposedRecoveryPaths:
         loop.split.return_value = ([_make_result("id-1"), _make_result("id-2")], [], {})
         mock_build_loop.return_value = (loop, strategy)
 
+        context, identity = _make_context_and_identity(
+            service=service, entry=_make_entry(recovery_type="reprompt"),
+        )
+
         result = handle_reprompt_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=[_make_result("id-1"), _make_result("id-2")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(recovery_type="reprompt"),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         assert result == "/tmp/output.json"
@@ -367,7 +375,7 @@ class TestRecoveryStateRoundtrip:
 
     def test_invalid_phase_raises(self):
         """Invalid phase value raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid recovery phase"):
+        with pytest.raises(ValueError, match="is not a valid RecoveryPhase"):
             RecoveryState(phase="invalid")
 
 
@@ -403,20 +411,17 @@ class TestGraduatedPoolMonotonicity:
 
         recovery_results = [_make_result("id-new"), _make_result("id-still-bad")]
 
+        context, identity = _make_context_and_identity(
+            service=service, entry=_make_entry(recovery_type="reprompt"),
+        )
+
         handle_reprompt_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=recovery_results,
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(recovery_type="reprompt"),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         # Key invariant: split() received ONLY recovery_results, not prior graduated
@@ -448,20 +453,17 @@ class TestGraduatedPoolMonotonicity:
             graduated_results=[{"custom_id": "id-1", "content": "c1", "success": True}],
         )
 
+        context, identity = _make_context_and_identity(
+            service=service, entry=_make_entry(recovery_type="reprompt"),
+        )
+
         handle_reprompt_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=[_make_result("id-2"), _make_result("id-3")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(recovery_type="reprompt"),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         # Monotonicity: prior graduate preserved + new one appended

--- a/tests/unit/llm/batch/test_composed_recovery.py
+++ b/tests/unit/llm/batch/test_composed_recovery.py
@@ -297,7 +297,8 @@ class TestComposedRecoveryPaths:
         mock_build_loop.return_value = (loop, strategy)
 
         context, identity = _make_context_and_identity(
-            service=service, entry=_make_entry(recovery_type="reprompt"),
+            service=service,
+            entry=_make_entry(recovery_type="reprompt"),
         )
 
         result = handle_reprompt_recovery(
@@ -412,7 +413,8 @@ class TestGraduatedPoolMonotonicity:
         recovery_results = [_make_result("id-new"), _make_result("id-still-bad")]
 
         context, identity = _make_context_and_identity(
-            service=service, entry=_make_entry(recovery_type="reprompt"),
+            service=service,
+            entry=_make_entry(recovery_type="reprompt"),
         )
 
         handle_reprompt_recovery(
@@ -454,7 +456,8 @@ class TestGraduatedPoolMonotonicity:
         )
 
         context, identity = _make_context_and_identity(
-            service=service, entry=_make_entry(recovery_type="reprompt"),
+            service=service,
+            entry=_make_entry(recovery_type="reprompt"),
         )
 
         handle_reprompt_recovery(

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -17,7 +17,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry, BatchRegistryStats
+from agent_actions.llm.batch.core.batch_models import (
+    BatchIdentity,
+    BatchJobEntry,
+    BatchRegistryStats,
+    RecoveryContext,
+)
 from agent_actions.llm.batch.infrastructure.recovery_state import RecoveryState
 from agent_actions.llm.batch.services.processing import BatchProcessingService
 from agent_actions.llm.batch.services.processing_recovery import (
@@ -94,6 +99,47 @@ def _mock_service():
     service._cleanup_recovery_entries = MagicMock()
     service._update_prompt_trace_responses = MagicMock()
     return service
+
+
+def _make_context_and_identity(
+    service=None,
+    entry=None,
+    manager=None,
+    provider=None,
+    agent_config=None,
+    output_directory="/tmp",
+    action_name="test_action",
+    start_time=0.0,
+    file_name="test_file",
+    batch_id="batch-123",
+):
+    """Construct a (RecoveryContext, BatchIdentity) pair for tests."""
+    if service is None:
+        service = _mock_service()
+    if entry is None:
+        entry = _make_entry()
+    if manager is None:
+        manager = MagicMock()
+    if provider is None:
+        provider = MagicMock()
+    if agent_config is None:
+        agent_config = {"kind": "llm"}
+
+    context = RecoveryContext(
+        service=service,
+        manager=manager,
+        provider=provider,
+        agent_config=agent_config,
+        output_directory=output_directory,
+        action_name=action_name,
+        start_time=start_time,
+    )
+    identity = BatchIdentity(
+        batch_id=batch_id,
+        file_name=file_name,
+        entry=entry,
+    )
+    return context, identity
 
 
 # ---------------------------------------------------------------------------
@@ -243,23 +289,20 @@ class TestHandleRetryRecovery:
         )
         service._retry_service.submit_retry_batch.return_value = ("new-batch-id", 1)
 
+        ctx, ident = _make_context_and_identity(
+            service=service, manager=manager, file_name="test_file"
+        )
+
         with patch(
             "agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager"
         ) as mock_mgr:
             result = handle_retry_recovery(
-                service,
+                ctx,
+                ident,
                 state=state,
                 recovery_results=[_make_result("id-1")],
                 accumulated=[],
                 context_map={},
-                output_directory="/tmp",
-                parent_file_name="test_file",
-                entry=_make_entry(),
-                agent_config={"kind": "llm"},
-                manager=manager,
-                provider=MagicMock(),
-                action_name="test_action",
-                start_time=0.0,
             )
 
         assert result is None  # More retries pending
@@ -311,23 +354,18 @@ class TestHandleRetryRecovery:
         loop.split.return_value = ([_make_result("id-1")], [], {})  # all pass
         mock_build_loop.return_value = (loop, strategy)
 
+        ctx, ident = _make_context_and_identity(service=service, file_name="test_file")
+
         with patch(
             "agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager"
         ) as mock_mgr:
             result = handle_retry_recovery(
-                service,
+                ctx,
+                ident,
                 state=state,
                 recovery_results=[_make_result("id-1")],
                 accumulated=[],
                 context_map={},
-                output_directory="/tmp",
-                parent_file_name="test_file",
-                entry=_make_entry(),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
-                action_name="test_action",
-                start_time=0.0,
             )
 
         # Observable: phase transition happened (reprompt ran), then finalized
@@ -356,23 +394,20 @@ class TestHandleRetryRecovery:
         )
         mock_build_loop.return_value = None  # no reprompt configured
 
+        ctx, ident = _make_context_and_identity(
+            service=service, manager=manager, file_name="test_file"
+        )
+
         with patch(
             "agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager"
         ) as mock_mgr:
             result = handle_retry_recovery(
-                service,
+                ctx,
+                ident,
                 state=state,
                 recovery_results=[_make_result("id-1"), _make_result("id-2")],
                 accumulated=[],
                 context_map={},
-                output_directory="/tmp",
-                parent_file_name="test_file",
-                entry=_make_entry(),
-                agent_config={"kind": "llm"},
-                manager=manager,
-                provider=MagicMock(),
-                action_name="test_action",
-                start_time=0.0,
             )
 
         # Observable: output written, event fired with correct payload, state cleaned
@@ -419,24 +454,21 @@ class TestHandleRepromptRecovery:
         service = _mock_service()
         state = _make_state(phase="reprompt", reprompt_attempt=1)
 
+        ctx, ident = _make_context_and_identity(
+            service=service, entry=_make_entry(recovery_type="reprompt"), file_name="test_file"
+        )
+
         with patch(
             "agent_actions.llm.batch.services.processing_recovery.finalize_batch_output",
             return_value="/tmp/output.json",
         ) as mock_finalize:
             result = handle_reprompt_recovery(
-                service,
+                ctx,
+                ident,
                 state=state,
                 recovery_results=[_make_result("id-1"), _make_result("id-2")],
                 accumulated=[],
                 context_map={},
-                output_directory="/tmp",
-                parent_file_name="test_file",
-                entry=_make_entry(recovery_type="reprompt"),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
-                action_name="test_action",
-                start_time=0.0,
             )
 
         assert result == "/tmp/output.json"
@@ -456,20 +488,20 @@ class TestHandleRepromptRecovery:
 
         service._retry_service.submit_reprompt_batch.return_value = ("reprompt-batch-2", 1)
 
+        ctx, ident = _make_context_and_identity(
+            service=service,
+            manager=manager,
+            entry=_make_entry(recovery_type="reprompt"),
+            file_name="test_file",
+        )
+
         result = handle_reprompt_recovery(
-            service,
+            ctx,
+            ident,
             state=state,
             recovery_results=[_make_result("id-1"), _make_result("id-2")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(recovery_type="reprompt"),
-            agent_config={"kind": "llm"},
-            manager=manager,
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         assert result is None  # More reprompts pending
@@ -488,24 +520,21 @@ class TestHandleRepromptRecovery:
         # reprompt_attempt == max → exhausted
         state = _make_state(phase="reprompt", reprompt_attempt=2, reprompt_max_attempts=2)
 
+        ctx, ident = _make_context_and_identity(
+            service=service, entry=_make_entry(recovery_type="reprompt"), file_name="test_file"
+        )
+
         with patch(
             "agent_actions.llm.batch.services.processing_recovery.finalize_batch_output",
             return_value="/tmp/output.json",
         ):
             result = handle_reprompt_recovery(
-                service,
+                ctx,
+                ident,
                 state=state,
                 recovery_results=[_make_result("id-1"), _make_result("id-2")],
                 accumulated=[],
                 context_map={},
-                output_directory="/tmp",
-                parent_file_name="test_file",
-                entry=_make_entry(recovery_type="reprompt"),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
-                action_name="test_action",
-                start_time=0.0,
             )
 
         assert result == "/tmp/output.json"
@@ -525,20 +554,17 @@ class TestHandleRepromptRecovery:
 
         service._retry_service.submit_reprompt_batch.return_value = ("reprompt-batch", 1)
 
+        ctx, ident = _make_context_and_identity(
+            service=service, entry=_make_entry(recovery_type="reprompt"), file_name="test_file"
+        )
+
         handle_reprompt_recovery(
-            service,
+            ctx,
+            ident,
             state=state,
             recovery_results=[_make_result("id-1"), _make_result("id-2")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(recovery_type="reprompt"),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         assert len(state.graduated_results) == 2  # 1 old + 1 new (id-1 graduated)
@@ -559,21 +585,18 @@ class TestFinalizeBatchOutput:
         if results is None:
             results = [_make_result("id-1"), _make_result("id-2", success=False)]
 
+        ctx, ident = _make_context_and_identity(
+            service=service, manager=manager, batch_id=batch_id, file_name="test_file"
+        )
+
         with (
             patch("agent_actions.llm.batch.services.processing_recovery.fire_event") as mock_event,
         ):
             output_path = finalize_batch_output(
-                service,
+                ctx,
+                ident,
                 batch_results=results,
-                exhausted_recovery=None,
                 context_map={},
-                output_directory="/tmp",
-                file_name="test_file",
-                batch_id=batch_id,
-                agent_config={"kind": "llm"},
-                manager=manager,
-                action_name="test_action",
-                start_time=0.0,
             )
 
         event = mock_event.call_args[0][0]
@@ -619,19 +642,16 @@ class TestFinalizeBatchOutput:
         manager = MagicMock()
         context_map = {"custom-filtered-1": {"source_guid": "sg-001"}}
 
+        ctx, ident = _make_context_and_identity(
+            service=service, manager=manager, file_name="test_file"
+        )
+
         with patch("agent_actions.llm.batch.services.processing_recovery.fire_event"):
             finalize_batch_output(
-                service,
+                ctx,
+                ident,
                 batch_results=[_make_result("id-1")],
-                exhausted_recovery=None,
                 context_map=context_map,
-                output_directory="/tmp",
-                file_name="test_file",
-                batch_id="batch-123",
-                agent_config={"kind": "llm"},
-                manager=manager,
-                action_name="test_action",
-                start_time=0.0,
             )
 
         service._write_filtered_dispositions.assert_called_once_with(context_map, "test_action")
@@ -648,19 +668,16 @@ class TestFinalizeBatchOutput:
         manager = MagicMock()
         context_map = {"custom-filtered-1": {"source_guid": "sg-001"}}
 
+        ctx, ident = _make_context_and_identity(
+            service=service, manager=manager, action_name=None, file_name="test_file"
+        )
+
         with patch("agent_actions.llm.batch.services.processing_recovery.fire_event"):
             finalize_batch_output(
-                service,
+                ctx,
+                ident,
                 batch_results=[_make_result("id-1")],
-                exhausted_recovery=None,
                 context_map=context_map,
-                output_directory="/tmp",
-                file_name="test_file",
-                batch_id="batch-123",
-                agent_config={"kind": "llm"},
-                manager=manager,
-                action_name=None,
-                start_time=0.0,
             )
 
         service._write_filtered_dispositions.assert_called_once_with(context_map, "fallback_action")
@@ -687,23 +704,18 @@ class TestRecoveryStatePersistence:
         )
         service._retry_service.submit_retry_batch.return_value = ("new-batch", 1)
 
+        ctx, ident = _make_context_and_identity(service=service, file_name="test_file")
+
         with patch(
             "agent_actions.llm.batch.services.processing_recovery.RecoveryStateManager"
         ) as mock_mgr:
             handle_retry_recovery(
-                service,
+                ctx,
+                ident,
                 state=state,
                 recovery_results=[],
                 accumulated=[],
                 context_map={},
-                output_directory="/tmp",
-                parent_file_name="test_file",
-                entry=_make_entry(),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
-                action_name="test_action",
-                start_time=0.0,
             )
 
         assert state.retry_attempt == 2
@@ -723,20 +735,17 @@ class TestRecoveryStatePersistence:
         state = _make_state(phase="reprompt", reprompt_attempt=1, reprompt_max_attempts=3)
         service._retry_service.submit_reprompt_batch.return_value = ("reprompt-batch", 1)
 
+        ctx, ident = _make_context_and_identity(
+            service=service, entry=_make_entry(recovery_type="reprompt"), file_name="test_file"
+        )
+
         handle_reprompt_recovery(
-            service,
+            ctx,
+            ident,
             state=state,
             recovery_results=[_make_result("id-1")],
             accumulated=[],
             context_map={},
-            output_directory="/tmp",
-            parent_file_name="test_file",
-            entry=_make_entry(recovery_type="reprompt"),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         assert state.reprompt_attempt == 2
@@ -1039,16 +1048,17 @@ class TestRecoveryLoopRootCauses:
             mock_build_loop.return_value = (loop, strategy)
             service._retry_service.submit_reprompt_batch.return_value = ("reprompt-batch-2", 1)
 
+            ctx, ident = _make_context_and_identity(
+                service=service,
+                entry=_make_parent_entry(record_count=1),
+                file_name="my_action",
+            )
+
             should_continue = check_and_submit_reprompt(
-                service,
+                ctx,
+                ident,
                 batch_results=results,
                 context_map={"id-fail": {"user_content": "test"}},
-                output_directory="/tmp",
-                file_name="my_action",
-                entry=_make_parent_entry(record_count=1),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
                 recovery_state=persisted_state,
             )
 
@@ -1069,16 +1079,17 @@ class TestRecoveryLoopRootCauses:
             loop.split.return_value = ([], results, {})
             mock_build_loop.return_value = (loop, strategy)
 
+            ctx, ident = _make_context_and_identity(
+                service=service,
+                entry=_make_parent_entry(record_count=1),
+                file_name="my_action",
+            )
+
             should_continue = check_and_submit_reprompt(
-                service,
+                ctx,
+                ident,
                 batch_results=results,
                 context_map={},
-                output_directory="/tmp",
-                file_name="my_action",
-                entry=_make_parent_entry(record_count=1),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
                 recovery_state=exhausted_state,
             )
 
@@ -1133,16 +1144,17 @@ class TestDownstreamBugs:
             accumulated_results=[{"custom_id": "id-1", "content": "retry-data", "success": True}],
         )
 
+        ctx, ident = _make_context_and_identity(
+            service=service,
+            entry=_make_parent_entry(record_count=1),
+            file_name="my_action",
+        )
+
         check_and_submit_reprompt(
-            service,
+            ctx,
+            ident,
             batch_results=[_make_result("id-1", success=False)],
             context_map={},
-            output_directory="/tmp",
-            file_name="my_action",
-            entry=_make_parent_entry(record_count=1),
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            provider=MagicMock(),
             recovery_state=state,
         )
 
@@ -1166,16 +1178,17 @@ class TestDownstreamBugs:
             mock_build_loop.return_value = (loop, strategy)
             service._retry_service.submit_reprompt_batch.return_value = ("reprompt-batch", 1)
 
+            ctx, ident = _make_context_and_identity(
+                service=service,
+                entry=_make_parent_entry(record_count=2),
+                file_name="my_action",
+            )
+
             check_and_submit_reprompt(
-                service,
+                ctx,
+                ident,
                 batch_results=results,
                 context_map={"id-real-fail": {}, "id-none": {}},
-                output_directory="/tmp",
-                file_name="my_action",
-                entry=_make_parent_entry(record_count=2),
-                agent_config={"kind": "llm"},
-                manager=MagicMock(),
-                provider=MagicMock(),
             )
 
         submitted = service._retry_service.submit_reprompt_batch.call_args.kwargs["failed_results"]
@@ -1217,17 +1230,18 @@ class TestStaleRecoveryState:
         svc._storage_backend = MagicMock()
         svc._action_name = "test_action"
 
-        svc._finalize_batch_output(
-            batch_results=[_make_result("id-1")],
-            exhausted_recovery=None,
-            context_map={},
+        ctx, ident = _make_context_and_identity(
+            service=svc,
             output_directory="/tmp/output",
             file_name="my_action",
             batch_id="batch-123",
-            agent_config={"kind": "llm"},
-            manager=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
+        )
+
+        svc._finalize_batch_output(
+            context=ctx,
+            identity=ident,
+            batch_results=[_make_result("id-1")],
+            context_map={},
         )
 
         # Recovery state must be deleted before finalization

--- a/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
+++ b/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
@@ -10,6 +10,7 @@ that actually failed validation.
 import contextlib
 from unittest.mock import MagicMock, patch
 
+from agent_actions.llm.batch.core.batch_models import BatchIdentity, RecoveryContext
 from agent_actions.llm.providers.batch_base import BatchResult
 
 # ---------------------------------------------------------------------------
@@ -296,21 +297,30 @@ class TestSelectiveRepromptResubmission:
         entry.provider = "openai"
         entry.batch_id = "batch_rp_1"
         manager = MagicMock()
+        provider = MagicMock()
+
+        context = RecoveryContext(
+            service=service,
+            manager=manager,
+            provider=provider,
+            agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
+            output_directory="/tmp/out",
+            action_name="test_action",
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id="batch_rp_1",
+            file_name="batch_1",
+            entry=entry,
+        )
 
         result = handle_reprompt_recovery(
-            service,
+            context,
+            identity,
             state=state,
             recovery_results=recovery_results,
             accumulated=accumulated,
             context_map=_make_context_map(10),
-            output_directory="/tmp/out",
-            parent_file_name="batch_1",
-            entry=entry,
-            agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
-            manager=manager,
-            provider=MagicMock(),
-            action_name="test_action",
-            start_time=0.0,
         )
 
         assert result is None
@@ -685,17 +695,28 @@ class TestCheckAndSubmitRepromptSelectivity:
         entry = MagicMock()
         entry.provider = "openai"
         manager = MagicMock()
+        provider = MagicMock()
 
-        result = check_and_submit_reprompt(
-            service,
-            batch_results=all_results,
-            context_map=_make_context_map(10),
+        context = RecoveryContext(
+            service=service,
+            manager=manager,
+            provider=provider,
+            agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
             output_directory="/tmp/out",
+            action_name=None,
+            start_time=0.0,
+        )
+        identity = BatchIdentity(
+            batch_id="batch_1",
             file_name="batch_1",
             entry=entry,
-            agent_config={"reprompt": {"validation": "check_it", "max_attempts": 3}},
-            manager=manager,
-            provider=MagicMock(),
+        )
+
+        result = check_and_submit_reprompt(
+            context,
+            identity,
+            batch_results=all_results,
+            context_map=_make_context_map(10),
         )
 
         assert result is False

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
-from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.core.batch_models import (
+    BatchIdentity,
+    BatchJobEntry,
+    RecoveryContext,
+)
 from agent_actions.llm.batch.infrastructure.recovery_state import (
     RecoveryStateManager,
 )
@@ -145,7 +149,29 @@ class TestHandleRepromptRecoveryGraduatedPool:
             start_time=0.0,
         )
         defaults.update(kwargs)
-        return handle_reprompt_recovery(service, **defaults)
+        context = RecoveryContext(
+            service=service,
+            manager=defaults.pop("manager"),
+            provider=defaults.pop("provider"),
+            agent_config=defaults.pop("agent_config"),
+            output_directory=defaults.pop("output_directory"),
+            action_name=defaults.pop("action_name"),
+            start_time=defaults.pop("start_time"),
+        )
+        entry = defaults.pop("entry")
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name=defaults.pop("parent_file_name"),
+            entry=entry,
+        )
+        return handle_reprompt_recovery(
+            context=context,
+            identity=identity,
+            state=defaults["state"],
+            recovery_results=defaults["recovery_results"],
+            accumulated=defaults["accumulated"],
+            context_map=defaults["context_map"],
+        )
 
     def test_split_called_with_only_recovery_results(self, mock_loop):
         """loop.split() receives recovery_results, NOT merged accumulated."""
@@ -310,9 +336,33 @@ class TestCheckAndSubmitRepromptGraduatedPool:
             agent_config={"reprompt": {"validation": "v", "max_attempts": 2}},
             manager=MagicMock(),
             provider=MagicMock(),
+            recovery_state=None,
+            exhausted_recovery=None,
         )
         defaults.update(kwargs)
-        return check_and_submit_reprompt(service, **defaults)
+        context = RecoveryContext(
+            service=service,
+            manager=defaults.pop("manager"),
+            provider=defaults.pop("provider"),
+            agent_config=defaults.pop("agent_config"),
+            output_directory=defaults.pop("output_directory"),
+            action_name=None,
+            start_time=0.0,
+        )
+        entry = defaults.pop("entry")
+        identity = BatchIdentity(
+            batch_id=entry.batch_id,
+            file_name=defaults.pop("file_name"),
+            entry=entry,
+        )
+        return check_and_submit_reprompt(
+            context=context,
+            identity=identity,
+            batch_results=defaults["batch_results"],
+            context_map=defaults["context_map"],
+            recovery_state=defaults["recovery_state"],
+            exhausted_recovery=defaults["exhausted_recovery"],
+        )
 
     def test_uses_evaluation_loop_split(self, mock_loop):
         """EvaluationLoop.split() is used instead of validate_results()."""


### PR DESCRIPTION
## Summary

- **O(1) lookups**: Replace linear scans in `BatchResultReconciler.get_record_index()` and `BatchRegistryManager.get_batch_job_by_id()`/`update_status()` with dict-based index lookups
- **RecoveryType/RecoveryPhase enums**: Replace bare `"retry"`/`"reprompt"`/`"done"` strings with `str` enums (JSON round-trip transparent — existing recovery state files on disk load without breaking)
- **RecoveryContext + BatchIdentity dataclasses**: Reduce 5 recovery functions from 11–13 positional params down to 5–6 using context objects
- **Quick wins**: Eliminate TOCTOU race in `_merge_carry_forward()`, deduplicate schema compilation in `BatchTaskPreparator`, extract `_attach_passthrough_context` helper from 3 copy-pasted passthrough builders

15 files changed, 7311 tests pass, 2 skipped, ruff clean.

## Test plan

- [x] All 7311 existing tests pass (no new tests needed — pure refactor)
- [x] `ruff check` and `ruff format --check` clean
- [x] Verification checks from spec:
  - No `list().index()` in reconciler
  - No `carry_path.exists()` TOCTOU guard
  - `_prepare_schema` called only twice (definition + inside `_validate_config`)
  - No bare `"retry"`/`"reprompt"` strings outside enum definitions
  - No linear scan in `get_batch_job_by_id`/`update_status`
  - `BatchContextAdapter.to_processing_context` called only 2x in batch_result_strategy (successful + helper)
- [x] RecoveryState JSON roundtrip preserved (str enums serialize transparently)