### PR TITLE
refactor: LLM module cleanup — remove guards, fix TOCTOU, standardize timing, thread safety

### DIFF
--- a/agent_actions/llm/batch/core/batch_constants.py
+++ b/agent_actions/llm/batch/core/batch_constants.py
@@ -50,6 +50,17 @@ class FilterStatus(str, Enum):
         return self.value
 
 
+class OnExhaustedPolicy(str, Enum):
+    """Policy when retry/reprompt attempts are exhausted."""
+
+    RETURN_LAST = "return_last"
+    RAISE = "raise"
+
+    def __str__(self) -> str:
+        """Return the string value for str() conversion."""
+        return self.value
+
+
 class ContextMetaKeys:
     """Internal underscore-prefixed metadata keys used in batch context maps."""
 

--- a/agent_actions/llm/batch/infrastructure/context.py
+++ b/agent_actions/llm/batch/infrastructure/context.py
@@ -52,12 +52,6 @@ class BatchContextManager:
         try:
             context_path = BatchContextManager._get_context_path(output_directory, batch_name)
 
-            if not context_path.exists():
-                raise ProcessingError(
-                    f"Context map file not found: {context_path}",
-                    context={"output_directory": output_directory, "batch_name": batch_name},
-                )
-
             with open(context_path, encoding="utf-8") as f:
                 context_map = json.load(f)
 
@@ -105,9 +99,9 @@ class BatchContextManager:
         """Delete batch context map file if it exists."""
         context_path = BatchContextManager._get_context_path(output_directory, batch_name)
 
-        if context_path.exists():
+        try:
             context_path.unlink()
             logger.debug("Deleted context map at %s", context_path)
             return True
-
-        return False
+        except FileNotFoundError:
+            return False

--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from agent_actions.llm.batch.core.batch_constants import OnExhaustedPolicy
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.path_utils import ensure_directory_exists
 
@@ -31,6 +32,10 @@ class RecoveryState:
                 f"Invalid recovery phase '{self.phase}'. "
                 f"Expected one of: {', '.join(sorted(_VALID_PHASES))}"
             )
+        if isinstance(self.on_exhausted, str) and not isinstance(
+            self.on_exhausted, OnExhaustedPolicy
+        ):
+            self.on_exhausted = OnExhaustedPolicy(self.on_exhausted)
 
     # Retry state
     retry_attempt: int = 0
@@ -44,7 +49,7 @@ class RecoveryState:
     validation_name: str | None = None
     reprompt_attempts_per_record: dict[str, int] = field(default_factory=dict)
     validation_status: dict[str, bool] = field(default_factory=dict)
-    on_exhausted: str = "return_last"
+    on_exhausted: OnExhaustedPolicy = OnExhaustedPolicy.RETURN_LAST
 
     # Accumulated results (serialized BatchResult dicts)
     accumulated_results: list[dict[str, Any]] = field(default_factory=list)

--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -109,13 +109,12 @@ class RecoveryStateManager:
     def load(output_directory: str, file_name: str) -> RecoveryState | None:
         """Load recovery state from disk, or None if not found."""
         state_path = RecoveryStateManager._get_path(output_directory, file_name)
-        if not state_path.exists():
-            return None
-
         try:
             with open(state_path, encoding="utf-8") as f:
                 data = json.load(f)
             return RecoveryState(**data)
+        except FileNotFoundError:
+            return None
         except (json.JSONDecodeError, TypeError) as e:
             logger.warning("Failed to load recovery state from %s: %s", state_path, e)
             return None
@@ -124,11 +123,12 @@ class RecoveryStateManager:
     def delete(output_directory: str, file_name: str) -> bool:
         """Delete recovery state file. Returns True if deleted, False if not found."""
         state_path = RecoveryStateManager._get_path(output_directory, file_name)
-        if state_path.exists():
+        try:
             state_path.unlink()
             logger.debug("Deleted recovery state at %s", state_path)
             return True
