### PR TITLE
fix(llm): log recovery state corruption at error level, catch ValueError

### DIFF
--- a/.changes/unreleased/Bug Fix-20260527-505000.yaml
+++ b/.changes/unreleased/Bug Fix-20260527-505000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Log recovery state corruption at error level instead of warning, catch ValueError from enum coercion"
+time: 2026-05-27T05:05:00.000000Z

--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -113,8 +113,8 @@ class RecoveryStateManager:
             return RecoveryState(**data)
         except FileNotFoundError:
             return None
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning("Failed to load recovery state from %s: %s", state_path, e)
+        except (json.JSONDecodeError, TypeError, ValueError) as e:
+            logger.error("Corrupt recovery state at %s: %s", state_path, e)
             return None
 
     @staticmethod

--- a/tests/unit/llm/conftest.py
+++ b/tests/unit/llm/conftest.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for LLM module tests."""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Ensure agent_actions loggers propagate to root so caplog captures them.
+
+    The agent_actions root logger has propagate=False (set by LoggingBridgeHandler),
+    so caplog (which hooks the Python root logger) can't see child log records.
+    Temporarily enable propagation for the duration of each test.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig

--- a/tests/unit/llm/test_recovery_state_graduated.py
+++ b/tests/unit/llm/test_recovery_state_graduated.py
@@ -246,7 +246,10 @@ class TestRecoveryStateCorruptionHandling:
             result = RecoveryStateManager.load(str(tmp_path), "test_action")
 
         assert result is None
-        assert any("Corrupt recovery state" in r.message for r in caplog.records)
+        assert any(
+            "Corrupt recovery state" in r.message and r.levelno == logging.ERROR
+            for r in caplog.records
+        )
 
     def test_valid_state_loads_without_error(self, tmp_path, caplog):
         """Valid recovery state loads normally, no error logs."""

--- a/tests/unit/llm/test_recovery_state_graduated.py
+++ b/tests/unit/llm/test_recovery_state_graduated.py
@@ -1,6 +1,7 @@
 """Tests for graduated results tracking in RecoveryState."""
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -199,6 +200,65 @@ class TestRecoveryStateManagerIntegration:
         assert loaded is not None
         assert len(loaded.graduated_results) == 2
         assert loaded.evaluation_strategy_name == "validation"
+
+
+class TestRecoveryStateCorruptionHandling:
+    """Verify load() logs at error-level on corruption and returns None."""
+
+    def _write_raw(self, tmp_path, content: str) -> Path:
+        """Write raw content to the recovery state file location."""
+        state_path = tmp_path / "batch" / ".recovery_state_test_action.json"
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(content)
+        return state_path
+
+    _LOGGER = "agent_actions"
+
+    def test_corrupt_json_logs_error_and_returns_none(self, tmp_path, caplog):
+        """Truncated/invalid JSON logs at error-level, returns None."""
+        self._write_raw(tmp_path, '{"phase": "retry", "retry_at')
+
+        with caplog.at_level(logging.ERROR, logger=self._LOGGER):
+            result = RecoveryStateManager.load(str(tmp_path), "test_action")
+
+        assert result is None
+        assert any(
+            "Corrupt recovery state" in r.message and r.levelno == logging.ERROR
+            for r in caplog.records
+        )
+
+    def test_missing_file_returns_none_silently(self, tmp_path, caplog):
+        """Missing file (first run) returns None with no error log."""
+        with caplog.at_level(logging.DEBUG, logger=self._LOGGER):
+            result = RecoveryStateManager.load(str(tmp_path), "nonexistent")
+
+        assert result is None
+        assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_invalid_enum_value_logs_error(self, tmp_path, caplog):
+        """Valid JSON with bad enum value triggers ValueError in __post_init__."""
+        self._write_raw(
+            tmp_path,
+            json.dumps({"phase": "not_a_real_phase", "retry_attempt": 0, "reprompt_attempt": 0}),
+        )
+
+        with caplog.at_level(logging.ERROR, logger=self._LOGGER):
+            result = RecoveryStateManager.load(str(tmp_path), "test_action")
+
+        assert result is None
+        assert any("Corrupt recovery state" in r.message for r in caplog.records)
+
+    def test_valid_state_loads_without_error(self, tmp_path, caplog):
+        """Valid recovery state loads normally, no error logs."""
+        state = RecoveryState(phase="retry", retry_attempt=1)
+        RecoveryStateManager.save(str(tmp_path), "test_action", state)
+
+        with caplog.at_level(logging.DEBUG, logger=self._LOGGER):
+            result = RecoveryStateManager.load(str(tmp_path), "test_action")
+
+        assert result is not None
+        assert result.retry_attempt == 1
+        assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
 class TestRecoveryStateAtomicWrite:


### PR DESCRIPTION
## Summary
- Promoted `RecoveryStateManager.load()` corruption logging from `warning` to `error` so operators notice data loss scenarios
- Added `ValueError` to the except clause so invalid enum values from `RecoveryState.__post_init__` are caught instead of propagating as unhandled exceptions
- Added 4 corruption-handling tests (corrupt JSON, missing file, invalid enum, valid state)
- Extracted `_enable_log_propagation` fixture to `tests/unit/llm/conftest.py` (matches existing pattern in `tests/unit/unification/conftest.py`)

## Verification
- `ruff format --check` — clean
- `ruff check` — clean
- `pytest` — 7400 passed, 2 skipped