### PR TITLE
fix(llm): remove silent os.getenv API key fallbacks in batch factory

### DIFF
--- a/.changes/unreleased/Bug Fix-20260527-504000.yaml
+++ b/.changes/unreleased/Bug Fix-20260527-504000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Remove silent os.getenv API key fallbacks in batch client factory — batch clients now raise ConfigurationError when no key is configured instead of silently trying hardcoded vendor env vars"
+time: 2026-05-27T05:04:00.000000Z

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -180,7 +180,7 @@ class BatchClientResolver:
         Resolution order:
         1. agent_config["api_key"] → resolve env var (same path online mode uses)
         2. Vendor config class default env var name (e.g. ANTHROPIC_API_KEY)
-        3. Empty dict → factory tries its own hardcoded fallback
+        3. Empty dict → factory raises ConfigurationError (no silent fallback)
         """
         import os
 

--- a/agent_actions/llm/providers/batch_client_factory.py
+++ b/agent_actions/llm/providers/batch_client_factory.py
@@ -86,8 +86,13 @@ def _resolve_api_key(config: dict[str, Any], hint_env_var: str) -> str:
     key = raw.get_secret_value() if isinstance(raw, SecretStr) else raw
 
     if key is not None and key != "":
+        if not isinstance(key, str):
+            raise ConfigurationError(
+                f"api_key must be a string, got {type(key).__name__}",
+                context={"value_type": type(key).__name__, "hint_env_var": hint_env_var},
+            )
         # Support ${VAR_NAME} interpolation (same as BaseClient.get_api_key)
-        if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        if key.startswith("${") and key.endswith("}"):
             env_var = key[2:-1]
             resolved = os.getenv(env_var)
             if not resolved:

--- a/agent_actions/llm/providers/batch_client_factory.py
+++ b/agent_actions/llm/providers/batch_client_factory.py
@@ -72,9 +72,10 @@ def _resolve_api_key(config: dict[str, Any], hint_env_var: str) -> str:
 
     * ``BaseClient.get_api_key`` treats ``config["api_key"]`` as an **env var
       name** and always resolves it via ``os.getenv``.  Used by online clients.
-    * This function treats ``config["api_key"]`` as a **literal secret** (the
-      resolver already called ``get_api_key`` upstream).  Used by the batch
-      client factory.
+    * This function receives a **pre-resolved literal** (the
+      ``BatchClientResolver`` calls ``get_api_key`` upstream).  ``${VAR_NAME}``
+      interpolation is supported as a safety net for direct factory calls
+      that bypass the resolver.
 
     No silent fallbacks — if no key is provided, raises ``ConfigurationError``.
     The resolver (``BatchClientResolver``) is responsible for env var resolution
@@ -139,6 +140,7 @@ def _create_gemini(config: dict[str, Any]) -> BaseBatchClient:
 def _create_ollama_local(config: dict[str, Any]) -> BaseBatchClient:
     from .ollama.batch_client import OllamaBatchClient
 
+    # Base URL, not an API key — os.getenv is intentional here.
     base_url = config.get("base_url") or os.getenv("OLLAMA_HOST", OllamaDefaults.BASE_URL)
     max_workers = config.get("batch_max_workers")
     return OllamaBatchClient(
@@ -150,6 +152,7 @@ def _create_ollama_cloud(config: dict[str, Any]) -> BaseBatchClient:
     from .ollama.batch_client import OllamaBatchClient
 
     api_key = _resolve_api_key(config, "OLLAMA_API_KEY")
+    # Base URL, not an API key — os.getenv is intentional here.
     base_url = config.get("base_url") or os.getenv(
         "OLLAMA_CLOUD_HOST", OllamaCloudDefaults.BASE_URL
     )

--- a/agent_actions/llm/providers/batch_client_factory.py
+++ b/agent_actions/llm/providers/batch_client_factory.py
@@ -63,26 +63,71 @@ def _require_class(cls, available: bool, client_type: str, package: str):
     return cls
 
 
+def _resolve_api_key(config: dict[str, Any], hint_env_var: str) -> str:
+    """Resolve API key from vendor config dict.
+
+    This is the batch-side counterpart to ``BaseClient.get_api_key()`` in
+    ``client_base.py``.  The two functions share ``SecretStr`` unwrapping and
+    ``${VAR_NAME}`` interpolation but differ in semantics:
+
+    * ``BaseClient.get_api_key`` treats ``config["api_key"]`` as an **env var
+      name** and always resolves it via ``os.getenv``.  Used by online clients.
+    * This function treats ``config["api_key"]`` as a **literal secret** (the
+      resolver already called ``get_api_key`` upstream).  Used by the batch
+      client factory.
+
+    No silent fallbacks — if no key is provided, raises ``ConfigurationError``.
+    The resolver (``BatchClientResolver``) is responsible for env var resolution
+    before calling the factory.
+    """
+    from agent_actions.errors import ConfigurationError
+
+    raw = config.get("api_key")
+    key = raw.get_secret_value() if isinstance(raw, SecretStr) else raw
+
+    if key is not None and key != "":
+        # Support ${VAR_NAME} interpolation (same as BaseClient.get_api_key)
+        if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+            env_var = key[2:-1]
+            resolved = os.getenv(env_var)
+            if not resolved:
+                raise ConfigurationError(
+                    f"Environment variable '{env_var}' is not set",
+                    context={
+                        "env_var": env_var,
+                        "config_value": key,
+                        "hint": f"Set the environment variable: export {env_var}=your-api-key",
+                    },
+                )
+            return resolved
+        return key
+
+    raise ConfigurationError(
+        "API key not configured for batch client",
+        context={
+            "env_var": hint_env_var,
+            "hint": (
+                f"Set 'api_key' in your vendor config or ensure the "
+                f"{hint_env_var} environment variable is set"
+            ),
+        },
+    )
+
+
 # --- Vendor factory functions ---
 
 
 def _create_openai(config: dict[str, Any]) -> BaseBatchClient:
     from .openai.batch_client import OpenAIBatchClient
 
-    _raw = config.get("api_key")
-    api_key = (_raw.get_secret_value() if isinstance(_raw, SecretStr) else _raw) or os.getenv(
-        "OPENAI_API_KEY"
-    )
+    api_key = _resolve_api_key(config, "OPENAI_API_KEY")
     return OpenAIBatchClient(api_key=api_key)
 
 
 def _create_gemini(config: dict[str, Any]) -> BaseBatchClient:
     cls, available = _try_import(".gemini.batch_client", "GeminiBatchClient")
     cls = _require_class(cls, available, "gemini", "google-genai")
-    _raw = config.get("api_key")
-    api_key = (_raw.get_secret_value() if isinstance(_raw, SecretStr) else _raw) or os.getenv(
-        "GEMINI_API_KEY"
-    )
+    api_key = _resolve_api_key(config, "GEMINI_API_KEY")
     return cls(api_key=api_key)  # type: ignore[no-any-return]
 
 
@@ -99,10 +144,7 @@ def _create_ollama_local(config: dict[str, Any]) -> BaseBatchClient:
 def _create_ollama_cloud(config: dict[str, Any]) -> BaseBatchClient:
     from .ollama.batch_client import OllamaBatchClient
 
-    _raw = config.get("api_key")
-    api_key = (_raw.get_secret_value() if isinstance(_raw, SecretStr) else _raw) or os.getenv(
-        "OLLAMA_API_KEY"
-    )
+    api_key = _resolve_api_key(config, "OLLAMA_API_KEY")
     base_url = config.get("base_url") or os.getenv(
         "OLLAMA_CLOUD_HOST", OllamaCloudDefaults.BASE_URL
     )
@@ -119,10 +161,7 @@ def _create_ollama_cloud(config: dict[str, Any]) -> BaseBatchClient:
 def _create_anthropic(config: dict[str, Any]) -> BaseBatchClient:
     cls, available = _try_import(".anthropic.batch_client", "AnthropicBatchClient")
     cls = _require_class(cls, available, "anthropic", "anthropic")
-    _raw = config.get("api_key")
-    api_key = (_raw.get_secret_value() if isinstance(_raw, SecretStr) else _raw) or os.getenv(
-        "ANTHROPIC_API_KEY"
-    )
+    api_key = _resolve_api_key(config, "ANTHROPIC_API_KEY")
     return cls(  # type: ignore[no-any-return]
         api_key=api_key,
         version=config.get("anthropic_version"),
@@ -133,10 +172,7 @@ def _create_anthropic(config: dict[str, Any]) -> BaseBatchClient:
 def _create_groq(config: dict[str, Any]) -> BaseBatchClient:
     cls, available = _try_import(".groq.batch_client", "GroqBatchClient")
     cls = _require_class(cls, available, "groq", "groq")
-    _raw = config.get("api_key")
-    api_key = (_raw.get_secret_value() if isinstance(_raw, SecretStr) else _raw) or os.getenv(
-        "GROQ_API_KEY"
-    )
+    api_key = _resolve_api_key(config, "GROQ_API_KEY")
     return cls(api_key=api_key)  # type: ignore[no-any-return]
 
 

--- a/agent_actions/llm/providers/client_base.py
+++ b/agent_actions/llm/providers/client_base.py
@@ -65,6 +65,11 @@ class BaseClient(ABC):
         """
         Return the API key using the name specified in ``agent_config``.
 
