### PR TITLE
fix(llm): minor hardening — comment truncation, immutable merge, cleanup resilience

### DIFF
--- a/agent_actions/llm/providers/hitl/server.py
+++ b/agent_actions/llm/providers/hitl/server.py
@@ -321,8 +321,9 @@ class HitlServer:
             ), 400
         payload = self._get_request_payload()
         if self.record_count == 1:
+            comment = str(payload.get("comment", ""))[:2000]
             review = self._normalize_single_review(
-                {"hitl_status": "approved", "user_comment": payload.get("comment", "")}
+                {"hitl_status": "approved", "user_comment": comment}
             )
             with self._lock:
                 self.record_reviews[0] = review
@@ -341,9 +342,9 @@ class HitlServer:
                 }
             ), 400
         payload = self._get_request_payload()
-        comment = payload.get("comment", "")
+        comment = str(payload.get("comment", ""))[:2000]
         reject_error = self._validate_reject_comment(
-            {"hitl_status": "rejected", "user_comment": str(comment)}
+            {"hitl_status": "rejected", "user_comment": comment}
         )
         if reject_error:
             return jsonify({"success": False, "error": reject_error}), 400

--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -120,10 +120,9 @@ def create_dynamic_agent(
         source_content,
     )
 
-    # Merge captured results if any
     if captured_results:
-        for item in result:
-            if isinstance(item, dict):
-                item.update(captured_results)
+        result = [
+            {**item, **captured_results} if isinstance(item, dict) else item for item in result
+        ]
 
     return result

--- a/agent_actions/llm/realtime/cleaner.py
+++ b/agent_actions/llm/realtime/cleaner.py
@@ -59,9 +59,21 @@ class Cleaner:
         if not self.force and (not self._confirm(directories)):
             click.echo("Aborted – nothing was cleaned.")
             return
+        failures = []
         for directory in directories:
-            self.agent_manager.clean_directory(self.agent, directory)
-        click.echo(f"✅  Cleaned {len(directories)} directories for agent '{self.agent}'.")
+            try:
+                self.agent_manager.clean_directory(self.agent, directory)
+            except OSError as e:
+                failures.append((directory, e))
+                logger.warning("Failed to clean %s: %s", directory, e)
+        if failures:
+            click.echo(
+                f"⚠️  Cleaned {len(directories) - len(failures)}/{len(directories)} "
+                f"directories for agent '{self.agent}' "
+                f"({len(failures)} failed)."
+            )
+        else:
+            click.echo(f"✅  Cleaned {len(directories)} directories for agent '{self.agent}'.")
 
     def _confirm(self, directories: Iterable[Path]) -> bool:
         """Request user confirmation before executing a destructive action."""


### PR DESCRIPTION
## Summary
- **HITL comment truncation**: truncate approve/reject comment to 2000 chars to prevent unbounded input
- **Builder immutable merge**: replace `item.update(captured_results)` with `{**item, **captured_results}` to avoid mutating result dicts in-place
- **Cleaner continue-on-error**: if one directory cleanup fails, continue with remaining directories and report partial failures

Deliberately excluded from this PR:
- Ollama failure injection thread safety (test-only chaos code, not worth the complexity)
- Context map save ordering (correctness implications, needs its own PR)

## Verification
- 7422 tests pass
- `ruff check && ruff format --check` clean
- No behavioral changes to happy paths