### PR TITLE
refactor: simplify batch recovery — deduplicate registration, extract cache helper

### DIFF
--- a/.changes/unreleased/Under the Hood-20260525-630000.yaml
+++ b/.changes/unreleased/Under the Hood-20260525-630000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Batch recovery cleanup: deduplicate registry entry creation via _register_recovery_batch, extract _get_cache helper in BatchRegistryManager, remove dead defensive code"
+time: 2026-05-25T06:30:00.000000Z

--- a/agent_actions/llm/batch/core/batch_constants.py
+++ b/agent_actions/llm/batch/core/batch_constants.py
@@ -15,7 +15,6 @@ class BatchStatus(str, Enum):
     CANCELLED = "cancelled"
 
     def __str__(self) -> str:
-        """Return the string value for str() conversion."""
         return self.value
 
     @classmethod
@@ -46,7 +45,6 @@ class FilterStatus(str, Enum):
     FAILED = "failed"
 
     def __str__(self) -> str:
-        """Return the string value for str() conversion."""
         return self.value
 
 
@@ -57,7 +55,6 @@ class RecoveryType(str, Enum):
     REPROMPT = "reprompt"
 
     def __str__(self) -> str:
-        """Return the string value for str() conversion."""
         return self.value
 
 
@@ -69,7 +66,6 @@ class RecoveryPhase(str, Enum):
     DONE = "done"
 
     def __str__(self) -> str:
-        """Return the string value for str() conversion."""
         return self.value
 
 

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -50,15 +50,10 @@ class BatchRegistryManager:
             IOError: If write fails
         """
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
-            self._cache[file_name] = entry
+            cache = self._get_cache()
+            cache[file_name] = entry
             self._batch_id_index = None
-            self._persist_registry(self._cache)
+            self._persist_registry(cache)
             logger.info("Saved batch job %s for file %s", entry.batch_id, file_name)
 
             fire_event(CacheUpdateEvent(cache_type="batch_registry", key=file_name))
@@ -66,30 +61,20 @@ class BatchRegistryManager:
     def remove_batch_job(self, file_name: str) -> bool:
         """Remove a batch job entry. Returns True if removed, False if not found."""
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
-            if file_name not in self._cache:
+            cache = self._get_cache()
+            if file_name not in cache:
                 return False
-            del self._cache[file_name]
+            del cache[file_name]
             self._batch_id_index = None
-            self._persist_registry(self._cache)
+            self._persist_registry(cache)
             logger.info("Removed batch job entry for %s", file_name)
             return True
 
     def get_batch_job(self, file_name: str) -> BatchJobEntry | None:
         """Retrieve batch job entry by file name."""
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
-            entry = self._cache.get(file_name)
+            cache = self._get_cache()
+            entry = cache.get(file_name)
 
             if entry is not None:
                 fire_event(CacheHitEvent(cache_type="batch_registry", key=file_name))
@@ -105,18 +90,14 @@ class BatchRegistryManager:
     def get_batch_job_by_id(self, batch_id: str) -> BatchJobEntry | None:
         """Retrieve batch job entry by batch ID."""
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
+            cache = self._get_cache()
             if self._batch_id_index is None:
                 self._rebuild_batch_id_index()
-            file_name = (self._batch_id_index or {}).get(batch_id)
-            if file_name and file_name in self._cache:
+            assert self._batch_id_index is not None  # guaranteed by _rebuild above
+            file_name = self._batch_id_index.get(batch_id)
+            if file_name and file_name in cache:
                 fire_event(CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}"))
-                return self._cache[file_name]
+                return cache[file_name]
 
             fire_event(
                 CacheMissEvent(
@@ -130,20 +111,16 @@ class BatchRegistryManager:
     def update_status(self, batch_id: str, new_status: str) -> bool:
         """Update status for a batch job. Returns False if batch_id not found."""
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
+            cache = self._get_cache()
 
             if self._batch_id_index is None:
                 self._rebuild_batch_id_index()
-            file_name = (self._batch_id_index or {}).get(batch_id)
-            if file_name and file_name in self._cache:
-                updated_entry = dataclasses.replace(self._cache[file_name], status=new_status)
-                self._cache[file_name] = updated_entry
-                self._persist_registry(self._cache)
+            assert self._batch_id_index is not None  # guaranteed by _rebuild above
+            file_name = self._batch_id_index.get(batch_id)
+            if file_name and file_name in cache:
+                updated_entry = dataclasses.replace(cache[file_name], status=new_status)
+                cache[file_name] = updated_entry
+                self._persist_registry(cache)
                 logger.info("Updated batch %s status to %s", batch_id, new_status)
                 return True
 
@@ -153,29 +130,18 @@ class BatchRegistryManager:
     def get_all_jobs(self) -> dict[str, BatchJobEntry]:
         """Get all batch jobs in registry."""
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
-            return self._cache.copy()  # Return copy to prevent external mutation
+            return self._get_cache().copy()
 
     def get_registry_stats(self) -> BatchRegistryStats:
         """Get aggregated statistics for all batches."""
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
+            cache = self._get_cache()
 
             stats = BatchRegistryStats(
-                total_jobs=len(self._cache), completed=0, failed=0, in_progress=0, cancelled=0
+                total_jobs=len(cache), completed=0, failed=0, in_progress=0, cancelled=0
             )
 
-            for entry in self._cache.values():
+            for entry in cache.values():
                 if entry.status == BatchStatus.COMPLETED:
                     stats.completed += 1
                 elif entry.status == BatchStatus.FAILED:
@@ -199,21 +165,16 @@ class BatchRegistryManager:
             check_provider: Optional callable(batch_id) -> status to refresh from provider
         """
         with self._lock:
