### PR TITLE
refactor: unify content extraction and enforce source namespace contract

### DIFF
--- a/.changes/unreleased/Under the Hood-20260525-634000.yaml
+++ b/.changes/unreleased/Under the Hood-20260525-634000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Unified content extraction into single get_existing_content function, extracted shared source resolution logic, and added debug logging for missing source namespace"
+time: 2026-05-25T06:34:00.000000Z

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -24,7 +24,6 @@ from agent_actions.processing.record_helpers import (
     build_exhausted_tombstone,
     build_tombstone,
     carry_framework_fields,
-    extract_existing_content,
 )
 from agent_actions.processing.types import (
     ProcessingResult,
@@ -41,7 +40,7 @@ from agent_actions.record.reasons import (
     GUARD_SKIP,
     PREP_FAILED,
 )
-from agent_actions.utils.content import is_version_merge
+from agent_actions.utils.content import get_existing_content, is_version_merge
 from agent_actions.utils.schema_echo import is_schema_echo as _is_schema_echo
 from agent_actions.utils.schema_echo import make_schema_echo_error as _make_schema_echo_error
 
@@ -350,7 +349,7 @@ class BatchResultStrategy:
             raise ValueError("agent_config must contain 'action_name' for content namespacing")
 
         is_first_stage = not ctx.agent_config.get("dependencies")
-        existing_content = extract_existing_content(original_row, is_first_stage=is_first_stage)
+        existing_content = get_existing_content(original_row, is_first_stage=is_first_stage)
 
         action_name = ctx.agent_config["action_name"]
         is_tool_version_merge = ctx.agent_config.get("kind") == "tool" and is_version_merge(

--- a/agent_actions/processing/_MANIFEST.md
+++ b/agent_actions/processing/_MANIFEST.md
@@ -22,7 +22,7 @@ lineage helpers, recovery flows, and transformation pipelines.
 | `error_handling.py` | Module | `ProcessorErrorHandlerMixin` for wrapping file loading/processing logic. | `logging` |
 | `exhausted_builder.py` | Module | Builds reports once a workflow’s retries are exhausted. | `validation`, `logging` |
 | `helpers.py` | Module | Shared helpers (UUID construction, tuple flattening) for processors. | `processing` |
-| `record_helpers.py` | Module | Shared record assembly helpers: `build_tombstone`, `build_exhausted_tombstone`, `carry_framework_fields`, `apply_version_merge`, `extract_existing_content`. Used by all processing paths (online, batch, FILE). | `record`, `processing` |
+| `record_helpers.py` | Module | Shared record assembly helpers: `build_tombstone`, `build_exhausted_tombstone`, `carry_framework_fields`, `apply_version_merge`. Used by all processing paths (online, batch, FILE). | `record`, `processing` |
 | `result_collector.py` | Module | Collects main vs side outputs, handles duplicates. Counts UNPROCESSED results separately from successes. Exports `write_node_level_disposition` (node-level skip/passthrough) and `write_record_dispositions` (batch record dispositions). All `set_disposition` calls (except executor-level) are centralized here. | `output` |
 | `prepared_task.py` | Module | `GuardStatus` enum (PASSED, SKIPPED, FILTERED, UPSTREAM_UNPROCESSED), `PreparedTask` dataclass, and `PreparationContext` (carries `mode: RunMode` directly). | `typing` |
 | `task_preparer.py` | Module | Unified task preparation (normalize, prompt, guard) for batch/online. Short-circuits upstream-unprocessed records before context loading. | `input`, `prompt` |

--- a/agent_actions/processing/_MANIFEST.md
+++ b/agent_actions/processing/_MANIFEST.md
@@ -23,6 +23,7 @@ lineage helpers, recovery flows, and transformation pipelines.
 | `exhausted_builder.py` | Module | Builds reports once a workflow’s retries are exhausted. | `validation`, `logging` |
 | `helpers.py` | Module | Shared helpers (UUID construction, tuple flattening) for processors. | `processing` |
 | `record_helpers.py` | Module | Shared record assembly helpers: `build_tombstone`, `build_exhausted_tombstone`, `carry_framework_fields`, `apply_version_merge`. Used by all processing paths (online, batch, FILE). | `record`, `processing` |
+| `source_resolution.py` | Module | Shared source content resolution for non-first-stage records. Three-tier: content envelope source key → guid lookup → fallback. Used by `task_preparer.py` and `guard_context.py`. | `input`, `prompt` |
 | `result_collector.py` | Module | Collects main vs side outputs, handles duplicates. Counts UNPROCESSED results separately from successes. Exports `write_node_level_disposition` (node-level skip/passthrough) and `write_record_dispositions` (batch record dispositions). All `set_disposition` calls (except executor-level) are centralized here. | `output` |
 | `prepared_task.py` | Module | `GuardStatus` enum (PASSED, SKIPPED, FILTERED, UPSTREAM_UNPROCESSED), `PreparedTask` dataclass, and `PreparationContext` (carries `mode: RunMode` directly). | `typing` |
 | `task_preparer.py` | Module | Unified task preparation (normalize, prompt, guard) for batch/online. Short-circuits upstream-unprocessed records before context loading. | `input`, `prompt` |

--- a/agent_actions/processing/guard_context.py
+++ b/agent_actions/processing/guard_context.py
@@ -60,21 +60,14 @@ def build_guard_context(
     elif is_first_stage:
         resolved_source = content
     else:
-        record_content = record.get("content", {})
-        if isinstance(record_content, dict) and "source" in record_content:
-            resolved_source = record
-        elif source_data and record.get("source_guid"):
-            from agent_actions.input.preprocessing.transformation.transformer import (
-                DataTransformer,
-            )
+        from agent_actions.processing.source_resolution import resolve_source_content
 
-            resolved_source = DataTransformer.get_content_by_source_guid(
-                source_data, record["source_guid"]
-            )
-            if resolved_source is None:
-                resolved_source = record
-        else:
-            resolved_source = record
+        resolved_source = resolve_source_content(
+            record,
+            record.get("source_guid"),
+            source_data,
+            action_name=agent_name,
+        )
 
     field_context = build_field_context_with_history(
         agent_name=agent_name,

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS, RecordEnvelope
+from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.record.reasons import RETRY_EXHAUSTED
-from agent_actions.utils.content import get_existing_content, is_version_merge
+from agent_actions.utils.content import is_version_merge
 
 # Framework fields carried from input to output when the envelope builder
 # does not manage them automatically.
@@ -133,22 +133,3 @@ def apply_version_merge(
         return {**(existing_content or {}), **action_output}
     action_name = agent_config["action_name"]
     return RecordEnvelope.build_content(action_name, action_output, existing_content)
-
-
-def extract_existing_content(
-    record: dict[str, Any],
-    *,
-    is_first_stage: bool = False,
-) -> dict[str, Any]:
-    """Extract existing content with consistent first-stage fallback.
-
-    On first-stage records that have no ``content`` dict, the raw
-    non-framework fields are wrapped under ``{"source": ...}`` so
-    downstream actions can reference source data.
-    """
-    existing = get_existing_content(record)
-    if not existing and is_first_stage:
-        raw = {k: v for k, v in record.items() if k not in RECORD_FRAMEWORK_FIELDS}
-        if raw:
-            return {"source": raw}
-    return existing

--- a/agent_actions/processing/source_resolution.py
+++ b/agent_actions/processing/source_resolution.py
@@ -25,7 +25,7 @@ def resolve_source_content(
     2. source_guid + source_data -> look up by guid
     3. Fall back to item (scope_builder enforces the source contract)
     """
-    record_content = item.get("content", {}) if isinstance(item, dict) else {}
+    record_content = item.get("content", {})
     if isinstance(record_content, dict) and "source" in record_content:
         return item
 

--- a/agent_actions/processing/source_resolution.py
+++ b/agent_actions/processing/source_resolution.py
@@ -1,0 +1,48 @@
+"""Shared source content resolution for non-first-stage records.
+
+Single implementation used by task_preparer.py and guard_context.py.
+Three-tier resolution: content envelope source key -> guid lookup -> fallback to item.
+The source contract is enforced downstream in scope_builder.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_source_content(
+    item: dict[str, Any],
+    source_guid: str | None,
+    source_data: list[dict[str, Any]] | None,
+    action_name: str = "unknown",
+) -> Any:
+    """Resolve source content for a non-first-stage record.
+
+    1. Record content has "source" key -> return record
+    2. source_guid + source_data -> look up by guid
+    3. Fall back to item (scope_builder enforces the source contract)
+    """
+    record_content = item.get("content", {}) if isinstance(item, dict) else {}
+    if isinstance(record_content, dict) and "source" in record_content:
+        return item
+
+    if source_guid and source_data:
+        from agent_actions.input.preprocessing.transformation.transformer import (
+            DataTransformer,
+        )
+
+        result = DataTransformer.get_content_by_source_guid(source_data, source_guid)
+        if result is not None:
+            return result
+
+    logger.debug(
+        "Could not resolve source content for action '%s' "
+        "(guid=%s, source_data=%s) — falling back to item",
+        action_name,
+        source_guid,
+        "available" if source_data else "None",
+    )
+    return item

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -32,7 +32,6 @@ from agent_actions.processing.record_helpers import (
     build_exhausted_tombstone,
     build_tombstone,
     carry_framework_fields,
-    extract_existing_content,
 )
 from agent_actions.processing.result_collector import _safe_set_disposition
 from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
@@ -53,6 +52,7 @@ from agent_actions.record.reasons import (
 )
 from agent_actions.record.state import RecordState
 from agent_actions.storage.backend import DISPOSITION_FAILED
+from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
 
@@ -481,7 +481,7 @@ class OnlineLLMStrategy:
 
         # Transform response
         item_existing_content = (
-            extract_existing_content(item, is_first_stage=context.is_first_stage)
+            get_existing_content(item, is_first_stage=context.is_first_stage)
             if isinstance(item, dict)
             else None
         )

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -58,25 +58,14 @@ class TaskPreparer:
         if context.is_first_stage:
             source_content = content
         else:
-            # Use the record (with content envelope) so SourceNamespaceBuilder
-            # can extract the source sub-namespace.  If the record's content
-            # dict lacks a "source" key (batch mode), fall back to looking up
-            # the original staging record by source_guid.
-            record_content = item.get("content", {}) if isinstance(item, dict) else {}
-            if isinstance(record_content, dict) and "source" in record_content:
-                source_content = item
-            elif source_guid and context.source_data:
-                from agent_actions.input.preprocessing.transformation.transformer import (
-                    DataTransformer,
-                )
+            from agent_actions.processing.source_resolution import resolve_source_content
 
-                source_content = DataTransformer.get_content_by_source_guid(
-                    context.source_data, source_guid
-                )
-                if source_content is None:
-                    source_content = item
-            else:
-                source_content = item
+            source_content = resolve_source_content(
+                item if isinstance(item, dict) else {},
+                source_guid,
+                context.source_data,
+                action_name=context.agent_name,
+            )
 
         current_item = item if isinstance(item, dict) else context.current_item
         field_context = self._load_full_context(content, source_content, context, current_item)

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -53,15 +53,10 @@ class SourceNamespaceBuilder:
                 if "source" in inner and isinstance(inner["source"], dict):
                     source_namespace = inner["source"]
                 else:
-                    # Content envelope has no "source" sub-namespace.  This
-                    # happens for non-first-stage records whose source_content
-                    # fell back to the record itself (no guid lookup).  Use
-                    # all content keys as source namespace — downstream
-                    # actions expect to find upstream outputs here.
+                    # No "source" sub-namespace — use full content as source
                     logger.debug(
-                        "Record envelope for action '%s' has no 'source' "
-                        "sub-namespace (content keys: %s) — using full "
-                        "content as source namespace",
+                        "Action '%s': no 'source' in content envelope "
+                        "(keys: %s) — using full content as source namespace",
                         agent_name,
                         sorted(inner.keys()),
                     )

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -53,6 +53,18 @@ class SourceNamespaceBuilder:
                 if "source" in inner and isinstance(inner["source"], dict):
                     source_namespace = inner["source"]
                 else:
+                    # Content envelope has no "source" sub-namespace.  This
+                    # happens for non-first-stage records whose source_content
+                    # fell back to the record itself (no guid lookup).  Use
+                    # all content keys as source namespace — downstream
+                    # actions expect to find upstream outputs here.
+                    logger.debug(
+                        "Record envelope for action '%s' has no 'source' "
+                        "sub-namespace (content keys: %s) — using full "
+                        "content as source namespace",
+                        agent_name,
+                        sorted(inner.keys()),
+                    )
                     source_namespace = dict(inner)
             else:
                 source_namespace = dict(source_content)

--- a/agent_actions/utils/content.py
+++ b/agent_actions/utils/content.py
@@ -82,12 +82,23 @@ def is_version_merge(agent_config: Mapping[str, Any]) -> bool:
     return bool(agent_config.get("version_consumption_config"))
 
 
-def get_existing_content(record: dict[str, Any]) -> dict[str, Any]:
-    """Return the existing namespaced content dict from a record.
+def get_existing_content(
+    record: dict[str, Any],
+    *,
+    is_first_stage: bool = False,
+) -> dict[str, Any]:
+    """Return existing namespaced content, synthesizing source for first-stage.
 
-    Returns an empty dict if the record has no content.
+    This is the SINGLE function for content extraction — batch and online
+    paths both use this. Never bypass with raw record.get("content").
     """
     content = record.get("content")
     if isinstance(content, dict):
         return content
+    if is_first_stage:
+        from agent_actions.record.envelope import RECORD_FRAMEWORK_FIELDS
+
+        raw = {k: v for k, v in record.items() if k not in RECORD_FRAMEWORK_FIELDS}
+        if raw:
+            return {"source": raw}
     return {}

--- a/agent_actions/utils/transformation/passthrough.py
+++ b/agent_actions/utils/transformation/passthrough.py
@@ -93,7 +93,7 @@ class PassthroughTransformer:
         #
         # When input_record is provided we use it as-is, EXCEPT when existing_content
         # is also provided and differs from input_record["content"]. This happens on
-        # first-stage records: extract_existing_content synthesises {"source": raw_fields}
+        # first-stage records: get_existing_content(is_first_stage=True) synthesises {"source": raw_fields}
         # even when the record has no "content" key, so existing_content can be richer
         # than input_record.get("content"). We honour existing_content in that case so
         # upstream namespaces are not lost.

--- a/tests/unit/processing/test_record_helpers.py
+++ b/tests/unit/processing/test_record_helpers.py
@@ -6,8 +6,8 @@ from agent_actions.processing.record_helpers import (
     build_exhausted_tombstone,
     build_tombstone,
     carry_framework_fields,
-    extract_existing_content,
 )
+from agent_actions.utils.content import get_existing_content
 
 # ---------------------------------------------------------------------------
 # build_tombstone
@@ -308,26 +308,26 @@ class TestApplyVersionMerge:
 
 
 # ---------------------------------------------------------------------------
-# extract_existing_content
+# get_existing_content
 # ---------------------------------------------------------------------------
 
 
 class TestExtractExistingContent:
-    """Tests for extract_existing_content()."""
+    """Tests for get_existing_content()."""
 
     def test_returns_content_dict(self):
         record = {"content": {"ns_a": {"x": 1}}, "source_guid": "sg"}
-        assert extract_existing_content(record) == {"ns_a": {"x": 1}}
+        assert get_existing_content(record) == {"ns_a": {"x": 1}}
 
     def test_returns_empty_dict_when_no_content(self):
-        assert extract_existing_content({"source_guid": "sg"}) == {}
+        assert get_existing_content({"source_guid": "sg"}) == {}
 
     def test_returns_empty_dict_when_content_is_not_dict(self):
-        assert extract_existing_content({"content": "string_value"}) == {}
+        assert get_existing_content({"content": "string_value"}) == {}
 
     def test_first_stage_wraps_raw_fields(self):
         record = {"field_a": 1, "field_b": "two", "source_guid": "sg"}
-        result = extract_existing_content(record, is_first_stage=True)
+        result = get_existing_content(record, is_first_stage=True)
         assert result == {"source": {"field_a": 1, "field_b": "two"}}
 
     def test_first_stage_excludes_framework_fields(self):
@@ -338,22 +338,22 @@ class TestExtractExistingContent:
             "metadata": {},
             "user_field": "val",
         }
-        result = extract_existing_content(record, is_first_stage=True)
+        result = get_existing_content(record, is_first_stage=True)
         assert result == {"source": {"user_field": "val"}}
 
     def test_first_stage_with_existing_content_returns_content(self):
         """First-stage fallback only applies when content is missing."""
         record = {"content": {"ns": {"x": 1}}, "field_a": 1}
-        result = extract_existing_content(record, is_first_stage=True)
+        result = get_existing_content(record, is_first_stage=True)
         assert result == {"ns": {"x": 1}}
 
     def test_first_stage_empty_raw_fields_returns_empty(self):
         """If only framework fields remain after filtering, return {}."""
         record = {"source_guid": "sg", "target_id": "tid"}
-        result = extract_existing_content(record, is_first_stage=True)
+        result = get_existing_content(record, is_first_stage=True)
         assert result == {}
 
     def test_non_first_stage_ignores_raw_fields(self):
         record = {"field_a": 1, "field_b": "two"}
-        result = extract_existing_content(record, is_first_stage=False)
+        result = get_existing_content(record, is_first_stage=False)
         assert result == {}

--- a/tests/unit/processing/test_record_helpers.py
+++ b/tests/unit/processing/test_record_helpers.py
@@ -312,7 +312,7 @@ class TestApplyVersionMerge:
 # ---------------------------------------------------------------------------
 
 
-class TestExtractExistingContent:
+class TestGetExistingContent:
     """Tests for get_existing_content()."""
 
     def test_returns_content_dict(self):

--- a/tests/unit/processing/test_source_resolution.py
+++ b/tests/unit/processing/test_source_resolution.py
@@ -1,0 +1,45 @@
+"""Tests for shared source content resolution."""
+
+from agent_actions.processing.source_resolution import resolve_source_content
+
+
+class TestResolveSourceContent:
+    """Tests for resolve_source_content()."""
+
+    def test_returns_item_when_source_in_content(self):
+        """Tier 1: record content has 'source' key -> return record."""
+        item = {"content": {"source": {"field": "val"}}, "source_guid": "sg"}
+        result = resolve_source_content(item, "sg", None)
+        assert result is item
+
+    def test_guid_lookup_when_no_source_key(self):
+        """Tier 2: source_guid + source_data -> look up by guid."""
+        item = {"content": {"upstream": {"x": 1}}, "source_guid": "sg-123"}
+        source_data = [{"source_guid": "sg-123", "content": {"source": {"a": 1}}}]
+        result = resolve_source_content(item, "sg-123", source_data)
+        assert result == {"source_guid": "sg-123", "content": {"source": {"a": 1}}}
+
+    def test_falls_back_to_item_when_no_guid(self):
+        """Tier 3: no source_guid -> fall back to item."""
+        item = {"content": {"upstream": {"x": 1}}}
+        result = resolve_source_content(item, None, None)
+        assert result is item
+
+    def test_falls_back_to_item_when_guid_not_found(self):
+        """Tier 3: guid exists but not in source_data -> fall back to item."""
+        item = {"content": {"upstream": {"x": 1}}, "source_guid": "sg-miss"}
+        source_data = [{"source_guid": "sg-other", "content": {"source": {"a": 1}}}]
+        result = resolve_source_content(item, "sg-miss", source_data)
+        assert result is item
+
+    def test_non_dict_content_falls_back(self):
+        """Non-dict content -> fall back to item."""
+        item = {"content": "string"}
+        result = resolve_source_content(item, None, None)
+        assert result is item
+
+    def test_empty_item_falls_back(self):
+        """Empty dict -> fall back to item."""
+        item: dict = {}
+        result = resolve_source_content(item, None, None)
+        assert result is item

--- a/tests/unit/utils/test_passthrough_tracking_fields.py
+++ b/tests/unit/utils/test_passthrough_tracking_fields.py
@@ -90,7 +90,7 @@ class TestPassthroughTransformerInputRecord:
         assert "metadata" not in results[0]
 
     def test_existing_content_wins_when_richer_than_input_record_content(self):
-        """First-stage records: existing_content (synthesised by extract_existing_content)
+        """First-stage records: existing_content (synthesised by get_existing_content(is_first_stage=True))
         may be richer than input_record['content']. Both are honoured — tracking fields
         come from input_record, namespaces come from existing_content.
         """


### PR DESCRIPTION
## Summary
- Merged `extract_existing_content` into `get_existing_content` with `is_first_stage` parameter — single function for batch and online content extraction
- Extracted shared `resolve_source_content` into `processing/source_resolution.py` — single implementation replacing duplicated 3-tier source resolution in `task_preparer.py` and `guard_context.py`
- Added debug logging in `scope_builder.py` when content envelope has no `source` sub-namespace (was silent)
- Updated all callers: `batch_result_strategy.py`, `online_llm.py`, tests, comments, manifest

## Verification
- `grep -rn "def extract_existing_content" agent_actions/` → 0 matches (deleted)
- `grep -rn "import.*extract_existing_content" agent_actions/` → 0 matches (all callers updated)
- `grep -rn "resolve_source_content" agent_actions/processing/` → 1 definition + 2 imports
- `ruff check` clean on all changed files
- `ruff format --check` clean on all changed files
- 7350 passed, 2 skipped, 0 failed