### PR TITLE
fix: prevent InlineSchema leak into record content via dict response path

### DIFF
--- a/.changes/unreleased/Bug Fix-20260525-635000.yaml
+++ b/.changes/unreleased/Bug Fix-20260525-635000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Fixed dict-shaped schema-echo responses bypassing detection in _reject_schema_echo_items — raw InlineSchema dicts from LLM now correctly replaced with _parse_error for reprompt"
+time: 2026-05-25T06:35:00.000000Z

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -83,11 +83,20 @@ def _resolve_schema_mismatch_mode(agent_config: dict[str, Any]) -> str:
 
 
 def _reject_schema_echo_items(response: Any, agent_name: str) -> Any:
-    """Replace schema-echo items in a response list with ``_parse_error`` dicts.
+    """Replace schema-echo responses with ``_parse_error`` dicts.
 
-    Runs unconditionally because schema echoes are never valid output
-    regardless of validation settings.
+    Handles both dict responses (single schema-echo) and list responses
+    (schema-echo items within a list).  Runs unconditionally because
+    schema echoes are never valid output regardless of validation settings.
     """
+    # Single dict response — check and replace directly
+    if isinstance(response, dict) and _is_schema_echo(response):
+        logger.warning(
+            "[%s] Schema-echo detected in LLM response (dict) — replacing with _parse_error.",
+            agent_name,
+        )
+        return _make_schema_echo_error(response)
+
     if not isinstance(response, list):
         return response
 

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -89,7 +89,6 @@ def _reject_schema_echo_items(response: Any, agent_name: str) -> Any:
     (schema-echo items within a list).  Runs unconditionally because
     schema echoes are never valid output regardless of validation settings.
     """
-    # Single dict response — check and replace directly
     if isinstance(response, dict) and _is_schema_echo(response):
         logger.warning(
             "[%s] Schema-echo detected in LLM response (dict) — replacing with _parse_error.",

--- a/tests/unit/processing/test_schema_echo_detection.py
+++ b/tests/unit/processing/test_schema_echo_detection.py
@@ -115,8 +115,21 @@ class TestRejectSchemaEchoItems:
         assert "_parse_error" in result[1]
         assert "Schema-echo" in result[1]["_parse_error"]
 
-    def test_non_list_passthrough(self):
-        """Non-list responses pass through unchanged."""
+    def test_dict_schema_echo_replaced(self):
+        """Dict response that is itself a schema-echo — replaced with _parse_error."""
+        result = _reject_schema_echo_items(FULL_ECHO, "test_action")
+        assert isinstance(result, dict)
+        assert "_parse_error" in result
+        assert "raw_response" in result
+        assert "Schema-echo" in result["_parse_error"]
+
+    def test_dict_valid_output_passthrough(self):
+        """Dict response that is NOT a schema-echo — passed through unchanged."""
+        result = _reject_schema_echo_items(VALID_OUTPUT, "test_action")
+        assert result is VALID_OUTPUT
+
+    def test_non_list_non_dict_passthrough(self):
+        """Non-list, non-dict responses pass through unchanged."""
         result = _reject_schema_echo_items("not a list", "test_action")
         assert result == "not a list"
 


### PR DESCRIPTION
## Summary
- Fixed `_reject_schema_echo_items()` to detect dict-shaped schema-echo responses, not just list items
- Root cause: when an LLM returns a raw schema-echo dict (e.g. `{"title": "InlineSchema", "type": "object", ...}`), the function returned it unchanged because it only scanned list items
- The dict passes through `_validate_llm_output_schema()` → reprompt loop → gets stored as record content → crashes downstream actions with `RecordContextError`
- Fix adds dict check before the list scan, replacing schema-echo dicts with `_parse_error` sentinel for reprompt
- Added 3 tests for the dict response path (echo replaced, valid passthrough, non-dict passthrough)

## Verification
- `pytest tests/unit/processing/test_schema_echo_detection.py` — 18 passed (3 new)
- `pytest tests/` — 7352 passed, 2 skipped
- `ruff check` + `ruff format --check` clean