+        Treats ``agent_config["api_key"]`` as an **env var name** and resolves
+        it via ``os.getenv``.  Used by online clients.  The batch-side
+        counterpart is ``_resolve_api_key()`` in ``batch_client_factory.py``,
+        which treats the value as a literal secret instead.
+
         Supports two formats:
         1. Environment variable interpolation: ${VAR_NAME}
         2. Direct environment variable name: VAR_NAME (legacy)

--- a/agent_actions/llm/providers/groq/batch_client.py
+++ b/agent_actions/llm/providers/groq/batch_client.py
@@ -3,7 +3,6 @@ Groq Batch API client implementation.
 """
 
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
@@ -44,14 +43,13 @@ class GroqBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
         Initialize Groq client with optional API key.
 
         Args:
-            api_key: Groq API key (falls back to GROQ_API_KEY env var)
+            api_key: Groq API key
         """
         try:
             from groq import Groq
 
             self._groq_module = Groq
-            resolved_key = api_key or os.getenv("GROQ_API_KEY")
-            self.client = Groq(api_key=resolved_key)
+            self.client = Groq(api_key=api_key)
         except ImportError as e:
             from agent_actions.errors import DependencyError
 

--- a/tests/unit/config/test_api_key_secret.py
+++ b/tests/unit/config/test_api_key_secret.py
@@ -99,6 +99,84 @@ class TestBatchClientFactorySecretStr:
         mock_cls.assert_called_once()
         assert mock_cls.call_args.kwargs["api_key"] == "sk-vendor-test"
 