-        return False
+        except FileNotFoundError:
+            return False
 
     @staticmethod
     def exists(output_directory: str, file_name: str) -> bool:

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -50,11 +50,6 @@ class BatchRegistryManager:
         """
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
             self._cache[file_name] = entry
             self._persist_registry(self._cache)
             logger.info("Saved batch job %s for file %s", entry.batch_id, file_name)
@@ -65,11 +60,6 @@ class BatchRegistryManager:
         """Remove a batch job entry. Returns True if removed, False if not found."""
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
             if file_name not in self._cache:
                 return False
             del self._cache[file_name]
@@ -81,11 +71,6 @@ class BatchRegistryManager:
         """Retrieve batch job entry by file name."""
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
             entry = self._cache.get(file_name)
 
             if entry is not None:
@@ -103,11 +88,6 @@ class BatchRegistryManager:
         """Retrieve batch job entry by batch ID."""
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
             for entry in self._cache.values():
                 if entry.batch_id == batch_id:
                     fire_event(
@@ -128,11 +108,6 @@ class BatchRegistryManager:
         """Update status for a batch job. Returns False if batch_id not found."""
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
 
             for file_name, entry in self._cache.items():
                 if entry.batch_id == batch_id:
@@ -149,22 +124,12 @@ class BatchRegistryManager:
         """Get all batch jobs in registry."""
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
             return self._cache.copy()  # Return copy to prevent external mutation
 
     def get_registry_stats(self) -> BatchRegistryStats:
         """Get aggregated statistics for all batches."""
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
 
             stats = BatchRegistryStats(
                 total_jobs=len(self._cache), completed=0, failed=0, in_progress=0, cancelled=0
@@ -195,11 +160,6 @@ class BatchRegistryManager:
         """
         with self._lock:
             self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
 
             if not self._cache:
                 return True  # No jobs = all complete
@@ -275,6 +235,8 @@ class BatchRegistryManager:
         """Lazy load cache if not already loaded."""
         if self._cache is None:
             self._cache = self._load_registry()
+        if self._cache is None:
+            raise RuntimeError("Cache initialization failed")
 
     def _load_registry(self) -> dict[str, BatchJobEntry]:
         """

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -35,6 +35,7 @@ class BatchRegistryManager:
         """
         self._registry_path = Path(registry_path)
         self._cache: dict[str, BatchJobEntry] | None = None
+        self._batch_id_index: dict[str, str] | None = None  # batch_id -> file_name
         self._lock = threading.Lock()
         logger.debug("Initialized BatchRegistryManager for %s", registry_path)
 
@@ -50,6 +51,12 @@ class BatchRegistryManager:
         """
         with self._lock:
             self._ensure_cache_loaded()
+            # Evict stale index entry if file_name was mapped to a different batch_id
+            old = self._cache.get(file_name)
+            if old and self._batch_id_index and old.batch_id != entry.batch_id:
+                self._batch_id_index.pop(old.batch_id, None)
+            if self._batch_id_index is not None:
+                self._batch_id_index[entry.batch_id] = file_name
             self._cache[file_name] = entry
             self._persist_registry(self._cache)
             logger.info("Saved batch job %s for file %s", entry.batch_id, file_name)
@@ -62,6 +69,9 @@ class BatchRegistryManager:
             self._ensure_cache_loaded()
             if file_name not in self._cache:
                 return False
+            old_entry = self._cache[file_name]
+            if self._batch_id_index and old_entry.batch_id in self._batch_id_index:
+                del self._batch_id_index[old_entry.batch_id]
             del self._cache[file_name]
             self._persist_registry(self._cache)
             logger.info("Removed batch job entry for %s", file_name)
@@ -85,11 +95,13 @@ class BatchRegistryManager:
             return entry
 
     def get_batch_job_by_id(self, batch_id: str) -> BatchJobEntry | None:
-        """Retrieve batch job entry by batch ID."""
+        """Retrieve batch job entry by batch ID (O(1) via index)."""
         with self._lock:
             self._ensure_cache_loaded()
-            for entry in self._cache.values():
-                if entry.batch_id == batch_id:
+            file_name = self._batch_id_index.get(batch_id) if self._batch_id_index else None
+            if file_name is not None:
+                entry = self._cache.get(file_name)
+                if entry is not None:
                     fire_event(
                         CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}")
                     )
@@ -109,13 +121,14 @@ class BatchRegistryManager:
         with self._lock:
             self._ensure_cache_loaded()
 
-            for file_name, entry in self._cache.items():
-                if entry.batch_id == batch_id:
-                    updated_entry = dataclasses.replace(entry, status=new_status)
-                    self._cache[file_name] = updated_entry
-                    self._persist_registry(self._cache)
-                    logger.info("Updated batch %s status to %s", batch_id, new_status)
-                    return True
+            file_name = self._batch_id_index.get(batch_id) if self._batch_id_index else None
+            if file_name is not None and file_name in self._cache:
+                entry = self._cache[file_name]
+                updated_entry = dataclasses.replace(entry, status=new_status)
+                self._cache[file_name] = updated_entry
+                self._persist_registry(self._cache)
+                logger.info("Updated batch %s status to %s", batch_id, new_status)
+                return True
 
             logger.warning("Batch ID %s not found in registry", batch_id)
             return False
@@ -217,6 +230,7 @@ class BatchRegistryManager:
         with self._lock:
             entries_removed = len(self._cache) if self._cache is not None else 0
             self._cache = None
+            self._batch_id_index = None
             logger.debug("Registry cache invalidated")
 
             fire_event(
@@ -235,6 +249,9 @@ class BatchRegistryManager:
         """Lazy load cache if not already loaded."""
         if self._cache is None:
             self._cache = self._load_registry()
+            self._batch_id_index = {
+                entry.batch_id: file_name for file_name, entry in self._cache.items()
+            }
         if self._cache is None:
             raise RuntimeError("Cache initialization failed")
 

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -148,12 +148,13 @@ class BatchRegistryManager:
                 total_jobs=len(self._cache), completed=0, failed=0, in_progress=0, cancelled=0
             )
 
+            in_flight = BatchStatus.in_flight_states()
             for entry in self._cache.values():
                 if entry.status == BatchStatus.COMPLETED:
                     stats.completed += 1
                 elif entry.status == BatchStatus.FAILED:
                     stats.failed += 1
-                elif entry.status in BatchStatus.in_flight_states():
+                elif entry.status in in_flight:
                     stats.in_progress += 1
                 elif entry.status == BatchStatus.CANCELLED:
                     stats.cancelled += 1

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -249,11 +249,11 @@ class BatchRegistryManager:
         """Lazy load cache if not already loaded."""
         if self._cache is None:
             self._cache = self._load_registry()
+            if self._cache is None:
+                raise RuntimeError("Cache initialization failed")
             self._batch_id_index = {
                 entry.batch_id: file_name for file_name, entry in self._cache.items()
             }
-        if self._cache is None:
-            raise RuntimeError("Cache initialization failed")
 
     def _load_registry(self) -> dict[str, BatchJobEntry]:
         """

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -56,8 +56,8 @@ class BatchProcessingContext:
     json_mode: bool = True
     output_field: str = "raw_response"
 
