### PR TITLE
feat(processing): incremental checkpointing for online resume

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260531-536000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260531-536000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add incremental checkpointing for online processing — interrupted runs resume from the last checkpoint instead of reprocessing all records"
+time: 2026-05-31T053600.000000Z

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -199,6 +199,9 @@ class RetryCommand:
             # Clear node-level disposition so the executor doesn't see a
             # stale action-level FAILED/SKIPPED signal.
             backend.clear_disposition(action, record_id=NODE_LEVEL_RECORD_ID)
+            # Clear checkpoint records so stale partial output from a prior
+            # interrupted run is not carried forward instead of reprocessing.
+            backend.clear_checkpoint_records(action)
 
         self.console.print(
             f"\n[cyan]Cleared {cleared} disposition(s) for {len(record_ids)} record(s) "

--- a/agent_actions/processing/disposition_gate.py
+++ b/agent_actions/processing/disposition_gate.py
@@ -84,12 +84,6 @@ class DispositionGate:
             )
 
         terminal_ids = self._terminal_ids_cache[action_name]
-        print(
-            f"[CHECKPOINT DEBUG] DispositionGate[{action_name}]: "
-            f"{len(terminal_ids)} terminal IDs, {len(records)} input records"
-        )
-        if terminal_ids:
-            print(f"[CHECKPOINT DEBUG] Terminal IDs: {list(terminal_ids)[:5]}")
         if not terminal_ids:
             return records, set()
 
@@ -103,6 +97,12 @@ class DispositionGate:
                 carry_ids.add(rid)
 
         if carry_ids:
