### PR TITLE
fix(workflow): stop rewinding to partially-failed actions on re-run

### DIFF
--- a/.changes/unreleased/Bug Fix-20260531-534000.yaml
+++ b/.changes/unreleased/Bug Fix-20260531-534000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Stop re-running partially-failed actions on workflow resume — only the retry command should go back to fix partial failures"
+time: 2026-05-31T053400.000000Z

--- a/agent_actions/workflow/managers/state.py
+++ b/agent_actions/workflow/managers/state.py
@@ -48,7 +48,6 @@ RETRYABLE_STATUSES: frozenset[ActionStatus] = frozenset(
         ActionStatus.SKIPPED,
         ActionStatus.RUNNING,
         ActionStatus.CHECKING_BATCH,
-        ActionStatus.COMPLETED_WITH_FAILURES,
     }
 )
 

--- a/tests/unit/workflow/managers/test_state_manager.py
+++ b/tests/unit/workflow/managers/test_state_manager.py
@@ -305,16 +305,16 @@ class TestResetRetryable:
         assert mgr.get_status("a") == ActionStatus.COMPLETED
         assert reset == []
 
-    def test_resets_completed_with_failures(self, tmp_path):
-        """COMPLETED_WITH_FAILURES must be retried on rerun — partial failures need reprocessing."""
+    def test_preserves_completed_with_failures(self, tmp_path):
+        """COMPLETED_WITH_FAILURES is preserved on rerun — use `retry` to fix partial failures."""
         status_file = tmp_path / "status.json"
         mgr = ActionStateManager(status_file, ["a"])
         mgr.update_status("a", ActionStatus.COMPLETED_WITH_FAILURES)
 
         reset = mgr.reset_retryable()
 
-        assert mgr.get_status("a") == ActionStatus.PENDING
-        assert reset == ["a"]
+        assert mgr.get_status("a") == ActionStatus.COMPLETED_WITH_FAILURES
+        assert reset == []
 
     def test_resets_checking_batch_to_pending(self, tmp_path):
         """CHECKING_BATCH from a prior crash should be retried."""


### PR DESCRIPTION
## Summary
- Remove `COMPLETED_WITH_FAILURES` from `RETRYABLE_STATUSES` so `agent-actions run` resumes from where it stopped instead of rewinding to earlier actions with partial failures
- Previously, re-running a workflow that was interrupted at action 9 would go back to action 3 (which had 2 failed records out of 10) and reprocess all 10 records, instead of finishing actions 9-10 first
- The `retry` command remains the dedicated path for selectively fixing partial failures

## Verification
- `ruff format --check` and `ruff check` clean
- 7422 tests pass, 0 failures
- Updated test `test_preserves_completed_with_failures` confirms the status is no longer reset