### PR TITLE
fix: prevent InlineSchema leak into record content + defensive guard

### DIFF
--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -20,6 +20,7 @@ from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.response.config_fields import get_default
 from agent_actions.processing.batch_context_adapter import BatchContextAdapter
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
+from agent_actions.processing.helpers import _is_schema_echo
 from agent_actions.processing.record_helpers import (
     build_exhausted_tombstone,
     build_tombstone,
@@ -319,6 +320,23 @@ class BatchResultStrategy:
                 }
             else:
                 generated_obj = {ctx.output_field: generated_obj}
+
+        # Schema-echo guard: LLM returned the JSON Schema definition itself
+        # instead of conforming data (e.g. {"title": "InlineSchema", ...}).
+        # Replace with _parse_error so reprompt can retry.
+        if isinstance(generated_obj, dict) and _is_schema_echo(generated_obj):
+            logger.warning(
+                "[%s] Schema-echo detected in batch result — the model returned "
+                "the JSON Schema definition instead of conforming data. "
+                "Replacing with _parse_error for custom_id=%s.",
+                ctx.agent_config.get("action_name", "unknown") if ctx.agent_config else "unknown",
+                custom_id,
+            )
+            generated_obj = {
+                "raw_response": str(generated_obj),
+                "_parse_error": "Schema-echo: LLM returned the schema definition "
+                "instead of conforming data",
+            }
 
         generated_list = DataTransformer.ensure_list(generated_obj)
 

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -20,7 +20,6 @@ from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.response.config_fields import get_default
 from agent_actions.processing.batch_context_adapter import BatchContextAdapter
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
-from agent_actions.processing.helpers import _is_schema_echo
 from agent_actions.processing.record_helpers import (
     build_exhausted_tombstone,
     build_tombstone,
@@ -43,6 +42,8 @@ from agent_actions.record.reasons import (
     PREP_FAILED,
 )
 from agent_actions.utils.content import is_version_merge
+from agent_actions.utils.schema_echo import is_schema_echo as _is_schema_echo
+from agent_actions.utils.schema_echo import make_schema_echo_error as _make_schema_echo_error
 
 logger = logging.getLogger(__name__)
 
@@ -321,22 +322,15 @@ class BatchResultStrategy:
             else:
                 generated_obj = {ctx.output_field: generated_obj}
 
-        # Schema-echo guard: LLM returned the JSON Schema definition itself
-        # instead of conforming data (e.g. {"title": "InlineSchema", ...}).
-        # Replace with _parse_error so reprompt can retry.
-        if isinstance(generated_obj, dict) and _is_schema_echo(generated_obj):
+        # Schema-echo guard: replace with _parse_error so reprompt can retry
+        if _is_schema_echo(generated_obj):
             logger.warning(
-                "[%s] Schema-echo detected in batch result — the model returned "
-                "the JSON Schema definition instead of conforming data. "
-                "Replacing with _parse_error for custom_id=%s.",
+                "[%s] Schema-echo detected in batch result — replacing with "
+                "_parse_error for custom_id=%s.",
                 ctx.agent_config.get("action_name", "unknown") if ctx.agent_config else "unknown",
                 custom_id,
             )
-            generated_obj = {
-                "raw_response": str(generated_obj),
-                "_parse_error": "Schema-echo: LLM returned the schema definition "
-                "instead of conforming data",
-            }
+            generated_obj = _make_schema_echo_error(generated_obj)
 
         generated_list = DataTransformer.ensure_list(generated_obj)
 

--- a/agent_actions/llm/providers/ollama/client.py
+++ b/agent_actions/llm/providers/ollama/client.py
@@ -92,16 +92,27 @@ def _extract_ollama_schema(schema: dict[str, Any] | None) -> dict[str, Any] | No
 
     OpenAI wraps as ``{"name": "...", "schema": {...}}``; Ollama expects the
     raw ``{"type": "object", "properties": {...}}`` directly.
+
+    Strips ``title`` — Ollama's format param uses only structural keys
+    (type, properties, required, additionalProperties).  Including ``title``
+    leaks framework metadata (e.g. "InlineSchema") into the LLM context and
+    can trigger schema-echo behavior where the model returns the schema
+    definition itself instead of conforming data.
     """
     if not schema:
         return None
     if not isinstance(schema, dict):
         raise ConfigurationError(f"Schema must be a dict, got {type(schema).__name__}")
     if "schema" in schema and isinstance(schema["schema"], dict):
-        return schema["schema"]
-    if "type" in schema or "properties" in schema:
-        return schema
-    raise ConfigurationError(f"Unrecognised schema format (keys: {list(schema.keys())})")
+        inner = schema["schema"]
+    elif "type" in schema or "properties" in schema:
+        inner = schema
+    else:
+        raise ConfigurationError(f"Unrecognised schema format (keys: {list(schema.keys())})")
+    # Strip title — not a structural constraint, leaks framework metadata
+    if "title" in inner:
+        inner = {k: v for k, v in inner.items() if k != "title"}
+    return inner
 
 
 def _call_ollama_json(

--- a/agent_actions/processing/evaluation/strategies/validation.py
+++ b/agent_actions/processing/evaluation/strategies/validation.py
@@ -10,6 +10,7 @@ from agent_actions.processing.recovery.response_validator import (
     safe_validate,
 )
 from agent_actions.processing.types import EvaluationOutcome
+from agent_actions.utils.schema_echo import is_schema_echo
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,6 +40,9 @@ def detect_parse_error(content: Any, *, json_mode: bool) -> str | None:
     # Dict with _parse_error = pre-wrapped parse error (online convention)
     if isinstance(content, dict) and "_parse_error" in content:
         return content["_parse_error"] or None
+    # Schema-echo: LLM returned the JSON Schema definition instead of data
+    if is_schema_echo(content):
+        return "Schema-echo: LLM returned the schema definition instead of conforming data"
     # List with _parse_error at index 0 = online list-wrapped format
     if isinstance(content, list) and content and isinstance(content[0], dict):
         return content[0].get("_parse_error") or None

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from agent_actions.errors import SchemaValidationError
 from agent_actions.utils.constants import SCHEMA_KEY
+from agent_actions.utils.schema_echo import is_schema_echo as _is_schema_echo
+from agent_actions.utils.schema_echo import make_schema_echo_error as _make_schema_echo_error
 from agent_actions.utils.transformation import PassthroughTransformer
 
 logger = logging.getLogger(__name__)
@@ -80,56 +82,36 @@ def _resolve_schema_mismatch_mode(agent_config: dict[str, Any]) -> str:
     return "warn"
 
 
-def _is_schema_echo(data: dict[str, Any]) -> bool:
-    """Detect if a response dict is a schema-echo.
-
-    An LLM sometimes returns the JSON Schema definition itself instead of
-    conforming data.  The Ollama compiled format is the most common echo
-    shape: ``{"title": "InlineSchema", "type": "object", "properties": {...}}``.
-
-    Detection uses three structural keys (``type == "object"`` + ``properties``
-    as a dict + ``title`` present) which are extremely unlikely to appear
-    together in legitimate action output.
-    """
-    return (
-        isinstance(data, dict)
-        and data.get("type") == "object"
-        and isinstance(data.get("properties"), dict)
-        and "title" in data
-    )
-
-
 def _reject_schema_echo_items(response: Any, agent_name: str) -> Any:
     """Replace schema-echo items in a response list with ``_parse_error`` dicts.
 
-    Runs unconditionally — not gated by ``skip_schema_validation`` — because
-    schema echoes are never valid output regardless of validation settings.
+    Runs unconditionally because schema echoes are never valid output
+    regardless of validation settings.
     """
     if not isinstance(response, list):
         return response
 
-    changed = False
-    result: list[Any] = []
-    for item in response:
-        if isinstance(item, dict) and _is_schema_echo(item):
+    # Fast path: scan for echoes before allocating a new list
+    first_echo = None
+    for i, item in enumerate(response):
+        if _is_schema_echo(item):
+            first_echo = i
+            break
+    if first_echo is None:
+        return response
+
+    # Build replacement list only when at least one echo was found
+    result: list[Any] = list(response[:first_echo])
+    for item in response[first_echo:]:
+        if _is_schema_echo(item):
             logger.warning(
-                "[%s] Schema-echo detected in LLM response — the model returned "
-                "the JSON Schema definition instead of conforming data. "
-                "Replacing with _parse_error.",
+                "[%s] Schema-echo detected in LLM response — replacing with _parse_error.",
                 agent_name,
             )
-            result.append(
-                {
-                    "raw_response": str(item),
-                    "_parse_error": "Schema-echo: LLM returned the schema definition "
-                    "instead of conforming data",
-                }
-            )
-            changed = True
+            result.append(_make_schema_echo_error(item))
         else:
             result.append(item)
-
-    return result if changed else response
+    return result
 
 
 def _validate_llm_output_schema(

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -80,6 +80,58 @@ def _resolve_schema_mismatch_mode(agent_config: dict[str, Any]) -> str:
     return "warn"
 
 
+def _is_schema_echo(data: dict[str, Any]) -> bool:
+    """Detect if a response dict is a schema-echo.
+
+    An LLM sometimes returns the JSON Schema definition itself instead of
+    conforming data.  The Ollama compiled format is the most common echo
+    shape: ``{"title": "InlineSchema", "type": "object", "properties": {...}}``.
+
+    Detection uses three structural keys (``type == "object"`` + ``properties``
+    as a dict + ``title`` present) which are extremely unlikely to appear
+    together in legitimate action output.
+    """
+    return (
+        isinstance(data, dict)
+        and data.get("type") == "object"
+        and isinstance(data.get("properties"), dict)
+        and "title" in data
+    )
+
+
+def _reject_schema_echo_items(response: Any, agent_name: str) -> Any:
+    """Replace schema-echo items in a response list with ``_parse_error`` dicts.
+
+    Runs unconditionally — not gated by ``skip_schema_validation`` — because
+    schema echoes are never valid output regardless of validation settings.
+    """
+    if not isinstance(response, list):
+        return response
+
+    changed = False
+    result: list[Any] = []
+    for item in response:
+        if isinstance(item, dict) and _is_schema_echo(item):
+            logger.warning(
+                "[%s] Schema-echo detected in LLM response — the model returned "
+                "the JSON Schema definition instead of conforming data. "
+                "Replacing with _parse_error.",
+                agent_name,
+            )
+            result.append(
+                {
+                    "raw_response": str(item),
+                    "_parse_error": "Schema-echo: LLM returned the schema definition "
+                    "instead of conforming data",
+                }
+            )
+            changed = True
+        else:
+            result.append(item)
+
+    return result if changed else response
+
+
 def _validate_llm_output_schema(
     response: Any,
     agent_config: dict[str, Any],
@@ -93,9 +145,15 @@ def _validate_llm_output_schema(
     "reprompt" and ``skip_schema_validation`` is True, validation is deferred
     to the outer reprompt loop.
 
+    Schema-echo detection runs unconditionally (not gated by
+    ``skip_schema_validation``) because echoed schemas are never valid output.
+
     Raises:
         SchemaValidationError: If on_schema_mismatch="reject" and validation fails.
     """
+    # Unconditional schema-echo rejection — runs even when validation is skipped
+    response = _reject_schema_echo_items(response, agent_name)
+
     schema = agent_config.get(SCHEMA_KEY)
     if not schema or not isinstance(schema, dict):
         mismatch_mode = _resolve_schema_mismatch_mode(agent_config)

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -20,7 +20,6 @@ from agent_actions.prompt.context.scope_namespace import (
     _extract_content_data,
     _filter_and_store_fields,
 )
-from agent_actions.utils.schema_echo import is_schema_echo as _is_schema_echo
 
 logger = logging.getLogger(__name__)
 
@@ -156,18 +155,6 @@ class DependencyNamespaceBuilder:
                         dep_namespaces[dep_name] = SKIPPED_NAMESPACE
                         continue
 
-                    # Detect corrupted namespace: compiled JSON Schema stored
-                    # as action content via schema-echo.
-                    if _is_schema_echo(dep_data) and dep_data.get("title") == "InlineSchema":
-                        logger.warning(
-                            "[OBSERVE NULL-SAFE] '%s': namespace contains InlineSchema "
-                            "definition instead of action output — treating as skipped. "
-                            "This indicates a bug in the output pipeline for this action.",
-                            dep_name,
-                        )
-                        dep_namespaces[dep_name] = SKIPPED_NAMESPACE
-                        continue
-
                     if not isinstance(dep_data, dict):
                         logger.warning(
                             "[RECORD NAMESPACE] '%s' for action '%s' is %s, not dict — skipping",
@@ -178,6 +165,23 @@ class DependencyNamespaceBuilder:
                         continue
 
                     allowed_fields = allowed_fields_map.get(dep_name)
+
+                    # Zero-overlap guard: if specific fields are declared but
+                    # none of them exist in the namespace, the content is
+                    # corrupted (e.g. schema-echo, wrong action output).
+                    # Wrap as SKIPPED_NAMESPACE to prevent RecordContextError.
+                    if allowed_fields and not set(dep_data.keys()) & set(allowed_fields):
+                        logger.warning(
+                            "[OBSERVE NULL-SAFE] '%s': namespace has zero overlap "
+                            "with declared fields %s (actual keys: %s) — "
+                            "treating as skipped",
+                            dep_name,
+                            sorted(allowed_fields),
+                            sorted(dep_data.keys()),
+                        )
+                        dep_namespaces[dep_name] = SKIPPED_NAMESPACE
+                        continue
+
                     _filter_and_store_fields(
                         dep_namespaces,
                         dep_name,

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -155,6 +155,25 @@ class DependencyNamespaceBuilder:
                         dep_namespaces[dep_name] = SKIPPED_NAMESPACE
                         continue
 
+                    # Detect corrupted namespace: compiled JSON Schema stored
+                    # as action content instead of actual LLM output.
+                    # (InlineSchema from vendor_compilation.py leaking into
+                    # record output via schema-echo.)
+                    if (
+                        isinstance(dep_data, dict)
+                        and dep_data.get("type") == "object"
+                        and isinstance(dep_data.get("properties"), dict)
+                        and dep_data.get("title") == "InlineSchema"
+                    ):
+                        logger.warning(
+                            "[OBSERVE NULL-SAFE] '%s': namespace contains InlineSchema "
+                            "definition instead of action output — treating as skipped. "
+                            "This indicates a bug in the output pipeline for this action.",
+                            dep_name,
+                        )
+                        dep_namespaces[dep_name] = SKIPPED_NAMESPACE
+                        continue
+
                     if not isinstance(dep_data, dict):
                         logger.warning(
                             "[RECORD NAMESPACE] '%s' for action '%s' is %s, not dict — skipping",

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -20,6 +20,7 @@ from agent_actions.prompt.context.scope_namespace import (
     _extract_content_data,
     _filter_and_store_fields,
 )
+from agent_actions.utils.schema_echo import is_schema_echo as _is_schema_echo
 
 logger = logging.getLogger(__name__)
 
@@ -156,15 +157,8 @@ class DependencyNamespaceBuilder:
                         continue
 
                     # Detect corrupted namespace: compiled JSON Schema stored
-                    # as action content instead of actual LLM output.
-                    # (InlineSchema from vendor_compilation.py leaking into
-                    # record output via schema-echo.)
-                    if (
-                        isinstance(dep_data, dict)
-                        and dep_data.get("type") == "object"
-                        and isinstance(dep_data.get("properties"), dict)
-                        and dep_data.get("title") == "InlineSchema"
-                    ):
+                    # as action content via schema-echo.
+                    if _is_schema_echo(dep_data) and dep_data.get("title") == "InlineSchema":
                         logger.warning(
                             "[OBSERVE NULL-SAFE] '%s': namespace contains InlineSchema "
                             "definition instead of action output — treating as skipped. "

--- a/agent_actions/prompt/message_builder.py
+++ b/agent_actions/prompt/message_builder.py
@@ -305,7 +305,8 @@ class MessageBuilder:
         # output support ships (ollama/ollama#12362).
         effective_prompt = prompt_config
         if schema_injection == SchemaInjection.PROMPT and schema is not None:
-            schema_text = json.dumps(schema, indent=2, ensure_ascii=False)
+            clean_schema = MessageBuilder._strip_schema_metadata(schema)
+            schema_text = json.dumps(clean_schema, indent=2, ensure_ascii=False)
             effective_prompt = (
                 f"{prompt_config}\n\n"
                 f"You MUST respond with valid JSON matching this schema:\n"
@@ -372,7 +373,8 @@ class MessageBuilder:
         effective_prompt = prompt
         config = PROVIDER_MESSAGE_CONFIGS.get(provider)
         if config and config.schema_injection == SchemaInjection.PROMPT and schema is not None:
-            schema_text = json.dumps(schema, indent=2, ensure_ascii=False)
+            clean_schema = MessageBuilder._strip_schema_metadata(schema)
+            schema_text = json.dumps(clean_schema, indent=2, ensure_ascii=False)
             effective_prompt = (
                 f"{prompt}\n\n"
                 f"You MUST respond with valid JSON matching this schema:\n"
@@ -424,6 +426,32 @@ class MessageBuilder:
         return str(StringProcessor.process_as_string(context_data))
 
     @staticmethod
+    def _strip_schema_metadata(schema: Any) -> Any:
+        """Remove framework metadata keys before injecting schema into prompts.
+
+        Keys like ``name``, ``title``, and ``description`` are framework
+        labels (e.g. "InlineSchema") that leak implementation details into
+        LLM context and can trigger schema-echo behavior where the model
+        returns the schema definition itself instead of conforming data.
+        """
+        _META_KEYS = {"name", "title", "description"}
+        if isinstance(schema, dict):
+            stripped = {k: v for k, v in schema.items() if k not in _META_KEYS}
+            # Also strip from nested schema wrappers (OpenAI: {"name":..., "schema": {...}})
+            if "schema" in stripped and isinstance(stripped["schema"], dict):
+                stripped["schema"] = {
+                    k: v for k, v in stripped["schema"].items() if k not in _META_KEYS
+                }
+            if "input_schema" in stripped and isinstance(stripped["input_schema"], dict):
+                stripped["input_schema"] = {
+                    k: v for k, v in stripped["input_schema"].items() if k not in _META_KEYS
+                }
+            return stripped
+        if isinstance(schema, list):
+            return [MessageBuilder._strip_schema_metadata(item) for item in schema]
+        return schema
+
+    @staticmethod
     def _assemble_body(
         *,
         style: PromptStyle,
@@ -473,12 +501,15 @@ class MessageBuilder:
             f"<|begin_of_text|>: {str(context_str)} :<|end_of_text|>",
         ]
 
-        # Schema injection (only in json mode)
+        # Schema injection (only in json mode) — strip metadata keys to
+        # prevent schema-echo (model returning the definition as content)
         if schema_injection == SchemaInjection.INLINE_FULL and schema is not None:
-            parts.append(f"<|begin_of_output_schema|> : {schema} : <|end_of_output_schema|>")
+            clean = MessageBuilder._strip_schema_metadata(schema)
+            parts.append(f"<|begin_of_output_schema|> : {clean} : <|end_of_output_schema|>")
         elif schema_injection == SchemaInjection.INLINE_FULL_LIST and schema is not None:
+            clean = MessageBuilder._strip_schema_metadata(schema)
             parts.append(
-                f"<|begin_of_output_schema|> : list of this [{schema}] : <|end_of_output_schema|>"
+                f"<|begin_of_output_schema|> : list of this [{clean}] : <|end_of_output_schema|>"
             )
         elif schema_injection == SchemaInjection.INLINE_FIELDS:
             parts.append(MessageBuilder._build_field_schema_instruction(schema))

--- a/agent_actions/prompt/message_builder.py
+++ b/agent_actions/prompt/message_builder.py
@@ -425,6 +425,8 @@ class MessageBuilder:
             return str(ensure_json_safe(context_data))
         return str(StringProcessor.process_as_string(context_data))
 
+    _SCHEMA_META_KEYS = frozenset({"name", "title", "description"})
+
     @staticmethod
     def _strip_schema_metadata(schema: Any) -> Any:
         """Remove framework metadata keys before injecting schema into prompts.
@@ -434,7 +436,7 @@ class MessageBuilder:
         LLM context and can trigger schema-echo behavior where the model
         returns the schema definition itself instead of conforming data.
         """
-        _META_KEYS = {"name", "title", "description"}
+        _META_KEYS = MessageBuilder._SCHEMA_META_KEYS
         if isinstance(schema, dict):
             stripped = {k: v for k, v in schema.items() if k not in _META_KEYS}
             # Also strip from nested schema wrappers (OpenAI: {"name":..., "schema": {...}})

--- a/agent_actions/utils/schema_echo.py
+++ b/agent_actions/utils/schema_echo.py
@@ -1,0 +1,38 @@
+"""Schema-echo detection utilities.
+
+An LLM sometimes returns the JSON Schema definition itself instead of
+conforming data.  The Ollama compiled format is the most common echo
+shape: ``{"title": "InlineSchema", "type": "object", "properties": {...}}``.
+
+These helpers detect and replace schema-echo responses so they can be
+treated as parse errors and retried via reprompt.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def is_schema_echo(data: Any) -> bool:
+    """Detect if a response dict is a schema-echo.
+
+    Detection uses three structural keys (``type == "object"`` + ``properties``
+    as a dict + ``title`` present) which are extremely unlikely to appear
+    together in legitimate action output.
+    """
+    return (
+        isinstance(data, dict)
+        and data.get("type") == "object"
+        and isinstance(data.get("properties"), dict)
+        and "title" in data
+    )
+
+
+def make_schema_echo_error(raw: dict[str, Any]) -> dict[str, Any]:
+    """Build a ``_parse_error`` sentinel for a schema-echo response."""
+    return {
+        "raw_response": json.dumps(raw, ensure_ascii=False, default=str),
+        "_parse_error": "Schema-echo: LLM returned the schema definition "
+        "instead of conforming data",
+    }

--- a/tests/unit/llm/providers/ollama/test_ollama_vendor_split.py
+++ b/tests/unit/llm/providers/ollama/test_ollama_vendor_split.py
@@ -327,6 +327,88 @@ class TestOllamaCloudClient:
         assert result[0]["label"] == "fruit"
         assert "_parse_error" not in result[0]
 
+
+# ---------------------------------------------------------------------------
+# Schema-echo prevention: title stripped from format param
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaEchoPrevention:
+    """Regression: _extract_ollama_schema strips ``title`` to prevent echo."""
+
+    def test_title_stripped_from_ollama_format(self):
+        """Compiled Ollama schema has title — format param must NOT."""
+        from agent_actions.llm.providers.ollama.client import _extract_ollama_schema
+
+        compiled = {
+            "title": "InlineSchema",
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+        result = _extract_ollama_schema(compiled)
+        assert "title" not in result
+        assert result["type"] == "object"
+        assert "answer" in result["properties"]
+
+    def test_title_stripped_from_nested_schema(self):
+        """OpenAI-wrapped schema with title in inner dict — title stripped."""
+        from agent_actions.llm.providers.ollama.client import _extract_ollama_schema
+
+        wrapped = {
+            "name": "InlineSchema",
+            "schema": {
+                "title": "InlineSchema",
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+            },
+        }
+        result = _extract_ollama_schema(wrapped)
+        assert "title" not in result
+        assert result["type"] == "object"
+
+    def test_schema_without_title_unchanged(self):
+        """Schema without title passes through unmodified."""
+        from agent_actions.llm.providers.ollama.client import _extract_ollama_schema
+
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": [],
+        }
+        result = _extract_ollama_schema(schema)
+        assert result == schema
+
+    @patch("agent_actions.llm.providers.ollama.client.ResponseBuilder")
+    @patch("agent_actions.llm.providers.ollama.client.fire_event")
+    @patch("agent_actions.llm.providers.ollama.client._build_ollama_client")
+    @patch("agent_actions.llm.providers.ollama.client.MessageBuilder")
+    def test_local_chat_format_has_no_title(self, mock_mb, mock_build, mock_fire, mock_rb):
+        """End-to-end: title never reaches client.chat(format=...) for local."""
+        mock_envelope = MagicMock()
+        mock_envelope.to_dicts.return_value = [{"role": "user", "content": "hi"}]
+        mock_mb.build.return_value = mock_envelope
+
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _fake_chat_response()
+        mock_build.return_value = mock_client
+
+        compiled_schema = {
+            "title": "InlineSchema",
+            "type": "object",
+            "properties": {"label": {"type": "string"}},
+            "required": [],
+            "additionalProperties": False,
+        }
+        config = _make_agent_config()
+        OllamaLocalClient.invoke(config, PROMPT, CONTEXT, compiled_schema)
+
+        chat_kwargs = mock_client.chat.call_args
+        format_param = chat_kwargs.kwargs.get("format") or chat_kwargs[1].get("format")
+        assert isinstance(format_param, dict)
+        assert "title" not in format_param
+
     @patch("agent_actions.llm.providers.ollama.client.ResponseBuilder")
     @patch("agent_actions.llm.providers.ollama.client.fire_event")
     @patch("agent_actions.llm.providers.ollama.client._build_ollama_client")

--- a/tests/unit/processing/test_batch_parse_error_detection.py
+++ b/tests/unit/processing/test_batch_parse_error_detection.py
@@ -86,6 +86,39 @@ class TestDetectParseError:
         """None content → not a parse error."""
         assert detect_parse_error(None, json_mode=True) is None
 
+    def test_schema_echo_detected(self):
+        """Schema-echo dict (LLM returned schema definition) → parse error."""
+        content = {
+            "title": "InlineSchema",
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": [],
+            "additionalProperties": False,
+        }
+        error = detect_parse_error(content, json_mode=True)
+        assert error is not None
+        assert "Schema-echo" in error
+
+    def test_named_schema_echo_detected(self):
+        """Named schema echo (not InlineSchema) also detected."""
+        content = {
+            "title": "QuizOutput",
+            "type": "object",
+            "properties": {"score": {"type": "number"}},
+        }
+        error = detect_parse_error(content, json_mode=True)
+        assert error is not None
+        assert "Schema-echo" in error
+
+    def test_schema_echo_detected_non_json_mode(self):
+        """Schema echo detected even in non-json mode."""
+        content = {
+            "title": "InlineSchema",
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+        }
+        assert detect_parse_error(content, json_mode=False) is not None
+
 
 # ---------------------------------------------------------------------------
 # ValidationStrategy.evaluate() parse error detection
@@ -194,6 +227,33 @@ class TestParseErrorDetectionInEvaluate:
 
         assert outcome.passed is False
         assert outcome.failure_type == "api_error"
+
+    def test_schema_echo_detected_before_udf(self):
+        """Schema-echo content fails with failure_type='parse_error', UDF never called."""
+        call_log = []
+
+        def tracking_validate(response):
+            call_log.append(response)
+            return True
+
+        strategy = ValidationStrategy(
+            validation_func=tracking_validate,
+            feedback_message="fix",
+            json_mode=True,
+        )
+        content = {
+            "title": "InlineSchema",
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": [],
+            "additionalProperties": False,
+        }
+        result = _make_result("r1", content=content)
+        outcome = strategy.evaluate(result)
+
+        assert outcome.passed is False
+        assert outcome.failure_type == "parse_error"
+        assert call_log == [], "UDF should NOT have been called"
 
     def test_non_json_mode_string_content_reaches_udf(self):
         """In non-json-mode, string content is NOT a parse error — UDF is called."""

--- a/tests/unit/processing/test_batch_schema_echo.py
+++ b/tests/unit/processing/test_batch_schema_echo.py
@@ -67,18 +67,12 @@ class TestBatchSchemaEchoDetection:
             agent_config=agent_config,
         )
 
-        # The result should contain a record with _parse_error
+        # The result should contain a record with _parse_error in the action namespace
         assert len(results) >= 1
-        data = results[0].data
-        assert len(data) >= 1
-        record = data[0]
-        content = record.get("content", record)
-        # The content namespace for the action should contain _parse_error
-        action_ns = content.get(agent_config["action_name"], content)
-        assert "_parse_error" in action_ns or "_parse_error" in record
-        assert any("Schema-echo" in str(v) for v in action_ns.values()) or any(
-            "Schema-echo" in str(v) for v in record.values()
-        )
+        record = results[0].data[0]
+        action_ns = record["content"][agent_config["action_name"]]
+        assert "_parse_error" in action_ns
+        assert "Schema-echo" in action_ns["_parse_error"]
 
     def test_valid_output_not_affected(self):
         """Normal LLM output flows through unchanged."""

--- a/tests/unit/processing/test_batch_schema_echo.py
+++ b/tests/unit/processing/test_batch_schema_echo.py
@@ -1,0 +1,110 @@
+"""Tests for schema-echo detection in batch result strategy.
+
+Verifies that ``BatchResultStrategy._process_successful_result`` replaces
+schema-echo content with ``_parse_error`` dicts before structuring records.
+"""
+
+from agent_actions.llm.batch.processing.batch_result_strategy import (
+    BatchResultStrategy,
+)
+from agent_actions.llm.providers.batch_base import BatchResult
+
+SCHEMA_ECHO = {
+    "title": "InlineSchema",
+    "type": "object",
+    "properties": {"distractor_explanation_1": {"type": "string"}},
+    "required": [],
+    "additionalProperties": False,
+}
+
+VALID_OUTPUT = {"distractor_explanation_1": "The earth is not flat because..."}
+
+
+def _make_agent_config(action_name="generate_quiz"):
+    return {
+        "action_name": action_name,
+        "agent_type": action_name,
+        "json_mode": True,
+        "output_field": "raw_response",
+        "dependencies": ["extract"],
+    }
+
+
+def _make_context_map(custom_id, row):
+    """Build a minimal context map entry for reconciliation."""
+    return {custom_id: row}
+
+
+def _make_original_row(custom_id):
+    return {
+        "target_id": custom_id,
+        "source_guid": "sg-001",
+        "content": {"extract": {"text": "hello"}},
+        "lineage": ["node-1"],
+    }
+
+
+class TestBatchSchemaEchoDetection:
+    """Schema-echo in batch result content is replaced with _parse_error."""
+
+    def test_schema_echo_replaced(self):
+        """Full schema echo in batch result → _parse_error in output record."""
+        custom_id = "tid-001"
+        original_row = _make_original_row(custom_id)
+        context_map = _make_context_map(custom_id, original_row)
+        agent_config = _make_agent_config()
+
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content=SCHEMA_ECHO,
+            success=True,
+        )
+
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            [batch_result],
+            context_map=context_map,
+            agent_config=agent_config,
+        )
+
+        # The result should contain a record with _parse_error
+        assert len(results) >= 1
+        data = results[0].data
+        assert len(data) >= 1
+        record = data[0]
+        content = record.get("content", record)
+        # The content namespace for the action should contain _parse_error
+        action_ns = content.get(agent_config["action_name"], content)
+        assert "_parse_error" in action_ns or "_parse_error" in record
+        assert any("Schema-echo" in str(v) for v in action_ns.values()) or any(
+            "Schema-echo" in str(v) for v in record.values()
+        )
+
+    def test_valid_output_not_affected(self):
+        """Normal LLM output flows through unchanged."""
+        custom_id = "tid-002"
+        original_row = _make_original_row(custom_id)
+        context_map = _make_context_map(custom_id, original_row)
+        agent_config = _make_agent_config()
+
+        batch_result = BatchResult(
+            custom_id=custom_id,
+            content=VALID_OUTPUT,
+            success=True,
+        )
+
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            [batch_result],
+            context_map=context_map,
+            agent_config=agent_config,
+        )
+
+        assert len(results) >= 1
+        data = results[0].data
+        assert len(data) >= 1
+        record = data[0]
+        content = record.get("content", record)
+        action_ns = content.get(agent_config["action_name"], content)
+        assert "_parse_error" not in action_ns
+        assert "distractor_explanation_1" in action_ns

--- a/tests/unit/processing/test_schema_echo_detection.py
+++ b/tests/unit/processing/test_schema_echo_detection.py
@@ -5,10 +5,8 @@ data, the schema-echo guard must detect and replace the response with a
 ``_parse_error`` dict.
 """
 
-from agent_actions.processing.helpers import (
-    _is_schema_echo,
-    _reject_schema_echo_items,
-)
+from agent_actions.processing.helpers import _reject_schema_echo_items
+from agent_actions.utils.schema_echo import is_schema_echo as _is_schema_echo
 
 # ---------------------------------------------------------------------------
 # Fixture: exact schema-echo payloads from production bug evidence

--- a/tests/unit/processing/test_schema_echo_detection.py
+++ b/tests/unit/processing/test_schema_echo_detection.py
@@ -1,0 +1,132 @@
+"""Tests for schema-echo detection in online and batch paths.
+
+When an LLM returns the JSON Schema definition itself instead of conforming
+data, the schema-echo guard must detect and replace the response with a
+``_parse_error`` dict.
+"""
+
+from agent_actions.processing.helpers import (
+    _is_schema_echo,
+    _reject_schema_echo_items,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture: exact schema-echo payloads from production bug evidence
+# ---------------------------------------------------------------------------
+
+FULL_ECHO = {
+    "title": "InlineSchema",
+    "type": "object",
+    "properties": {"distractor_explanation_1": {"type": "string"}},
+    "required": [],
+    "additionalProperties": False,
+}
+
+PARTIAL_ECHO = {
+    "title": "InlineSchema",
+    "type": "object",
+    "properties": {"optimal_code": {"type": "string"}},
+    "required": ["optimal_code"],
+    "additionalProperties": False,
+}
+
+VALID_OUTPUT = {
+    "distractor_explanation_1": "The earth is not flat because...",
+    "score": 0.95,
+}
+
+PARSE_ERROR = {
+    "raw_response": "invalid json",
+    "_parse_error": "Failed to parse JSON from LLM response",
+}
+
+
+# ---------------------------------------------------------------------------
+# _is_schema_echo
+# ---------------------------------------------------------------------------
+
+
+class TestIsSchemaEcho:
+    """Unit tests for the low-level schema-echo detector."""
+
+    def test_full_echo_detected(self):
+        assert _is_schema_echo(FULL_ECHO) is True
+
+    def test_partial_echo_detected(self):
+        assert _is_schema_echo(PARTIAL_ECHO) is True
+
+    def test_valid_output_not_detected(self):
+        assert _is_schema_echo(VALID_OUTPUT) is False
+
+    def test_parse_error_not_detected(self):
+        assert _is_schema_echo(PARSE_ERROR) is False
+
+    def test_empty_dict_not_detected(self):
+        assert _is_schema_echo({}) is False
+
+    def test_no_title_not_detected(self):
+        """Missing 'title' key — not a schema echo."""
+        data = {"type": "object", "properties": {"x": {"type": "string"}}}
+        assert _is_schema_echo(data) is False
+
+    def test_type_not_object_not_detected(self):
+        """type != 'object' — not a schema echo."""
+        data = {"title": "X", "type": "array", "properties": {"x": {"type": "string"}}}
+        assert _is_schema_echo(data) is False
+
+    def test_properties_not_dict_not_detected(self):
+        """properties is a list, not dict — not a schema echo."""
+        data = {"title": "X", "type": "object", "properties": ["x"]}
+        assert _is_schema_echo(data) is False
+
+    def test_user_data_with_title_field(self):
+        """Real user data that happens to have a 'title' field — NOT a schema echo."""
+        data = {"title": "My Document", "body": "Some text content"}
+        assert _is_schema_echo(data) is False
+
+    def test_non_dict_returns_false(self):
+        assert _is_schema_echo("not a dict") is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _reject_schema_echo_items (online path)
+# ---------------------------------------------------------------------------
+
+
+class TestRejectSchemaEchoItems:
+    """Tests for the online-path schema-echo rejection wrapper."""
+
+    def test_replaces_echo_with_parse_error(self):
+        response = [FULL_ECHO]
+        result = _reject_schema_echo_items(response, "test_action")
+        assert len(result) == 1
+        assert "_parse_error" in result[0]
+        assert "raw_response" in result[0]
+        assert "Schema-echo" in result[0]["_parse_error"]
+
+    def test_preserves_valid_items(self):
+        response = [VALID_OUTPUT]
+        result = _reject_schema_echo_items(response, "test_action")
+        assert result is response  # unchanged — same object
+        assert result[0] == VALID_OUTPUT
+
+    def test_mixed_response_replaces_only_echoes(self):
+        response = [VALID_OUTPUT, FULL_ECHO]
+        result = _reject_schema_echo_items(response, "test_action")
+        assert result[0] == VALID_OUTPUT
+        assert "_parse_error" in result[1]
+        assert "Schema-echo" in result[1]["_parse_error"]
+
+    def test_non_list_passthrough(self):
+        """Non-list responses pass through unchanged."""
+        result = _reject_schema_echo_items("not a list", "test_action")
+        assert result == "not a list"
+
+    def test_empty_list_passthrough(self):
+        result = _reject_schema_echo_items([], "test_action")
+        assert result == []
+
+    def test_all_echoes_replaced(self):
+        response = [FULL_ECHO, PARTIAL_ECHO]
+        result = _reject_schema_echo_items(response, "test_action")
+        assert all("_parse_error" in item for item in result)

--- a/tests/unit/prompt/test_message_builder.py
+++ b/tests/unit/prompt/test_message_builder.py
@@ -652,3 +652,96 @@ class TestContextSerialisationJsonSafety:
         # After split: context is in user message (messages[1])
         content = env.messages[1].content
         assert isinstance(content, str)
+
+
+# ---------------------------------------------------------------------------
+# Schema metadata stripping (schema-echo prevention)
+# ---------------------------------------------------------------------------
+
+
+class TestStripSchemaMetadata:
+    """_strip_schema_metadata removes name/title/description before prompt injection."""
+
+    def test_strips_title_from_ollama_schema(self):
+        schema = {
+            "title": "InlineSchema",
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+        }
+        result = MessageBuilder._strip_schema_metadata(schema)
+        assert "title" not in result
+        assert result["type"] == "object"
+        assert "x" in result["properties"]
+
+    def test_strips_name_from_openai_wrapper(self):
+        schema = {
+            "name": "InlineSchema",
+            "schema": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+            },
+        }
+        result = MessageBuilder._strip_schema_metadata(schema)
+        assert "name" not in result
+        assert result["schema"]["type"] == "object"
+
+    def test_strips_name_and_description_from_anthropic(self):
+        schema = {
+            "name": "InlineSchema",
+            "description": "Tool description",
+            "input_schema": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+            },
+        }
+        result = MessageBuilder._strip_schema_metadata(schema)
+        assert "name" not in result
+        assert "description" not in result
+        assert result["input_schema"]["type"] == "object"
+
+    def test_strips_from_list(self):
+        schema = [
+            {"name": "InlineSchema", "input_schema": {"type": "object", "properties": {}}},
+        ]
+        result = MessageBuilder._strip_schema_metadata(schema)
+        assert "name" not in result[0]
+
+    def test_preserves_structural_keys(self):
+        schema = {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+        result = MessageBuilder._strip_schema_metadata(schema)
+        assert result == schema
+
+    def test_ollama_cloud_prompt_injection_has_no_title(self):
+        """End-to-end: ollama_cloud prompt injection strips title."""
+        schema = {
+            "title": "InlineSchema",
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": [],
+            "additionalProperties": False,
+        }
+        env = MessageBuilder.build(
+            "ollama_cloud", PROMPT, CONTEXT_STR, schema=schema, json_mode=True
+        )
+        prompt_text = env.messages[0].content
+        assert "InlineSchema" not in prompt_text
+        assert '"answer"' in prompt_text
+
+    def test_gemini_inline_injection_has_no_name(self):
+        """End-to-end: Gemini INLINE_FULL_LIST strips name."""
+        schema = {
+            "name": "InlineSchema",
+            "schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+            },
+        }
+        env = MessageBuilder.build("gemini", PROMPT, CONTEXT_STR, schema=schema, json_mode=True)
+        body = env.prompt_body
+        assert "InlineSchema" not in body
+        assert "answer" in body

--- a/tests/unit/prompt/test_scope_builder_inline_schema_guard.py
+++ b/tests/unit/prompt/test_scope_builder_inline_schema_guard.py
@@ -1,0 +1,118 @@
+"""Tests for the InlineSchema corruption guard in DependencyNamespaceBuilder.
+
+When a corrupted namespace contains a compiled JSON Schema definition
+(``{"title": "InlineSchema", ...}``) instead of actual action output,
+the guard wraps it as ``SKIPPED_NAMESPACE`` to prevent RecordContextError
+crashes in downstream actions.
+"""
+
+from agent_actions.prompt.context.null_namespace import is_null_namespace
+from agent_actions.prompt.context.scope_builder import build_field_context_with_history
+
+
+def _make_current_item(content: dict) -> dict:
+    return {
+        "content": content,
+        "lineage": ["node-1"],
+        "source_guid": "sg-1",
+    }
+
+
+INLINE_SCHEMA_CORRUPTION = {
+    "title": "InlineSchema",
+    "type": "object",
+    "properties": {"distractor_explanation_1": {"type": "string"}},
+    "required": [],
+    "additionalProperties": False,
+}
+
+PARTIAL_CORRUPTION = {
+    "title": "InlineSchema",
+    "type": "object",
+    "properties": {"optimal_code": {"type": "string"}},
+    "required": ["optimal_code"],
+    "additionalProperties": False,
+}
+
+VALID_NAMESPACE = {"distractor_explanation_1": "The answer is wrong because..."}
+
+
+class TestInlineSchemaGuard:
+    """Corrupted InlineSchema namespaces are wrapped as SKIPPED_NAMESPACE."""
+
+    def test_full_corruption_skipped(self):
+        """Full InlineSchema corruption → SKIPPED_NAMESPACE."""
+        current_item = _make_current_item({"generate_quiz": INLINE_SCHEMA_CORRUPTION})
+        agent_config = {
+            "dependencies": ["generate_quiz"],
+            "context_scope": {"observe": ["generate_quiz.distractor_explanation_1"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="review",
+            agent_config=agent_config,
+            agent_indices={"generate_quiz": 0, "review": 1},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        assert is_null_namespace(result["generate_quiz"])
+
+    def test_partial_corruption_skipped(self):
+        """InlineSchema with different fields → SKIPPED_NAMESPACE."""
+        current_item = _make_current_item({"generate_quiz": PARTIAL_CORRUPTION})
+        agent_config = {
+            "dependencies": ["generate_quiz"],
+            "context_scope": {"observe": ["generate_quiz.optimal_code"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="review",
+            agent_config=agent_config,
+            agent_indices={"generate_quiz": 0, "review": 1},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        assert is_null_namespace(result["generate_quiz"])
+
+    def test_valid_namespace_not_affected(self):
+        """Normal action output flows through without triggering the guard."""
+        current_item = _make_current_item({"generate_quiz": VALID_NAMESPACE})
+        agent_config = {
+            "dependencies": ["generate_quiz"],
+            "context_scope": {"observe": ["generate_quiz.distractor_explanation_1"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="review",
+            agent_config=agent_config,
+            agent_indices={"generate_quiz": 0, "review": 1},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        assert not is_null_namespace(result["generate_quiz"])
+        assert result["generate_quiz"] == {
+            "distractor_explanation_1": "The answer is wrong because..."
+        }
+
+    def test_user_data_with_title_not_affected(self):
+        """Real user data that has 'title' field is not falsely detected."""
+        user_data = {"title": "My Document", "body": "Some text"}
+        current_item = _make_current_item({"extract": user_data})
+        agent_config = {
+            "dependencies": ["extract"],
+            "context_scope": {"observe": ["extract.title", "extract.body"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="summarize",
+            agent_config=agent_config,
+            agent_indices={"extract": 0, "summarize": 1},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        assert not is_null_namespace(result["extract"])
+        assert result["extract"] == {"title": "My Document", "body": "Some text"}

--- a/tests/unit/prompt/test_scope_builder_inline_schema_guard.py
+++ b/tests/unit/prompt/test_scope_builder_inline_schema_guard.py
@@ -1,9 +1,9 @@
-"""Tests for the InlineSchema corruption guard in DependencyNamespaceBuilder.
+"""Tests for the zero-overlap corruption guard in DependencyNamespaceBuilder.
 
-When a corrupted namespace contains a compiled JSON Schema definition
-(``{"title": "InlineSchema", ...}``) instead of actual action output,
-the guard wraps it as ``SKIPPED_NAMESPACE`` to prevent RecordContextError
-crashes in downstream actions.
+When a namespace has zero overlap with declared observe fields (e.g. a
+compiled JSON Schema stored as action content, or any other form of
+content corruption), the guard wraps it as ``SKIPPED_NAMESPACE`` to
+prevent RecordContextError crashes in downstream actions.
 """
 
 from agent_actions.prompt.context.null_namespace import is_null_namespace
@@ -26,22 +26,25 @@ INLINE_SCHEMA_CORRUPTION = {
     "additionalProperties": False,
 }
 
-PARTIAL_CORRUPTION = {
-    "title": "InlineSchema",
+# Named schema corruption — NOT title == "InlineSchema"
+NAMED_SCHEMA_CORRUPTION = {
+    "title": "QuizOutputSchema",
     "type": "object",
-    "properties": {"optimal_code": {"type": "string"}},
-    "required": ["optimal_code"],
-    "additionalProperties": False,
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
 }
+
+# Arbitrary garbage namespace — no schema keys at all
+GARBAGE_NAMESPACE = {"foo": 1, "bar": 2, "baz": 3}
 
 VALID_NAMESPACE = {"distractor_explanation_1": "The answer is wrong because..."}
 
 
-class TestInlineSchemaGuard:
-    """Corrupted InlineSchema namespaces are wrapped as SKIPPED_NAMESPACE."""
+class TestZeroOverlapGuard:
+    """Namespaces with zero overlap with declared fields are wrapped as SKIPPED_NAMESPACE."""
 
-    def test_full_corruption_skipped(self):
-        """Full InlineSchema corruption → SKIPPED_NAMESPACE."""
+    def test_inline_schema_corruption_skipped(self):
+        """InlineSchema echo has zero overlap with declared fields → SKIPPED."""
         current_item = _make_current_item({"generate_quiz": INLINE_SCHEMA_CORRUPTION})
         agent_config = {
             "dependencies": ["generate_quiz"],
@@ -58,12 +61,30 @@ class TestInlineSchemaGuard:
 
         assert is_null_namespace(result["generate_quiz"])
 
-    def test_partial_corruption_skipped(self):
-        """InlineSchema with different fields → SKIPPED_NAMESPACE."""
-        current_item = _make_current_item({"generate_quiz": PARTIAL_CORRUPTION})
+    def test_named_schema_corruption_skipped(self):
+        """Named schema corruption (not InlineSchema) also caught by zero-overlap."""
+        current_item = _make_current_item({"generate_quiz": NAMED_SCHEMA_CORRUPTION})
         agent_config = {
             "dependencies": ["generate_quiz"],
-            "context_scope": {"observe": ["generate_quiz.optimal_code"]},
+            "context_scope": {"observe": ["generate_quiz.distractor_explanation_1"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="review",
+            agent_config=agent_config,
+            agent_indices={"generate_quiz": 0, "review": 1},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        assert is_null_namespace(result["generate_quiz"])
+
+    def test_garbage_namespace_skipped(self):
+        """Arbitrary garbage with zero field overlap → SKIPPED."""
+        current_item = _make_current_item({"generate_quiz": GARBAGE_NAMESPACE})
+        agent_config = {
+            "dependencies": ["generate_quiz"],
+            "context_scope": {"observe": ["generate_quiz.distractor_explanation_1"]},
         }
 
         result = build_field_context_with_history(
@@ -77,7 +98,7 @@ class TestInlineSchemaGuard:
         assert is_null_namespace(result["generate_quiz"])
 
     def test_valid_namespace_not_affected(self):
-        """Normal action output flows through without triggering the guard."""
+        """Normal action output has overlap with declared fields → flows through."""
         current_item = _make_current_item({"generate_quiz": VALID_NAMESPACE})
         agent_config = {
             "dependencies": ["generate_quiz"],
@@ -97,8 +118,8 @@ class TestInlineSchemaGuard:
             "distractor_explanation_1": "The answer is wrong because..."
         }
 
-    def test_user_data_with_title_not_affected(self):
-        """Real user data that has 'title' field is not falsely detected."""
+    def test_user_data_with_matching_fields(self):
+        """User data with fields matching observe spec → not affected."""
         user_data = {"title": "My Document", "body": "Some text"}
         current_item = _make_current_item({"extract": user_data})
         agent_config = {
@@ -116,3 +137,22 @@ class TestInlineSchemaGuard:
 
         assert not is_null_namespace(result["extract"])
         assert result["extract"] == {"title": "My Document", "body": "Some text"}
+
+    def test_wildcard_observe_bypasses_guard(self):
+        """Wildcard observe (action.*) sets allowed_fields=None → guard skipped."""
+        current_item = _make_current_item({"generate_quiz": INLINE_SCHEMA_CORRUPTION})
+        agent_config = {
+            "dependencies": ["generate_quiz"],
+            "context_scope": {"observe": ["generate_quiz.*"]},
+        }
+
+        result = build_field_context_with_history(
+            agent_name="review",
+            agent_config=agent_config,
+            agent_indices={"generate_quiz": 0, "review": 1},
+            current_item=current_item,
+            context_scope=agent_config["context_scope"],
+        )
+
+        # Wildcard → allowed_fields is None → guard doesn't fire → all keys loaded
+        assert not is_null_namespace(result["generate_quiz"])


### PR DESCRIPTION
## Summary

**Root cause prevention + multi-layer defense** for a production bug where LLMs echo JSON Schema definitions back as response content, causing `RecordContextError` crashes in downstream actions.

### Prevention (root cause)
- `_extract_ollama_schema` now strips `title` from the format param sent to `client.chat()`. The `title: "InlineSchema"` key leaked framework metadata into LLM context and triggered schema-echo behavior. Ollama's format param only needs structural keys (`type`, `properties`, `required`, `additionalProperties`).

### Detection (defense in depth)
- **Online path**: `_reject_schema_echo_items` in `_validate_llm_output_schema` — runs unconditionally, replaces echoes with `_parse_error` dicts so reprompt retries
- **Batch processing**: Schema-echo check in `_process_successful_result` — prevents corrupted content from reaching records
- **Batch reprompt**: `detect_parse_error` now calls `is_schema_echo` — batch reprompt retries schema echoes on the same cycle

### Guard (already-corrupted records)
- **Zero-overlap guard** in `scope_builder.py` — if a dependency namespace has zero field overlap with declared observe fields, wraps as `SKIPPED_NAMESPACE`. Catches any content corruption generically, not just InlineSchema.

## Changes

| File | Change |
|------|--------|
| `agent_actions/llm/providers/ollama/client.py` | Strip `title` from format param in `_extract_ollama_schema` |
| `agent_actions/utils/schema_echo.py` | Shared `is_schema_echo()` + `make_schema_echo_error()` |
| `agent_actions/processing/helpers.py` | `_reject_schema_echo_items` in `_validate_llm_output_schema` |
| `agent_actions/llm/batch/processing/batch_result_strategy.py` | Schema-echo check in `_process_successful_result` |
| `agent_actions/processing/evaluation/strategies/validation.py` | Schema-echo detection in `detect_parse_error` |
| `agent_actions/prompt/context/scope_builder.py` | Zero-overlap guard in `DependencyNamespaceBuilder.build` |
| 5 test files | 36 new tests |

## Test plan

- [x] 36 new tests (prevention, detection, reprompt integration, zero-overlap guard)
- [x] 7343 total tests pass, 2 skipped (pre-existing)
- [x] ruff check + format clean
- [ ] Manual: run inline-schema workflow on Ollama to confirm no echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)