-    # Reconciliation — always set by _init_context()
-    reconciler: BatchResultReconciler = None  # type: ignore[assignment]
+    # Reconciliation — set by _init_context() before any method accesses it
+    reconciler: BatchResultReconciler | None = None
 
     # Per-record recovery metadata for exhausted records (custom_id -> RecoveryMetadata)
     exhausted_recovery: dict[str, RecoveryMetadata] | None = None

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -56,8 +56,8 @@ class BatchProcessingContext:
     json_mode: bool = True
     output_field: str = "raw_response"
 
-    # Reconciliation
-    reconciler: BatchResultReconciler | None = None
+    # Reconciliation — always set by _init_context()
+    reconciler: BatchResultReconciler = None  # type: ignore[assignment]
 
     # Per-record recovery metadata for exhausted records (custom_id -> RecoveryMetadata)
     exhausted_recovery: dict[str, RecoveryMetadata] | None = None
@@ -152,7 +152,6 @@ class BatchResultStrategy:
             agent_config,
             exhausted_recovery,
         )
-        ctx.reconciler = BatchResultReconciler(ctx.context_map)
 
         results = self._process_batch_results(ctx)
         results.extend(self._reconcile_passthroughs(ctx))
@@ -198,6 +197,7 @@ class BatchResultStrategy:
             agent_config=agent_config,
             json_mode=json_mode,
             output_field=output_field,
+            reconciler=BatchResultReconciler(context_map),
             exhausted_recovery=exhausted_recovery,
         )
 
@@ -213,11 +213,6 @@ class BatchResultStrategy:
 
     def _process_batch_results(self, ctx: BatchProcessingContext) -> list[ProcessingResult]:
         """Process all batch results, returning one ProcessingResult per result."""
-        if ctx.reconciler is None:
-            raise RuntimeError(
-                "BatchProcessingContext.reconciler is None; "
-                "reconciler must be initialized before processing results"
-            )
         results: list[ProcessingResult] = []
 
         for batch_result in ctx.batch_results:
@@ -293,11 +288,6 @@ class BatchResultStrategy:
         custom_id: str,
     ) -> ProcessingResult:
         """Parse a successful batch result into a ProcessingResult."""
-        if ctx.reconciler is None:
-            raise RuntimeError(
-                "BatchProcessingContext.reconciler is None; "
-                "reconciler must be initialized before processing results"
-            )
         generated_obj = batch_result.content
         if isinstance(generated_obj, str):
             if ctx.json_mode:
