### PR TITLE
fix(llm): dead code cleanup, log levels, and missing log context

### DIFF
--- a/.changes/unreleased/Under the Hood-20260530-525000.yaml
+++ b/.changes/unreleased/Under the Hood-20260530-525000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove dead code (unused methods, parameters), fix log levels, and add missing context to batch log messages"
+time: 2026-05-30T05:25:00.000000Z

--- a/agent_actions/llm/batch/core/batch_context_metadata.py
+++ b/agent_actions/llm/batch/core/batch_context_metadata.py
@@ -39,11 +39,6 @@ class BatchContextMetadata:
         """Check if record has SKIPPED filter status."""
         return BatchContextMetadata.get_filter_status(record) == FilterStatus.SKIPPED
 
-    @staticmethod
-    def is_filtered(record: dict[str, Any]) -> bool:
-        """Check if record has FILTERED filter status."""
-        return BatchContextMetadata.get_filter_status(record) == FilterStatus.FILTERED
-
     # =========================================================================
     # Passthrough Fields Methods
     # =========================================================================
@@ -86,9 +81,3 @@ class BatchContextMetadata:
         """Return a copy of record with all internal metadata fields removed."""
         internal_keys = ContextMetaKeys.all_internal_keys()
         return {k: v for k, v in record.items() if k not in internal_keys}
