### PR TITLE
cleanup(llm): remove dead VendorRegistry, SINGLE_RESPONSE_CLIENTS, stale comment

### DIFF
--- a/agent_actions/llm/config/vendor.py
+++ b/agent_actions/llm/config/vendor.py
@@ -176,43 +176,6 @@ VendorConfig = (
 )
 
 
-class VendorRegistry(BaseModel):
-    """Registry for all configured vendors."""
-
-    vendors: dict[str, VendorConfig] = Field(
-        default_factory=dict, description="Map of vendor name to vendor configuration"
-    )
-    default_vendor: str | None = Field(
-        default=None,
-        description="Default vendor to use when not specified (must be explicitly configured)",
-    )
-
-    def get_vendor_config(self, vendor_name: str) -> VendorConfig | None:
-        """Get configuration for a specific vendor."""
-        return self.vendors.get(vendor_name)
-
-    def get_default_vendor_config(self) -> VendorConfig | None:
-        """Get the default vendor configuration."""
-        return self.vendors.get(self.default_vendor)  # type: ignore[arg-type]
-
-    def register_vendor(self, name: str, config: VendorConfig):
-        """Register a new vendor configuration."""
-        self.vendors[name] = config
-
-    def list_vendor_types(self) -> list[VendorType]:
-        """Get list of all registered vendor types."""
-        return [config.vendor_type for config in self.vendors.values()]
-
-    @classmethod
-    def create_default_registry(cls) -> "VendorRegistry":
-        """Create a registry with default vendor configurations."""
-        registry = cls()
-        registry.register_vendor("openai", OpenAIConfig(model_name="gpt-4o-mini"))
-        registry.register_vendor("claude", AnthropicConfig(model_name="claude-3-sonnet-20240229"))
-        registry.register_vendor("gemini", GoogleConfig(model_name="gemini-1.5-flash"))
-        return registry
-
-
 __all__ = [
     "VendorType",
     "ResponseFormat",
@@ -229,5 +192,4 @@ __all__ = [
     "HitlVendorConfig",
     "AgacProviderConfig",
     "VendorConfig",
-    "VendorRegistry",
 ]

--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -72,7 +72,6 @@ def create_dynamic_agent(
 
     context_data = ContextService.prepare_context_data(context_data_str, is_tool)
 
-    # Note: dispatch_task() injection now happens in PromptPreparationService
     captured_results = {}
 
     # Append additional_context if provided (context_scope.observe fields)

--- a/agent_actions/llm/realtime/services/invocation.py
+++ b/agent_actions/llm/realtime/services/invocation.py
@@ -41,10 +41,6 @@ CLIENT_REGISTRY: dict[str, Any] = {
     "hitl": HitlClient,
 }
 
-# All providers now normalise their return type to List[Dict] internally,
-# so no wrapping is needed here.
-SINGLE_RESPONSE_CLIENTS: set = set()
-
 
 def _resolve_client(model_vendor: str) -> Any:
     """Resolve provider client from registry, importing lazy entries on demand."""
@@ -143,9 +139,6 @@ class ClientInvocationService:
         else:
             # Standard client invocation (all providers, including Groq)
             result = client.invoke(agent_config, prompt_config, context_data, schema)
-            # Single-response clients return single item, wrap in list for consistency
-            if model_vendor in SINGLE_RESPONSE_CLIENTS:
-                result = [result]
 
         elapsed = time.perf_counter() - start
         logger.info(

--- a/tests/unit/llm_invocation/providers/test_non_json_standardization.py
+++ b/tests/unit/llm_invocation/providers/test_non_json_standardization.py
@@ -984,20 +984,6 @@ class TestOllamaTopPStopForwarding:
 
 
 # ---------------------------------------------------------------------------
-# SINGLE_RESPONSE_CLIENTS audit (collapsed to 1 test)
-# ---------------------------------------------------------------------------
-
-
-class TestSingleResponseClients:
-    """All providers now return List[Dict] — SINGLE_RESPONSE_CLIENTS is empty."""
-
-    def test_set_is_empty(self):
-        from agent_actions.llm.realtime.services.invocation import SINGLE_RESPONSE_CLIENTS
-
-        assert SINGLE_RESPONSE_CLIENTS == set()
-
-
-# ---------------------------------------------------------------------------
 # call_json normalization: dict → List[Dict] (parameterized across providers)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Delete `VendorRegistry` class — never wired into runtime; vendor configs resolved via `resolution_service` instead
- Delete `SINGLE_RESPONSE_CLIENTS` empty set + dead wrapping branch — all providers return lists natively
- Delete stale `dispatch_task()` comment referencing completed refactor
- Delete test that asserted the empty set was empty

## Verification
- `grep -rn "VendorRegistry\|SINGLE_RESPONSE_CLIENTS" agent_actions/` — zero matches
- `GoogleConfig` alias deliberately kept (has live consumers in docs scanner + VendorConfig union)
- 7422 tests pass, `ruff check` clean
- Pure deletion: 59 lines removed, 0 added