+    def test_missing_api_key_raises_configuration_error(self, monkeypatch):
+        """Factory must raise ConfigurationError when no key is available."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.llm.providers.batch_client_factory import _create_openai
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ConfigurationError, match="API key not configured"):
+            _create_openai({})
+
+    @pytest.mark.parametrize(
+        "factory_name,env_var",
+        [
+            ("_create_gemini", "GEMINI_API_KEY"),
+            ("_create_anthropic", "ANTHROPIC_API_KEY"),
+            ("_create_groq", "GROQ_API_KEY"),
+        ],
+    )
+    def test_optional_vendor_missing_key_raises(self, monkeypatch, factory_name, env_var):
+        """All vendor factories raise ConfigurationError when key is missing."""
+        import agent_actions.llm.providers.batch_client_factory as factory_module
+        from agent_actions.errors import ConfigurationError
+
+        monkeypatch.delenv(env_var, raising=False)
+        factory_fn = getattr(factory_module, factory_name)
+        mock_cls = MagicMock()
+        mock_cls.return_value = MagicMock()
+
+        with patch.object(factory_module, "_try_import", return_value=(mock_cls, True)):
+            with pytest.raises(ConfigurationError, match="API key not configured"):
+                factory_fn({})
+
+    def test_env_var_interpolation(self, monkeypatch):
+        """Factory must resolve ${VAR_NAME} syntax like online clients."""
+        from agent_actions.llm.providers.batch_client_factory import _create_openai
+
+        monkeypatch.setenv("MY_CUSTOM_KEY", "sk-custom-123")
+        with patch("agent_actions.llm.providers.openai.batch_client.OpenAIBatchClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _create_openai({"api_key": "${MY_CUSTOM_KEY}"})
+
+        mock_cls.assert_called_once_with(api_key="sk-custom-123")
+
+    def test_env_var_interpolation_missing_raises(self, monkeypatch):
+        """Factory must raise when ${VAR_NAME} references an unset variable."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.llm.providers.batch_client_factory import _create_openai
+
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+        with pytest.raises(ConfigurationError, match="NONEXISTENT_VAR"):
+            _create_openai({"api_key": "${NONEXISTENT_VAR}"})
+
+    def test_empty_string_api_key_raises(self, monkeypatch):
+        """Empty string api_key should not silently fall back to env var."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.llm.providers.batch_client_factory import _create_openai
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ConfigurationError, match="API key not configured"):
+            _create_openai({"api_key": ""})
+
+    def test_empty_secret_str_api_key_raises(self, monkeypatch):
+        """SecretStr('') should not silently fall back to env var."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.llm.providers.batch_client_factory import _create_openai
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ConfigurationError, match="API key not configured"):
+            _create_openai({"api_key": SecretStr("")})
+
+    def test_missing_api_key_raises_even_when_env_var_set(self, monkeypatch):
+        """When config has no api_key, raise even if the vendor env var is set."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.llm.providers.batch_client_factory import _create_openai
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        with pytest.raises(ConfigurationError, match="API key not configured"):
+            _create_openai({})
+
     def test_cache_key_unwraps_secret_str(self):
         from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
             BatchClientResolver,

--- a/tests/unit/config/test_api_key_secret.py
+++ b/tests/unit/config/test_api_key_secret.py
@@ -112,6 +112,7 @@ class TestBatchClientFactorySecretStr:
         "factory_name,env_var",
         [
             ("_create_gemini", "GEMINI_API_KEY"),
+            ("_create_ollama_cloud", "OLLAMA_API_KEY"),
             ("_create_anthropic", "ANTHROPIC_API_KEY"),
             ("_create_groq", "GROQ_API_KEY"),
         ],
@@ -167,6 +168,14 @@ class TestBatchClientFactorySecretStr:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with pytest.raises(ConfigurationError, match="API key not configured"):
             _create_openai({"api_key": SecretStr("")})
+
+    def test_non_string_api_key_raises(self):
+        """Non-string api_key (e.g. YAML parsed int) must raise, not pass through to SDK."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.llm.providers.batch_client_factory import _create_openai
+
+        with pytest.raises(ConfigurationError, match="must be a string"):
+            _create_openai({"api_key": 12345})
 
     def test_missing_api_key_raises_even_when_env_var_set(self, monkeypatch):
         """When config has no api_key, raise even if the vendor env var is set."""


