### PR TITLE
refactor: CLI cleanup — deduplicate workflow loading, fix TOCTOU, consolidate constants

### DIFF
--- a/agent_actions/cli/compile.py
+++ b/agent_actions/cli/compile.py
@@ -62,8 +62,8 @@ class RenderCommand:
             ) from e
 
     def execute(self, create_dirs: bool = False) -> None:
-        if create_dirs and not self.template_dir.exists():
-            self.template_dir.mkdir(parents=True)
+        if create_dirs:
+            self.template_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Starting template rendering for agent: %s", self.args.agent_name)
         paths = ProjectPathsFactory.create_project_paths(
             self.args.agent_name, self.args.agent_name, project_root=self._project_root

--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -17,17 +17,11 @@ from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.storage import get_storage_backend
 from agent_actions.storage.backend import (
-    DISPOSITION_EXHAUSTED,
-    DISPOSITION_FAILED,
+    FAILURE_DISPOSITIONS,
     NODE_LEVEL_RECORD_ID,
 )
 
 logger = logging.getLogger(__name__)
-
-# Records shown by --quarantined: only primary failures that a user can
-# act on via `retry`.  UNPROCESSED (cascade casualties) are excluded —
-# they resolve automatically when the upstream failure is retried.
-_QUARANTINE_DISPOSITIONS = frozenset({DISPOSITION_FAILED, DISPOSITION_EXHAUSTED})
 
 
 class DispositionsCommand:
@@ -123,7 +117,7 @@ class DispositionsCommand:
             for row in rows:
                 if row.get("record_id") == NODE_LEVEL_RECORD_ID:
                     continue
-                if row.get("disposition") not in _QUARANTINE_DISPOSITIONS:
+                if row.get("disposition") not in FAILURE_DISPOSITIONS:
                     continue
                 found += 1
                 table.add_row(

--- a/agent_actions/cli/inspect_action.py
+++ b/agent_actions/cli/inspect_action.py
@@ -15,6 +15,7 @@ from agent_actions.output.response.config_fields import get_default
 from agent_actions.utils.constants import DEFAULT_ACTION_KIND
 
 from .inspect_base import BaseInspectCommand
+from .workflow_loader import validate_action_exists
 
 logger = logging.getLogger(__name__)
 
@@ -34,12 +35,7 @@ class ActionCommand(BaseInspectCommand):
 
     def execute(self, project_root: Path | None = None) -> None:
         workflow = self._load_workflow(project_root=project_root)
-
-        if self.action_name not in workflow.action_configs:
-            available = ", ".join(workflow.action_configs.keys())
-            raise click.ClickException(
-                f"Action '{self.action_name}' not found. Available: {available}"
-            )
+        validate_action_exists(self.action_name, workflow.action_configs)
 
         action_config = workflow.action_configs[self.action_name]
         dependency_info = self._analyze_dependencies(workflow)
@@ -172,12 +168,7 @@ class ContextCommand(BaseInspectCommand):
 
     def execute(self, project_root: Path | None = None) -> None:
         workflow = self._load_workflow(project_root=project_root)
-
-        if self.target_action_name not in workflow.action_configs:
-            available = ", ".join(workflow.action_configs.keys())
-            raise click.ClickException(
-                f"Action '{self.target_action_name}' not found. Available: {available}"
-            )
+        validate_action_exists(self.target_action_name, workflow.action_configs)
 
         action_config = workflow.action_configs[self.target_action_name]
         dependency_info = self._analyze_dependencies(workflow)

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -28,7 +28,6 @@ from agent_actions.validation.retry_validator import RetryCommandArgs
 
 logger = logging.getLogger(__name__)
 
-
 _RETRY_MANIFEST_NAME = "_retry_manifest.json"
 
 

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -20,8 +20,7 @@ from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.storage import get_storage_backend
 from agent_actions.storage.backend import (
-    DISPOSITION_EXHAUSTED,
-    DISPOSITION_FAILED,
+    FAILURE_DISPOSITIONS,
     NODE_LEVEL_RECORD_ID,
 )
 from agent_actions.utils.atomic_write import atomic_json_write
@@ -29,17 +28,6 @@ from agent_actions.validation.retry_validator import RetryCommandArgs
 
 logger = logging.getLogger(__name__)
 
-# Dispositions eligible for retry.  Allowlist — new disposition types
-# won't accidentally become retryable.
-#
-# Excluded (and why):
-#   success     — already done
-#   unprocessed — cascade casualty; resolves when upstream failure is retried
-#   passthrough — guard-skipped; not a failure
-#   skipped     — deliberately skipped (WHERE clause)
-#   filtered    — removed by predicate; not a failure
-#   deferred    — pending HITL/batch; retrying would clobber in-flight state
-_FAILURE_DISPOSITIONS = (DISPOSITION_FAILED, DISPOSITION_EXHAUSTED)
 
 _RETRY_MANIFEST_NAME = "_retry_manifest.json"
 
@@ -219,9 +207,6 @@ class RetryCommand:
         )
 
         self.console.print("\n[bold]Re-running workflow...[/bold]\n")
-        # Fresh workflow: dispositions were cleared above, so the coordinator
-        # needs to see the updated storage state at construction time.
-        workflow = load_workflow(self.agent_name, paths, project_root)
 
         # Reset action-level status for downstream actions to PENDING so the
         # coordinator doesn't skip them as "already completed."
@@ -248,7 +233,7 @@ class RetryCommand:
         failures: dict[str, list[dict]] = {}
         for action in execution_order:
             rows = backend.get_disposition(action)
-            action_failures = [r for r in rows if r.get("disposition") in _FAILURE_DISPOSITIONS]
+            action_failures = [r for r in rows if r.get("disposition") in FAILURE_DISPOSITIONS]
             if action_failures:
                 failures[action] = action_failures
         return failures

--- a/agent_actions/cli/run.py
+++ b/agent_actions/cli/run.py
@@ -17,12 +17,12 @@ from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.logging.factory import LoggerFactory
 from agent_actions.tooling.docs.run_tracker import RunTracker
 from agent_actions.validation.prompt_validator import PromptValidator
+from agent_actions.validation.run_validator import RunCommandArgs
 
 if TYPE_CHECKING:
     from agent_actions.workflow.coordinator import AgentWorkflow
 
 logger = logging.getLogger(__name__)
-from agent_actions.validation.run_validator import RunCommandArgs
 
 
 class RunCommand:

--- a/agent_actions/cli/run.py
+++ b/agent_actions/cli/run.py
@@ -1,22 +1,25 @@
 """Run command for the Agent Actions CLI."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time
 import traceback
 from pathlib import Path
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import click
 
 from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
-from agent_actions.config.project_paths import ProjectPathsFactory, find_config_file
+from agent_actions.cli.workflow_loader import load_workflow
+from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.logging.factory import LoggerFactory
-from agent_actions.prompt.renderer import ConfigRenderingService
 from agent_actions.tooling.docs.run_tracker import RunTracker
 from agent_actions.validation.prompt_validator import PromptValidator
-from agent_actions.workflow.coordinator import AgentWorkflow
-from agent_actions.workflow.models import WorkflowPaths, WorkflowRuntimeConfig
+
+if TYPE_CHECKING:
+    from agent_actions.workflow.coordinator import AgentWorkflow
 
 logger = logging.getLogger(__name__)
 from agent_actions.validation.run_validator import RunCommandArgs
@@ -66,33 +69,14 @@ class RunCommand:
             self.agent_name, self.args.agent, project_root=project_root
         )
         PromptValidator().validate(paths.prompt_dir, config={"workflow_name": self.agent_name})
-        filename = f"{self.agent_name}.yml"
-        full_path = find_config_file(
+        workflow = load_workflow(
             self.agent_name,
-            paths.agent_config_dir,
-            filename,
-            check_alternatives=True,
-            project_root=project_root,
-        )
-        ConfigRenderingService().render_and_load_config(
-            self.agent_name,
-            full_path,
-            paths.template_dir,
-            paths.rendered_workflows_dir,
-            project_root=project_root,
-        )
-        workflow = AgentWorkflow(
-            WorkflowRuntimeConfig(
-                paths=WorkflowPaths(
-                    constructor_path=str(full_path),
-                    user_code_path=str(self.args.user_code) if self.args.user_code else None,
-                    default_path=str(paths.default_config_path),
-                ),
-                use_tools=self.args.use_tools,
-                fresh=self.args.fresh,
-                verify_keys=self.args.verify_keys,
-                project_root=project_root,
-            )
+            paths,
+            project_root,
+            user_code_path=str(self.args.user_code) if self.args.user_code else None,
+            use_tools=self.args.use_tools,
+            fresh=self.args.fresh,
+            verify_keys=self.args.verify_keys,
         )
 
         tracker = RunTracker(project_root=project_root)

--- a/agent_actions/cli/schema.py
+++ b/agent_actions/cli/schema.py
@@ -9,13 +9,11 @@ from rich.console import Console
 
 from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
 from agent_actions.cli.renderers import SchemaRenderer
-from agent_actions.config.project_paths import ProjectPathsFactory, find_config_file
+from agent_actions.cli.workflow_loader import load_workflow
+from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.errors import DependencyError
 from agent_actions.output.response.loader import SchemaLoader
-from agent_actions.prompt.renderer import ConfigRenderingService
 from agent_actions.workflow import WorkflowSchemaService
-from agent_actions.workflow.coordinator import AgentWorkflow
-from agent_actions.workflow.models import WorkflowPaths, WorkflowRuntimeConfig
 
 
 class SchemaCommand:
@@ -41,25 +39,11 @@ class SchemaCommand:
         paths = ProjectPathsFactory.create_project_paths(
             self.agent_name, self.agent, auto_create=False, project_root=project_root
         )
-        filename = f"{self.agent_name}.yml"
-        full_path = find_config_file(
-            self.agent_name, paths.agent_config_dir, filename, check_alternatives=True
-        )
-
-        ConfigRenderingService().render_and_load_config(
-            self.agent_name, full_path, paths.template_dir, project_root=project_root
-        )
-
-        workflow = AgentWorkflow(
-            WorkflowRuntimeConfig(
-                paths=WorkflowPaths(
-                    constructor_path=str(full_path),
-                    user_code_path=str(self.user_code) if self.user_code else None,
-                    default_path=str(paths.default_config_path),
-                ),
-                use_tools=False,
-                project_root=project_root,
-            )
+        workflow = load_workflow(
+            self.agent_name,
+            paths,
+            project_root,
+            user_code_path=str(self.user_code) if self.user_code else None,
         )
 
         workflow_config = WorkflowSchemaService.build_workflow_config(

--- a/agent_actions/cli/status.py
+++ b/agent_actions/cli/status.py
@@ -23,15 +23,15 @@ class StatusCommand:
             self.agent_name, self.args.agent, auto_create=False, project_root=project_root
         )
         status_file = paths.io_dir / ".agent_status.json"
-        if not status_file.exists():
+        try:
+            with open(status_file, encoding="utf-8") as f:
+                status_data = json.load(f)
+        except FileNotFoundError:
             self.console.print(
                 f"[yellow]No status file found for agent '{self.agent_name}'. "
                 "Has a workflow been run?[/yellow]"
             )
             return
-        try:
-            with open(status_file, encoding="utf-8") as f:
-                status_data = json.load(f)
         except json.JSONDecodeError as e:
             raise click.ClickException(f"Status file is corrupted: {status_file}\n{e}") from e
         if not isinstance(status_data, dict):

--- a/agent_actions/cli/workflow_loader.py
+++ b/agent_actions/cli/workflow_loader.py
@@ -6,8 +6,11 @@ paths, avoiding duplicate config loading / rendering across commands.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import click
 
 if TYPE_CHECKING:
     from agent_actions.config.project_paths import ProjectPaths
@@ -18,6 +21,11 @@ def load_workflow(
     agent_name: str,
     paths: ProjectPaths,
     project_root: Path | None = None,
+    *,
+    user_code_path: str | None = None,
+    use_tools: bool = False,
+    fresh: bool = False,
+    verify_keys: bool = False,
 ) -> AgentWorkflow:
     """Load and return an initialized AgentWorkflow.
 
@@ -49,10 +57,19 @@ def load_workflow(
         WorkflowRuntimeConfig(
             paths=WorkflowPaths(
                 constructor_path=str(full_path),
-                user_code_path=None,
+                user_code_path=user_code_path,
                 default_path=str(paths.default_config_path),
             ),
-            use_tools=False,
+            use_tools=use_tools,
+            fresh=fresh,
+            verify_keys=verify_keys,
             project_root=project_root,
         )
     )
+
+
+def validate_action_exists(action_name: str, action_configs: Mapping[str, Any]) -> None:
+    """Raise ClickException if *action_name* is not in *action_configs*."""
+    if action_name not in action_configs:
+        available = ", ".join(action_configs.keys())
+        raise click.ClickException(f"Action '{action_name}' not found. Available: {available}")

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -38,6 +38,12 @@ class Disposition(str, Enum):
 
 VALID_DISPOSITIONS = frozenset(d.value for d in Disposition)
 
+# Records eligible for retry: only primary failures the user can act on.
+# Excluded: success (done), unprocessed (cascade casualty — resolves when
+# upstream is retried), passthrough (guard-skipped), skipped (WHERE clause),
+# filtered (predicate), deferred (in-flight HITL/batch).
+FAILURE_DISPOSITIONS = frozenset({DISPOSITION_FAILED, DISPOSITION_EXHAUSTED})
+
 DispositionRow = tuple[str, str, str, str | None, str | None, str | None, str | None]
 """(action_name, record_id, disposition, reason, relative_path, input_snapshot, detail)."""
 

--- a/tests/cli/test_run_command_execute.py
+++ b/tests/cli/test_run_command_execute.py
@@ -35,13 +35,14 @@ class TestRunCommandProjectRootWiring:
     def test_execute_sets_path_manager_with_project_root(self, tmp_path):
         """When project_root is provided, the global PathManager is set with that root."""
         cmd = RunCommand(_make_args())
+        wf_mock = MagicMock()
+        wf_mock.execution_order = ["a1"]
+        wf_mock.action_configs = {"a1": {}}
 
         with (
             patch("agent_actions.cli.run.ProjectPathsFactory.create_project_paths") as mock_paths,
-            patch("agent_actions.cli.run.find_config_file", return_value=tmp_path / "cfg.yml"),
             patch("agent_actions.cli.run.PromptValidator"),
-            patch("agent_actions.cli.run.ConfigRenderingService.render_and_load_config"),
-            patch("agent_actions.cli.run.AgentWorkflow") as mock_wf,
+            patch("agent_actions.cli.run.load_workflow", return_value=wf_mock),
             patch("agent_actions.cli.run.RunTracker") as mock_tracker,
             patch.object(cmd, "_run_workflow_execution"),
         ):
@@ -53,10 +54,6 @@ class TestRunCommandProjectRootWiring:
                 default_config_path=tmp_path / "default.yml",
                 io_dir=tmp_path,
             )
