### PR TITLE
fix(llm): use ConfigurationError for config-related errors in realtime path

### DIFF
--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from agent_actions.errors import ConfigurationError
 from agent_actions.output.response.schema import ResponseSchemaCompiler
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 
@@ -51,7 +52,7 @@ def create_dynamic_agent(
     # - Few-shot sample injection
     # - Consistent behavior across batch and online modes
     if formatted_prompt is None:
-        raise ValueError(
+        raise ConfigurationError(
             "formatted_prompt is required. "
             "Please use PromptPreparationService.prepare_prompt_with_context() "
             "to prepare the prompt before calling create_dynamic_agent(). "

--- a/agent_actions/llm/realtime/services/invocation.py
+++ b/agent_actions/llm/realtime/services/invocation.py
@@ -110,11 +110,19 @@ class ClientInvocationService:
             List of response data from the LLM
 
         Raises:
-            ValueError: If client is not supported
+            ConfigurationError: If client is not supported
             DependencyError: If the provider's SDK package is not installed
         """
         if model_vendor not in CLIENT_REGISTRY:
-            raise ValueError(f"Unsupported model vendor: {model_vendor}")
+            from agent_actions.errors import ConfigurationError
+
+            raise ConfigurationError(
+                f"Unsupported model vendor: {model_vendor}",
+                context={
+                    "model_vendor": model_vendor,
+                    "supported_vendors": list(CLIENT_REGISTRY.keys()),
+                },
+            )
 
         client = _resolve_client(model_vendor)
 


### PR DESCRIPTION
## Summary
- Replace `ValueError` with `ConfigurationError` in `builder.py` (missing formatted_prompt) and `invocation.py` (unsupported vendor) to match batch module conventions
- Adds structured `context` dict to the unsupported vendor error with vendor name and supported list
- `DependencyError` for missing SDK packages unchanged (correct category)

## Verification
- `grep -rn "raise ValueError" agent_actions/llm/realtime/` returns zero matches
- Zero `except ValueError` blocks in the realtime module — no catch-site migration needed
- No tests assert `pytest.raises(ValueError)` for these paths
- `ruff check && ruff format --check` clean
- `pytest tests/ -k "builder or invocation or realtime or vendor"` — 518 passed