### PR TITLE
fix(llm): batch silent failures, error guards, and log levels

### DIFF
--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -172,7 +172,14 @@ class BatchRegistryManager:
             cache = self._get_cache()
 
             if not cache:
-                return True  # No jobs = all complete
+                if self._registry_path.exists():
+                    logger.warning(
+                        "Registry file exists at %s but cache is empty — "
+                        "possible corruption. Reporting jobs as NOT completed.",
+                        self._registry_path,
+                    )
+                    return False
+                return True  # No registry file = no jobs = all complete
 
             # Collect entries that need a provider check (non-terminal) while holding the lock
             if check_provider:

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -291,7 +291,7 @@ class BatchProcessingService:
             status = provider.check_status(batch_id)
             return status == BatchStatus.COMPLETED
         except Exception as e:
-            logger.debug("Failed to check batch status for %s: %s", batch_id, e, exc_info=True)
+            logger.warning("Failed to check batch status for %s: %s", batch_id, e, exc_info=True)
             return False
 
     def _determine_output_path(
@@ -698,8 +698,11 @@ class BatchProcessingService:
                     action_name, source_guid, DISPOSITION_FILTERED, reason=reason
                 )
             except Exception:
-                logger.debug(
-                    "Failed to write FILTERED disposition for %s", source_guid, exc_info=True
+                logger.warning(
+                    "Failed to write FILTERED disposition for %s — "
+                    "record may be reprocessed on next run",
+                    source_guid,
+                    exc_info=True,
                 )
 
     def _try_clear_deferred(self, action_name: str, record_id: str) -> None:

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -614,5 +614,7 @@ def _remove_batch_placeholder(output_file: Path) -> None:
         try:
             output_file.unlink()
             logger.debug("Removed batch placeholder: %s", output_file)
-        except OSError:
+        except FileNotFoundError:
             pass  # Already removed by concurrent worker
+        except OSError as e:
+            logger.warning("Failed to remove batch placeholder %s: %s", output_file, e)

--- a/agent_actions/llm/batch/services/reprompt_ops.py
+++ b/agent_actions/llm/batch/services/reprompt_ops.py
@@ -78,6 +78,7 @@ def _load_source_data_for_reprompt(
                 records = storage_backend.read_source(path)
                 all_source_data.extend(records)
             except FileNotFoundError:
+                logger.warning("Source file not found during reprompt data load: %s", path)
                 continue
 
         return all_source_data if all_source_data else None

--- a/agent_actions/llm/providers/groq/client.py
+++ b/agent_actions/llm/providers/groq/client.py
@@ -165,6 +165,8 @@ class GroqClient(BaseClient, JSONResponseMixin):
         start_time = time.perf_counter()
         try:
             response = client.chat.completions.create(**completion_kwargs)
+        except (RateLimitError, NetworkError, VendorAPIError):
+            raise
         except groq.APIError as e:
             raise _wrap_groq_error(e, model_name, request_id) from e
 


### PR DESCRIPTION
## Summary
6 verified bugs from the LLM module audit:

- Batch status check failure logged at DEBUG → silent permanent skip. Promoted to WARNING.
- Corrupt registry returns empty dict → `are_all_jobs_completed` returns True → pipeline processes nothing. Now detects file-exists-but-empty-cache and returns False with warning.
- Groq `call_non_json` missing `except (RateLimitError, NetworkError, VendorAPIError): raise` pre-guard that `call_json` has. Added for consistency.
- Filtered disposition write failure at DEBUG → records silently reprocess. Promoted to WARNING.
- Missing source files during reprompt silently skipped via `except FileNotFoundError: continue`. Now logs warning with file path.
- Placeholder removal catches broad `OSError` (swallows permission errors). Narrowed to `FileNotFoundError`; other OS errors now logged at WARNING.

## Verification
- 7422 tests pass
- `ruff check && ruff format --check` clean
- Each fix is a 1-3 line change with no behavioral change to happy paths