-            mock_wf_instance = MagicMock()
-            mock_wf_instance.execution_order = ["a1"]
-            mock_wf_instance.action_configs = {"a1": {}}
-            mock_wf.return_value = mock_wf_instance
             mock_tracker_instance = MagicMock()
             mock_tracker_instance.start_workflow_run.return_value = "run-123"
             mock_tracker.return_value = mock_tracker_instance
@@ -69,13 +66,14 @@ class TestRunCommandProjectRootWiring:
     def test_execute_without_project_root_skips_set_path_manager(self, tmp_path):
         """When project_root is None, set_path_manager is not called."""
         cmd = RunCommand(_make_args())
+        wf_mock = MagicMock()
+        wf_mock.execution_order = ["a1"]
+        wf_mock.action_configs = {"a1": {}}
 
         with (
             patch("agent_actions.cli.run.ProjectPathsFactory.create_project_paths") as mock_paths,
-            patch("agent_actions.cli.run.find_config_file", return_value=tmp_path / "cfg.yml"),
             patch("agent_actions.cli.run.PromptValidator"),
-            patch("agent_actions.cli.run.ConfigRenderingService.render_and_load_config"),
-            patch("agent_actions.cli.run.AgentWorkflow") as mock_wf,
+            patch("agent_actions.cli.run.load_workflow", return_value=wf_mock),
             patch("agent_actions.cli.run.RunTracker") as mock_tracker,
             patch.object(cmd, "_run_workflow_execution"),
             patch("agent_actions.utils.path_utils.set_path_manager") as mock_set_pm,
@@ -88,10 +86,6 @@ class TestRunCommandProjectRootWiring:
                 default_config_path=tmp_path / "default.yml",
                 io_dir=tmp_path,
             )
