### PR TITLE
fix(scope): raise on missing observe fields instead of silent None injection

### DIFF
--- a/.changes/unreleased/Bug Fix-20260604-538000.yaml
+++ b/.changes/unreleased/Bug Fix-20260604-538000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Observe directives on missing fields now skip the record instead of silently injecting None into prompts"
+time: 2026-06-04T05:38:00.000000Z

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -6,7 +6,7 @@ from collections import Counter
 from copy import deepcopy
 from typing import Any
 
-from agent_actions.errors import ConfigurationError, RecordContextError
+from agent_actions.errors import RecordContextError
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import (
     ContextFieldSkippedEvent,
@@ -19,6 +19,7 @@ from agent_actions.prompt.context.scope_parsing import (
     extract_field_value,
     parse_field_reference,
 )
+from agent_actions.record.reasons import OBSERVE_FIELD_MISSING
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
@@ -34,11 +35,13 @@ def _resolve_missing_field(
     action_name: str,
     directive: str,
 ) -> None:
-    """Return None if namespace exists (null or present), raise if namespace absent.
+    """Handle a missing field reference during scope application.
 
     Three cases:
     1. Namespace is null (NullNamespace sentinel or legacy None) → return None
-    2. Namespace exists as dict but field is missing → return None (match guard semantics)
+    2. Namespace exists as dict but field is missing:
+       - observe → raise RecordContextError (prevents None injection into prompts)
+       - passthrough/drop → return None (match guard semantics)
     3. Namespace not in prompt_context at all → raise (config bug / typo)
     """
     if ns_name in prompt_context and is_null_namespace(prompt_context[ns_name]):
@@ -53,6 +56,18 @@ def _resolve_missing_field(
         return None
 
     if ns_name in prompt_context and isinstance(prompt_context[ns_name], dict):
+        if directive == "observe":
+            raise RecordContextError(
+                f"context_scope.observe field '{field_ref}' not found in namespace '{ns_name}'",
+                context={
+                    "action": action_name,
+                    "field_ref": field_ref,
+                    "directive": directive,
+                    "operation": "apply_context_scope",
+                    "hint": f"Namespace '{ns_name}' exists but field is missing. "
+                    f"Upstream action may have produced incomplete output.",
+                },
+            )
         logger.warning(
             "[%s NULL-SAFE] '%s' on action '%s': field not found in namespace '%s', "
             "resolving as None to match guard semantics",
@@ -477,7 +492,7 @@ def apply_context_scope_for_records(
     context_scope: dict,
     action_name: str = "unknown",
     source_data: list[dict] | None = None,
-) -> list[dict]:
+) -> tuple[list[dict], list[dict]]:
     """Apply context_scope to a list of records (FILE mode).
 
     For each record:
@@ -489,13 +504,18 @@ def apply_context_scope_for_records(
     Unlike apply_context_scope() which gates prompt_context to observed namespaces
     only (correct for Jinja), this function preserves ALL original namespaces in the
     enriched record because downstream guards need full namespace visibility.
+
+    Returns:
+        Tuple of (enriched_records, skipped_records).  Skipped records had
+        missing observe fields (upstream produced incomplete output) and carry
+        ``{"source_guid": ..., "reason": "observe_field_missing"}``.
     """
     observe_refs = context_scope.get("observe", [])
     passthrough_refs = context_scope.get("passthrough", [])
     drop_refs = context_scope.get("drop", [])
 
     if not observe_refs and not passthrough_refs and not drop_refs:
-        return records
+        return records, []
 
     # Check if any directive references the source namespace
     has_source_refs = (
@@ -513,6 +533,7 @@ def apply_context_scope_for_records(
 
     source_cache: dict[str | None, dict] = {}
     enriched: list[dict] = []
+    skipped: list[dict] = []
 
     for record in records:
         content = get_existing_content(record)
@@ -528,18 +549,19 @@ def apply_context_scope_for_records(
                 field_context["source"] = source_content
 
         # Call unified bus filter (validates refs, fires events).
-        # Records where an upstream action failed may have empty namespaces —
-        # skip enrichment for those rather than failing the entire file.
+        # Records where an observe field is missing (upstream produced incomplete
+        # output) are skipped — not enriched — so they don't proceed with None
+        # values that would produce garbage LLM output downstream.
         try:
             apply_context_scope(field_context, context_scope, action_name=action_name)
-        except ConfigurationError as e:
-            logger.warning(
-                "[%s] Skipping record %s — observe field missing (likely upstream failure): %s",
+        except RecordContextError as e:
+            logger.debug(
+                "[%s] Skipping record %s — observe field missing (upstream incomplete): %s",
                 action_name,
                 sguid,
                 e,
             )
-            enriched.append(record)
+            skipped.append({"source_guid": sguid, "reason": OBSERVE_FIELD_MISSING})
             continue
 
         # Rebuild enriched record: ALL namespaces preserved, drops applied, flat keys
@@ -551,4 +573,12 @@ def apply_context_scope_for_records(
 
         enriched.append({**record, "content": enriched_content})
 
-    return enriched
+    if skipped:
+        logger.warning(
+            "[%s] %d of %d records skipped — missing upstream observe fields",
+            action_name,
+            len(skipped),
+            len(records),
+        )
+
+    return enriched, skipped

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -552,6 +552,10 @@ def apply_context_scope_for_records(
         # Records where an observe field is missing (upstream produced incomplete
         # output) are skipped — not enriched — so they don't proceed with None
         # values that would produce garbage LLM output downstream.
+        # Note: RecordContextError also fires for absent namespaces on any
+        # directive (Branch 3 of _resolve_missing_field). A passthrough ref
+        # with a typo would be caught here too — preflight validation catches
+        # those in practice, so the misclassification risk is low.
         try:
             apply_context_scope(field_context, context_scope, action_name=action_name)
         except RecordContextError as e:

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -548,14 +548,9 @@ def apply_context_scope_for_records(
             if source_content:
                 field_context["source"] = source_content
 
-        # Call unified bus filter (validates refs, fires events).
-        # Records where an observe field is missing (upstream produced incomplete
-        # output) are skipped — not enriched — so they don't proceed with None
-        # values that would produce garbage LLM output downstream.
-        # Note: RecordContextError also fires for absent namespaces on any
-        # directive (Branch 3 of _resolve_missing_field). A passthrough ref
-        # with a typo would be caught here too — preflight validation catches
-        # those in practice, so the misclassification risk is low.
+        # Validate observe/passthrough/drop refs against the record's namespaces.
+        # RecordContextError means a required namespace or field is missing —
+        # skip this record rather than enriching it with None values.
         try:
             apply_context_scope(field_context, context_scope, action_name=action_name)
         except RecordContextError as e:

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -18,6 +18,7 @@ LLM_LAYER_GUARD_FILTER = "llm_layer_guard_filter"
 
 # -- Cascade / upstream ------------------------------------------------------
 UPSTREAM_UNPROCESSED = "upstream_unprocessed"
+OBSERVE_FIELD_MISSING = "observe_field_missing"
 
 # -- Prep failures -----------------------------------------------------------
 PREP_FAILED = "prep_failed"

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -23,7 +23,11 @@ from agent_actions.processing.types import ProcessingContext
 from agent_actions.processing.unified import ProcessingStrategy, UnifiedProcessor
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
 from agent_actions.record.reasons import OBSERVE_FIELD_MISSING
-from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
+from agent_actions.storage.backend import (
+    DISPOSITION_PASSTHROUGH,
+    DISPOSITION_SKIPPED,
+    DispositionRow,
+)
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 from agent_actions.utils.safe_format import safe_format_error
@@ -577,10 +581,10 @@ class ProcessingPipeline:
                 source_data=source_data,
             )
             if scope_skipped and self.config.storage_backend:
-                batch = [
+                batch: list[DispositionRow] = [
                     (
                         self.config.action_name,
-                        skip["source_guid"],
+                        str(skip["source_guid"]),
                         DISPOSITION_SKIPPED,
                         OBSERVE_FIELD_MISSING,
                         None,

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -22,7 +22,8 @@ from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
 from agent_actions.processing.types import ProcessingContext
 from agent_actions.processing.unified import ProcessingStrategy, UnifiedProcessor
 from agent_actions.prompt.context.scope_application import apply_context_scope_for_records
-from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH
+from agent_actions.record.reasons import OBSERVE_FIELD_MISSING
+from agent_actions.storage.backend import DISPOSITION_PASSTHROUGH, DISPOSITION_SKIPPED
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 from agent_actions.utils.safe_format import safe_format_error
@@ -567,7 +568,7 @@ class ProcessingPipeline:
             # enrich + collect to UnifiedProcessor with raw_records for
             # pre-observe alignment.  UnifiedProcessor sets context.source_data
             # to original_passing after the guard filter runs.
-            filtered = apply_context_scope_for_records(
+            filtered, scope_skipped = apply_context_scope_for_records(
                 records=data,
                 context_scope=cast(dict[str, Any], self.config.action_config).get(
                     "context_scope", {}
@@ -575,6 +576,29 @@ class ProcessingPipeline:
                 action_name=self.config.action_name,
                 source_data=source_data,
             )
+            if scope_skipped and self.config.storage_backend:
+                batch = [
+                    (
+                        self.config.action_name,
+                        skip["source_guid"],
+                        DISPOSITION_SKIPPED,
+                        OBSERVE_FIELD_MISSING,
+                        None,
+                        None,
+                        None,
+                    )
+                    for skip in scope_skipped
+                    if skip.get("source_guid")
+                ]
+                if batch:
+                    try:
+                        self.config.storage_backend.set_dispositions_batch(batch)
+                    except Exception:
+                        logger.exception(
+                            "Failed to batch-write %d scope-skip dispositions for %s",
+                            len(batch),
+                            self.config.action_name,
+                        )
             output, stats = self._unified_processor.process(
                 filtered, context, strategy, raw_records=data
             )

--- a/tests/integration/test_context_scope_audit.py
+++ b/tests/integration/test_context_scope_audit.py
@@ -75,12 +75,12 @@ class TestObserveDirective:
         assert llm_ctx["dep_a"]["x"] == 10
         assert llm_ctx["dep_b"]["y"] == 20
 
-    def test_observe_missing_field_returns_none(self):
-        """Missing field from present namespace resolves to None (U-4.2)."""
+    def test_observe_missing_field_raises(self):
+        """Missing field from present namespace raises RecordContextError for observe."""
         field_context = _fc(dep={"present": "yes"})
         scope = {"observe": ["dep.absent"]}
-        _, llm_ctx, _ = apply_context_scope(field_context, scope, action_name="act")
-        assert llm_ctx["dep"]["absent"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(field_context, scope, action_name="act")
 
     def test_observe_preserves_falsy_values(self):
         """0, False, None, '' must all survive observe extraction."""
@@ -200,12 +200,12 @@ class TestDropDirective:
         assert prompt_ctx.get("dep", {}) == {}
         assert llm_ctx.get("dep", {}) == {}
 
-    def test_drop_then_observe_specific_returns_none(self):
-        """Observing a dropped field resolves to None — secret not leaked (U-4.2)."""
+    def test_drop_then_observe_specific_raises(self):
+        """Observing a dropped field raises — secret not leaked, config contradiction detected."""
         field_context = _fc(dep={"field_a": "value"})
         scope = {"drop": ["dep.field_a"], "observe": ["dep.field_a"]}
-        _, llm_ctx, _ = apply_context_scope(field_context, scope, action_name="act")
-        assert llm_ctx["dep"]["field_a"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(field_context, scope, action_name="act")
 
     def test_drop_on_nonexistent_field_warns_no_crash(self):
         field_context = _fc(dep={"real": "value"})
@@ -304,7 +304,7 @@ class TestFileModeObserve:
             "dependencies": "dep",
             "context_scope": {"observe": ["dep.question", "dep.answer"]},
         }
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=agent_config["context_scope"],
             action_name="act",
@@ -327,7 +327,7 @@ class TestFileModeObserve:
             {"q": "Why?", "a": "because"},
         )
         context_scope = {"observe": ["dep.*"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="act",
@@ -351,7 +351,7 @@ class TestFileModeObserve:
             }
         ]
         context_scope = {"observe": ["dep_a.*", "dep_b.extra"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="act",
@@ -366,7 +366,9 @@ class TestFileModeObserve:
     def test_file_mode_no_observe_returns_data_unchanged(self):
         """No observe refs -> data returned as-is."""
         data = [{"content": {"dep": {"a": 1}}, "source_guid": "sg_0"}]
-        result = apply_context_scope_for_records(records=data, context_scope={}, action_name="act")
+        result, _ = apply_context_scope_for_records(
+            records=data, context_scope={}, action_name="act"
+        )
         assert result == data
 
 

--- a/tests/integration/test_context_scope_integrity.py
+++ b/tests/integration/test_context_scope_integrity.py
@@ -109,15 +109,15 @@ class TestObserveBasic:
         assert llm_context["dep"]["none_val"] is None
         assert llm_context["dep"]["normal"] == "ok"
 
-    def test_observe_missing_field_returns_none(self):
-        """Missing field from present namespace resolves to None (U-4.2)."""
+    def test_observe_missing_field_raises(self):
+        """Missing field from present namespace raises RecordContextError for observe."""
         field_context = {
             "dep": {"existing_a": 1, "existing_b": 2, "existing_c": 3},
         }
         context_scope = {"observe": ["dep.nonexistent"]}
 
-        _, llm_ctx, _ = apply_context_scope(field_context, context_scope, action_name="test")
-        assert llm_ctx["dep"]["nonexistent"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(field_context, context_scope, action_name="test")
 
     def test_observe_multiple_namespaces(self):
         """observe: ['dep_a.x', 'dep_b.y'] -> llm_context has both namespaces."""
@@ -702,8 +702,8 @@ class TestDropSecurity:
         assert llm_context["dep"]["name"] == "public_name"
         assert llm_context["dep"]["value"] == "public_value"
 
-    def test_observe_dropped_field_returns_none(self):
-        """drop: ['dep.x'], observe: ['dep.x'] -> None, secret not leaked (U-4.2)."""
+    def test_observe_dropped_field_raises(self):
+        """drop: ['dep.x'], observe: ['dep.x'] -> raises (contradictory config, secret not leaked)."""
         field_context = {
             "dep": {"x": "secret_value", "y": "other", "z": "more"},
         }
@@ -712,8 +712,8 @@ class TestDropSecurity:
             "observe": ["dep.x"],
         }
 
-        _, llm_ctx, _ = apply_context_scope(field_context, context_scope, action_name="test")
-        assert llm_ctx["dep"]["x"] is None  # None, NOT "secret_value"
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(field_context, context_scope, action_name="test")
 
     def test_drop_happens_before_observe(self):
         """Execution order: drop first, then observe reads from post-drop state."""
@@ -824,7 +824,7 @@ class TestFileModeObserve:
             "dependencies": "dep",
         }
 
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=agent_config["context_scope"],
             action_name="consumer",
@@ -859,7 +859,7 @@ class TestFileModeObserve:
             "dependencies": "dep",
         }
 
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=agent_config["context_scope"],
             action_name="consumer",
@@ -891,7 +891,7 @@ class TestFileModeObserve:
             "dependencies": "extract",
         }
 
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=agent_config["context_scope"],
             action_name="enrich",
@@ -905,11 +905,12 @@ class TestFileModeObserve:
         assert result[0]["content"]["extract"]["length"] == 500
         assert result[0]["source_guid"] == "sg1"
 
-    def test_file_mode_missing_field_enriches_with_none(self):
-        """FILE-mode: missing observe field resolves to None in enriched record (U-4.2).
+    def test_file_mode_missing_field_skips_record(self):
+        """FILE-mode: missing observe field skips the record (not enriched with None).
 
-        Missing fields from present namespaces resolve to None (matching guard
-        semantics) instead of skipping enrichment for the entire record.
+        When upstream produced a namespace but is missing the observed field,
+        the record is skipped rather than enriched with None values that would
+        produce garbage LLM output downstream.
         """
         data = [
             {
@@ -921,20 +922,16 @@ class TestFileModeObserve:
         ]
         context_scope = {"observe": ["dep.title", "dep.nonexistent_field"]}
 
-        result = apply_context_scope_for_records(
+        enriched, skipped = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="consumer",
         )
 
-        # Record is enriched (not skipped) — present field survives, missing field
-        # doesn't crash enrichment. Flat key injection only covers present fields.
-        assert result[0] is not data[0]  # enriched copy, not original
-        enriched_content = result[0]["content"]
-        assert enriched_content["dep"]["title"] == "Exists"
-        assert enriched_content["dep"]["body"] == "Also exists"
-        # Missing field not injected as flat key (only present fields get flat keys)
-        assert "nonexistent_field" not in enriched_content
+        assert len(enriched) == 0
+        assert len(skipped) == 1
+        assert skipped[0]["source_guid"] == "sg1"
+        assert skipped[0]["reason"] == "observe_field_missing"
 
     def test_file_mode_wildcard_on_partial_namespace_graceful(self):
         """FILE-mode: wildcard on namespace with missing fields is graceful."""
@@ -948,7 +945,7 @@ class TestFileModeObserve:
         ]
         context_scope = {"observe": ["dep.*"]}
 
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="consumer",

--- a/tests/manual/repro_bug_03_version_merge_tool.py
+++ b/tests/manual/repro_bug_03_version_merge_tool.py
@@ -43,7 +43,7 @@ def test_version_wildcard_expansion():
         "observe": ["gen_code_1.*", "gen_code_2.*", "gen_code_3.*"],
     }
 
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data,
         context_scope=context_scope,
         action_name="aggregate",
@@ -84,7 +84,7 @@ def test_version_specific_field_resolution():
         "observe": ["gen_code_1.code", "gen_code_2.code"],
     }
 
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data,
         context_scope=context_scope,
         action_name="aggregate",