-
-    @staticmethod
-    def has_internal_fields(record: dict[str, Any]) -> bool:
-        """Check if record contains any internal metadata fields."""
-        internal_keys = ContextMetaKeys.all_internal_keys()
-        return any(k in record for k in internal_keys)

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -12,7 +12,6 @@ from agent_actions.llm.batch.core.batch_models import BatchJobEntry, BatchRegist
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.cache_events import (
     CacheHitEvent,
-    CacheInvalidationEvent,
     CacheLoadEvent,
     CacheMissEvent,
     CacheUpdateEvent,
@@ -228,22 +227,6 @@ class BatchRegistryManager:
                 self._persist_registry(self._cache)
 
             return all(entry.is_terminal for entry in self._cache.values())
-
-    def invalidate_cache(self) -> None:
-        """Force cache reload on next access."""
-        with self._lock:
-            entries_removed = len(self._cache) if self._cache is not None else 0
-            self._cache = None
-            self._batch_id_index = None
-            logger.debug("Registry cache invalidated")
-
-            fire_event(
-                CacheInvalidationEvent(
-                    cache_type="batch_registry",
-                    entries_removed=entries_removed,
-                    reason="manual invalidation",
-                )
-            )
 
     # ============================================================
     # PRIVATE METHODS - Internal implementation

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -349,7 +349,7 @@ class BatchProcessingService:
         except FileNotFoundError:
             return batch_output
         except (json.JSONDecodeError, KeyError):
-            logger.warning("Malformed .batch_carry_forward.json — skipping merge")
+            logger.warning("Malformed %s — skipping merge", carry_path)
             return batch_output
 
         if not carry_guids or not self._storage_backend or not action_name:

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -65,12 +65,18 @@ def process_recovery_batch(
     """
     parent_file_name = entry.parent_file_name
     if not parent_file_name:
-        logger.error("Recovery entry %s has no parent_file_name", file_name)
+        logger.error(
+            "Recovery entry file_name=%s batch_id=%s has no parent_file_name",
+            file_name,
+            entry.batch_id,
+        )
         return None
 
     state = RecoveryStateManager.load(output_directory, parent_file_name)
     if not state:
-        logger.error("No recovery state found for %s", parent_file_name)
+        logger.error(
+            "No recovery state found for parent=%s file_name=%s", parent_file_name, file_name
+        )
         return None
 
     agent_config = service._apply_workflow_session_id(agent_config, entry)

--- a/agent_actions/llm/batch/services/retry_ops.py
+++ b/agent_actions/llm/batch/services/retry_ops.py
@@ -63,7 +63,11 @@ def submit_retry_batch(
 
     missing_records = _collect_missing_records(missing_ids, context_map)
     if not missing_records:
-        logger.warning("No records found in context_map for missing IDs")
+        logger.warning(
+            "No records found in context_map for %d missing IDs (file_name=%s)",
+            len(missing_ids),
+            file_name,
+        )
         return None
 
     try:
@@ -78,7 +82,7 @@ def submit_retry_batch(
         )
 
         if not prepared.tasks:
-            logger.warning("No tasks prepared for retry batch")
+            logger.warning("No tasks prepared for retry batch (file_name=%s)", file_name)
             return None
 
         retry_batch_id, _ = provider.submit_batch(
@@ -112,7 +116,11 @@ def resubmit_missing_records(
 
     missing_records = _collect_missing_records(missing_ids, context_map)
     if not missing_records:
-        logger.warning("No records found in context_map for missing IDs")
+        logger.warning(
+            "No records found in context_map for %d missing IDs (file_name=%s)",
+            len(missing_ids),
+            file_name,
+        )
         return []
 
     try:
@@ -127,7 +135,7 @@ def resubmit_missing_records(
         )
 
         if not prepared.tasks:
-            logger.warning("No tasks prepared for retry batch")
+            logger.warning("No tasks prepared for retry batch (file_name=%s)", file_name)
             return []
 
         retry_batch_id, _ = provider.submit_batch(

--- a/agent_actions/llm/providers/batch_base.py
+++ b/agent_actions/llm/providers/batch_base.py
@@ -186,7 +186,9 @@ class BaseBatchClient(ABC):
                     batch_result = self.parse_provider_response(raw_result)
                     batch_results.append(batch_result)
                 except json.JSONDecodeError as e:
-                    logger.error("JSON parsing error on line %s: %s", line_num, e)
+                    logger.warning(
+                        "JSON parsing error on line %d (%.120s): %s", line_num, line.strip(), e
+                    )
                     batch_results.append(
                         BatchResult(
                             custom_id=f"error_line_{line_num}",
@@ -245,10 +247,6 @@ class BaseBatchClient(ABC):
     @abstractmethod
     def _extract_usage_from_response(self, raw_response: Any) -> dict[str, Any] | None:
         """Extract token usage information from response."""
-
-    def get_supported_models(self) -> list[str]:
-        """Get list of model names supported by this provider."""
-        return []
 
     def validate_config(self, agent_config: dict[str, Any]) -> tuple[bool, str | None]:
         """Validate agent configuration compatibility with this provider (Template Method)."""
@@ -309,7 +307,9 @@ class BaseBatchClient(ABC):
                         batch_result = self.parse_provider_response(raw_result)
                         batch_results.append(batch_result)
                     except json.JSONDecodeError as e:
-                        logger.error("JSON parsing error on line %s: %s", line_num, e)
+                        logger.warning(
+                            "JSON parsing error on line %d (%.120s): %s", line_num, line.strip(), e
+                        )
                         batch_results.append(
                             BatchResult(
                                 custom_id=f"error_line_{line_num}",

--- a/agent_actions/llm/providers/ollama/batch_client.py
+++ b/agent_actions/llm/providers/ollama/batch_client.py
@@ -163,7 +163,7 @@ class OllamaBatchClient(OpenAICompatibleResponseMixin, BaseBatchClient):
     ) -> dict[str, Any] | None:
         """Process one batch task. Returns result dict, or None if injection-dropped."""
         custom_id = task["custom_id"]
-        logger.info("Processing request %d/%d: %s", idx + 1, total, custom_id)
+        logger.debug("Processing request %d/%d: %s", idx + 1, total, custom_id)
 
         try:
             body = task["body"]

--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -115,9 +115,8 @@ def create_dynamic_agent(
         context_data,
         schema,  # type: ignore[arg-type]
         granularity,
-        formatted_prompt,
-        tool_args,
-        source_content,
+        tool_args=tool_args,
+        source_content=source_content,
     )
 
     if captured_results:

--- a/agent_actions/llm/realtime/services/invocation.py
+++ b/agent_actions/llm/realtime/services/invocation.py
@@ -78,7 +78,6 @@ class ClientInvocationService:
         context_data: str | dict,
         schema: dict[str, Any] | None,
         granularity: str,
-        formatted_prompt: str | None = None,
         tool_args: dict[str, Any] | None = None,
         source_content: Any | None = None,
         action_name: str | None = None,
@@ -97,7 +96,6 @@ class ClientInvocationService:
             context_data: Context data (str or dict)
             schema: Prepared schema (optional)
             granularity: Processing granularity ('record' or 'file')
-            formatted_prompt: Pre-formatted prompt (unused, kept for API compat)
             tool_args: Tool arguments (optional)
             source_content: Source content for tool client (optional)
             action_name: Action name for logging (optional)


### PR DESCRIPTION
## Summary

**Dead code removal:**
- Remove unused `formatted_prompt` parameter from `invoke_client` and its caller in `builder.py`
- Remove 4 dead methods: `BatchContextMetadata.is_filtered`, `BatchContextMetadata.has_internal_fields`, `BatchRegistryManager.invalidate_cache`, `BaseBatchClient.get_supported_models`
- Remove unused `CacheInvalidationEvent` import

**Log level fixes:**
- Demote `batch_base.py` JSON parse error from ERROR to WARNING (recovered condition — creates BatchResult with success=False)
- Demote Ollama batch per-record log from INFO to DEBUG (10k records was producing 10k INFO lines)

**Missing log context:**
- Add `batch_id`/`file_name` to recovery error messages in `processing_recovery.py`
- Add missing ID count and `file_name` to retry warnings in `retry_ops.py`
- Add file path to carry-forward corruption warning in `processing.py`

## Verification
- 7422 tests pass
- `ruff check && ruff format --check` clean
- 9 files changed, 33 additions, 47 deletions (net -14 lines)