@@ -428,11 +418,6 @@ class BatchResultStrategy:
 
         Error results are NOT enriched (matching the original pipeline behaviour).
         """
-        if ctx.reconciler is None:
-            raise RuntimeError(
-                "BatchProcessingContext.reconciler is None; "
-                "reconciler must be initialized before creating error items"
-            )
         source_guid = ctx.reconciler.get_source_guid(custom_id, fallback=custom_id or "NOT_SET")
 
         error_item: dict[str, Any] = {
@@ -467,11 +452,6 @@ class BatchResultStrategy:
         Routes exhausted-retry and passthrough records through enrichment
         for consistent lineage, metadata, and version_correlation_id.
         """
-        if ctx.reconciler is None:
-            raise RuntimeError(
-                "BatchProcessingContext.reconciler is None; "
-                "reconciler must be initialized before merging passthroughs"
-            )
         reconciliation = ctx.reconciler.reconcile()
         results: list[ProcessingResult] = []
 

--- a/agent_actions/llm/batch/processing/reconciler.py
+++ b/agent_actions/llm/batch/processing/reconciler.py
@@ -102,6 +102,16 @@ class BatchResultReconciler:
             return -1
 
     @staticmethod
+    def find_missing_ids(
+        context_map: dict[str, Any],
+        batch_results: list[Any],
+    ) -> set[str]:
+        """Find custom_ids expected but not received in batch results."""
+        expected = BatchResultReconciler.collect_expected_custom_ids(context_map)
+        received = BatchResultReconciler.collect_result_custom_ids(batch_results)
+        return expected - received
+
+    @staticmethod
     def collect_expected_custom_ids(context_map: dict[str, Any]) -> set:
         """Collect custom_ids of records submitted to batch API (status='included' only)."""
         return {

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -478,9 +478,7 @@ class BatchProcessingService:
         retry_enabled = retry_config and retry_config.get("enabled", True)
 
         if retry_enabled:
-            expected_ids = BatchResultReconciler.collect_expected_custom_ids(context_map)
-            received_ids = BatchResultReconciler.collect_result_custom_ids(batch_results)
-            missing_ids = expected_ids - received_ids
+            missing_ids = BatchResultReconciler.find_missing_ids(context_map, batch_results)
 
             if missing_ids:
                 max_attempts = retry_config.get("max_attempts", 3) if retry_config else 3

--- a/agent_actions/llm/batch/services/retry.py
+++ b/agent_actions/llm/batch/services/retry.py
@@ -91,9 +91,7 @@ class BatchRetryService:
         exhausted_recovery: dict[str, RecoveryMetadata] | None = None
 
         if retry_enabled:
-            expected_ids = BatchResultReconciler.collect_expected_custom_ids(context_map)
-            received_ids = BatchResultReconciler.collect_result_custom_ids(all_results)
-            missing_ids = expected_ids - received_ids
+            missing_ids = BatchResultReconciler.find_missing_ids(context_map, all_results)
 
             if missing_ids:
                 from datetime import UTC, datetime

--- a/agent_actions/llm/providers/agac/client.py
+++ b/agent_actions/llm/providers/agac/client.py
@@ -7,8 +7,8 @@ without real API calls. Generates realistic data based on schema and prompts.
 
 import json
 import logging
+import time
 import uuid
-from datetime import datetime
 from typing import Any, ClassVar
 
 from agent_actions.llm.providers.agac.fake_data import FakeDataGenerator
@@ -138,7 +138,7 @@ class AgacClient(BaseClient):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
 
         logger.info(
             "AgacClient.call_json: id=%s, attempt=%d, schema=%s, prompt_len=%d",
@@ -170,7 +170,7 @@ class AgacClient(BaseClient):
             }
             logger.debug("No schema provided, using generic response")
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(
@@ -214,7 +214,7 @@ class AgacClient(BaseClient):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
 
         logger.info(
             "AgacClient.call_non_json: id=%s, attempt=%d, prompt_len=%d",
@@ -226,7 +226,7 @@ class AgacClient(BaseClient):
         # Generate text response based on prompt
         content = FakeDataGenerator.generate_text_response(prompt, attempt)
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(

--- a/agent_actions/llm/providers/anthropic/client.py
+++ b/agent_actions/llm/providers/anthropic/client.py
@@ -9,8 +9,8 @@ consistent retry handling across all providers.
 """
 
 import logging
+import time
 import uuid
-from datetime import datetime
 from typing import Any, ClassVar
 
 import anthropic
@@ -158,12 +158,12 @@ class AnthropicClient(BaseClient):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             response = client.messages.create(**api_args)
         except anthropic.APIError as e:
             raise _wrap_anthropic_error(e, model_name, request_id) from e
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(

--- a/agent_actions/llm/providers/cohere/client.py
+++ b/agent_actions/llm/providers/cohere/client.py
@@ -9,8 +9,8 @@ consistent retry handling across all providers.
 """
 
 import logging
+import time
 import uuid
-from datetime import datetime
 from typing import Any, ClassVar
 
 import cohere
@@ -93,7 +93,7 @@ class CohereClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             co = cohere.ClientV2(api_key=api_key)
             envelope = MessageBuilder.build(
@@ -129,7 +129,7 @@ class CohereClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
             )
             CohereClient.handle_generic_error(e, "Cohere", "call_json", model_name)
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(
@@ -168,7 +168,7 @@ class CohereClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             co = cohere.ClientV2(api_key=api_key)
             envelope = MessageBuilder.build("cohere", prompt_config, context_data, json_mode=False)
@@ -213,7 +213,7 @@ class CohereClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
                 cause=e,
             ) from e
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(

--- a/agent_actions/llm/providers/gemini/client.py
+++ b/agent_actions/llm/providers/gemini/client.py
@@ -9,8 +9,8 @@ consistent retry handling across all providers.
 """
 
 import logging
+import time
 import uuid
-from datetime import datetime
 from typing import Any, ClassVar
 
 from google import genai
@@ -83,7 +83,7 @@ class GeminiClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             client = _build_client(api_key)
             gen_params = extract_generation_params(
@@ -117,7 +117,7 @@ class GeminiClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
             )
             GeminiClient.handle_generic_error(e, "Gemini", "call_json", model_name)
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(
@@ -148,7 +148,7 @@ class GeminiClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             client = _build_client(api_key)
             gen_params = extract_generation_params(
@@ -191,7 +191,7 @@ class GeminiClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
                 cause=e,
             ) from e
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(

--- a/agent_actions/llm/providers/groq/client.py
+++ b/agent_actions/llm/providers/groq/client.py
@@ -12,8 +12,8 @@ as Groq's json_object mode can produce malformed output.
 """
 
 import logging
+import time
 import uuid
-from datetime import datetime
 from typing import Any, ClassVar
 
 import groq
@@ -100,7 +100,7 @@ class GroqClient(BaseClient, JSONResponseMixin):
             ),
         }
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             llm = client.chat.completions.create(**json_completion_kwargs)
         except (RateLimitError, NetworkError, VendorAPIError):
@@ -127,7 +127,7 @@ class GroqClient(BaseClient, JSONResponseMixin):
                 cause=e,
             ) from e
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(llm, "groq", model_name, latency_ms, request_id)
@@ -163,13 +163,13 @@ class GroqClient(BaseClient, JSONResponseMixin):
             )
         )
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             response = client.chat.completions.create(**completion_kwargs)
         except groq.APIError as e:
             raise _wrap_groq_error(e, model_name, request_id) from e
 
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(response, "groq", model_name, latency_ms, request_id)

