### PR TITLE
docs: add ARCHITECTURE.md for all 18 modules

### DIFF
--- a/agent_actions/cli/ARCHITECTURE.md
+++ b/agent_actions/cli/ARCHITECTURE.md
@@ -1,0 +1,497 @@
+# CLI Module Architecture
+
+This document maps the moving parts of `agent_actions/cli/` -- the Click-based command-line interface that bootstraps the framework, routes user commands, and renders output.
+
+---
+
+## High-Level Overview
+
+```
+                          agent_actions/cli/
+                               │
+            ┌──────────────────┼──────────────────┐
+            │                  │                  │
+        bootstrap          commands            renderers/
+     (main.py,          (run, retry,        (execution_renderer,
+      cli_decorators,    preview, schema,    schema_renderer)
+      workflow_loader)   inspect, init, ...)
+```
+
+The module is a **Click group** (`agent-actions`) with 17 registered commands. Every command follows the same structural pattern:
+
+1. A `@click.command()` function handles Click options/arguments
+2. A companion `*Command` class (e.g., `RunCommand`, `RetryCommand`) holds the business logic in an `execute()` method
+3. Two decorators -- `@handles_user_errors` and `@requires_project` -- wrap most commands
+
+| Layer | What it does |
+|-------|-------------|
+| `main.py` | CLI bootstrap, Click group creation, logging init, signal handlers, top-level error catch |
+| `cli_decorators.py` | `@handles_user_errors` (error formatting) + `@requires_project` (project root injection) |
+| `workflow_loader.py` | Shared `load_workflow()` helper used by run, retry, schema, dispositions |
+| `inspect_base.py` | `BaseInspectCommand` base class for all inspect subcommands |
+| `renderers/` | Rich terminal output: `ExecutionRenderer` (post-run summary), `SchemaRenderer` (schema tables) |
+
+---
+
+## Bootstrap Flow
+
+What happens when a user types `agac run -a my_workflow`:
+
+```
+main_entrypoint()                           ← entry point (pyproject.toml console_scripts)
+  │
+  ├─ find_project_root_dir()                ← walk up looking for agent_actions.yml
+  ├─ load_dotenv(.env)                      ← load environment variables
+  │
+  └─ CLI()                                  ← instantiate Click application
+       │
+       ├─ fire_event(CLIInitStartEvent)     ← structured event
+       ├─ _create_click_group()             ← @click.group with --debug/--verbose/--quiet
+       ├─ _register_commands()              ← add_command() for all 17 commands
+       ├─ _register_signal_handlers()       ← SIGINT, SIGTERM, SIGBREAK
+       └─ fire_event(CLIInitCompleteEvent)
+       │
+       └─ execute(argv)
+            │
+            ├─ _configure_logging()         ← Phase 2: defaults before Click callback
+            ├─ fire_event(CLIArgumentParsingEvent)
+            │
+            └─ click_group.main(argv)       ← Click dispatches to command
+                 │
+                 ├─ group callback           ← Phase 3: --debug/--verbose/--quiet override
+                 │   └─ _configure_logging(debug=True)
+                 │
+                 └─ command function          ← e.g., run()
+                      │
+                      ├─ @requires_project   ← find + inject project_root
+                      ├─ @handles_user_errors ← catch AgentActionsError → ClickException
+                      │
+                      └─ RunCommand.execute()
+```
+
+### Logging Initialization Order (3 Phases)
+
+Logging is initialized multiple times because CLI flags are not available until Click parses them:
+
+```
+Phase 1: CLI() constructor
+  └─ logging.getLogger(__name__)        ← bare Python logger, no config yet
+
+Phase 2: CLI.execute() — before Click dispatch
+  └─ _configure_logging()              ← LoggerFactory.initialize() with env defaults
+     (LoggingConfig.from_environment() reads AGAC_LOG_LEVEL, AGAC_LOG_FORMAT, etc.)
+
+Phase 3: Click group callback — after arg parsing
+  └─ _configure_logging(debug=True)    ← re-initialize with --debug/--verbose/--quiet
+     (force=True overwrites Phase 2)
+
+Phase 4 (run command only): after workflow loads
+  └─ LoggerFactory.initialize(output_dir=..., workflow_name=..., invocation_id=...)
+     (adds file handler in agent_io/target/ for run logs)
+```
+
+Phase 1 events (CLIInitStartEvent) use a bare logger. If you add logging before Phase 2, messages may be lost or go to stderr with default formatting.
+
+---
+
+## Decorator Stack
+
+Every command that operates on a project uses two decorators. **Order matters.**
+
+```python
+@click.command()
+@click.option(...)
+@handles_user_errors("run")      # ← outer: catches exceptions from everything below
+@requires_project                 # ← inner: runs first, injects project_root
+def run(..., project_root=None):
+    ...
+```
+
+### Why order matters
+
+Click decorators execute bottom-up. `@requires_project` runs first, calling `ensure_in_project()` to find the project root. If it fails with `ProjectNotFoundError`, the error propagates up through `@handles_user_errors`, which catches `AgentActionsError` subclasses and converts them to `click.ClickException` with formatted messages.
+
+If you swap the order, `@handles_user_errors` would wrap the Click option processing but NOT the project root resolution, so `ProjectNotFoundError` would escape to the top-level catch in `CLI.execute()`.
+
+```
+Decorator application order (bottom-up):
+
+  @handles_user_errors        ← applied last, wraps everything
+    @requires_project          ← applied first, runs first at call time
+      def command(...)
+
+Call-time execution order (top-down):
+
+  handles_user_errors wrapper
+    └─ requires_project wrapper
+         └─ command body
+```
+
+### `@handles_user_errors(command_name)`
+
+- Catches `AgentActionsError` → formats via `format_user_error()` → raises `click.ClickException`
+- Passes through `click.ClickException` unchanged (already formatted)
+- Passes through unexpected `Exception` for the top-level catch in `CLI.execute()`
+- Checks `_already_displayed` flag to avoid double-printing errors
+
+### `@requires_project`
+
+- Calls `ensure_in_project()` → walks up directories looking for `agent_actions.yml`
+- Injects `project_root: Path` as a keyword argument into the wrapped function
+- Prints the project root path to stderr for user feedback
+
+---
+
+## Read-Only vs Write Commands
+
+Commands split into two categories based on whether they mutate the filesystem:
+
+```
+Write commands (auto_create=True, default):
+  run          → creates agent_io/target/, writes output, logs
+  compile      → renders Jinja2 templates to disk
+  init         → creates entire project directory
+  clean        → deletes target/staging directories
+  retry        → clears dispositions, re-runs workflow
+
+Read-only commands (auto_create=False):
+  inspect *    → reads config, no side effects
+  schema       → reads config + schema files
+  preview      → reads SQLite database
+  status       → reads .agent_status.json
+  dispositions → reads disposition table
+```
+
+The split is enforced at two points:
+
+1. **`ProjectPathsFactory.create_project_paths(auto_create=False)`** -- skips `mkdir()` calls for output directories
+2. **`ConfigRenderingService().render_and_load_config()` without `output_dir`** -- skips writing rendered config to disk
+
+Read-only commands must pass `auto_create=False` explicitly. Forgetting this means `agac schema -a foo` would create empty `agent_io/target/` directories as a side effect.
+
+---
+
+## `load_workflow()` Shared Helper
+
+`workflow_loader.py` provides a single function used by `run`, `retry`, `schema`, and `dispositions`:
+
+```
+load_workflow(agent_name, paths, project_root, ...)
+  │
+  ├─ find_config_file()         ← resolve agent_config/{name}.yml (with alternatives)
+  ├─ ConfigRenderingService()   ← render Jinja2 templates in the config
+  │   .render_and_load_config()
+  │
+  └─ AgentWorkflow(             ← construct the workflow object
+       WorkflowRuntimeConfig(
+         paths=WorkflowPaths(...),
+         use_tools=...,
+         fresh=...,
+         verify_keys=...,
+         project_root=...,
+       )
+     )
+```
+
+The inspect commands do NOT use this helper -- `BaseInspectCommand._load_workflow()` has its own copy of this logic because it omits `output_dir` from the rendering step and always sets `use_tools=False`.
+
+---
+
+## Command Execution Flows
+
+### `run` -- Execute a Workflow
+
+```
+RunCommand.execute()
+  │
+  ├─ ProjectPathsFactory.create_project_paths()    ← auto_create=True (default)
+  ├─ PromptValidator().validate()                   ← check prompt files exist
+  ├─ load_workflow(... fresh=, verify_keys=)        ← load + validate config
+  │
+  ├─ RunTracker.start_workflow_run()                ← docs tracking (run_results.json)
+  ├─ LoggerFactory.initialize(output_dir=...)       ← Phase 4 logging init
+  │
+  ├─ _determine_execution_mode()                    ← auto/parallel/sequential
+  │   └─ should_use_parallel_execution()            ← checks dependency graph
+  │
+  ├─ workflow.run() or asyncio.run(workflow.async_run())
+  │
+  ├─ build_execution_snapshot() + ExecutionRenderer  ← post-run summary
+  │   (wrapped in try/except -- failures are swallowed to logger.debug)
+  │
+  ├─ State check: is_workflow_complete / is_workflow_done / batch pending
+  │
+  └─ tracker.finalize_workflow_run()
+     └─ LoggerFactory.flush()
+```
+
+### `retry` -- Retry Failed Records
+
+```
+RetryCommand.execute()
+  │
+  ├─ ProjectPathsFactory.create_project_paths(auto_create=False)
+  ├─ get_storage_backend() + initialize()
+  │
+  ├─ Check for prior retry manifest (crash recovery)
+  │   └─ If found: restore dispositions from snapshot → delete manifest
+  │
+  ├─ load_workflow()
+  ├─ _find_failures()                               ← query FAILURE_DISPOSITIONS
+  │
+  ├─ Resolve from_action (explicit or earliest failure)
+  ├─ _display_retry_plan()                          ← Rich table of what will be retried
+  │
+  ├─ (dry_run? → stop here)
+  │
+  ├─ Snapshot dispositions → _write_manifest()      ← crash-safe: written BEFORE clearing
+  ├─ clear_disposition() per record per downstream action
+  ├─ clear_disposition(NODE_LEVEL_RECORD_ID)        ← clear action-level FAILED/SKIPPED
+  ├─ clear_checkpoint_records()                     ← clear stale partial output
+  │
+  ├─ Reset downstream ActionStatus → PENDING
+  ├─ workflow.run()
+  │
+  └─ _delete_manifest()                             ← only after successful completion
+```
+
+### `inspect` -- Command Group
+
+```
+@click.group("inspect")
+  ├─ dependencies     ← DependenciesCommand (BaseInspectCommand)
+  ├─ graph            ← GraphCommand (BaseInspectCommand)
+  ├─ action           ← ActionCommand (BaseInspectCommand)
+  └─ context          ← ContextCommand (BaseInspectCommand)
+```
+
+All inherit from `BaseInspectCommand` which provides:
+- `_load_workflow()` with `auto_create=False`
+- `_analyze_dependencies()` for inferring data flow
+- `_get_action_schema()`, `_get_output_fields()`, `_get_input_fields()` helpers
+
+### `preview` -- Read SQLite Storage
+
+```
+PreviewCommand.execute()
+  │
+  ├─ ProjectPathsFactory.create_project_paths(auto_create=False)
+  ├─ Check db_path exists (agent_io/store/{name}.db)
+  ├─ get_storage_backend(backend_type="sqlite")
+  │
+  ├─ stats_only? → _show_stats()
+  ├─ action specified? → _preview_action()
+  │   └─ _unwrap_records()    ← strip namespace: content[action_name] → content
+  └─ no action? → _list_actions()
+```
+
+### `schema` -- Display Action Schemas
+
+```
+SchemaCommand.execute()
+  │
+  ├─ ProjectPathsFactory.create_project_paths(auto_create=False)
+  ├─ load_workflow()
+  ├─ WorkflowSchemaService.build_workflow_config()
+  ├─ WorkflowSchemaService(...).get_all_schemas()
+  │
+  ├─ json_output? → click.echo(json.dumps(...))
+  └─ rich output? → SchemaRenderer.render_summary_table()
+                    SchemaRenderer.render_data_flow_panel() (if --verbose)
+```
+
+### `init` -- Create a New Project
+
+```
+init (Click group with _InitGroup routing)
+  │
+  ├─ new     → InitCommand.execute()
+  │   ├─ ProjectValidator.validate()
+  │   ├─ _create_project_directory() (with backup/rollback on failure)
+  │   └─ ProjectInitializer.init_project()
+  │
+  ├─ list    → _list_remote_examples() (GitHub API)
+  │
+  └─ example → _fetch_example() (download tarball, extract, inject project_name)
+```
+
+Note: `init` does NOT use `@requires_project` since it creates the project. It only uses `@handles_user_errors`.
+
+---
+
+## Error Propagation Model
+
+Errors flow through three layers, each catching progressively broader exception types:
+
+```
+Layer 1: @handles_user_errors (per-command)
+  │  Catches: AgentActionsError → click.ClickException
+  │  Passes: click.ClickException, unexpected Exception
+  │
+Layer 2: CLI.execute() (application-level)
+  │  Catches:
+  │    click.Abort → exit 130
+  │    click.UsageError → "Error: ..." to stderr, exit 2
+  │    click.ClickException → formatted message, exit 1
+  │    ProjectNotFoundError → special multi-line message with solutions
+  │    Exception (catch-all) → format_user_error() + optional --debug traceback
+  │
+Layer 3: main_entrypoint() / main()
+     sys.exit(return_code)
+```
+
+Key design decisions:
+- `AgentActionsError` (application errors) are formatted prettily at Layer 1
+- `ProjectNotFoundError` gets special treatment at Layer 2 with a multi-line message showing the search path and suggesting solutions
+- Unexpected exceptions (bugs) escape Layer 1 and are caught at Layer 2 with `format_user_error()` -- raw tracebacks only appear with `--debug`
+- `_already_displayed` flag on exceptions prevents double-printing when errors have already been shown to the user
+
+---
+
+## Inspect Command Group Architecture
+
+`inspect` is a Click group with four subcommands, all sharing a base class:
+
+```
+BaseInspectCommand
+  │
+  │  Fields: agent, agent_name, user_code, json_output, console
+  │  Fields set by _load_workflow(): paths, schema_service
+  │
+  │  _load_workflow(project_root)     ← auto_create=False, no output_dir
+  │  _analyze_dependencies(workflow)  ← infer_dependencies() per action
+  │  _get_action_schema(name)         ← via schema_service
+  │  _get_output_fields(config)       ← schema properties → field names
+  │  _get_input_fields(config)        ← context_scope observe/passthrough
+  │  _get_action_type(inputs, ctx)    ← Source/Transform/Merge classification
+  │
+  ├── DependenciesCommand   ← table of explicit + inferred deps per action
+  ├── GraphCommand          ← visual dependency graph (ASCII art)
+  ├── ActionCommand         ← detailed view of a single action
+  └── ContextCommand        ← context debug info for a single action
+```
+
+All subcommands use `@handles_user_errors` and `@requires_project`. Each implements its own `execute()` that calls `self._load_workflow()` from the base class.
+
+---
+
+## Renderers Sub-Module
+
+```
+renderers/
+  ├─ __init__.py              ← exports SchemaRenderer
+  ├─ execution_renderer.py    ← post-run workflow summary
+  └─ schema_renderer.py       ← schema display tables
+```
+
+### ExecutionRenderer
+
+Renders a structured post-run summary with execution levels, status icons, kind badges, provider info, and latency. Used only by `RunCommand`.
+
+```
+build_execution_snapshot(workflow, elapsed)    ← reads action_configs + state_manager
+  └─ WorkflowExecutionSnapshot                ← frozen dataclass
+
+ExecutionRenderer(console).render(snapshot)
+  ├─ _render_header()      ← workflow name, version, action/vendor counts
+  ├─ _render_levels()      ← per-level: sequential or parallel box
+  │   ├─ _render_sequential_action()   ← "├─ ✓ action_name  llm  openai  1.2s"
+  │   └─ _render_parallel_level()      ← boxed group of concurrent actions
+  └─ _render_footer()      ← "✓ Done in 5.2s (3 completed, 1 skipped)"
+```
+
+### SchemaRenderer
+
+Renders schema summary tables and data flow panels for the `schema` command. Imported from `renderers/__init__.py`.
+
+---
+
+## File Index
+
+### Bootstrap
+
+| File | Role |
+|------|------|
+| `main.py` | CLI entry point, Click group, logging init, signal handlers, top-level error handling, `_LazyCLI` proxy |
+| `cli_decorators.py` | `@handles_user_errors` + `@requires_project` decorators |
+| `workflow_loader.py` | `load_workflow()` shared helper + `validate_action_exists()` |
+
+### Shared / Base
+
+| File | Role |
+|------|------|
+| `inspect_base.py` | `BaseInspectCommand` base class for all inspect subcommands |
+| `inspect.py` | Click group for `inspect` + subcommand registration |
+
+### Write Commands (mutate filesystem)
+
+| File | Role |
+|------|------|
+| `run.py` | `RunCommand` -- full workflow execution with tracking + parallel/sequential modes |
+| `retry.py` | `RetryCommand` -- retry failed records with crash-safe manifest |
+| `compile.py` | `RenderCommand` -- render Jinja2 templates in agent config |
+| `init.py` | `InitCommand` -- project scaffolding + GitHub example fetching |
+| `clean.py` | `clean_cli` -- delete target/staging/store directories |
+
+### Read Commands (no side effects)
+
+| File | Role |
+|------|------|
+| `preview.py` | `PreviewCommand` -- SQLite data viewer with table/json/raw formats |
+| `schema.py` | `SchemaCommand` -- display input/output schemas per action |
+| `status.py` | `StatusCommand` -- read `.agent_status.json` |
+| `dispositions.py` | `DispositionsCommand` -- per-action disposition breakdown |
+| `inspect_deps.py` | `DependenciesCommand` -- dependency analysis table |
+| `inspect_graph.py` | `GraphCommand` -- visual dependency graph |
+| `inspect_action.py` | `ActionCommand` + `ContextCommand` -- action detail + context debug |
+
+### Utility
+
+| File | Role |
+|------|------|
+| `list_udfs.py` | `ListUDFsCommand` -- discover and list UDF scripts |
+| `docs.py` | Documentation generation + dev server |
+| `example.py` | Browse and install example projects |
+| `skills.py` | Install AI coding assistant skills (Claude Code, Codex) |
+
+### Renderers
+
+| File | Role |
+|------|------|
+| `renderers/__init__.py` | Exports `SchemaRenderer` |
+| `renderers/execution_renderer.py` | `ExecutionRenderer` + `build_execution_snapshot()` -- post-run visual summary |
+| `renderers/schema_renderer.py` | `SchemaRenderer` -- schema tables and data flow panels |
+
+---
+
+## Caveats
+
+1. **`auto_create=False` is not the default.** `ProjectPathsFactory.create_project_paths()` defaults to `auto_create=True`. Every read-only command must pass `auto_create=False` explicitly, or it will create empty `agent_io/target/` directories as a side effect of being run.
+
+2. **Decorator order matters.** `@handles_user_errors` must be the outer decorator (listed first/above `@requires_project` in source). Swapping them means `ProjectNotFoundError` from `@requires_project` escapes the error formatter and falls through to `CLI.execute()`'s catch-all, which produces a different (less informative for some error types) message.
+
+3. **`project_root` injection.** `@requires_project` injects `project_root` as a keyword argument. The wrapped function's signature must accept `project_root: Path | None = None` or the call will fail with a `TypeError`. Commands that do not need project root (like `init new`) must not use `@requires_project`.
+
+4. **Retry manifest crash safety.** `RetryCommand` writes a manifest of snapshotted dispositions BEFORE clearing them from the database. If the process crashes between clearing and re-run completion, the next `retry` invocation detects the manifest, restores the dispositions, deletes the manifest, and proceeds. The manifest is only deleted on successful completion.
+
+5. **`NODE_LEVEL_RECORD_ID` clearing.** During retry, in addition to clearing per-record dispositions, the code clears `NODE_LEVEL_RECORD_ID` -- a synthetic record ID used for action-level status. Without this, the executor would see a stale action-level FAILED signal and skip the action entirely.
+
+6. **Checkpoint clearing on retry.** `backend.clear_checkpoint_records(action)` is called for each downstream action during retry. Without this, stale partial output from a prior interrupted run would be carried forward instead of reprocessing the records.
+
+7. **`ExecutionRenderer` failures are swallowed.** The post-run summary render in `RunCommand._execute_single()` is wrapped in a bare `try/except` that logs to `logger.debug`. If the renderer crashes (e.g., accessing state that was cleaned up), the user never sees the summary but the run still succeeds. This is intentional -- the summary is informational, not functional.
+
+8. **Logging is initialized 3-4 times.** See "Logging Initialization Order" above. Each call to `LoggerFactory.initialize(force=True)` replaces the previous configuration. Events fired before Phase 2 use a bare logger. The Phase 4 init (run command only) adds a file handler after the workflow is loaded, so early log messages are not written to the run log file.
+
+9. **`_LazyCLI` proxy.** `main.py` exports a module-level `cli` object that defers `CLI()` instantiation until first access. This exists so that tools importing the module (e.g., for testing or documentation) don't trigger the full bootstrap (signal handlers, event firing) on import.
+
+10. **`BaseInspectCommand._load_workflow()` duplicates `load_workflow()`.** The inspect base class has its own workflow loading logic instead of calling the shared `workflow_loader.load_workflow()`. This is because inspect commands omit `output_dir` from `ConfigRenderingService().render_and_load_config()` and always set `use_tools=False`. The duplication is intentional but means changes to config loading must be applied in both places.
+
+11. **`init` uses `_InitGroup` for implicit routing.** `agac init my_project` works because `_InitGroup.resolve_command()` detects that `my_project` is not a known subcommand and routes it to the `new` subcommand. This means you cannot name a project `list`, `new`, or `example` without using the explicit `agac init new list` form.
+
+12. **Preview unwraps namespaced content.** Records in storage use the additive model where `content` is `{"action_a": {...}, "action_b": {...}}`. `PreviewCommand._unwrap_records()` strips this namespace when previewing a specific action so the table shows flat fields. Guard-skipped actions have `content[action] = None`, which is replaced with `{}` rather than showing a sentinel.
+
+13. **`retry` uses `auto_create=False` despite being a write command.** Even though retry re-runs the workflow (which writes output), the `ProjectPathsFactory` call uses `auto_create=False` because the directories must already exist from a prior run. The actual directory creation happens inside the workflow engine during re-execution.
+
+14. **Signal handler registration can fail silently.** `_register_signal_handlers()` catches `AttributeError` and `ValueError` (e.g., when running in a non-main thread or certain embedded environments) and logs a warning instead of crashing. This means SIGINT handling may not work in all contexts.
+
+15. **`--debug` flag detection in catch-all.** The top-level `Exception` handler in `CLI.execute()` checks for `"--debug" in argv` to decide whether to print the full traceback. This is a string match against raw argv, not a Click-parsed flag, because the exception may have occurred before Click finished parsing.

--- a/agent_actions/cli/_MANIFEST.md
+++ b/agent_actions/cli/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Cli Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)** -- bootstrap flow, decorator stack, error propagation, command execution flows, caveats.
+
 ## Conventions
 
 - **Read-only commands** (inspect, schema, status, preview) must pass `auto_create=False` to `ProjectPathsFactory.create_project_paths()` and omit `output_dir` from `ConfigRenderingService().render_and_load_config()` to avoid filesystem mutations.

--- a/agent_actions/config/ARCHITECTURE.md
+++ b/agent_actions/config/ARCHITECTURE.md
@@ -1,0 +1,456 @@
+# Config Module Architecture
+
+This document maps the moving parts of `agent_actions/config/` — the module that loads, validates, merges, and resolves all configuration for the framework: workflow YAML files, environment variables, project paths, default constants, and dependency injection wiring.
+
+---
+
+## High-Level Overview
+
+```
+                        agent_actions/config/
+                              │
+          ┌───────────────────┼──────────────────────┐
+          │                   │                       │
+    Schema & Types       Path Resolution           DI System
+   (validation layer)   (project discovery)    (container + factory)
+          │                   │                       │
+    schema.py             paths.py              di/container.py
+    types.py              path_config.py        di/configurator.py
+    environment.py        project_paths.py      di/application.py
+          │                   │                       │
+          └─────────┬─────────┘                       │
+                    │                                 │
+              manager.py ◄────────────────────────────┘
+           (orchestrates the full
+            config loading pipeline)
+```
+
+The module has **four concerns**:
+
+| Concern | Files | What it does |
+|---------|-------|-------------|
+| Schema & validation | `schema.py`, `types.py`, `environment.py` | Pydantic models for workflow YAML, typed dicts for runtime config shapes, environment settings from `.env` |
+| Path resolution | `paths.py`, `path_config.py`, `project_paths.py` | Discover project root, resolve standard paths, validate directory structure |
+| Defaults & constants | `defaults.py` | Zero-import default values grouped by domain (storage, locks, API, prompts) |
+| DI system | `di/container.py`, `di/configurator.py`, `di/application.py`, `factory.py`, `interfaces.py` | Lightweight DI container, service registration, `ActionRunner` creation |
+
+Supporting files: `init.py` (project scaffolding), `__init__.py` (re-exports `WorkflowConfig`).
+
+---
+
+## Config Loading Pipeline
+
+This is the full path from a YAML file on disk to a running workflow. `ConfigManager` orchestrates every step.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    ConfigManager Pipeline                        │
+│                                                                  │
+│  Step 1: load_configs()                                         │
+│  ┌────────────────────────────────────────────────────────┐     │
+│  │  Read workflow YAML (agent_config/{name}.yml)           │     │
+│  │  Read default YAML (agent_actions.yml)                  │     │
+│  │  Jinja2-render both files (template vars from env)      │     │
+│  │  yaml.safe_load() → raw dicts                           │     │
+│  │  Resolve tool_path (workflow > default > project)       │     │
+│  └──────────────────────────┬─────────────────────────────┘     │
+│                             │                                    │
+│  Step 2: validate_agent_name()                                  │
+│  ┌────────────────────────────────────────────────────────┐     │
+│  │  Extract top-level name from config                     │     │
+│  │  ENFORCE: name == config filename stem                  │     │
+│  └──────────────────────────┬─────────────────────────────┘     │
+│                             │                                    │
+│  Step 3: get_user_agents()                                      │
+│  ┌────────────────────────────────────────────────────────┐     │
+│  │  Load project defaults (agent_actions.yml)              │     │
+│  │  WorkflowConfig.model_validate() ← Pydantic stage 1    │     │
+│  │  Warn on unknown defaults keys                          │     │
+│  │  model_dump(exclude_unset=True) per action              │     │
+│  │  Merge: project_defaults ← workflow_defaults            │     │
+│  │  ActionExpander.expand_actions_to_agents()              │     │
+│  │    → expands versions, chunks, etc. into agent dicts    │     │
+│  └──────────────────────────┬─────────────────────────────┘     │
+│                             │                                    │
+│  Step 4: merge_agent_configs()                                  │
+│  ┌────────────────────────────────────────────────────────┐     │
+│  │  AgentConfig.model_validate() per agent ← stage 2       │     │
+│  │  Merge: DefaultAgentConfig ← per-agent overrides        │     │
+│  │  Deep-merge chunk_config specifically                    │     │
+│  │  Inject tool_path into every agent config               │     │
+│  └──────────────────────────┬─────────────────────────────┘     │
+│                             │                                    │
+│  Step 5: determine_execution_order()                            │
+│  ┌────────────────────────────────────────────────────────┐     │
+│  │  Normalize context_scope refs (versioned names)         │     │
+│  │  infer_dependencies() from context_scope per agent      │     │
+│  │  Build dependency graph (operational agents only)       │     │
+│  │  topological_sort() → execution_order                   │     │
+│  └────────────────────────────────────────────────────────┘     │
+│                                                                  │
+│  Step 6: load_environment_config()                              │
+│  ┌────────────────────────────────────────────────────────┐     │
+│  │  Resolve .env at project root                           │     │
+│  │  EnvironmentConfig (pydantic-settings) loads env vars   │     │
+│  └────────────────────────────────────────────────────────┘     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Two-Stage Validation
+
+Config validation happens in two distinct Pydantic passes with different `extra` policies. This is deliberate, not accidental.
+
+```
+Stage 1: WorkflowConfig (pre-expansion)
+  ├── ActionConfig    → extra="forbid"
+  │   Typos in YAML action fields raise immediately.
+  │   e.g. "temperture" instead of "temperature" → ValidationError
+  │
+  ├── DefaultsConfig  → extra="ignore"
+  │   Workflow defaults may contain vendor-specific params
+  │   (frequency_penalty, presence_penalty) that vary by provider.
+  │   These are consumed by extract_generation_params(), not by
+  │   the Pydantic model. Known fields still validate.
+  │
+  └── WorkflowConfig  → model_validator checks:
+      ├── Duplicate action names
+      ├── Dangling dependency references
+      ├── Invalid primary_dependency references
+      └── Circular dependencies (iterative DFS)
+
+Stage 2: AgentConfig (post-expansion)
+  └── AgentConfig     → extra="allow"
+      The ActionExpander injects many runtime fields (agent_type,
+      code_path, schema_name, tools_path, is_versioned_agent, etc.)
+      that don't exist in the original YAML. extra="allow" lets
+      these pass through without declaring every injected field.
+```
+
+---
+
+## Defaults Cascade
+
+Values flow through five layers. Later layers override earlier ones. The first non-None value wins at each merge step.
+
+```
+Layer 1: Pydantic field defaults
+  ActionConfig(temperature=None, json_mode=None, ...)
+  RetryConfig(max_attempts=3, on_exhausted="return_last")
+  RepromptConfig(max_attempts=2, use_self_reflection=False)
+
+Layer 2: Project defaults (agent_actions.yml → default_agent_config)
+  default_agent_config:
+    api_key: OPENAI_API_KEY
+    model_name: gpt-3.5-turbo
+    chunk_config: {chunk_size: 300, overlap: 10}
+
+Layer 3: Workflow defaults (agent_config/{name}.yml → defaults section)
+  defaults:
+    model_vendor: openai
+    model_name: gpt-4o
+    temperature: 0.3
+
+Layer 4: Per-action overrides (each action in the actions list)
+  actions:
+    - name: extract
+      temperature: 0.0    ← overrides workflow default
+
+Layer 5: Runtime injection (by ConfigManager and ActionExpander)
+  model_vendor → forced to "tool" when kind=="tool"
+  model_vendor → forced to "hitl" when kind=="hitl"
+  tool_path → injected from resolved tool_path chain
+  optional None fields → coerced to "" for downstream string safety
+```
+
+The merge in `merge_agent_configs()` is a flat dict merge (`{**defaults, **agent}`) with one exception: `chunk_config` gets a shallow deep-merge (`{**default_chunk, **agent_chunk}`).
+
+---
+
+## Path Resolution
+
+### Project Root Discovery
+
+```
+find_project_root_dir(start=cwd)
+  │
+  │  Walk up from start directory toward filesystem root.
+  │  At each level, check (in order):
+  │
+  ├─ Marker files: agent_actions.yml, agent_actions.yaml, .agent_actions.yml
+  │    Found? → return this directory
+  │
+  ├─ Fallback heuristics: agent_actions/ or agent_config/ directory exists
+  │    Found? → return this directory (with debug log: "fallback heuristic")
+  │
+  └─ Hit filesystem root → return None → ProjectRootNotFoundError
+```
+
+### PathManager Caching
+
+```
+PathManager._project_root     ← cached resolved root
+PathManager._cached_cwd       ← CWD at time of resolution
+PathManager._path_cache        ← cached resolved paths by type+params
+
+Cache invalidation rules:
+  1. Explicit project_root (constructor arg) → _cached_cwd = None → never invalidated
+  2. CWD-resolved root → _cached_cwd = cwd at resolution time
+     → invalidated if cwd changes between calls
+  3. clear_cache() → resets everything
+```
+
+### Standard Path Templates
+
+```
+PathType.AGENT_CONFIG      → {agent_name}/agent_config
+PathType.AGENT_IO          → {agent_name}/agent_io
+PathType.SOURCE            → {agent_name}/agent_io/source
+PathType.TARGET            → {agent_name}/agent_io/target/{action_name}
+PathType.SCHEMA            → schema
+PathType.PROMPT_STORE      → prompt_store
+PathType.TEMPLATES         → templates
+PathType.RENDERED_WORKFLOWS → artefact/rendered_workflows
+PathType.BATCH             → batch
+PathType.SEED_DATA         → seed_data
+```
+
+All relative to project root.
+
+---
+
+## Environment Settings
+
+`EnvironmentConfig` extends `pydantic_settings.BaseSettings` to load from `.env` and environment variables.
+
+```
+EnvironmentConfig
+  ├── API keys (SecretStr, validated ≥10 chars)
+  │   ├── openai_api_key
+  │   ├── anthropic_api_key
+  │   └── gemini_api_key
+  │
+  ├── Runtime settings
+  │   ├── agent_actions_env    (development/staging/production)
+  │   ├── default_api_timeout  (1-600 seconds, default 120)
+  │   ├── default_max_retries  (0-10, default 3)
+  │   ├── default_batch_size   (1-10000, default 100)
+  │   └── max_concurrency      (1-100, default 10)
+  │
+  └── Feature flags
+      ├── debug_logging           (default false)
+      ├── enable_parallel_processing (default true)
+      └── cache_ttl              (seconds, default 300)
+
+model_config: extra="ignore"
+  Unknown env vars are silently ignored — EnvironmentConfig only
+  reads the keys it declares. Users can have arbitrary env vars
+  in .env without causing validation errors.
+```
+
+The `.env` file path is resolved by `ConfigManager._resolve_dotenv()` relative to the project root, not the working directory.
+
+---
+
+## DI System
+
+### Container Architecture
+
+```
+DependencyContainer
+  │
+  ├── register_singleton(interface, impl)  → one instance, created on first get()
+  ├── register_transient(interface, impl)  → new instance every get()
+  ├── register_factory(interface, fn)      → fn() called every get()
+  ├── register_instance(interface, obj)    → pre-built object
+  │
+  └── get(interface) → T
+        1. Check _services → create via _create_instance (auto-resolves deps)
+        2. Check _instances → return directly
+        3. Check _factories → call factory
+        4. None found → DependencyError
+
+  _create_instance(cls):
+    Introspects cls.__init__ signature + type hints.
+    For each param: resolve from container, use default, or raise.
+    Thread-safe for singletons (RLock).
+```
+
+### Registration Map
+
+```
+DIConfigurator.configure_container():
+
+  Singletons (shared across all callers):
+    PathManager      → PathManager
+    PromptLoader     → PromptLoader
+    LoggerFactory    → LoggerFactory
+
+  Transients (new instance per resolution):
+    IDataProcessor      → DataProcessor
+    IGenerator          → DataGenerator
+    ISourceDataLoader   → SourceDataLoader
+    IDataLoader         → JsonLoader
+```
+
+### Application Bootstrap
+
+```
+factory.py: application_container_context(config)
+  │
+  └─ ApplicationContainer(config)
+       │
+       ├── DIConfigurator.configure_container(config) → DependencyContainer
+       ├── DIConfigurator.create_processor_factory()   → ProcessorFactory
+       │
+       └── get_action_runner(use_tools, storage_backend)
+             └── ActionRunner(use_tools, processor_factory, storage_backend)
+
+Profiles:
+  development → DEBUG logging, no cache, no parallel
+  production  → INFO logging, cache on, parallel on
+  testing     → ERROR logging, mock everything
+```
+
+### ProcessorRegistry (Separate from DI Container)
+
+```
+ProcessorRegistry (module-level singleton: registry)
+  │
+  ├── @registry.register_processor("name")  → decorator
+  ├── @registry.register_loader("name")
+  ├── @registry.register_generator("name")
+  └── @registry.register_service("name")
+
+ProcessorFactory uses both:
+  ProcessorFactory(container, registry)
+    create_processor("name") → registry.get_processor("name") → cls
+                              → _build_init_kwargs(cls, container) → instance
+```
+
+---
+
+## File Index
+
+### Schema & Validation
+| File | Role |
+|------|------|
+| `schema.py` | `WorkflowConfig`, `ActionConfig` (extra=forbid), `DefaultsConfig` (extra=ignore), `RetryConfig`, `RepromptConfig`, `HitlConfig`, `VersionConfig`; cross-validation (duplicates, dangling deps, cycles) |
+| `types.py` | `Granularity`, `RunMode` enums; `ActionConfigDict`, `ActionEntryDict`, `ContextScopeDict`, `GuardConfigDict`, `WhereClauseDict`, `HitlConfigDict` typed dicts |
+| `environment.py` | `EnvironmentConfig` (pydantic-settings), API key validation, environment detection helpers |
+
+### Path Resolution
+| File | Role |
+|------|------|
+| `paths.py` | `PathManager` — project root discovery with CWD-aware cache, standard path templates, boundary-guarded `clean_path()`, permission validation |
+| `path_config.py` | `find_project_root_dir()` (walk-up marker search), `load_project_config()` (YAML loader with search order), `resolve_project_root()`, `get_tool_dirs()`, `get_schema_path()`, `get_seed_data_path()` |
+| `project_paths.py` | `ProjectPathsFactory.create_project_paths()` — resolves all standard directories, validates required dirs, auto-creates optional dirs |
+
+### Config Assembly
+| File | Role |
+|------|------|
+| `manager.py` | `ConfigManager` — orchestrates the full pipeline: YAML load, Jinja2 render, Pydantic validate, merge defaults, expand actions, infer dependencies, topological sort, environment config |
+| `defaults.py` | Zero-import default constants: `StorageDefaults`, `LockDefaults`, `OllamaDefaults`, `ApiDefaults`, `SeedDataDefaults`, `PromptDefaults`, `DocsDefaults` |
+
+### DI System
+| File | Role |
+|------|------|
+| `di/container.py` | `DependencyContainer` (singleton/transient/factory/instance), `ProcessorRegistry` (decorator-based), `ProcessorFactory` (registry + container), `_build_init_kwargs()` |
+| `di/configurator.py` | `DIConfigurator` — registers all services, `ConfigurationProfile` presets (dev/prod/test) |
+| `di/application.py` | `ApplicationContainer` — top-level bootstrap, creates `ActionRunner` with all deps |
+| `di/types.py` | `DIConfig`, `LoggingConfig`, `ProcessorsConfig`, `ServicesConfig` typed dicts |
+| `factory.py` | `application_container_context()` context manager, `create_action_runner()` convenience function |
+| `interfaces.py` | `ILoader`, `IProcessor`, `IGenerator`, `IDataLoader`, `ISourceDataLoader`, `IDataProcessor` ABCs with async mixins; `ProcessingMode` enum |
+
+### Project Lifecycle
+| File | Role |
+|------|------|
+| `init.py` | `ProjectInitializer` — scaffolds new projects (directories + `agent_actions.yml`) |
+| `__init__.py` | Re-exports `WorkflowConfig` |
+
+---
+
+## Caveats
+
+These are the non-obvious behaviors, edge cases, and invariants that will bite you if you don't know about them.
+
+### 1. ActionConfig uses `extra="forbid"`
+
+Any unknown key in an action definition raises a `ValidationError`. This is intentional — it catches YAML typos like `temperture` before they silently do nothing. If you add a new action-level field, you must add it to `ActionConfig` in `schema.py`.
+
+### 2. DefaultsConfig uses `extra="ignore"`
+
+Unlike `ActionConfig`, the defaults section silently ignores unknown keys. This is because vendor-specific generation parameters (`frequency_penalty`, `presence_penalty`, `top_k`, etc.) flow through defaults and are consumed by `extract_generation_params()` at LLM call time, not by the Pydantic model. A warning is logged for unknown keys, but validation does not fail.
+
+### 3. AgentConfig uses `extra="allow"`
+
+The post-expansion `AgentConfig` (in `output/response/config_schema.py`, not in this module) uses `extra="allow"` because `ActionExpander` injects many runtime-only fields (`agent_type`, `code_path`, `schema_name`, `tools_path`, `is_versioned_agent`, etc.) that aren't in the original YAML. These pass through without Pydantic rejecting them.
+
+### 4. chunk_config gets a shallow deep-merge
+
+In `merge_agent_configs()`, most keys do a flat override (`agent_value wins`). But `chunk_config` is special-cased: `{**default_chunk, **agent_chunk}`. This means per-action chunk_config can override individual sub-keys without losing the rest of the default. However, this is only one level deep — nested sub-keys inside chunk_config are not recursively merged.
+
+### 5. tool_path is always normalized to a list
+
+`tool_path` can be a string or a list in YAML. `ConfigManager.load_configs()` normalizes it to `list[str]` immediately. All downstream code can assume `tool_path` is always a list. When no tool_path is configured anywhere (workflow, default, or project config), it defaults to `["tools"]` with a warning.
+
+### 6. Filename must match the `name` field
+
+`validate_agent_name()` enforces that the workflow's `name` field matches the config file's stem. If your file is `extraction.yml`, the `name:` must be `extraction`. This prevents silent mismatches where a renamed file still loads with the old name.
+
+### 7. Jinja2 rendering happens before YAML parsing
+
+Config files are Jinja2-rendered first via `render_pipeline_with_templates()`, then `yaml.safe_load()`'d. This means you can use Jinja2 syntax in YAML config files (template variables, conditionals, loops). But it also means a Jinja2 syntax error will surface as a `TemplateRenderingError`, not a YAML error.
+
+### 8. Project root search has fallback heuristics
+
+`find_project_root_dir()` first looks for marker files (`agent_actions.yml`, `agent_actions.yaml`, `.agent_actions.yml`). If none are found, it falls back to checking for `agent_actions/` or `agent_config/` directories. When the fallback triggers, a debug log is emitted. This can produce surprising results in monorepos with multiple `agent_config/` directories.
+
+### 9. PathManager cache is CWD-sensitive
+
+When `PathManager` resolves the project root from CWD (no explicit `project_root` argument), it caches both the result and the CWD at resolution time. If CWD changes between calls, the cache is invalidated and re-resolved. When an explicit `project_root` is passed to the constructor, the cache is pinned and never invalidated by CWD changes.
+
+### 10. kind overrides model_vendor at the end
+
+In `get_all_agent_configs_as_dicts()`, after all merging is done, `kind=="tool"` forces `model_vendor="tool"` and `kind=="hitl"` forces `model_vendor="hitl"`. This happens regardless of what `model_vendor` was set to in YAML or defaults. It ensures tool and HITL actions always route to the correct client, even if they inherited `model_vendor: openai` from defaults.
+
+### 11. None fields are coerced to empty strings for downstream safety
+
+`get_all_agent_configs_as_dicts()` converts several `None`-valued optional fields to `""` (or their domain defaults). This prevents downstream code from crashing on `None` where it expects a string (template rendering, conditional checks, etc.). The coerced fields include `conditional_clause`, `granularity`, `run_mode`, `prompt`, `schema_name`, `code_path`, and `anthropic_version`.
+
+### 12. Dependencies are inferred, not just declared
+
+`determine_execution_order()` does not simply read the `dependencies` list from each action. It calls `infer_dependencies()` which analyzes `context_scope` to discover implicit dependencies (e.g., an action that observes fields from another action depends on it). The dependency graph is built from both `input_sources` and `context_sources`. Explicit `dependencies` are only used as a fallback when inference fails.
+
+### 13. Circular dependency detection is iterative, not recursive
+
+The cycle detection in `WorkflowConfig.validate_workflow_invariants()` uses an iterative DFS with explicit stack management (WHITE/GRAY/BLACK coloring). This avoids `RecursionError` on deep dependency chains. When a cycle is detected, the full cycle path is reconstructed from the stack for the error message.
+
+### 14. EnvironmentConfig loads from project root, not CWD
+
+`ConfigManager._resolve_dotenv()` resolves the `.env` file relative to the project root (or `find_project_root_dir()`), not the current working directory. This is important when running the CLI from a subdirectory — it still finds the project's `.env` file.
+
+### 15. ProcessorRegistry is a module-level singleton
+
+`registry = ProcessorRegistry()` at the bottom of `di/container.py` is a module-level singleton. All `@registry.register_*` decorators across the codebase write to this single instance. It is separate from the DI container — the container resolves dependencies by type, while the registry resolves components by name string.
+
+### 16. DI container is thread-safe for singletons only
+
+`DependencyContainer.get()` uses an `RLock` when creating singleton instances (double-check locking pattern). Transient and factory resolutions are not locked. The `_instances` dict can be read without the lock, but writes (first singleton creation) are serialized.
+
+### 17. clean_path refuses to delete outside project root
+
+`PathManager.clean_path()` calls `is_within_project()` before deleting anything. If the path is not under the project root, it raises `ValueError` immediately. This is a safety boundary to prevent accidental deletion of system files. The check depends on `get_project_root()` being resolvable — if the manager was not primed with a root, it will resolve from CWD.
+
+### 18. retry and reprompt reject boolean `true` in YAML
+
+Both `ActionConfig` and `DefaultsConfig` have validators that accept `retry: false` (disables) but reject `retry: true` (ambiguous). You must use a mapping like `retry: {max_attempts: 3}`. This prevents users from enabling retry/reprompt without specifying parameters, which would use defaults they might not be aware of.
+
+### 19. guard expressions are validated at parse time
+
+`ActionConfig.validate_guard()` calls `GuardParser.parse()` (for string guards) or `parse_guard_config()` (for dict guards) during Pydantic validation. Invalid guard expressions fail at config load time, not at runtime when the action executes. This provides early feedback for guard syntax errors.
+
+### 20. seed_data_path rejects path traversal
+
+`get_seed_data_path()` in `path_config.py` rejects any `seed_data_path` containing `..`, `/`, or `\\`. These are interpreted as path traversal attempts and fall back to the default `"seed_data"` with a warning. The `seed_data_path` must be a simple directory name, not a path.