@@ -134,7 +134,7 @@ def test_content_empty_fallback_trap():
         "observe": ["source.url", "upstream.*"],
     }
 
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data,
         context_scope=context_scope,
         action_name="downstream",

--- a/tests/unit/prompt/context/test_file_mode_observe.py
+++ b/tests/unit/prompt/context/test_file_mode_observe.py
@@ -90,7 +90,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["extract.text"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="classify"
         )
         assert result[0]["content"]["text"] == "article about physics"
@@ -108,7 +108,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["extract.text", "classify.topic"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="summarize"
         )
         assert result[0]["content"]["text"] == "physics article"
@@ -125,7 +125,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["extract.*"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="summarize"
         )
         assert result[0]["content"]["text"] == "hello"
@@ -142,7 +142,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["extract.*", "classify.*"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="summarize"
         )
         # Qualified keys because multiple wildcards
@@ -163,7 +163,7 @@ class TestApplyContextScopeForRecords:
             {"source_guid": "sg-1", "content": {"url": "https://example.com", "title": "Ex"}},
         ]
         context_scope = {"observe": ["extract.text", "source.url"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="classify",
@@ -183,7 +183,7 @@ class TestApplyContextScopeForRecords:
             {"source_guid": "sg-B", "content": {"url": "https://b.com"}},
         ]
         context_scope = {"observe": ["extract.text", "source.url"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="classify",
@@ -203,7 +203,7 @@ class TestApplyContextScopeForRecords:
             {"source_guid": "sg-other", "content": {"url": "https://fallback.com"}},
         ]
         context_scope = {"observe": ["extract.text", "source.url"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="classify",
@@ -217,7 +217,7 @@ class TestApplyContextScopeForRecords:
         data = [{"content": {"extract": {"text": "Q"}}}]
         source_data = [{"url": "https://example.com", "title": "Example"}]
         context_scope = {"observe": ["extract.text", "source.url"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="classify",
@@ -227,26 +227,27 @@ class TestApplyContextScopeForRecords:
         assert result[0]["content"]["url"] == "https://example.com"
 
     def test_explicit_ref_to_missing_namespace_skips_record(self):
-        """Explicit ref to absent namespace skips enrichment for that record.
+        """Explicit ref to absent namespace skips the record (not enriched).
 
-        FILE mode is tolerant of missing fields because individual records
-        may have failed upstream (empty namespaces). The record passes through
-        unenriched rather than crashing the entire action.
+        When an observe field references a namespace that doesn't exist,
+        the record is skipped rather than enriched with None values.
         """
         data = [
             {
+                "source_guid": "g1",
                 "content": {
                     "generate": {"question": "Q?"},
                     "validate": {"pass": True},
-                }
+                },
             },
         ]
         context_scope = {"observe": ["rewrite.output", "generate.question"]}
-        result = apply_context_scope_for_records(
+        enriched, skipped = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="review"
         )
-        # Record passes through unenriched
-        assert result[0] is data[0]
+        assert len(enriched) == 0
+        assert len(skipped) == 1
+        assert skipped[0]["source_guid"] == "g1"
 
     def test_wildcard_on_missing_namespace_graceful(self):
         """Wildcard on absent namespace is graceful — no crash, no fields injected."""
@@ -259,7 +260,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["rewrite.*", "generate.question"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="review"
         )
         assert result[0]["content"]["question"] == "Q?"
@@ -267,23 +268,27 @@ class TestApplyContextScopeForRecords:
         assert "output" not in result[0]["content"]
 
     def test_missing_namespace_explicit_ref_skips_record(self):
-        """Explicit ref to a guard-skipped action's namespace skips that record."""
+        """Explicit ref to absent namespace skips the record."""
         data = [
             {
+                "source_guid": "g1",
                 "content": {
                     "generate": {"question": "Q?"},
-                }
+                },
             },
         ]
         context_scope = {"observe": ["rewrite.output", "generate.question"]}
-        result = apply_context_scope_for_records(
+        enriched, skipped = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="review"
         )
-        assert result[0] is data[0]
+        assert len(enriched) == 0
+        assert len(skipped) == 1
 
     def test_no_observe_returns_data_as_is(self):
         data = [{"content": {"extract": {"a": 1}}}]
-        result = apply_context_scope_for_records(records=data, context_scope={}, action_name="test")
+        result, _ = apply_context_scope_for_records(
+            records=data, context_scope={}, action_name="test"
+        )
         assert result is data
 
     def test_no_mutation_of_input_data(self):
@@ -317,7 +322,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["dep_a.title", "dep_b.title", "dep_a.body"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="merge"
         )
         # "title" collides → qualified keys
@@ -336,7 +341,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["extract.text", "classify.topic"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="summarize",
@@ -354,7 +359,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["extract.text"], "drop": ["extract.secret"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
         assert result[0]["content"]["text"] == "hello"
@@ -373,7 +378,7 @@ class TestApplyContextScopeForRecords:
             "observe": ["extract.text"],
             "passthrough": ["extract.metadata"],
         }
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
         assert result[0]["content"]["text"] == "hello"
@@ -390,7 +395,7 @@ class TestApplyContextScopeForRecords:
             },
         ]
         context_scope = {"observe": ["action_a.*"], "drop": ["action_a.secret"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
         assert result[0]["content"]["field1"] == "keep"
@@ -427,7 +432,7 @@ class TestVersionNamespaceObserve:
         context_scope = {
             "observe": ["gen_code_1.*", "gen_code_2.*", "gen_code_3.*"],
         }
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="aggregate"
         )
         content = result[0]["content"]
@@ -443,7 +448,7 @@ class TestVersionNamespaceObserve:
         context_scope = {
             "observe": ["gen_code_1.code", "gen_code_2.code"],
         }
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="aggregate"
         )
         content = result[0]["content"]
@@ -461,7 +466,7 @@ class TestVersionNamespaceObserve:
             },
         ]
         context_scope = {"observe": ["gen_code_1.*"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="aggregate"
         )
         content = result[0]["content"]
@@ -487,7 +492,7 @@ class TestVersionNamespaceObserve:
         context_scope = {
             "observe": ["gen_code_1.code", "gen_code_2.code"],
         }
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="aggregate"
         )
         assert result[0]["content"]["gen_code_1.code"] == "code_A1"
@@ -501,7 +506,7 @@ class TestVersionNamespaceObserve:
         context_scope = {
             "observe": ["gen_code_1.*", "gen_code_2.*"],
         }
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="aggregate"
         )
         content = result[0]["content"]
@@ -533,55 +538,58 @@ class TestEdgeCases:
     """Edge case tests for file-mode context_scope."""
 
     def test_empty_content_explicit_ref_skips(self):
-        """Record with empty content {} — explicit ref skips enrichment."""
-        data = [{"content": {}}]
+        """Record with empty content {} — explicit ref skips the record."""
+        data = [{"source_guid": "g1", "content": {}}]
         context_scope = {"observe": ["extract.text"]}
-        result = apply_context_scope_for_records(
+        enriched, skipped = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
-        assert result[0] is data[0]
+        assert len(enriched) == 0
+        assert len(skipped) == 1
 
     def test_empty_content_wildcard_graceful(self):
         """Record with empty content {} — wildcard is graceful, no fields extracted."""
         data = [{"content": {}}]
         context_scope = {"observe": ["extract.*"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
         assert result[0]["content"] == {}
 
     def test_no_content_key_explicit_ref_skips(self):
-        """Record without content key — explicit ref skips enrichment."""
+        """Record without content key — explicit ref skips the record."""
         data = [{"source_guid": "sg-1"}]
         context_scope = {"observe": ["extract.text"]}
-        result = apply_context_scope_for_records(
+        enriched, skipped = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
-        assert result[0] is data[0]
+        assert len(enriched) == 0
+        assert len(skipped) == 1
 
     def test_no_content_key_wildcard_graceful(self):
         """Record without content key — wildcard is graceful."""
         data = [{"source_guid": "sg-1"}]
         context_scope = {"observe": ["extract.*"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
         assert result[0]["content"] == {}
 
     def test_namespace_is_not_dict_explicit_ref_skips(self):
-        """Namespace value is not a dict — explicit ref skips enrichment."""
-        data = [{"content": {"extract": "not_a_dict"}}]
+        """Namespace value is not a dict — explicit ref skips the record."""
+        data = [{"source_guid": "g1", "content": {"extract": "not_a_dict"}}]
         context_scope = {"observe": ["extract.text"]}
-        result = apply_context_scope_for_records(
+        enriched, skipped = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
-        assert result[0] is data[0]
+        assert len(enriched) == 0
+        assert len(skipped) == 1
 
     def test_namespace_is_not_dict_wildcard_graceful(self):
         """Namespace value is not a dict — wildcard is graceful."""
         data = [{"content": {"extract": "not_a_dict"}}]
         context_scope = {"observe": ["extract.*"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records=data, context_scope=context_scope, action_name="test"
         )
         assert "text" not in result[0]["content"]

--- a/tests/unit/prompt/context/test_null_safe_observe.py
+++ b/tests/unit/prompt/context/test_null_safe_observe.py
@@ -1,4 +1,4 @@
-"""Tests for null-safe observe/passthrough resolution (specs 401 + 402).
+"""Tests for null-safe observe/passthrough resolution.
 
 When a guard skips or filters an upstream action, its namespace is null
 on the record.  Downstream observe/passthrough must yield None for its
@@ -23,7 +23,7 @@ def _make_field_context(**namespaces):
 
 
 class TestObserveNullNamespace:
-    """Spec 401: observe from guard-skipped namespace yields None."""
+    """Observe from guard-skipped namespace yields None."""
 
     def test_specific_field_yields_none(self):
         """observe: ['skipped.field'] where skipped is None → field is None, no crash."""
@@ -111,7 +111,7 @@ class TestObserveStrictPreserved:
 
 
 class TestPassthroughNullNamespace:
-    """Spec 401/402: passthrough from guard-skipped namespace yields None."""
+    """Passthrough from guard-skipped namespace yields None."""
 
     def test_specific_field_yields_none(self):
         """passthrough: ['skipped.field'] where skipped is None → field is None."""
@@ -134,7 +134,7 @@ class TestPassthroughNullNamespace:
         assert "skipped" not in pt
 
     def test_passthrough_missing_field_returns_none(self):
-        """passthrough: ['dep.nonexistent'] from present namespace → None (U-4.2)."""
+        """passthrough: ['dep.nonexistent'] from present namespace → None."""
         fc = _make_field_context(dep={"actual": "value"})
         _prompt_ctx, _llm_ctx, pt = apply_context_scope(
             field_context=fc,
@@ -181,11 +181,11 @@ class TestGatingNullNamespace:
         assert prompt_ctx["present"]["f"] == 1
 
 
-# ── Fan-in: filter scenario (spec 402) ──────────────────────────────
+# ── Fan-in: filter scenario ──────────────────────────────────────────
 
 
 class TestFanInFilterScenario:
-    """Spec 402: fan-in where one branch was guard-filtered."""
+    """Fan-in where one branch was guard-filtered."""
 
     def test_observe_from_filtered_branch(self):
         """Action D depends on B and C; C was guard-filtered.

--- a/tests/unit/prompt/context/test_null_safe_observe.py
+++ b/tests/unit/prompt/context/test_null_safe_observe.py
@@ -84,17 +84,17 @@ class TestObserveNullNamespace:
 
 
 class TestObserveStrictPreserved:
-    """Observe null-safety: missing field from present namespace returns None (U-4.2)."""
+    """Observe strict: missing field from present namespace raises RecordContextError."""
 
-    def test_missing_field_from_present_namespace_returns_none(self):
-        """observe: ['dep.nonexistent'] where dep is a real dict → None (match guard semantics)."""
+    def test_missing_field_from_present_namespace_raises(self):
+        """observe: ['dep.nonexistent'] where dep is a real dict → RecordContextError."""
         fc = _make_field_context(dep={"actual_field": "value"})
-        _prompt_ctx, llm_ctx, _ = apply_context_scope(
-            field_context=fc,
-            context_scope={"observe": ["dep.nonexistent"]},
-            action_name="downstream",
-        )
-        assert llm_ctx["dep"]["nonexistent"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["dep.nonexistent"]},
+                action_name="downstream",
+            )
 
     def test_undeclared_namespace_raises(self):
         """observe: ['ghost.field'] where ghost is not in field_context → ConfigurationError."""

--- a/tests/unit/prompt/context/test_observe_tool_udf_namespace.py
+++ b/tests/unit/prompt/context/test_observe_tool_udf_namespace.py
@@ -5,6 +5,9 @@ structure as LLM outputs, so downstream observe references resolve
 identically regardless of source action kind.
 """
 
+import pytest
+
+from agent_actions.errors import ConfigurationError
 from agent_actions.prompt.context.scope_application import (
     apply_context_scope,
 )
@@ -90,13 +93,13 @@ class TestCrossActionToolFeedsLlm:
         )
         assert llm_ctx["tool_b"]["summary"] == "42"
 
-        # observe: ["tool_b.question_type"] → None because it's under "A", not top-level (U-4.2)
-        _, llm_ctx2, _ = apply_context_scope(
-            field_context,
-            {"observe": ["tool_b.question_type"]},
-            action_name="downstream_llm",
-        )
-        assert llm_ctx2["tool_b"]["question_type"] is None
+        # observe: ["tool_b.question_type"] → raises because field is missing from namespace
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(
+                field_context,
+                {"observe": ["tool_b.question_type"]},
+                action_name="downstream_llm",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +128,7 @@ class TestFileModeObserveToolUdf:
         ]
         context_scope = {"observe": ["upstream.question_type"]}
 
-        filtered = apply_context_scope_for_records(
+        filtered, _ = apply_context_scope_for_records(
             records=data,
             context_scope=context_scope,
             action_name="tool_b",

--- a/tests/unit/prompt/context/test_scope_application.py
+++ b/tests/unit/prompt/context/test_scope_application.py
@@ -133,7 +133,7 @@ class TestDropWildcard:
 
 
 class TestFalsyFieldPassthrough:
-    """G-2: falsy values (0, "", False, None) must not be silently dropped."""
+    """Falsy values (0, "", False, None) must not be silently dropped."""
 
     def test_observe_includes_zero_value(self):
         """observe: field with value 0 must appear in llm_context."""
@@ -186,7 +186,7 @@ class TestFalsyFieldPassthrough:
             )
 
     def test_observe_includes_explicit_none_value(self):
-        """G-2 boundary: field whose value IS None must still appear in llm_context.
+        """Field whose value IS None must still appear in llm_context.
         None is a valid observed value — only a missing field should be excluded."""
         field_context = {"dep": {"nullable_field": None}}
         _, llm_context, _ = apply_context_scope(
@@ -197,7 +197,7 @@ class TestFalsyFieldPassthrough:
         assert llm_context["dep"]["nullable_field"] is None
 
     def test_passthrough_nested_path_missing_field_returns_none(self):
-        """G-2 nested-path: missing nested field resolves to None (U-4.2)."""
+        """Missing nested field resolves to None."""
         field_context = {"dep": {"top": {"exists": 1}}}
         _, _, pt = apply_context_scope(
             field_context=field_context,

--- a/tests/unit/prompt/context/test_scope_application.py
+++ b/tests/unit/prompt/context/test_scope_application.py
@@ -105,15 +105,15 @@ class TestDropWildcard:
         # Field must NOT be removed (drop failed to parse — safe failure)
         assert prompt_context["dep"]["api_key"] == "secret"
 
-    def test_wildcard_drop_then_observe_specific_field_returns_none(self):
-        """After drop: ['dep.*'], observe: ['dep.name'] → None (U-4.2)."""
+    def test_wildcard_drop_then_observe_specific_field_raises(self):
+        """After drop: ['dep.*'], observe: ['dep.name'] → raises (contradictory config)."""
         field_context = {"dep": {"api_key": "secret", "name": "test", "value": "data"}}
-        _, llm_ctx, _ = apply_context_scope(
-            field_context=field_context,
-            context_scope={"drop": ["dep.*"], "observe": ["dep.name"]},
-            action_name="test_action",
-        )
-        assert llm_ctx["dep"]["name"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(
+                field_context=field_context,
+                context_scope={"drop": ["dep.*"], "observe": ["dep.name"]},
+                action_name="test_action",
+            )
 
     def test_drop_then_observe_wildcard_excludes_dropped_field(self):
         """Existing security test: drop + observe wildcard must not leak dropped field."""
@@ -175,15 +175,15 @@ class TestFalsyFieldPassthrough:
         )
         assert passthrough["dep"]["enabled"] is False
 
-    def test_missing_field_returns_none(self):
-        """Fields absent from present namespace resolve to None (U-4.2)."""
+    def test_missing_field_raises_for_observe(self):
+        """Fields absent from present namespace raise RecordContextError for observe."""
         field_context = {"dep": {"other": "value"}}
-        _, llm_ctx, _ = apply_context_scope(
-            field_context=field_context,
-            context_scope={"observe": ["dep.missing"]},
-            action_name="test_action",
-        )
-        assert llm_ctx["dep"]["missing"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(
+                field_context=field_context,
+                context_scope={"observe": ["dep.missing"]},
+                action_name="test_action",
+            )
 
     def test_observe_includes_explicit_none_value(self):
         """G-2 boundary: field whose value IS None must still appear in llm_context.

--- a/tests/unit/prompt/context/test_scope_application_file_mode.py
+++ b/tests/unit/prompt/context/test_scope_application_file_mode.py
@@ -43,7 +43,7 @@ class TestAllDirectives:
             "observe": ["extract_qa.question"],
             "drop": ["validate.internal_token_count"],
         }
-        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
         validate = result[0]["content"]["validate"]
         assert "internal_token_count" not in validate
         assert validate["pass"] is True
@@ -54,13 +54,13 @@ class TestAllDirectives:
             "observe": ["extract_qa.question"],
             "passthrough": ["extract_qa.confidence"],
         }
-        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
         assert result[0]["content"]["extract_qa"]["confidence"] == 0.9
 
     def test_observe_injects_flat_keys(self):
         """Observe refs inject flat keys at the top level of content."""
         scope = {"observe": ["extract_qa.question", "extract_qa.answer"]}
-        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
         content = result[0]["content"]
         assert content["question"] == "What is X?"
         assert content["answer"] == "Y"
@@ -72,7 +72,7 @@ class TestAllDirectives:
             "drop": ["validate.internal_token_count"],
             "passthrough": ["extract_qa.confidence"],
         }
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             [deepcopy(RECORD)], scope, action_name="test", source_data=SOURCE_DATA
         )
         content = result[0]["content"]
@@ -92,7 +92,7 @@ class TestGuardVisibility:
     def test_all_namespaces_preserved(self):
         """Guards see ALL namespaces, not gated to observed ones only."""
         scope = {"observe": ["extract_qa.question"]}
-        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
         content = result[0]["content"]
         assert "extract_qa" in content
         assert "validate" in content
@@ -100,7 +100,7 @@ class TestGuardVisibility:
     def test_metadata_fields_preserved_on_record(self):
         """source_guid, node_id, etc. preserved on the record envelope."""
         scope = {"observe": ["extract_qa.question"]}
-        result = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([deepcopy(RECORD)], scope, action_name="test")
         assert result[0]["source_guid"] == "guid-1"
         assert result[0]["node_id"] == "node_123"
 
@@ -118,7 +118,7 @@ class TestCollisionDetection:
             },
         }
         scope = {"observe": ["action_a.*", "action_b.*"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         content = result[0]["content"]
         assert content["action_a.name"] == "Alice"
         assert content["action_b.name"] == "Bob"
@@ -134,7 +134,7 @@ class TestCollisionDetection:
             },
         }
         scope = {"observe": ["ns_a.id", "ns_b.id"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         content = result[0]["content"]
         assert content["ns_a.id"] == "a1"
         assert content["ns_b.id"] == "b1"
@@ -148,7 +148,7 @@ class TestCollisionDetection:
             },
         }
         scope = {"observe": ["ns_a.name", "ns_b.score"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         content = result[0]["content"]
         assert content["name"] == "Alice"
         assert content["score"] == 10
@@ -157,7 +157,7 @@ class TestCollisionDetection:
         """Single wildcard namespace -> bare keys (no qualification needed)."""
         record = {"content": {"dep": {"a": 1, "b": 2}}}
         scope = {"observe": ["dep.*"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         content = result[0]["content"]
         assert content["a"] == 1
         assert content["b"] == 2
@@ -170,20 +170,24 @@ class TestEmptyObserve:
     def test_empty_scope_returns_records_unchanged(self):
         """No directives = records returned as-is (identity)."""
         records = [deepcopy(RECORD)]
-        result = apply_context_scope_for_records(records, {}, action_name="test")
+        result, skipped = apply_context_scope_for_records(records, {}, action_name="test")
         assert result is records  # same list reference (no copy)
+        assert skipped == []
 
     def test_empty_lists_returns_records_unchanged(self):
         """Explicit empty lists = records returned as-is."""
         records = [deepcopy(RECORD)]
         scope = {"observe": [], "drop": [], "passthrough": []}
-        result = apply_context_scope_for_records(records, scope, action_name="test")
+        result, _ = apply_context_scope_for_records(records, scope, action_name="test")
         assert result is records
 
     def test_empty_records_list(self):
         """Empty input list returns empty output."""
-        result = apply_context_scope_for_records([], {"observe": ["x.y"]}, action_name="test")
+        result, skipped = apply_context_scope_for_records(
+            [], {"observe": ["x.y"]}, action_name="test"
+        )
         assert result == []
+        assert skipped == []
 
 
 # ── Source resolution ─────────────────────────────────────────────────
@@ -197,7 +201,7 @@ class TestSourceResolution:
             {"source_guid": "guid-2", "content": {"dep": {"f": 2}}},
         ]
         scope = {"observe": ["source.url", "dep.f"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records, scope, action_name="test", source_data=SOURCE_DATA
         )
         assert result[0]["content"]["url"] == "http://1.com"
@@ -207,25 +211,27 @@ class TestSourceResolution:
         """Unknown source_guid falls back to first source record."""
         records = [{"source_guid": "unknown", "content": {"dep": {"f": 1}}}]
         scope = {"observe": ["source.url", "dep.f"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records, scope, action_name="test", source_data=SOURCE_DATA
         )
         assert result[0]["content"]["url"] == "http://1.com"
 
     def test_no_source_data_with_source_refs_skips_record(self):
-        """Explicit source ref without source_data skips enrichment for that record."""
-        records = [{"content": {"dep": {"f": 1}}}]
+        """Explicit source ref without source_data → record skipped (source namespace absent)."""
+        records = [{"source_guid": "g1", "content": {"dep": {"f": 1}}}]
         scope = {"observe": ["source.url"]}
-        result = apply_context_scope_for_records(
+        enriched, skipped = apply_context_scope_for_records(
             records, scope, action_name="test", source_data=None
         )
-        assert result[0] is records[0]
+        assert len(enriched) == 0
+        assert len(skipped) == 1
+        assert skipped[0]["source_guid"] == "g1"
 
     def test_no_source_refs_skips_resolution(self):
         """If no directive references source, source_data is ignored."""
         records = [deepcopy(RECORD)]
         scope = {"observe": ["extract_qa.question"]}
-        result = apply_context_scope_for_records(
+        result, _ = apply_context_scope_for_records(
             records, scope, action_name="test", source_data=SOURCE_DATA
         )
         # Source not injected since no source.* refs
@@ -245,7 +251,7 @@ class TestNoneNamespace:
             },
         }
         scope = {"observe": ["skipped.*", "active.field"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         content = result[0]["content"]
         assert content["field"] == "value"
         assert "skipped" in content  # None namespace preserved for guards
@@ -254,7 +260,7 @@ class TestNoneNamespace:
         """Explicit field ref on guard-skipped namespace resolves as None (null-safe)."""
         record = {"content": {"skipped": None}}
         scope = {"observe": ["skipped.field"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         # Record is enriched (not skipped) — null namespace preserved in content
         assert result[0]["content"]["skipped"] is None
 
@@ -270,7 +276,7 @@ class TestDropPassthroughInteraction:
             "passthrough": ["dep.secret", "dep.public"],
             "drop": ["dep.secret"],
         }
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         assert "secret" not in result[0]["content"]["dep"]
         assert result[0]["content"]["dep"]["public"] == "p"
 
@@ -278,7 +284,7 @@ class TestDropPassthroughInteraction:
         """drop: [dep.*] clears all fields from the namespace."""
         record = {"content": {"dep": {"a": 1, "b": 2}, "other": {"c": 3}}}
         scope = {"observe": ["other.c"], "drop": ["dep.*"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         assert result[0]["content"]["dep"] == {}
         assert result[0]["content"]["other"]["c"] == 3
 
@@ -286,7 +292,7 @@ class TestDropPassthroughInteraction:
         """Dropped fields must not appear as flat observed keys."""
         record = {"content": {"dep": {"secret": "s", "name": "n"}}}
         scope = {"observe": ["dep.*"], "drop": ["dep.secret"]}
-        result = apply_context_scope_for_records([record], scope, action_name="test")
+        result, _ = apply_context_scope_for_records([record], scope, action_name="test")
         content = result[0]["content"]
         assert "secret" not in {k for k in content if not isinstance(content[k], dict)}
         assert content["name"] == "n"
@@ -303,7 +309,7 @@ class TestMultipleRecords:
             {"content": {"dep": {"field": "B"}}},
         ]
         scope = {"observe": ["dep.field"]}
-        result = apply_context_scope_for_records(records, scope, action_name="test")
+        result, _ = apply_context_scope_for_records(records, scope, action_name="test")
         assert result[0]["content"]["field"] == "A"
         assert result[1]["content"]["field"] == "B"
 
@@ -314,3 +320,68 @@ class TestMultipleRecords:
         scope = {"drop": ["validate.internal_token_count"], "observe": ["extract_qa.*"]}
         apply_context_scope_for_records(records, scope, action_name="test")
         assert records[0]["content"] == original["content"]
+
+
+# ── Observe field missing from present namespace ─────────────────────
+
+
+class TestObserveFieldMissing:
+    """When upstream ran but produced incomplete output, observe-referenced
+    fields that are missing from a present (non-null) namespace should cause
+    the record to be skipped — not silently filled with None."""
+
+    def test_missing_observe_field_skips_record(self):
+        """Record with present namespace but missing observe field goes to skipped."""
+        record = {"source_guid": "g1", "content": {"dep": {"other": "x"}}}
+        scope = {"observe": ["dep.nonexistent"]}
+        enriched, skipped = apply_context_scope_for_records([record], scope, action_name="test")
+        assert len(enriched) == 0
+        assert len(skipped) == 1
+        assert skipped[0]["source_guid"] == "g1"
+        assert skipped[0]["reason"] == "observe_field_missing"
+
+    def test_passthrough_missing_field_still_enriches(self):
+        """Passthrough of missing field from present namespace still enriches (None-safe)."""
+        record = {"source_guid": "g1", "content": {"dep": {"actual": "value"}}}
+        scope = {"passthrough": ["dep.nonexistent"]}
+        enriched, skipped = apply_context_scope_for_records([record], scope, action_name="test")
+        assert len(enriched) == 1
+        assert len(skipped) == 0
+
+    def test_mixed_records_some_skip_some_enrich(self):
+        """Batch with good and bad records: good enriched, bad skipped."""
+        good = {"source_guid": "g1", "content": {"dep": {"field": "ok"}}}
+        bad = {"source_guid": "g2", "content": {"dep": {"other": "x"}}}
+        scope = {"observe": ["dep.field"]}
+        enriched, skipped = apply_context_scope_for_records([good, bad], scope, action_name="test")
+        assert len(enriched) == 1
+        assert enriched[0]["source_guid"] == "g1"
+        assert len(skipped) == 1
+        assert skipped[0]["source_guid"] == "g2"
+
+    def test_summary_warning_logged(self):
+        """One summary WARNING for N skipped records, not N individual warnings."""
+        from unittest.mock import patch
+
+        records = [{"source_guid": f"g{i}", "content": {"dep": {"other": "x"}}} for i in range(5)]
+        scope = {"observe": ["dep.missing_field"]}
+        with patch("agent_actions.prompt.context.scope_application.logger") as mock_logger:
+            enriched, skipped = apply_context_scope_for_records(
+                records, scope, action_name="test_action"
+            )
+        assert len(skipped) == 5
+        # Per-record logs are DEBUG, not WARNING
+        for call in mock_logger.warning.call_args_list:
+            assert "Skipping record" not in str(call)
+        # One summary WARNING
+        assert mock_logger.warning.call_count == 1
+        summary_msg = mock_logger.warning.call_args[0][0] % mock_logger.warning.call_args[0][1:]
+        assert "5 of 5 records skipped" in summary_msg
+
+    def test_null_namespace_still_enriches(self):
+        """Null namespace (guard-skipped upstream) still enriches — not skipped."""
+        record = {"source_guid": "g1", "content": {"skipped": None}}
+        scope = {"observe": ["skipped.field"]}
+        enriched, skipped = apply_context_scope_for_records([record], scope, action_name="test")
+        assert len(enriched) == 1
+        assert len(skipped) == 0

--- a/tests/unit/security/test_security_drop_observe.py
+++ b/tests/unit/security/test_security_drop_observe.py
@@ -39,18 +39,21 @@ class TestDropObserveNoLeak:
         assert "name" in llm_context["dep"]
         assert "value" in llm_context["dep"]
 
-    def test_drop_then_observe_single_field_returns_none(self):
-        """Dropped field resolves to None — secret not leaked (U-4.2)."""
+    def test_drop_then_observe_single_field_raises(self):
+        """Dropped field raises when observed — secret not leaked, config contradiction caught."""
+        import pytest
+
+        from agent_actions.errors import ConfigurationError
         from agent_actions.prompt.context.scope_application import apply_context_scope
 
         field_context = {"dep": {"secret": "hunter2", "public": "hello"}}
 
-        _, llm_ctx, _ = apply_context_scope(
-            field_context=field_context,
-            context_scope={"drop": ["dep.secret"], "observe": ["dep.secret"]},
-            action_name="test",
-        )
-        assert llm_ctx["dep"]["secret"] is None  # None, NOT "hunter2"
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(
+                field_context=field_context,
+                context_scope={"drop": ["dep.secret"], "observe": ["dep.secret"]},
+                action_name="test",
+            )
 
 
 class TestPathTraversalRejection:

--- a/tests/unit/unification/test_observe_missing_field_behavior.py
+++ b/tests/unit/unification/test_observe_missing_field_behavior.py
@@ -1,4 +1,4 @@
-"""Phase 9a: Guard/Observe null safety tests — U-4.2.
+"""Observe missing field behavior tests.
 
 Tests that observe correctly handles missing fields:
 - Null namespace (guard-skipped) → resolves to None (safe)
@@ -22,7 +22,7 @@ def _make_field_context(**namespaces):
 
 
 class TestObserveNullSafety:
-    """U-4.2 revised: Observe raises for missing fields in present namespaces."""
+    """Observe raises for missing fields in present namespaces."""
 
     def test_observe_missing_field_raises(self):
         """Observing a field that doesn't exist in a present namespace → raises."""

--- a/tests/unit/unification/test_phase9a_observe_null.py
+++ b/tests/unit/unification/test_phase9a_observe_null.py
@@ -1,10 +1,13 @@
 """Phase 9a: Guard/Observe null safety tests — U-4.2.
 
-Tests that observe resolves missing fields from present namespaces to None
-(matching guard semantics) instead of raising RecordContextError.
+Tests that observe correctly handles missing fields:
+- Null namespace (guard-skipped) → resolves to None (safe)
+- Present namespace, missing field → raises RecordContextError (prevents
+  garbage LLM output from None injection)
+- Absent namespace → raises RecordContextError (config bug)
 
-Preflight still catches config typos. Only VALID references to
-legitimately-missing data resolve to null at runtime.
+Passthrough still resolves missing fields to None (matching guard semantics)
+since passthrough fields are not rendered into prompts.
 """
 
 import pytest
@@ -19,28 +22,27 @@ def _make_field_context(**namespaces):
 
 
 class TestObserveNullSafety:
-    """U-4.2: Observe must resolve missing fields to None, not throw."""
+    """U-4.2 revised: Observe raises for missing fields in present namespaces."""
 
-    def test_observe_missing_field_returns_none(self):
-        """Observing a field that doesn't exist in a present namespace → None, not error."""
+    def test_observe_missing_field_raises(self):
+        """Observing a field that doesn't exist in a present namespace → raises."""
         fc = _make_field_context(upstream_step={"field_a": "value"})
-        _prompt_ctx, llm_ctx, _ = apply_context_scope(
-            field_context=fc,
-            context_scope={"observe": ["upstream_step.field_b"]},
-            action_name="downstream",
-        )
-        assert llm_ctx["upstream_step"]["field_b"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["upstream_step.field_b"]},
+                action_name="downstream",
+            )
 
-    def test_observe_missing_field_preserves_present_fields(self):
-        """Missing field returns None without affecting existing field resolution."""
+    def test_observe_missing_field_raises_even_with_present_fields(self):
+        """Missing field raises even when other fields in the namespace exist."""
         fc = _make_field_context(dep={"real_field": "real_value"})
-        _prompt_ctx, llm_ctx, _ = apply_context_scope(
-            field_context=fc,
-            context_scope={"observe": ["dep.real_field", "dep.ghost_field"]},
-            action_name="downstream",
-        )
-        assert llm_ctx["dep"]["real_field"] == "real_value"
-        assert llm_ctx["dep"]["ghost_field"] is None
+        with pytest.raises(ConfigurationError, match="not found in namespace"):
+            apply_context_scope(
+                field_context=fc,
+                context_scope={"observe": ["dep.real_field", "dep.ghost_field"]},
+                action_name="downstream",
+            )
 
     def test_observe_undeclared_namespace_still_raises(self):
         """Namespace not in field_context at all → still errors (config bug)."""
@@ -62,18 +64,12 @@ class TestObserveNullSafety:
         )
         assert llm_ctx["skipped"]["field"] is None
 
-    def test_guard_and_observe_agree_on_missing(self):
-        """Guard returns None for missing field; observe must do the same.
-
-        Guards treat missing fields as 'condition not matched' (falsy/None).
-        Observe must resolve the same field to None — not throw.
-        """
+    def test_passthrough_missing_field_returns_none(self):
+        """Passthrough still resolves missing field to None (not rendered in prompts)."""
         fc = _make_field_context(ns={"existing": "value"})
-        # Observe a field that doesn't exist → should be None (matching guard)
-        _prompt_ctx, llm_ctx, _ = apply_context_scope(
+        _prompt_ctx, _llm_ctx, pt = apply_context_scope(
             field_context=fc,
-            context_scope={"observe": ["ns.missing"]},
+            context_scope={"passthrough": ["ns.missing"]},
             action_name="downstream",
         )
-        observe_result = llm_ctx["ns"]["missing"]
-        assert observe_result is None
+        assert pt["ns"]["missing"] is None

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -326,7 +326,7 @@ def test_file_mode_hitl_observe_filters_and_orders_fields():
 
     # Apply the filter using unified context_scope
     context_scope = action_config.get("context_scope", {})
-    filtered = apply_context_scope_for_records(
+    filtered, _ = apply_context_scope_for_records(
         records=original_data,
         context_scope=context_scope,
         action_name="review_data",
@@ -503,7 +503,7 @@ def test_file_mode_hitl_bad_namespace_in_observe_warns():
 def test_no_observe_returns_data_as_is():
     """Without observe config, apply_context_scope_for_records returns data unchanged."""
     data = [{"content": {"a": 1, "b": 2}}]
-    result = apply_context_scope_for_records(records=data, context_scope={}, action_name="test")
+    result, _ = apply_context_scope_for_records(records=data, context_scope={}, action_name="test")
     assert result is data
 
 
@@ -517,7 +517,7 @@ def test_observe_extracts_from_namespace():
         },
     ]
     context_scope = {"observe": ["upstream.question", "upstream.answer"]}
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data, context_scope=context_scope, action_name="test"
     )
     assert result[0]["content"]["question"] == "Q1"
@@ -533,7 +533,7 @@ def test_wildcard_observe_preserves_all_content():
         {"content": {"upstream": {"question": "Q2", "answer": "A2", "extra": "also keep"}}},
     ]
     context_scope = {"observe": ["upstream.*"]}
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data, context_scope=context_scope, action_name="test"
     )
     assert result[0]["content"]["question"] == "Q1"
@@ -553,7 +553,7 @@ def test_collision_uses_qualified_keys():
         },
     ]
     context_scope = {"observe": ["dep_a.title", "dep_b.title", "dep_a.body"]}
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data, context_scope=context_scope, action_name="test"
     )
     assert result[0]["content"]["dep_a.title"] == "Title from A"
@@ -571,7 +571,7 @@ def test_no_collision_stays_bare():
         },
     ]
     context_scope = {"observe": ["upstream.question", "upstream.answer"]}
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data, context_scope=context_scope, action_name="test"
     )
     assert result[0]["content"]["question"] == "Q1"
@@ -589,7 +589,7 @@ def test_invalid_ref_does_not_misalign_pairs():
         },
     ]
     context_scope = {"observe": ["dep_a.title", "bad_ref_no_dot", "dep_b.title", "dep_a.body"]}
-    result = apply_context_scope_for_records(
+    result, _ = apply_context_scope_for_records(
         records=data, context_scope=context_scope, action_name="test"
     )
     # "title" collides → qualified


### PR DESCRIPTION
## Summary
- When an observe directive references a field missing from a present (non-null) namespace, `_resolve_missing_field` now raises `RecordContextError` instead of silently returning `None`. This prevents garbage LLM output from None values cascading through downstream actions.
- `apply_context_scope_for_records` (FILE mode) returns `(enriched, skipped)` tuple. Skipped records get `DISPOSITION_SKIPPED` with reason `observe_field_missing` via batch disposition write.
- Per-record WARNING logs replaced with one summary WARNING (`"N of M records skipped"`). Per-record logs demoted to DEBUG.
- Exception catch narrowed from `ConfigurationError` to `RecordContextError` — true config bugs now propagate instead of being silently swallowed.

## Verification
- `ruff check` — clean
- `ruff format --check` — clean
- `pytest` — 7443 passed, 2 skipped