--- a/agent_actions/llm/providers/ollama/client.py
+++ b/agent_actions/llm/providers/ollama/client.py
@@ -12,8 +12,8 @@ ProviderMessageConfig from SchemaInjection.PROMPT to SchemaInjection.NONE.
 
 import logging
 import os
+import time
 import uuid
-from datetime import datetime
 from typing import Any, ClassVar
 
 import httpx
@@ -132,7 +132,7 @@ def _call_ollama_json(
         agent_config, key_map={"max_tokens": "num_predict"}, stop_as_list=True
     )
 
-    start_time = datetime.now()
+    start_time = time.perf_counter()
     try:
         chat_kwargs: dict[str, Any] = {
             "model": model,
@@ -159,7 +159,7 @@ def _call_ollama_json(
             e, model, _ERROR_MAPPING_CLOUD if cloud else _ERROR_MAPPING_LOCAL, request_id
         ) from e
 
-    latency_ms = (datetime.now() - start_time).total_seconds() * 1000
+    latency_ms = (time.perf_counter() - start_time) * 1000
     ResponseBuilder.record_usage_and_event(response, vendor_slug, model, latency_ms, request_id)
     maybe_inject_online_failure(model, vendor_slug=vendor_slug)
 
@@ -204,7 +204,7 @@ def _call_ollama_non_json(
     request_id = str(uuid.uuid4())
     fire_event(LLMRequestEvent(provider=vendor_slug, model=model, request_id=request_id))
 
-    start_time = datetime.now()
+    start_time = time.perf_counter()
     try:
         non_json_options = extract_generation_params(
             agent_config, key_map={"max_tokens": "num_predict"}, stop_as_list=True
@@ -224,7 +224,7 @@ def _call_ollama_non_json(
             e, model, _ERROR_MAPPING_CLOUD if cloud else _ERROR_MAPPING_LOCAL, request_id
         ) from e
 
-    latency_ms = (datetime.now() - start_time).total_seconds() * 1000
+    latency_ms = (time.perf_counter() - start_time) * 1000
     ResponseBuilder.record_usage_and_event(response, vendor_slug, model, latency_ms, request_id)
     maybe_inject_online_failure(model, vendor_slug=vendor_slug)
 

--- a/agent_actions/llm/providers/openai/client.py
+++ b/agent_actions/llm/providers/openai/client.py
@@ -9,8 +9,8 @@ consistent retry handling across all providers.
 """
 
 import logging
+import time
 import uuid
-from datetime import datetime
 from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
@@ -107,12 +107,12 @@ class OpenAIClient(BaseClient):
             ),
         }
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             response = client.chat.completions.create(**completion_kwargs)
         except openai.APIError as e:
             raise _wrap_openai_error(e, model_name, request_id) from e
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(
@@ -207,12 +207,12 @@ class OpenAIClient(BaseClient):
             ),
         }
 
-        start_time = datetime.now()
+        start_time = time.perf_counter()
         try:
             response = client.chat.completions.create(**completion_kwargs)
         except openai.APIError as e:
             raise _wrap_openai_error(e, model_name, request_id) from e
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = time.perf_counter() - start_time
         latency_ms = duration * 1000
 
         ResponseBuilder.record_usage_and_event(

--- a/agent_actions/llm/realtime/output.py
+++ b/agent_actions/llm/realtime/output.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.output.writer import FileWriter
+from agent_actions.utils.path_utils import ensure_directory_exists
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -56,7 +57,7 @@ class OutputHandler:
             output_file_path = Path(output_directory) / relative_path
             # Only create directory if not using storage backend
             if self.storage_backend is None:
-                self._ensure_directory_exists(str(output_file_path))
+                ensure_directory_exists(str(output_file_path), is_file=True)
             file_writer = FileWriter(
                 str(output_file_path),
                 storage_backend=self.storage_backend,
@@ -85,7 +86,3 @@ class OutputHandler:
                 cause=e,
             ) from e
 
-    def _ensure_directory_exists(self, file_path):
-        """Ensure the directory for the file path exists."""
-        directory = Path(file_path).parent
-        directory.mkdir(parents=True, exist_ok=True)

--- a/agent_actions/llm/realtime/output.py
+++ b/agent_actions/llm/realtime/output.py
@@ -85,4 +85,3 @@ class OutputHandler:
                 },
                 cause=e,
             ) from e
-

--- a/agent_actions/llm/realtime/services/invocation.py
+++ b/agent_actions/llm/realtime/services/invocation.py
@@ -66,8 +66,8 @@ def _resolve_client(model_vendor: str) -> Any:
                     "install_command": f"uv pip install {package}",
                 },
             ) from err
-        CLIENT_REGISTRY[model_vendor] = cls
-        return cls
+        CLIENT_REGISTRY.setdefault(model_vendor, cls)  # atomic under CPython GIL
+        return CLIENT_REGISTRY[model_vendor]  # return whatever won the race
     return entry
 
 

--- a/tests/unit/llm/batch/test_llm_simplify.py
+++ b/tests/unit/llm/batch/test_llm_simplify.py
@@ -1,0 +1,147 @@
+"""Tests for LLM simplify refactor: batch_id index, find_missing_ids, OnExhaustedPolicy."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.llm.batch.core.batch_constants import OnExhaustedPolicy
+from agent_actions.llm.batch.core.batch_models import BatchJobEntry
+from agent_actions.llm.batch.infrastructure.recovery_state import RecoveryState
+from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+
+
+def _entry(batch_id: str, status: str = "completed") -> BatchJobEntry:
+    return BatchJobEntry(
+        batch_id=batch_id, status=status, timestamp="2026-01-01T00:00:00", provider="test"
+    )
+
+
+# -- batch_id index ----------------------------------------------------------
+
+
+class TestBatchIdIndex:
+    """Verify the batch_id -> file_name index stays coherent."""
+
+    def test_index_built_on_first_access(self, tmp_path):
+        mgr = BatchRegistryManager(tmp_path / "reg.json")
+        mgr.save_batch_job("a.json", _entry("batch-1"))
+        # Invalidate and re-load to force index rebuild from disk
+        mgr.invalidate_cache()
+        entry = mgr.get_batch_job_by_id("batch-1")
+        assert entry is not None
+        assert entry.batch_id == "batch-1"
+
+    def test_overwrite_remaps_index(self, tmp_path):
+        """When file_name gets a new batch_id, old batch_id should be evicted."""
+        mgr = BatchRegistryManager(tmp_path / "reg.json")
+        mgr.save_batch_job("a.json", _entry("batch-old"))
+        mgr.save_batch_job("a.json", _entry("batch-new"))
+
+        assert mgr.get_batch_job_by_id("batch-new") is not None
+        assert mgr.get_batch_job_by_id("batch-old") is None
+
+    def test_remove_clears_index(self, tmp_path):
+        mgr = BatchRegistryManager(tmp_path / "reg.json")
+        mgr.save_batch_job("a.json", _entry("batch-1"))
+        mgr.remove_batch_job("a.json")
+        assert mgr.get_batch_job_by_id("batch-1") is None
+
+    def test_update_status_via_index(self, tmp_path):
+        mgr = BatchRegistryManager(tmp_path / "reg.json")
+        mgr.save_batch_job("a.json", _entry("batch-1", status="submitted"))
+        assert mgr.update_status("batch-1", "completed") is True
+        assert mgr.get_batch_job_by_id("batch-1").status == "completed"
+
+    def test_update_status_not_found(self, tmp_path):
+        mgr = BatchRegistryManager(tmp_path / "reg.json")
+        mgr.save_batch_job("a.json", _entry("batch-1"))
+        assert mgr.update_status("nonexistent", "completed") is False
+
+    def test_invalidate_clears_index(self, tmp_path):
+        mgr = BatchRegistryManager(tmp_path / "reg.json")
+        mgr.save_batch_job("a.json", _entry("batch-1"))
+        mgr.invalidate_cache()
+        # After invalidation, next access rebuilds — should still find it
+        assert mgr.get_batch_job_by_id("batch-1") is not None
+
+    def test_save_remove_save_cycle(self, tmp_path):
+        """Index stays consistent through save/remove/save cycles."""
+        mgr = BatchRegistryManager(tmp_path / "reg.json")
+        mgr.save_batch_job("a.json", _entry("batch-1"))
+        mgr.remove_batch_job("a.json")
+        mgr.save_batch_job("a.json", _entry("batch-2"))
+
+        assert mgr.get_batch_job_by_id("batch-1") is None
+        assert mgr.get_batch_job_by_id("batch-2") is not None
+
+
+# -- find_missing_ids ---------------------------------------------------------
+
+
+class TestFindMissingIds:
+    """Verify BatchResultReconciler.find_missing_ids consolidation."""
+
+    def _make_result(self, custom_id: str) -> MagicMock:
+        r = MagicMock()
+        r.custom_id = custom_id
+        return r
+
+    def test_all_received(self):
+        context_map = {"id-1": {"_batch_filter_status": "included"}}
+        results = [self._make_result("id-1")]
+        assert BatchResultReconciler.find_missing_ids(context_map, results) == set()
+
+    def test_some_missing(self):
+        context_map = {
+            "id-1": {"_batch_filter_status": "included"},
+            "id-2": {"_batch_filter_status": "included"},
+        }
+        results = [self._make_result("id-1")]
+        assert BatchResultReconciler.find_missing_ids(context_map, results) == {"id-2"}
+
+    def test_empty_results(self):
+        context_map = {"id-1": {"_batch_filter_status": "included"}}
+        missing = BatchResultReconciler.find_missing_ids(context_map, [])
+        assert "id-1" in missing
+
+    def test_empty_context(self):
+        results = [self._make_result("id-1")]
+        assert BatchResultReconciler.find_missing_ids({}, results) == set()
+
+
+# -- OnExhaustedPolicy coercion ----------------------------------------------
+
+
+class TestOnExhaustedPolicyCoercion:
+    """Verify __post_init__ coerces raw strings to OnExhaustedPolicy."""
+
+    def test_string_coerced_to_enum(self):
+        state = RecoveryState(phase="retry", on_exhausted="raise")
+        assert state.on_exhausted is OnExhaustedPolicy.RAISE
+        assert isinstance(state.on_exhausted, OnExhaustedPolicy)
+
+    def test_default_is_return_last(self):
+        state = RecoveryState(phase="retry")
+        assert state.on_exhausted is OnExhaustedPolicy.RETURN_LAST
+
+    def test_enum_value_unchanged(self):
+        state = RecoveryState(phase="retry", on_exhausted=OnExhaustedPolicy.RAISE)
+        assert state.on_exhausted is OnExhaustedPolicy.RAISE
+
+    def test_json_roundtrip(self):
+        """on_exhausted survives dict serialization + deserialization."""
+        original = RecoveryState(phase="retry", on_exhausted=OnExhaustedPolicy.RAISE)
+        data = original.to_dict()
+        assert data["on_exhausted"] == "raise"
+        restored = RecoveryState(**data)
+        assert restored.on_exhausted is OnExhaustedPolicy.RAISE
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            RecoveryState(phase="retry", on_exhausted="invalid_policy")
+
+    def test_str_equality_preserved(self):
+        """Enum compares equal to raw string (str inheritance)."""
+        assert OnExhaustedPolicy.RAISE == "raise"
+        assert OnExhaustedPolicy.RETURN_LAST == "return_last"

--- a/tests/unit/llm_invocation/test_output_handler.py
+++ b/tests/unit/llm_invocation/test_output_handler.py
@@ -47,8 +47,9 @@ class TestSaveMainOutputUnboundLocal:
         src.touch()
 
         with (
-            patch.object(
-                handler, "_ensure_directory_exists", side_effect=PermissionError("denied")
+            patch(
+                "agent_actions.llm.realtime.output.ensure_directory_exists",
+                side_effect=PermissionError("denied"),
             ),
             pytest.raises(AgentActionsError, match="IOError saving main output") as exc_info,
         ):

--- a/tests/unit/test_assert_replacement_smoke.py
+++ b/tests/unit/test_assert_replacement_smoke.py
@@ -40,14 +40,16 @@ class TestBatchRegistryManagerCacheGuard:
         from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
 
         mgr = BatchRegistryManager(tmp_path / "registry.json")
-        # Force cache to None after init (simulating a corrupted state)
+        # Force cache to None and make _load_registry return None
+        # to simulate a corrupted state where cache init fails.
+        # Guard is now inside _ensure_cache_loaded itself.
         mgr._cache = None
-        mgr._ensure_cache_loaded = lambda: None  # no-op to keep cache None
+        mgr._load_registry = lambda: None  # type: ignore[assignment]
 
         entry = BatchJobEntry(
             batch_id="b1", status="pending", timestamp="2026-01-01T00:00:00", provider="test"
         )
-        with pytest.raises(RuntimeError, match="_cache is None"):
+        with pytest.raises(RuntimeError, match="Cache initialization failed"):
             mgr.save_batch_job("test.json", entry)
 
 


### PR DESCRIPTION
## Summary

- **Parts 1–2**: Removed 13 redundant null guards in `registry.py` (9) and `batch_result_strategy.py` (4) by moving guards into `_ensure_cache_loaded()` and `_init_context()` respectively
- **Part 3**: Added `batch_id → file_name` index to `BatchRegistryManager` with incremental maintenance — `get_batch_job_by_id` and `update_status` now O(1) instead of O(N)
- **Part 4**: Fixed TOCTOU races in `recovery_state.py` and `context.py` — replaced `exists()`-then-open/unlink with exception handling
- **Part 5**: Added `BatchResultReconciler.find_missing_ids()` to consolidate the expected−received pattern (2 call sites replaced; `shared.py` left as-is since it uses intermediates for logging)
- **Part 6**: Added `OnExhaustedPolicy(str, Enum)` to `batch_constants.py` with `__post_init__` coercion in `RecoveryState` for JSON/YAML backward compat
- **Part 7**: Standardized latency measurement to `time.perf_counter()` across all 7 provider clients (was `datetime.now()`)
- **Part 8**: Replaced private `_ensure_directory_exists()` in `OutputHandler` with shared `ensure_directory_exists()` utility
- **Part 9**: Thread-safe `CLIENT_REGISTRY` mutation via `setdefault()` (atomic under CPython GIL)

## Test plan

- [x] 7419 tests pass, 2 skipped (pre-existing), ruff clean
- [x] 1 pre-existing test failure on base branch (`test_batch_timeout.py` circular import) — not caused by this PR
- [x] Updated 2 tests to match refactored code (poisoned-cache guard location, patched `ensure_directory_exists` import)
- [x] Spec verification checks pass (guard counts, no `datetime.now()` in providers, no `_ensure_directory_exists` in output.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)