--- a/agent_actions/config/_MANIFEST.md
+++ b/agent_actions/config/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Config Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)** — config loading pipeline, two-stage validation, defaults cascade, path resolution, DI system, and 20 caveats.
+
 ## Overview
 
 What: Configuration and initialization surfaces for Agent Actions—schema models, environment

--- a/agent_actions/errors/ARCHITECTURE.md
+++ b/agent_actions/errors/ARCHITECTURE.md
@@ -1,0 +1,276 @@
+# Errors Module Architecture
+
+This document maps the error hierarchy, retry/terminal classification, and propagation patterns for `agent_actions/errors/` — the module that defines every exception type the framework can raise.
+
+---
+
+## Error Hierarchy
+
+```
+Exception
+└── AgentActionsError                          base.py
+    │
+    ├── InvalidParameterError                  common.py
+    │
+    ├── ConfigurationError                     configuration.py
+    │   ├── ConfigValidationError
+    │   ├── DuplicateFunctionError
+    │   ├── FunctionNotFoundError
+    │   ├── UDFLoadError
+    │   ├── AgentNotFoundError
+    │   ├── ProjectNotFoundError
+    │   └── RecordContextError                 (per-record recoverable)
+    │
+    ├── ExternalServiceError                   external_services.py
+    │   ├── VendorAPIError
+    │   │   ├── AnthropicError
+    │   │   ├── RateLimitError                 (retryable)
+    │   │   ├── PromptTooLargeError
+    │   │   └── LLMResponseParseError
+    │   └── NetworkError                       (retryable)
+    │
+    ├── FileSystemError                        filesystem.py
+    │   ├── FileLoadError
+    │   ├── FileWriteError
+    │   └── DirectoryError
+    │
+    ├── OperationalError                       operations.py
+    │   ├── AgentExecutionError
+    │   └── TemplateRenderingError
+    │       └── TemplateVariableError          (per-record recoverable)
+    │
+    ├── PreFlightValidationError               preflight.py
+    │   ├── ContextStructureError
+    │   ├── VendorConfigError
+    │   └── PathValidationError
+    │
+    ├── ProcessingError                        processing.py
+    │   ├── TransformationError
+    │   ├── GenerationError
+    │   ├── WorkflowError
+    │   ├── SerializationError
+    │   └── EmptyOutputError
+    │
+    ├── ResourceError                          resources.py
+    │   └── DependencyError
+    │
+    └── ValidationError                        validation.py
+        ├── PromptValidationError
+        ├── DataValidationError
+        └── SchemaValidationError
+```
+
+---
+
+## Retryable vs Terminal Classification
+
+The retry system lives in `processing/recovery/retry.py`. Only two error types trigger automatic retry with exponential backoff:
+
+```python
+RETRIABLE_ERRORS = (NetworkError, RateLimitError)
+```
+
+There is also a soft extension: `VendorAPIError` instances whose message matches a known transient pattern are treated as retryable. The current patterns are:
+
+```python
+_TRANSIENT_API_ERROR_PATTERNS = (
+    "could not parse the json body",
+    "we are currently processing your json schema",
+)
+```
+
+### Classification table
+
+| Error | Retryable? | Why |
+|-------|-----------|-----|
+| `NetworkError` | Yes | Transient connection/timeout failures |
+| `RateLimitError` | Yes | HTTP 429 with optional retry-after header |
+| `VendorAPIError` (transient pattern match) | Yes | Known intermittent provider bugs |
+| `VendorAPIError` (all other) | No | Provider rejected the request (bad input, content filter, etc.) |
+| `AnthropicError` | No | Subclass of VendorAPIError, not in RETRIABLE_ERRORS tuple |
+| `PromptTooLargeError` | No | Deterministic — same prompt will always be too large |
+| `LLMResponseParseError` | No | JSON parse failure — handled by reprompt, not retry |
+| Everything else | No | Configuration, filesystem, validation errors are not transient |
+
+### How `is_retriable_error()` decides
+
+```
+is_retriable_error(error)
+  │
+  ├── isinstance(error, (NetworkError, RateLimitError))?  ──► True
+  │
+  ├── isinstance(error, VendorAPIError)?
+  │     └── message matches _TRANSIENT_API_ERROR_PATTERNS? ──► True
+  │
+  └── else ──► False (re-raised immediately by RetryService)
+```
+
+---
+
+## Error Propagation Patterns
+
+Errors propagate through three distinct paths depending on where they originate and whether they affect one record or the entire run.
+
+### Pattern 1: Vendor SDK → Unified Error → Retry or Raise
+
+LLM provider SDK exceptions are caught at the provider layer and converted to the unified hierarchy by `wrap_vendor_error()` in `llm/providers/error_wrapper.py`.
+
+```
+SDK exception (openai.RateLimitError, httpx.TimeoutException, etc.)
+     │
+     ▼
+wrap_vendor_error()
+     │
+     ├── Type-based match (OpenAI, Anthropic, Groq)
+     │     ├── rate_limit_types     → RateLimitError + fire RateLimitEvent
+     │     ├── network_error_types  → NetworkError   + fire LLMErrorEvent
+     │     └── base_api_error_type  → VendorAPIError + fire LLMErrorEvent
+     │
+     ├── Status-code match (Gemini, Cohere, Ollama)
+     │     ├── 429                  → RateLimitError + fire RateLimitEvent
+     │     ├── 500/502/503/504      → NetworkError   + fire LLMErrorEvent
+     │     └── other codes          → VendorAPIError + fire LLMErrorEvent
+     │
+     └── extra_network_types (Python builtins, httpx)
+           └── ConnectionError, etc → NetworkError   + fire LLMErrorEvent
+     │
+     ▼
+RetryService.execute()
+     │
+     ├── is_retriable_error() = True  → exponential backoff → retry
+     │     └── exhausted? → RetryResult(exhausted=True) or RetryExhaustedException
+     │
+     └── is_retriable_error() = False → re-raise immediately
+```
+
+### Pattern 2: Pre-flight Validation → CLI Abort
+
+Pre-flight errors are raised before any LLM calls happen. They abort the entire run with a user-friendly message.
+
+```
+Config loading / validation
+     │
+     ├── Missing agent_actions.yml        → ProjectNotFoundError
+     ├── Bad YAML config                  → ConfigValidationError
+     ├── Missing vendor fields            → VendorConfigError
+     ├── Invalid file paths               → PathValidationError
+     ├── Mismatched context schema        → ContextStructureError
+     ├── Missing SDK package              → DependencyError
+     └── Duplicate UDF names              → DuplicateFunctionError
+     │
+     ▼
+CLI catches AgentActionsError
+     │
+     └── PreFlightValidationError.__str__() calls format_user_message()
+           └── _render_sections() builds a structured multi-line message
+                 with Missing/Available/Hint/Agent/Mode sections
+```
+
+Pre-flight errors are never retried. They represent misconfiguration that must be fixed by the user.
+
+### Pattern 3: Template Rendering → Per-Record Tombstone
+
+Some errors affect a single record without terminating the pipeline. The record gets a tombstone disposition (FAILED) and processing continues for the remaining records.
+
+```
+Template rendering for record N
+     │
+     ├── Jinja2 UndefinedError
+     │     └── caught → TemplateVariableError
+     │           carries: missing_variables, available_variables,
+     │                    namespace_context, storage_hints,
+     │                    null_namespace_hints
+     │           → record N gets FAILED disposition
+     │           → records N+1... continue processing
+     │
+     └── RecordContextError
+           └── record's context data incomplete
+                 → record N gets FAILED disposition
+                 → records N+1... continue processing
+```
+
+---
+
+## Per-Record Recoverable Errors
+
+Two errors are designed for per-record recovery rather than pipeline abort:
+
+### RecordContextError
+
+Raised when a single record's context data is incomplete (e.g., a required upstream field is missing for this record but present for others). The pipeline skips the record and continues.
+
+Defined in `configuration.py` as a subclass of `ConfigurationError` — it is a configuration problem, but scoped to one record rather than the entire project.
+
+### TemplateVariableError
+
+Raised when Jinja2 template rendering fails for a specific record because a referenced variable is undefined. Carries rich diagnostic metadata:
+
+- `missing_variables` / `available_variables` — what was expected vs what exists
+- `namespace_context` — maps namespace names to their available fields
+- `template_line` — line number in the template where the error occurred
+- `field_context_metadata` — stored vs loaded fields per namespace
+- `storage_hints` — when a field exists in storage but was not loaded (missing schema declaration)
+- `null_namespace_hints` — when a namespace is null due to guard-filter at a fan-in point
+
+Both errors result in a FAILED disposition for the affected record. The pipeline does not abort.
+
+---
+
+## The Base Class Contract
+
+`AgentActionsError.__init__` defensively copies its `context` argument:
+
+```python
+self.context = dict(context) if isinstance(context, dict) else (context or {})
+```
+
+This means callers cannot mutate the error's context after construction by holding a reference to the original dict. Every subclass inherits this behavior.
+
+### Helper functions
+
+| Function | Purpose |
+|----------|---------|
+| `enrich_exception_context(exc, **kv)` | Attach additional key-value pairs to any exception's `.context` dict. Works on both `AgentActionsError` and stdlib exceptions. |
+| `get_error_detail(error)` | Returns `error.detailed_str()` for `AgentActionsError` (message + context dict), otherwise `str(error)`. Use at structured-logging boundaries. |
+
+---
+
+## File Index
+
+| File | What it defines |
+|------|----------------|
+| `__init__.py` | Centralized re-exports — every error class is importable from `agent_actions.errors` |
+| `base.py` | `AgentActionsError`, `enrich_exception_context`, `get_error_detail` |
+| `common.py` | `InvalidParameterError` — cross-cutting parameter validation |
+| `configuration.py` | `ConfigurationError` tree: config validation, UDF loading, agent/project lookup, record context |
+| `external_services.py` | `ExternalServiceError` tree: vendor API, rate limit, network, prompt size, parse errors |
+| `filesystem.py` | `FileSystemError` tree: load, write, directory operations |
+| `operations.py` | `OperationalError` tree: agent execution, template rendering, template variables |
+| `preflight.py` | `PreFlightValidationError` tree: context structure, vendor config, path validation; plus `_render_sections()` |
+| `processing.py` | `ProcessingError` tree: transformation, generation, workflow, serialization, empty output |
+| `resources.py` | `ResourceError` tree: missing dependencies |
+| `validation.py` | `ValidationError` tree: prompt, data, and schema validation |
+
+---
+
+## Caveats and Invariants
+
+1. **`AnthropicError` is NOT retryable.** It subclasses `VendorAPIError`, not `RateLimitError` or `NetworkError`. The retry system checks `isinstance(error, RETRIABLE_ERRORS)` — `AnthropicError` does not match. Rate limits from Anthropic are wrapped as `RateLimitError` by `wrap_vendor_error()`, not as `AnthropicError`. If you catch `AnthropicError` expecting it to be retried, it will not be.
+
+2. **`VendorAPIError` transient patterns are a soft extension.** `is_retriable_error()` checks message substrings for known intermittent provider bugs. These patterns are hardcoded in `_TRANSIENT_API_ERROR_PATTERNS` in `processing/recovery/retry.py`. Adding a new pattern there changes retry behavior globally. The match is case-insensitive (`.lower()` before comparison).
+
+3. **`NetworkError` is a sibling of `VendorAPIError`, not a child.** Both inherit from `ExternalServiceError`. Code that catches `VendorAPIError` will NOT catch `NetworkError`. This is intentional — they have different retry semantics — but it means a broad `except VendorAPIError` will miss timeout and connection failures.
+
+4. **`PreFlightValidationError` overrides `__str__`.** It calls `format_user_message()` which uses `_render_sections()` to produce a multi-line structured message. If you catch this error and call `str(e)`, you get the full formatted output, not just the header. `SchemaValidationError` (in `validation.py`) does the same.
+
+5. **`TemplateVariableError` uses keyword-only `__init__`.** Unlike other errors in the hierarchy, it does not accept a positional `message` argument. It constructs its own message from `agent_name` and `missing_variables`. Calling `TemplateVariableError("some message")` will raise a `TypeError`.
+
+6. **Context dict is always copied, never shared.** `AgentActionsError.__init__` does `dict(context)` on construction. Subclass `__init__` methods that build their own `ctx = dict(context) if context else {}` before calling `super().__init__` are doing a double-copy, which is harmless. But the invariant is: the `.context` attribute on any `AgentActionsError` instance is owned exclusively by that instance.
+
+7. **`RecordContextError` lives under `ConfigurationError`, not `ProcessingError`.** This is a deliberate classification: a record's missing context is a configuration/data issue, not a processing failure. But its propagation behavior (per-record tombstone, pipeline continues) is more like a processing error. Do not move it without updating the callers that catch `ConfigurationError` subtypes.
+
+8. **`LLMResponseParseError` is not retried by `RetryService`.** It subclasses `VendorAPIError` but does not match `RETRIABLE_ERRORS` or `_TRANSIENT_API_ERROR_PATTERNS`. JSON parse failures are handled by the reprompt loop (corrective feedback to the LLM), not by transport-layer retry. Conflating the two recovery mechanisms will cause parse failures to burn through retry attempts without sending corrective feedback.
+
+9. **`RateLimitError` subclasses `VendorAPIError`.** This means `except VendorAPIError` will also catch rate limit errors. If you add error handling that catches `VendorAPIError` and treats it as terminal, you will accidentally suppress retry for rate limits. Always check for `RateLimitError` first, or use `is_retriable_error()`.
+
+10. **`wrap_vendor_error()` returns the original exception if nothing matches.** If a vendor SDK raises an exception type not covered by the mapping, `wrap_vendor_error()` returns it unchanged. It does NOT wrap it in `VendorAPIError`. This means unknown vendor exceptions bypass the entire unified error handling and event-firing pipeline. Any new vendor SDK exception types must be added to the vendor's `VendorErrorMapping`.

--- a/agent_actions/errors/_MANIFEST.md
+++ b/agent_actions/errors/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Errors Manifest
 
+**[> Architecture Guide (ARCHITECTURE.md)](ARCHITECTURE.md)** — error hierarchy, retry vs terminal classification, propagation patterns, invariants.
+
 ## Modules
 
 | Name | Type | Description | Signals |

--- a/agent_actions/guards/ARCHITECTURE.md
+++ b/agent_actions/guards/ARCHITECTURE.md
@@ -1,0 +1,334 @@
+# Guards Module Architecture
+
+This document maps `agent_actions/guards/` — a leaf package that parses and validates guard expressions from workflow config. Guards control whether individual records are processed by an action, skipped with a tombstone, or excluded entirely.
+
+---
+
+## High-Level Overview
+
+```
+agent_actions/guards/          ← THIS PACKAGE (config-time parsing)
+├── guard_parser.py            Parse string → GuardExpression (SQL or UDF)
+└── consolidated_guard.py      Parse string-or-dict → GuardConfig (expression + behavior)
+
+input/preprocessing/filtering/ ← EVALUATION LAYER (runtime)
+├── evaluator.py               GuardEvaluator — runs guard against record data
+└── guard_filter.py            GuardFilter — AST eval, caching, timeout, circuit breaker
+
+output/response/
+└── expander_action_types.py   Expands guard config into agent dict at config time
+```
+
+The package has **two files** and **no state**. It exists as a separate leaf package to break a circular import between `config/` (which reads guard definitions) and `output/` (which expands them into agent dicts). Both `guards/` modules depend only on `errors` and `utils.constants`.
+
+---
+
+## Two Input Formats
+
+Guard configuration in `agent_config/{workflow}.yml` supports two formats:
+
+```yaml
+# Legacy string format
+guard: "status == 'active'"            # SQL — defaults to on_false: filter
+guard: "udf:tools.check_eligibility"   # UDF — defaults to on_false: skip
+
+# Current dict format
+guard:
+  condition: "status == 'active'"
+  on_false: skip                       # explicit behavior control
+```
+
+`parse_guard_config()` is the single entry point. It dispatches to `GuardConfig.from_string()` (legacy) or `GuardConfig.from_dict()` (current). The legacy path assigns default behaviors: SQL guards default to FILTER, UDF guards default to SKIP.
+
+---
+
+## Guard Types
+
+### SQL Guards
+
+SQL-like boolean expressions evaluated against record data using an AST parser. Supports comparison operators, logical operators (AND/OR/NOT), IS NULL, IN, LIKE, and dotted field paths for namespaced content.
+
+```yaml
+guard:
+  condition: "validate.pass == true AND score > 0.8"
+```
+
+Validated at parse time against `DANGEROUS_PATTERNS` (blocks `exec`, `eval`, `__import__`, etc.). No actual SQL engine is involved — the AST evaluator in `input/preprocessing/filtering/` handles execution.
+
+### UDF Guards
+
+User-defined Python functions referenced by module path. The function receives the record data and returns a boolean.
+
+```yaml
+guard:
+  condition: "udf:tools.guards.check_eligibility"
+  on_false: skip
+```
+
+Validated at parse time: must match `module.function` dotted path format, checked against `DANGEROUS_PATTERNS_UDF`. UDF guards **cannot use FILTER behavior** — this is enforced during config expansion in `expander_action_types.py`, which raises `ConfigurationError` if a UDF guard specifies `on_false: filter`.
+
+### Safety Validation
+
+Both types run through safety checks at parse time:
+
+- SQL expressions: blocked patterns include `exec(`, `eval(`, `__import__`, `system(`, `subprocess`
+- UDF expressions: same checks plus format validation (must be `module.function` or `module.submodule.function`)
+- Built-in Python names (`file`, `input`, `vars`, `dir`) are treated as column references in SQL guards, not as Python builtins
+
+---
+
+## Guard Behaviors
+
+Three behaviors control what happens when a guard condition evaluates to false:
+
+```
+FILTER  Record is excluded entirely. No output row is written.
+        The record does not appear in agent_io/target/{action}/.
+        In batch mode, the context_map marks it as FILTERED.
+
+SKIP    Record is not sent to the LLM, but a tombstone disposition
+        is written to storage. The record appears in output with its
+        original content (passthrough) but no LLM-generated fields.
+
+WARN    Record proceeds to LLM processing normally. A warning is
+        logged but execution is not blocked. The record is treated
+        as if the guard passed.
+```
+
+Unsupported behaviors (`write_to`, `reprocess`) are recognized during config loading but rejected with `ConfigValidationError`.
+
+---
+
+## Full Evaluation Pipeline
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ 1. CONFIG VALIDATION (parse time)                            │
+│                                                              │
+│    agent_config/{workflow}.yml                                │
+│    guard: "status == 'active'"                               │
+│         │                                                    │
+│         ▼                                                    │
+│    parse_guard_config()  →  GuardConfig                      │
+│      validates expression safety (dangerous patterns)        │
+│      validates UDF format (module.function)                  │
+│      validates behavior (skip/filter/warn)                   │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+┌──────────────────────────▼───────────────────────────────────┐
+│ 2. EXPANSION (config expansion)                              │
+│                                                              │
+│    expander_action_types.py :: process_guard_config()         │
+│                                                              │
+│    Converts GuardConfig into agent dict keys:                │
+│      SQL  → agent["guard"] = {clause, scope, behavior}       │
+│      UDF  → agent["conditional_clause"] = "module.func"      │
+│                                                              │
+│    Enforces: UDF cannot use FILTER behavior                  │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+┌──────────────────────────▼───────────────────────────────────┐
+│ 3. TASK PREPARATION (per-record, before LLM call)            │
+│                                                              │
+│    processing/task_preparer.py :: TaskPreparer.prepare()      │
+│                                                              │
+│    For each record:                                          │
+│      load field_context (upstream outputs, seed data)        │
+│      call GuardEvaluator.evaluate(item, guard_config)        │
+│      result → INCLUDED / FILTERED / SKIPPED                  │
+│                                                              │
+│    Filtered/skipped records get a PreparedTask with          │
+│    guard_status set; they are never sent to the LLM.         │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+┌──────────────────────────▼───────────────────────────────────┐
+│ 4. GUARD EVALUATOR (runtime evaluation)                      │
+│                                                              │
+│    input/preprocessing/filtering/evaluator.py                │
+│      GuardEvaluator.evaluate()                               │
+│        │                                                     │
+│        ├─ _prepare_eval_context()                            │
+│        │    promotes content namespaces to top-level keys     │
+│        │    {"content": {"action_a": {"f": 1}}}              │
+│        │       → {"action_a": {"f": 1}}                      │
+│        │                                                     │
+│        ├─ _evaluate_conditional_clause() (legacy UDF path)   │
+│        │    calls execute_user_defined_function()             │
+│        │                                                     │
+│        └─ _evaluate_guard() (SQL path)                       │
+│             builds FilterItemRequest                         │
+│             calls GuardFilter.filter_item()                  │
+│             reclassifies missing-field errors                │
+│             maps FilterResult → GuardResult                  │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+┌──────────────────────────▼───────────────────────────────────┐
+│ 5. GUARD FILTER (AST evaluation engine)                      │
+│                                                              │
+│    input/preprocessing/filtering/guard_filter.py             │
+│      GuardFilter.filter_item()                               │
+│        │                                                     │
+│        ├─ circuit breaker check (semantic error cache)       │
+│        ├─ submit to ThreadPoolExecutor (timeout protection)  │
+│        ├─ parse condition (LRU cached)                       │
+│        └─ AST evaluate against record data                   │
+│                                                              │
+│    Returns FilterResult with:                                │
+│      success, matched, error, error_category, execution_time │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Error Classification
+
+Guard evaluation errors fall into three categories, each with different handling:
+
+```
+SEMANTIC    The condition itself is broken (unquoted string literal,
+            syntax error, invalid operator). Bypasses passthrough_on_error
+            — the guard behavior always applies. Circuit-breaker caches
+            these so the same broken condition is not re-evaluated.
+
+DATA        A field referenced in the condition does not exist in this
+            particular record. Respects passthrough_on_error: if true,
+            the record passes through; if false, the guard behavior
+            applies. Missing fields in namespaced content may be
+            reclassified (see reclassify_missing_field_error).
+
+TIMEOUT     Evaluation exceeded the time limit (default 5 seconds).
+            Treated like a DATA error for passthrough_on_error purposes.
+```
+
+### passthrough_on_error
+
+A per-guard config flag (default: `true`). When `true`, DATA and TIMEOUT errors cause the record to pass through as if the guard matched. When `false`, the configured behavior (filter/skip/warn) applies on error.
+
+SEMANTIC errors **always bypass** `passthrough_on_error` — a broken condition is a config bug, not a data issue, and should not silently pass records through.
+
+---
+
+## Record Disposition After Guard
+
+```
+Guard matched (true)     → record proceeds to LLM
+Guard not matched:
+  FILTER behavior        → no output row written, no tombstone
+                           batch context_map: _batch_filter_status = "filtered"
+  SKIP behavior          → tombstone disposition written to storage
+                           record appears in output with original content
+  WARN behavior          → warning logged, record proceeds to LLM
+```
+
+In batch mode, filtered records are marked in the context_map during preparation and never submitted to the provider. The disposition must be explicitly written during batch finalization. In online mode, the disposition is written immediately by the result collector.
+
+---
+
+## Batch vs Online Timing
+
+```
+BATCH:
+  Guards run in Phase 1 (preparation), BEFORE provider submission.
+  Filtered/skipped records are marked in context_map.
+  They never appear in the JSONL file sent to the provider.
+  Dispositions are written during finalization.
+
+ONLINE:
+  Guards run per-record in task_preparer, BEFORE the LLM call.
+  Filtered/skipped records get immediate disposition writes.
+  No context_map involved — state is in-memory only.
+```
+
+The guard evaluation code is identical in both paths — `GuardEvaluator` is used by both `TaskPreparer` (online) and the batch preparator. The difference is only in when dispositions are persisted.
+
+---
+
+## Evaluation Context
+
+What the guard condition sees at evaluation time:
+
+```
+Raw record from storage:
+  {
+    "source_guid": "abc",
+    "content": {
+      "extraction": {"title": "Report", "score": 0.9},
+      "validation": {"pass": true}
+    },
+    "_passthrough_fields": {"name": "Alice"}
+  }
+
+After _prepare_eval_context() promotes namespaces:
+  {
+    "source_guid": "abc",
+    "extraction": {"title": "Report", "score": 0.9},
+    "validation": {"pass": true},
+    "_passthrough_fields": {"name": "Alice"}
+  }
+
+Guard condition uses dotted paths:
+  extraction.score > 0.8 AND validation.pass == true
+```
+
+If `_build_evaluation_context()` is used (Phase 2 evaluation with full context), the item's content is merged with context data (passthrough fields, source data). Content fields take precedence over top-level fields on collision.
+
+---
+
+## File Index
+
+### Core Package (guards/)
+
+| File | Role |
+|------|------|
+| `guard_parser.py` | Parse guard string into `GuardExpression` (SQL or UDF type), safety validation |
+| `consolidated_guard.py` | Parse string-or-dict into `GuardConfig` (expression + behavior), behavior validation |
+| `__init__.py` | Re-exports: `GuardType`, `GuardExpression`, `GuardParser`, `parse_guard`, `GuardBehavior`, `GuardConfig`, `parse_guard_config` |
+
+### Evaluation Layer (input/preprocessing/filtering/)
+
+| File | Role |
+|------|------|
+| `evaluator.py` | `GuardEvaluator` — unified guard evaluation, context preparation, error reclassification |
+| `guard_filter.py` | `GuardFilter` — AST-based eval, LRU parse cache, ThreadPoolExecutor timeout, circuit breaker |
+
+### Integration Points
+
+| File | Role |
+|------|------|
+| `output/response/expander_action_types.py` | `process_guard_config()` — expands guard into agent dict keys during config expansion |
+| `processing/task_preparer.py` | `TaskPreparer.prepare()` — evaluates guard per-record before LLM call |
+| `workflow/executor.py` | `_compute_action_config_hash()` — includes guard clause + behavior in config hash |
+| `workflow/coordinator.py` | `validate_guard_conditions()` — pre-flight AST parse and semantic checks |
+| `workflow/managers/skip.py` | Action-scope guard evaluation (scope: action, not item) |
+| `config/types.py` | `GuardConfig` TypedDict — `passthrough_on_error`, `passthrough_on_empty` config shape |
+
+### Re-export Shims (backward compatibility)
+
+| File | Role |
+|------|------|
+| `output/response/guard_parser.py` | Re-exports from `guards.guard_parser` |
+| `output/response/consolidated_guard.py` | Re-exports from `guards.consolidated_guard` |
+
+---
+
+## Caveats
+
+1. **Leaf package is intentional.** `guards/` depends only on `errors` and `utils.constants`. This breaks the `config` <-> `output` circular import that would occur if guard parsing lived in either package. Do not add dependencies on `config`, `output`, `processing`, or `input`.
+
+2. **UDF guards cannot use FILTER behavior.** Enforced in `expander_action_types.py`, not in the guards package itself. UDF guards only support SKIP (default) and WARN. This is because UDF execution happens through `execute_user_defined_function()`, which has a different evaluation path than the AST-based SQL filter.
+
+3. **WARN does not block execution.** A guard with `on_false: warn` logs a warning but the record proceeds to the LLM. It is observability-only — the record is treated identically to one that matched the guard.
+
+4. **Semantic errors bypass passthrough_on_error.** If the guard condition itself is broken (syntax error, unquoted string), `passthrough_on_error: true` does not save it. The guard behavior (filter/skip/warn) always applies. This prevents silently processing records when the guard is misconfigured.
+
+5. **Circuit breaker caches semantic errors.** `GuardFilter._semantic_error_cache` stores conditions that failed with `GuardSemanticError`. Subsequent evaluations of the same condition skip the AST entirely and return the cached error. The cache is per-`GuardFilter` instance (process-scoped singleton). Call `clear_cache()` to reset.
+
+6. **Batch mode needs explicit disposition writing.** In batch, filtered/skipped records are marked in the context_map but dispositions are not written until finalization. If a batch run crashes between preparation and finalization, filtered records have no persisted disposition. Online mode writes dispositions immediately.
+
+7. **Guard clause is included in the config hash.** `_compute_action_config_hash()` in `workflow/executor.py` hashes the guard clause and behavior. Changing a guard condition invalidates previously completed action results, forcing a re-run. This prevents stale results from persisting after guard logic changes.
+
+8. **Missing fields are reclassified, not failed.** `reclassify_missing_field_error()` in `evaluator.py` handles two cases: (a) a flat field reference that exists inside a namespace is reclassified as SEMANTIC (config error); (b) a genuinely missing field is treated as "condition not matched" rather than an error. This prevents `passthrough_on_error` from accidentally passing records that should be filtered.
+
+9. **GuardFilter uses a ThreadPoolExecutor for timeout protection.** Each evaluation runs in a thread with a configurable timeout (default 5 seconds). This prevents runaway AST evaluation from blocking the pipeline. The executor has 4 worker threads and is cleaned up via `atexit`.
+
+10. **Legacy UDF path (conditional_clause) is separate from the guard dict path.** When a UDF guard is expanded, it sets `agent["conditional_clause"]` instead of `agent["guard"]`. The evaluator handles this in `_evaluate_conditional_clause()`, which swallows exceptions and proceeds (never skips on UDF error). The SQL guard path goes through `_evaluate_guard()` with full error classification.

--- a/agent_actions/guards/_MANIFEST.md
+++ b/agent_actions/guards/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Guards
 