-            self._ensure_cache_loaded()
-            if self._cache is None:
-                raise RuntimeError(
-                    "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
-                    "cache initialization failed"
-                )
+            cache = self._get_cache()
 
-            if not self._cache:
+            if not cache:
                 return True  # No jobs = all complete
 
             # Collect entries that need a provider check (non-terminal) while holding the lock
             if check_provider:
                 to_check = [
                     (file_name, entry)
-                    for file_name, entry in self._cache.items()
+                    for file_name, entry in cache.items()
                     if not entry.is_terminal
                 ]
             else:
@@ -221,7 +182,7 @@ class BatchRegistryManager:
 
             # Fast path: no provider checks needed
             if not check_provider:
-                return all(entry.is_terminal for entry in self._cache.values())
+                return all(entry.is_terminal for entry in cache.values())
 
         # Release the lock before performing network I/O
         updates: list[tuple[str, str]] = []  # (file_name, new_status)
@@ -288,6 +249,16 @@ class BatchRegistryManager:
         if self._cache is None:
             self._cache = self._load_registry()
             self._rebuild_batch_id_index()
+
+    def _get_cache(self) -> dict[str, BatchJobEntry]:
+        """Load cache and return it, raising if load fails. Must be called under lock."""
+        self._ensure_cache_loaded()
+        if self._cache is None:
+            raise RuntimeError(
+                "BatchRegistryManager._cache is None after _ensure_cache_loaded(); "
+                "cache initialization failed"
+            )
+        return self._cache
 
     def _load_registry(self) -> dict[str, BatchJobEntry]:
         """

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -4,7 +4,6 @@ import json
 import logging
 import time
 from collections.abc import Callable
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
 
@@ -32,6 +31,9 @@ from agent_actions.llm.batch.processing.batch_result_strategy import (
     BatchResultStrategy,
 )
 from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+from agent_actions.llm.batch.services.processing_recovery import (
+    _register_recovery_batch,
+)
 from agent_actions.llm.batch.services.processing_recovery import (
     check_and_submit_reprompt as _check_and_submit_reprompt_impl,
 )
@@ -492,21 +494,15 @@ class BatchProcessingService:
                     agent_config=agent_config,
                 )
                 if submission:
-                    retry_batch_id, record_count = submission
-                    # Register recovery entry
-                    recovery_file_name = f"{file_name}_retry_1"
-                    recovery_entry = BatchJobEntry(
-                        batch_id=retry_batch_id,
-                        status=BatchStatus.SUBMITTED,
-                        timestamp=datetime.now(UTC).isoformat(),
-                        provider=entry.provider,
-                        record_count=record_count,
-                        file_name=recovery_file_name,
-                        parent_file_name=file_name,
-                        recovery_type=RecoveryType.RETRY,
-                        recovery_attempt=1,
+                    retry_batch_id, _record_count = submission
+                    _register_recovery_batch(
+                        manager,
+                        submission,
+                        file_name,
+                        entry.provider,
+                        RecoveryType.RETRY,
+                        1,
                     )
-                    manager.save_batch_job(recovery_file_name, recovery_entry)
 
                     record_failure_counts = {rid: 1 for rid in missing_ids}
                     state = RecoveryState(


### PR DESCRIPTION
## Summary
- Replace inline `BatchJobEntry` construction in `processing.py` with `_register_recovery_batch()` call — eliminates duplicate registration logic between original batch path and recovery path
- Extract `_get_cache()` helper in `BatchRegistryManager` to eliminate 8 copies of the ensure-cache + None-check guard pattern (-36 lines)
- Remove dead `(or {})` defensive code in batch_id index lookups (index is guaranteed non-None after `_rebuild_batch_id_index`)
- Remove unnecessary docstrings from `__str__` methods on enums
- Use local `cache` variable consistently instead of `self._cache` after `_get_cache()` returns

## Verification
- `ruff check agent_actions/llm/batch/` — all checks passed
- `ruff format --check agent_actions/llm/batch/` — all formatted
- `pytest tests/ -x` — 7350 passed, 2 skipped