### PR TITLE
fix(llm): reject unknown keys in vendor config (extra=forbid)

### DIFF
--- a/agent_actions/llm/config/vendor.py
+++ b/agent_actions/llm/config/vendor.py
@@ -52,7 +52,7 @@ class BaseVendorConfig(BaseModel):
     top_p: float | None = Field(
         default=None, ge=0.0, le=1.0, description="Top-p sampling parameter"
     )
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "forbid"}
 
 
 class OpenAIConfig(BaseVendorConfig):

--- a/tests/unit/llm/test_vendor_config_extra_forbid.py
+++ b/tests/unit/llm/test_vendor_config_extra_forbid.py
@@ -1,0 +1,65 @@
+"""Tests that vendor configs reject unknown keys (extra='forbid').
+
+Validates that typos in vendor configuration YAML (e.g., 'temperture'
+instead of 'temperature') raise ValidationError instead of being
+silently accepted.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from agent_actions.llm.config.vendor import (
+    AgacProviderConfig,
+    AnthropicConfig,
+    CohereConfig,
+    GeminiConfig,
+    GroqConfig,
+    HitlVendorConfig,
+    OllamaCloudConfig,
+    OllamaLocalConfig,
+    OpenAIConfig,
+    ToolVendorConfig,
+)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        OpenAIConfig,
+        AnthropicConfig,
+        GeminiConfig,
+        GroqConfig,
+        CohereConfig,
+        OllamaLocalConfig,
+        OllamaCloudConfig,
+        ToolVendorConfig,
+        HitlVendorConfig,
+        AgacProviderConfig,
+    ],
+)
+class TestVendorConfigForbidsExtraFields:
+    """All vendor config subclasses reject unknown keys."""
+
+    def test_rejects_unknown_field(self, cls):
+        with pytest.raises(ValidationError, match="bogus_field"):
+            cls(model_name="test", bogus_field="value")
+
+    def test_rejects_typo_field(self, cls):
+        with pytest.raises(ValidationError, match="temperture"):
+            cls(model_name="test", temperture=0.7)
+
+
+class TestVendorConfigAcceptsValidFields:
+    """Smoke tests that declared fields still work."""
+
+    def test_openai_frequency_penalty(self):
+        config = OpenAIConfig(model_name="gpt-4o", frequency_penalty=0.5)
+        assert config.frequency_penalty == 0.5
+
+    def test_anthropic_version(self):
+        config = AnthropicConfig(model_name="claude-3", anthropic_version="2024-01-01")
+        assert config.anthropic_version == "2024-01-01"
+
+    def test_base_temperature(self):
+        config = OpenAIConfig(model_name="gpt-4o", temperature=0.7)
+        assert config.temperature == 0.7


### PR DESCRIPTION
## Summary
- Change `BaseVendorConfig.model_config` from `extra=allow` to `extra=forbid`
- Typos in vendor YAML (e.g., `temperture` instead of `temperature`) now raise `ValidationError` at load time instead of being silently ignored
- All 10 vendor config subclasses inherit the change

## Verification
- 7400 existing tests pass (no code was relying on extra fields)
- 23 new tests: parametrized across all vendor subclasses for rejection + smoke tests for valid fields
- `ruff check && ruff format --check` clean