+**[> Architecture deep-dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 Guard expression parsing and configuration for conditional action execution.
 
 Extracted from `output/response/` to break the `config ↔ output` import cycle.

--- a/agent_actions/input/ARCHITECTURE.md
+++ b/agent_actions/input/ARCHITECTURE.md
@@ -1,0 +1,459 @@
+# Input Module Architecture
+
+This document maps the moving parts of `agent_actions/input/` -- the module that handles everything before an LLM sees a record: file reading, format conversion, data source resolution, UDF discovery, field chunking, guard evaluation, context normalization, and the initial staging pipeline.
+
+---
+
+## High-Level Overview
+
+```
+                          agent_actions/input/
+                               |
+               +---------------+---------------+
+               |               |               |
+           context/        loaders/      preprocessing/
+        (context_scope   (file I/O,     (staging, filtering,
+         normalization)   UDF loading,    parsing, chunking,
+                          data sources)   field resolution,
+                                          transformation)
+```
+
+The module has **three packages**:
+
+| Package | What it does |
+|---------|-------------|
+| `context/` | Normalizes `context_scope` directives (observe, drop, passthrough) and expands version references |
+| `loaders/` | Reads files from disk (JSON, CSV, XLSX, XML, PDF, text), discovers UDFs, resolves data sources |
+| `preprocessing/` | Staging pipeline, guard filter (WHERE clause AST), field reference resolution, chunking, and text transformation |
+
+---
+
+## Data Flow: From File to LLM-Ready Records
+
+```
+User data files (agent_io/staging/)
+       |
+       v
++---------------------+
+| FileReader.read()   |     Format dispatch: .json, .csv, .xlsx,
+| (loaders/file_reader)|     .xml, .pdf, .docx, .txt, .md, .html
++----------+----------+
+           |
+           v
++---------------------+
+| Format loaders      |     JsonLoader, TabularLoader, XmlLoader
+| (loaders/*.py)      |     convert raw content to list[dict]
++----------+----------+
+           |
+           v
++---------------------+
+| Field validation    |     Rejects reserved field names
+| (staging/           |     (source_guid, target_id, etc.)
+|  field_validation)  |     in user-supplied data
++----------+----------+
+           |
+           v
++---------------------+
+| Prompt validation   |     Validates staged data against
+| (_validate_staged_  |     Jinja2 prompt template
+|  data)              |     requirements before processing
++----------+----------+
+           |
+           v
++---------------------+
+| Data preparation    |     Batch: assign batch_id, source_guid,
+| (_prepare_batch_    |     target_id, node_id per record
+|  data /             |     Online: chunk text, wrap JSON items
+|  _prepare_online_   |
+|  data)              |
++----------+----------+
+           |
+           v
++---------------------+
+| Source save          |     Deduplicated write to agent_io/source/
+| (UnifiedSource      |     via storage backend
+|  DataSaver)         |
++----------+----------+
+           |
+           v
++---------------------+
+| Processing dispatch |     Batch: BatchSubmissionService
+|                     |     Online: UnifiedProcessor + OnlineLLMStrategy
++---------------------+
+```
+
+---
+
+## Source Data Loading Pipeline (loaders/)
+
+### FileReader -- format dispatch
+
+`FileReader` is a thin dispatcher. Given a file path, it picks the handler by extension and returns the raw content:
+
+```
+FileReader(file_path)
+  |
+  +-- .json  --> json.load()        --> dict | list[dict]
+  +-- .csv   --> csv.reader()       --> list[list[str]]
+  +-- .xlsx  --> pandas read_excel  --> list[dict]
+  +-- .xml   --> defusedxml parse   --> (tree, root) tuple
+  +-- .pdf   --> pypdf extract_text --> str
+  +-- .docx  --> python-docx        --> str (paragraphs joined)
+  +-- .txt   --> file.read()        --> str
+  +-- .md    --> file.read()        --> str
+  +-- .html  --> BeautifulSoup      --> str (text content)
+```
+
+Note that CSV returns raw rows (list of lists), not dicts. The `TabularLoader` handles dict conversion downstream. XLSX returns `list[dict]` directly via pandas.
+
+### SourceDataLoader -- storage backend reads
+
+`SourceDataLoader` wraps the `StorageBackend` for reading/writing intermediate source data. It implements the `ISourceDataLoader` interface. Used by downstream actions that need to read a previous action's output as their input:
+
+```
+SourceDataLoader(agent_name, storage_backend)
+  .load_source_data(relative_path)  --> storage_backend.read_source()
+  .save_source_data(relative_path, data)  --> storage_backend.write_source()
+```
+
+### Data source resolution
+
+`resolve_start_node_data_source()` determines *where* the initial data comes from:
+
+```
+data_source config value
+       |
+       +-- None / "staging" --> agent_io/staging/ directory
+       +-- "/path/to/dir"   --> local folder (validated inside project root)
+       +-- {type: "local", folder: "...", file_type: ["json"]}  --> filtered local
+       +-- {type: "api", url: "https://...", headers: {...}}     --> fetch + cache
+```
+
+API responses are cached by fingerprint (SHA-256 of url + query + headers) under `_remote_cache/api/`. Delete the cache directory to force a refresh.
+
+---
+
+## UDF Discovery and Loading (loaders/udf.py)
+
+UDFs (User-Defined Functions) are Python files in `tools/{workflow}/`. The discovery process:
+
+```
+discover_udfs(user_code_path)
+  |
+  1. discover_tool_files() -- rglob("*.py"), skip _-prefixed and test_-prefixed
+  |
+  2. For each .py file:
+  |    a. Convert path to module name (dir separators -> dots)
+  |    b. Skip if already in sys.modules (idempotent)
+  |    c. importlib.util.spec_from_file_location() + exec_module()
+  |    d. @udf_tool-decorated functions self-register into UDF_REGISTRY
+  |
+  3. Return UDF_REGISTRY (global dict: name -> {func, metadata})
+
+validate_udf_references(config)
+  |
+  Walks config tree recursively, collects all "impl" string values,
+  verifies each exists in UDF_REGISTRY via get_udf().
+  Raises FunctionNotFoundError on miss.
+```
+
+The `@udf_tool` decorator (from `utils/udf_management/registry.py`) registers functions at import time. `discover_udfs` triggers the imports; after that, any action config with `impl: my_function` resolves through the global registry.
+
+---
+
+## Initial Pipeline (preprocessing/staging/initial_pipeline.py)
+
+The `process_initial_stage()` function is the entry point for all first-stage data processing. It reads a file, prepares records, saves source data, and dispatches to either batch or online processing.
+
+```
+process_initial_stage(InitialStageContext)
+  |
+  1. FileReader.read() -- raw content + file_type
+  2. validate_staging_field_names() -- reject reserved names
+  3. _validate_staged_data() -- prompt template compatibility
+  4. Branch on run_mode:
+  |
+  +-- BATCH: _prepare_batch_data()
+  |     a. Generate batch_id, node_id
+  |     b. Format dispatch (text->chunks, JSON->list, CSV/XLSX->rows, XML->records)
+  |     c. _add_batch_metadata() per record:
+  |          source_guid, target_id, batch_id, batch_uuid,
+  |          parent_target_id=None, root_target_id=target_id
+  |     d. Apply record_limit slice
+  |     e. _save_source_data()
+  |     f. _process_batch_mode() --> BatchSubmissionService
+  |
+  +-- ONLINE: _prepare_online_data()
+        a. Format dispatch (text->Tokenizer chunks, JSON->JsonLoader, etc.)
+        b. Generate source_guid per item (online does NOT assign target_id here)
+        c. Apply record_limit slice
+        d. _save_source_data()
+        e. _process_online_mode_with_record_processor() --> UnifiedProcessor
+```
+
+### source_guid and target_id assignment
+
+In **batch mode**, every record gets `source_guid` and `target_id` assigned during preparation, before anything is sent to the LLM. First-stage records are their own root: `parent_target_id = None`, `root_target_id = target_id`.
+
+In **online mode**, `source_guid` is generated for source saving, but `target_id` assignment happens later inside `UnifiedProcessor`. The source data items get `source_guid` so the source file can be written, but the raw `data_chunk` passed to the processor is *not mutated* -- `OnlineLLMStrategy` hashes raw items independently.
+
+### Source save deduplication
+
+`_should_save_source_items()` compares field counts between new and existing source files. If the existing source data has more fields (richer), the save is skipped. This prevents subsequent runs from overwriting enriched source data with sparser versions.
+
+---
+
+## Context Normalization (context/)
+
+The `normalizer.py` module handles `context_scope` expansion before processing begins:
+
+```
+context_scope:           version_base_map:
+  observe:                 summarize: [summarize_v1, summarize_v2]
+    - summarize.score
+    - summarize.*         After expansion:
+  drop:                     observe:
+    - extraction.ssn          - summarize_v1.score
+                              - summarize_v2.score
+                              - summarize_v1.*
+                              - summarize_v2.*
+                            drop:
+                              - extraction.ssn
+```
+
+`normalize_all_agent_configs()` mutates agent configs in place. It also detects YAML indentation errors where `observe`/`passthrough`/`drop` appear as sibling keys of `context_scope` instead of children (the `context_scope: null` + orphaned directives pattern).
+
+---
+
+## Guard Filtering (preprocessing/filtering/)
+
+Guards control whether a record gets processed, skipped, or filtered out. The system has two layers:
+
+### Layer 1: GuardFilter (guard_filter.py)
+
+The low-level evaluation engine. Parses WHERE clauses into an AST and evaluates them against record data.
+
+```
+GuardFilter(cache_size=1000, default_timeout=5)
+  |
+  .filter_item(FilterItemRequest)
+  |
+  1. Circuit breaker: if condition previously failed with
+  |  GuardSemanticError, return cached error immediately
+  |
+  2. Submit to ThreadPoolExecutor(max_workers=4)
+  |
+  3. _evaluate_guard_condition():
+  |    a. _parse_condition_cached() -- LRU cache on condition string
+  |    b. WhereClauseParser.parse() --> ParseResult with AST
+  |    c. ast.evaluate(data, functions) --> bool
+  |
+  4. Timeout protection: future.result(timeout=N)
+  |    Timeout -> FilterResult(error_category=TIMEOUT)
+  |
+  Returns FilterResult:
+    success: bool       -- did evaluation complete?
+    matched: bool       -- did the condition match?
+    error_category:     -- SEMANTIC | DATA | TIMEOUT
+```
+
+### Layer 2: GuardEvaluator (evaluator.py)
+
+The high-level coordinator. Maps `FilterResult` to `GuardResult` using the guard behavior policy.
+
+```
+GuardEvaluator.evaluate(item, guard_config, context)
+  |
+  1. Build evaluation context (merge item + upstream data)
+  2. Evaluate conditional_clause (legacy UDF path)
+  3. _evaluate_guard():
+  |    a. Parse behavior from config: skip | filter | warn
+  |    b. Call GuardFilter.filter_item()
+  |    c. Reclassify missing-field errors for namespaced content
+  |    d. Map FilterResult to GuardResult via behavior policy:
+  |
+  |    FilterResult        Behavior    GuardResult
+  |    -----------------------------------------------
+  |    success + matched   any         passed (execute)
+  |    success + !matched  skip        skipped (passthrough)
+  |    success + !matched  filter      filtered (exclude)
+  |    success + !matched  warn        warned (execute + log)
+  |    error (SEMANTIC)    any         behavior applies (bypasses passthrough_on_error)
+  |    error (DATA)        poe=True    passed (execute anyway)
+  |    error (DATA)        poe=False   behavior applies
+  |    error (TIMEOUT)     poe=True    passed (execute anyway)
+  |    error (TIMEOUT)     poe=False   behavior applies
+```
+
+Both `GuardFilter` and `GuardEvaluator` are per-process singletons, accessed via `get_global_guard_filter()` and `get_guard_evaluator()`. The `GuardFilter` executor is cleaned up via `atexit`.
+
+---
+
+## WHERE Clause Parsing (preprocessing/parsing/)
+
+The parser converts guard condition strings into an evaluable AST.
+
+```
+"status == 'active' AND score > 0.8"
+       |
+       v
+WhereClauseParser.parse()
+       |
+       v
+  LogicalNode(AND)
+   /          \
+ComparisonNode  ComparisonNode
+(status EQ      (score GT
+ 'active')       0.8)
+```
+
+### Grammar
+
+Built with pyparsing's `infix_notation` for operator precedence:
+
+| Precedence | Operators |
+|-----------|-----------|
+| Highest | NOT (unary prefix) |
+| | IS NULL, IS NOT NULL (unary postfix) |
+| | ==, !=, <, <=, >, >=, IN, NOT IN, LIKE, BETWEEN, CONTAINS |
+| | AND |
+| Lowest | OR |
+
+### AST node types
+
+| Node | Fields | Evaluate |
+|------|--------|----------|
+| `LiteralNode` | value (str, number, bool, None, list) | Returns value |
+| `FieldNode` | field_path (dotted string) | Looks up `data[path]` via `get_nested_value()` |
+| `ComparisonNode` | left, operator, right? | Dispatches to `OPERATORS[op]` |
+| `LogicalNode` | operator, left, right? | Short-circuit AND/OR/NOT |
+| `FunctionNode` | name, args | Dispatches to `FUNCTIONS[name]` |
+
+Field lookup raises `MissingFieldError` (DATA category) when the path does not exist. Unquoted string literals on the RHS of a comparison raise `GuardSemanticError` (SEMANTIC category) so the circuit breaker can fast-fail on subsequent records.
+
+### Caching
+
+- `WhereClauseParser.parse_cached()` -- LRU cache (1000 entries) on the condition string
+- `GuardFilter._cached_parse()` -- second LRU cache layer for the filter's own parse calls
+- Parser uses pyparsing's packrat caching (`ParserElement.enable_packrat()`)
+
+---
+
+## Field Resolution (preprocessing/field_resolution/)
+
+`ReferenceParser` handles the three syntaxes used across the system for referring to another action's output fields:
+
+```
+Format       Example                  Where used
+------       -------                  ----------
+SELECTOR     action.field             guard clauses, context_scope
+TEMPLATE     {action.field}           legacy prompt templates
+JINJA        {{ action.field }}       modern prompt templates
+```
+
+Parsing splits on the first dot: everything before is `action_name`, everything after is `field_path` (supports nested dotted paths like `action.nested.child`).
+
+```
+ReferenceParser.parse("extraction.tags")
+  --> ParsedReference(
+        action_name="extraction",
+        field_path=["tags"],
+        format_type=SELECTOR
+      )
+
+ReferenceParser.parse_batch(prompt_text)
+  --> [ParsedReference, ...]   (all references found in text)
+```
+
+The resolver (`resolver.py`) and validator (`validator.py`) use parsed references to:
+- Resolve field values from upstream action outputs
+- Validate that referenced actions and fields exist in the workflow graph
+- Detect typos via fuzzy matching suggestions
+
+---
+
+## File Index
+
+### Loaders
+| File | Role |
+|------|------|
+| `loaders/file_reader.py` | Format dispatcher -- reads any supported file type |
+| `loaders/json.py` | JSON list/dict normalization |
+| `loaders/tabular.py` | CSV/XLSX to list[dict] conversion |
+| `loaders/xml.py` | XML to dict conversion |
+| `loaders/text.py` | Text file handling |
+| `loaders/source_data.py` | StorageBackend wrapper for source reads/writes |
+| `loaders/data_source.py` | Start-node data source resolution (staging/local/API) |
+| `loaders/udf.py` | UDF discovery, import, and validation |
+| `loaders/base.py` | Abstract base classes for loaders |
+
+### Context
+| File | Role |
+|------|------|
+| `context/normalizer.py` | context_scope normalization, version expansion, orphan detection |
+| `context/context_preprocessor.py` | Context data preparation for prompt rendering |
+
+### Preprocessing -- staging
+| File | Role |
+|------|------|
+| `preprocessing/staging/initial_pipeline.py` | Entry point: file read -> prepare -> save -> dispatch |
+| `preprocessing/staging/field_validation.py` | Reserved field name validation for staged data |
+
+### Preprocessing -- filtering
+| File | Role |
+|------|------|
+| `preprocessing/filtering/guard_filter.py` | Low-level AST evaluation with timeout + circuit breaker |
+| `preprocessing/filtering/evaluator.py` | High-level guard evaluation with behavior policy |
+
+### Preprocessing -- parsing
+| File | Role |
+|------|------|
+| `preprocessing/parsing/parser.py` | WHERE clause parser (pyparsing grammar + LRU cache) |
+| `preprocessing/parsing/ast_nodes.py` | AST node types, evaluation logic, error types |
+| `preprocessing/parsing/operators.py` | Operator and function registries |
+
+### Preprocessing -- field resolution
+| File | Role |
+|------|------|
+| `preprocessing/field_resolution/reference_parser.py` | Unified parser for selector/template/Jinja references |
+| `preprocessing/field_resolution/resolver.py` | Resolves references to concrete field values |
+| `preprocessing/field_resolution/validator.py` | Validates references against workflow graph |
+| `preprocessing/field_resolution/schema_field_validator.py` | Schema-level field validation |
+| `preprocessing/field_resolution/context_provider.py` | Evaluation context assembly |
+| `preprocessing/field_resolution/exceptions.py` | InvalidReferenceError and related |
+
+### Preprocessing -- chunking and transformation
+| File | Role |
+|------|------|
+| `preprocessing/chunking/field_chunking.py` | Field-level chunking for long text values |
+| `preprocessing/chunking/strategies/` | Chunking, fallback, metadata, and validation strategies |
+| `preprocessing/transformation/string_transformer.py` | Tokenizer: text splitting by token count |
+| `preprocessing/transformation/transformer.py` | General data transformation utilities |
+| `preprocessing/processing/data_processor.py` | DataProcessor for record-level preprocessing |
+
+---
+
+## Caveats
+
+### Format-specific quirks
+
+- **CSV**: `FileReader` returns `list[list[str]]` (raw rows), not `list[dict]`. The `TabularLoader` handles dict conversion using the first row as headers. The initial pipeline passes `content=None` and `file_path` to `TabularLoader` so it reads the file itself.
+- **XML**: `FileReader` returns a `(tree, root)` tuple, not a string. Like CSV, the `XmlLoader` reads the file directly when invoked from the initial pipeline.
+- **XLSX**: `FileReader` returns `list[dict]` via pandas, which means XLSX is the only tabular format where `FileReader` does the full conversion. CSV and XML do not.
+- **JSON batch placeholders**: `FileReader._read_json()` rejects JSON files that look like batch job placeholders (`{"batch_job_id": ..., "status": "submitted"}`), raising an error to prevent re-processing in-flight batches.
+
+### source_guid assignment timing
+
+Batch mode assigns `source_guid` during `_add_batch_metadata()`, before source save and before LLM submission. Online mode generates `source_guid` for the source save copy, but the raw `data_chunk` is not mutated -- `OnlineLLMStrategy` independently hashes raw items to derive its own `source_guid`. The two GUIDs may differ because they serve different purposes (source lineage vs processing identity).
+
+### Guard filter thread pool
+
+`GuardFilter` uses a `ThreadPoolExecutor(max_workers=4)` to enforce evaluation timeouts. Every `filter_item()` call submits work to this pool and blocks on `future.result(timeout=N)`. The pool is a per-process singleton cleaned up via `atexit.register()`. In tests, call `reset_global_guard_filter()` to shut down and recreate the pool between test cases.
+
+### Semantic error circuit breaker
+
+When a guard condition raises `GuardSemanticError` (e.g., unquoted string literal), the error is cached by condition string. All subsequent evaluations of the same condition return the cached error immediately without re-evaluation. This prevents the same broken condition from logging thousands of warnings across a large dataset.
+
+### Context scope orphan detection
+
+A common YAML indentation mistake puts `observe`/`passthrough`/`drop` as siblings of `context_scope` instead of children. `normalize_all_agent_configs()` detects this pattern (null `context_scope` + orphaned directive keys) and raises `ConfigurationError` with a corrective YAML example.

--- a/agent_actions/input/_MANIFEST.md
+++ b/agent_actions/input/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Input Manifest
 
+**[> Architecture deep-dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Overview
 
 Input package centralizes context helpers, file loaders, and preprocessing pipelines

--- a/agent_actions/logging/ARCHITECTURE.md
+++ b/agent_actions/logging/ARCHITECTURE.md
@@ -1,0 +1,424 @@
+# Logging Module Architecture
+
+This document maps the moving parts of `agent_actions/logging/` -- the module that handles all structured logging, event dispatch, console output, JSON file logging, run-results collection, redaction, and user-facing error translation.
+
+---
+
+## High-Level Overview
+
+```
+                       agent_actions/logging/
+                              |
+           +------------------+------------------+
+           |                  |                  |
+         core/             events/            errors/
+    (dispatch engine)   (event library)   (error translation)
+           |                  |                  |
+    +------+------+     70+ event types    formatter chain
+    |      |      |     across 8 modules   -> UserError
+ manager  handlers protocols
+(singleton) (4 types) (EventHandler,
+                       EventFilter)
+
+Top-level files:
+  factory.py    -- LoggerFactory: wires everything together
+  config.py     -- LoggingConfig / FileHandlerSettings dataclasses
+  filters.py    -- RedactingFilter (stdlib logging layer)
+  formatters.py -- JSONFormatter (stdlib logging layer)
+```
+
+The module has **three packages** and **four top-level files**:
+
+| Package / File | What it does |
+|----------------|-------------|
+| `core/` | Singleton EventManager, handler protocols, and the four built-in handler implementations (Console, JSONFile, LoggingBridge, ContextDebug) |
+| `events/` | 106 concrete event dataclasses organized by domain (workflow, batch, LLM, validation, etc.) plus the AgentActionsFormatter for console display |
+| `errors/` | ErrorTranslator with a chain of 9 formatter strategies that convert any Python exception into a structured UserError for CLI display |
+| `factory.py` | LoggerFactory -- the single entry point that initializes EventManager, registers handlers, and wires the stdlib logging bridge |
+| `config.py` | LoggingConfig and FileHandlerSettings dataclasses, built from `agent_actions.yml` or `AGENT_ACTIONS_*` env vars |
+| `filters.py` | RedactingFilter for the stdlib logging layer -- regex-based scrubbing of API keys, tokens, secrets |
+| `formatters.py` | JSONFormatter for stdlib log records (used by legacy code paths, not the primary event system) |
+
+---
+
+## Initialization Flow
+
+Everything starts with `LoggerFactory.initialize()`, typically called by the CLI layer before any workflow runs.
+
+```
+LoggerFactory.initialize(config, output_dir, workflow_name, verbose, quiet)
+     |
+     +-- 1. Build LoggingConfig (from_environment() or from_project_config())
+     |
+     +-- 2. Get EventManager singleton (EventManager.get())
+     |
+     +-- 3. _register_handlers():
+     |       |
+     |       +-- Set context (invocation_id, workflow_name)
+     |       |
+     |       +-- ConsoleEventHandler
+     |       |     min_level from verbose/quiet/config
+     |       |     categories: {"workflow", "agent", "batch"} unless verbose
+     |       |     formatter: AgentActionsFormatter (Rich color output)
+     |       |
+     |       +-- JSONFileHandler (events.json) -- all levels, buffer_size=5
+     |       |     only when output_dir is provided
+     |       |
+     |       +-- JSONFileHandler (errors.json) -- ERROR only, buffer_size=1
+     |       |     only when output_dir is provided
+     |       |
+     |       +-- RunResultsCollector
+     |             collects workflow/action events -> run_results.json
+     |
+     +-- 4. _setup_logging_bridge():
+     |       |
+     |       +-- Attach LoggingBridgeHandler to "agent_actions" root logger
+     |       +-- Set root logger to DEBUG (handlers filter by level)
+     |       +-- Disable propagation
+     |
+     +-- 5. manager.initialize() -- marks system ready
+     |
+     +-- Return EventManager
+```
+
+On `force` re-initialization (e.g., when the CLI starts a new workflow in the same process), handlers are flushed and replaced atomically. If handler registration fails, previous handlers are restored.
+
+---
+
+## Two-Tier Logging
+
+The system has two separate entry points for log messages, and they converge in the EventManager.
+
+```
+Tier 1: Direct Event API              Tier 2: stdlib logging (bridge)
+================================       ================================
+
+fire_event(LLMRequestEvent(...))       logger.info("Submitting batch")
+         |                                        |
+         v                                        v
+  EventManager.fire()                  LoggingBridgeHandler.emit()
+         |                               |
+         |                               +-- Converts LogRecord -> LogEvent
+         |                               |     level: logging.INFO -> EventLevel.INFO
+         |                               |     category: extracted from logger name
+         |                               |       "agent_actions.workflow.x" -> "workflow"
+         |                               |
+         |                               +-- EventManager.fire(LogEvent)
+         |                                        |
+         +----------------------------------------+
+         |
+         v
+  EventManager dispatch loop
+    1. Inject context (invocation_id, correlation_id, extras)
+    2. Run global filters (if any)
+    3. For each handler:
+         handler.accepts(event)? -> handler.handle(event)
+```
+
+**When to use which tier:**
+
+- **Tier 1 (direct events):** Structured domain events with typed fields and event codes. Used by workflow engine, batch processing, LLM providers, validation.
+- **Tier 2 (stdlib bridge):** Traditional `logger.info("message")` calls. Used by lower-level modules and third-party code under the `agent_actions` namespace. These become `LogEvent` instances with code `X000`.
+
+---
+
+## EventManager Dispatch
+
+The EventManager is a **singleton** obtained via `EventManager.get()`. All event routing passes through it.
+
+```
+EventManager (singleton, thread-safe)
+  |
+  +-- _handlers: list[EventHandler]      -- registered in order
+  +-- _filters: list[EventFilter]        -- global pre-dispatch filters
+  +-- _context: dict[str, Any]           -- shared context (invocation_id, etc.)
+  +-- _context_overlay: ContextVar       -- per-thread/coroutine overlay
+  +-- _fire_lock: RLock                  -- serializes fire() calls
+  |
+  fire(event):
+    1. Snapshot handlers + filters under lock
+    2. Inject context into event.meta
+         invocation_id, correlation_id -> direct fields
+         everything else -> event.meta.extra
+    3. Run filters in order (filter can transform or drop event)
+    4. For each handler:
+         handler.accepts(event)? -> handler.handle(event)
+         Handler exceptions are caught and logged to stderr
+         (via non-propagating _stdlib_logger to avoid re-entry)
+```
+
+**Context management:**
+
+- `set_context(**kwargs)` sets global context values (invocation_id, workflow_name).
+- `context(**kwargs)` provides a thread-local overlay via `ContextVar`, nestable with `with` blocks.
+- `_effective_context()` merges global + overlay, with overlay winning on collision.
+
+**Lifecycle:**
+
+- `atexit` callback flushes all handlers at interpreter exit.
+- `reset()` clears everything (used in tests).
+
+---
+
+## Event System
+
+All events inherit from `BaseEvent`:
+
+```
+@dataclass
+BaseEvent
+  level: EventLevel     -- DEBUG, INFO, WARN, ERROR
+  category: str         -- "workflow", "batch", "llm", etc.
+  message: str          -- human-readable description
+  meta: EventMeta       -- timestamp, correlation_id, invocation_id, extra
+  data: dict[str, Any]  -- structured payload
+  |
+  event_type -> class name (e.g., "LLMRequestEvent")
+  code       -> short prefix + number (e.g., "L001")
+  to_dict()  -> full JSON-serializable representation
+```
+
+### Event Code Prefixes
+
+Each domain gets a letter prefix. The code is the primary stable identifier for tooling and filtering.
+
+| Prefix | Domain | Example |
+|--------|--------|---------|
+| W | Workflow lifecycle | W001 WorkflowStartEvent |
+| A | Action execution | A001 ActionStartEvent |
+| B | Batch processing | B001 BatchSubmittedEvent |
+| L | LLM interaction | L001 LLMRequestEvent |
+| V | Validation | V001 ValidationStartEvent |
+| C | Cache | C001 CacheHitEvent |
+| T | Template rendering | T001 TemplateRenderingFailedEvent |
+| D | Data loading/parsing | D001 DataParsingErrorEvent |
+| G | Guard evaluation | G001 GuardEvaluationErrorEvent |
+| R | Recovery/retry | R001 RetryExhaustedEvent |
+| F | Configuration | F001 ConfigLoadStartEvent |
+| E | Environment | E001 EnvironmentLoadStartEvent |
+| I | Initialization/CLI | I001 CLIInitStartEvent |
+| P | Plugin/UDF discovery | P001 UDFDiscoveryStartEvent |
+| RP | Record processing | RP01 RecordProcessingStartedEvent |
+| BP | Batch data processing | BP01 BatchProcessingStartedEvent |
+| FIO | File I/O | FIO1 FileWriteStartedEvent |
+| DV | Data validation | DV01 DataValidationStartedEvent |
+| SO | Schema operations | SO01 SchemaConstructionStartedEvent |
+| DT | Data transformation | DT01 EnrichmentPipelineStartedEvent |
+| RC | Result collection | RC01 ResultCollectionStartedEvent |
+| CX | Context introspection | CX01 ContextNamespaceLoadedEvent |
+| X | Bridged log records | X000 LogEvent (from stdlib bridge) |
+
+Event types are spread across 8 source files in `events/`:
+
+| File | Domain | Count (approx.) |
+|------|--------|-----------------|
+| `workflow_events.py` | Workflow + action lifecycle | 8 |
+| `batch_events.py` | Batch submission, polling, completion | 12 |
+| `llm_events.py` | LLM requests, responses, errors | 9 |
+| `validation_events.py` | Validation, recovery, guard | 14 |
+| `initialization_events.py` | CLI, config, env, project, UDF | 21 |
+| `io_events.py` | File I/O, schema, context | 13 |
+| `data_pipeline_events.py` | Record processing, enrichment, results | 18 |
+| `cache_events.py` | Cache hit/miss/invalidation | 6 |
+
+All 106 event types are re-exported from `events/__init__.py`.
+
+---
+
+## Registered Handlers
+
+Four handler types are registered during initialization. Each implements the `EventHandler` protocol: `accepts(event) -> bool`, `handle(event)`, `flush()`, `close()`.
+
+### ConsoleEventHandler
+
+```
+Purpose:  User-facing terminal output via Rich (or plain stderr fallback)
+Filter:   min_level (verbose=DEBUG, quiet=WARN, default=INFO)
+          + category filter: {"workflow", "agent", "batch"} unless verbose
+          WARN and ERROR bypass category filter -- always shown
+Format:   AgentActionsFormatter dispatch table for known event types,
+          _format_default for everything else
+Output:   Rich Console(stderr=True) or print(file=sys.stderr)
+```
+
+The `AgentActionsFormatter` has a dispatch table for 10 known event types (WorkflowStart, ActionComplete, BatchSubmitted, etc.) with structured formatting. Unknown event types fall through to `_format_default` which just prints the message.
+
+### JSONFileHandler
+
+```
+Purpose:  Persistent NDJSON log of all events
+Instances: events.json (all levels, buffer=5) + errors.json (ERROR only, buffer=1)
+Filter:   min_level only
+Buffering: Accumulates events in memory, flushes to disk when buffer fills
+           or when flush() is called (atexit, workflow complete, force re-init)
+Rotation:  Optional max_file_size with timestamp-based rotation
+Thread:    Internal threading.Lock protects buffer and file handle
+```
+
+### RunResultsCollector
+
+```
+Purpose:  Builds run_results.json summarizing workflow execution
+Filter:   category in ("workflow", "action") OR event_type in
+          ("RecordEmptyOutputEvent", "ResultCollectionCompleteEvent")
+State:    Accumulates ActionResult dataclasses keyed by action_name
+Output:   atomic_json_write to {output_dir}/target/run_results.json
+          Written on WorkflowComplete/WorkflowFailed events
+Tracks:   Per-action: status, timing, record count, token usage,
+          empty outputs, guard stats
+          Aggregate: total tokens, workflow elapsed time, overall status
+```
+
+### LoggingBridgeHandler
+
+```
+Purpose:  Routes stdlib logger.info/warning/error calls into EventManager
+Attached: To the "agent_actions" root logger (propagation disabled)
+Converts: logging.LogRecord -> LogEvent (code X000, category from logger name)
+Safety:   Catches all exceptions in emit() -- falls back to handleError()
+```
+
+### ContextDebugHandler (optional)
+
+```
+Purpose:  Aggregates context introspection events for --debug-context display
+Enabled:  Only when LoggerFactory.enable_context_debug() is called
+Filter:   Event codes CX001-CX006
+Output:   Rich tree display or plain text summary on demand
+```
+
+---
+
+## Redaction System
+
+Two independent layers ensure sensitive data does not appear in logs.
+
+### Layer 1: RedactingFilter (stdlib logging)
+
+Attached as a `logging.Filter` on stdlib log records before they reach the bridge. Scrubs:
+
+- Key-value patterns: `api_key=...`, `secret=...`, `token=...`, `password=...`
+- Vendor key patterns: `sk-ant-*` (Anthropic), `sk-*` (OpenAI), `AIza*` (Google)
+- Extra fields on LogRecord: dict/list values recursively redacted, string values pattern-matched
+
+### Layer 2: `_redact_sensitive_data()` (event data)
+
+Standalone function in `filters.py` used by code that builds event data dicts directly. Recursively walks nested structures and redacts:
+
+- Dict keys matching: `api_key`, `key`, `token`, `password`, `secret`, `authorization`
+- String values matching vendor key regex patterns
+
+Both layers use the same regex patterns but operate at different stages -- Layer 1 on stdlib LogRecords, Layer 2 on event data dicts before they reach handlers.
+
+---
+
+## Error Translation
+
+The `errors/` package converts raw Python exceptions into structured, user-friendly CLI messages.
+
+```
+Exception (any type)
+     |
+     v
+format_user_error(exc, context)          -- errors/__init__.py
+     |
+     +-- Debug logging of exception chain
+     |
+     v
+ErrorTranslator.translate(exc, context)  -- errors/translator.py
+     |
+     +-- ErrorContextService.merge_exception_context()
+     |     Extracts context from exception attributes
+     |
+     +-- extract_root_cause(exc)
+     |     Walks __cause__ / __context__ chain
+     |
+     +-- Formatter chain (first match wins):
+     |     1. YAMLSyntaxErrorFormatter    -- YAML parse errors
+     |     2. FunctionNotFoundFormatter   -- missing UDF functions
+     |     3. TemplateErrorFormatter      -- Jinja2 template errors
+     |     4. ConfigurationErrorFormatter -- config validation
+     |     5. ModelErrorFormatter         -- LLM model errors
+     |     6. AuthenticationErrorFormatter -- API key issues
+     |     7. FileErrorFormatter          -- file not found, permissions
+     |     8. APIErrorFormatter           -- vendor API errors
+     |     9. GenericErrorFormatter       -- fallback (always matches)
+     |
+     v
+UserError(category, title, details, fix, context, docs_url)
+     |
+     v
+UserError.format_for_cli() -> str
+     |
+     +-- "Category: Title"
+     +-- "  Problem: ..."
+     +-- "  Agent: ... / File: ... / Field: ..."   (priority context)
+     +-- "  Fix: ..."
+     +-- "  Learn more: ..."
+```
+
+Each formatter implements `can_handle(exc, root_cause, message) -> bool` and `format(...) -> UserError`. The chain is ordered from most specific to least specific, with `GenericErrorFormatter` as the guaranteed fallback.
+
+---
+
+## File Index
+
+### Top-level
+| File | Role |
+|------|------|
+| `factory.py` | LoggerFactory -- single entry point, handler registration, bridge setup |
+| `config.py` | LoggingConfig + FileHandlerSettings dataclasses |
+| `filters.py` | RedactingFilter + `_redact_sensitive_data()` |
+| `formatters.py` | JSONFormatter for stdlib LogRecords |
+
+### core/
+| File | Role |
+|------|------|
+| `core/manager.py` | EventManager singleton -- thread-safe dispatch, context management |
+| `core/events.py` | BaseEvent, EventLevel, EventCategory, EventMeta |
+| `core/protocols.py` | EventHandler / EventFilter protocols, LevelFilter, CategoryFilter |
+| `core/handlers/bridge.py` | LoggingBridgeHandler + LogEvent, DebugEvent, SystemEvent |
+| `core/handlers/console.py` | ConsoleEventHandler -- Rich or plain stderr output |
+| `core/handlers/json_file.py` | JSONFileHandler -- buffered NDJSON writer with rotation |
+| `core/handlers/context_debug.py` | ContextDebugHandler -- aggregates CX events for debug display |
+
+### events/
+| File | Role |
+|------|------|
+| `events/__init__.py` | Re-exports all 106 event types + AgentActionsFormatter |
+| `events/types.py` | EventCategories constants + `_safe_value_repr()` |
+| `events/formatters.py` | AgentActionsFormatter -- dispatch table for console display |
+| `events/workflow_events.py` | W/A prefix events (workflow + action lifecycle) |
+| `events/batch_events.py` | B prefix events (batch submission, polling, completion) |
+| `events/llm_events.py` | L prefix events (LLM request/response/error) |
+| `events/validation_events.py` | V/G/R prefix events (validation, guard, recovery) |
+| `events/initialization_events.py` | F/E/I/P prefix events (config, env, CLI, UDF) |
+| `events/io_events.py` | FIO/SO/CX prefix events (file I/O, schema, context) |
+| `events/data_pipeline_events.py` | RP/BP/DV/DT/RC prefix events (record processing, enrichment, results) |
+| `events/cache_events.py` | C prefix events (cache hit/miss/invalidation) |
+| `events/handlers/run_results.py` | RunResultsCollector + ActionResult |
+
+### errors/
+| File | Role |
+|------|------|
+| `errors/__init__.py` | `format_user_error()` entry point |
+| `errors/translator.py` | ErrorTranslator -- formatter chain dispatch |
+| `errors/user_error.py` | UserError dataclass + `format_for_cli()` |
+| `errors/services/` | ErrorContextService -- extracts context from exceptions |
+| `errors/formatters/` | 9 formatter strategies (YAML, config, model, auth, file, API, template, function, generic) |
+
+---
+
+## Caveats
+
+**Event codes are public API.** External tooling, the ContextDebugHandler, and RunResultsCollector all match on event codes and event_type strings. Changing a code prefix or renaming an event class is a breaking change.
+
+**RunResultsCollector matches by string.** The `accepts()` method checks `event.event_type` (class name as string) for `RecordEmptyOutputEvent` and `ResultCollectionCompleteEvent`. The `handle()` method dispatches on `event_type` strings in a long if/elif chain. Renaming an event class silently breaks result collection.
+
+**Bridge re-entry prevention.** The EventManager's internal `_stdlib_logger` has `propagate = False` to avoid a cycle: if a handler raises during `fire()`, the warning log must not re-enter `fire()` through the LoggingBridgeHandler. Similarly, `LoggingBridgeHandler.emit()` catches all exceptions to prevent bridge errors from propagating.
+
+**Category bypass for WARN/ERROR.** The ConsoleEventHandler always shows WARN and ERROR events regardless of the category filter. This means errors from modules outside the configured categories (e.g., `llm`, `processing`) are still visible on the console. This is intentional -- errors must not be silently hidden by category filtering.
+
+**JSONFileHandler buffering.** Events are buffered in memory (default buffer_size=5 for events.json, 1 for errors.json) and only flushed to disk when the buffer fills, when `flush()` is called, or at interpreter exit via `atexit`. A crash between buffer fills loses buffered events. The errors.json handler uses buffer_size=1 to minimize this risk for error events.
+
+**Force re-init atomicity.** When `initialize(force=True)` is called, existing handlers are stashed before new ones are registered. If registration fails, stashed handlers are restored. This prevents the logging system from being left in a degraded state during re-initialization (e.g., when switching workflows in the same process).

--- a/agent_actions/logging/_MANIFEST.md
+++ b/agent_actions/logging/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Logging Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Overview
 
 Structured logging helpers for the Agent Actions core—including configuration,

--- a/agent_actions/models/ARCHITECTURE.md
+++ b/agent_actions/models/ARCHITECTURE.md
@@ -1,0 +1,180 @@
+# Models Module Architecture
+
+The `agent_actions/models/` module is a small data-definition package: one source file, four exported symbols. It defines the domain types that describe workflow actions and their fields, consumed by the CLI, workflow engine, and docs generator.
+
+---
+
+## Overview
+
+```
+agent_actions/models/
+├── __init__.py          ← re-exports all 4 symbols
+└── action_schema.py     ← defines FieldSource, FieldInfo, ActionSchema;
+                            re-exports ActionKind from config.schema
+```
+
+Four symbols, three roles:
+
+| Symbol | Type | Defined in | Role |
+|--------|------|-----------|------|
+| `ActionKind` | `str, Enum` | `config/schema.py` | Action type discriminator (llm, tool, hitl, source, seed) |
+| `FieldSource` | `Enum` | `models/action_schema.py` | How a field is produced (schema, observe, passthrough, tool_output) |
+| `FieldInfo` | `@dataclass` | `models/action_schema.py` | Metadata for a single field (name, source, type, required, dropped) |
+| `ActionSchema` | `@dataclass` | `models/action_schema.py` | Full schema for one action: inputs, outputs, dependencies, flags |
+
+---
+
+## Data Models
+
+### ActionKind (re-export from config/schema.py)
+
+```python
+class ActionKind(str, Enum):
+    LLM = "llm"
+    TOOL = "tool"
+    HITL = "hitl"
+    SOURCE = "source"
+    SEED = "seed"
+
+    @classmethod
+    def _missing_(cls, value):  # case-insensitive lookup
+```
+
+A `str` enum so it serializes naturally to JSON. The `_missing_` override allows `ActionKind("LLM")` to resolve to `ActionKind.LLM`.
+
+### FieldSource
+
+```python
+class FieldSource(Enum):
+    SCHEMA = "schema"          # defined in the output schema YAML
+    OBSERVE = "observe"        # read-only context injected into the prompt
+    PASSTHROUGH = "passthrough" # copied from input to output unchanged
+    TOOL_OUTPUT = "tool_output" # produced by a tool/UDF function
+```
+
+This is a plain `Enum`, not `str, Enum`. Comparisons like `source == "schema"` will fail -- use `source == FieldSource.SCHEMA` or compare against `.value`.
+
+### FieldInfo
+
+```python
+@dataclass
+class FieldInfo:
+    name: str
+    source: FieldSource
+    is_required: bool = True
+    is_dropped: bool = False
+    field_type: str = "unknown"
+    description: str = ""
+```
+
+`to_dict()` serializes the field for JSON output. The key mapping is:
+
+```
+field_type  (attribute name)  -->  "type"  (dict key in to_dict output)
+```
+
+This is deliberate: the attribute is named `field_type` to avoid shadowing Python's `type` builtin, but the serialized form uses `"type"` because that is what consumers (CLI, docs) expect.
+
+### ActionSchema
+
+```python
+@dataclass
+class ActionSchema:
+    name: str
+    kind: ActionKind
+    input_fields: list[FieldInfo]
+    output_fields: list[FieldInfo]
+    dependencies: list[str]
+    is_dynamic: bool = False
+    is_schemaless: bool = False
+    is_template_based: bool = False
+```
+
+**Computed properties:**
+
+| Property | Returns | Logic |
+|----------|---------|-------|
+| `available_outputs` | `list[str]` | `output_fields` where `is_dropped == False`, sorted |
+| `dropped_outputs` | `list[str]` | `output_fields` where `is_dropped == True`, sorted |
+| `required_inputs` | `list[str]` | `input_fields` where `is_required == True`, sorted |
+| `optional_inputs` | `list[str]` | `input_fields` where `is_required == False`, sorted |
+
+`to_dict()` includes both the raw field lists and the computed properties, so downstream consumers get both views without re-filtering.
+
+---
+
+## How Models Fit in the Pipeline
+
+```
+                    BUILDER                      CONSUMERS
+                       │                             │
+     ┌─────────────────┼───────────┐     ┌───────────┼───────────┐
+     │                 │           │     │           │           │
+config/schema.py   workflow/      │     cli/        cli/       tooling/docs/
+ (ActionKind)    schema_service.py│  inspect_base  renderers/  generator.py
+                       │           │     .py        schema_     (catalog
+                       │           │                renderer    output)
+                       ▼           │                .py
+                 ActionSchema      │
+                 instances         │
+                                   │
+                          models/action_schema.py
+                          (type definitions)
+```
+
+**Builder:** `WorkflowSchemaService` (in `workflow/schema_service.py`) is the sole factory. It reads action configs + YAML schema files + UDF registries, constructs `FieldInfo` objects, and assembles `ActionSchema` instances. No other code creates these objects in production.
+
+**Display:** CLI commands (`inspect`, `schema`) receive `ActionSchema` from the service and render it via `schema_renderer.py`. The renderer reads `kind`, `available_outputs`, `dropped_outputs`, and the field lists.
+
+**Catalog:** The docs generator (`tooling/docs/generator.py`) iterates `ActionSchema.to_dict()` to produce documentation pages.
+
+---
+
+## Import Map
+
+Where each symbol is used in production code:
+
+| Symbol | Imported by |
+|--------|-------------|
+| `ActionKind` | `workflow/schema_service.py`, `cli/renderers/schema_renderer.py` |
+| `FieldSource` | `workflow/schema_service.py`, `cli/renderers/schema_renderer.py`, `tooling/docs/generator.py` |
+| `FieldInfo` | `workflow/schema_service.py`, `tooling/docs/generator.py` |
+| `ActionSchema` | `workflow/schema_service.py`, `cli/inspect_base.py`, `cli/renderers/schema_renderer.py`, `tooling/docs/generator.py` |
+
+Test files that exercise the models directly:
+
+- `tests/unit/models/test_action_schema.py`
+- `tests/services/test_workflow_schema_service.py`
+- `tests/cli/renderers/test_schema_renderer.py`
+- `tests/cli/test_inspect_commands_integration.py`
+- `tests/cli/test_cli_hardening.py`
+
+---
+
+## File Index
+
+| File | Role |
+|------|------|
+| `__init__.py` | Re-exports `ActionKind`, `ActionSchema`, `FieldInfo`, `FieldSource` |
+| `action_schema.py` | Defines `FieldSource`, `FieldInfo`, `ActionSchema`; re-exports `ActionKind` from `config.schema` |
+
+---
+
+## Caveats
+
+**ActionKind lives in `config/`, not `models/`.** It is defined in `config/schema.py` and re-exported here for convenience. The canonical definition is in `config/` because it is used in Pydantic config validation before `models/` is involved. Do not duplicate it.
+
+**FieldSource is NOT a `str` enum.** Unlike `ActionKind(str, Enum)`, `FieldSource` is a plain `Enum`. String comparisons like `field.source == "schema"` will silently evaluate to `False`. Always compare against the enum member or use `.value`.
+
+**`output_fields` includes dropped fields.** The `output_fields` list contains all fields regardless of drop status. Use `available_outputs` for the filtered list. This means `len(output_fields)` is not the same as the number of fields a downstream action can see.
+
+**Deduplication is the caller's responsibility.** If the same field name appears in both schema and passthrough sources, `output_fields` will contain both `FieldInfo` entries. `available_outputs` (which returns only names) will deduplicate via `sorted()` on a set-like comprehension, but the underlying list does not. Callers iterating `output_fields` directly must handle duplicates.
+
+**Rename impact table.** Because these types are imported across many modules, renaming any symbol requires updating all importers:
+
+| Symbol | Import sites (production + tests) |
+|--------|-----------------------------------|
+| `ActionKind` | 6 files |
+| `ActionSchema` | 8 files |
+| `FieldInfo` | 5 files |
+| `FieldSource` | 6 files |

--- a/agent_actions/models/_MANIFEST.md
+++ b/agent_actions/models/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Models Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Modules
 
 | Name | Type | Description | Signals |

--- a/agent_actions/output/ARCHITECTURE.md
+++ b/agent_actions/output/ARCHITECTURE.md
@@ -1,0 +1,433 @@
+# Output Module Architecture
+
+This document maps the moving parts of `agent_actions/output/` -- the module that handles file I/O, schema compilation, config expansion, and response handling for the entire framework.
+
+---
+
+## High-Level Overview
+
+```
+                       agent_actions/output/
+                            │
+              ┌─────────────┼──────────────┐
+              │             │              │
+          writer.py     saver.py      response/
+        (file I/O)    (source data)   (schema + config + expansion)
+              │             │              │
+              │             │    ┌─────────┼──────────┐──────────┐
+              │             │    │         │          │          │
+              │             │  schema   expander   config    response
+              │             │  pipeline  pipeline   models    builder
+              │             │    │         │          │          │
+              ▼             ▼    ▼         ▼          ▼          ▼
+         StorageBackend   StorageBackend  LLM      workflow   provider
+         (sqlite/tinydb)  (sqlite/tinydb) vendors  engine     clients
+```
+
+The module has **three responsibilities**:
+
+| Component | What it does |
+|-----------|-------------|
+| `writer.py` + `saver.py` | File writing pipeline -- atomic JSON writes, storage backend delegation, staging/target/source output |
+| `response/schema.py` + submodules | Schema compilation pipeline -- loads YAML/JSON schemas, compiles to vendor-specific formats, resolves dispatch_task calls |
+| `response/expander.py` + submodules | Config expansion pipeline -- transforms action-based YAML configs into fully resolved agent configurations |
+
+---
+
+## File Writing Pipeline
+
+FileWriter handles all disk I/O with atomic writes and optional database persistence.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     FileWriter                           │
+│                                                          │
+│   Constructor:                                           │
+│     file_path         → full path to output file         │
+│     storage_backend   → optional StorageBackend          │
+│     action_name       → node name for backend writes     │
+│     output_directory  → base dir for relative paths      │
+│                                                          │
+│   Three write methods:                                   │
+│                                                          │
+│   write_staging(data)                                    │
+│     ├── .json → atomic_json_write (temp + fsync + rename)│
+│     ├── .txt  → plain text (list joins with newlines)    │
+│     └── .csv  → csv.DictWriter or csv.writer             │
+│     Events: FileWriteStarted → write → FileWriteComplete │
+│                                                          │
+│   write_target(data)                                     │
+│     ├── Requires storage_backend AND action_name         │
+│     ├── Computes relative path from output_directory     │
+│     ├── assert_path_contained (path traversal guard)     │
+│     ├── storage_backend.write_target()  ← authoritative  │
+│     └── atomic_json_write()  ← disk materialization      │
+│                                                          │
+│   write_source(data)                                     │
+│     └── atomic_json_write (JSON only)                    │
+└─────────────────────────────────────────────────────────┘
+
+UnifiedSourceDataSaver:
+  save_source_items(items, relative_path)
+    ├── Requires storage_backend (raises ValueError if missing)
+    ├── storage_backend.write_source() with optional deduplication
+    └── Events: SourceDataSaving → write → SourceDataSaved
+```
+
+### Relative path preservation
+
+When `output_directory` is provided, `write_target` computes the relative path from `output_directory` to `file_path`, preserving subdirectory structure in the storage backend. This prevents collisions when multiple files share the same name but live in different subdirectories:
+
+```
+file_path:        /project/agent_io/target/agent_1/subdir/file.json
+output_directory: /project/agent_io/target/agent_1
+stored as:        subdir/file.json   (not just file.json)
+```
+
+---
+
+## Schema Compilation Pipeline
+
+How a YAML schema on disk becomes the vendor-specific format sent to the LLM API. The pipeline has **6 stages**, orchestrated by `ResponseSchemaCompiler.compile()`.
+
+```
+Stage 1: Load                     Stage 2: Resolve              Stage 3: Inject
+                                  dispatch_task()               dispatch_task()
+                                  in schema string              in schema fields
+
+schema/{wf}/{action}.yml   ──►  _load_named_schema()    ──►   _inject_functions_into_schema()
+  OR                              uses SchemaLoader              recursive walk of all
+inline schema: {...}        ──►  _load_inline_schema()          dict/list/string values
+  OR                              _resolve_dispatch()            captured_results populated
+dispatch_task() call        ──►  context_data_str
+                                                          ──►   Stage 4: Unwrap
+
+Stage 4: Unwrap              Stage 5: Compile             Stage 6: Sanitize
+                              for vendor
+
+_unwrap_nested_schema()  ──►  compile_unified_schema()  ──►  ensure_json_safe()
+  {schema: {fields: [...]}}     routes by vendor               strips non-JSON
+  → {fields: [...]}             (see matrix below)             values (NaN, Inf)
+```
+
+### Schema input formats
+
+The pipeline accepts three input shapes:
+
+```
+1. Unified format (native):
+   name: extraction
+   fields:
+     - id: title
+       type: string
+     - id: tags
+       type: array
+       items: {type: string}
+
+2. JSON Schema array format:
+   name: facts_list
+   type: array
+   items:
+     type: object
+     properties:
+       fact: {type: string}
+     required: [fact]
+
+   → auto-converted to unified by _convert_json_schema_to_unified()
+
+3. Inline shorthand (dict):
+   schema:
+     title: string!          ← trailing ! = required
+     tags: array[string]
+     items: array[object:{'name': 'string', 'price': 'number!'}]
+
+   → converted by SchemaLoader.construct_schema_from_dict()
+```
+
+### Vendor-specific compilation
+
+`compile_unified_schema()` transforms the unified format into the dialect each LLM vendor expects:
+
+```
+Stage 5 output per vendor:
+
+  OpenAI/Groq/AGAC:
+    {"name":"...","schema":{"type":"object","properties":{...},"required":[...],"additionalProperties":false}}
+
+  Anthropic:
+    [{"name":"...","description":"...","input_schema":{"type":"object","properties":{...},"required":[...],"additionalProperties":false}}]
+
+  Gemini:
+    {"name":"...","schema":{"type":"object","properties":{...},"required":[...]}}
+
+  Ollama Local/Cloud:
+    {"title":"...","type":"object","properties":{...},"required":[...],"additionalProperties":false}
+
+  Cohere:
+    {"type":"object","properties":{...},"required":[...]}
+```
+
+### Vendor compilation comparison matrix
+
+| | OpenAI | Anthropic | Gemini | Groq | Cohere | Ollama |
+|---|---|---|---|---|---|---|
+| **Wrapper** | `{name, schema}` | `[{name, description, input_schema}]` | `{name, schema}` | Same as OpenAI | Flat `{type, properties}` | Flat `{title, type, properties}` |
+| **Return type** | `dict` | `list[dict]` | `dict` | `dict` | `dict` | `dict` |
+| **additionalProperties** | `false` | `false` | Omitted | `false` | Omitted | `false` |
+| **Name field** | `name` | `name` | `name` | `name` | None | `title` |
+| **Field mappings** | Supported | Supported | Supported | Supported | Supported | Supported |
+
+---
+
+## Dispatch Injection System
+
+Schema fields can contain `dispatch_task()` calls that execute Python UDFs at schema-compile time and inject the results into the schema.
+
+```
+Schema YAML:
+  fields:
+    - id: category
+      type: string
+      enum: "dispatch_task('get_categories', context_data)"
+
+At compile time:
+  _inject_functions_into_schema()
+    └── recursive walk of every string value
+         └── "dispatch_task(" found?
+              └── PromptUtils.process_dispatch_in_text()
+                   └── runs UDF, returns result
+                        └── enum: ["electronics", "clothing", "food"]
+
+captured_results:
+  {"get_categories": ["electronics", "clothing", "food"]}
+  → merged into LLM response as add_dispatch output
+```
+
+Two functions handle dispatch:
+
+| Function | Scope |
+|----------|-------|
+| `_inject_functions_into_schema()` | Recursive walk of entire schema tree (dicts, lists, strings) |
+| `_resolve_dispatch_in_schema()` | Single string value resolution (used for inline schema loading) |
+
+Both delegate to `PromptUtils.process_dispatch_in_text()` with `preserve_type_on_exact_match=True` so that dispatch results retain their native Python type (list, dict) instead of being stringified.
+
+---
+
+## Action Expander Pipeline
+
+`ActionExpander.expand_actions_to_agents()` transforms action-based YAML workflow configs into fully resolved agent configurations. The core logic lives in `_create_agent_from_action()`, which executes 17 steps:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│          _create_agent_from_action() — 17 steps              │
+│                                                              │
+│   1.  inherit_simple_fields()                                │
+│       → 30+ fields from action > defaults > hardcoded        │
+│                                                              │
+│   2.  Force model_vendor = "hitl" for HITL actions           │
+│                                                              │
+│   3.  Force run_mode = online for tool/hitl actions          │
+│       (only if action doesn't explicitly override)           │
+│                                                              │
+│   4.  validate_vendor_exists()                               │
+│       → checks against VendorType enum                       │
+│                                                              │
+│   5.  validate_required_fields()                             │
+│       → model_vendor + model_name + api_key (LLM only)      │
+│                                                              │
+│   6.  process_schema_config()                                │
+│       → compiled schema passthrough OR template replacement  │
+│                                                              │
+│   7.  process_guard_config()                                 │
+│       → string guards → GuardParser.parse()                  │
+│       → dict guards → parse_guard_config()                   │
+│       → UDF guards → conditional_clause                      │
+│       → expression guards → agent["guard"] dict              │
+│                                                              │
+│   8.  Process prompt (template_replacer)                     │
+│                                                              │
+│   9.  process_tool_action()                                  │
+│       → validates impl field, rejects batch mode             │
+│       → requires output schema                               │
+│                                                              │
+│  10.  process_hitl_action()                                  │
+│       → validates hitl config block + instructions           │
+│       → applies workflow-level timeout default               │
+│       → injects canonical HITL output schema                 │
+│                                                              │
+│  11.  compile_output_schema()                                │
+│       → YAML schema → json_output_schema (JSON Schema)       │
+│       → skips if json_output_schema already set (HITL)       │
+│                                                              │
+│  12.  Process granularity                                    │
+│       → HITL defaults to "file", rejects "record"            │
+│       → LLM inherits from defaults                           │
+│                                                              │
+│  13.  deep_merge_context_scope()                             │
+│       → action directives merge with defaults (not replace)  │
+│                                                              │
+│  14.  Initialize dependencies                                │
+│                                                              │
+│  15.  process_chunk_config()                                 │
+│       → chunk_config block OR legacy chunk_size/overlap      │
+│                                                              │
+│  16.  initialize_optional_fields()                           │
+│       → skip_if, add_dispatch, conditional_clause, guard     │
+│                                                              │
+│  17.  Process version_consumption + interceptors             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Versioned action expansion
+
+Actions with a `versions` block are expanded into multiple agents:
+
+```
+versions:
+  param: round
+  range: [1, 3]
+
+→ Expands to 3 agents: action_1, action_2, action_3
+  Each gets:
+    is_versioned_agent: true
+    version_base_name: original action name
+    version_number: 1/2/3
+    version_mode: parallel (default)
+    _version_context: {i, idx, length, first, last}
+
+  Template variables available:
+    ${round}   → current iteration value
+    ${round-1} → previous iteration value
+```
+
+---
+
+## Three-Level Config Inheritance
+
+Every config field follows the same inheritance chain:
+
+```
+┌──────────────────────────────────────────────────┐
+│  Priority 1 (highest): Action-level value         │
+│    actions:                                        │
+│      - name: extract                               │
+│        temperature: 0.3    ← wins                  │
+├──────────────────────────────────────────────────┤
+│  Priority 2: Workflow defaults value               │
+│    defaults:                                       │
+│        temperature: 0.7                            │
+├──────────────────────────────────────────────────┤
+│  Priority 3 (lowest): Hardcoded default            │
+│    SIMPLE_CONFIG_FIELDS = {                        │
+│        "temperature": None,  ← use provider default│
+│    }                                               │
+└──────────────────────────────────────────────────┘
+
+inherit_simple_fields() applies this for 30+ fields:
+  model_vendor, model_name, api_key, run_mode, json_mode,
+  temperature, max_tokens, top_p, stop, reprompt, retry,
+  granularity, is_operational, prompt_debug, output_field,
+  chunk_size, chunk_overlap, record_limit, file_limit, ...
+
+Mutable values (list, dict) are deep-copied to prevent
+cross-agent state leakage.
+```
+
+`context_scope` is a special case -- it uses `deep_merge_context_scope()` which merges action-level directives **into** defaults (dicts merged, lists deduplicated) rather than replacing them. This lets an action add drop fields while inheriting seed_path from defaults.
+
+---
+
+## ResponseBuilder
+
+Centralizes response handling that was previously duplicated across every provider client.
+
+```
+ResponseBuilder (static methods):
+
+  wrap_non_json(content, agent_config) → list[dict]
+    Wraps plain-text LLM output in the configured output_field.
+    Used by all provider call_non_json() methods.
+
+  extract_usage(response, provider) → UsageResult
+    Dispatches to per-shape extractors based on PROVIDER_RESPONSE_CONFIGS:
+      OpenAI/Groq  → response.usage.prompt_tokens / completion_tokens
+      Anthropic    → response.usage.input_tokens / output_tokens
+      Gemini       → response.usage_metadata.prompt_token_count
+      Cohere       → response.usage.tokens.input_tokens
+      Ollama       → response.prompt_eval_count / eval_count
+
+  record_usage_and_event(response, provider, model, latency_ms, request_id)
+    → extract_usage + set_last_usage (ContextVar) + fire LLMResponseEvent
+```
+
+---
+
+## File Index
+
+### File I/O
+| File | Role |
+|------|------|
+| `writer.py` | FileWriter -- atomic writes to staging/target/source with storage backend delegation |
+| `saver.py` | UnifiedSourceDataSaver -- source data persistence with deduplication |
+
+### Schema pipeline
+| File | Role |
+|------|------|
+| `response/schema.py` | ResponseSchemaCompiler -- orchestrates the 6-stage compilation pipeline |
+| `response/loader.py` | SchemaLoader -- discovers and loads schema files from disk |
+| `response/schema_conversion.py` | JSON Schema to unified format conversion, per-field compilation |
+| `response/vendor_compilation.py` | compile_unified_schema -- vendor-specific output formatting |
+| `response/dispatch_injection.py` | Recursive dispatch_task() resolution in schema trees |
+| `response/context_data.py` | Context data preparation, schema loading/unwrapping helpers |
+
+### Config expansion
+| File | Role |
+|------|------|
+| `response/expander.py` | ActionExpander -- orchestrates action-to-agent transformation |
+| `response/expander_validation.py` | Vendor, name, and required-field validation |
+| `response/expander_schema.py` | Schema processing and compile_output_schema |
+| `response/expander_action_types.py` | Guard, tool, and HITL action processing |
+| `response/expander_merge.py` | Config merging, context_scope deep merge, chunk config |
+| `response/expander_guard_validation.py` | Guard reference validation against upstream actions |
+
+### Config models
+| File | Role |
+|------|------|
+| `response/config_fields.py` | SIMPLE_CONFIG_FIELDS registry, get_default(), inherit_simple_fields() |
+| `response/config_schema.py` | Pydantic models: AgentConfig, DefaultAgentConfig, WhereClauseConfig |
+
+### Response handling
+| File | Role |
+|------|------|
+| `response/response_builder.py` | ResponseBuilder -- usage extraction and non-JSON wrapping |
+
+---
+
+## Caveats
+
+1. **Gemini rejects additionalProperties.** The Gemini compilation path deliberately omits `additionalProperties: false` from its schema output. Including it causes the Gemini API to reject the request. All other vendors include it.
+
+2. **Anthropic returns a list.** `compile_unified_schema()` returns `list[dict]` for Anthropic (tools format) but `dict` for every other vendor. Callers that type-check the return value must handle both shapes.
+
+3. **compile_output_schema must run after process_hitl_action.** HITL actions inject a canonical output schema (`HITL_OUTPUT_SCHEMA`). `compile_output_schema` skips when `json_output_schema` is already set, preserving the HITL schema. Reordering these calls would overwrite the HITL schema with a compiled version.
+
+4. **Dispatch failures are non-fatal.** When `dispatch_task()` resolution fails inside a schema field, the unresolved string is passed through to the LLM vendor as-is (with a warning logged). This may cause vendor API errors downstream but does not crash the pipeline.
+
+5. **Schema name collision is a warning, not an error.** `SchemaLoader.discover_schema_files()` logs a warning when the same schema name appears in multiple directories. The first occurrence wins. Callers that need strict uniqueness must enforce it themselves.
+
+6. **write_target requires both storage_backend and action_name.** Calling `write_target()` without both raises `ValueError` at runtime. There is no compile-time check -- the constructor accepts `None` for both parameters because `write_staging()` and `write_source()` do not need them.
+
+7. **captured_results for add_dispatch.** The `captured_results` dict populated during dispatch injection is returned alongside the compiled schema. It carries the output of `dispatch_task()` UDF calls so that the caller (typically `create_dynamic_agent` in the builder) can merge those results into the LLM response. If no dispatch calls exist, it is an empty dict.
+
+8. **Inline schema takes precedence over schema_name.** When an action config has both `schema` (inline) and `schema_name`, the inline schema wins and `schema_name` is ignored. A warning is logged.
+
+9. **Tool actions must declare an output schema.** `process_tool_action()` raises `ConfigValidationError` if neither `json_output_schema` nor `schema` is present. This runs before `compile_output_schema`, which would otherwise silently skip schema-less actions.
+
+10. **HITL granularity must be "file".** HITL actions default to file-level granularity. Explicitly setting `granularity: record` on a HITL action raises `ConfigurationError` with the `HITL_FILE_GRANULARITY_ERROR` constant.
+
+11. **Mutable defaults are deep-copied.** `inherit_simple_fields()` deep-copies any list or dict value before assigning it to the agent dict. Without this, all agents in a versioned expansion would share the same mutable reference, causing cross-agent state leakage.
+
+12. **Array-type schemas produce separate output_schema and json_output_schema.** When the schema is `type: array`, the full unified schema goes to `output_schema` (for LLM providers) while `json_output_schema` gets just the `items` definition (for validation). This is because validation operates on individual items, not the outer array wrapper.
+
+13. **context_scope merges, not replaces.** Unlike all other config fields that follow "action overrides defaults", `context_scope` uses `deep_merge_context_scope()` which merges action-level directives into defaults. Dicts are shallow-merged; lists are concatenated and deduplicated. This lets an action add `drop` fields while inheriting `seed_path` from defaults.

--- a/agent_actions/output/_MANIFEST.md
+++ b/agent_actions/output/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Output Manifest
 
+**[> Architecture deep-dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Overview
 
 Writes processed workflow outputs (main/side files) and response artifacts while

--- a/agent_actions/processing/ARCHITECTURE.md
+++ b/agent_actions/processing/ARCHITECTURE.md
@@ -1,0 +1,586 @@
+# Processing Module Architecture
+
+This document maps the moving parts of `agent_actions/processing/` — the module that takes raw records, runs them through LLM/tool/HITL strategies, and produces enriched output with dispositions.
+
+---
+
+## High-Level Overview
+
+```
+                    agent_actions/processing/
+                           │
+         ┌─────────────────┼─────────────────────┐
+         │                 │                      │
+     strategies/       invocation/            recovery/
+   (what to do)     (how to call it)     (retry + reprompt)
+         │                 │                      │
+         └────────┬────────┘                      │
+                  │                               │
+            unified.py                            │
+        (the pipeline skeleton)                   │
+                  │                               │
+         ┌───────┼───────┐                        │
+         │       │       │                        │
+    enrichment  result   disposition              │
+    .py     _collector   _gate                    │
+              .py        .py                      │
+                                           evaluation/
+                                         (batch reprompt
+                                          validation)
+```
+
+The module has **five concerns**:
+
+| Concern | Where | What it does |
+|---------|-------|-------------|
+| Pipeline skeleton | `unified.py` | Guard → cascade → invoke → enrich → collect |
+| Strategies | `strategies/` | Per-record LLM, file-level tool, file-level HITL |
+| Invocation | `invocation/` | Online (sync + retry/reprompt) vs batch (deferred queue) |
+| Recovery | `recovery/` | RetryService (transport errors), RepromptService (validation) |
+| Post-processing | `enrichment.py`, `result_collector.py`, `disposition_gate.py` | Lineage, metadata, dispositions, carry-forward |
+
+---
+
+## The Record Lifecycle
+
+A record enters `UnifiedProcessor.process()` and exits as an enriched output dict with a disposition in SQLite.
+
+```
+Input records (from staging or upstream action)
+    │
+    ▼
+┌──────────────────────────────────────────────────────┐
+│  Step 1: GUARD FILTER                                │
+│  unified.py:108-115                                  │
+│                                                      │
+│  Evaluates guard clause from YAML config:            │
+│    guard: { condition: '...', on_false: "filter" }   │
+│                                                      │
+│  Results:                                            │
+│    passing    → continue to step 2                   │
+│    skipped    → ProcessingResult.skipped() tombstone  │
+│    filtered   → ProcessingResult.filtered() (dropped) │
+└──────────┬───────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────┐
+│  Step 2: SOURCE_GUID ASSIGNMENT (first-stage only)   │
+│  unified.py:121-126                                  │
+│                                                      │
+│  First-stage records have no source_guid (they come  │
+│  from staging files). Assigns deterministic UUID5    │
+│  content hash so DispositionGate can match across    │
+│  runs for checkpoint resume.                         │
+└──────────┬───────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────┐
+│  Step 3: DISPOSITION GATE                            │
+│  disposition_gate.py:67-107                          │
+│                                                      │
+│  Queries SQLite for terminal dispositions (SUCCESS,  │
+│  FILTERED, SKIPPED, PASSTHROUGH, EXHAUSTED).         │
+│                                                      │
+│  Records with terminal disposition → carry forward   │
+│    (read prior output from target_data or checkpoint │
+│     table, skip reprocessing)                        │
+│  Records without → continue to step 4               │
+│                                                      │
+│  FAILED is NOT terminal — failed records reprocess.  │
+└──────────┬───────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────┐
+│  Step 4: CASCADE FILTER                              │
+│  cascade_filter.py:25-84                             │
+│                                                      │
+│  Checks record._state against CASCADE_BLOCKING_VALUES│
+│  (cascade_skipped, failed, exhausted)                │
+│                                                      │
+│  Blocked records → ProcessingResult.unprocessed()    │
+│  (downstream can't process what upstream failed on)  │
+│  Processable records → continue to step 5            │
+└──────────┬───────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────┐
+│  Step 5: STRATEGY INVOCATION                         │
+│  strategy.invoke(processable, context)               │
+│                                                      │
+│  ┌─────────────────────────────────────────────────┐ │
+│  │  OnlineLLMStrategy (per-record)                 │ │
+│  │  strategies/online_llm.py:134                   │ │
+│  │                                                 │ │
+│  │  for each record:                               │ │
+│  │    1. TaskPreparer.prepare()                    │ │
+│  │       → resolve context, render prompt,         │ │
+│  │         evaluate per-record guard               │ │
+│  │    2. InvocationStrategy.invoke(prepared)       │ │
+│  │       → OnlineStrategy: LLM call + retry/       │ │
+│  │         reprompt wrappers                       │ │
+│  │       → BatchStrategy: queue for deferred API   │ │
+│  │    3. _checkpoint_record()                      │ │
+│  │       → write disposition + output to SQLite    │ │
+│  │         immediately (resume on interrupt)       │ │
+│  │    4. Transform response → output records       │ │
+│  └─────────────────────────────────────────────────┘ │
+│                                                      │
+│  ┌─────────────────────────────────────────────────┐ │
+│  │  FileToolStrategy (whole-file)                  │ │
+│  │  strategies/file_tool.py:29                     │ │
+│  │                                                 │ │
+│  │  1. Strip framework fields (TrackedItem)        │ │
+│  │  2. Call UDF tool with full record array        │ │
+│  │  3. reconcile_outputs() — match by source_index │ │
+│  │  4. Build tombstones for missing records        │ │
+│  └─────────────────────────────────────────────────┘ │
+│                                                      │
+│  ┌─────────────────────────────────────────────────┐ │
+│  │  HITLStrategy (whole-file)                      │ │
+│  │  strategies/hitl.py:25                          │ │
+│  │                                                 │ │
+│  │  1. Call HITL agent with filtered records       │ │
+│  │  2. Receive single decision payload             │ │
+│  │  3. Broadcast decision to all records           │ │
+│  │  4. Detect hitl_status == "timeout" → error     │ │
+│  └─────────────────────────────────────────────────┘ │
+└──────────┬───────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────┐
+│  Step 6: ENRICHMENT                                  │
+│  enrichment.py:289-369                               │
+│                                                      │
+│  6 enrichers applied sequentially to each result:    │
+│                                                      │
+│  1. LineageEnricher     → node_id, target_id,        │
+│                           parent lineage             │
+│  2. MetadataEnricher    → extracted metadata from     │
+│                           LLM response               │
+│  3. VersionIdEnricher   → version_correlation_id     │
+│  4. PassthroughEnricher → merge passthrough fields   │
+│                           into content namespace     │
+│  5. RequiredFieldsEnricher → source_guid, target_id  │
+│  6. RecoveryEnricher    → _recovery metadata         │
+│                           (retry/reprompt details)   │
+│                                                      │
+│  Carry-forward records bypass enrichment (already    │
+│  have correct lineage from prior run).               │
+└──────────┬───────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────┐
+│  Step 7: COLLECTION                                  │
+│  result_collector.py:324-748                         │
+│                                                      │
+│  For each ProcessingResult:                          │
+│    - Stamp _state on output records                  │
+│    - Accumulate disposition rows                     │
+│    - Build tombstones for FAILED (online)            │
+│    - Fire telemetry events                           │
+│                                                      │
+│  Flush all dispositions in single SQLite transaction │
+│                                                      │
+│  Status → Disposition mapping:                       │
+│    SUCCESS    → DISPOSITION_SUCCESS                  │
+│    SKIPPED    → DISPOSITION_PASSTHROUGH              │
+│    FILTERED   → DISPOSITION_FILTERED                 │
+│    FAILED     → DISPOSITION_FAILED                   │
+│    EXHAUSTED  → DISPOSITION_EXHAUSTED                │
+│    UNPROCESSED→ DISPOSITION_UNPROCESSED              │
+│    DEFERRED   → DISPOSITION_DEFERRED                 │
+│                                                      │
+│  Returns: (output_records, CollectionStats)           │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Invocation Layer Detail
+
+The invocation layer sits between the strategy and the LLM call.
+
+```
+OnlineLLMStrategy.process_record()
+    │
+    ├── TaskPreparer.prepare()
+    │     ├── _normalize_input() → source_guid, snapshot
+    │     ├── _load_full_context() → context data for LLM
+    │     ├── _evaluate_guard() → per-record guard check
+    │     └── _render_prompt() → formatted prompt string
+    │
+    └── InvocationStrategy.invoke(prepared_task)
+          │
+          ├── OnlineStrategy (online mode)
+          │     │
+          │     ├── retry only:     RetryService.execute(llm_call)
+          │     ├── reprompt only:  RepromptService.execute(llm_call)
+          │     ├── both:           reprompt(retry(llm_call))
+          │     └── neither:        direct llm_call
+          │
+          └── BatchStrategy (batch mode)
+                └── queue task, return InvocationResult.queued()
+```
+
+### Retry (transport-layer recovery)
+
+```
+RetryService.execute(operation)     recovery/retry.py:108
+    │
+    for attempt in 1..max_attempts:
+    │   try:
+    │       response = operation()  → success, return
+    │   except NetworkError, RateLimitError:
+    │       sleep(exponential backoff + jitter)
+    │       continue
+    │   except non-retriable:
+    │       re-raise immediately
+    │
+    └── all attempts failed → RetryResult(exhausted=True)
+```
+
+### Reprompt (validation-layer recovery)
+
+```
+RepromptService.execute(llm_operation, original_prompt)
+    │                                         recovery/reprompt.py:179
+    for attempt in 1..max_attempts:
+    │   response = llm_operation(current_prompt)
+    │   │
+    │   ├── JSON parse error?
+    │   │     → build parse-error feedback, retry
+    │   │
+    │   ├── Schema validation fail? (if on_schema_mismatch: reprompt)
+    │   │     → build schema feedback, retry
+    │   │
+    │   ├── UDF validation fail? (if validation: fn_name)
+    │   │     → build UDF feedback, retry
+    │   │
+    │   ├── LLM critique? (if use_self_reflection and attempt ≥ threshold)
+    │   │     → append critique to feedback
+    │   │
+    │   └── All pass → RepromptResult(passed=True)
+    │
+    └── exhausted → RepromptResult(passed=False, exhausted=True)
+        on_exhausted: "return_last" → return last response
+        on_exhausted: "raise" → raise AgentActionsError
+```
+
+---
+
+## Checkpoint and Resume
+
+Per-record checkpointing enables interrupted runs to resume without reprocessing.
+
+```
+First run (interrupted at record 150 of 200):
+
+  for each record:
+      result = process_record(item)           ← LLM call (slow)
+      _checkpoint_record(result, context)     ← SQLite write (instant)
+          ├── set_disposition(source_guid, SUCCESS)
+          └── save_checkpoint_records(output data)
+      # record 150 → Ctrl+C here
+      # SQLite has 150 SUCCESS dispositions + 150 output records
+
+Re-run:
+
+  _reset_retryable_actions():
+      action was RUNNING → selective clear (failures only)
+      150 SUCCESS dispositions preserved
+
+  UnifiedProcessor.process():
+      Step 2: assign same content-hash guids (deterministic)
+      Step 3: DispositionGate finds 150 terminal IDs
+              → carry forward from checkpoint_output table
+              → only 50 records to process
+
+      strategy.invoke(50 remaining records)
+      → enrich + collect (all 200)
+      → write final output
+      → clear_checkpoint_records()
+```
+
+### Checkpoint storage
+
+```
+checkpoint_output table:
+    UNIQUE(action_name, relative_path, source_guid)
+    INSERT OR REPLACE (upsert)
+
+    ┌──────────────┬──────────────┬──────────────┬────────────┐
+    │ action_name  │relative_path │ source_guid  │record_data │
+    ├──────────────┼──────────────┼──────────────┼────────────┤
+    │ summarize... │ combined.json│ 44462716-... │ {JSON...}  │
+    │ summarize... │ combined.json│ 973062f1-... │ {JSON...}  │
+    └──────────────┴──────────────┴──────────────┴────────────┘
+```
+
+### Cleanup paths
+
+Every path that resets action state also clears checkpoint records:
+
+| Path | When | Code |
+|------|------|------|
+| Normal completion | After `save_main_output` | `pipeline.py:591` |
+| `--fresh` | At workflow startup | `coordinator.py:285` |
+| `retry` command | Per downstream action | `cli/retry.py:201` |
+
+---
+
+## Disposition Gate — What Gets Reprocessed
+
+```
+GATE_TERMINAL_DISPOSITIONS (not reprocessed on re-run):
+  ✓ SUCCESS
+  ✓ FILTERED
+  ✓ SKIPPED
+  ✓ PASSTHROUGH
+  ✓ EXHAUSTED
+
+NOT terminal (reprocessed on re-run):
+  ✗ FAILED     ← user can fix the input and retry
+  ✗ DEFERRED   ← in-flight batch/HITL, not done yet
+```
+
+On resume, `build_carry_forward()` reads prior output for carried records:
+
+```
+try read_target(action_name, relative_path)     ← completed action
+except FileNotFoundError:
+    read_checkpoint_records(action_name, path)   ← interrupted action
+    if found → use as carry-forward data
+    else → reprocess all
+```
+
+---
+
+## Evaluation Loop (Batch Only)
+
+The `EvaluationLoop` is used exclusively in the batch path for post-retrieval validation.
+
+```
+Batch results retrieved from provider
+    │
+    ▼
+EvaluationLoop.split(results)
+    │
+    ├── graduated (passed validation) → never re-evaluated
+    └── still_failing → resubmit with feedback prompt
+                         │
+                         ▼
+                    provider API (new batch)
+                         │
+                    EvaluationLoop.split(new_results)
+                         │
+                         └── repeat until pass or exhausted
+```
+
+The graduated pool pattern: each round, only failing records are resubmitted. Graduated records accumulate permanently. The failing set can only shrink.
+
+---
+
+## Invariants and Caveats — What Breaks If You Change Things
+
+Read this before modifying processing code. These are the non-obvious constraints that have caused real bugs.
+
+### Ordering constraints (step sequence matters)
+
+```
+source_guid assignment (step 2) MUST happen BEFORE DispositionGate (step 3)
+    Why: the gate matches records by source_guid. First-stage records don't
+    have one from staging files. If you move guid assignment after the gate,
+    checkpoint resume stops working — the gate can't match anything.
+    Bug found: 2026-05-31 during checkpoint testing.
+
+Guard filter (step 1) MUST happen BEFORE source_guid assignment (step 2)
+    Why: generate_content_hash(record) hashes ALL keys in the dict. If the
+    guard evaluator adds metadata fields to the record dict before hashing,
+    the hash will differ between runs (guard may evaluate differently based
+    on prior state). The guard must not mutate passing records.
+
+Enrichment (step 6) MUST happen BEFORE collection (step 7)
+    Why: collection stamps _state on records. Downstream actions validate
+    _state exists. If you collect before enriching, the lineage fields
+    are missing and downstream breaks.
+
+Carry-forward records MUST bypass enrichment (step 8, after step 6)
+    Why: they already have correct lineage from the prior run. Re-enriching
+    would overwrite their node_id, target_id, and lineage with duplicates.
+```
+
+### source_guid identity contract
+
+```
+source_guid is the ONLY record identity used across the entire pipeline:
+  - DispositionGate matches by source_guid
+  - Checkpoint records keyed by source_guid
+  - Dispositions keyed by (action_name, record_id=source_guid)
+  - Carry-forward lookup: prior_by_guid[source_guid]
+  - Cascade filter checks record._state by source_guid
+
+For first-stage records: source_guid = UUID5 content hash (deterministic).
+    Same input dict → same guid every run.
+    Assigned in UnifiedProcessor.process() line 121-126.
+    TaskPreparer._normalize_input() PRESERVES existing guid (line 142-144).
+    If you break this (e.g., generate a new uuid4), checkpoint resume fails:
+    the gate looks for the content-hash guid but the checkpoint stored uuid4.
+    Bug found: 2026-05-31, took 3 debugging rounds to identify.
+
+For non-first-stage records: source_guid comes from upstream action output.
+    Already set on the record dict when it enters the pipeline.
+```
+
+### Disposition write ordering (checkpoint vs collection)
+
+```
+Per-record checkpoint writes happen DURING invocation (step 5):
+    _checkpoint_record() → set_disposition(SUCCESS) + save_checkpoint_records()
+
+Batch collection writes happen AFTER enrichment (step 7):
+    collect_results_from_processing_results() → set_dispositions_batch()
+
+Both write to the SAME disposition table with UNIQUE(action_name, record_id, disposition).
+The collection write overwrites the checkpoint write. This is intentional and idempotent:
+    - Checkpoint writes SUCCESS, collection writes SUCCESS → same value
+    - Checkpoint writes SUCCESS, but parse-error detected → collection writes FAILED
+      (this is the correct final disposition)
+
+If you remove the collection write thinking "checkpoint already wrote it":
+    - Parse-error reclassification breaks (SUCCESS → FAILED won't happen)
+    - SKIPPED/FILTERED/EXHAUSTED dispositions are never written (checkpoint
+      only writes SUCCESS/FAILED, not guard outcomes)
+```
+
+### _state mutation contract
+
+```
+_state is stamped by result_collector.py during collection (step 7).
+Checkpoint records need _state=PROCESSED stamped BEFORE saving to the
+checkpoint table, because build_carry_forward returns them directly to
+the output list without going through collection again.
+
+If you remove the _state stamping in _checkpoint_record():
+    Downstream actions reject carried-forward records with:
+    "Record is missing '_state'. Delete agent_io/target/ and re-run."
+    Bug found: 2026-05-31 during real workflow testing.
+
+Checkpoint stamps _state on COPIES of result.data, not in-place:
+    checkpoint_records = [{**item, "_state": PROCESSED} ...]
+    Why: result.data dicts are shared references. In-place mutation
+    would affect the enrichment pipeline and event payloads that hold
+    references to the same dicts.
+```
+
+### Cascade filter depends on upstream _state
+
+```
+cascade_filter.py checks record["_state"] against CASCADE_BLOCKING_VALUES:
+    {"cascade_skipped", "failed", "exhausted"}
+
+If upstream writes a tombstone without _state (or with wrong _state):
+    The cascade filter won't quarantine it → downstream tries to process
+    a tombstone as a real record → garbage output or crash.
+
+If you add a new RecordState value that should block downstream:
+    Add it to CASCADE_BLOCKING_VALUES in record/state.py.
+    If you forget, downstream actions will try to process failed records.
+```
+
+### Every reset path must clear checkpoint records
+
+```
+Three places clear action state. ALL THREE must clear checkpoint_output:
+
+1. pipeline.py:591      — after save_main_output (normal completion)
+2. coordinator.py:285   — _clear_for_fresh_run (--fresh flag)
+3. cli/retry.py:201     — RetryCommand.execute (retry command)
+
+If you add a new reset path (e.g., a new CLI command that resets actions):
+    You MUST also call storage_backend.clear_checkpoint_records(action_name).
+    If you forget: stale checkpoint data from a prior run is silently
+    carried forward instead of reprocessing. The output looks correct but
+    contains stale data from a different run.
+    Bug found: 2026-05-31 during /simplify review.
+```
+
+### RUNNING_CLEAR_DISPOSITIONS — selective vs bulk clear
+
+```
+When _reset_retryable_actions resets action statuses to PENDING:
+
+  RUNNING actions → clear only RUNNING_CLEAR_DISPOSITIONS
+                    (FAILED, EXHAUSTED, DEFERRED)
+                    Preserves: SUCCESS, PASSTHROUGH, FILTERED, SKIPPED
+
+  All other retryable statuses (FAILED, SKIPPED, CHECKING_BATCH)
+                 → bulk clear ALL dispositions
+
+Why the asymmetry:
+  RUNNING = interrupted mid-processing. May have checkpointed SUCCESS
+  dispositions that should survive for carry-forward on resume.
+
+  FAILED = zero successes by definition (_resolve_completion_status only
+  returns FAILED when has_successful_items() is False). Nothing to preserve.
+
+  SKIPPED = no records processed. Nothing to preserve.
+
+If you add COMPLETED_WITH_FAILURES back to RETRYABLE_STATUSES:
+    You reintroduce the v0.2.2 rewind bug — the workflow goes back to
+    earlier actions instead of finishing the current run.
+    Bug found: spec 534, 2026-05-31.
+```
+
+### FILE mode ordering matters
+
+```
+In UnifiedProcessor.process(), result ordering differs by mode:
+
+  FILE mode:  quarantined + invocation + guard
+  RECORD mode: guard + quarantined + invocation
+
+This is intentional. FILE mode workflows depend on sequential accumulation
+(record N can reference record N-1's output). Do not unify without
+verifying FILE-mode workflows that depend on positional ordering.
+
+Also: FILE mode prunes context.source_data after cascade filter (line 176-183)
+to maintain positional alignment with processable records. If you skip this
+pruning, FileToolStrategy.reconcile_outputs() matches records by wrong indices.
+```
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `unified.py` | Pipeline skeleton, `ProcessingStrategy` protocol, `UnifiedProcessor` |
+| `types.py` | `ProcessingResult`, `ProcessingContext`, `ProcessingStatus`, metadata types |
+| `strategies/online_llm.py` | Per-record LLM loop, checkpoint, response transform |
+| `strategies/file_tool.py` | FILE-granularity tool invocation + output reconciliation |
+| `strategies/hitl.py` | FILE-granularity HITL broadcast |
+| `invocation/strategy.py` | `InvocationStrategy` ABC, `BatchProvider` protocol |
+| `invocation/online.py` | `OnlineStrategy` — sync LLM call with retry + reprompt |
+| `invocation/batch.py` | `BatchStrategy` — deferred queue + flush |
+| `invocation/factory.py` | `InvocationStrategyFactory` — builds strategy from config |
+| `invocation/result.py` | `InvocationResult` — immediate / filtered / queued |
+| `enrichment.py` | `EnrichmentPipeline` and 6 enrichers |
+| `result_collector.py` | Flatten results → output records + dispositions |
+| `disposition_gate.py` | `DispositionGate` + `build_carry_forward` |
+| `cascade_filter.py` | Quarantine upstream-failed records |
+| `guard_context.py` | Build field context for guard evaluation |
+| `task_preparer.py` | `TaskPreparer.prepare()` — normalize, guard, prompt |
+| `prepared_task.py` | `PreparedTask`, `GuardStatus`, `PreparationContext` |
+| `record_helpers.py` | Tombstone builders, `derive_relative_path` |
+| `exhausted_builder.py` | Build exhausted retry tombstones |
+| `source_resolution.py` | Three-tier resolution for non-first-stage content |
+| `batch_context_adapter.py` | Bridge batch state into `ProcessingContext` |
+| `error_handling.py` | `ProcessorErrorHandlerMixin` |
+| `recovery/retry.py` | `RetryService` — transport-layer retry with backoff |
+| `recovery/reprompt.py` | `RepromptService` — validation-layer reprompt |
+| `recovery/response_validator.py` | Schema + UDF validators, `ComposedValidator` |
+| `recovery/critique.py` | LLM self-critique for stubborn failures |
+| `recovery/validation.py` | Thread-safe UDF registry |
+| `evaluation/loop.py` | `EvaluationLoop` — graduated pool (batch only) |
+| `evaluation/strategies/validation.py` | `ValidationStrategy` — batch result validation |
+| `evaluation/exhaustion.py` | `apply_exhausted_reprompt` metadata stamping |

--- a/agent_actions/processing/_MANIFEST.md
+++ b/agent_actions/processing/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Processing Manifest
 
+**[> Architecture Guide (ARCHITECTURE.md)](ARCHITECTURE.md)** — full data flow, record lifecycle, checkpoint/resume, ASCII diagrams.
+
 ## Overview
 
 Shared processing utilities used by batch/online runners: enrichment, error handling,

--- a/agent_actions/prompt/ARCHITECTURE.md
+++ b/agent_actions/prompt/ARCHITECTURE.md
@@ -1,0 +1,431 @@
+# Prompt Module Architecture
+
+This document maps the moving parts of `agent_actions/prompt/` -- the module that transforms raw prompt templates and record data into the final `messages[]` array sent to LLM providers.
+
+---
+
+## High-Level Overview
+
+```
+                        agent_actions/prompt/
+                              |
+              +---------------+---------------+
+              |                               |
+        PREPARATION LAYER               ASSEMBLY LAYER
+       (template + context)           (provider messages)
+              |                               |
+  +-----------+-----------+          +--------+--------+
+  |           |           |          |                 |
+service.py  handler.py  context/   message_builder.py |
+(orchestrate) (load .md) (scope)   (per-vendor msgs)  |
+  |           |           |          |                 |
+formatter.py  |   scope_builder.py   +--- LLMMessage   |
+(resolve $)   |   scope_application  |    Envelope     |
+              |   scope_inference    |                 |
+              |   null_namespace     |                 |
+              |   static_loader      |                 |
+              |   scope_parsing      |                 |
+              |                      |                 |
+     render_workflow.py         renderer.py      prompt_utils.py
+     (compile YAML configs)   (CLI rendering)   (dispatch_task)
+```
+
+The module has **two layers**:
+
+| Layer | What it does |
+|-------|-------------|
+| **Preparation** | Resolves the raw prompt template, builds the field context from upstream actions and seed data, applies context_scope (observe/drop/passthrough), renders Jinja2, and resolves `dispatch_task()` calls. Output: a rendered prompt string + filtered LLM context dict + passthrough fields. |
+| **Assembly** | Takes the rendered prompt and LLM context from the preparation layer and assembles the vendor-specific `messages[]` array (system/user roles, tagged formatting, schema injection). Output: `LLMMessageEnvelope` ready for the provider SDK. |
+
+---
+
+## Prompt Template Resolution
+
+Prompts can be defined in two ways:
+
+```
+INLINE (in agent_config YAML):
+  prompt: "Summarize the following text: {{ source.text }}"
+
+FILE REFERENCE (from prompt_store/*.md):
+  prompt: "$summarize.main_prompt"
+          ^       ^
+          |       +-- block name inside the .md file
+          +-- filename (prompt_store/summarize.md)
+```
+
+Resolution flow:
+
+```
+PromptFormatter.get_raw_prompt(agent_config)
+  |
+  +-- prompt starts with "$"?
+  |     YES --> PromptLoader.load_prompt("summarize.main_prompt")
+  |               1. Split on first dot: file="summarize", block="main_prompt"
+  |               2. Find prompt_store/summarize.md recursively
+  |               3. Extract text between {prompt main_prompt} and {end_prompt}
+  |               4. Validate: no duplicate blocks, all blocks closed
+  |     NO  --> Use string as-is
+  |
+  +-- prompt missing entirely?
+  |     --> Default: "Process the following content: {content}"
+  |
+  +-- prompt is empty/whitespace (non-tool action)?
+        --> ConfigValidationError
+```
+
+---
+
+## Context Scope System (Security-Critical)
+
+`context_scope` is the security boundary that controls what data the LLM sees in its prompt and what data appears in its output. Every action must declare one.
+
+```
+context_scope:
+  observe:      ["extract.title", "extract.body"]
+  passthrough:  ["source.customer_id"]
+  drop:         ["source.ssn", "source.salary"]
+  seed_path:
+    rules: "grading_rubric.json"
+```
+
+### The three directives
+
+| Directive | LLM sees it? | Output gets it? | Purpose |
+|-----------|-------------|-----------------|---------|
+| `observe` | YES (in prompt context + "Additional context" injection) | NO (unless also in passthrough) | Feed data to the LLM for reasoning |
+| `passthrough` | NO (not in LLM context) | YES (merged into output record) | Carry identifiers through without LLM exposure |
+| `drop` | NO | NO | **Remove from BOTH input AND output** |
+
+### Drop wins over passthrough
+
+Drop is applied **after** passthrough extraction. If a field appears in both `passthrough` and `drop`, it is removed from the passthrough dict. This is intentional: drop is the security override.
+
+```
+Processing order inside apply_context_scope():
+
+  1. Deep-copy field_context (never mutate original)
+  2. Add seed data under "seed" namespace
+  3. Extract PASSTHROUGH fields from pre-drop context
+  4. Apply DROP: remove from prompt_context AND passthrough_fields
+  5. Extract OBSERVE fields to llm_context (kept in prompt_context too)
+  6. GATE prompt_context: only observed/passthrough namespaces + FRAMEWORK_NAMESPACES
+```
+
+### Visual example
+
+```
+Input Record:
+  {name: "Alice", age: 30, ssn: "123-45-6789", dept: "Eng", salary: 90000}
+
+context_scope:
+  drop: [source.ssn, source.salary]
+  observe: [source.dept]
+  passthrough: [source.name]
+
+                    +--- What the LLM prompt gets ---+
+                    | {name: "Alice", age: 30,       |
+                    |  dept: "Eng"}                   |
+                    | (ssn and salary dropped)        |
+                    |                                 |
+                    | Additional context:             |
+                    |   source.dept: "Eng"            |
+                    +---------------------------------+
+
+                    +--- What the OUTPUT gets --------+
+                    | {<llm_output>, name: "Alice"}   |
+                    | (passthrough merged, LLM wins   |
+                    |  on key collision)               |
+                    +---------------------------------+
+```
+
+---
+
+## Field Context Namespace Anatomy
+
+`build_field_context_with_history()` assembles the field context from four composable namespace builders:
+
+```
+field_context = {
+    "source":     {...},    # Namespace 1: Original input data (SourceNamespaceBuilder)
+    "{dep_name}": {...},    # Namespace 2: Upstream action outputs (DependencyNamespaceBuilder)
+    "seed":       {...},    # Namespace 3: Static reference data (added by apply_context_scope)
+    "version":    {...},    # Namespace 4: Loop iteration info (VersionNamespaceBuilder)
+    "workflow":   {...},    # Namespace 5: Workflow metadata (WorkflowMetadataBuilder)
+}
+```
+
+| Namespace | Builder | Source | Template access |
+|-----------|---------|--------|-----------------|
+| `source` | `SourceNamespaceBuilder` | User input data from staging | `{{ source.text }}` |
+| `{dep_name}` | `DependencyNamespaceBuilder` | Output of upstream action(s) | `{{ extract.title }}` |
+| `seed` | Added in `apply_context_scope` | Static files from `seed_data/` | `{{ seed.rubric }}` |
+| `version` | `VersionNamespaceBuilder` | Loop iteration context (`i`, `idx`, `length`, `first`, `last`) | `{{ version.i }}` or `{{ i }}` |
+| `workflow` | `WorkflowMetadataBuilder` | Workflow-level metadata | `{{ workflow.name }}` |
+
+Version and workflow convenience: `i`, `idx`, and custom version params are promoted to top-level so `{{ i }}` works alongside `{{ version.i }}`.
+
+---
+
+## NullNamespace Sentinel
+
+When a guard skips or filters an upstream action, the downstream record has `{action_name: None}` in its content. The `DependencyNamespaceBuilder` wraps this in a `NullNamespace` sentinel so downstream code can distinguish three cases:
+
+```
+1. NullNamespace(reason="skipped")  --> Namespace declared but absent (guard-skipped)
+2. Dict with fields                 --> Normal namespace with data
+3. Key absent from field_context    --> Undeclared namespace (config bug / typo --> error)
+```
+
+`is_null_namespace(value)` returns True for both `NullNamespace` instances and legacy `None` values. This is used by:
+- `apply_context_scope` -- resolves observe/passthrough fields to `None` instead of crashing
+- `_render_prompt_template` -- identifies skipped actions for `_PermissiveNamespace` injection
+- Guard evaluator AST nodes -- null-safe field access
+
+---
+
+## Jinja2 Rendering Pipeline
+
+```
+_render_prompt_template(raw_prompt, prompt_context)
+  |
+  1. If prompt_context is empty --> return raw_prompt unchanged
+  |
+  2. Create Environment(undefined=StrictUndefined,
+  |                     finalize=lambda x: "" if x is None else x)
+  |
+  3. escape_jinja_in_inline_code(raw_prompt)
+  |     Escapes {{ }} inside code fences so they are not interpreted
+  |
+  4. template.render(**prompt_context)
+  |     |
+  |     +-- UndefinedError?
+  |           |
+  |           +-- Is the missing variable a skipped dependency?
+  |           |     YES --> Inject _PermissiveNamespace (returns None for
+  |           |             any attribute; finalize converts None --> "")
+  |           |             Re-render with all skipped deps injected
+  |           |     NO  --> Raise TemplateVariableError with diagnostics:
+  |           |             - namespace_context (available refs per namespace)
+  |           |             - storage_hints (field exists in DB but not loaded)
+  |           |             - null_namespace_hints (guard-filtered dep advice)
+  |
+  5. Return rendered string
+```
+
+**StrictUndefined** means typos in template references fail loudly rather than silently rendering empty. The `_PermissiveNamespace` exception is narrow: it only applies to namespaces known to be skipped by guards, not arbitrary missing variables.
+
+---
+
+## Complete Prompt Preparation Pipeline
+
+`PromptPreparationService.prepare_prompt_with_context()` is the single source of truth for prompt preparation. Both batch and online modes call it.
+
+```
+Step 1: LOAD RAW PROMPT
+  PromptFormatter.get_raw_prompt(agent_config)
+  --> inline string or $file.block reference resolved
+  
+Step 2: BUILD FIELD CONTEXT
+  build_field_context_with_history(...)
+  --> Assembles {source, deps, version, workflow} namespaces
+  --> Pops _dependency_metadata for diagnostic use later
+  
+Step 3: LOAD SEED DATA
+  StaticDataLoader.load_static_data(seed_path_config)
+  --> Loads JSON/YAML/CSV/text files from seed_data/ directory
+  --> Returns dict keyed by field_name from config
+  
+Step 4: APPLY CONTEXT SCOPE
+  apply_context_scope(field_context, context_scope, static_data)
+  --> Returns (prompt_context, llm_additional_context, passthrough_fields)
+  --> Deep-copies input, applies drop/observe/passthrough, gates prompt_context
+  
+Step 5: BUILD LLM CONTEXT
+  LLMContextBuilder.build_llm_context_for_{batch|online}(...)
+  --> Merges observe fields into base context
+  --> Applies seed drop rules
+  
+Step 6: RENDER JINJA2 TEMPLATE
+  _render_prompt_template(raw_prompt, prompt_context)
+  --> Jinja2 with StrictUndefined, skipped-dep fallback
+  --> Produces formatted_prompt string
+  
+Step 7: RESOLVE DISPATCH_TASK() CALLS
+  PromptUtils.inject_function_outputs_into_prompt(...)
+  --> Finds dispatch_task('function_name') patterns in rendered prompt
+  --> Calls user Python functions from tools/ directory
+  --> Replaces pattern with function return value
+  --> Runs AFTER Jinja2 so dispatch sees the rendered prompt
+```
+
+---
+
+## MessageBuilder and Provider Message Configs
+
+After the preparation layer produces a rendered prompt and LLM context, provider clients call `MessageBuilder.build()` to assemble the vendor-specific `messages[]` array.
+
+```
+MessageBuilder.build(provider, prompt, context, schema, json_mode, ...)
+  |
+  1. Look up PROVIDER_MESSAGE_CONFIGS[provider]
+  |     --> ProviderMessageConfig(json_prompt_style, non_json_prompt_style,
+  |         json_role, non_json_role, schema_injection, json_rules, ...)
+  |
+  2. Serialise context to string
+  |     --> dict -> str(ensure_json_safe(data))  (most providers)
+  |     --> dict -> json.dumps(data)             (ollama)
+  |
+  3. Assemble body (based on PromptStyle)
+  |     TAGGED      --> <|begin_of_user_instruction|>: {prompt} :<|end|>
+  |                     <|begin_of_text|>: {context} :<|end|>
+  |     TAGGED_GROQ --> Same tags, different colon/spacing convention
+  |     PLAIN_TEXT  --> "Instructions: ... / Input Text: ..."
+  |     RAW         --> Empty (roles handle separation)
+  |
+  4. Inject schema (based on SchemaInjection)
+  |     NONE            --> Schema passed via API param (OpenAI, Anthropic)
+  |     INLINE_FULL     --> <|begin_of_output_schema|> : {schema}
+  |     INLINE_FULL_LIST--> list of this [{schema}] (Gemini)
+  |     INLINE_FIELDS   --> Field names only (Cohere)
+  |     PROMPT          --> Schema appended to prompt text (Ollama Cloud)
+  |
+  5. Wrap in roles (based on MessageRole)
+  |     SINGLE_USER      --> [{role: "user", content: body}]
+  |     SYSTEM_PLUS_USER --> [{role: "system", content: prompt},
+  |                          {role: "user", content: context}]
+  |     SYSTEM_ONLY      --> [{role: "system", content: body}]
+  |       (TAGGED + context --> splits into system + user for injection safety)
+  |
+  6. Anthropic prompt caching
+  |     --> Adds cache_control: {type: "ephemeral"} to messages
+  |
+  7. Token overflow pre-flight
+  |     --> chars/4 heuristic vs _MODEL_CONTEXT_LIMITS
+  |     --> PromptTooLargeError if exceeded
+  |
+  --> Returns LLMMessageEnvelope(messages, prompt_body, rules)
+```
+
+### Provider configuration matrix
+
+| Provider | JSON Style | Non-JSON Style | JSON Role | Schema Injection | Special Rules |
+|----------|-----------|----------------|-----------|------------------|---------------|
+| `openai` | TAGGED | TAGGED | SYSTEM_ONLY | NONE | "CANNOT RETURN SCHEMA", "READ INPUT AS STRING" |
+| `anthropic` | TAGGED | TAGGED | SINGLE_USER | NONE | (none) |
+| `gemini` | TAGGED | TAGGED | SINGLE_USER | INLINE_FULL_LIST | "DO NOT ADD KEY NOT IN SCHEMA" |
+| `groq` | TAGGED_GROQ | PLAIN_TEXT | SYSTEM_ONLY | NONE | "Respond in valid JSON" |
+| `cohere` | TAGGED | TAGGED | SINGLE_USER | INLINE_FIELDS | "CANNOT RETURN SCHEMA" |
+| `ollama_local` | RAW | RAW | SYSTEM_PLUS_USER | NONE | (none) |
+| `ollama_cloud` | RAW | RAW | SYSTEM_PLUS_USER | PROMPT | (none) |
+
+---
+
+## Seed Data Loading
+
+`StaticDataLoader` loads reference data from the `seed_data/` directory for injection into prompts via the `seed` namespace.
+
+```
+context_scope:
+  seed_path:
+    rubric: "grading_rubric.json"
+    examples: "few_shot_examples.yml"
+
+StaticDataLoader(static_data_dir=Path("seed_data/"))
+  .load_static_data({"rubric": "grading_rubric.json", ...})
+    |
+    For each field_name, file_spec:
+      1. Parse path: strip "$file:" prefix if present
+      2. Resolve path relative to seed_data/ directory
+      3. SECURITY: reject absolute paths, reject path traversal (../../etc/passwd)
+         --> Delegates to resolve_seed_path() which validates resolved path
+             stays within static_data_dir
+      4. Check file size (configurable max, prevents memory exhaustion)
+      5. Load by extension:
+           .json --> json.load()
+           .yml/.yaml --> yaml.safe_load()
+           .md/.txt --> raw text string
+           .csv --> list of dicts (DictReader)
+      6. Cache by resolved path (in-memory, per-loader instance)
+    |
+    Returns: {"rubric": {...}, "examples": [...]}
+    --> Merged into prompt_context["seed"] by apply_context_scope
+```
+
+---
+
+## Workflow Rendering Pipeline
+
+`render_pipeline_with_templates()` compiles a workflow YAML into a self-contained configuration. This runs at workflow load time, before any records are processed.
+
+```
+render_pipeline_with_templates(yaml_path, templates_folder)
+  |
+  Step 1: Jinja2 template rendering (workflow-level macros and includes)
+  Step 2: Parse YAML
+  Step 3: Resolve prompt references ($file.block --> inline text)
+  Step 4: Expand versioned actions (versions: {param: i, range: [1,3]})
+  Step 5: Compile schemas (schema_name: "foo" --> inline schema from file)
+  |
+  --> Fully self-contained YAML string
+```
+
+---
+
+## File Index
+
+### Core orchestration
+| File | Role |
+|------|------|
+| `service.py` | `PromptPreparationService` -- single source of truth for prompt preparation (both batch and online). Orchestrates all 7 pipeline steps. |
+| `formatter.py` | `PromptFormatter` -- resolves raw prompt from agent_config (inline or `$file.block` reference). |
+| `handler.py` | `PromptLoader` -- loads and validates prompts from `prompt_store/*.md` files. Extracts named blocks, validates uniqueness and closure. |
+| `message_builder.py` | `MessageBuilder` -- assembles vendor-specific `LLMMessageEnvelope` from prompt + context. `PROVIDER_MESSAGE_CONFIGS` registry. |
+
+### Context scope (security-critical)
+| File | Role |
+|------|------|
+| `context/scope_application.py` | `apply_context_scope()` -- the security gate. Observe/drop/passthrough filtering, prompt_context gating, FILE mode variant. |
+| `context/scope_builder.py` | `build_field_context_with_history()` -- assembles field_context from 4 namespace builders: source, dependency, version, workflow. |
+| `context/scope_inference.py` | `infer_dependencies()` -- auto-infers input/context sources from action config, fan-in detection, version branch expansion. |
+| `context/scope_parsing.py` | `parse_field_reference()` -- parses "action.field" references. `extract_action_names_from_template()` -- AST-based Jinja2 dependency extraction. |
+| `context/scope_namespace.py` | Namespace enrichment, field filtering, allowed-fields-per-dependency extraction. |
+| `context/null_namespace.py` | `NullNamespace` sentinel and `is_null_namespace()` for guard-skipped/filtered upstream actions. |
+| `context/static_loader.py` | `StaticDataLoader` -- loads seed data files (JSON, YAML, CSV, text) with path traversal prevention and caching. |
+| `context/builder.py` | `LLMContextBuilder` -- merges observe fields into LLM context, applies seed drop rules. Shared implementation for batch and online. |
+
+### Rendering and utilities
+| File | Role |
+|------|------|
+| `render_workflow.py` | `render_pipeline_with_templates()` -- compiles workflow YAML (Jinja2 macros, prompt resolution, schema inlining, version expansion). |
+| `renderer.py` | `JinjaTemplateRenderer` + `ConfigRenderingService` -- CLI/validation entry points for config rendering and loading. |
+| `prompt_utils.py` | `PromptUtils` -- `dispatch_task()` resolution, field reference parsing and replacement. |
+| `data_generator.py` | `DataGenerator` -- composes prompt preparation with `OnlineLLMStrategy` for the generate CLI command. |
+
+---
+
+## Caveats
+
+1. **context_scope is a security boundary.** It controls what the LLM sees and what appears in output. A misconfigured scope can leak PII (missing drop) or silently lose data (over-aggressive drop). Every action must declare one; omitting it raises `ConfigurationError`.
+
+2. **apply_context_scope deep-copies field_context.** The original input dict is never mutated. This is load-bearing: the same field_context may be reused across records in FILE mode, and mutation would corrupt subsequent records.
+
+3. **PromptPreparationService is the single source of truth.** Both batch (`TaskPreparer`) and online (`OnlineLLMStrategy`) must call `prepare_prompt_with_context()`. Adding mode-specific context logic elsewhere creates context parity bugs where batch and online produce different prompts for the same record.
+
+4. **The context gate is easy to break.** After observe/drop/passthrough processing, `apply_context_scope` gates `prompt_context` to only scoped namespaces plus `FRAMEWORK_NAMESPACES`. If you add a new framework namespace (like `loop` was added alongside `version`, `seed`, `workflow`), you must add it to `FRAMEWORK_NAMESPACES` in `scope_application.py` or it will be filtered out of templates.
+
+5. **NullNamespace is not None.** `NullNamespace(reason="skipped")` is a sentinel that is falsy (so `if ns_data:` skips it) but is not `None`. Use `is_null_namespace(value)` to check for either. Code that checks `value is None` will miss `NullNamespace` instances and crash. Code that checks `not value` will catch both but also catch empty dicts -- which have different semantics.
+
+6. **FRAMEWORK_NAMESPACES bypass the context gate.** The namespaces `version`, `seed`, `workflow`, and `loop` are always available for Jinja2 template rendering regardless of what is declared in observe/passthrough. They are not user data -- they are iteration context and metadata. Adding user-data namespaces to this set would create a security bypass.
+
+7. **Schema metadata stripping prevents schema-echo.** `MessageBuilder._strip_schema_metadata()` removes `name`, `title`, and `description` keys before injecting schemas into prompt text (for providers using `INLINE_FULL`, `INLINE_FULL_LIST`, or `PROMPT` injection). Without this, models return the schema definition itself instead of conforming data. This only affects prompt-injected schemas -- providers with native structured output (OpenAI, Anthropic) pass the full schema via API parameters.
+
+8. **dispatch_task() runs after Jinja2 rendering.** The resolution order is: Jinja2 template render first (step 6), then `dispatch_task()` resolution (step 7). This means `dispatch_task()` calls see the fully rendered prompt with all template variables resolved. User functions receive the LLM context as a JSON string argument.
+
+9. **StrictUndefined with _PermissiveNamespace is a narrow exception.** Jinja2 uses `StrictUndefined` so typos in template references fail loudly. The `_PermissiveNamespace` fallback only activates for namespaces identified as guard-skipped (via `NullNamespace` detection). It returns `None` for any attribute, which the `finalize` callback converts to `""`. This prevents template crashes when an upstream action was legitimately skipped by a guard.
+
+10. **Drop order matters for passthrough.** Passthrough fields are extracted from the pre-drop prompt_context, then drop is applied to both prompt_context and passthrough_fields. This means passthrough captures the value before drop, but drop still removes it. If the order were reversed (drop then passthrough), passthrough would never see the field. The current order ensures drop is the final authority.
+
+11. **Seed data path traversal prevention is delegated.** `StaticDataLoader._resolve_path()` delegates to `resolve_seed_path()` from `utils/path_security.py`. This validates that the resolved path stays within `static_data_dir` after symlink resolution. The loader also rejects absolute paths as a first-pass check before delegation.
+
+12. **Token overflow is a heuristic.** `MessageBuilder` estimates tokens as `total_chars / 4` and compares against `_MODEL_CONTEXT_LIMITS`. This is within approximately 20% of actual tokenization for English text. The check raises `PromptTooLargeError` before the API call, saving latency and cost. Models not in the lookup table fall back to 128K tokens.

--- a/agent_actions/prompt/_MANIFEST.md
+++ b/agent_actions/prompt/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Prompt Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Overview
 
 Prompt utilities cover generation, templating, formatting, context scope helpers,

--- a/agent_actions/record/ARCHITECTURE.md
+++ b/agent_actions/record/ARCHITECTURE.md
@@ -1,0 +1,363 @@
+# Record Module Architecture
+
+This document maps the moving parts of `agent_actions/record/` — the module that defines how every pipeline record is assembled, versioned, and transitioned through its lifecycle.
+
+---
+
+## High-Level Overview
+
+```
+                        agent_actions/record/
+                              │
+          ┌───────────┬───────┼───────────┬──────────────┐
+          │           │       │           │              │
+     envelope.py   state.py  tracking.py  disposition.py  lifecycle_read.py
+     (assembly)   (enum +    (FILE mode) (state →        (load-time
+                   sets)      provenance)  disposition)    validation)
+                                    │
+                              reasons.py
+                              (string constants)
+```
+
+RecordEnvelope is a stateless utility — all methods are `@staticmethod` and return plain dicts. There is no `RecordEnvelope` instance. The module is the single authority for record content assembly: every action type, granularity, and strategy converges here.
+
+---
+
+## Record Envelope Structure
+
+Every record that flows through the pipeline is a plain dict with this shape:
+
+```
+{
+    "content": {                         ← namespaced action outputs
+        "extraction": {"title": ".."},   ← action_name: action_output
+        "classification": {"type": ".."},
+    },
+    "source_guid": "abc-123-...",        ← stable identity (UUID4)
+    "version_correlation_id": "def-...", ← links versions across re-runs
+    "_state": "processed",               ← current lifecycle state
+    "_state_history": [                  ← audit trail (capped at 64)
+        {
+            "timestamp": "2026-06-02T...",
+            "action": "extraction",
+            "from": null,
+            "to": "active",
+            "reason": "initial",
+            "detail": null
+        },
+        ...
+    ],
+    "_state_schema_version": 1,          ← history format version
+
+    // Per-stage fields (rebuilt by enrichers, NOT carried forward):
+    "target_id": "...",
+    "node_id": "...",
+    "parent_target_id": "...",
+    "root_target_id": "...",
+    "lineage": {...},
+    "metadata": {...},
+    "_unprocessed": {...},
+    "_recovery": {...},
+    "chunk_info": {...},
+}
+```
+
+---
+
+## Field Categories
+
+The module defines four frozen sets that classify every framework field. These sets drive which fields are carried forward between pipeline stages and which are rebuilt.
+
+```
+RECORD_TRACKING_FIELDS (stable identity — set once, carried forward)
+├── source_guid
+└── version_correlation_id
+
+RECORD_LIFECYCLE_FIELDS (cumulative — carried forward AND appended to)
+├── _state_history
+└── _state_schema_version
+
+RECORD_STAGE_FIELDS (per-stage — rebuilt by enrichers, NOT carried)
+├── target_id
+├── node_id
+├── lineage
+├── metadata
+├── content
+├── _unprocessed
+├── _recovery
+├── parent_target_id
+├── root_target_id
+├── chunk_info
+└── _state
+
+_PERSISTENT_FIELDS = TRACKING_FIELDS | LIFECYCLE_FIELDS
+    (everything that build() copies from input → output)
+
+RECORD_FRAMEWORK_FIELDS = _PERSISTENT_FIELDS | STAGE_FIELDS
+    (union of all framework fields — used to strip metadata
+     from user content in scope_namespace, record_processor,
+     and pipeline_file_mode)
+```
+
+Note: `_state` is a stage field, not a lifecycle field. It is set by `transition()` at each stage, not carried forward by `_carry_persistent_fields()`. History is carried; the current state value is not.
+
+---
+
+## The Three Build Methods
+
+All three are `@staticmethod` on `RecordEnvelope`. All return new dicts.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  build(action_name, action_output, input_record)                     │
+│                                                                      │
+│  Normal record assembly. Wraps action_output under action_name       │
+│  inside content, preserves upstream namespaces from input_record,    │
+│  carries persistent fields (source_guid, version_correlation_id,     │
+│  _state_history, _state_schema_version).                             │
+│                                                                      │
+│  action_output is stored by REFERENCE inside content.                │
+│  Collision on action_name overwrites the existing namespace.         │
+│                                                                      │
+│  Used by: online strategy, batch result strategy, exhausted builder  │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────┐
+│  build_skipped(action_name, input_record)                            │
+│                                                                      │
+│  Guard-skipped record. Sets action_name namespace to None.           │
+│  Does NOT set _unprocessed or metadata — callers add those.          │
+│  Carries persistent fields same as build().                          │
+│                                                                      │
+│  Used by: tombstone builders (record_helpers.build_tombstone)        │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────┐
+│  build_content(action_name, action_output, existing_content)         │
+│                                                                      │
+│  Content-level only. Returns a plain dict, no record wrapper,        │
+│  no source_guid, no persistent fields. Just merges action_output     │
+│  under action_name into existing_content.                            │
+│                                                                      │
+│  Used by: utils/content.py wrap_content()                            │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Internal helper `_carry_persistent_fields()` copies tracking + lifecycle fields from `input_record` into the result. Mutable values (lists) are shallow-copied to prevent aliasing — see Caveat 3.
+
+Internal helper `_extract_existing()` pulls the `content` dict from `input_record` so upstream namespaces are preserved when building the new record.
+
+---
+
+## Record State Machine
+
+```
+                              ┌─────────┐
+                 ┌────────────│  ACTIVE  │────────────┐
+                 │            └─────────┘            │
+                 │           (processable)           │
+                 │                                    │
+        ┌────────▼────────┐                  ┌───────▼────────┐
+        │   PROCESSED     │                  │  GUARD_SKIPPED  │
+        │   (settled,     │                  │  (settled,      │
+        │    resettable)  │                  │   resettable)   │
+        └─────────────────┘                  └────────────────┘
+                 │
+        ┌────────▼────────┐                  ┌────────────────┐
+        │   COMMITTED     │                  │ GUARD_DEFERRED  │
+        │   (settled,     │                  │  (settled,      │
+        │    resettable)  │                  │   resettable)   │
+        └─────────────────┘                  └────────────────┘
+
+        ┌─────────────────┐   ┌──────────┐   ┌───────────────┐
+        │ CASCADE_SKIPPED │   │  FAILED  │   │   EXHAUSTED   │
+        │  (settled,      │   │ (settled,│   │  (settled,    │
+        │   blocking)     │   │ blocking)│   │   blocking)   │
+        └─────────────────┘   └──────────┘   └───────────────┘
+```
+
+### Transition Rules
+
+| From | To | Allowed? | Why |
+|------|----|----------|-----|
+| `None` (new record) | any | Yes | First write — no prior state |
+| `ACTIVE` | any settled | Yes | Normal processing progression |
+| `PROCESSED`, `COMMITTED`, `GUARD_SKIPPED`, `GUARD_DEFERRED` | `ACTIVE` | Yes | Downstream reset for re-processing |
+| any | same state | Yes | Idempotent re-application |
+| `CASCADE_SKIPPED`, `FAILED`, `EXHAUSTED` | `ACTIVE` | **No** | Blocking states cannot be reset |
+| `CASCADE_SKIPPED`, `FAILED`, `EXHAUSTED` | `CASCADE_SKIPPED` | Yes | Cascade propagation through blocking states |
+| settled | different settled | **No** | Cross-settled writes are invalid |
+
+Illegal transitions raise `RecordEnvelopeError`.
+
+---
+
+## State Sets
+
+```python
+PROCESSABLE_STATES     = {ACTIVE}
+    # Records eligible for LLM/tool processing
+
+SETTLED_STATES         = {all states} - {ACTIVE}
+    # Records that have reached a terminal state for this action
+
+RESETTABLE_DOWNSTREAM_STATES = {PROCESSED, COMMITTED, GUARD_SKIPPED, GUARD_DEFERRED}
+    # Can be reset to ACTIVE when fed as input to a downstream action
+
+CASCADE_BLOCKING_STATES = {CASCADE_SKIPPED, FAILED, EXHAUSTED}
+    # Cannot be reset — downstream actions must cascade-skip these
+
+RETRIABLE_STATES       = {FAILED, EXHAUSTED}
+    # The CLI retry command targets records in these states
+```
+
+`lifecycle_read.py` uses these sets at load time. When records are loaded from target storage as upstream input, `reset_for_downstream()` transitions resettable records back to `ACTIVE`. Records in blocking states stay as-is for the cascade logic to handle.
+
+---
+
+## transition() Rules and History Entries
+
+`transition()` is the **only sanctioned writer** of `_state`, `_state_history`, and `_state_schema_version`. It mutates the record in-place and returns it for chaining.
+
+Each call appends a history entry:
+
+```python
+{
+    "timestamp": "2026-06-02T12:34:56.789012+00:00",  # UTC ISO-8601
+    "action": "extraction",                             # which action
+    "from": "active",                                   # previous state (None for first)
+    "to": "processed",                                  # new state
+    "reason": "success",                                # why the transition happened
+    "detail": None                                      # optional extra context
+}
+```
+
+History is capped at `STATE_HISTORY_CAP` (64 entries). When overflow occurs, the oldest entries are dropped. `_state_schema_version` (currently 1) bumps when a required key is added to history entries or an existing key changes semantics.
+
+`can_transition()` is the read-only check — returns `True`/`False` without mutating.
+
+---
+
+## Source GUID Generation
+
+Source GUIDs are **not** generated by the record module — they are assigned upstream by `IDGenerator` (`utils/id_generation/generator.py`) and carried through by `_carry_persistent_fields()`.
+
+```
+First-stage records:
+    IDGenerator.generate_source_guid() → uuid4()
+    Assigned at initial_pipeline.py during staging
+
+Non-first-stage records:
+    source_guid comes from upstream action output
+    Preserved by RecordEnvelope.build() via _carry_persistent_fields()
+
+Content hashing (separate concept):
+    IDGenerator.generate_content_hash(content) → uuid5(NAMESPACE_OID, json)
+    Used for deduplication comparison, NOT as source_guid
+```
+
+The source_guid is a record's stable identity across pipeline stages. Checkpoint resume depends on this stability — the disposition gate looks up records by source_guid. If a stage overwrites the guid (e.g., generates a fresh uuid4), checkpoint resume breaks because the stored checkpoint references the original guid.
+
+---
+
+## State to Disposition Mapping
+
+`disposition.py` maps lifecycle states to storage dispositions. This is the bridge between the record module and the storage backend.
+
+```
+RecordState          →  Disposition
+─────────────────────────────────────
+PROCESSED            →  SUCCESS
+COMMITTED            →  SUCCESS
+GUARD_SKIPPED        →  PASSTHROUGH
+CASCADE_SKIPPED      →  UNPROCESSED
+GUARD_DEFERRED       →  DEFERRED
+FAILED               →  FAILED
+EXHAUSTED            →  EXHAUSTED
+ACTIVE               →  PASSTHROUGH
+```
+
+`derive_disposition()` reads `_state` from a record and returns the disposition string value. Raises `RecordEnvelopeError` if `_state` is missing or unrecognized.
+
+---
+
+## TrackedItem for FILE Mode
+
+```python
+class TrackedItem(dict):
+    __slots__ = ("_source_index",)
+```
+
+A `dict` subclass that carries a hidden `_source_index` attribute. Used in FILE mode tool processing:
+
+1. Framework wraps each input item as `TrackedItem(data, source_index=i)` before calling the user's tool function.
+2. User code accesses fields normally: `item["question_text"]`.
+3. Framework reads `_source_index` after the tool returns to map each output back to its input record.
+
+If user code spreads the item (`{**item}`), `_source_index` is lost because a plain dict is created. The framework detects this and raises `ValueError`.
+
+---
+
+## Lifecycle Validation (lifecycle_read.py)
+
+Records loaded from target storage as upstream input are validated fail-closed:
+
+- `validate_lifecycle()` — single record: requires `_state` present and recognized, `_state_schema_version` supported
+- `validate_lifecycle_batch()` — list of records: validates each, fails on first invalid
+- `reset_for_downstream()` — resets resettable records to `ACTIVE` via `transition()`
+
+Missing `_state` means the record pre-dates the lifecycle machine or was written outside `transition()`. There is no migration path — the remedy is to delete `agent_io/target/` and re-run.
+
+---
+
+## Reason Constants (reasons.py)
+
+Canonical string constants for every reason that flows through disposition writes, tombstone metadata, `ProcessingResult` factories, or telemetry events. Production code imports from this module instead of using bare string literals.
+
+```
+SUCCESS, GUARD_SKIP, GUARD_PREFILTER_SKIP, GUARD_FILTER,
+LLM_LAYER_GUARD_SKIP, LLM_LAYER_GUARD_FILTER,
+UPSTREAM_UNPROCESSED, PREP_FAILED, BATCH_NOT_RETURNED,
+TOOL_MISSING_RECORD, EMPTY_OUTPUT, RETRY_EXHAUSTED,
+UNPROCESSED, PARSE_ERROR, GUARD_FILTERED_ALL
+```
+
+---
+
+## File Index
+
+| File | Role |
+|------|------|
+| `envelope.py` | `RecordEnvelope` (build, build_skipped, build_content, transition, can_transition), field category frozensets, `RecordEnvelopeError` |
+| `state.py` | `RecordState` enum, state sets (PROCESSABLE, SETTLED, RESETTABLE_DOWNSTREAM, CASCADE_BLOCKING, RETRIABLE), predicate functions |
+| `tracking.py` | `TrackedItem` dict subclass with hidden `_source_index` for FILE mode provenance |
+| `disposition.py` | `derive_disposition()` — maps `_state` to storage `Disposition` value |
+| `lifecycle_read.py` | `validate_lifecycle()`, `validate_lifecycle_batch()`, `reset_for_downstream()` — load-time validation and downstream reset |
+| `reasons.py` | Canonical reason string constants for all lifecycle events |
+| `__init__.py` | Re-exports: `RecordEnvelope`, `RecordEnvelopeError`, `RecordState`, `TrackedItem`, `RECORD_FRAMEWORK_FIELDS`, `RECORD_LIFECYCLE_FIELDS` |
+
+---
+
+## Caveats
+
+1. **transition() is the only state writer.** Never assign `_state`, `_state_history`, or `_state_schema_version` directly on a record dict. All writes must go through `RecordEnvelope.transition()` to enforce legal edges and maintain the audit trail. Code that bypasses this will produce records that fail `validate_lifecycle()` on reload.
+
+2. **source_guid stability is critical for checkpoint resume.** The disposition gate looks up records by source_guid to determine what has already been processed. If any stage overwrites or regenerates the guid, checkpoint resume silently reprocesses records or skips them entirely. `_carry_persistent_fields()` preserves it; `TaskPreparer._normalize_input()` preserves it. Do not break this chain.
+
+3. **_state_history is shallow-copied to prevent aliasing.** `_carry_persistent_fields()` does `list(value)` on the history list. Without this, input and output records share the same list object, and `transition()` (which appends in-place) would corrupt the input record's audit trail. The copy is shallow — the inner entry dicts are shared — which is safe because entries are never mutated after creation.
+
+4. **TrackedItem spread drops provenance.** If user tool code does `new_dict = {**tracked_item}`, the result is a plain dict without `_source_index`. The framework checks for this after tool execution and raises `ValueError`. This is a deliberate fail-loud contract, not a bug.
+
+5. **build() stores action_output by reference.** The content dict contains a direct reference to the `action_output` dict passed in. Callers must not mutate `action_output` after calling `build()` or the record's content will change silently.
+
+6. **_state is a stage field, not a lifecycle field.** It lives in `RECORD_STAGE_FIELDS`, not `RECORD_LIFECYCLE_FIELDS`. This means `_carry_persistent_fields()` does NOT carry `_state` from input to output. Each stage must call `transition()` to set the state explicitly. The *history* is carried; the *current value* is not.
+
+7. **History cap drops oldest entries.** When `_state_history` exceeds 64 entries, the list is trimmed to the most recent 64. For records that pass through many actions or retry loops, early history entries may be lost. The cap prevents unbounded growth in storage.
+
+8. **No migration path for missing _state.** `validate_lifecycle()` is fail-closed. Records without `_state` (pre-dating the lifecycle machine or written by external tools) cannot be migrated. The only remedy is `rm -rf agent_io/target/` and re-run from scratch.
+
+9. **derive_disposition() covers all states including ACTIVE.** ACTIVE maps to PASSTHROUGH, not to an error. This handles the edge case where a record is written to storage before processing completes (e.g., during incremental checkpointing).
+
+10. **CASCADE_SKIPPED can transition to CASCADE_SKIPPED.** Blocking states cannot be reset to ACTIVE, but `_is_legal_transition()` allows a cascade-blocking state to transition to `CASCADE_SKIPPED`. This enables cascade propagation: if an upstream record is FAILED, the downstream record becomes CASCADE_SKIPPED, and that cascade can continue further downstream.
+
+11. **reason constants must be used in production code.** `reasons.py` exists so that disposition writes, tombstone metadata, and telemetry events use consistent strings. Bare string literals for these values are a bug — they silently diverge from the canonical set and break downstream filtering or reporting.

--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Record
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 Single authority for record content assembly. Every action type, granularity, and strategy converges here.
 
 ## Modules

--- a/agent_actions/skills/ARCHITECTURE.md
+++ b/agent_actions/skills/ARCHITECTURE.md
@@ -1,0 +1,199 @@
+# Skills Module Architecture
+
+This document maps the moving parts of `agent_actions/skills/` — the module that ships bundled documentation, reference material, and templates for AI coding assistants. It contains no runtime Python code.
+
+---
+
+## High-Level Overview
+
+```
+                      agent_actions/skills/
+                            │
+                    agac-agent-skills/           ← the only bundled skill
+                            │
+              ┌─────────────┼─────────────┐
+              │             │             │
+          SKILL.md     references/    assets/
+        (descriptor)   (14 guides)   templates/
+              │             │             │
+              │             │         workflow.yml.template
+              │             │         udf_tool.py.template
+              │             │
+              │        yaml-schema.md
+              │        prompt-patterns.md
+              │        udf-reference.md
+              │        debugging-guide.md
+              │        context-scope-guide.md
+              │        workflow-patterns.md
+              │        framework-contracts.md
+              │        guards.md
+              │        hitl-patterns.md
+              │        reprompt-patterns.md
+              │        schema-design-guide.md
+              │        aggregation-patterns.md
+              │        cli-reference.md
+              │        data-flow-patterns.md
+              │        action-anatomy.md
+              │        dynamic-content-injection.md
+              │
+          (installed into user project via `agac skills install`)
+```
+
+This is a **docs/template payload**, not a Python package. There is no `__init__.py`, no imports, no runtime behavior. The CLI reads this directory tree with `pathlib` and copies it wholesale into the user's project.
+
+---
+
+## Skill Discovery
+
+Discovery is **filesystem-based**, not registry-based. There is no manifest file listing skills and no plugin system.
+
+```
+get_bundled_skills_path()                 (cli/skills.py)
+  │
+  └─ Path(__file__).parent.parent / "skills"
+       │
+       └─ iterdir() → [d for d in path.iterdir() if d.is_dir()]
+            │
+            └─ ["agac-agent-skills"]      ← every subdirectory is a skill
+```
+
+The `list` command reads `SKILL.md` from each discovered directory to extract a description. The description comes from the YAML frontmatter `description:` field, but the current implementation reads the first non-empty, non-heading line after line 1 — so both sources need to agree.
+
+Adding a new skill means creating a new subdirectory under `skills/` with a `SKILL.md` at its root. No registration step needed.
+
+---
+
+## Installation Pipeline
+
+```
+agac skills install --claude
+agac skills install --codex
+agac skills install --claude --force
+
+                 ┌──────────────────────────────────────────┐
+                 │            install() flow                 │
+                 │                                          │
+                 │  1. Resolve project root                 │
+                 │     find_project_root()                  │
+                 │     (walks up looking for                │
+                 │      agent_actions.yml)                  │
+                 │                                          │
+                 │  2. Build target path                    │
+                 │     --claude → .claude/skills/           │
+                 │     --codex  → .codex/skills/            │
+                 │                                          │
+                 │  3. For each skill directory:            │
+                 │     dest exists + no --force → skip      │
+                 │     dest exists + --force:               │
+                 │       shutil.rmtree(dest)  ← DESTRUCTIVE │
+                 │       shutil.copytree(src, dest)         │
+                 │     dest missing:                        │
+                 │       shutil.copytree(src, dest)         │
+                 │                                          │
+                 │  4. Report installed / skipped           │
+                 └──────────────────────────────────────────┘
+```
+
+The copy is `shutil.copytree` — a full recursive copy of the skill directory. There is no merging, diffing, or selective update. `--force` does `shutil.rmtree` first, which **destroys any user edits** in the target directory without warning.
+
+---
+
+## SKILL.md Descriptor and AI Trigger
+
+Each skill has a `SKILL.md` at its root. This file serves two purposes:
+
+1. **YAML frontmatter** — machine-readable metadata:
+   ```yaml
+   ---
+   name: agac
+   description: Build, configure, and debug agent-actions agentic workflows.
+                Trigger on workflow YAML, UDFs, context_scope, guards, versions,
+                schemas, seed data, prompts, reprompt, HITL, or debugging
+                empty/filtered/mismatched output.
+   ---
+   ```
+   The `description` field lists trigger keywords. AI coding assistants (Claude Code, Codex) match user queries against these keywords to decide when to load the skill.
+
+2. **Markdown body** — the skill's primary knowledge payload. For `agac-agent-skills`, this is a comprehensive guide covering:
+   - The additive bus data model
+   - Record mode and FILE mode tool patterns
+   - Context scope (observe / passthrough / drop)
+   - Guards, versions, fan-in, seed data, schemas
+   - Action templates (LLM, Record tool, FILE tool)
+   - Debugging checklists
+   - 15 agentic patterns with YAML examples
+
+When an AI assistant triggers on the skill, it reads `SKILL.md` as its primary context, then follows links into `references/` for deeper detail.
+
+---
+
+## What the Skill Contains
+
+### references/ (14 guides)
+
+Deep-dive documentation that `SKILL.md` links to. Each file covers one topic in detail:
+
+| File | Topic |
+|------|-------|
+| `yaml-schema.md` | Complete `agent_config/*.yml` schema reference |
+| `prompt-patterns.md` | Template syntax, Jinja2, seed access, `dispatch_task()` |
+| `udf-reference.md` | Record mode, FILE mode, `@udf_tool`, `TrackedItem`, `FileUDFResult` |
+| `context-scope-guide.md` | observe / drop / passthrough resolution and semantics |
+| `workflow-patterns.md` | Fan-in, diamond, ensemble, map-reduce topologies |
+| `framework-contracts.md` | The 20 rules that govern framework behavior |
+| `guards.md` | Guard conditions, `skip` vs `filter`, namespace effects |
+| `debugging-guide.md` | Triage checklist for silent failures |
+| `hitl-patterns.md` | Human-in-the-loop configuration and flow |
+| `reprompt-patterns.md` | Validation retry with corrective feedback |
+| `schema-design-guide.md` | Output schema authoring (inline and file-based) |
+| `aggregation-patterns.md` | Version merge, `reduce_key`, consensus |
+| `cli-reference.md` | `agac` CLI commands and flags |
+| `data-flow-patterns.md` | Record lifecycle through the pipeline |
+| `action-anatomy.md` | Anatomy of a single action configuration |
+| `dynamic-content-injection.md` | `dispatch_task()` and dynamic prompt content |
+
+### assets/templates/ (2 templates)
+
+Starter files for scaffolding new workflows:
+
+| File | Generates |
+|------|-----------|
+| `workflow.yml.template` | `agent_config/{workflow}.yml` — 3-step workflow skeleton with defaults, LLM action, tool action, and context scope action |
+| `udf_tool.py.template` | `tools/{workflow}/*.py` — Record-mode `@udf_tool` with namespaced data access |
+
+Templates use `{{PLACEHOLDER}}` syntax (not Jinja2). They are reference examples, not used by any automated scaffolding command — the AI assistant fills in placeholders when helping users create workflows.
+
+---
+
+## File Index
+
+| File | Role |
+|------|------|
+| `_MANIFEST.md` | Module manifest (AMP protocol) |
+| `ARCHITECTURE.md` | This file |
+| `agac-agent-skills/SKILL.md` | Skill descriptor + primary knowledge payload |
+| `agac-agent-skills/references/*.md` | 16 deep-dive reference guides |
+| `agac-agent-skills/assets/templates/workflow.yml.template` | Workflow YAML starter template |
+| `agac-agent-skills/assets/templates/udf_tool.py.template` | UDF tool starter template |
+
+CLI entry point (outside this module):
+
+| File | Role |
+|------|------|
+| `cli/skills.py` | `agac skills install` and `agac skills list` commands |
+
+---
+
+## Caveats
+
+1. **No runtime code.** This module has no Python files, no `__init__.py`, no imports. It is invisible to the Python import system. The only code that touches it is `cli/skills.py`, which uses `pathlib` and `shutil`.
+
+2. **`--force` is destructive.** `shutil.rmtree` deletes the entire target skill directory before copying. If users have edited installed skill files (customized reference docs, added notes), those edits are lost without confirmation.
+
+3. **Bus snapshot rule.** The data model described in `SKILL.md` follows the additive bus pattern: every record's `content` dict only grows. Each action writes its output under a namespace key (`content["action_name"] = {...}`). Nothing is removed. `context_scope.observe` is the selector that controls what each action sees, but the bus carries everything. This is the foundational invariant that all reference docs assume.
+
+4. **`seed.` prefix.** Seed data loaded via `context_scope.seed_path` is available in prompts as `{{ seed.key }}`. The config key is `seed_path:` but the template variable prefix is `seed.` — a naming asymmetry that the debugging guide calls out as a common source of confusion.
+
+5. **Skill naming convention.** Skill directories must start with `agac-` by convention (the current skill is `agac-agent-skills`). Discovery does not enforce this — any subdirectory is treated as a skill — but the convention exists for namespace clarity.
+
+6. **No selective update.** Installation is all-or-nothing per skill. You cannot install only `references/` or only `assets/`. The entire skill directory tree is copied.

--- a/agent_actions/skills/_MANIFEST.md
+++ b/agent_actions/skills/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Skills Manifest
 
+**[> Architecture deep-dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Overview
 
 Bundled skills for the Agent Actions CLI are stored under standardized directories

--- a/agent_actions/storage/ARCHITECTURE.md
+++ b/agent_actions/storage/ARCHITECTURE.md
@@ -1,0 +1,382 @@
+# Storage Module Architecture
+
+This document maps the moving parts of `agent_actions/storage/` — the module that provides durable persistence for workflow data, dispositions, prompt traces, and checkpoint state. Everything lives in a single SQLite database per workflow.
+
+---
+
+## High-Level Overview
+
+```
+                      agent_actions/storage/
+                            │
+              ┌─────────────┼─────────────┐
+              │             │             │
+         __init__.py    backend.py    backends/
+        (factory +     (abstract      (concrete
+         registry)      interface)     implementations)
+              │             │             │
+              │             │        sqlite_backend.py
+              │             │         (the only backend
+              │             │          today)
+              └──────┬──────┘
+                     │
+              One DB per workflow:
+          {workflow}/agent_io/store/{name}.db
+```
+
+The module has three parts:
+
+| File | What it does |
+|------|-------------|
+| `__init__.py` | Factory function `get_storage_backend()` and `BACKENDS` registry (`{"sqlite": SQLiteBackend}`) |
+| `backend.py` | Abstract `StorageBackend` base class — defines the contract for all backends |
+| `backends/sqlite_backend.py` | The SQLite implementation — the only concrete backend |
+
+The architecture is designed for future backends (S3, DuckDB), but today SQLite is the only one. All callers go through the abstract interface; none import `SQLiteBackend` directly except the factory.
+
+---
+
+## Table Schemas
+
+The SQLite backend creates five tables. All are created in `initialize()` via `CREATE TABLE IF NOT EXISTS`.
+
+### 1. source_data — ingested input records
+
+```sql
+CREATE TABLE IF NOT EXISTS source_data (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    relative_path TEXT NOT NULL,
+    source_guid TEXT NOT NULL,
+    data TEXT NOT NULL,               -- JSON blob: the full input record
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(relative_path, source_guid)
+)
+```
+
+Index: `idx_source_path ON source_data(relative_path)`
+
+Deduplication: `INSERT OR IGNORE` when `enable_deduplication=True` (default), `INSERT OR REPLACE` otherwise. Keyed on `(relative_path, source_guid)`.
+
+### 2. target_data — action output records
+
+```sql
+CREATE TABLE IF NOT EXISTS target_data (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    action_name TEXT NOT NULL,
+    relative_path TEXT NOT NULL,
+    data TEXT NOT NULL,                -- JSON blob: list[dict] of ALL records for this path
+    record_count INTEGER,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(action_name, relative_path)
+)
+```
+
+No additional indexes — the UNIQUE constraint provides one.
+
+The `data` column stores the **entire list of records** as a single JSON blob, not one row per record. This is a blob model: `write_target()` serializes the full `list[dict]` with `json.dumps()`, and `_read_target_raw()` deserializes it back. `record_count` is a denormalized count stored alongside for efficient stats queries.
+
+### 3. record_disposition — per-record processing status
+
+```sql
+CREATE TABLE IF NOT EXISTS record_disposition (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    action_name TEXT NOT NULL,
+    record_id TEXT NOT NULL,
+    disposition TEXT NOT NULL,
+    reason TEXT,
+    detail TEXT,                       -- extended error message or context
+    relative_path TEXT,
+    input_snapshot TEXT,               -- JSON of input record (capped at 10KB)
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(action_name, record_id, disposition)
+)
+```
+
+Indexes:
+- `idx_disp_action ON record_disposition(action_name)`
+- `idx_disp_action_disp ON record_disposition(action_name, disposition)`
+- `idx_disp_action_record ON record_disposition(action_name, record_id)`
+
+### 4. prompt_trace — LLM call telemetry
+
+```sql
+CREATE TABLE IF NOT EXISTS prompt_trace (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    action_name TEXT NOT NULL,
+    record_id TEXT NOT NULL,
+    attempt INTEGER NOT NULL DEFAULT 0,
+    compiled_prompt TEXT NOT NULL,
+    llm_context TEXT,
+    response_text TEXT,
+    model_name TEXT,
+    model_vendor TEXT,
+    run_mode TEXT,
+    prompt_length INTEGER,            -- length of original prompt before truncation
+    context_length INTEGER,
+    response_length INTEGER,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(action_name, record_id, attempt)
+)
+```
+
+Indexes:
+- `idx_trace_action ON prompt_trace(action_name)`
+- `idx_trace_action_record ON prompt_trace(action_name, record_id)`
+
+Large fields (prompt, context, response) are capped at 1MB (`_MAX_TRACE_FIELD_SIZE`). Overflow is replaced with `{"__truncated__": true, "original_length": N}`.
+
+### 5. checkpoint_output — incremental online resume
+
+```sql
+CREATE TABLE IF NOT EXISTS checkpoint_output (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    action_name TEXT NOT NULL,
+    relative_path TEXT NOT NULL,
+    source_guid TEXT,
+    record_data TEXT NOT NULL,         -- JSON blob: one record
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(action_name, relative_path, source_guid)
+)
+```
+
+Index: `idx_checkpoint_action ON checkpoint_output(action_name, relative_path)`
+
+---
+
+## The Disposition System
+
+Every record that flows through the pipeline gets a disposition — a terminal label recording what happened to it. There are eight values:
+
+```
+Disposition        Meaning
+─────────────────  ──────────────────────────────────────────────
+SUCCESS            LLM returned valid output, written to target
+FAILED             Something went wrong (provider error, parse error, prep error)
+EXHAUSTED          Retried max times, provider never returned valid output
+FILTERED           Guard evaluation said "don't process this record"
+SKIPPED            Upstream action didn't produce output for this record
+DEFERRED           Batch submitted but not yet completed (temporary)
+PASSTHROUGH        Record passed through without LLM processing
+UNPROCESSED        Cascade casualty — upstream failure prevented processing
+```
+
+### Disposition sets (behavioral groupings)
+
+Three frozen sets partition dispositions by how the system treats them:
+
+```
+GATE_TERMINAL_DISPOSITIONS (not reprocessed on re-run):
+  SUCCESS, FILTERED, SKIPPED, PASSTHROUGH, EXHAUSTED
+
+  These records are "done" from the disposition gate's perspective.
+  The gate carries them forward without reprocessing.
+
+RUNNING_CLEAR_DISPOSITIONS (cleared when resuming an interrupted action):
+  FAILED, EXHAUSTED, DEFERRED
+
+  When a RUNNING action resumes, these dispositions are deleted so the
+  records flow through again. SUCCESS, PASSTHROUGH, FILTERED, SKIPPED
+  are preserved so checkpointed progress survives.
+
+FAILURE_DISPOSITIONS (eligible for retry):
+  FAILED, EXHAUSTED
+
+  Only primary failures the user can act on. Excludes UNPROCESSED
+  (cascade casualty — resolves when upstream is retried).
+```
+
+### DELETE-then-INSERT write semantics
+
+The UNIQUE constraint on `record_disposition` is `(action_name, record_id, disposition)`, which means the same record could theoretically have rows for multiple dispositions (e.g., an old FAILED and a new SUCCESS). To prevent this coexistence, `set_disposition()` uses DELETE-then-INSERT:
+
+```
+1. DELETE FROM record_disposition
+   WHERE action_name = ? AND record_id = ?
+
+2. INSERT INTO record_disposition
+   (action_name, record_id, disposition, ...)
+   VALUES (?, ?, ?, ...)
+```
+
+This ensures each `(action_name, record_id)` pair has exactly one disposition row at any time. The batch variant `set_dispositions_batch()` uses the same pattern with `executemany`.
+
+---
+
+## NODE_LEVEL_RECORD_ID Sentinel
+
+```python
+NODE_LEVEL_RECORD_ID = "__node__"
+```
+
+Some signals apply to an entire action node, not to individual records. For example, when the entire action is deferred (batch submitted) or when a node-level failure occurs. The sentinel `__node__` is used as the `record_id` in these cases.
+
+Methods like `get_failed_items()` and `has_successful_items()` explicitly filter out `__node__` rows so they only return item-level dispositions.
+
+`get_terminal_record_ids()` also excludes `__node__` from its results — it returns only real record IDs with gate-terminal dispositions.
+
+---
+
+## Checkpoint System (Incremental Online Resume)
+
+The checkpoint table enables crash recovery for the online (synchronous) processing path. During online processing, each successfully processed record is checkpointed immediately:
+
+```
+Processing record 1 → SUCCESS → save_checkpoint_records()
+Processing record 2 → SUCCESS → save_checkpoint_records()
+Processing record 3 → [CRASH]
+
+On resume:
+  read_checkpoint_records() → records 1 and 2
+  Skip records 1 and 2 (already done)
+  Resume from record 3
+```
+
+The flow:
+
+1. **During processing**: `save_checkpoint_records()` upserts each batch of processed records using `INSERT OR REPLACE` keyed on `(action_name, relative_path, source_guid)`.
+2. **On resume**: `read_checkpoint_records()` retrieves all checkpointed records for the action/path, ordered by insertion ID.
+3. **After completion**: `clear_checkpoint_records()` deletes all checkpoint rows for the action. Checkpoint data is transient — it exists only between start and successful finish.
+
+Unlike target_data (which stores all records as one JSON blob), checkpoint_output stores **one row per record** with `source_guid` as the dedup key. This allows incremental appending without rewriting the entire blob on each checkpoint.
+
+---
+
+## Thread Safety
+
+The SQLite backend is designed for multi-threaded access within a single process:
+
+```
+┌──────────────────────────────────────────┐
+│  SQLiteBackend                           │
+│                                          │
+│  self._lock = threading.RLock()          │
+│    └─ Every public method acquires this  │
+│       before touching self._connection   │
+│                                          │
+│  self._connection = sqlite3.connect(     │
+│    check_same_thread=False,              │
+│    timeout=30.0                          │  ← StorageDefaults.SQLITE_LOCK_TIMEOUT_SECONDS
+│  )                                       │
+│                                          │
+│  PRAGMA journal_mode=WAL                 │
+│    └─ Allows concurrent readers while    │
+│       one writer holds the lock          │
+│                                          │
+│  PRAGMA foreign_keys=ON                  │
+└──────────────────────────────────────────┘
+```
+
+The lock is an `RLock` (reentrant) because the `connection` property may be called from within code that already holds the lock. All write methods follow the pattern: acquire lock, execute, commit on success / rollback on failure, release lock. Read methods also hold the lock for the full execute-fetch pair to prevent interleaving.
+
+---
+
+## Schema Migration (_enforce_schema)
+
+When the framework upgrades and adds columns to a table, existing databases need to be updated without losing data. `_enforce_schema()` runs at initialization, before `CREATE TABLE` statements:
+
+```
+For each table in _REQUIRED_COLUMNS:
+  1. PRAGMA table_info(table_name) → get existing columns
+  2. If table doesn't exist yet → skip (CREATE TABLE will handle it)
+  3. Compute: missing = required_columns - existing_columns
+  4. For each missing column:
+       ALTER TABLE "table" ADD COLUMN "column" TEXT DEFAULT NULL
+```
+
+Key design decisions:
+- **Never drops tables** — user data must survive framework upgrades.
+- **Only adds columns** — does not remove or rename existing columns.
+- **All new columns are TEXT DEFAULT NULL** — the most permissive type; application code handles typing.
+- **Table names in `_REQUIRED_COLUMNS` are hardcoded** — not user input, but the implementation still quotes identifiers as defense-in-depth.
+
+The `_REQUIRED_COLUMNS` dictionary lists the columns each table must have:
+
+| Table | Required columns |
+|-------|-----------------|
+| `source_data` | relative_path, source_guid, data, created_at |
+| `target_data` | action_name, relative_path, data, record_count, created_at |
+| `record_disposition` | action_name, record_id, disposition, reason, relative_path, input_snapshot, detail, created_at |
+| `prompt_trace` | action_name, record_id, attempt, compiled_prompt, llm_context, response_text, model_name, model_vendor, run_mode, prompt_length, context_length, response_length, created_at |
+
+Note: `checkpoint_output` is not in `_REQUIRED_COLUMNS` because it was added after the migration system and has no legacy schemas to handle.
+
+---
+
+## Maintenance Operations
+
+`perform_maintenance()` runs four idempotent cleanup operations after each workflow completes:
+
+### 1. WAL checkpoint (`_checkpoint_wal`)
+
+Runs `PRAGMA wal_checkpoint(TRUNCATE)` to flush the write-ahead log back into the main database file and reclaim disk space. Non-fatal on failure.
+
+### 2. Stale disposition cleanup (`_cleanup_stale_dispositions`)
+
+When a workflow re-runs, records that previously FAILED may now succeed. This operation finds records that have both a FAILED/EXHAUSTED disposition and a newer SUCCESS disposition (by `id` ordering), and deletes the old failure rows. Prevents stale failure data from accumulating.
+
+### 3. Prompt trace retention (`_enforce_prompt_trace_retention`)
+
+Keeps traces from the N most recent calendar days (default: 10, from `StorageDefaults.PROMPT_TRACE_RETENTION_RUNS`). Uses `DATE(created_at)` as the boundary — multiple runs on the same day count as one retention unit. Deletes all traces older than the Nth distinct date.
+
+### 4. Source data TTL (`_enforce_source_data_ttl`)
+
+Deletes `source_data` rows older than the configured TTL in days. Default is `None` (keep forever). Uses SQLite's `datetime('now', '-N days')` for the cutoff.
+
+---
+
+## Identifier Validation
+
+All action names, relative paths, and record IDs pass through `_validate_identifier()` before being used in queries:
+
+```
+Allowed characters:  a-z A-Z 0-9 _ - . / (space)
+Blocked:
+  - Empty or whitespace-only strings
+  - Path traversal ("..") as a path component
+  - Backslashes (normalized to forward slashes)
+  - Any character outside the allowlist
+```
+
+This is defense-in-depth. All SQL uses parameterized queries, so injection is not possible through values. The validation catches malformed identifiers early with clear error messages rather than letting them propagate to confusing SQL errors.
+
+---
+
+## File Index
+
+| File | Role |
+|------|------|
+| `__init__.py` | Factory: `get_storage_backend(workflow_path, workflow_name, backend_type)` and `BACKENDS` registry |
+| `backend.py` | Abstract base class: `StorageBackend`, disposition constants, `Disposition` enum, `NODE_LEVEL_RECORD_ID`, `FAILURE_DISPOSITIONS`, `RUNNING_CLEAR_DISPOSITIONS` |
+| `backends/sqlite_backend.py` | SQLite implementation: all 5 tables, schema migration, maintenance, thread-safe CRUD |
+
+---
+
+## Caveats
+
+1. **target_data uses a blob model.** The `data` column stores the entire `list[dict]` as one JSON string. This means `write_target()` replaces all records for an `(action_name, relative_path)` pair atomically. There is no way to update a single record within the blob without rewriting the whole thing. This is deliberate — the workflow writes complete output for a path in one shot.
+
+2. **checkpoint_output uses a row-per-record model.** Unlike target_data, each checkpointed record gets its own row. This allows incremental appending via `INSERT OR REPLACE` without rewriting a blob. The two models serve different access patterns: target_data is write-once-read-many, checkpoint_output is append-during-processing-then-delete.
+
+3. **DELETE-then-INSERT is not atomic at the SQL level.** If the process crashes between the DELETE and INSERT in `set_disposition()`, the disposition row is lost. This is acceptable because a missing disposition means the record will be reprocessed on the next run, which is the safe default.
+
+4. **delete_target vs clear_disposition are independent.** `delete_target()` removes rows from `target_data` but does NOT touch `record_disposition`. `clear_disposition()` removes rows from `record_disposition` but does NOT touch `target_data`. Callers must call both if they want a clean reset. The `--fresh` flag in the workflow layer coordinates this.
+
+5. **Schema migration only adds columns.** If a column is renamed or removed in a future version, `_enforce_schema()` will not handle it. The table will have both old and new columns. There is no `DROP COLUMN` or `ALTER COLUMN` path.
+
+6. **input_snapshot truncation is lossy.** When `input_snapshot` exceeds 10KB, it is replaced with a JSON wrapper containing only the first 8KB. The original data is not recoverable from the truncated form.
+
+7. **Prompt trace fields are capped at 1MB.** Any `compiled_prompt`, `llm_context`, or `response_text` exceeding `_MAX_TRACE_FIELD_SIZE` (1,048,576 bytes) is replaced with a truncation marker. The original lengths are preserved in `prompt_length`, `context_length`, and `response_length` columns (computed before truncation).
+
+8. **WAL mode persists across connections.** Once `PRAGMA journal_mode=WAL` is set, it persists in the database file. Future connections inherit it regardless of whether they set it explicitly. This means the `.db-wal` and `.db-shm` files may exist even when no connection is open.
+
+9. **Threading model is single-process only.** The `RLock` serializes access within one Python process. Multiple processes writing to the same database rely on SQLite's file-level locking (with the 30-second timeout). The framework does not currently use multi-process writes, but the lock timeout is the safety net if it ever does.
+
+10. **get_terminal_record_ids imports from processing at call time.** The method does `from agent_actions.processing.disposition_gate import GATE_TERMINAL_DISPOSITIONS` inside the method body to avoid a circular import. This means the set of terminal dispositions is defined in the processing module, not in storage.
+
+11. **source_data deduplication is by source_guid only within a path.** The UNIQUE constraint is `(relative_path, source_guid)`. The same `source_guid` can exist under different `relative_path` values without conflict. Records without a `source_guid` are silently skipped with a warning.
+
+12. **read_target goes through a template method.** The public `read_target()` on `StorageBackend` calls `_read_target_raw()` (implemented by SQLiteBackend), then runs `validate_lifecycle_batch()` and `reset_for_downstream()`. This ensures lifecycle validation happens for every backend without each one reimplementing it.
+
+13. **Maintenance operations are non-fatal.** All four maintenance operations (`_checkpoint_wal`, `_cleanup_stale_dispositions`, `_enforce_prompt_trace_retention`, `_enforce_source_data_ttl`) catch `sqlite3.Error` and log warnings instead of raising. A maintenance failure does not block workflow completion.
+
+14. **The base class uses no-op defaults for optional methods.** `set_disposition()`, `write_prompt_trace()`, `save_checkpoint_records()`, and `clear_checkpoint_records()` are no-ops on `StorageBackend`. This means a backend that forgets to override them will silently drop data. The `# noqa: B027` comments acknowledge this intentional pattern.

--- a/agent_actions/storage/_MANIFEST.md
+++ b/agent_actions/storage/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Storage Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)** — table schemas, disposition system, checkpoint model, thread safety, schema migration, caveats.
+
 ## Overview
 
 Extensible storage backend module for workflow data persistence. Provides a pluggable

--- a/agent_actions/tooling/ARCHITECTURE.md
+++ b/agent_actions/tooling/ARCHITECTURE.md
@@ -1,0 +1,361 @@
+# Tooling Module Architecture
+
+This document maps the moving parts of `agent_actions/tooling/` — the module that powers documentation generation, run tracking, the Language Server Protocol (LSP) experience, and shared rendering utilities.
+
+---
+
+## High-Level Overview
+
+```
+                        agent_actions/tooling/
+                              |
+          +-------------------+-------------------+
+          |                   |                   |
+      code_scanner.py      docs/              rendering/
+      (AST introspection)  (docs generation    (data card
+                            + run tracking      rendering)
+                            + HTTP server)
+          |                   |                   |
+          |           +-------+-------+           |
+          |           |       |       |           |
+          |       scanner/  generator  server     |
+          |       parser   run_tracker            |
+          |                                       |
+          +-------------------+-------------------+
+                              |
+                           lsp/
+                     (Language Server
+                      Protocol IDE
+                      integration)
+```
+
+The module has **four packages**:
+
+| Package | What it does |
+|---------|-------------|
+| `docs/` | Scans a user project, generates `catalog.json`, tracks workflow runs in `runs.json`, and serves a static documentation site |
+| `lsp/` | Language Server Protocol server providing go-to-definition, hover, completions, diagnostics, semantic tokens, and code lenses for workflow YAML files |
+| `rendering/` | Shared constants and markdown formatting for data cards, consumed by LSP hover, HITL approval UI, and the docs frontend |
+| `code_scanner.py` | AST-based introspection of user tool scripts (`@udf_tool` functions and `TypedDict` schemas) — top-level to break a circular import |
+
+---
+
+## Documentation Generation Pipeline
+
+The `agac docs` CLI command triggers `generate_docs()`, which runs a three-phase pipeline: scan, catalog, write.
+
+```
+Phase 1: SCAN                     Phase 2: CATALOG              Phase 3: WRITE
+                                                                 
+  scan_workflows()                  CatalogGenerator              atomic_json_write()
+  scan_prompts()                      .generate()                   catalog.json
+  scan_schemas()                                                    runs.json (init only)
+  scan_tool_functions()             Enrichment:                   
+  scan_runs()                       - Parse workflow YAML        
+  scan_logs()                       - Build WorkflowSchemaService 
+  scan_vendors()                    - Enrich actions with fields  
+  scan_error_types()                - Cross-ref prompts/schemas   
+  scan_event_types()                - Aggregate stats             
+  scan_examples()                   - Copy README images          
+  scan_data_loaders()                                             
+  scan_processing_states()                                        
+  scan_workflow_data()                                            
+  scan_readmes()                                                  
+```
+
+### Scanner Organization
+
+The `scanner/` package splits scanning by concern:
+
+```
+scanner/
+  __init__.py               Orchestration: scan_workflows(), scan_readmes(), re-exports
+  data_scanners.py          Project data: prompts, schemas, runs, logs, workflow output
+  component_scanners.py     Framework introspection: vendors, error types, event types,
+                            examples, data loaders, processing states
+```
+
+All scanners accept `project_root: Path` and return dicts. The code scanner (`code_scanner.py`) is imported by `scanner/__init__.py` for tool function discovery, and separately by the static analyzer for input schema inference.
+
+### CatalogGenerator
+
+`CatalogGenerator.generate()` takes all scanned data and produces the catalog structure:
+
+```
+catalog = {
+  metadata:           {generated_at, total_workflows, generator_version, project_name}
+  workflows:          {workflow_id: {actions, readme, latest_run, manifest, ...}}
+  actions:            {workflow.action: {...}}   <-- flattened index for fast lookup
+  prompts:            {name: {content, used_by: [...]}}
+  schemas:            {name: {fields, used_by: [...]}}
+  tool_functions:     {name: {signature, docstring, is_udf, input_schema}}
+  runs:               {workflow_id: {latest_run, action_metrics, ...}}
+  logs:               {validation_errors, validation_warnings, runtime_*}
+  vendors:            ...
+  error_types:        ...
+  event_types:        ...
+  examples:           ...
+  data_loaders:       ...
+  processing_states:  ...
+  workflow_data:      ...
+  stats:              {total_workflows, total_actions, ...}  <-- 16 counters
+}
+```
+
+Key enrichment: for each action, the generator builds a `WorkflowSchemaService` to resolve field-level lineage (input fields from `context_scope`, output fields from schema files). This gives the docs frontend enough information to render data flow diagrams.
+
+---
+
+## Run Tracker System
+
+`RunTracker` records workflow execution history to `artefact/runs.json`. It is used at runtime (not just during docs generation) to capture live run progress.
+
+### State Machine
+
+```
+start_workflow_run()
+       |
+       v
+  +----------+     record_action_start()     +---------------+
+  | running  | ---------------------------->  | action running |
+  +----------+                                +-------+-------+
+       |                                              |
+       |                              record_action_complete()
+       |                                              |
+       |                                      +-------v-------+
+       |                                      | action done   |
+       |                                      | (success/     |
+       |                                      |  failed/      |
+       |                                      |  skipped)     |
+       |                                      +---------------+
+       |
+  finalize_workflow_run()
+       |
+       v
+  +-----------+
+  | completed |  (status: success or failed)
+  +-----------+
+```
+
+### Concurrency and Locking
+
+All mutations to `runs.json` use `portalocker.Lock` with exclusive non-blocking mode and a timeout. The pattern is atomic read-modify-write:
+
+1. Acquire exclusive lock (LOCK_EX | LOCK_NB, with timeout)
+2. Read JSON from file handle
+3. Modify in memory
+4. Seek to 0, truncate, write back
+5. Lock released on context manager exit
+
+Write operations that contend on the lock use a `@retry` decorator with exponential backoff (3 attempts, 2s backoff). The file is `touch()`ed before locking to handle the initial-creation race.
+
+### runs.json Structure
+
+```json
+{
+  "metadata": {"generated_at": "...", "total_runs": N, "schema_version": "1.0"},
+  "executions": [
+    {
+      "id": "run_{workflow_id}_{hex8}",
+      "status": "running|success|failed",
+      "actions": {
+        "action_name": {
+          "status": "running|success|failed|skipped",
+          "duration_seconds": 1.23,
+          "tokens": {"prompt_tokens": N, "completion_tokens": N, "total_tokens": N}
+        }
+      }
+    }
+  ],
+  "workflow_metrics": {
+    "workflow_id": {
+      "total_runs": N, "successful_runs": N, "failed_runs": N,
+      "success_rate": 0.95, "avg_duration_seconds": 12.3, "total_tokens": N
+    }
+  }
+}
+```
+
+Executions are capped at 100 entries (newest first). Workflow metrics are recalculated on every `finalize_workflow_run()` call.
+
+---
+
+## HTTP Server
+
+`serve_docs()` starts a local HTTP server that multiplexes two filesystem roots through a single port:
+
+```
+Browser request              DocsRequestHandler.translate_path()
+     |
+     +-- /artefact/catalog.json  -->  {user_project}/artefact/catalog.json
+     +-- /artefact/runs.json     -->  {user_project}/artefact/runs.json
+     +-- /artefact/images/...    -->  {user_project}/artefact/images/...
+     +-- /index.html             -->  {package}/docs/docs_site/index.html
+     +-- /static/...             -->  {package}/docs/docs_site/static/...
+     +-- everything else         -->  {package}/docs/docs_site/{path}
+```
+
+The `docs_site/` directory under the package contains a pre-built static frontend (Next.js export). The `artefact/` directory in the user's project contains the generated data files.
+
+Path traversal is guarded: `_guard_path()` resolves the target and verifies it is inside its designated root directory, returning an empty string (which becomes a 404) if the path escapes.
+
+---
+
+## LSP Architecture
+
+The LSP server provides IDE integration for agent-actions workflow YAML files, prompt markdown, and tool Python scripts.
+
+### Indexer
+
+`build_index()` creates a `ProjectIndex` by scanning four artifact types:
+
+```
+build_index(project_root)
+     |
+     +-- _index_workflows()  --> actions, dependencies, context_scope, guards, versions
+     +-- _index_prompts()    --> prompt names and content previews
+     +-- _index_tools()      --> @udf_tool function signatures and docstrings
+     +-- _index_schemas()    --> schema field definitions
+```
+
+The index supports multi-root workspaces: `find_all_project_roots()` discovers all `agent_actions.yml` files across workspace folders (searching both upward and downward up to 3 levels). Each project gets its own `ProjectIndex`, and `_index_for_file()` routes requests to the deepest matching root.
+
+### Capabilities
+
+| Capability | What it does |
+|-----------|-------------|
+| Go-to-definition | Jump from `$workflow.PromptName` to the prompt file, `impl: func` to the Python function, `schema: name` to the YAML file, dependency names to their action definitions |
+| Hover | Show prompt previews, tool signatures/docstrings, schema fields, action metadata |
+| Completions | Prompt names (after `$`), tool functions (after `impl:`), schema names (after `schema:`), action names (in `dependencies`), context scope fields, guard variables, versions keys |
+| Diagnostics | Validate references exist, detect duplicate action names, check guard variable availability |
+| Document symbols | Outline view showing actions in workflow files, sections in prompt markdown |
+| Document highlight | Highlight all references to the symbol under cursor |
+| Semantic tokens | Colorize prompt refs, tool refs, schema refs, action refs, seed file refs, context fields |
+| Code lenses | Inline summaries for `guard:` and `versions:` blocks |
+| Signature help | Available guard/validation variables when typing conditions |
+| File watchers | Dynamic registration for workflow YAML, prompts, tools, and schemas |
+
+### Models
+
+`ProjectIndex` is the central data structure:
+
+```
+ProjectIndex
+  root: Path
+  actions:                 {action_name -> Location}
+  prompts:                 {"file.PromptName" -> PromptDefinition}
+  tools:                   {function_name -> ToolDefinition}
+  schemas:                 {schema_name -> SchemaDefinition}
+  workflows:               {workflow_name -> directory Path}
+  file_actions:            {file_path -> {action_name -> ActionMetadata}}
+  workflow_actions:         {workflow_name -> {action_name -> Location}}
+  references_by_file:      {file_path -> [Reference]}
+  duplicate_actions_by_file: {file_path -> {action_name}}
+```
+
+Lookup methods (`get_action`, `get_action_metadata`) resolve with increasing scope: same file, same workflow, then global (flat layout only). This prevents cross-workflow leakage in multi-workflow projects.
+
+---
+
+## Rendering Module
+
+`rendering/data_card.py` provides shared data card formatting used in three places:
+
+1. **LSP hover** -- renders a record as markdown when hovering over output data
+2. **HITL approval UI** -- renders records in the Flask-based human review interface
+3. **Docs frontend** -- JavaScript mirrors the same field classification logic
+
+### Field Classification
+
+Every record field is classified into one of three groups:
+
+```
+IDENTITY:  source_guid, target_id
+CONTENT:   everything not in METADATA_KEYS or IDENTITY_KEYS
+METADATA:  lineage, node_id, _state, _state_history, _recovery, etc.
+```
+
+`METADATA_KEYS` is defined as a `frozenset` of 13 keys. `LONG_FORM_HINTS` identifies fields like `reasoning`, `description`, `summary` that get block-quote rendering instead of inline display.
+
+### render_card_markdown()
+
+```
+Input: record dict + optional action_name
+       |
+       +-- Unwrap namespaced content if action_name provided
+       +-- classify_record() -> {identity: [...], content: [...], metadata: [...]}
+       |
+       v
+Output: markdown string
+       **Source Guid**: `abc123...`
+       ---
+       **Field Label**: value
+       **Long Field**:
+       > block quoted text...
+       ---
+       _metadata: lineage, node_id, ..._
+```
+
+Content fields are capped at `max_fields` (default 12) with a "...and N more fields" overflow notice. Values are truncated at 80-120 characters depending on context.
+
+---
+
+## File Index
+
+### Top-level
+| File | Role |
+|------|------|
+| `code_scanner.py` | AST-based `@udf_tool` and TypedDict extraction (top-level to break circular import) |
+
+### docs/
+| File | Role |
+|------|------|
+| `__init__.py` | Public API: `generate_docs`, `serve_docs`, `RunTracker`, `track_workflow_run` |
+| `generator.py` | `CatalogGenerator` + `generate_docs()` orchestration |
+| `parser.py` | `WorkflowParser` -- YAML parsing and field extraction for catalog |
+| `run_tracker.py` | `RunTracker` -- concurrent-safe run recording with file locking |
+| `server.py` | `DocsRequestHandler` + `serve_docs()` HTTP server |
+| `scanner/__init__.py` | Scanner orchestration: `scan_workflows()`, `scan_readmes()`, re-exports |
+| `scanner/data_scanners.py` | Project data scanners: prompts, schemas, runs, logs, workflow output |
+| `scanner/component_scanners.py` | Framework introspection: vendors, errors, events, examples, loaders, states |
+
+### lsp/
+| File | Role |
+|------|------|
+| `__init__.py` | Package marker |
+| `__main__.py` | `python -m agent_actions.tooling.lsp` entry point |
+| `server.py` | `AgentActionsLanguageServer` + all LSP request/notification handlers |
+| `indexer.py` | `build_index()`, `find_project_root()`, `find_all_project_roots()` |
+| `models.py` | `ProjectIndex`, `ActionMetadata`, `Reference`, `ReferenceType`, `Location`, etc. |
+| `resolver.py` | Reference resolution: map a reference to a file location |
+| `handlers.py` | Hover content, semantic tokens, document symbols, reference finding |
+| `completions.py` | Completion item builders for context scope, guards, versions |
+| `diagnostics.py` | Diagnostic publishing, guard variable collection |
+| `utils.py` | `uri_to_path()`, `is_in_dependencies_context()` |
+
+### rendering/
+| File | Role |
+|------|------|
+| `__init__.py` | Package marker |
+| `data_card.py` | `METADATA_KEYS`, `classify_record()`, `render_card_markdown()` |
+
+---
+
+## Caveats
+
+1. **`code_scanner.py` lives at the top level** to break a circular import chain: `generator.py` -> `schema_service` -> `static_analyzer` -> `schema_extractor` -> `docs.scanner` -> `docs.__init__` -> `generator.py`. Moving it into `docs/scanner/` would re-create this cycle.
+
+2. **`docs_site/` is a build artifact.** It contains the pre-built static frontend (Next.js export). Do not edit files inside it directly -- rebuild from `agent_actions/tooling/docs/frontend/` instead.
+
+3. **`runs.json` is owned by `RunTracker`.** The docs generator only initializes it if it does not exist. All subsequent writes come from `RunTracker` during live workflow execution. Never write to `runs.json` outside of `RunTracker` -- its locking protocol assumes exclusive ownership.
+
+4. **`METADATA_KEYS` is mirrored in 3 places.** The source of truth is `rendering/data_card.py`. The same set must be kept in sync in:
+   - `rendering/data_card.py` (Python -- LSP hover, HITL server)
+   - `docs/frontend/lib/data-card-utils.ts` (TypeScript -- docs UI)
+   - `llm/providers/hitl/approval.html` (injected via server context)
+
+   If you add or remove a metadata key, update all three or fields will be misclassified in one of the surfaces.
+
+5. **LSP multi-root routing uses deepest-match.** When a file belongs to nested projects (e.g., monorepo), `_index_for_file()` picks the project root with the most path components. This prevents a parent project from accidentally claiming files that belong to a child project.
+
+6. **Scanner collision policy is last-write-wins.** Both `scan_workflows()` and `scan_readmes()` use `rglob` ordering (filesystem-dependent). If two `agent_config/` directories contain the same workflow stem, the last one discovered wins. This is by design -- it matches how the catalog pairs READMEs with workflows.

--- a/agent_actions/tooling/_MANIFEST.md
+++ b/agent_actions/tooling/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Tooling Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Overview
 
 Agent Actions tooling bundles helper packages that power documentation generation

--- a/agent_actions/utils/ARCHITECTURE.md
+++ b/agent_actions/utils/ARCHITECTURE.md
@@ -1,0 +1,363 @@
+# Utils Module Architecture
+
+This document maps the moving parts of `agent_actions/utils/` — the shared utility layer that every other module depends on. It is a pure dependency sink: nothing outside `utils/` is imported at module load time, with two narrow exceptions (lazy imports inside function bodies).
+
+---
+
+## High-Level Overview
+
+```
+                        agent_actions/utils/
+                              │
+        ┌─────────┬───────────┼──────────┬──────────────┐
+        │         │           │          │              │
+   identity &   constants   UDF       JSON &        filesystem
+    lineage                registry   safety          & path
+        │         │           │          │              │
+   id_generation  constants.py  udf_management  json_parsing.py  atomic_write.py
+   lineage/       (~57 importers) registry.py   json_safety.py   path_utils.py
+   correlation/                module_loader.py                  path_safety.py
+   field_management/
+```
+
+The module has **no outward imports at load time**. Two files use lazy (in-function) imports to avoid circular dependencies:
+
+| File | Lazy import | Why |
+|------|-------------|-----|
+| `content.py` | `agent_actions.record.envelope.RecordEnvelope` | Needs `build_content()` and `RECORD_FRAMEWORK_FIELDS` |
+| `transformation/strategies/context_scope.py` | `agent_actions.input.preprocessing.transformation.transformer.DataTransformer` | Reuses existing transformation logic |
+
+Everything else imports only from `config` (types, paths), `errors`, and `logging` — all lower-level or peer modules.
+
+---
+
+## Identity & Lineage
+
+Four classes handle identity, lineage, field enforcement, and version correlation.
+
+```
+IDGenerator (id_generation/generator.py)
+├── generate_target_id()       → UUID4  (unique record identity)
+├── generate_node_id(action)   → "{action}_{uuid4}"  (lineage node)
+├── generate_source_guid()     → UUID4  (record instance identity)
+└── generate_content_hash()    → UUID5  (deterministic content fingerprint)
+
+LineageBuilder (lineage/builder.py)
+├── build_lineage(item, node_id)           → append node to chain
+├── add_lineage_tracking(obj, item, node)  → node_id + lineage + ancestry
+├── add_lineage_tracking_from_sources()    → many-to-one (FILE tools)
+├── add_unified_lineage()                  → single entry point for enrichers
+├── set_parent_tracking()                  → propagate parent/root target_id
+└── filter_node_lineage()                  → strip invalid node IDs
+
+FieldManager (field_management/manager.py)
+└── ensure_required_fields(obj, source_guid, action_name)
+    → guarantees target_id, source_guid, node_id, lineage exist
+
+VersionIdGenerator (correlation/version_id.py)
+├── get_or_create_version_correlation_id()          → GUID-based
+├── get_or_create_position_based_version_correlation_id()  → index-based
+├── add_version_correlation_id(obj, agent_config)   → main entry point
+└── _evict_oldest_if_needed()                       → LRU cap at 10,000
+```
+
+`VersionIdGenerator` uses a class-level `OrderedDict` registry with LRU eviction and a reentrant lock. IDs are deterministic: `sha256(session_id:content)[:16]` prefixed with `corr_`.
+
+---
+
+## Constants
+
+`constants.py` is imported by ~57 files across the codebase. It defines:
+
+| Constant | Type | Used by |
+|----------|------|---------|
+| `RESERVED_AGENT_NAMES` | `frozenset` | Config validators, static analyzers, CLI |
+| `DANGEROUS_PATTERNS` | `frozenset` | Guard parser, UDF expression checker |
+| `DANGEROUS_PATTERNS_UDF` | `frozenset` | UDF-specific superset (adds `__`) |
+| `SPECIAL_NAMESPACES` | `frozenset` | `RESERVED_AGENT_NAMES - {"context_scope"}` |
+| `HITL_FILE_GRANULARITY_ERROR` | `str` | HITL config validation |
+| `HITL_OUTPUT_SCHEMA` / `HITL_OUTPUT_JSON_SCHEMA` | `dict` | Pre-compiled to avoid circular imports |
+| `SCHEMA_SUFFIXES` / `SCHEMA_FILE_GLOBS` | `tuple` | Schema file discovery |
+| Config key constants | `str` | `MODEL_VENDOR_KEY`, `PROMPT_KEY`, etc. |
+
+`contains_dangerous_pattern()` uses `\b` word-boundary matching so `"exec"` blocks `exec(` but not `execution_status`. The `"__"` pattern is the sole exception — it uses substring matching.
+
+---
+
+## UDF Registry
+
+```
+┌──────────────────────────────────────────────────────┐
+│                  UDF_REGISTRY                         │
+│          (process-wide dict, guarded by RLock)        │
+│                                                       │
+│  "my_tool" → {                                        │
+│    function: <callable>,                              │
+│    module: "agent_actions._udfs.my_tool",             │
+│    name: "my_tool",                                   │
+│    file: "/path/to/my_tool.py",                       │
+│    docstring: "...",                                   │
+│    signature: <inspect.Signature>,                     │
+│    granularity: Granularity.RECORD | Granularity.FILE  │
+│  }                                                    │
+└──────────────────────────────────────────────────────┘
+         ▲                              │
+   @udf_tool decorator            get_udf(name)
+   (registration)                 (lookup, case-insensitive)
+```
+
+### Registration flow
+
+1. User writes `@udf_tool` in `tools/{workflow}/my_tool.py`
+2. `discover_and_load_udfs()` or `discover_and_load_udfs_recursive()` globs for `.py` files
+3. `load_module_from_path()` loads via `importlib.util.spec_from_file_location` — **never mutates `sys.path`**
+4. Module execution triggers the `@udf_tool` decorator, which registers into `UDF_REGISTRY`
+5. Duplicate detection: same file + different import path = silently reuse; different file = `DuplicateFunctionError`
+
+### module_loader.py design
+
+- Uses `importlib.util.spec_from_file_location` + `exec_module` instead of `sys.path` manipulation
+- Registers loaded modules under `sys.modules["agent_actions._udfs.{name}"]` so decorators resolve correctly
+- Thread-safe via `threading.RLock`
+- Module cache keyed by `"{module_name}:{module_path}"`
+- If path-based load fails (broken code), `path_load_failed` flag blocks fallback import to prevent silent substitution
+
+### clear_registry()
+
+Cleans both `UDF_REGISTRY` and `sys.modules` entries for all registered module names. Used in tests.
+
+---
+
+## JSON Parsing
+
+### parse_llm_json — 3-stage parser
+
+```
+LLM text response
+     │
+     ▼
+Stage 1: json.loads()                    ← fast path, well-formed JSON
+     │ (JSONDecodeError)
+     ▼
+Stage 2: strip_code_fences() + retry     ← removes ```json ... ``` wrappers
+     │ (JSONDecodeError)
+     ▼
+Stage 3: json_repair (lazy import)       ← trailing commas, unquoted keys
+     │
+     ├── dict/list with content → return
+     ├── empty {} or [] → REJECT         ← json_repair "repairs" prose into
+     │                                      empty containers; guard blocks this
+     └── all failed → return raw string
+```
+
+Return type is `dict | list | str`. Callers branch on the type: structured data means success, `str` means parse failure.
+
+### ensure_json_safe — serialization boundary
+
+Recursively converts non-JSON-safe types before handing data to SDK calls or JSONL writes:
+
+- `float('nan')` / `float('inf')` → `None` (with warning)
+- `bytes` → UTF-8 string
+- `set` / `frozenset` / `tuple` → `list`
+- `datetime` / `date` → ISO-8601 string
+- Non-string dict keys → `str(key)`
+
+---
+
+## Filesystem & Path
+
+### atomic_write.py
+
+```
+atomic_json_write(path, data)
+  1. tempfile.mkstemp() in same directory as target
+  2. json.dump() to temp file
+  3. flush + fsync (optional, default on)
+  4. atomic rename (temp → target)
+  On failure: temp file unlinked, original untouched
+```
+
+Used by batch infrastructure (registry, context maps, recovery state) and HITL review persistence.
+
+### path_utils.py
+
+| Function | What it does |
+|----------|-------------|
+| `get_path_manager()` | Thread-safe singleton (double-checked locking) for `PathManager` |
+| `set_path_manager(pm)` | DI injection point for scoped instances |
+| `derive_workflow_root(path)` | Find workflow root from a path inside a workflow |
+| `resolve_relative_to(path, base)` | Safe relative resolution (avoids silent discard on absolute paths) |
+| `find_project_root()` | Walk up looking for `agent_actions.yml` |
+
+### derive_workflow_root — 3-strategy resolution
+
+```
+Input: any path inside a workflow (e.g. agent_io/target/extract/data.json)
+
+Strategy 1 (fast path):
+  Find "agent_io" in path parts → truncate to parent
+  /project/agent_io/target/extract → /project
+
+Strategy 2 (walk-up):
+  Resolve path, walk up checking for agent_config/ sibling directory
+
+Strategy 3 (fallback):
+  Return path itself (if dir) or path.parent (if file) + log warning
+  Never blindly chains .parent — bounded by the walk-up termination
+```
+
+### path_safety.py
+
+- `assert_path_contained(child, parent)` — resolves symlinks, raises `ValueError` on traversal escape
+- `sanitize_path_component(name)` — replaces separators/null bytes, truncates with hash suffix if > 200 bytes
+
+---
+
+## Passthrough Transformation
+
+```
+PassthroughTransformer.transform_with_passthrough()
+     │
+     ▼
+Strategy dispatch (first match wins — ORDER IS LOAD-BEARING):
+     │
+     ├── 1. PrecomputedStructuredStrategy    ← passthrough_fields + already structured
+     ├── 2. PrecomputedUnstructuredStrategy   ← passthrough_fields + flat data
+     ├── 3. ContextScopeStructuredStrategy   ← context_scope.passthrough + structured
+     ├── 4. ContextScopeUnstructuredStrategy ← context_scope.passthrough + flat
+     ├── 5. NoOpStrategy                     ← no passthrough configured
+     └── 6. DefaultStructureStrategy         ← catch-all fallback
+           │
+           ▼
+     Strategy returns flat action output dicts
+           │
+           ▼
+     RecordEnvelope.build() wraps under action namespace
+     + preserves upstream namespaces
+           │
+           ▼
+     FieldManager.ensure_required_fields() guarantees metadata
+```
+
+Strategies are evaluated in list order. `PrecomputedStructuredStrategy` must come before `ContextScopeStructuredStrategy` because pre-computed passthrough fields (from `field_context`) take precedence over raw `context_scope` config — they carry ancestry-resolved data that `context_scope` alone cannot reconstruct.
+
+---
+
+## Content Helpers
+
+```
+content.py — namespaced content model
+
+wrap_content(action_name, output, existing)
+  → delegates to RecordEnvelope.build_content() (lazy import)
+  → {**existing_namespaces, action_name: output}
+
+read_namespace(record, action_name, field)
+  → record["content"][action_name][field]
+
+get_existing_content(record, is_first_stage=False)
+  → PRIMARY ENTRY POINT for both batch and online paths
+  │
+  ├── record has "content" dict → return it
+  ├── is_first_stage=True → synthesize {"source": {non-framework fields}}
+  └── else → return {}
+```
+
+`get_existing_content` is critical for first-stage actions (the first action in a workflow). Raw input records have no `"content"` key — they are flat dicts of user data. This function synthesizes a `{"source": ...}` namespace so downstream code can treat all records uniformly. Both batch preparator and online strategy call this function. Never bypass it with `record.get("content")`.
+
+---
+
+## Safe Error Formatting
+
+`safe_format.py` provides crash-proof exception formatting:
+
+| Function | Purpose |
+|----------|---------|
+| `safe_format_error(exc)` | `str()` → `repr()` → type name → last resort string. Never raises. |
+| `extract_root_cause(exc)` | Walks `__cause__` / `__context__` chain with cycle detection (max depth 10) |
+| `get_error_chain(exc)` | Returns full chain as list, outermost to root |
+| `format_exception_chain_for_debug(exc)` | Multi-line formatted chain with context for logging |
+
+---
+
+## File Index
+
+### Core utilities
+| File | Role |
+|------|------|
+| `constants.py` | Shared constants — public API surface for the entire codebase |
+| `content.py` | Namespaced content model (wrap, read, synthesize for first-stage) |
+| `atomic_write.py` | Crash-safe JSON file writes (temp + fsync + rename) |
+| `json_parsing.py` | 3-stage LLM JSON parser (json.loads → fence strip → json_repair) |
+| `json_safety.py` | Recursive JSON serialization safety (NaN, bytes, datetime, etc.) |
+| `safe_format.py` | Crash-proof exception formatting and chain walking |
+| `dict.py` | `get_nested_value` — dot-separated field access on nested dicts |
+| `graph_utils.py` | `topological_sort` for action dependency resolution |
+| `schema_utils.py` | Schema file loading and format detection |
+| `schema_echo.py` | Detects when an LLM returns its schema definition instead of data |
+| `template_escape.py` | Jinja2 template escaping utilities |
+
+### Path and filesystem
+| File | Role |
+|------|------|
+| `path_utils.py` | PathManager singleton, `derive_workflow_root`, path resolution |
+| `path_safety.py` | Containment assertion, path component sanitization |
+| `path_security.py` | Path security validation |
+| `file_handler.py` | Recursive file/folder discovery (stdlib only) |
+| `file_utils.py` | Additional file utilities |
+| `project_root.py` | Project root detection (`find_project_root`, `ensure_in_project`) |
+| `tools_resolver.py` | Normalizes `tools` / `tool_path` config syntax |
+
+### Identity and tracking
+| File | Role |
+|------|------|
+| `id_generation/generator.py` | UUID4/UUID5 generation for target_id, node_id, source_guid, content_hash |
+| `lineage/builder.py` | Lineage chain construction and ancestry propagation |
+| `correlation/version_id.py` | Deterministic version correlation IDs (LRU-capped, thread-safe) |
+| `field_management/manager.py` | Ensures required metadata fields on every output record |
+
+### UDF system
+| File | Role |
+|------|------|
+| `module_loader.py` | Thread-safe module loading via importlib (no sys.path mutation) |
+| `udf_management/registry.py` | `UDF_REGISTRY` dict, `@udf_tool` decorator, lookup functions |
+| `udf_management/tooling.py` | UDF execution, error wrapping, `FileUDFResult` validation |
+
+### Transformation
+| File | Role |
+|------|------|
+| `transformation/passthrough.py` | `PassthroughTransformer` — strategy dispatch orchestrator |
+| `transformation/strategies/` | Six strategies: Precomputed/ContextScope x Structured/Unstructured + NoOp + Default |
+| `passthrough_builder.py` | `PassthroughItemBuilder` — builds normalized passthrough records with metadata |
+
+### Error handling
+| File | Role |
+|------|------|
+| `error_handler.py` | Configuration and validation error utilities |
+| `error_wrap.py` | Decorator for wrapping validation errors with context |
+
+---
+
+## Caveats
+
+1. **constants.py is public API.** Imported by ~57 files. Renaming or removing any constant is a breaking change across the entire codebase. Treat every export as a stable interface.
+
+2. **`generate_content_hash` is a checkpoint key.** The UUID5 hash produced by `IDGenerator.generate_content_hash()` is used for deduplication and incremental checkpointing. Changing the hash algorithm or serialization order would invalidate all existing checkpoints.
+
+3. **`UDF_REGISTRY` is process-wide.** It assumes one workflow per process. Running concurrent workflows in the same process would share (and potentially corrupt) the registry. The `clear_registry()` function cleans both the dict and `sys.modules` entries.
+
+4. **module_loader avoids sys.path mutation.** This is deliberate — `sys.path` manipulation is process-global and non-reversible in a meaningful way. Instead, `load_module_from_path` uses `importlib.util.spec_from_file_location` and registers under a synthetic `agent_actions._udfs.{name}` namespace.
+
+5. **atomic_write requires the parent directory to exist.** `tempfile.mkstemp(dir=path.parent)` will raise `FileNotFoundError` if `path.parent` does not exist. Callers must ensure the directory exists before calling.
+
+6. **derive_workflow_root fallback is intentionally conservative.** The third strategy returns `path` itself (or `path.parent`) rather than walking up indefinitely. This prevents silent misidentification of a random ancestor as the workflow root when neither `agent_io` nor `agent_config/` markers are found.
+
+7. **Passthrough strategy order is load-bearing.** `PrecomputedStructuredStrategy` must precede `ContextScopeStructuredStrategy` because pre-computed fields carry ancestry-resolved data. Reordering the strategy list changes which passthrough source wins.
+
+8. **get_existing_content synthesizes source namespace for first-stage.** When `is_first_stage=True` and the record has no `"content"` key, it builds `{"source": {non-framework fields}}`. This is the only place where raw input records are promoted into the namespaced content model. Bypassing this function with `record.get("content")` will lose the source namespace on first-stage records.
+
+9. **json_repair empty-container guard.** `json_repair` aggressively "repairs" arbitrary prose into `{}` or `[]`. The guard in `parse_llm_json` rejects empty results from `json_repair` to prevent downstream code from treating garbage input as a valid empty response.
+
+10. **VersionIdGenerator uses class-level state.** The `OrderedDict` registry and `RLock` live on the class, not on instances. All callers share the same registry. `clear()` must be called between test runs to avoid cross-test contamination.
+
+11. **Content.py lazy imports are load-order sensitive.** Both `wrap_content` and `get_existing_content` import from `agent_actions.record.envelope` inside the function body. This breaks a circular dependency (`record` imports from `utils`, `utils/content.py` imports from `record`). Moving these to top-level imports would cause an `ImportError` at startup.

--- a/agent_actions/utils/_MANIFEST.md
+++ b/agent_actions/utils/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Utils Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)**
+
 ## Overview
 
 Shared helpers for IDs, field management, metadata, lineage, UDF tooling, path

--- a/agent_actions/validation/ARCHITECTURE.md
+++ b/agent_actions/validation/ARCHITECTURE.md
@@ -1,0 +1,395 @@
+# Validation Module Architecture
+
+This document maps the moving parts of `agent_actions/validation/` -- the module that validates everything from YAML config files to LLM output at runtime.
+
+---
+
+## High-Level Overview
+
+Validation happens in **three phases**, at three different times:
+
+```
+Phase 1: CONFIG LOAD                Phase 2: PRE-RUN                Phase 3: PER-RECORD
+(when YAML is parsed)               (before first LLM call)         (after each LLM response)
+
+  agent_config/*.yml                 Workflow config (expanded)       LLM output dict
+        |                                   |                              |
+        v                                   v                              v
+  ConfigValidator                   WorkflowStaticAnalyzer          validate_output_against_schema()
+  SchemaValidator                   WorkflowResolutionService         - field presence
+  PromptValidator                   apply_guard_nullable_           - type checking
+  PathValidator                       schema_fixes()                  - schema-echo detection
+        |                                   |                              |
+        v                                   v                              v
+  errors[] / warnings[]             StaticValidationResult          SchemaValidationReport
+  (blocks CLI startup)              (blocks workflow run)            (triggers reprompt or reject)
+```
+
+Phase 1 catches structural problems (missing keys, bad types, invalid YAML).
+Phase 2 catches semantic problems (broken field references, missing API keys, type mismatches across actions).
+Phase 3 catches runtime problems (LLM returned wrong fields, wrong types, echoed the schema back).
+
+---
+
+## Phase 1: Config Load Validation
+
+### BaseValidator
+
+All Phase 1 validators inherit from `BaseValidator` (ABC). It provides:
+
+- `_errors` / `_warnings` collection lists
+- `_prepare_validation()` -- clears state, fires `ValidationStartEvent`
+- `_complete_validation()` -- fires `ValidationCompleteEvent`, returns `not has_errors`
+- `add_error()` / `add_warning()` -- appends message and fires event
+- Static path helpers: `_ensure_path_exists()`, `_is_file()`, `_is_directory()`
+
+```
+BaseValidator (ABC)
+  |
+  +--> ConfigValidator     Validates agent_config/*.yml structure
+  |     - operation dispatch (validate_agent_config_file_meta, validate_agent_entries)
+  |     - file uniqueness, agent name uniqueness
+  |     - dependency graph: missing deps, circular deps, inactive dep references
+  |     - delegates per-entry validation to ActionEntryValidationOrchestrator
+  |
+  +--> SchemaValidator     Validates schema/*.yml against JSON Schema meta-schema
+  |     - uses jsonschema library for meta-validation
+  |     - detects suspicious keys (typos in JSON Schema keywords)
+  |     - validates $ref references resolve
+  |
+  +--> PromptValidator     Validates prompt_store/*.md files
+  |     - prompt ID extraction (delegates to PromptLoader.get_all_prompt_names)
+  |     - duplicate ID detection (within-file = error, cross-file = warning)
+  |     - unclosed {prompt_id}...{end_prompt} blocks
+  |     - file size limits (PromptDefaults.MAX_PROMPT_SIZE_BYTES)
+  |     - workflow-scoped: only validates {workflow_name}.md when config provided
+  |
+  +--> PathValidator       Validates file/directory paths
+        - existence, readability, writability, executability
+        - configurable via PathValidationOptions dataclass
+```
+
+### ActionEntryValidationOrchestrator
+
+`ConfigValidator` delegates per-action-entry validation to this orchestrator, which runs a **chain of 8 specialized validators** in order:
+
+```
+ActionEntryValidationOrchestrator
+  |
+  |  For each action entry dict:
+  |
+  1. ActionEntryStructureValidator    Must be a dict (critical failure stops chain)
+  2. ActionRequiredFieldsValidator    Required keys present (name, prompt, etc.)
+  3. ActionTypeSpecificValidator      Type-specific rules (tool needs impl, etc.)
+  4. VendorCompatibilityValidator     Vendor string valid, features supported
+  5. OptionalFieldTypeValidator       Optional fields have correct types
+  6. GranularityAndOutputFieldValidator  Granularity + output_field + on_schema_mismatch
+  7. InlineSchemaValidator            Complex inline schema notation (array[object:...])
+  8. UnknownKeysDetector              Typo detection (warnings only)
+```
+
+The chain stops early on `is_critical_failure` (e.g., entry is not a dict). Each validator returns an `ActionEntryValidationResult` dataclass with errors, warnings, and the critical flag.
+
+These validators inherit from `BaseActionEntryValidator` (ABC), **not** from `BaseValidator`. The two base classes have incompatible interfaces: `BaseValidator.validate(data, config)` vs `BaseActionEntryValidator.validate(context) -> ActionEntryValidationResult`.
+
+---
+
+## Phase 2: Pre-Run Static Analysis
+
+### WorkflowStaticAnalyzer
+
+The core of Phase 2. Builds a `DataFlowGraph` from the expanded workflow config and runs compile-time type checking analogous to TypeScript's type system.
+
+```
+WorkflowStaticAnalyzer.analyze()
+  |
+  Step 0:  Validate context_scope structure (BEFORE normalization)
+  Step 0b: Normalize context_scope (null -> {}, ensures downstream sees dicts)
+  |
+  |  Guard warnings computed BEFORE wildcard expansion
+  |  (expansion turns wildcards into specific refs, causing false positives)
+  |
+  Step 1:  Build DataFlowGraph
+  |          - source node (always present, represents input data)
+  |          - one DataFlowNode per action
+  |          - edges built from InputRequirements
+  |
+  Step 2:  Expand wildcards (namespace.* -> concrete fields)
+  |          - modifies context_scope in the workflow config IN PLACE
+  |          - unknown namespaces -> error
+  |          - dynamic/schemaless schemas -> left as *
+  |
+  Step 3:  StaticTypeChecker.check_all()
+  |          - referenced actions exist
+  |          - referenced actions are in depends_on
+  |          - referenced fields exist in upstream output schema
+  |          - fields not dropped from output
+  |          - unused dependency warnings
+  |
+  Step 3+: Additional checks
+             - reserved action name validation
+             - template namespace coverage
+             - context_scope field references
+             - seed_data/seed_path misuse
+             - schema structure validation
+             - drop directive targeting
+             - guard-nullable field detection
+             - lineage reachability
+             - reprompt UDF references
+             - json_mode vs schema mismatch
+```
+
+### DataFlowGraph
+
+A directed graph where nodes are actions and edges represent data flow.
+
+```
+DataFlowGraph
+  nodes: dict[str, DataFlowNode]
+  edges: list[DataFlowEdge]
+
+DataFlowNode
+  name: str
+  agent_kind: ActionKind
+  output_schema: OutputSchema    schema_fields, observe_fields, passthrough_fields,
+  |                               dropped_fields, available_fields (computed)
+  input_schema: InputSchema      required_fields, optional_fields
+  input_requirements: list[InputRequirement]   source_agent + field_path + location
+  dependencies: set[str]
+
+DataFlowEdge
+  source: str (action name)
+  target: str (action name)
+  fields_used: set[str]
+```
+
+Key graph operations:
+- `topological_sort()` -- Kahn's algorithm, raises on cycles
+- `get_reachable_upstream_names()` -- transitive closure of dependencies
+- `is_special_namespace()` -- checks against SPECIAL_NAMESPACES (source, loop, etc.)
+
+### WorkflowResolutionService
+
+Performs resource resolution checks that require I/O (env vars, filesystem, network):
+
+```
+WorkflowResolutionService.resolve_all()
+  |
+  1. API key checks
+  |    - resolves env var name from vendor config class (single source of truth)
+  |    - skips _NO_KEY_SENTINELS ("NO_KEY_REQUIRED" for tool, hitl)
+  |    - supports custom $ENV_VAR and literal key syntax
+  |    - optional --verify-keys: probes vendor endpoints
+  |    - AA_SKIP_ENV_VALIDATION=1 skips key checks ONLY (not seed/vendor checks)
+  |
+  2. Seed file checks
+  |    - $file: reference existence and path security (resolve_seed_path)
+  |    - loads JSON content, validates seed field references in templates
+  |    - namespace mismatch = error, nested field mismatch = warning
+  |
+  3. Vendor run-mode compatibility
+       - batch mode requires vendor support (e.g., Cohere has no batch)
+       - capabilities read from client class CAPABILITIES attribute
+```
+
+### Guard Condition Validation
+
+Guard conditions are validated in the static analyzer through several checks:
+
+- `_check_guard_nullable_fields()` -- detects fields that may be None at runtime due to upstream guard filtering, warns when downstream tool schemas reject null
+- `_check_guard_skipped_observe_refs()` -- warns when observe refs target specific fields from skip-guarded actions (the entire namespace is None)
+- `_check_filter_fanin_observe_hazard()` -- warns about guard-filter + fan-in observe combinations
+
+These checks run **before** wildcard expansion to avoid false positives from expanded wildcards.
+
+### apply_guard_nullable_schema_fixes()
+
+A module-level function (not a method on the analyzer) that **mutates `json_output_schema` dicts in place**. Called after schema compilation and static validation but before workflow execution:
+
+```
+apply_guard_nullable_schema_fixes(action_configs)
+  |
+  1. Find guarded actions with filter/skip behavior
+  2. For each downstream action that observes guarded fields:
+     - If the field's schema type rejects null (e.g., "string")
+     - Mutate the type to ["string", "null"] or add null to anyOf
+  3. Return list of fixed field paths (e.g., ["consumer.field"])
+```
+
+This mutation is necessary because guarded actions produce None for filtered records, but JSON Schema would reject null by default.
+
+---
+
+## Phase 3: Per-Record Output Validation
+
+### validate_output_against_schema()
+
+Called after each LLM response to check compliance. Handles **5 schema formats**:
+
+```
+_extract_schema_fields(schema) handles:
+
+1. "fields" format     fields: [{id: "title", type: "string", required: true}]
+2. "properties" format properties: {title: {type: "string"}}  (standard JSON Schema)
+3. "schema" wrapper    schema: {properties: {...}}  (OpenAI compiled format)
+4. Array schema        type: "array", items: {type: "object", properties: {...}}
+5. Inline schema       {optimal_code: "string", score: "number"}  (key=fieldname, value=type)
+```
+
+The validation pipeline:
+
+```
+LLM output dict
+      |
+      v
+_check_properties_type()     Structural check: properties must be dict
+      |
+      v
+_extract_schema_fields()     -> (all_fields, required_fields, field_types)
+_extract_output_fields()     -> actual_fields (set of keys)
+      |
+      v
+Field comparison:
+  missing_required = required - actual
+  missing_optional = (all - required) - actual
+  extra_fields = actual - all
+      |
+      v
+_check_field_types()         Python isinstance checks per field
+  type_map: string->str, number->(int,float), boolean->bool, etc.
+  Special: bool is subclass of int, so booleans rejected for integer/number
+  None values always pass (optional fields)
+      |
+      v
+Schema-echo detection:
+  If schema declares fields but output has NONE of them,
+  and the output keys are all JSON Schema meta-keys (type, properties, etc.)
+  -> "Schema-echo detected" error
+      |
+      v
+Namespace hint:
+  If missing_required AND extra_fields are dicts
+  -> suggests UDF is passing namespaced input without unwrapping
+      |
+      v
+SchemaValidationReport
+  is_compliant: bool
+  (all field analysis + type_errors + validation_errors)
+```
+
+### on_schema_mismatch modes
+
+Configured in `reprompt.on_schema_mismatch` in action config:
+
+| Mode | Behavior |
+|------|----------|
+| `reject` | Raises `SchemaValidationError` immediately |
+| `reprompt` | Sends corrective feedback to LLM, retries |
+| `warn` | Logs warning, passes output through unchanged |
+| (not set) | Schema validation skipped entirely |
+
+`validate_and_raise_if_invalid()` is the convenience wrapper that calls `validate_output_against_schema()` and raises `SchemaValidationError` on failure (used by the reject path).
+
+---
+
+## File Index
+
+### Core validators (Phase 1)
+| File | Role |
+|------|------|
+| `base_validator.py` | ABC for Phase 1 validators, error/warning collection, event firing |
+| `config_validator.py` | Agent config YAML validation, dependency graph checks |
+| `schema_validator.py` | JSON Schema meta-schema validation, suspicious key detection |
+| `prompt_validator.py` | Prompt file validation (IDs, blocks, size, duplicates) |
+| `path_validator.py` | File/directory path validation with configurable options |
+| `project_validator.py` | Project name and directory validation |
+| `prompt_ast.py` | Jinja2 AST parsing for template variable extraction |
+
+### Action entry validators (Phase 1, orchestrated)
+| File | Role |
+|------|------|
+| `orchestration/action_entry_validation_orchestrator.py` | Chain runner for 8 action validators |
+| `action_validators/base_action_validator.py` | ABC for action validators (separate from BaseValidator) |
+| `action_validators/action_entry_structure_validator.py` | Checks entry is a dict (critical gate) |
+| `action_validators/action_required_fields_validator.py` | Required keys: name, prompt, etc. |
+| `action_validators/action_type_specific_validator.py` | Type-specific rules (tool needs impl) |
+| `action_validators/vendor_compatibility_validator.py` | Vendor string valid, features supported |
+| `action_validators/optional_field_type_validator.py` | Optional field type correctness |
+| `action_validators/granularity_output_field_validator.py` | Granularity + output_field + on_schema_mismatch |
+| `action_validators/inline_schema_validator.py` | array[object:...] notation validation |
+| `action_validators/unknown_keys_detector.py` | Typo detection via edit distance (warnings) |
+
+### Static analyzer (Phase 2)
+| File | Role |
+|------|------|
+| `static_analyzer/workflow_static_analyzer.py` | Main orchestrator, all Phase 2 checks, wildcard expansion, guard analysis |
+| `static_analyzer/data_flow_graph.py` | DataFlowGraph, DataFlowNode, OutputSchema, InputSchema |
+| `static_analyzer/type_checker.py` | StaticTypeChecker: field reference validation against schemas |
+| `static_analyzer/reference_extractor.py` | Extracts field references from prompts, guards, context_scope |
+| `static_analyzer/schema_extractor.py` | Extracts output schemas from action configs and tool UDFs |
+| `static_analyzer/schema_structure_validator.py` | Pre-flight schema structure checks |
+| `static_analyzer/field_flow_analyzer.py` | Field-level data flow analysis |
+| `static_analyzer/conflict_detector.py` | Detects field naming conflicts |
+| `static_analyzer/errors.py` | StaticTypeError, StaticTypeWarning, StaticValidationResult, FieldLocation |
+
+### Preflight (Phase 2, resource resolution)
+| File | Role |
+|------|------|
+| `preflight/resolution_service.py` | WorkflowResolutionService: API keys, seed files, vendor compat |
+| `preflight/vendor_compatibility_validator.py` | VALID_VENDORS from CLIENT_REGISTRY, capability checks |
+| `preflight/key_verifier.py` | Optional API key probing (--verify-keys) |
+| `preflight/path_validator.py` | Preflight path validation |
+| `preflight/error_formatter.py` | Human-readable preflight error formatting |
+
+### Output validation (Phase 3)
+| File | Role |
+|------|------|
+| `schema_output_validator.py` | validate_output_against_schema(), SchemaValidationReport |
+
+### CLI command validators
+| File | Role |
+|------|------|
+| `batch_validator.py` | BatchCommandArgs pydantic model |
+| `clean_validator.py` | CleanCommandArgs pydantic model |
+| `init_validator.py` | InitCommandArgs pydantic model |
+| `render_validator.py` | RenderCommandArgs pydantic model |
+| `run_validator.py` | RunCommandArgs and pre-flight gating |
+| `status_validator.py` | StatusCommandArgs pydantic model |
+| `retry_validator.py` | Retry command validation |
+
+### Utilities
+| File | Role |
+|------|------|
+| `utils/action_config_validation_utilities.py` | Key normalization, context formatting |
+| `utils/schema_type_validator.py` | Schema type string validation helpers |
+| `validate_udfs.py` | UDF reference existence validation |
+
+---
+
+## Caveats
+
+1. **Two incompatible base classes.** `BaseValidator` (Phase 1, `validate(data, config) -> bool`) and `BaseActionEntryValidator` (orchestrated chain, `validate(context) -> ActionEntryValidationResult`) have completely different interfaces. The action entry validators do NOT inherit from `BaseValidator`. Mixing them up will cause type errors at runtime.
+
+2. **apply_guard_nullable_schema_fixes() mutates in place.** It modifies the `json_output_schema` dicts inside `action_configs` directly. The caller must ensure this runs after schema compilation and before execution. The mutation is not reversible -- the original schema types are overwritten.
+
+3. **"fields" format bypasses required-field validation.** When the schema uses the `fields` array format (format 1 above), `_extract_schema_fields` checks per-field `required` annotations. But when `required` is omitted from both the field dict and the top-level `required` array, the field is treated as optional. The inline schema format (format 5) has no concept of required fields at all.
+
+4. **Wildcard expansion modifies the workflow config.** `_expand_wildcards()` replaces `namespace.*` with concrete field lists in `context_scope` of the workflow config dict. This is a shallow copy of the context_scope dict, but the replacement happens on the config that all downstream checks see. Any code reading the original wildcards after analysis will see expanded values.
+
+5. **Guard warnings run before wildcard expansion.** `_check_guard_skipped_observe_refs()` and `_check_filter_fanin_observe_hazard()` are computed before `_expand_wildcards()` because expansion turns safe wildcards into specific refs, producing false positives. If you reorder the analyze() steps, these checks will produce incorrect results.
+
+6. **AA_SKIP_ENV_VALIDATION only skips API key checks.** Setting `AA_SKIP_ENV_VALIDATION=1` skips the `_check_api_keys()` call in `WorkflowResolutionService.resolve_all()`, but seed file checks and vendor run-mode compatibility checks still run.
+
+7. **VALID_VENDORS is derived from CLIENT_REGISTRY at import time.** `preflight/vendor_compatibility_validator.py` imports `CLIENT_REGISTRY` from `llm.realtime.services.invocation` and builds `VALID_VENDORS = set(CLIENT_REGISTRY.keys())`. If a new vendor is added to the registry, it is automatically valid. But vendor capabilities are resolved lazily from each client class's `CAPABILITIES` attribute, so adding a registry entry without a `CAPABILITIES` dict will cause `_resolve_capabilities()` to return None (silently skipping capability checks).
+
+8. **Schema-echo detection uses a frozen set of JSON Schema keywords.** `schema_output_validator.py` imports `JSON_SCHEMA_RESERVED_KEYWORDS` from `SchemaValidator` and uses it to detect when the LLM echoed the schema definition. If the LLM returns a mix of schema keywords and real data, the check may not trigger -- it only fires when ALL actual fields are meta-keys and NONE of the declared fields are present.
+
+9. **ConfigValidator dispatches on an "operation" key.** Unlike the other validators that take direct data, `ConfigValidator.validate()` expects `data["operation"]` to be one of `"validate_agent_config_file_meta"` or `"validate_agent_entries"`. Passing raw config data without an operation key will produce an error, not a validation.
+
+10. **PromptValidator validates differently with/without workflow_name.** When `config["workflow_name"]` is provided, only `{workflow_name}.md` is validated. Without it, every `.md` file in the prompt directory is scanned. Cross-file duplicate prompt IDs are warnings (not errors) because the runtime loads prompts per-workflow.
+
+11. **ActionEntryValidationOrchestrator stops on critical failure.** If `ActionEntryStructureValidator` returns `is_critical_failure=True` (entry is not a dict), the remaining 7 validators never run. This means you will only see structural errors, not semantic ones, until the structure is fixed.
+
+12. **WorkflowResolutionService resolves API key env var names from vendor config Pydantic models.** It reads `model_fields["api_key_env_name"].default` from the vendor's config class. If a vendor config class changes its default env var name, the resolution service picks it up automatically -- there is no separate mapping to maintain.
+
+13. **Type checking rejects booleans for integer/number.** `_check_field_types()` explicitly rejects `bool` values when the expected type is `integer` or `number`, even though Python's `isinstance(True, int)` returns True. This is intentional: JSON Schema treats boolean and integer as distinct types.

--- a/agent_actions/validation/_MANIFEST.md
+++ b/agent_actions/validation/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Validation Manifest
 
+**[> Architecture Deep Dive (ARCHITECTURE.md)](ARCHITECTURE.md)** -- Three validation phases, data flow, caveats.
+
 ## Overview
 
 Validators guard every CLI command and runtime operation—from agent config

--- a/agent_actions/workflow/ARCHITECTURE.md
+++ b/agent_actions/workflow/ARCHITECTURE.md
@@ -1,0 +1,545 @@
+# Workflow Module Architecture
+
+This document maps the moving parts of `agent_actions/workflow/` — the module that orchestrates action execution, manages state, handles batch lifecycles, and coordinates the processing pipeline.
+
+---
+
+## High-Level Overview
+
+```
+agac run -a my_workflow
+    │
+    ▼
+┌──────────────────────────────────────────────────────────┐
+│  CLI (cli/run.py)                                        │
+│    → load YAML, render templates, build AgentWorkflow    │
+└──────────┬───────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────────┐
+│  AgentWorkflow.__init__ (coordinator.py)                 │
+│    1. load_workflow_configs → YAML → action configs       │
+│    2. initialize_storage_backend → SQLite                 │
+│    3. initialize_services → executor, runner, managers    │
+│    4. _reset_retryable_actions or _clear_for_fresh_run    │
+└──────────┬───────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────────┐
+│  _run_workflow_with_context (coordinator.py)              │
+│    Compute levels (topological sort)                     │
+│    For each level:                                       │
+│      For each pending action:                            │
+│        → ActionExecutor.execute_action_sync()            │
+└──────────┬───────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────────┐
+│  ActionExecutor (executor.py)                            │
+│    1. Config change detection → invalidate completed     │
+│    2. Circuit breaker → skip if upstream failed           │
+│    3. Skip evaluator → WHERE clause check                │
+│    4. _execute_action_run → ActionRunner.run_action()    │
+│    5. _resolve_completion_status → COMPLETED / FAILED    │
+└──────────┬───────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────────┐
+│  ActionRunner (runner.py)                                │
+│    Initial stage → staging pipeline (input preprocessing)│
+│    Standard stage → ProcessingPipeline                   │
+└──────────┬───────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────────┐
+│  ProcessingPipeline (pipeline.py)                        │
+│    Batch mode → submit to provider API, return           │
+│    Online mode → UnifiedProcessor.process()              │
+│                  (see processing/ARCHITECTURE.md)        │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Action Status Lifecycle
+
+Every action has a status that controls what happens on the current run and on re-runs.
+
+```
+                     ┌─────────────────────────────────────────────┐
+                     │          On re-run (no --fresh)             │
+                     │     _reset_retryable_actions()              │
+                     │  RETRYABLE_STATUSES → PENDING               │
+                     └──────────┬──────────────────────────────────┘
+                                │
+    ┌───────────────────────────┼───────────────────────────────────┐
+    │                           │                                   │
+    ▼                           ▼                                   ▼
+┌─────────┐  start action  ┌──────────┐  batch detected   ┌───────────────────┐
+│ PENDING │───────────────►│ RUNNING  │──────────────────►│ BATCH_SUBMITTED   │
+└─────────┘                └──────────┘                    └───────────────────┘
+    ▲                         │  │  │                          │
+    │ reset_retryable()       │  │  │                     poll │
+    │                         │  │  │                          ▼
+    │          ┌──────────────┘  │  └───────────┐        ┌──────────────┐
+    │          ▼                 ▼               ▼        │CHECKING_BATCH│
+    │    ┌──────────┐  ┌─────────────────┐  ┌─────────┐  └──────┬───────┘
+    ├────│  FAILED  │  │  COMPLETED_WITH │  │ SKIPPED │         │
+    │    └──────────┘  │    _FAILURES    │  └─────────┘         │
+    │                  └─────────────────┘       ▲              │
+    │                        │                   │              │
+    │                        │ (in COMPLETED_    │              │
+    │                        │  STATUSES — NOT   ├──────────────┘
+    │                        │  retryable)       │
+    │                   ┌────┴─────┐             │
+    └───────────────────│COMPLETED │─────────────┘
+       (only via config └──────────┘
+        change or         (survives re-run)
+        missing output)
+```
+
+### Status Sets
+
+```
+COMPLETED_STATUSES = {COMPLETED, COMPLETED_WITH_FAILURES}
+  → "Has valid output, skip on re-run"
+  → Used by: is_completed(), coordinator level skip, executor early-exit
+
+TERMINAL_STATUSES = {COMPLETED, FAILED, SKIPPED, COMPLETED_WITH_FAILURES}
+  → "Done for this run, regardless of outcome"
+  → Used by: is_workflow_complete(), is_workflow_done(), get_pending_actions()
+
+RETRYABLE_STATUSES = {FAILED, SKIPPED, RUNNING, CHECKING_BATCH}
+  → "Reset to PENDING on next run"
+  → COMPLETED_WITH_FAILURES is NOT retryable (spec 534, 2026-05-31)
+```
+
+### Completion Classification
+
+`executor.py:_resolve_completion_status()` — called after every action run:
+
+```
+get_failed_items() returns failures?
+    │
+    NO → COMPLETED
+    │
+    YES → has_successful_items()?
+           │
+           YES → COMPLETED_WITH_FAILURES
+           NO  → FAILED (zero successes = hard failure)
+```
+
+---
+
+## The Execution Loop
+
+### Sequential Mode
+
+```
+coordinator.py:_run_workflow_with_context()
+
+for each level in topological order:
+    │
+    ├── verify_completion_status() for completed actions
+    │   (guards against stale DB — resets if output missing)
+    │
+    ├── filter to pending actions only
+    │
+    └── for each pending action:
+          _run_single_action(action_name)
+              │
+              ├── ActionExecutor.execute_action_sync()
+              │
+              └── returns True → STOP (batch submitted)
+                  returns False → continue
+```
+
+`_run_single_action` returns True ONLY for `BATCH_SUBMITTED`. Even `FAILED` returns False — the circuit breaker in the next level handles cascade.
+
+### Parallel Mode
+
+```
+parallel/action_executor.py:execute_level_async()
+
+for each level:
+    │
+    ├── verify completed actions
+    │
+    ├── get pending actions
+    │
+    ├── 1 pending → execute_single_action (no semaphore)
+    │   N pending → asyncio.gather(*tasks) with Semaphore
+    │               (each task runs in asyncio.to_thread)
+    │
+    └── check for BATCH_SUBMITTED → pause if found
+```
+
+Important: `asyncio.to_thread` wraps synchronous `run_action()`. Parallel execution is thread-based, not coroutine-based. True I/O overlap is between different actions only; within a single action, processing is synchronous.
+
+---
+
+## ActionExecutor — Decision Tree
+
+Every action goes through this decision tree before any code runs:
+
+```
+execute_action_sync(action_name)
+    │
+    ▼
+Config changed since last run?
+(prompt, model, schema, guard changed)
+    YES → invalidate COMPLETED, reset to PENDING
+    │
+    ▼
+Already COMPLETED?
+    YES → verify output exists
+          output missing → reset to PENDING
+          output present → skip, return success
+    │
+    ▼
+BATCH_SUBMITTED?
+    YES → _handle_batch_check() → poll provider
+    │
+    ▼
+Upstream dependency FAILED or SKIPPED?
+    YES → _handle_dependency_skip()
+          set SKIPPED, write node-level DISPOSITION_SKIPPED
+          (cascade — all downstream will also skip)
+    │
+    ▼
+WHERE clause says skip?
+    YES → _handle_action_skip()
+          set COMPLETED (not SKIPPED — additive model)
+    │
+    ▼
+_execute_action_run()
+    → set RUNNING
+    → ActionRunner.run_action()
+    → _resolve_completion_status()
+```
+
+---
+
+## Config Pipeline: YAML → Action Configs
+
+```
+agent_config/{workflow}.yml
+    │
+    ▼
+ConfigRenderingService.render_and_load_config()
+    → Jinja2 template rendering (env vars, includes)
+    → yaml.safe_load()
+    │
+    ▼
+ConfigManager.load_configs()
+    │
+    ├── get_user_agents()
+    │     └── ActionExpander.expand_actions_to_agents()
+    │           ├── Loop expansion: versions: {range: [1,2,3]}
+    │           │   → creates action_1, action_2, action_3
+    │           ├── Guard normalization
+    │           ├── Schema compilation
+    │           └── Tool/HITL kind detection
+    │
+    ├── merge_agent_configs()
+    │     └── Each action merged onto DefaultAgentConfig
+    │         Priority: action > workflow defaults > project defaults
+    │
+    └── determine_execution_order()
+          ├── Normalize context_scope field references
+          ├── Infer dependencies from field references
+          ├── Build dependency graph
+          └── Topological sort → execution_order
+```
+
+### Defaults Merging Priority
+
+```
+1. Action-level config (from YAML actions: section)
+2. Workflow-level defaults (from YAML defaults: section)
+3. Project-level defaults (from agent_actions.yml default_agent_config)
+4. Framework defaults (from DefaultAgentConfig / SIMPLE_CONFIG_FIELDS)
+```
+
+Simple fields: direct override. `chunk_config`: deep merge. `context_scope`: deep merge with defaults.
+
+---
+
+## ProcessingPipeline — The Fork Point
+
+`pipeline.py:_process_by_strategy()` is where online and batch paths diverge:
+
+```
+_process_by_strategy(data, file_path, ...)
+    │
+    ├── Load source_data from SQLite (if available)
+    ├── Apply record_limit
+    ├── Build shared pipeline context
+    │
+    ▼
+run_mode == BATCH and not tool/HITL?
+    │
+    YES → _handle_batch_generation()
+    │       ├── BatchTaskPreparator.prepare_tasks()
+    │       ├── BatchSubmissionService.submit_batch_job()
+    │       └── Write placeholder JSON + registry
+    │
+    NO → Build ProcessingContext
+         ├── _select_strategy()
+         │     ├── FILE + tool → FileToolStrategy
+         │     ├── FILE + HITL → HITLStrategy
+         │     └── else → OnlineLLMStrategy
+         │
+         ├── FILE mode:
+         │     apply_context_scope_for_records()
+         │     UnifiedProcessor.process(filtered, raw_records=data)
+         │
+         └── RECORD mode:
+               UnifiedProcessor.process(data)
+         │
+         ▼
+    stats.raise_if_terminal_failure()
+    output_handler.save_main_output()
+    clear_checkpoint_records()
+```
+
+---
+
+## Batch Lifecycle
+
+```
+Run 1: Submit
+  _handle_batch_generation()
+    → submit_batch_job() → provider API (OpenAI/Anthropic batch)
+    → write .batch_registry.json
+    → DISPOSITION_DEFERRED for all records
+    → action status → BATCH_SUBMITTED
+    → workflow pauses
+
+Run 2: Poll
+  _handle_batch_check()
+    → CHECKING_BATCH
+    → BatchLifecycleManager.handle_batch_agent()
+        │
+        ├── get_registry_status()
+        │     reads .batch_registry.json
+        │
+        ├── "completed" → process_all_batch_results()
+        │     → retrieve results from provider
+        │     → reconcile (expected - received = missing)
+        │     → recovery state machine (retry → reprompt → finalize)
+        │     → write output + dispositions
+        │
+        ├── "in_progress" → poll provider APIs
+        │     all done? → process
+        │     not done? → return "in_progress" → BATCH_SUBMITTED again
+        │
+        └── "failed"/"cancelled" → return error
+
+Run N: Resume (if recovery submitted)
+  Same poll path — recovery batches are registered in .batch_registry.json
+  with recovery_type and parent_file_name. Processed like original batches.
+```
+
+---
+
+## Service Initialization Order
+
+`initialize_services()` creates objects in strict dependency order:
+
+```
+1. ActionRunner          ← DI container, tool discovery
+2. BatchClientResolver   ← resolves provider SDK by vendor name
+3. BatchContextManager   ← context map persistence
+4. BatchSourceHandler    ← source data for retry
+5. BatchJobManager       ← registry manager factory
+6. BatchProcessingService← orchestrates result processing
+7. VersionOutputCorrelator← version/loop input correlation
+8. ActionStateManager    ← .agent_status.json persistence
+9. SkipEvaluator         ← WHERE clause evaluation
+10. BatchLifecycleManager ← polling + processing lifecycle
+11. ActionOutputManager   ← previous output loading
+12. ActionExecutor        ← bundles all above + console
+13. ActionLevelOrchestrator ← topological sort + parallel dispatch
+14. ManifestManager       ← .manifest.json for external tools
+```
+
+---
+
+## State Persistence
+
+| What | Where | Format | Written when |
+|------|-------|--------|-------------|
+| Action status | `agent_io/.agent_status.json` | JSON dict | Every `update_status()` call |
+| Record dispositions | `agent_io/store/{name}.db` | SQLite table | After collection or checkpoint |
+| Checkpoint records | `agent_io/store/{name}.db` | SQLite table | Per-record during invocation |
+| Target output | `agent_io/store/{name}.db` + `agent_io/target/` | SQLite + JSON file | After `save_main_output` |
+| Batch registry | `agent_io/target/{action}/batch/.batch_registry.json` | JSON | After batch submit |
+| Recovery state | `agent_io/target/{action}/batch/.recovery_state_{file}.json` | JSON | Between retry/reprompt rounds |
+| Prompt traces | `agent_io/store/{name}.db` | SQLite table | During collection |
+
+---
+
+## Invariants and Caveats — What Breaks If You Change Things
+
+### Initialization order is load-bearing
+
+```
+Storage backend MUST initialize before services.
+    Why: 6 of the 14 services take storage_backend as a constructor arg.
+    If you defer storage init, those services get None → silent no-ops
+    or NoneType crashes at runtime.
+
+_reset_retryable_actions MUST run after services init, before execution.
+    Why: it queries ActionStateManager (needs status file loaded) and
+    calls storage_backend.clear_disposition (needs DB connection).
+    If you move it before services init → AttributeError on state_manager.
+```
+
+### COMPLETED_WITH_FAILURES is NOT retryable
+
+```
+COMPLETED_WITH_FAILURES was removed from RETRYABLE_STATUSES in spec 534.
+
+If you add it back:
+    On re-run, the workflow rewinds to earlier partially-failed actions
+    instead of finishing the current run. A 10-action workflow interrupted
+    at action 9 goes back to action 3 (which had 2 failures out of 10)
+    and reprocesses all 10 records.
+
+The retry command is the dedicated path for fixing partial failures.
+It clears only the failed records' dispositions, preserving successes.
+```
+
+### RUNNING actions get selective disposition clearing
+
+```
+_reset_retryable_actions clears RUNNING_CLEAR_DISPOSITIONS
+(FAILED, EXHAUSTED, DEFERRED) for previously-RUNNING actions.
+
+It does NOT clear SUCCESS, PASSTHROUGH, FILTERED, SKIPPED.
+
+Why: RUNNING actions may have checkpointed SUCCESS dispositions.
+Bulk-wiping them destroys resume progress.
+
+If you change this to bulk-clear for RUNNING:
+    Checkpoint resume breaks — the DispositionGate finds no terminal
+    IDs and reprocesses everything from scratch.
+```
+
+### The snapshot ordering in _reset_retryable_actions matters
+
+```
+running_actions = {... get_status == RUNNING ...}   ← snapshot BEFORE
+reset_actions = state_mgr.reset_retryable()          ← mutates to PENDING
+
+The snapshot MUST be captured before reset_retryable() because
+reset_retryable() transitions all matching statuses to PENDING.
+After the call, you can't tell which actions were RUNNING.
+
+If you swap the order:
+    running_actions is always empty → all actions get bulk-cleared
+    → checkpoint resume breaks.
+```
+
+### Config hash invalidation scope
+
+```
+_compute_action_config_hash() covers:
+    prompt, model_name, model_vendor, schema, guard clause, guard behavior
+
+If you change one of these fields and re-run WITHOUT --fresh:
+    The executor detects the hash mismatch, resets the action to PENDING,
+    and clears its dispositions. The action re-runs with new config.
+
+If you add a new config field that affects output but don't add it
+to the hash computation:
+    Stale output from a prior config is silently reused. The user
+    must manually --fresh to get updated results.
+```
+
+### _run_single_action stop semantics
+
+```
+_run_single_action returns True ONLY for BATCH_SUBMITTED.
+
+FAILED returns False — the loop continues to the next action.
+The circuit breaker (upstream health check) handles cascade.
+
+If you add a new status that returns True:
+    The sequential loop stops at that action. All remaining actions
+    in the current level AND all subsequent levels are skipped.
+    Use this only for conditions that genuinely require pausing
+    the entire workflow (like batch polling).
+```
+
+### Parallel execution uses threads, not coroutines
+
+```
+_execute_action_run_async wraps synchronous run_action in
+asyncio.to_thread(). This means:
+
+  - Parallel execution = thread-based (GIL applies to CPU work)
+  - True overlap only for I/O between different actions
+  - Within a single action, processing is fully synchronous
+  - The threading.Lock in ActionStateManager protects status writes
+
+If you add async I/O inside run_action (e.g., aiohttp calls):
+    It won't benefit from the event loop — it's running in a
+    thread, not a coroutine. You'd need to restructure the entire
+    execution path to use native async.
+```
+
+### Every path that resets actions must clear checkpoint records
+
+```
+Three places reset action state. ALL THREE clear checkpoint_output:
+
+1. pipeline.py:591      — after save_main_output (normal completion)
+2. coordinator.py:285   — _clear_for_fresh_run (--fresh flag)
+3. cli/retry.py:201     — RetryCommand.execute (retry command)
+
+If you add a new CLI command or reset path:
+    You MUST call storage_backend.clear_checkpoint_records(action_name).
+    If you forget, stale checkpoint data from a prior run silently
+    contaminates the next run's output.
+```
+
+### WHERE skip produces COMPLETED, not SKIPPED
+
+```
+SkipEvaluator.should_skip_action() → True results in:
+    _handle_action_skip() → status = COMPLETED
+
+NOT SKIPPED. This is intentional — the additive content model means
+a WHERE-skipped action simply adds nothing to the record. It's not
+a failure or cascade trigger.
+
+If you change this to SKIPPED:
+    All downstream actions that depend on this action will cascade-skip
+    via the circuit breaker, even though there's nothing wrong.
+```
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `coordinator.py` | `AgentWorkflow` — init, run, async_run, reset logic |
+| `executor.py` | `ActionExecutor` — full action lifecycle, circuit breaker, batch check |
+| `pipeline.py` | `ProcessingPipeline` — online/batch fork, strategy selection |
+| `runner.py` | `ActionRunner` — strategy dispatch, directory resolution |
+| `runner_file_processing.py` | File walking, storage-first loading, merge-branch processing |
+| `strategies.py` | `InitialStrategy`, `StandardStrategy` — runner-level strategies |
+| `config_pipeline.py` | `load_workflow_configs` — YAML parsing, UDF discovery |
+| `service_init.py` | `initialize_storage_backend`, `initialize_services` |
+| `models.py` | All workflow dataclasses (`WorkflowRuntimeConfig`, etc.) |
+| `execution_events.py` | `WorkflowEventLogger` — telemetry events |
+| `schema_service.py` | Schema compilation and validation |
+| `managers/state.py` | `ActionStateManager` — status persistence, status sets |
+| `managers/batch.py` | `BatchLifecycleManager` — polling, result processing |
+| `managers/output.py` | `ActionOutputManager` — previous output, version correlation |
+| `managers/skip.py` | `SkipEvaluator` — WHERE clause, guard, legacy skip_if |
+| `managers/manifest.py` | `ManifestManager` — .manifest.json for external tools |
+| `parallel/action_executor.py` | `ActionLevelOrchestrator` — topological sort, parallel dispatch |

--- a/agent_actions/workflow/_MANIFEST.md
+++ b/agent_actions/workflow/_MANIFEST.md
@@ -1,5 +1,7 @@
 # Workflow Manifest
 
+**[> Architecture Guide (ARCHITECTURE.md)](ARCHITECTURE.md)** — full execution flow, status lifecycle, config pipeline, batch lifecycle, caveats.
+
 ## Overview
 
 Workflow orchestration, execution, schema services, and workspace metadata for


### PR DESCRIPTION
## Summary
- Add comprehensive ARCHITECTURE.md for every module in `agent_actions/` (15 new, 2 updated with links)
- Each doc follows the same pattern as the existing `llm/ARCHITECTURE.md`: ASCII diagrams, data flow traces, file indexes, and 8-15 caveats/invariants
- Each `_MANIFEST.md` updated with a link to its ARCHITECTURE.md
- 6,718 lines of documentation across 34 files

### Modules covered
`cli`, `config`, `errors`, `guards`, `input`, `logging`, `models`, `output`, `processing`, `prompt`, `record`, `skills`, `storage`, `tooling`, `utils`, `validation`, `workflow`

### What each doc includes
- High-level overview with ASCII architecture diagrams
- Key data flows and execution paths
- File index with roles
- 8-15 caveats and invariants that future AI agents need to know before making changes (what breaks if they change X)

## Verification
- All files are documentation only (`.md`) — no code changes
- Each ARCHITECTURE.md follows the established pattern from `llm/ARCHITECTURE.md`
- Each `_MANIFEST.md` has a single added line linking to ARCHITECTURE.md