### PR TITLE
release: v0.2.2

### DIFF
--- a/.changes/unreleased/Under the Hood-20260530-022000.yaml
+++ b/.changes/unreleased/Under the Hood-20260530-022000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Release v0.2.2 — batch changie entries, bump version"
+time: 2026-05-30T00:22:00.000000Z

--- a/.changes/v0.2.2.md
+++ b/.changes/v0.2.2.md
@@ -1,0 +1,12 @@
+## v0.2.2 - 2026-05-30
+### Bug Fix
+* Add exponential backoff with jitter to batch retry loop to prevent retry storms when provider is overloaded
+* Stop silently graduating records on reprompt batch submission failure; transient and permanent errors now handled distinctly with proper metadata
+* Remove silent os.getenv API key fallbacks in batch client factory — batch clients now raise ConfigurationError when no key is configured instead of silently trying hardcoded vendor env vars
+* Log recovery state corruption at error level instead of warning, catch ValueError from enum coercion
+* Use ConfigurationError for config-related errors in realtime LLM path instead of ValueError
+* Reject unknown keys in vendor config (extra=forbid) so YAML typos raise validation errors
+* Log provider error records (error_line_*) filtered during batch reconciliation instead of silently discarding them
+* HITL comment truncation (2000 chars), immutable result merge in builder, and continue-on-error in cleaner
+### Under the Hood
+* Remove dead VendorRegistry class, SINGLE_RESPONSE_CLIENTS empty set, and stale dispatch_task comment

--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.2.1"
+version = "0.2.2"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},


### PR DESCRIPTION
## v0.2.2

### Bug Fix
* Add exponential backoff with jitter to batch retry loop to prevent retry storms when provider is overloaded
* Stop silently graduating records on reprompt batch submission failure; transient and permanent errors now handled distinctly with proper metadata
* Remove silent os.getenv API key fallbacks in batch client factory — batch clients now raise ConfigurationError when no key is configured
* Log recovery state corruption at error level instead of warning, catch ValueError from enum coercion
* Use ConfigurationError for config-related errors in realtime LLM path instead of ValueError
* Reject unknown keys in vendor config (extra=forbid) so YAML typos raise validation errors
* Log provider error records (error_line_*) filtered during batch reconciliation instead of silently discarding them
* HITL comment truncation (2000 chars), immutable result merge in builder, and continue-on-error in cleaner

### Under the Hood
* Remove dead VendorRegistry class, SINGLE_RESPONSE_CLIENTS empty set, and stale dispatch_task comment

### Files changed
- `pyproject.toml` — version 0.2.1 → 0.2.2
- `agent_actions/__version__.py` — version 0.2.1 → 0.2.2
- `.changes/v0.2.2.md` — new changelog entry
- `.changes/unreleased/*.yaml` — 9 entries batched and removed