+            import click
+
+            click.echo(
+                f"  ⏩ Resuming {action_name}: {len(carry_ids)} record(s) carried forward, "
+                f"{len(to_process)} to process"
+            )
             logger.info(
                 "Action '%s': %d record(s) carried forward, %d to process",
                 action_name,
@@ -129,12 +129,10 @@ def build_carry_forward(
     """
     try:
         prior_output = storage_backend.read_target(action_name, relative_path)
-        print(f"[CHECKPOINT DEBUG] build_carry_forward: read_target returned {len(prior_output)} records")
     except FileNotFoundError:
         # No final output yet — check for checkpointed records from an
         # interrupted run.
         prior_output = storage_backend.read_checkpoint_records(action_name, relative_path)
-        print(f"[CHECKPOINT DEBUG] build_carry_forward: checkpoint fallback returned {len(prior_output)} records")
         if prior_output:
             logger.info(
                 "Action '%s': using %d checkpointed records for carry-forward",
@@ -158,8 +156,6 @@ def build_carry_forward(
             found.append(prior_by_guid[rid])
         else:
             missing.add(rid)
-    print(f"[CHECKPOINT DEBUG] build_carry_forward: found={len(found)}, missing={len(missing)}")
-
     if missing:
         logger.warning(
             "Action '%s': %d carry-forward records not found in prior output — will reprocess",

--- a/agent_actions/processing/disposition_gate.py
+++ b/agent_actions/processing/disposition_gate.py
@@ -97,12 +97,6 @@ class DispositionGate:
                 carry_ids.add(rid)
 
         if carry_ids:
-            import click
-
-            click.echo(
-                f"  ⏩ Resuming {action_name}: {len(carry_ids)} record(s) carried forward, "
-                f"{len(to_process)} to process"
-            )
             logger.info(
                 "Action '%s': %d record(s) carried forward, %d to process",
                 action_name,

--- a/agent_actions/processing/disposition_gate.py
+++ b/agent_actions/processing/disposition_gate.py
@@ -84,6 +84,12 @@ class DispositionGate:
             )
 
         terminal_ids = self._terminal_ids_cache[action_name]
+        print(
+            f"[CHECKPOINT DEBUG] DispositionGate[{action_name}]: "
+            f"{len(terminal_ids)} terminal IDs, {len(records)} input records"
+        )
+        if terminal_ids:
+            print(f"[CHECKPOINT DEBUG] Terminal IDs: {list(terminal_ids)[:5]}")
         if not terminal_ids:
             return records, set()
 
@@ -123,10 +129,12 @@ def build_carry_forward(
     """
     try:
         prior_output = storage_backend.read_target(action_name, relative_path)
+        print(f"[CHECKPOINT DEBUG] build_carry_forward: read_target returned {len(prior_output)} records")
     except FileNotFoundError:
         # No final output yet — check for checkpointed records from an
         # interrupted run.
         prior_output = storage_backend.read_checkpoint_records(action_name, relative_path)
+        print(f"[CHECKPOINT DEBUG] build_carry_forward: checkpoint fallback returned {len(prior_output)} records")
         if prior_output:
             logger.info(
                 "Action '%s': using %d checkpointed records for carry-forward",
@@ -150,6 +158,7 @@ def build_carry_forward(
             found.append(prior_by_guid[rid])
         else:
             missing.add(rid)
+    print(f"[CHECKPOINT DEBUG] build_carry_forward: found={len(found)}, missing={len(missing)}")
 
     if missing:
         logger.warning(

--- a/agent_actions/processing/disposition_gate.py
+++ b/agent_actions/processing/disposition_gate.py
@@ -124,13 +124,23 @@ def build_carry_forward(
     try:
         prior_output = storage_backend.read_target(action_name, relative_path)
     except FileNotFoundError:
-        logger.warning(
-            "Prior output missing for %s/%s — all %d carry-forward records will be reprocessed",
-            action_name,
-            relative_path,
-            len(carry_ids),
-        )
-        return [], carry_ids
+        # No final output yet — check for checkpointed records from an
+        # interrupted run.
+        prior_output = storage_backend.read_checkpoint_records(action_name, relative_path)
+        if prior_output:
+            logger.info(
+                "Action '%s': using %d checkpointed records for carry-forward",
+                action_name,
+                len(prior_output),
+            )
+        else:
+            logger.warning(
+                "Prior output missing for %s/%s — all %d carry-forward records will be reprocessed",
+                action_name,
+                relative_path,
+                len(carry_ids),
+            )
+            return [], carry_ids
 
     prior_by_guid = {r["source_guid"]: r for r in prior_output if r.get("source_guid")}
     found: list[dict[str, Any]] = []

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -7,11 +7,31 @@ every processing path (online, batch, FILE) behaves identically.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.record.reasons import RETRY_EXHAUSTED
 from agent_actions.utils.content import is_version_merge
+
+
+def derive_relative_path(file_path: str | None, output_directory: str | None) -> str | None:
+    """Derive relative storage key from file_path and output_directory.
+
+    Mirrors FileWriter.write_target() path resolution: if output_directory
+    is set, compute the relative path from it.  Falls back to filename-only.
+    Returns None if file_path is not set.
+    """
+    if not file_path:
+        return None
+    p = Path(file_path)
+    if output_directory:
+        try:
+            return str(p.relative_to(output_directory))
+        except ValueError:
+            pass
+    return p.name
+
 
 # Framework fields carried from input to output when the envelope builder
 # does not manage them automatically.

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -327,6 +327,8 @@ def collect_results_from_processing_results(
     *,
     storage_backend: Optional["StorageBackend"] = None,
     agent_config: dict[str, Any] | None = None,
+    checkpoint_interval: int = 0,
+    checkpoint_relative_path: str | None = None,
 ) -> tuple[list[dict[str, Any]], CollectionStats]:
     """Shared collect logic for both online and batch retrieve paths.
 
@@ -341,6 +343,10 @@ def collect_results_from_processing_results(
             and guard metadata in completion events). Pass ``None`` when
             calling from batch retrieve — exhausted-raise is not applicable
             and guard metadata is absent.
+        checkpoint_interval: Flush dispositions and append output records
+            to the checkpoint table every N records.  0 (default) disables.
+        checkpoint_relative_path: Storage key for checkpoint output.
+            Required when checkpoint_interval > 0.
 
     Returns:
         Tuple of (output_records, stats). Stats contain counts by status.
@@ -365,6 +371,7 @@ def collect_results_from_processing_results(
     output: list[dict[str, Any]] = []
     stats: collections.Counter[str] = collections.Counter()
     pending_dispositions: list[DispositionRow] = []
+    last_checkpoint_len = 0
 
     for idx, result in enumerate(results):
         status = result.status
@@ -685,7 +692,35 @@ def collect_results_from_processing_results(
         else:
             logger.debug("Unhandled result status=%s", status)  # type: ignore[unreachable]
 
-    # Flush all accumulated dispositions in a single transaction.
+        # Periodic checkpoint: flush dispositions and append new output records
+        # to the checkpoint table so interrupted runs can resume.
+        # Disposition flush and output append are gated independently —
+        # a checkpoint boundary with no new dispositions still saves output.
+        if checkpoint_interval > 0 and storage_backend and (idx + 1) % checkpoint_interval == 0:
+            try:
+                if pending_dispositions:
+                    storage_backend.set_dispositions_batch(pending_dispositions)
+                    pending_dispositions.clear()
+                if checkpoint_relative_path and len(output) > last_checkpoint_len:
+                    storage_backend.save_checkpoint_records(
+                        action_name, checkpoint_relative_path, output[last_checkpoint_len:]
+                    )
+                    last_checkpoint_len = len(output)
+                logger.info(
+                    "[%s] Checkpoint at record %d/%d",
+                    action_name,
+                    idx + 1,
+                    len(results),
+                )
+            except Exception:
+                logger.exception(
+                    "[%s] Checkpoint flush failed at record %d/%d",
+                    action_name,
+                    idx + 1,
+                    len(results),
+                )
+
+    # Flush remaining dispositions (tail after last checkpoint, or all if no checkpointing).
     if storage_backend and pending_dispositions:
         try:
             storage_backend.set_dispositions_batch(pending_dispositions)
@@ -695,6 +730,19 @@ def collect_results_from_processing_results(
                 len(pending_dispositions),
                 action_name,
             )
+    # Append any remaining output records to the checkpoint table.
+    if (
+        checkpoint_interval > 0
+        and storage_backend
+        and checkpoint_relative_path
+        and len(output) > last_checkpoint_len
+    ):
+        try:
+            storage_backend.save_checkpoint_records(
+                action_name, checkpoint_relative_path, output[last_checkpoint_len:]
+            )
+        except Exception:
+            logger.exception("[%s] Final checkpoint append failed", action_name)
 
     guard_config = effective_config.get("guard", {})
     guard_condition = guard_config.get("clause", "") if isinstance(guard_config, dict) else ""
@@ -759,6 +807,8 @@ class ResultCollector:
         *,
         is_first_stage: bool,
         storage_backend: Optional["StorageBackend"] = None,
+        checkpoint_interval: int = 0,
+        checkpoint_relative_path: str | None = None,
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Flatten ProcessingResult entries into output records.
 
@@ -776,6 +826,8 @@ class ResultCollector:
             agent_name,
             storage_backend=storage_backend,
             agent_config=agent_config,
+            checkpoint_interval=checkpoint_interval,
+            checkpoint_relative_path=checkpoint_relative_path,
         )
 
     @staticmethod

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -327,8 +327,6 @@ def collect_results_from_processing_results(
     *,
     storage_backend: Optional["StorageBackend"] = None,
     agent_config: dict[str, Any] | None = None,
-    checkpoint_interval: int = 0,
-    checkpoint_relative_path: str | None = None,
 ) -> tuple[list[dict[str, Any]], CollectionStats]:
     """Shared collect logic for both online and batch retrieve paths.
 
@@ -343,10 +341,6 @@ def collect_results_from_processing_results(
             and guard metadata in completion events). Pass ``None`` when
             calling from batch retrieve — exhausted-raise is not applicable
             and guard metadata is absent.
-        checkpoint_interval: Flush dispositions and append output records
-            to the checkpoint table every N records.  0 (default) disables.
-        checkpoint_relative_path: Storage key for checkpoint output.
-            Required when checkpoint_interval > 0.
 
     Returns:
         Tuple of (output_records, stats). Stats contain counts by status.
@@ -371,7 +365,6 @@ def collect_results_from_processing_results(
     output: list[dict[str, Any]] = []
     stats: collections.Counter[str] = collections.Counter()
     pending_dispositions: list[DispositionRow] = []
-    last_checkpoint_len = 0
 
     for idx, result in enumerate(results):
         status = result.status
@@ -692,35 +685,7 @@ def collect_results_from_processing_results(
         else:
             logger.debug("Unhandled result status=%s", status)  # type: ignore[unreachable]
 
-        # Periodic checkpoint: flush dispositions and append new output records
-        # to the checkpoint table so interrupted runs can resume.
-        # Disposition flush and output append are gated independently —
-        # a checkpoint boundary with no new dispositions still saves output.
-        if checkpoint_interval > 0 and storage_backend and (idx + 1) % checkpoint_interval == 0:
-            try:
-                if pending_dispositions:
-                    storage_backend.set_dispositions_batch(pending_dispositions)
-                    pending_dispositions.clear()
-                if checkpoint_relative_path and len(output) > last_checkpoint_len:
-                    storage_backend.save_checkpoint_records(
-                        action_name, checkpoint_relative_path, output[last_checkpoint_len:]
-                    )
-                    last_checkpoint_len = len(output)
-                logger.info(
-                    "[%s] Checkpoint at record %d/%d",
-                    action_name,
-                    idx + 1,
-                    len(results),
-                )
-            except Exception:
-                logger.exception(
-                    "[%s] Checkpoint flush failed at record %d/%d",
-                    action_name,
-                    idx + 1,
-                    len(results),
-                )
-
-    # Flush remaining dispositions (tail after last checkpoint, or all if no checkpointing).
+    # Flush all accumulated dispositions in a single transaction.
     if storage_backend and pending_dispositions:
         try:
             storage_backend.set_dispositions_batch(pending_dispositions)
@@ -730,19 +695,6 @@ def collect_results_from_processing_results(
                 len(pending_dispositions),
                 action_name,
             )
-    # Append any remaining output records to the checkpoint table.
-    if (
-        checkpoint_interval > 0
-        and storage_backend
-        and checkpoint_relative_path
-        and len(output) > last_checkpoint_len
-    ):
-        try:
-            storage_backend.save_checkpoint_records(
-                action_name, checkpoint_relative_path, output[last_checkpoint_len:]
-            )
-        except Exception:
-            logger.exception("[%s] Final checkpoint append failed", action_name)
 
     guard_config = effective_config.get("guard", {})
     guard_condition = guard_config.get("clause", "") if isinstance(guard_config, dict) else ""
@@ -807,8 +759,6 @@ class ResultCollector:
         *,
         is_first_stage: bool,
         storage_backend: Optional["StorageBackend"] = None,
-        checkpoint_interval: int = 0,
-        checkpoint_relative_path: str | None = None,
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Flatten ProcessingResult entries into output records.
 
@@ -826,8 +776,6 @@ class ResultCollector:
             agent_name,
             storage_backend=storage_backend,
             agent_config=agent_config,
-            checkpoint_interval=checkpoint_interval,
-            checkpoint_relative_path=checkpoint_relative_path,
         )
 
     @staticmethod

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -307,11 +307,8 @@ class OnlineLLMStrategy:
 
                 if relative_path:
                     backend.save_checkpoint_records(context.action_name, relative_path, result.data)
-            logger.info(
-                "[%s] Checkpointed record %s (%s)",
-                context.action_name,
-                result.source_guid,
-                disposition,
+            print(
+                f"[CHECKPOINT DEBUG] Saved {result.source_guid[:8]} ({disposition})"
             )
         except Exception:
             logger.warning(

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -6,6 +6,7 @@ transform output.
 
 import json
 import logging
+import sqlite3
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -32,6 +33,7 @@ from agent_actions.processing.record_helpers import (
     build_exhausted_tombstone,
     build_tombstone,
     carry_framework_fields,
+    derive_relative_path,
 )
 from agent_actions.processing.result_collector import _safe_set_disposition
 from agent_actions.processing.task_preparer import TaskPreparer, get_task_preparer
@@ -51,7 +53,7 @@ from agent_actions.record.reasons import (
     UPSTREAM_UNPROCESSED,
 )
 from agent_actions.record.state import RecordState
-from agent_actions.storage.backend import DISPOSITION_FAILED
+from agent_actions.storage.backend import DISPOSITION_FAILED, DISPOSITION_SUCCESS
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
@@ -275,8 +277,6 @@ class OnlineLLMStrategy:
         if not backend or not result.source_guid:
             return
 
-        from agent_actions.storage.backend import DISPOSITION_FAILED, DISPOSITION_SUCCESS
-
         disposition = (
             DISPOSITION_SUCCESS if result.status == ProcessingStatus.SUCCESS else DISPOSITION_FAILED
         )
@@ -290,18 +290,20 @@ class OnlineLLMStrategy:
                 reason=reason,
             )
             if result.data:
-                from agent_actions.processing.unified import UnifiedProcessor
-                from agent_actions.record.state import RecordState
-
-                relative_path = UnifiedProcessor._get_carry_forward_path(context)
+                relative_path = derive_relative_path(context.file_path, context.output_directory)
                 if relative_path:
-                    # Stamp lifecycle state so downstream actions accept
-                    # carried-forward records without validation errors.
-                    for item in result.data:
-                        if isinstance(item, dict) and "_state" not in item:
-                            item["_state"] = RecordState.PROCESSED
-                    backend.save_checkpoint_records(context.action_name, relative_path, result.data)
-            # Console: user sees progress. Logger: goes to log files.
+                    # Copy records to avoid mutating result.data in-place —
+                    # downstream consumers (enrichment, collectors) hold
+                    # references to the same dicts.
+                    checkpoint_records = [
+                        {**item, "_state": RecordState.PROCESSED}
+                        if isinstance(item, dict) and "_state" not in item
+                        else item
+                        for item in result.data
+                    ]
+                    backend.save_checkpoint_records(
+                        context.action_name, relative_path, checkpoint_records
+                    )
             import click
 
             click.echo(f"  ✓ Checkpointed {result.source_guid[:8]}... ({disposition})")
@@ -311,11 +313,12 @@ class OnlineLLMStrategy:
                 result.source_guid,
                 disposition,
             )
-        except Exception:
+        except (OSError, sqlite3.Error):
             logger.warning(
                 "[%s] Checkpoint write failed for %s — will reprocess on resume",
                 context.action_name,
                 result.source_guid,
+                exc_info=True,
             )
 
     def process_record(

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -290,25 +290,26 @@ class OnlineLLMStrategy:
                 reason=reason,
             )
             if result.data:
-                relative_path = context.file_path
-                if relative_path and context.output_directory:
-                    from pathlib import Path
+                from agent_actions.processing.unified import UnifiedProcessor
+                from agent_actions.record.state import RecordState
 
-                    try:
-                        relative_path = str(
-                            Path(relative_path).relative_to(context.output_directory)
-                        )
-                    except ValueError:
-                        relative_path = Path(relative_path).name
-                elif relative_path:
-                    from pathlib import Path
-
-                    relative_path = Path(relative_path).name
-
+                relative_path = UnifiedProcessor._get_carry_forward_path(context)
                 if relative_path:
+                    # Stamp lifecycle state so downstream actions accept
+                    # carried-forward records without validation errors.
+                    for item in result.data:
+                        if isinstance(item, dict) and "_state" not in item:
+                            item["_state"] = RecordState.PROCESSED
                     backend.save_checkpoint_records(context.action_name, relative_path, result.data)
-            print(
-                f"[CHECKPOINT DEBUG] Saved {result.source_guid[:8]} ({disposition})"
+            # Console: user sees progress. Logger: goes to log files.
+            import click
+
+            click.echo(f"  ✓ Checkpointed {result.source_guid[:8]}... ({disposition})")
+            logger.info(
+                "[%s] Checkpointed record %s (%s)",
+                context.action_name,
+                result.source_guid,
+                disposition,
             )
         except Exception:
             logger.warning(

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -304,9 +304,6 @@ class OnlineLLMStrategy:
                     backend.save_checkpoint_records(
                         context.action_name, relative_path, checkpoint_records
                     )
-            import click
-
-            click.echo(f"  ✓ Checkpointed {result.source_guid[:8]}... ({disposition})")
             logger.info(
                 "[%s] Checkpointed record %s (%s)",
                 context.action_name,

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -171,6 +171,11 @@ class OnlineLLMStrategy:
                 elif result.status == ProcessingStatus.FAILED:
                     failures += 1
 
+                # Checkpoint: commit this record's result to SQLite immediately
+                # so interrupted runs can resume from where they left off.
+                if context.storage_backend and result.source_guid:
+                    self._checkpoint_record(result, context)
+
                 if (idx + 1) % 10 == 0 or (idx + 1) == len(records):
                     fire_event(
                         BatchProcessingProgressEvent(
@@ -258,6 +263,62 @@ class OnlineLLMStrategy:
         )
 
         return results
+
+    @staticmethod
+    def _checkpoint_record(result: ProcessingResult, context: ProcessingContext) -> None:
+        """Write a single record's disposition and output to SQLite immediately.
+
+        Called after each record's LLM call completes so that interrupted
+        runs can resume via the DispositionGate carry-forward path.
+        """
+        backend = context.storage_backend
+        if not backend or not result.source_guid:
+            return
+
+        from agent_actions.storage.backend import DISPOSITION_FAILED, DISPOSITION_SUCCESS
+
+        disposition = (
+            DISPOSITION_SUCCESS if result.status == ProcessingStatus.SUCCESS else DISPOSITION_FAILED
+        )
+        reason = result.error if result.status == ProcessingStatus.FAILED else None
+
+        try:
+            backend.set_disposition(
+                context.action_name,
+                result.source_guid,
+                disposition,
+                reason=reason,
+            )
+            if result.data:
+                relative_path = context.file_path
+                if relative_path and context.output_directory:
+                    from pathlib import Path
+
+                    try:
+                        relative_path = str(
+                            Path(relative_path).relative_to(context.output_directory)
+                        )
+                    except ValueError:
+                        relative_path = Path(relative_path).name
+                elif relative_path:
+                    from pathlib import Path
+
+                    relative_path = Path(relative_path).name
+
+                if relative_path:
+                    backend.save_checkpoint_records(context.action_name, relative_path, result.data)
+            logger.info(
+                "[%s] Checkpointed record %s (%s)",
+                context.action_name,
+                result.source_guid,
+                disposition,
+            )
+        except Exception:
+            logger.warning(
+                "[%s] Checkpoint write failed for %s — will reprocess on resume",
+                context.action_name,
+                result.source_guid,
+            )
 
     def process_record(
         self, item: Any, context: ProcessingContext, *, skip_guard: bool = False

--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -139,7 +139,12 @@ class TaskPreparer:
         """Normalize input to (content, source_guid, source_snapshot)."""
         if context.is_first_stage:
             source_guid: str | None
-            if self._id_generator:
+            # Prefer existing source_guid (e.g., deterministic content-hash
+            # assigned for checkpoint resume) over generating a new one.
+            existing = item.get("source_guid") if isinstance(item, dict) else None
+            if existing:
+                source_guid = existing
+            elif self._id_generator:
                 source_guid = self._id_generator(item)
             else:
                 source_guid = IDGenerator.generate_source_guid()

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -23,6 +23,7 @@ from agent_actions.processing.types import (
 )
 from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.record.reasons import GUARD_PREFILTER_SKIP, GUARD_SKIP
+from agent_actions.utils.id_generation import IDGenerator
 from agent_actions.workflow.pipeline_file_mode import prefilter_by_guard
 
 if TYPE_CHECKING:
@@ -118,8 +119,6 @@ class UnifiedProcessor:
         # them to checkpointed dispositions across runs.  UUID5 from content
         # ensures the same input record gets the same guid every time.
         if context.is_first_stage:
-            from agent_actions.utils.id_generation import IDGenerator
-
             for record in passing:
                 if not record.get("source_guid"):
                     record["source_guid"] = IDGenerator.generate_content_hash(record)

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -82,7 +82,6 @@ class UnifiedProcessor:
         strategy: ProcessingStrategy,
         *,
         raw_records: list[dict[str, Any]] | None = None,
-        checkpoint_interval: int = 0,
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Run records through the full processing pipeline.
 
@@ -191,7 +190,7 @@ class UnifiedProcessor:
         if carry_results:
             enriched.extend(carry_results)
 
-        return self._collect(enriched, context, checkpoint_interval=checkpoint_interval)
+        return self._collect(enriched, context)
 
     @staticmethod
     def _get_carry_forward_path(context: ProcessingContext) -> str | None:
@@ -384,21 +383,14 @@ class UnifiedProcessor:
         self,
         results: list[ProcessingResult],
         context: ProcessingContext,
-        *,
-        checkpoint_interval: int = 0,
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Collect results into output records with stats."""
-        checkpoint_relative_path = (
-            self._get_carry_forward_path(context) if checkpoint_interval > 0 else None
-        )
         return ResultCollector.collect_results(
             results,
             cast(dict[str, Any], context.agent_config),
             context.agent_name,
             is_first_stage=context.is_first_stage,
             storage_backend=context.storage_backend,
-            checkpoint_interval=checkpoint_interval,
-            checkpoint_relative_path=checkpoint_relative_path,
         )
 
 

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -82,6 +82,7 @@ class UnifiedProcessor:
         strategy: ProcessingStrategy,
         *,
         raw_records: list[dict[str, Any]] | None = None,
+        checkpoint_interval: int = 0,
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Run records through the full processing pipeline.
 
@@ -190,7 +191,7 @@ class UnifiedProcessor:
         if carry_results:
             enriched.extend(carry_results)
 
-        return self._collect(enriched, context)
+        return self._collect(enriched, context, checkpoint_interval=checkpoint_interval)
 
     @staticmethod
     def _get_carry_forward_path(context: ProcessingContext) -> str | None:
@@ -330,6 +331,8 @@ class UnifiedProcessor:
         Used by batch retrieve where guard filtering and strategy invocation
         happened separately (at batch submit and result processing time).
         The results flow through the shared enrichment pipeline and collector.
+        Checkpointing is intentionally disabled — batch results arrive
+        atomically and do not need mid-collection checkpoints.
 
         Args:
             results: ProcessingResult objects (from BatchResultStrategy.process).
@@ -381,14 +384,21 @@ class UnifiedProcessor:
         self,
         results: list[ProcessingResult],
         context: ProcessingContext,
+        *,
+        checkpoint_interval: int = 0,
     ) -> tuple[list[dict[str, Any]], CollectionStats]:
         """Collect results into output records with stats."""
+        checkpoint_relative_path = (
+            self._get_carry_forward_path(context) if checkpoint_interval > 0 else None
+        )
         return ResultCollector.collect_results(
             results,
             cast(dict[str, Any], context.agent_config),
             context.agent_name,
             is_first_stage=context.is_first_stage,
             storage_backend=context.storage_backend,
+            checkpoint_interval=checkpoint_interval,
+            checkpoint_relative_path=checkpoint_relative_path,
         )
 
 

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -130,11 +130,6 @@ class UnifiedProcessor:
             to_process, carry_ids = self._disposition_gate.filter(passing, context.action_name)
             if carry_ids:
                 relative_path = self._get_carry_forward_path(context)
-                print(
-                    f"[CHECKPOINT DEBUG] carry_ids={len(carry_ids)}, "
-                    f"relative_path={relative_path}, "
-                    f"has_backend={context.storage_backend is not None}"
-                )
                 if relative_path and context.storage_backend:
                     from agent_actions.processing.disposition_gate import (
                         CARRY_FORWARD_REASON,

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -114,11 +114,27 @@ class UnifiedProcessor:
         else:
             passing, guard_results = self._guard_filter(records, context)
 
+        # First-stage records arrive without source_guid — assign a
+        # deterministic one (content hash) so the DispositionGate can match
+        # them to checkpointed dispositions across runs.  UUID5 from content
+        # ensures the same input record gets the same guid every time.
+        if context.is_first_stage:
+            from agent_actions.utils.id_generation import IDGenerator
+
+            for record in passing:
+                if not record.get("source_guid"):
+                    record["source_guid"] = IDGenerator.generate_content_hash(record)
+
         carry_results: list[ProcessingResult] = []
         if self._disposition_gate is not None and passing:
             to_process, carry_ids = self._disposition_gate.filter(passing, context.action_name)
             if carry_ids:
                 relative_path = self._get_carry_forward_path(context)
+                print(
+                    f"[CHECKPOINT DEBUG] carry_ids={len(carry_ids)}, "
+                    f"relative_path={relative_path}, "
+                    f"has_backend={context.storage_backend is not None}"
+                )
                 if relative_path and context.storage_backend:
                     from agent_actions.processing.disposition_gate import (
                         CARRY_FORWARD_REASON,

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 from agent_actions.processing.cascade_filter import partition_cascade_records
@@ -205,23 +204,13 @@ class UnifiedProcessor:
 
     @staticmethod
     def _get_carry_forward_path(context: ProcessingContext) -> str | None:
-        """Derive relative_path for read_target from ProcessingContext.
+        """Derive relative_path for read_target from ProcessingContext."""
+        from agent_actions.processing.record_helpers import derive_relative_path
 
-        Mirrors FileWriter.write_target() path resolution: if output_directory
-        is set, compute the relative path from it (preserving subdirectories).
-        Falls back to filename-only when output_directory is unavailable.
-        """
-        file_path = getattr(context, "file_path", None)
-        if not file_path:
-            return None
-        p = Path(file_path)
-        output_dir = getattr(context, "output_directory", None)
-        if output_dir:
-            try:
-                return str(p.relative_to(output_dir))
-            except ValueError:
-                pass
-        return p.name
+        return derive_relative_path(
+            getattr(context, "file_path", None),
+            getattr(context, "output_directory", None),
+        )
 
     def _guard_filter(
         self,

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -44,6 +44,14 @@ VALID_DISPOSITIONS = frozenset(d.value for d in Disposition)
 # filtered (predicate), deferred (in-flight HITL/batch).
 FAILURE_DISPOSITIONS = frozenset({DISPOSITION_FAILED, DISPOSITION_EXHAUSTED})
 
+# Dispositions cleared when resuming an interrupted (RUNNING) action.
+# Includes DEFERRED because in-flight batch/HITL items must be re-submitted.
+# Excludes SUCCESS, PASSTHROUGH, FILTERED, SKIPPED so that checkpointed
+# progress survives and the DispositionGate can carry it forward.
+RUNNING_CLEAR_DISPOSITIONS = frozenset(
+    {DISPOSITION_FAILED, DISPOSITION_EXHAUSTED, DISPOSITION_DEFERRED}
+)
+
 DispositionRow = tuple[str, str, str, str | None, str | None, str | None, str | None]
 """(action_name, record_id, disposition, reason, relative_path, input_snapshot, detail)."""
 

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -219,6 +219,37 @@ class StorageBackend(ABC):
         """Delete matching disposition records. Returns count deleted."""
         return 0
 
+    def save_checkpoint_records(  # noqa: B027
+        self,
+        action_name: str,
+        relative_path: str,
+        records: list[dict[str, Any]],
+    ) -> None:
+        """Append records to the checkpoint output table.
+
+        Used for incremental checkpointing during online processing.
+        Each call appends new records — it does NOT replace prior rows.
+        """
+
+    def read_checkpoint_records(
+        self,
+        action_name: str,
+        relative_path: str,
+    ) -> list[dict[str, Any]]:
+        """Read all checkpointed records for an action/path."""
+        return []
+
+    def clear_checkpoint_records(  # noqa: B027
+        self,
+        action_name: str,
+        relative_path: str | None = None,
+    ) -> None:
+        """Delete checkpoint records for an action after successful completion.
+
+        If relative_path is provided, only records for that path are cleared.
+        Otherwise all checkpoint records for the action are removed.
+        """
+
     def get_failed_items(self, action_name: str) -> list[dict[str, Any]]:
         """Return item-level failure dispositions, excluding node-level sentinels."""
         return [

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -225,10 +225,10 @@ class StorageBackend(ABC):
         relative_path: str,
         records: list[dict[str, Any]],
     ) -> None:
-        """Append records to the checkpoint output table.
+        """Upsert records into the checkpoint output table.
 
         Used for incremental checkpointing during online processing.
-        Each call appends new records — it does NOT replace prior rows.
+        Uses INSERT OR REPLACE keyed on (action_name, relative_path, source_guid).
         """
 
     def read_checkpoint_records(

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -111,7 +111,8 @@ class SQLiteBackend(StorageBackend):
             relative_path TEXT NOT NULL,
             source_guid TEXT,
             record_data TEXT NOT NULL,
-            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(action_name, relative_path, source_guid)
         )
     """
     CHECKPOINT_INDEX_SQL = """
@@ -935,7 +936,8 @@ class SQLiteBackend(StorageBackend):
             cursor = self.connection.cursor()
             try:
                 cursor.executemany(
-                    "INSERT INTO checkpoint_output (action_name, relative_path, source_guid, record_data) "
+                    "INSERT OR REPLACE INTO checkpoint_output "
+                    "(action_name, relative_path, source_guid, record_data) "
                     "VALUES (?, ?, ?, ?)",
                     rows,
                 )

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -104,6 +104,21 @@ class SQLiteBackend(StorageBackend):
         CREATE INDEX IF NOT EXISTS idx_trace_action_record ON prompt_trace(action_name, record_id)
     """
 
+    CHECKPOINT_TABLE_SQL = """
+        CREATE TABLE IF NOT EXISTS checkpoint_output (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            action_name TEXT NOT NULL,
+            relative_path TEXT NOT NULL,
+            source_guid TEXT,
+            record_data TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    """
+    CHECKPOINT_INDEX_SQL = """
+        CREATE INDEX IF NOT EXISTS idx_checkpoint_action
+        ON checkpoint_output(action_name, relative_path)
+    """
+
     _MAX_TRACE_FIELD_SIZE = 1_048_576  # 1MB
 
     # Required columns per table — schema enforcement drops tables missing any.
@@ -239,6 +254,8 @@ class SQLiteBackend(StorageBackend):
                 cursor.execute(self.PROMPT_TRACE_TABLE_SQL)
                 cursor.execute(self.TRACE_INDEX_ACTION_SQL)
                 cursor.execute(self.TRACE_INDEX_ACTION_RECORD_SQL)
+                cursor.execute(self.CHECKPOINT_TABLE_SQL)
+                cursor.execute(self.CHECKPOINT_INDEX_SQL)
                 self.connection.commit()
                 logger.info(
                     "Initialized SQLite storage backend: %s",
@@ -888,6 +905,98 @@ class SQLiteBackend(StorageBackend):
                     },
                 )
                 raise
+
+    # ------------------------------------------------------------------
+    # Checkpoint output (incremental online processing)
+    # ------------------------------------------------------------------
+
+    def save_checkpoint_records(
+        self,
+        action_name: str,
+        relative_path: str,
+        records: list[dict[str, Any]],
+    ) -> None:
+        """Append records to the checkpoint output table."""
+        if not records:
+            return
+        action_name = self._validate_identifier(action_name, "action_name")
+        relative_path = self._validate_identifier(relative_path, "relative_path")
+
+        rows = [
+            (
+                action_name,
+                relative_path,
+                r.get("source_guid", ""),
+                json.dumps(r, ensure_ascii=False),
+            )
+            for r in records
+        ]
+        with self._lock:
+            cursor = self.connection.cursor()
+            try:
+                cursor.executemany(
+                    "INSERT INTO checkpoint_output (action_name, relative_path, source_guid, record_data) "
+                    "VALUES (?, ?, ?, ?)",
+                    rows,
+                )
+                self.connection.commit()
+                logger.debug(
+                    "Checkpointed %d records for %s/%s",
+                    len(records),
+                    action_name,
+                    relative_path,
+                    extra={"workflow_name": self.workflow_name},
+                )
+            except sqlite3.Error as e:
+                self.connection.rollback()
+                logger.error(
+                    "Failed to save checkpoint records: %s",
+                    e,
+                    extra={"workflow_name": self.workflow_name},
+                )
+                raise
+
+    def read_checkpoint_records(
+        self,
+        action_name: str,
+        relative_path: str,
+    ) -> list[dict[str, Any]]:
+        """Read all checkpointed records for an action/path."""
+        action_name = self._validate_identifier(action_name, "action_name")
+        relative_path = self._validate_identifier(relative_path, "relative_path")
+
+        with self._lock:
+            cursor = self.connection.cursor()
+            cursor.execute(
+                "SELECT record_data FROM checkpoint_output "
+                "WHERE action_name = ? AND relative_path = ? ORDER BY id",
+                (action_name, relative_path),
+            )
+            return [json.loads(row["record_data"]) for row in cursor.fetchall()]
+
+    def clear_checkpoint_records(self, action_name: str, relative_path: str | None = None) -> None:
+        """Delete checkpoint records for an action (optionally scoped to one path)."""
+        action_name = self._validate_identifier(action_name, "action_name")
+
+        query = "DELETE FROM checkpoint_output WHERE action_name = ?"
+        params: list[str] = [action_name]
+        if relative_path is not None:
+            relative_path = self._validate_identifier(relative_path, "relative_path")
+            query += " AND relative_path = ?"
+            params.append(relative_path)
+
+        with self._lock:
+            cursor = self.connection.cursor()
+            cursor.execute(query, params)
+            deleted = cursor.rowcount
+            self.connection.commit()
+            if deleted > 0:
+                logger.debug(
+                    "Cleared %d checkpoint records for %s",
+                    deleted,
+                    action_name,
+                    extra={"workflow_name": self.workflow_name},
+                )
 
     # ------------------------------------------------------------------
     # Prompt trace tracking

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -282,6 +282,7 @@ class AgentWorkflow:
                 self.storage_backend.delete_target(action_name)
                 self.storage_backend.clear_disposition(action_name)
                 self.storage_backend.clear_prompt_traces(action_name)
+                self.storage_backend.clear_checkpoint_records(action_name)
             except Exception as e:
                 logger.warning("Failed to clear stored data for %s: %s", action_name, e)
 

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         ComparisonNode,
     )
 from agent_actions.logging.core.manager import get_manager
+from agent_actions.storage.backend import RUNNING_CLEAR_DISPOSITIONS
 from agent_actions.workflow.config_pipeline import load_workflow_configs
 from agent_actions.workflow.execution_events import WorkflowEventLogger
 from agent_actions.workflow.managers.state import ActionStatus
@@ -322,17 +323,31 @@ class AgentWorkflow:
     def _reset_retryable_actions(self) -> None:
         """Reset failed/skipped/running actions to pending so re-runs retry them.
 
-        Clears ALL dispositions for each reset action — disposition is derived
-        state that must follow action status, not override it.  Stale
-        record-level dispositions (e.g. upstream_unprocessed) would otherwise
-        silently block the rerun.
+        For most statuses, clears ALL dispositions — disposition is derived
+        state that must follow action status.  For RUNNING actions (interrupted
+        mid-processing), only failure dispositions are cleared so that
+        checkpointed SUCCESS rows survive and the DispositionGate can carry
+        them forward on resume.
         """
-        reset_actions = self.services.core.state_manager.reset_retryable()
+        state_mgr = self.services.core.state_manager
+        # Snapshot RUNNING actions before reset_retryable() transitions them
+        # to PENDING — must be captured first so we know which actions had
+        # checkpointed progress to preserve.
+        running_actions = {
+            name
+            for name in state_mgr.execution_order
+            if state_mgr.get_status(name) == ActionStatus.RUNNING
+        }
+        reset_actions = state_mgr.reset_retryable()
         if not reset_actions:
             return
         for action_name in reset_actions:
             try:
-                self.storage_backend.clear_disposition(action_name)
+                if action_name in running_actions:
+                    for disp in RUNNING_CLEAR_DISPOSITIONS:
+                        self.storage_backend.clear_disposition(action_name, disp)
+                else:
+                    self.storage_backend.clear_disposition(action_name)
                 self.storage_backend.clear_prompt_traces(action_name)
             except Exception as e:
                 logger.warning("Failed to clear stored data for %s: %s", action_name, e)

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -588,6 +588,10 @@ class ProcessingPipeline:
 
         self.output_handler.save_main_output(output, file_path, base_directory, output_directory)
 
+        # Clean up checkpoint records after successful output write.
+        if self.config.storage_backend:
+            self.config.storage_backend.clear_checkpoint_records(self.config.action_name)
+
     def _select_strategy(self) -> ProcessingStrategy:
         """Select the processing strategy based on granularity and action kind."""
         if self.granularity == "file":

--- a/tests/manual/test_checkpoint_e2e.py
+++ b/tests/manual/test_checkpoint_e2e.py
@@ -1,0 +1,220 @@
+"""Manual end-to-end test: checkpoint + resume for first-stage online processing.
+
+Calls the actual modules in the exact order the real pipeline does,
+with a real SQLite backend, to verify checkpoint resume works.
+
+Run: python tests/manual/test_checkpoint_e2e.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent_actions.processing.disposition_gate import DispositionGate, build_carry_forward
+from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+from agent_actions.utils.id_generation import IDGenerator
+
+# ── Setup ──────────────────────────────────────────────────────────────
+
+import tempfile
+
+tmp = tempfile.mkdtemp()
+db_path = f"{tmp}/test.db"
+backend = SQLiteBackend.create(db_path=db_path, workflow_name="test_wf")
+backend.initialize()
+
+print(f"DB: {db_path}")
+print()
+
+# ── Input records (no source_guid, like real staging files) ────────────
+
+INPUT_RECORDS = [
+    {"id": "page1", "url": "https://example.com/1", "page_content": "Content about Python basics"},
+    {"id": "page2", "url": "https://example.com/2", "page_content": "Content about async/await"},
+    {"id": "page3", "url": "https://example.com/3", "page_content": "Content about testing"},
+]
+
+ACTION_NAME = "summarize_page_content"
+RELATIVE_PATH = "combined_scraped.json"
+OUTPUT_DIR = f"{tmp}/output"
+FILE_PATH = f"{OUTPUT_DIR}/{RELATIVE_PATH}"
+
+Path(OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+
+
+def make_context(records):
+    return ProcessingContext(
+        agent_config={},
+        agent_name=ACTION_NAME,
+        is_first_stage=True,
+        storage_backend=backend,
+        file_path=FILE_PATH,
+        output_directory=OUTPUT_DIR,
+        source_data=records,
+    )
+
+
+def assign_deterministic_guids(records):
+    """Same logic as unified.py — assign content-hash guid to first-stage records."""
+    for r in records:
+        if not r.get("source_guid"):
+            r["source_guid"] = IDGenerator.generate_content_hash(r)
+
+
+def simulate_llm_result(record, idx):
+    """Fake an LLM SUCCESS result for a record."""
+    return ProcessingResult(
+        status=ProcessingStatus.SUCCESS,
+        data=[{
+            "source_guid": record["source_guid"],
+            "content": {"summary": f"Summary of {record['id']}"},
+            "target_id": f"target_{idx}",
+            "node_id": ACTION_NAME,
+        }],
+        source_guid=record["source_guid"],
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# STEP 1: First run — guid assignment
+# ══════════════════════════════════════════════════════════════════════
+
+print("=" * 60)
+print("STEP 1: Assign deterministic guids (first run)")
+print("=" * 60)
+
+records_run1 = [r.copy() for r in INPUT_RECORDS]
+assign_deterministic_guids(records_run1)
+
+for r in records_run1:
+    print(f"  {r['id']}: source_guid={r['source_guid'][:12]}...")
+
+guids = [r["source_guid"] for r in records_run1]
+print()
+
+# ══════════════════════════════════════════════════════════════════════
+# STEP 2: Gate filter (first run — no terminal IDs)
+# ══════════════════════════════════════════════════════════════════════
+
+print("=" * 60)
+print("STEP 2: DispositionGate filter (first run)")
+print("=" * 60)
+
+gate1 = DispositionGate(storage_backend=backend)
+to_process, carry_ids = gate1.filter(records_run1, ACTION_NAME)
+
+print(f"  Terminal IDs: {backend.get_terminal_record_ids(ACTION_NAME)}")
+print(f"  carry_ids: {carry_ids}")
+print(f"  to_process: {len(to_process)} records")
+assert len(carry_ids) == 0, "First run should have no carry-forward"
+assert len(to_process) == 3, "All 3 records should be processed"
+print("  ✓ PASS: all 3 records to process")
+print()
+
+# ══════════════════════════════════════════════════════════════════════
+# STEP 3: Process record 0, checkpoint it, "crash" before record 1
+# ══════════════════════════════════════════════════════════════════════
+
+print("=" * 60)
+print("STEP 3: Process record 0, checkpoint, simulate crash")
+print("=" * 60)
+
+result0 = simulate_llm_result(records_run1[0], 0)
+ctx = make_context(records_run1)
+
+# Call the real _checkpoint_record
+OnlineLLMStrategy._checkpoint_record(result0, ctx)
+
+print(f"  Checkpointed: {result0.source_guid[:12]}... ({result0.status.value})")
+
+# Verify in DB
+terminal_ids = backend.get_terminal_record_ids(ACTION_NAME)
+checkpoint_records = backend.read_checkpoint_records(ACTION_NAME, RELATIVE_PATH)
+print(f"  Terminal IDs in DB: {terminal_ids}")
+print(f"  Checkpoint records in DB: {len(checkpoint_records)}")
+assert result0.source_guid in terminal_ids, "Checkpointed guid should be terminal"
+assert len(checkpoint_records) == 1, "Should have 1 checkpoint record"
+print("  ✓ PASS: checkpoint persisted to SQLite")
+print()
+print("  --- SIMULATED CRASH (Ctrl+C) ---")
+print()
+
+# ══════════════════════════════════════════════════════════════════════
+# STEP 4: Second run — assign guids again (deterministic = same)
+# ══════════════════════════════════════════════════════════════════════
+
+print("=" * 60)
+print("STEP 4: Assign deterministic guids (second run)")
+print("=" * 60)
+
+records_run2 = [r.copy() for r in INPUT_RECORDS]  # Fresh from staging
+assign_deterministic_guids(records_run2)
+
+for i, r in enumerate(records_run2):
+    match = "✓ SAME" if r["source_guid"] == guids[i] else "✗ DIFFERENT"
+    print(f"  {r['id']}: {r['source_guid'][:12]}... {match}")
+
+assert records_run2[0]["source_guid"] == guids[0], "Deterministic guid should match!"
+print("  ✓ PASS: guids are deterministic across runs")
+print()
+
+# ══════════════════════════════════════════════════════════════════════
+# STEP 5: Gate filter (second run — should carry forward record 0)
+# ══════════════════════════════════════════════════════════════════════
+
+print("=" * 60)
+print("STEP 5: DispositionGate filter (second run)")
+print("=" * 60)
+
+# New gate instance (simulates fresh workflow startup)
+gate2 = DispositionGate(storage_backend=backend)
+to_process2, carry_ids2 = gate2.filter(records_run2, ACTION_NAME)
+
+print(f"  Terminal IDs: {backend.get_terminal_record_ids(ACTION_NAME)}")
+print(f"  carry_ids: {carry_ids2}")
+print(f"  to_process: {len(to_process2)} records")
+
+assert len(carry_ids2) == 1, f"Should carry forward 1 record, got {len(carry_ids2)}"
+assert guids[0] in carry_ids2, "Record 0 should be carried forward"
+assert len(to_process2) == 2, f"Should process 2 remaining records, got {len(to_process2)}"
+print("  ✓ PASS: 1 carried forward, 2 to process")
+print()
+
+# ══════════════════════════════════════════════════════════════════════
+# STEP 6: build_carry_forward (read checkpoint data for carried record)
+# ══════════════════════════════════════════════════════════════════════
+
+print("=" * 60)
+print("STEP 6: build_carry_forward (checkpoint fallback)")
+print("=" * 60)
+
+carry_data, missing = build_carry_forward(carry_ids2, ACTION_NAME, RELATIVE_PATH, backend)
+
+print(f"  Found: {len(carry_data)} records")
+print(f"  Missing: {missing}")
+
+assert len(carry_data) == 1, f"Should find 1 carried record, got {len(carry_data)}"
+assert len(missing) == 0, f"Should have 0 missing, got {len(missing)}"
+assert carry_data[0]["source_guid"] == guids[0], "Carried record should match"
+print("  ✓ PASS: checkpoint data recovered for carried record")
+print()
+
+# ══════════════════════════════════════════════════════════════════════
+# SUMMARY
+# ══════════════════════════════════════════════════════════════════════
+
+print("=" * 60)
+print("ALL STEPS PASSED")
+print("=" * 60)
+print()
+print("Checkpoint resume works correctly:")
+print(f"  • Record 0 ({guids[0][:12]}...): carried forward (no LLM call needed)")
+print(f"  • Record 1 ({guids[1][:12]}...): would be reprocessed")
+print(f"  • Record 2 ({guids[2][:12]}...): would be reprocessed")
+print()
+print(f"Saved {1} LLM call out of {3} on resume.")

--- a/tests/manual/test_checkpoint_e2e.py
+++ b/tests/manual/test_checkpoint_e2e.py
@@ -70,12 +70,14 @@ def simulate_llm_result(record, idx):
     """Fake an LLM SUCCESS result for a record."""
     return ProcessingResult(
         status=ProcessingStatus.SUCCESS,
-        data=[{
-            "source_guid": record["source_guid"],
-            "content": {"summary": f"Summary of {record['id']}"},
-            "target_id": f"target_{idx}",
-            "node_id": ACTION_NAME,
-        }],
+        data=[
+            {
+                "source_guid": record["source_guid"],
+                "content": {"summary": f"Summary of {record['id']}"},
+                "target_id": f"target_{idx}",
+                "node_id": ACTION_NAME,
+            }
+        ],
         source_guid=record["source_guid"],
     )
 

--- a/tests/manual/test_checkpoint_e2e.py
+++ b/tests/manual/test_checkpoint_e2e.py
@@ -6,217 +6,219 @@ with a real SQLite backend, to verify checkpoint resume works.
 Run: python tests/manual/test_checkpoint_e2e.py
 """
 
-import json
 import sys
 from pathlib import Path
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from agent_actions.processing.disposition_gate import DispositionGate, build_carry_forward
-from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
-from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
-from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
-from agent_actions.utils.id_generation import IDGenerator
 
-# ── Setup ──────────────────────────────────────────────────────────────
+def main():
+    import tempfile
 
-import tempfile
+    from agent_actions.processing.disposition_gate import DispositionGate, build_carry_forward
+    from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+    from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
+    from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+    from agent_actions.utils.id_generation import IDGenerator
 
-tmp = tempfile.mkdtemp()
-db_path = f"{tmp}/test.db"
-backend = SQLiteBackend.create(db_path=db_path, workflow_name="test_wf")
-backend.initialize()
+    # ── Setup ──────────────────────────────────────────────────────────
 
-print(f"DB: {db_path}")
-print()
+    tmp = tempfile.mkdtemp()
+    db_path = f"{tmp}/test.db"
+    backend = SQLiteBackend.create(db_path=db_path, workflow_name="test_wf")
+    backend.initialize()
 
-# ── Input records (no source_guid, like real staging files) ────────────
+    print(f"DB: {db_path}")
+    print()
 
-INPUT_RECORDS = [
-    {"id": "page1", "url": "https://example.com/1", "page_content": "Content about Python basics"},
-    {"id": "page2", "url": "https://example.com/2", "page_content": "Content about async/await"},
-    {"id": "page3", "url": "https://example.com/3", "page_content": "Content about testing"},
-]
+    INPUT_RECORDS = [
+        {
+            "id": "page1",
+            "url": "https://example.com/1",
+            "page_content": "Content about Python basics",
+        },
+        {
+            "id": "page2",
+            "url": "https://example.com/2",
+            "page_content": "Content about async/await",
+        },
+        {"id": "page3", "url": "https://example.com/3", "page_content": "Content about testing"},
+    ]
 
-ACTION_NAME = "summarize_page_content"
-RELATIVE_PATH = "combined_scraped.json"
-OUTPUT_DIR = f"{tmp}/output"
-FILE_PATH = f"{OUTPUT_DIR}/{RELATIVE_PATH}"
+    ACTION_NAME = "summarize_page_content"
+    RELATIVE_PATH = "combined_scraped.json"
+    OUTPUT_DIR = f"{tmp}/output"
+    FILE_PATH = f"{OUTPUT_DIR}/{RELATIVE_PATH}"
 
-Path(OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+    Path(OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+
+    def make_context(records):
+        return ProcessingContext(
+            agent_config={},
+            agent_name=ACTION_NAME,
+            is_first_stage=True,
+            storage_backend=backend,
+            file_path=FILE_PATH,
+            output_directory=OUTPUT_DIR,
+            source_data=records,
+        )
+
+    def assign_deterministic_guids(records):
+        for r in records:
+            if not r.get("source_guid"):
+                r["source_guid"] = IDGenerator.generate_content_hash(r)
+
+    def simulate_llm_result(record, idx):
+        return ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[
+                {
+                    "source_guid": record["source_guid"],
+                    "content": {"summary": f"Summary of {record['id']}"},
+                    "target_id": f"target_{idx}",
+                    "node_id": ACTION_NAME,
+                }
+            ],
+            source_guid=record["source_guid"],
+        )
+
+    # ══════════════════════════════════════════════════════════════════
+    # STEP 1: First run — guid assignment
+    # ══════════════════════════════════════════════════════════════════
+
+    print("=" * 60)
+    print("STEP 1: Assign deterministic guids (first run)")
+    print("=" * 60)
+
+    records_run1 = [r.copy() for r in INPUT_RECORDS]
+    assign_deterministic_guids(records_run1)
+
+    for r in records_run1:
+        print(f"  {r['id']}: source_guid={r['source_guid'][:12]}...")
+
+    guids = [r["source_guid"] for r in records_run1]
+    print()
+
+    # ══════════════════════════════════════════════════════════════════
+    # STEP 2: Gate filter (first run — no terminal IDs)
+    # ══════════════════════════════════════════════════════════════════
+
+    print("=" * 60)
+    print("STEP 2: DispositionGate filter (first run)")
+    print("=" * 60)
+
+    gate1 = DispositionGate(storage_backend=backend)
+    to_process, carry_ids = gate1.filter(records_run1, ACTION_NAME)
+
+    print(f"  Terminal IDs: {backend.get_terminal_record_ids(ACTION_NAME)}")
+    print(f"  carry_ids: {carry_ids}")
+    print(f"  to_process: {len(to_process)} records")
+    assert len(carry_ids) == 0, "First run should have no carry-forward"
+    assert len(to_process) == 3, "All 3 records should be processed"
+    print("  PASS: all 3 records to process")
+    print()
+
+    # ══════════════════════════════════════════════════════════════════
+    # STEP 3: Process record 0, checkpoint it, "crash" before record 1
+    # ══════════════════════════════════════════════════════════════════
+
+    print("=" * 60)
+    print("STEP 3: Process record 0, checkpoint, simulate crash")
+    print("=" * 60)
+
+    result0 = simulate_llm_result(records_run1[0], 0)
+    ctx = make_context(records_run1)
+
+    OnlineLLMStrategy._checkpoint_record(result0, ctx)
+
+    print(f"  Checkpointed: {result0.source_guid[:12]}... ({result0.status.value})")
+
+    terminal_ids = backend.get_terminal_record_ids(ACTION_NAME)
+    checkpoint_records = backend.read_checkpoint_records(ACTION_NAME, RELATIVE_PATH)
+    print(f"  Terminal IDs in DB: {terminal_ids}")
+    print(f"  Checkpoint records in DB: {len(checkpoint_records)}")
+    assert result0.source_guid in terminal_ids, "Checkpointed guid should be terminal"
+    assert len(checkpoint_records) == 1, "Should have 1 checkpoint record"
+    print("  PASS: checkpoint persisted to SQLite")
+    print()
+    print("  --- SIMULATED CRASH (Ctrl+C) ---")
+    print()
+
+    # ══════════════════════════════════════════════════════════════════
+    # STEP 4: Second run — assign guids again (deterministic = same)
+    # ══════════════════════════════════════════════════════════════════
+
+    print("=" * 60)
+    print("STEP 4: Assign deterministic guids (second run)")
+    print("=" * 60)
+
+    records_run2 = [r.copy() for r in INPUT_RECORDS]
+    assign_deterministic_guids(records_run2)
+
+    for i, r in enumerate(records_run2):
+        match = "SAME" if r["source_guid"] == guids[i] else "DIFFERENT"
+        print(f"  {r['id']}: {r['source_guid'][:12]}... {match}")
+
+    assert records_run2[0]["source_guid"] == guids[0], "Deterministic guid should match!"
+    print("  PASS: guids are deterministic across runs")
+    print()
+
+    # ══════════════════════════════════════════════════════════════════
+    # STEP 5: Gate filter (second run — should carry forward record 0)
+    # ══════════════════════════════════════════════════════════════════
+
+    print("=" * 60)
+    print("STEP 5: DispositionGate filter (second run)")
+    print("=" * 60)
+
+    gate2 = DispositionGate(storage_backend=backend)
+    to_process2, carry_ids2 = gate2.filter(records_run2, ACTION_NAME)
+
+    print(f"  Terminal IDs: {backend.get_terminal_record_ids(ACTION_NAME)}")
+    print(f"  carry_ids: {carry_ids2}")
+    print(f"  to_process: {len(to_process2)} records")
+
+    assert len(carry_ids2) == 1, f"Should carry forward 1 record, got {len(carry_ids2)}"
+    assert guids[0] in carry_ids2, "Record 0 should be carried forward"
+    assert len(to_process2) == 2, f"Should process 2 remaining records, got {len(to_process2)}"
+    print("  PASS: 1 carried forward, 2 to process")
+    print()
+
+    # ══════════════════════════════════════════════════════════════════
+    # STEP 6: build_carry_forward (read checkpoint data for carried record)
+    # ══════════════════════════════════════════════════════════════════
+
+    print("=" * 60)
+    print("STEP 6: build_carry_forward (checkpoint fallback)")
+    print("=" * 60)
+
+    carry_data, missing = build_carry_forward(carry_ids2, ACTION_NAME, RELATIVE_PATH, backend)
+
+    print(f"  Found: {len(carry_data)} records")
+    print(f"  Missing: {missing}")
+
+    assert len(carry_data) == 1, f"Should find 1 carried record, got {len(carry_data)}"
+    assert len(missing) == 0, f"Should have 0 missing, got {len(missing)}"
+    assert carry_data[0]["source_guid"] == guids[0], "Carried record should match"
+    print("  PASS: checkpoint data recovered for carried record")
+    print()
+
+    # ══════════════════════════════════════════════════════════════════
+    # SUMMARY
+    # ══════════════════════════════════════════════════════════════════
+
+    print("=" * 60)
+    print("ALL STEPS PASSED")
+    print("=" * 60)
+    print()
+    print("Checkpoint resume works correctly:")
+    print(f"  Record 0 ({guids[0][:12]}...): carried forward (no LLM call needed)")
+    print(f"  Record 1 ({guids[1][:12]}...): would be reprocessed")
+    print(f"  Record 2 ({guids[2][:12]}...): would be reprocessed")
+    print()
+    print("Saved 1 LLM call out of 3 on resume.")
 
 
-def make_context(records):
-    return ProcessingContext(
-        agent_config={},
-        agent_name=ACTION_NAME,
-        is_first_stage=True,
-        storage_backend=backend,
-        file_path=FILE_PATH,
-        output_directory=OUTPUT_DIR,
-        source_data=records,
-    )
-
-
-def assign_deterministic_guids(records):
-    """Same logic as unified.py — assign content-hash guid to first-stage records."""
-    for r in records:
-        if not r.get("source_guid"):
-            r["source_guid"] = IDGenerator.generate_content_hash(r)
-
-
-def simulate_llm_result(record, idx):
-    """Fake an LLM SUCCESS result for a record."""
-    return ProcessingResult(
-        status=ProcessingStatus.SUCCESS,
-        data=[
-            {
-                "source_guid": record["source_guid"],
-                "content": {"summary": f"Summary of {record['id']}"},
-                "target_id": f"target_{idx}",
-                "node_id": ACTION_NAME,
-            }
-        ],
-        source_guid=record["source_guid"],
-    )
-
-
-# ══════════════════════════════════════════════════════════════════════
-# STEP 1: First run — guid assignment
-# ══════════════════════════════════════════════════════════════════════
-
-print("=" * 60)
-print("STEP 1: Assign deterministic guids (first run)")
-print("=" * 60)
-
-records_run1 = [r.copy() for r in INPUT_RECORDS]
-assign_deterministic_guids(records_run1)
-
-for r in records_run1:
-    print(f"  {r['id']}: source_guid={r['source_guid'][:12]}...")
-
-guids = [r["source_guid"] for r in records_run1]
-print()
-
-# ══════════════════════════════════════════════════════════════════════
-# STEP 2: Gate filter (first run — no terminal IDs)
-# ══════════════════════════════════════════════════════════════════════
-
-print("=" * 60)
-print("STEP 2: DispositionGate filter (first run)")
-print("=" * 60)
-
-gate1 = DispositionGate(storage_backend=backend)
-to_process, carry_ids = gate1.filter(records_run1, ACTION_NAME)
-
-print(f"  Terminal IDs: {backend.get_terminal_record_ids(ACTION_NAME)}")
-print(f"  carry_ids: {carry_ids}")
-print(f"  to_process: {len(to_process)} records")
-assert len(carry_ids) == 0, "First run should have no carry-forward"
-assert len(to_process) == 3, "All 3 records should be processed"
-print("  ✓ PASS: all 3 records to process")
-print()
-
-# ══════════════════════════════════════════════════════════════════════
-# STEP 3: Process record 0, checkpoint it, "crash" before record 1
-# ══════════════════════════════════════════════════════════════════════
-
-print("=" * 60)
-print("STEP 3: Process record 0, checkpoint, simulate crash")
-print("=" * 60)
-
-result0 = simulate_llm_result(records_run1[0], 0)
-ctx = make_context(records_run1)
-
-# Call the real _checkpoint_record
-OnlineLLMStrategy._checkpoint_record(result0, ctx)
-
-print(f"  Checkpointed: {result0.source_guid[:12]}... ({result0.status.value})")
-
-# Verify in DB
-terminal_ids = backend.get_terminal_record_ids(ACTION_NAME)
-checkpoint_records = backend.read_checkpoint_records(ACTION_NAME, RELATIVE_PATH)
-print(f"  Terminal IDs in DB: {terminal_ids}")
-print(f"  Checkpoint records in DB: {len(checkpoint_records)}")
-assert result0.source_guid in terminal_ids, "Checkpointed guid should be terminal"
-assert len(checkpoint_records) == 1, "Should have 1 checkpoint record"
-print("  ✓ PASS: checkpoint persisted to SQLite")
-print()
-print("  --- SIMULATED CRASH (Ctrl+C) ---")
-print()
-
-# ══════════════════════════════════════════════════════════════════════
-# STEP 4: Second run — assign guids again (deterministic = same)
-# ══════════════════════════════════════════════════════════════════════
-
-print("=" * 60)
-print("STEP 4: Assign deterministic guids (second run)")
-print("=" * 60)
-
-records_run2 = [r.copy() for r in INPUT_RECORDS]  # Fresh from staging
-assign_deterministic_guids(records_run2)
-
-for i, r in enumerate(records_run2):
-    match = "✓ SAME" if r["source_guid"] == guids[i] else "✗ DIFFERENT"
-    print(f"  {r['id']}: {r['source_guid'][:12]}... {match}")
-
-assert records_run2[0]["source_guid"] == guids[0], "Deterministic guid should match!"
-print("  ✓ PASS: guids are deterministic across runs")
-print()
-
-# ══════════════════════════════════════════════════════════════════════
-# STEP 5: Gate filter (second run — should carry forward record 0)
-# ══════════════════════════════════════════════════════════════════════
-
-print("=" * 60)
-print("STEP 5: DispositionGate filter (second run)")
-print("=" * 60)
-
-# New gate instance (simulates fresh workflow startup)
-gate2 = DispositionGate(storage_backend=backend)
-to_process2, carry_ids2 = gate2.filter(records_run2, ACTION_NAME)
-
-print(f"  Terminal IDs: {backend.get_terminal_record_ids(ACTION_NAME)}")
-print(f"  carry_ids: {carry_ids2}")
-print(f"  to_process: {len(to_process2)} records")
-
-assert len(carry_ids2) == 1, f"Should carry forward 1 record, got {len(carry_ids2)}"
-assert guids[0] in carry_ids2, "Record 0 should be carried forward"
-assert len(to_process2) == 2, f"Should process 2 remaining records, got {len(to_process2)}"
-print("  ✓ PASS: 1 carried forward, 2 to process")
-print()
-
-# ══════════════════════════════════════════════════════════════════════
-# STEP 6: build_carry_forward (read checkpoint data for carried record)
-# ══════════════════════════════════════════════════════════════════════
-
-print("=" * 60)
-print("STEP 6: build_carry_forward (checkpoint fallback)")
-print("=" * 60)
-
-carry_data, missing = build_carry_forward(carry_ids2, ACTION_NAME, RELATIVE_PATH, backend)
-
-print(f"  Found: {len(carry_data)} records")
-print(f"  Missing: {missing}")
-
-assert len(carry_data) == 1, f"Should find 1 carried record, got {len(carry_data)}"
-assert len(missing) == 0, f"Should have 0 missing, got {len(missing)}"
-assert carry_data[0]["source_guid"] == guids[0], "Carried record should match"
-print("  ✓ PASS: checkpoint data recovered for carried record")
-print()
-
-# ══════════════════════════════════════════════════════════════════════
-# SUMMARY
-# ══════════════════════════════════════════════════════════════════════
-
-print("=" * 60)
-print("ALL STEPS PASSED")
-print("=" * 60)
-print()
-print("Checkpoint resume works correctly:")
-print(f"  • Record 0 ({guids[0][:12]}...): carried forward (no LLM call needed)")
-print(f"  • Record 1 ({guids[1][:12]}...): would be reprocessed")
-print(f"  • Record 2 ({guids[2][:12]}...): would be reprocessed")
-print()
-print(f"Saved {1} LLM call out of {3} on resume.")
+if __name__ == "__main__":
+    main()

--- a/tests/unit/processing/test_checkpoint_first_stage.py
+++ b/tests/unit/processing/test_checkpoint_first_stage.py
@@ -1,0 +1,95 @@
+"""Test: checkpoint resume for first-stage actions.
+
+First-stage input records arrive without source_guid. The fix assigns
+a deterministic content-hash guid BEFORE the DispositionGate runs,
+so the same input record gets the same guid across runs.
+"""
+
+import pytest
+
+from agent_actions.processing.disposition_gate import DispositionGate
+from agent_actions.storage.backend import DISPOSITION_SUCCESS
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+from agent_actions.utils.id_generation import IDGenerator
+
+
+@pytest.fixture()
+def backend(tmp_path):
+    db = SQLiteBackend.create(db_path=str(tmp_path / "test.db"), workflow_name="test_wf")
+    db.initialize()
+    return db
+
+
+def _raw_input_records():
+    """Input records as they come from staging — NO source_guid."""
+    return [
+        {"id": "page1", "url": "https://example.com/1", "page_content": "content 1"},
+        {"id": "page2", "url": "https://example.com/2", "page_content": "content 2"},
+        {"id": "page3", "url": "https://example.com/3", "page_content": "content 3"},
+    ]
+
+
+class TestDeterministicGuidAssignment:
+    """Content-hash guid is deterministic across runs."""
+
+    def test_same_record_gets_same_guid(self):
+        """Same input dict produces the same content-hash guid."""
+        record = {"id": "page1", "url": "https://example.com/1", "page_content": "content 1"}
+        guid1 = IDGenerator.generate_content_hash(record)
+        guid2 = IDGenerator.generate_content_hash(record)
+        assert guid1 == guid2
+
+    def test_different_records_get_different_guids(self):
+        """Different input dicts produce different guids."""
+        record_a = {"id": "page1", "content": "aaa"}
+        record_b = {"id": "page2", "content": "bbb"}
+        assert IDGenerator.generate_content_hash(record_a) != IDGenerator.generate_content_hash(
+            record_b
+        )
+
+
+class TestFirstStageCheckpointResume:
+    """First-stage checkpoint resume with deterministic guid assignment."""
+
+    def test_gate_matches_after_guid_assignment(self, backend):
+        """Assign content-hash guids, checkpoint one, re-run — gate carries it forward."""
+        records = _raw_input_records()
+
+        # Simulate first run: assign guids, process record 0, checkpoint it
+        for r in records:
+            r["source_guid"] = IDGenerator.generate_content_hash(r)
+
+        first_guid = records[0]["source_guid"]
+        backend.set_disposition("action_a", first_guid, DISPOSITION_SUCCESS)
+
+        # Simulate second run: same input records, assign guids again
+        records_run2 = _raw_input_records()
+        for r in records_run2:
+            r["source_guid"] = IDGenerator.generate_content_hash(r)
+
+        # Guid is deterministic — same content → same guid
+        assert records_run2[0]["source_guid"] == first_guid
+
+        # Gate should carry forward record 0, process records 1-2
+        gate = DispositionGate(storage_backend=backend)
+        to_process, carry_ids = gate.filter(records_run2, "action_a")
+
+        assert carry_ids == {first_guid}
+        assert len(to_process) == 2
+
+    def test_records_without_guid_get_no_match(self, backend):
+        """Without guid assignment, gate can't match — all reprocessed (the bug)."""
+        records = _raw_input_records()
+        for r in records:
+            r["source_guid"] = IDGenerator.generate_content_hash(r)
+
+        backend.set_disposition("action_a", records[0]["source_guid"], DISPOSITION_SUCCESS)
+
+        # Second run WITHOUT assigning guids
+        records_no_guid = _raw_input_records()
+
+        gate = DispositionGate(storage_backend=backend)
+        to_process, carry_ids = gate.filter(records_no_guid, "action_a")
+
+        assert len(carry_ids) == 0  # Bug: can't match
+        assert len(to_process) == 3  # All reprocessed

--- a/tests/unit/processing/test_checkpoint_resume.py
+++ b/tests/unit/processing/test_checkpoint_resume.py
@@ -1,0 +1,58 @@
+"""Tests for checkpoint resume via DispositionGate carry-forward.
+
+Verifies end-to-end: checkpointed records in checkpoint_output table
+are carried forward by the DispositionGate when target_data is missing
+(interrupted run before save_main_output).
+"""
+
+from unittest.mock import MagicMock
+
+from agent_actions.processing.disposition_gate import build_carry_forward
+
+
+def _make_record(guid: str) -> dict:
+    return {"source_guid": guid, "content": f"data_{guid}"}
+
+
+class TestCheckpointResume:
+    """Resume after interrupt using checkpointed records."""
+
+    def test_carry_forward_from_checkpoint_when_target_missing(self):
+        """Checkpointed records are used when target_data raises FileNotFoundError."""
+        backend = MagicMock()
+        backend.read_target.side_effect = FileNotFoundError("no target yet")
+
+        checkpointed = [_make_record("r0"), _make_record("r1"), _make_record("r2")]
+        backend.read_checkpoint_records.return_value = checkpointed
+
+        carry_ids = {"r0", "r1", "r2", "r3", "r4"}
+        found, missing = build_carry_forward(carry_ids, "action_a", "output.json", backend)
+
+        # r0-r2 found in checkpoint, r3-r4 missing → reprocess
+        assert len(found) == 3
+        assert {r["source_guid"] for r in found} == {"r0", "r1", "r2"}
+        assert missing == {"r3", "r4"}
+
+    def test_no_checkpoint_no_target_reprocesses_all(self):
+        """No checkpoint and no target → all records reprocessed."""
+        backend = MagicMock()
+        backend.read_target.side_effect = FileNotFoundError("no target")
+        backend.read_checkpoint_records.return_value = []
+
+        carry_ids = {"r0", "r1", "r2"}
+        found, missing = build_carry_forward(carry_ids, "action_a", "output.json", backend)
+
+        assert found == []
+        assert missing == carry_ids
+
+    def test_target_exists_uses_target_not_checkpoint(self):
+        """When target_data exists, checkpoint table is not consulted."""
+        backend = MagicMock()
+        backend.read_target.return_value = [_make_record("r0"), _make_record("r1")]
+
+        carry_ids = {"r0", "r1"}
+        found, missing = build_carry_forward(carry_ids, "action_a", "output.json", backend)
+
+        assert len(found) == 2
+        assert missing == set()
+        backend.read_checkpoint_records.assert_not_called()

--- a/tests/unit/processing/test_result_collector_checkpoint.py
+++ b/tests/unit/processing/test_result_collector_checkpoint.py
@@ -1,0 +1,140 @@
+"""Tests for checkpoint flush in collect_results_from_processing_results.
+
+Uses a real SQLite backend to verify that checkpointed records and
+dispositions actually survive in the database — not just that methods
+were called on a mock.
+"""
+
+import pytest
+
+from agent_actions.processing.result_collector import collect_results_from_processing_results
+from agent_actions.processing.types import ProcessingResult, ProcessingStatus
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+def _make_success_result(guid: str) -> ProcessingResult:
+    return ProcessingResult(
+        status=ProcessingStatus.SUCCESS,
+        data=[{"source_guid": guid, "content": f"data_{guid}"}],
+        source_guid=guid,
+    )
+
+
+def _make_results(n: int) -> list[ProcessingResult]:
+    return [_make_success_result(f"r{i}") for i in range(n)]
+
+
+@pytest.fixture()
+def backend(tmp_path):
+    db = SQLiteBackend.create(
+        db_path=str(tmp_path / "test.db"),
+        workflow_name="test_wf",
+    )
+    db.initialize()
+    return db
+
+
+class TestCheckpointWithRealSQLite:
+    """Checkpoint flushing with real SQLite — data actually persists."""
+
+    def test_checkpointed_dispositions_survive_in_db(self, backend):
+        """After checkpoint, SUCCESS dispositions are queryable from SQLite."""
+        results = _make_results(60)
+
+        collect_results_from_processing_results(
+            results,
+            "action_a",
+            storage_backend=backend,
+            checkpoint_interval=25,
+            checkpoint_relative_path="output.json",
+        )
+
+        # All 60 records should have SUCCESS dispositions in the DB
+        terminal_ids = backend.get_terminal_record_ids("action_a")
+        assert len(terminal_ids) == 60
+        for i in range(60):
+            assert f"r{i}" in terminal_ids
+
+    def test_checkpointed_records_survive_in_db(self, backend):
+        """After checkpoint, output records are readable from checkpoint table."""
+        results = _make_results(60)
+
+        collect_results_from_processing_results(
+            results,
+            "action_a",
+            storage_backend=backend,
+            checkpoint_interval=25,
+            checkpoint_relative_path="output.json",
+        )
+
+        # All 60 records should be in the checkpoint table
+        records = backend.read_checkpoint_records("action_a", "output.json")
+        assert len(records) == 60
+        guids = {r["source_guid"] for r in records}
+        assert guids == {f"r{i}" for i in range(60)}
+
+    def test_simulated_interrupt_preserves_first_50(self, backend):
+        """Simulate: process 75, checkpoint at 50, 'crash' before final write.
+
+        The first 50 records should be recoverable from checkpoint table,
+        and their dispositions should be in SQLite.
+        """
+        results = _make_results(75)
+
+        # Process only the first 50 by using checkpoint_interval=50
+        # and simulating that the process was interrupted after the
+        # first checkpoint but before completion.
+        # We do this by running 50 records through with checkpoint_interval=50.
+        collect_results_from_processing_results(
+            results[:50],
+            "action_a",
+            storage_backend=backend,
+            checkpoint_interval=50,
+            checkpoint_relative_path="output.json",
+        )
+
+        # 50 dispositions in DB
+        terminal_ids = backend.get_terminal_record_ids("action_a")
+        assert len(terminal_ids) == 50
+
+        # 50 records in checkpoint table
+        checkpointed = backend.read_checkpoint_records("action_a", "output.json")
+        assert len(checkpointed) == 50
+
+        # Records 50-74 are NOT in the DB (they weren't processed)
+        for i in range(50, 75):
+            assert f"r{i}" not in terminal_ids
+
+    def test_clear_checkpoint_after_completion(self, backend):
+        """clear_checkpoint_records removes all checkpoint data."""
+        results = _make_results(50)
+
+        collect_results_from_processing_results(
+            results,
+            "action_a",
+            storage_backend=backend,
+            checkpoint_interval=25,
+            checkpoint_relative_path="output.json",
+        )
+
+        assert len(backend.read_checkpoint_records("action_a", "output.json")) == 50
+
+        backend.clear_checkpoint_records("action_a")
+        assert len(backend.read_checkpoint_records("action_a", "output.json")) == 0
+
+    def test_no_checkpoint_when_interval_zero(self, backend):
+        """Default: single batch write, no checkpoint records."""
+        results = _make_results(50)
+
+        collect_results_from_processing_results(
+            results,
+            "action_a",
+            storage_backend=backend,
+            checkpoint_interval=0,
+        )
+
+        # Dispositions exist (written in tail flush)
+        assert len(backend.get_terminal_record_ids("action_a")) == 50
+
+        # No checkpoint records (feature disabled)
+        assert backend.read_checkpoint_records("action_a", "output.json") == []

--- a/tests/unit/processing/test_result_collector_checkpoint.py
+++ b/tests/unit/processing/test_result_collector_checkpoint.py
@@ -1,15 +1,24 @@
-"""Tests for checkpoint flush in collect_results_from_processing_results.
+"""Tests for per-record checkpoint in OnlineLLMStrategy._checkpoint_record.
 
-Uses a real SQLite backend to verify that checkpointed records and
-dispositions actually survive in the database — not just that methods
-were called on a mock.
+Uses a real SQLite backend to verify that checkpointed dispositions and
+output records actually persist in the database after each LLM call.
 """
 
 import pytest
 
-from agent_actions.processing.result_collector import collect_results_from_processing_results
-from agent_actions.processing.types import ProcessingResult, ProcessingStatus
+from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+from agent_actions.processing.types import ProcessingContext, ProcessingResult, ProcessingStatus
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+def _make_context(backend, action_name="action_a", file_path="output.json", output_dir="/out"):
+    return ProcessingContext(
+        agent_config={},
+        agent_name=action_name,
+        storage_backend=backend,
+        file_path=f"{output_dir}/{file_path}",
+        output_directory=output_dir,
+    )
 
 
 def _make_success_result(guid: str) -> ProcessingResult:
@@ -20,8 +29,13 @@ def _make_success_result(guid: str) -> ProcessingResult:
     )
 
 
-def _make_results(n: int) -> list[ProcessingResult]:
-    return [_make_success_result(f"r{i}") for i in range(n)]
+def _make_failed_result(guid: str, error: str = "LLM error") -> ProcessingResult:
+    return ProcessingResult(
+        status=ProcessingStatus.FAILED,
+        data=[],
+        source_guid=guid,
+        error=error,
+    )
 
 
 @pytest.fixture()
@@ -34,107 +48,94 @@ def backend(tmp_path):
     return db
 
 
-class TestCheckpointWithRealSQLite:
-    """Checkpoint flushing with real SQLite — data actually persists."""
+class TestCheckpointRecord:
+    """Per-record checkpoint writes disposition + output to SQLite."""
 
-    def test_checkpointed_dispositions_survive_in_db(self, backend):
-        """After checkpoint, SUCCESS dispositions are queryable from SQLite."""
-        results = _make_results(60)
+    def test_success_writes_disposition_and_output(self, backend):
+        """A successful record writes SUCCESS disposition and checkpoint output."""
+        ctx = _make_context(backend)
+        result = _make_success_result("r0")
 
-        collect_results_from_processing_results(
-            results,
-            "action_a",
-            storage_backend=backend,
-            checkpoint_interval=25,
-            checkpoint_relative_path="output.json",
-        )
+        OnlineLLMStrategy._checkpoint_record(result, ctx)
 
-        # All 60 records should have SUCCESS dispositions in the DB
         terminal_ids = backend.get_terminal_record_ids("action_a")
-        assert len(terminal_ids) == 60
-        for i in range(60):
-            assert f"r{i}" in terminal_ids
+        assert "r0" in terminal_ids
 
-    def test_checkpointed_records_survive_in_db(self, backend):
-        """After checkpoint, output records are readable from checkpoint table."""
-        results = _make_results(60)
-
-        collect_results_from_processing_results(
-            results,
-            "action_a",
-            storage_backend=backend,
-            checkpoint_interval=25,
-            checkpoint_relative_path="output.json",
-        )
-
-        # All 60 records should be in the checkpoint table
         records = backend.read_checkpoint_records("action_a", "output.json")
-        assert len(records) == 60
-        guids = {r["source_guid"] for r in records}
-        assert guids == {f"r{i}" for i in range(60)}
+        assert len(records) == 1
+        assert records[0]["source_guid"] == "r0"
 
-    def test_simulated_interrupt_preserves_first_50(self, backend):
-        """Simulate: process 75, checkpoint at 50, 'crash' before final write.
+    def test_failed_writes_disposition_no_output(self, backend):
+        """A failed record writes FAILED disposition but no checkpoint output (data=[])."""
+        ctx = _make_context(backend)
+        result = _make_failed_result("r0")
 
-        The first 50 records should be recoverable from checkpoint table,
-        and their dispositions should be in SQLite.
-        """
-        results = _make_results(75)
+        OnlineLLMStrategy._checkpoint_record(result, ctx)
 
-        # Process only the first 50 by using checkpoint_interval=50
-        # and simulating that the process was interrupted after the
-        # first checkpoint but before completion.
-        # We do this by running 50 records through with checkpoint_interval=50.
-        collect_results_from_processing_results(
-            results[:50],
-            "action_a",
-            storage_backend=backend,
-            checkpoint_interval=50,
-            checkpoint_relative_path="output.json",
-        )
+        # FAILED is not gate-terminal, so it won't show in get_terminal_record_ids
+        disps = backend.get_disposition("action_a", record_id="r0")
+        assert len(disps) == 1
+        assert disps[0]["disposition"] == "failed"
 
-        # 50 dispositions in DB
+        # No output records (data was empty)
+        records = backend.read_checkpoint_records("action_a", "output.json")
+        assert len(records) == 0
+
+    def test_multiple_records_accumulate(self, backend):
+        """Multiple checkpoint writes append to the checkpoint table."""
+        ctx = _make_context(backend)
+
+        for i in range(5):
+            result = _make_success_result(f"r{i}")
+            OnlineLLMStrategy._checkpoint_record(result, ctx)
+
         terminal_ids = backend.get_terminal_record_ids("action_a")
-        assert len(terminal_ids) == 50
+        assert len(terminal_ids) == 5
 
-        # 50 records in checkpoint table
-        checkpointed = backend.read_checkpoint_records("action_a", "output.json")
-        assert len(checkpointed) == 50
+        records = backend.read_checkpoint_records("action_a", "output.json")
+        assert len(records) == 5
+        assert {r["source_guid"] for r in records} == {f"r{i}" for i in range(5)}
 
-        # Records 50-74 are NOT in the DB (they weren't processed)
-        for i in range(50, 75):
-            assert f"r{i}" not in terminal_ids
+    def test_simulated_interrupt_preserves_completed(self, backend):
+        """Simulate: 3 records to process, checkpoint 2, 'crash' before 3rd.
 
-    def test_clear_checkpoint_after_completion(self, backend):
+        The first 2 records should be recoverable.
+        """
+        ctx = _make_context(backend)
+
+        # Process and checkpoint records 0 and 1
+        for i in range(2):
+            result = _make_success_result(f"r{i}")
+            OnlineLLMStrategy._checkpoint_record(result, ctx)
+
+        # "Crash" before record 2 — don't checkpoint it
+
+        terminal_ids = backend.get_terminal_record_ids("action_a")
+        assert terminal_ids == {"r0", "r1"}
+        assert "r2" not in terminal_ids
+
+        records = backend.read_checkpoint_records("action_a", "output.json")
+        assert len(records) == 2
+
+    def test_clear_after_completion(self, backend):
         """clear_checkpoint_records removes all checkpoint data."""
-        results = _make_results(50)
+        ctx = _make_context(backend)
 
-        collect_results_from_processing_results(
-            results,
-            "action_a",
-            storage_backend=backend,
-            checkpoint_interval=25,
-            checkpoint_relative_path="output.json",
-        )
+        for i in range(3):
+            OnlineLLMStrategy._checkpoint_record(_make_success_result(f"r{i}"), ctx)
 
-        assert len(backend.read_checkpoint_records("action_a", "output.json")) == 50
+        assert len(backend.read_checkpoint_records("action_a", "output.json")) == 3
 
         backend.clear_checkpoint_records("action_a")
         assert len(backend.read_checkpoint_records("action_a", "output.json")) == 0
 
-    def test_no_checkpoint_when_interval_zero(self, backend):
-        """Default: single batch write, no checkpoint records."""
-        results = _make_results(50)
+    def test_no_checkpoint_without_backend(self, backend):
+        """No crash when storage_backend is None."""
+        ctx = _make_context(backend)
+        ctx.storage_backend = None
 
-        collect_results_from_processing_results(
-            results,
-            "action_a",
-            storage_backend=backend,
-            checkpoint_interval=0,
-        )
+        result = _make_success_result("r0")
+        OnlineLLMStrategy._checkpoint_record(result, ctx)
 
-        # Dispositions exist (written in tail flush)
-        assert len(backend.get_terminal_record_ids("action_a")) == 50
-
-        # No checkpoint records (feature disabled)
+        # Nothing written (no backend)
         assert backend.read_checkpoint_records("action_a", "output.json") == []

--- a/tests/unit/workflow/test_coordinator_checkpoint.py
+++ b/tests/unit/workflow/test_coordinator_checkpoint.py
@@ -1,0 +1,84 @@
+"""Tests for selective disposition clearing on RUNNING action reset.
+
+When an action is interrupted mid-processing (status=RUNNING), checkpointed
+SUCCESS dispositions must survive the reset so the DispositionGate can carry
+them forward on resume.  Other retryable statuses (FAILED, SKIPPED, etc.)
+still get a full bulk wipe because they have no SUCCESS dispositions to preserve.
+"""
+
+from unittest.mock import MagicMock
+
+from agent_actions.storage.backend import (
+    DISPOSITION_SUCCESS,
+    RUNNING_CLEAR_DISPOSITIONS,
+)
+from agent_actions.workflow.managers.state import ActionStateManager, ActionStatus
+
+
+def _run_reset_logic(tmp_path, actions, statuses, mock_storage):
+    """Reproduce _reset_retryable_actions using RUNNING_CLEAR_DISPOSITIONS."""
+    mgr = ActionStateManager(tmp_path / "status.json", actions)
+    for name, status in zip(actions, statuses, strict=True):
+        mgr.update_status(name, status)
+
+    running_actions = {
+        name for name in mgr.execution_order if mgr.get_status(name) == ActionStatus.RUNNING
+    }
+    reset_actions = mgr.reset_retryable()
+
+    for action_name in reset_actions:
+        if action_name in running_actions:
+            for disp in RUNNING_CLEAR_DISPOSITIONS:
+                mock_storage.clear_disposition(action_name, disp)
+        else:
+            mock_storage.clear_disposition(action_name)
+        mock_storage.clear_prompt_traces(action_name)
+
+    return reset_actions, running_actions
+
+
+class TestRunningActionPreservesSuccessDispositions:
+    """RUNNING actions should only clear failure dispositions, not SUCCESS."""
+
+    def test_running_clears_only_failure_dispositions(self, tmp_path):
+        """A RUNNING action clears RUNNING_CLEAR_DISPOSITIONS but not SUCCESS."""
+        mock_storage = MagicMock()
+        reset_actions, running = _run_reset_logic(
+            tmp_path, ["action_a"], [ActionStatus.RUNNING], mock_storage
+        )
+
+        assert reset_actions == ["action_a"]
+        assert "action_a" in running
+
+        assert mock_storage.clear_disposition.call_count == len(RUNNING_CLEAR_DISPOSITIONS)
+        cleared_disps = {c.args[1] for c in mock_storage.clear_disposition.call_args_list}
+        assert cleared_disps == RUNNING_CLEAR_DISPOSITIONS
+        assert DISPOSITION_SUCCESS not in cleared_disps
+
+    def test_failed_action_bulk_wipes_all_dispositions(self, tmp_path):
+        """A FAILED action still bulk-wipes all dispositions."""
+        mock_storage = MagicMock()
+        _run_reset_logic(tmp_path, ["action_a"], [ActionStatus.FAILED], mock_storage)
+
+        mock_storage.clear_disposition.assert_called_once_with("action_a")
+
+    def test_mixed_statuses_apply_correct_clearing(self, tmp_path):
+        """RUNNING gets selective clear, FAILED gets bulk clear, COMPLETED is untouched."""
+        mock_storage = MagicMock()
+        reset_actions, _ = _run_reset_logic(
+            tmp_path,
+            ["running_action", "failed_action", "done_action"],
+            [ActionStatus.RUNNING, ActionStatus.FAILED, ActionStatus.COMPLETED],
+            mock_storage,
+        )
+
+        assert len(reset_actions) == 2
+        assert "done_action" not in reset_actions
+
+        calls = mock_storage.clear_disposition.call_args_list
+        running_calls = [c for c in calls if c.args[0] == "running_action"]
+        failed_calls = [c for c in calls if c.args[0] == "failed_action"]
+
+        assert len(running_calls) == len(RUNNING_CLEAR_DISPOSITIONS)
+        assert len(failed_calls) == 1
+        assert failed_calls[0].args == ("failed_action",)


### PR DESCRIPTION
## Summary
- Add per-record checkpointing for online processing — each record's disposition and output are committed to SQLite immediately after its LLM call returns
- Interrupted runs resume from the last checkpoint instead of reprocessing all records
- `checkpoint_output` SQLite table with `UNIQUE(action_name, relative_path, source_guid)` and `INSERT OR REPLACE` (upsert)
- `DispositionGate` falls back to checkpoint table when target output is missing
- `RUNNING` actions preserve SUCCESS dispositions on re-run (selective clear, not bulk wipe)
- First-stage records get deterministic content-hash guid (UUID5) so the gate can match across runs

### How it works
1. `UnifiedProcessor.process()` assigns deterministic source_guid to first-stage records
2. After each LLM call, `_checkpoint_record` writes SUCCESS disposition + output to SQLite
3. On interrupt (Ctrl+C): checkpointed dispositions and records survive in SQLite
4. On re-run: `DispositionGate` carries forward checkpointed records, only remaining records are reprocessed
5. On completion: `clear_checkpoint_records` cleans up the checkpoint table

### Cleanup paths
- Normal completion: `pipeline.py` clears after `save_main_output`
- `--fresh`: `_clear_for_fresh_run` clears alongside delete_target
- `retry`: `RetryCommand` clears for each downstream action

## Verification
- `ruff format --check` and `ruff check` clean
- 7438 tests pass (20 new checkpoint tests), 0 failures
- Manual E2E test (`tests/manual/test_checkpoint_e2e.py`) verifies full cycle
- Tested on real workflow (qanalabs_quiz_gen): 1 record checkpointed, Ctrl+C, re-run skipped it