### PR TITLE
chore: bump version to v0.2.1

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.2.0"
+version = "0.2.1"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},


### PR DESCRIPTION
## Summary
- Version bump for PyPI release: `0.2.0` → `0.2.1`
- Files: `pyproject.toml`, `agent_actions/__version__.py`

## What's in v0.2.1
- InlineSchema bug fix (#631)
- Batch recovery cleanup (#630)
- Codebase simplification — 6 parallel cleanup PRs (#641)
- Dependency bumps (cohere, google-genai, react, docusaurus)