-            mock_wf_instance = MagicMock()
-            mock_wf_instance.execution_order = ["a1"]
-            mock_wf_instance.action_configs = {"a1": {}}
-            mock_wf.return_value = mock_wf_instance
             mock_tracker_instance = MagicMock()
             mock_tracker_instance.start_workflow_run.return_value = "run-123"
             mock_tracker.return_value = mock_tracker_instance
@@ -143,10 +137,8 @@ class TestRunCommandStatusMessages:
 
         with (
             patch("agent_actions.cli.run.ProjectPathsFactory.create_project_paths") as mock_paths,
-            patch("agent_actions.cli.run.find_config_file", return_value=tmp_path / "cfg.yml"),
             patch("agent_actions.cli.run.PromptValidator"),
-            patch("agent_actions.cli.run.ConfigRenderingService.render_and_load_config"),
-            patch("agent_actions.cli.run.AgentWorkflow", return_value=wf_mock),
+            patch("agent_actions.cli.run.load_workflow", return_value=wf_mock),
             patch("agent_actions.cli.run.RunTracker") as mock_tracker,
             patch.object(cmd, "_run_workflow_execution"),
         ):
@@ -239,10 +231,8 @@ class TestRunCommandStatusMessages:
 
         with (
             patch("agent_actions.cli.run.ProjectPathsFactory.create_project_paths") as mock_paths,
-            patch("agent_actions.cli.run.find_config_file", return_value=tmp_path / "cfg.yml"),
             patch("agent_actions.cli.run.PromptValidator"),
-            patch("agent_actions.cli.run.ConfigRenderingService.render_and_load_config"),
-            patch("agent_actions.cli.run.AgentWorkflow", return_value=wf_mock),
+            patch("agent_actions.cli.run.load_workflow", return_value=wf_mock),
             patch("agent_actions.cli.run.RunTracker", return_value=tracker_inst),
             patch.object(cmd, "_run_workflow_execution"),
             pytest.raises(SystemExit),
@@ -295,3 +285,51 @@ class TestRunCommandStatusMessages:
         assert "Run again to continue" in out
         assert "batch" not in out.lower()
         assert tracker.finalize_workflow_run.call_args[1]["status"] == "PAUSED"
+
+
+class TestLoadWorkflowKwargsPassthrough:
+    """Verify load_workflow receives use_tools/fresh/verify_keys from RunCommand."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        reset_path_manager()
+        yield
+        reset_path_manager()
+
+    def test_load_workflow_receives_runtime_flags(self, tmp_path):
+        """use_tools, fresh, verify_keys, user_code_path forwarded to load_workflow."""
+        user_code_dir = tmp_path / "user_code"
+        user_code_dir.mkdir()
+        cmd = RunCommand(
+            _make_args(
+                use_tools=True,
+                fresh=True,
+                verify_keys=True,
+                user_code=user_code_dir,
+            )
+        )
+        wf_mock = MagicMock()
+        wf_mock.execution_order = ["a1"]
+
+        with (
+            patch("agent_actions.cli.run.ProjectPathsFactory.create_project_paths") as mock_paths,
+            patch("agent_actions.cli.run.PromptValidator"),
+            patch("agent_actions.cli.run.load_workflow", return_value=wf_mock) as mock_load,
+            patch("agent_actions.cli.run.RunTracker") as mock_tracker,
+            patch.object(cmd, "_run_workflow_execution"),
+        ):
+            mock_paths.return_value = MagicMock(
+                prompt_dir=tmp_path,
+                io_dir=tmp_path,
+            )
+            mock_tracker.return_value = MagicMock(
+                start_workflow_run=MagicMock(return_value="run-123")
+            )
+
+            cmd.execute(project_root=tmp_path)
+
+        _, kwargs = mock_load.call_args
+        assert kwargs["use_tools"] is True
+        assert kwargs["fresh"] is True
+        assert kwargs["verify_keys"] is True
+        assert kwargs["user_code_path"] == str(user_code_dir)

--- a/tests/cli/test_schema_udf_import.py
+++ b/tests/cli/test_schema_udf_import.py
@@ -11,16 +11,12 @@ from agent_actions.errors import DependencyError
 class TestUDFRegistryImportError:
     """Verify broken UDF registry import surfaces a DependencyError."""
 
-    @patch("agent_actions.cli.schema.AgentWorkflow")
-    @patch("agent_actions.cli.schema.ConfigRenderingService.render_and_load_config")
-    @patch("agent_actions.cli.schema.find_config_file", return_value="/fake/config.yml")
+    @patch("agent_actions.cli.schema.load_workflow")
     @patch("agent_actions.cli.schema.ProjectPathsFactory.create_project_paths")
     def test_import_error_raises_dependency_error(
         self,
         mock_paths_factory,
-        mock_find_config,
-        mock_render,
-        mock_workflow,
+        mock_load_workflow,
     ):
         """ImportError from UDF registry must raise DependencyError, not pass silently."""
         mock_paths = MagicMock()
@@ -33,7 +29,7 @@ class TestUDFRegistryImportError:
 
         mock_workflow_instance = MagicMock()
         mock_workflow_instance.action_configs = {"action1": {"kind": "llm"}}
-        mock_workflow.return_value = mock_workflow_instance
+        mock_load_workflow.return_value = mock_workflow_instance
 
         command = SchemaCommand(
             agent="test_agent",
@@ -53,16 +49,12 @@ class TestUDFRegistryImportError:
 
     @patch("agent_actions.cli.schema.WorkflowSchemaService")
     @patch("agent_actions.cli.schema.SchemaLoader")
-    @patch("agent_actions.cli.schema.AgentWorkflow")
-    @patch("agent_actions.cli.schema.ConfigRenderingService.render_and_load_config")
-    @patch("agent_actions.cli.schema.find_config_file", return_value="/fake/config.yml")
+    @patch("agent_actions.cli.schema.load_workflow")
     @patch("agent_actions.cli.schema.ProjectPathsFactory.create_project_paths")
     def test_successful_import_proceeds_normally(
         self,
         mock_paths_factory,
-        mock_find_config,
-        mock_render,
-        mock_workflow,
+        mock_load_workflow,
         mock_schema_loader,
         mock_schema_service,
     ):
@@ -78,7 +70,7 @@ class TestUDFRegistryImportError:
         mock_workflow_instance = MagicMock()
         mock_workflow_instance.action_configs = {"action1": {"kind": "llm"}}
         mock_workflow_instance.execution_order = ["action1"]
-        mock_workflow.return_value = mock_workflow_instance
+        mock_load_workflow.return_value = mock_workflow_instance
 
         mock_service_instance = MagicMock()
         mock_service_instance.get_all_schemas.return_value = {}


### PR DESCRIPTION
## Summary
- Extend `load_workflow()` with `user_code_path`/`use_tools`/`fresh`/`verify_keys` keyword args; migrate `run.py` and `schema.py` to use it (removes ~30 lines of duplicated config/rendering/construction)
- Remove redundant second `load_workflow()` call in `retry.py` (dispositions are in SQLite, not the workflow object)
- Fix TOCTOU race in `status.py` (catch `FileNotFoundError` instead of `exists()` guard)
- Fix TOCTOU race in `compile.py` (`mkdir(exist_ok=True)` instead of `exists()` check)
- Consolidate `FAILURE_DISPOSITIONS` frozenset in `storage/backend.py`; remove duplicate definitions in `retry.py` and `dispositions.py`
- Extract `validate_action_exists()` helper in `workflow_loader.py`; deduplicate 2 blocks in `inspect_action.py`
- Update test mocks to patch `load_workflow` instead of removed per-module imports

## Verification
- All spec grep checks pass (0 inline ConfigRenderingService in run/schema, single load_workflow call in retry, no exists() in status, no template_dir.exists() in compile, single FAILURE_DISPOSITIONS definition)
- `ruff check` + `ruff format --check` clean on all changed files
- 7351 tests passed, 2 skipped