### PR DESCRIPTION
## Summary
- Replaced 5 duplicated inline `os.getenv("VENDOR_API_KEY")` fallback patterns in `batch_client_factory.py` with a single `_resolve_api_key()` helper
- No silent fallbacks — if no API key is in the config, raises `ConfigurationError` immediately (the resolver is responsible for env var resolution upstream)
- Added `${VAR_NAME}` interpolation support to batch factory (parity with online clients)
- Fixed the same anti-pattern in `groq/batch_client.py` (sibling pattern)
- Updated stale docstring in `batch_client_resolver.py` that referenced the now-removed fallback behavior
- Cross-referenced docstrings between `BaseClient.get_api_key()` and `_resolve_api_key()` explaining why they are separate functions (different input semantics: env var name vs literal secret)

## Files changed
- `agent_actions/llm/providers/batch_client_factory.py` — new `_resolve_api_key()`, 5 call sites simplified
- `agent_actions/llm/providers/groq/batch_client.py` — removed redundant `os.getenv` fallback in constructor
- `agent_actions/llm/providers/client_base.py` — docstring cross-reference added
- `agent_actions/llm/batch/infrastructure/batch_client_resolver.py` — stale docstring fixed
- `tests/unit/config/test_api_key_secret.py` — 9 new tests: missing key errors, `${VAR}` interpolation, empty string/SecretStr edge cases, no-fallback verification

## Verification
- `ruff check` + `ruff format --check` — clean
- `pytest` — 7394 passed, 2 skipped
- `grep -n "os.getenv" batch_client_factory.py` — only `OLLAMA_HOST` and `OLLAMA_CLOUD_HOST` remain (base URLs, not API keys)