### PR TITLE
fix: revert CLIENT_REGISTRY setdefault — breaks all LLM provider calls

### DIFF
--- a/agent_actions/llm/realtime/services/invocation.py
+++ b/agent_actions/llm/realtime/services/invocation.py
@@ -66,8 +66,8 @@ def _resolve_client(model_vendor: str) -> Any:
                     "install_command": f"uv pip install {package}",
                 },
             ) from err
-        CLIENT_REGISTRY.setdefault(model_vendor, cls)  # atomic under CPython GIL
-        return CLIENT_REGISTRY[model_vendor]  # return whatever won the race
+        CLIENT_REGISTRY[model_vendor] = cls
+        return cls
     return entry
 
 


### PR DESCRIPTION
## Summary

- Reverts the `setdefault()` change from PR #632 Part 9 that broke ALL LLM provider invocations

## Root cause

`CLIENT_REGISTRY` stores lazy entries as `"module:Class"` strings. `_resolve_client()` imports the class and should overwrite the string with the resolved class. PR #632 changed `CLIENT_REGISTRY[vendor] = cls` to `CLIENT_REGISTRY.setdefault(vendor, cls)` for "thread safety", but `setdefault()` only sets if the key is **absent**. Since the key already exists (as a string), the string is never replaced. Every subsequent call returns the string, causing `'str' object has no attribute 'invoke'`.

## Fix

Revert to direct assignment: `CLIENT_REGISTRY[model_vendor] = cls`

## Test plan

- [x] The non-batch workflow (`qanalabs_quiz_gen`) fails with `'str' object has no attribute 'invoke'` on the integration branch — this fix resolves it
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)