### PR TITLE
fix(processing): empty dict [{}] bypasses _is_empty_output; reprompt exhaustion produces SUCCESS

### DIFF
--- a/.changes/unreleased/Bug Fix-20260604-539000.yaml
+++ b/.changes/unreleased/Bug Fix-20260604-539000.yaml
@@ -1,0 +1,3 @@
+kind: Bug Fix
+body: "Empty dict responses [{}] no longer bypass _is_empty_output check; reprompt exhaustion now routes through EXHAUSTED disposition instead of SUCCESS"
+time: 2026-06-04T05:39:00.000000Z

--- a/agent_actions/processing/invocation/online.py
+++ b/agent_actions/processing/invocation/online.py
@@ -164,7 +164,7 @@ class OnlineStrategy(InvocationStrategy):
             context=f"action={context.agent_name}",
         )
 
-        if reprompt_result.attempts > 1:
+        if reprompt_result.attempts > 1 or reprompt_result.exhausted:
             recovery_metadata.reprompt = RepromptMetadata(
                 attempts=reprompt_result.attempts,
                 passed=reprompt_result.passed,
@@ -173,6 +173,14 @@ class OnlineStrategy(InvocationStrategy):
                 schema_fail_count=reprompt_result.schema_fail_count,
                 udf_fail_count=reprompt_result.udf_fail_count,
             )
+
+        if reprompt_result.exhausted:
+            logger.warning(
+                "Reprompt exhausted for action %s after %d attempts",
+                context.agent_name,
+                reprompt_result.attempts,
+            )
+            return None, False, recovery_metadata
 
         return reprompt_result.response, reprompt_result.executed, recovery_metadata
 
@@ -219,5 +227,6 @@ class OnlineStrategy(InvocationStrategy):
                 context.agent_name,
                 reprompt_result.attempts,
             )
+            return None, False, recovery_metadata
 
         return reprompt_result.response, reprompt_result.executed, recovery_metadata

--- a/agent_actions/processing/record_helpers.py
+++ b/agent_actions/processing/record_helpers.py
@@ -82,8 +82,9 @@ def build_exhausted_tombstone(
     *,
     source_guid: str | None = None,
     extra_metadata: dict[str, Any] | None = None,
+    reason: str = RETRY_EXHAUSTED,
 ) -> dict[str, Any]:
-    """Build an exhausted-retry tombstone that preserves existing content.
+    """Build an exhausted tombstone that preserves existing content.
 
     Unlike :func:`build_tombstone`, exhausted records need to carry
     the existing content (upstream namespaces) merged with an empty
@@ -96,14 +97,14 @@ def build_exhausted_tombstone(
     item = RecordEnvelope.build(action_name, empty_content, input_record)
     item["source_guid"] = source_guid
     item["metadata"] = {
-        "reason": RETRY_EXHAUSTED,
+        "reason": reason,
         "retry_exhausted": True,
         "agent_type": "tombstone",
     }
     if extra_metadata:
         item["metadata"].update(extra_metadata)
     item["_tombstone"] = True
-    item["_tombstone_reason"] = RETRY_EXHAUSTED
+    item["_tombstone_reason"] = reason
     carry_framework_fields(input_record, item, fields=("target_id",))
     return item
 

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -359,15 +359,6 @@ class RepromptService:
                 f"(validation: {self.validation_name})"
             )
 
-        if get_parse_error_marker(last_response) is not None:
-            logger.warning(
-                "[%s] Exhausted after %d attempts with persistent parse errors "
-                "— returning empty fields so downstream actions are not blocked",
-                context,
-                attempts,
-            )
-            last_response = [{}]
-
         return RepromptResult(
             response=last_response,
             executed=True,  # LLM was executed, validation just failed

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -50,6 +50,8 @@ from agent_actions.record.reasons import (
     LLM_LAYER_GUARD_FILTER,
     LLM_LAYER_GUARD_SKIP,
     PREP_FAILED,
+    REPROMPT_EXHAUSTED,
+    RETRY_EXHAUSTED,
     UPSTREAM_UNPROCESSED,
 )
 from agent_actions.record.state import RecordState
@@ -63,8 +65,13 @@ def _is_empty_output(response: Any) -> bool:
     """Check if a tool/LLM response is effectively empty."""
     if response is None:
         return True
-    if isinstance(response, dict | list) and len(response) == 0:
+    if isinstance(response, dict) and len(response) == 0:
         return True
+    if isinstance(response, list):
+        if len(response) == 0:
+            return True
+        if all(isinstance(item, dict) and len(item) == 0 for item in response):
+            return True
     return False
 
 
@@ -434,18 +441,32 @@ class OnlineLLMStrategy:
         # Not executed — exhausted, filtered, or guard skip
         if not executed:
             if response is None:
-                if recovery_metadata and recovery_metadata.retry:
+                if recovery_metadata and (recovery_metadata.retry or recovery_metadata.reprompt):
                     empty_content = ExhaustedRecordBuilder.build_empty_content(
                         cast(dict[str, Any], context.agent_config)
                     )
+                    if recovery_metadata.retry:
+                        tombstone_reason = RETRY_EXHAUSTED
+                        error_msg = (
+                            f"Retry exhausted after {recovery_metadata.retry.attempts} attempts"
+                        )
+                    else:
+                        reprompt = recovery_metadata.reprompt
+                        assert reprompt is not None
+                        tombstone_reason = REPROMPT_EXHAUSTED
+                        error_msg = (
+                            f"Reprompt exhausted after {reprompt.attempts} attempts "
+                            f"(validation: {reprompt.validation})"
+                        )
                     tombstone = build_exhausted_tombstone(
                         context.action_name,
                         input_record,
                         empty_content,
                         source_guid=source_guid,
+                        reason=tombstone_reason,
                     )
                     return ProcessingResult.exhausted(
-                        error=f"Retry exhausted after {recovery_metadata.retry.attempts} attempts",
+                        error=error_msg,
                         data=[tombstone],
                         source_guid=source_guid,
                         recovery_metadata=recovery_metadata,

--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -34,6 +34,7 @@ EMPTY_OUTPUT = "empty_output"
 
 # -- Exhaustion --------------------------------------------------------------
 RETRY_EXHAUSTED = "retry_exhausted"
+REPROMPT_EXHAUSTED = "reprompt_exhausted"
 
 # -- Disposition fallbacks ---------------------------------------------------
 UNPROCESSED = "unprocessed"

--- a/tests/processing/test_empty_output_detection.py
+++ b/tests/processing/test_empty_output_detection.py
@@ -46,6 +46,25 @@ class TestIsEmptyOutput:
     def test_false_is_not_empty(self):
         assert _is_empty_output(False) is False
 
+    def test_list_of_one_empty_dict_is_empty(self):
+        """[{}] is effectively empty — no usable fields in any item."""
+        assert _is_empty_output([{}]) is True
+
+    def test_list_of_two_empty_dicts_is_empty(self):
+        """[{}, {}] is effectively empty — all items are empty dicts."""
+        assert _is_empty_output([{}, {}]) is True
+
+    def test_list_with_mixed_dicts_is_not_empty(self):
+        """[{}, {"key": "val"}] has at least one non-empty item."""
+        assert _is_empty_output([{}, {"key": "val"}]) is False
+
+    def test_list_with_non_empty_dict_is_not_empty(self):
+        assert _is_empty_output([{"key": "val"}]) is False
+
+    def test_list_with_non_dict_items_is_not_empty(self):
+        """[1, 2] — non-dict items are not considered empty dicts."""
+        assert _is_empty_output([1, 2]) is False
+
 
 # =============================================================================
 # RecordEmptyOutputEvent tests

--- a/tests/unit/core/test_reprompt_service.py
+++ b/tests/unit/core/test_reprompt_service.py
@@ -829,8 +829,13 @@ class TestRepromptServiceParseError:
         assert "not valid JSON" in second_call_prompt
         assert "No markdown" in second_call_prompt
 
-    def test_parse_error_exhaustion_returns_empty(self):
-        """On exhaustion with persistent parse errors, return [{}] not the error dict."""
+    def test_parse_error_exhaustion_preserves_last_response(self):
+        """On exhaustion with persistent parse errors, preserve the last response as-is.
+
+        The caller (OnlineStrategy) detects exhaustion via RepromptResult.exhausted
+        and routes through the EXHAUSTED disposition path instead of treating the
+        response as SUCCESS output.
+        """
         service = RepromptService(
             validation_name="always_pass", max_attempts=2, on_exhausted="return_last"
         )
@@ -847,7 +852,7 @@ class TestRepromptServiceParseError:
         )
 
         assert llm_operation.call_count == 2
-        assert result.response == [{}]
+        assert result.response == [{"raw_response": "", "_parse_error": "Expecting value"}]
         assert result.passed is False
         assert result.exhausted is True
 

--- a/tests/unit/processing/test_reprompt_exhaustion_disposition.py
+++ b/tests/unit/processing/test_reprompt_exhaustion_disposition.py
@@ -29,6 +29,44 @@ def basic_context():
     )
 
 
+@pytest.fixture()
+def reprompt_exhausted_result():
+    """Run process_record with a reprompt-exhausted invocation result."""
+    from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+
+    mock_invocation = MagicMock()
+    mock_invocation.invoke.return_value = InvocationResult.immediate(
+        response=None,
+        executed=False,
+        recovery=RecoveryMetadata(
+            reprompt=RepromptMetadata(
+                attempts=3,
+                passed=False,
+                validation="check_json",
+                parse_error_count=3,
+            )
+        ),
+    )
+
+    agent_config = {"name": "test_action", "intent": "test"}
+    strategy = OnlineLLMStrategy(agent_config, "test_action", invocation_strategy=mock_invocation)
+    context = ProcessingContext(agent_config=agent_config, agent_name="test_action", record_index=0)
+
+    with patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_tp:
+        mock_prepared = MagicMock()
+        mock_prepared.source_guid = "sg-1"
+        mock_prepared.source_snapshot = None
+        mock_prepared.original_content = {"field1": "val1"}
+        mock_prepared.guard_status = None
+        mock_tp.return_value.prepare.return_value = mock_prepared
+
+        return strategy.process_record(
+            {"content": {"field1": "val1"}, "source_guid": "sg-1"},
+            context,
+            skip_guard=False,
+        )
+
+
 class TestOnlineStrategyRepromptExhaustion:
     """Reprompt exhaustion must signal executed=False so online_llm routes to EXHAUSTED."""
 
@@ -116,131 +154,13 @@ class TestOnlineStrategyRepromptExhaustion:
 class TestProcessRecordRepromptExhaustion:
     """process_record must produce EXHAUSTED status for reprompt exhaustion."""
 
-    def test_reprompt_exhaustion_produces_exhausted_result(self):
+    def test_reprompt_exhaustion_produces_exhausted_tombstone(self, reprompt_exhausted_result):
         """When invocation returns executed=False with reprompt metadata, result is EXHAUSTED."""
-        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+        assert reprompt_exhausted_result.status == ProcessingStatus.EXHAUSTED
+        assert reprompt_exhausted_result.data is not None
+        assert len(reprompt_exhausted_result.data) == 1
+        assert reprompt_exhausted_result.data[0].get("_tombstone") is True
 
-        mock_invocation = MagicMock()
-        mock_invocation.invoke.return_value = InvocationResult.immediate(
-            response=None,
-            executed=False,
-            recovery=RecoveryMetadata(
-                reprompt=RepromptMetadata(
-                    attempts=3,
-                    passed=False,
-                    validation="check_json",
-                    parse_error_count=3,
-                )
-            ),
-        )
-
-        agent_config = {"name": "test_action", "intent": "test"}
-        strategy = OnlineLLMStrategy(
-            agent_config, "test_action", invocation_strategy=mock_invocation
-        )
-        context = ProcessingContext(
-            agent_config=agent_config, agent_name="test_action", record_index=0
-        )
-
-        with patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_tp:
-            mock_prepared = MagicMock()
-            mock_prepared.source_guid = "sg-1"
-            mock_prepared.source_snapshot = None
-            mock_prepared.original_content = {"field1": "val1"}
-            mock_prepared.guard_status = None
-            mock_tp.return_value.prepare.return_value = mock_prepared
-
-            result = strategy.process_record(
-                {"content": {"field1": "val1"}, "source_guid": "sg-1"},
-                context,
-                skip_guard=False,
-            )
-
-        assert result.status == ProcessingStatus.EXHAUSTED
-        assert result.data is not None
-        assert len(result.data) == 1
-        assert result.data[0].get("_tombstone") is True
-
-    def test_reprompt_exhaustion_not_success(self):
-        """Reprompt exhaustion must never produce SUCCESS status."""
-        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
-
-        mock_invocation = MagicMock()
-        mock_invocation.invoke.return_value = InvocationResult.immediate(
-            response=None,
-            executed=False,
-            recovery=RecoveryMetadata(
-                reprompt=RepromptMetadata(
-                    attempts=2,
-                    passed=False,
-                    validation="check_json",
-                    parse_error_count=2,
-                )
-            ),
-        )
-
-        agent_config = {"name": "test_action", "intent": "test"}
-        strategy = OnlineLLMStrategy(
-            agent_config, "test_action", invocation_strategy=mock_invocation
-        )
-        context = ProcessingContext(
-            agent_config=agent_config, agent_name="test_action", record_index=0
-        )
-
-        with patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_tp:
-            mock_prepared = MagicMock()
-            mock_prepared.source_guid = "sg-1"
-            mock_prepared.source_snapshot = None
-            mock_prepared.original_content = {"field1": "val1"}
-            mock_prepared.guard_status = None
-            mock_tp.return_value.prepare.return_value = mock_prepared
-
-            result = strategy.process_record(
-                {"content": {"field1": "val1"}, "source_guid": "sg-1"},
-                context,
-                skip_guard=False,
-            )
-
-        assert result.status != ProcessingStatus.SUCCESS
-
-    def test_reprompt_exhaustion_tombstone_reason_is_reprompt(self):
+    def test_reprompt_exhaustion_tombstone_reason_is_reprompt(self, reprompt_exhausted_result):
         """Tombstone must carry _tombstone_reason='reprompt_exhausted', not 'retry_exhausted'."""
-        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
-
-        mock_invocation = MagicMock()
-        mock_invocation.invoke.return_value = InvocationResult.immediate(
-            response=None,
-            executed=False,
-            recovery=RecoveryMetadata(
-                reprompt=RepromptMetadata(
-                    attempts=3,
-                    passed=False,
-                    validation="check_json",
-                    parse_error_count=3,
-                )
-            ),
-        )
-
-        agent_config = {"name": "test_action", "intent": "test"}
-        strategy = OnlineLLMStrategy(
-            agent_config, "test_action", invocation_strategy=mock_invocation
-        )
-        context = ProcessingContext(
-            agent_config=agent_config, agent_name="test_action", record_index=0
-        )
-
-        with patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_tp:
-            mock_prepared = MagicMock()
-            mock_prepared.source_guid = "sg-1"
-            mock_prepared.source_snapshot = None
-            mock_prepared.original_content = {"field1": "val1"}
-            mock_prepared.guard_status = None
-            mock_tp.return_value.prepare.return_value = mock_prepared
-
-            result = strategy.process_record(
-                {"content": {"field1": "val1"}, "source_guid": "sg-1"},
-                context,
-                skip_guard=False,
-            )
-
-        assert result.data[0]["_tombstone_reason"] == "reprompt_exhausted"
+        assert reprompt_exhausted_result.data[0]["_tombstone_reason"] == "reprompt_exhausted"

--- a/tests/unit/processing/test_reprompt_exhaustion_disposition.py
+++ b/tests/unit/processing/test_reprompt_exhaustion_disposition.py
@@ -1,0 +1,246 @@
+"""Tests that reprompt exhaustion produces EXHAUSTED disposition, not SUCCESS.
+
+When reprompt exhausts max_attempts with persistent parse errors, the record
+must be routed through ProcessingResult.exhausted() — not through the SUCCESS
+transform path with an empty dict sentinel.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.processing.invocation.online import OnlineStrategy
+from agent_actions.processing.invocation.result import InvocationResult
+from agent_actions.processing.recovery.reprompt import RepromptResult
+from agent_actions.processing.types import (
+    ProcessingContext,
+    ProcessingStatus,
+    RecoveryMetadata,
+    RepromptMetadata,
+)
+
+
+@pytest.fixture()
+def basic_context():
+    return ProcessingContext(
+        agent_config={"name": "test_action", "intent": "test"},
+        agent_name="test_action",
+        record_index=0,
+    )
+
+
+class TestOnlineStrategyRepromptExhaustion:
+    """Reprompt exhaustion must signal executed=False so online_llm routes to EXHAUSTED."""
+
+    def test_reprompt_exhaustion_returns_not_executed(self, basic_context):
+        """_invoke_with_reprompt returns executed=False when exhausted."""
+        reprompt_service = MagicMock()
+        reprompt_service.execute.return_value = RepromptResult(
+            response=[{"_parse_error": "Failed to parse JSON"}],
+            executed=True,
+            attempts=3,
+            passed=False,
+            validation_name="check_json",
+            exhausted=True,
+            parse_error_count=3,
+        )
+
+        strategy = OnlineStrategy(reprompt_service=reprompt_service)
+        task = MagicMock()
+        task.should_execute = True
+        task.is_passthrough = False
+        task.passthrough_fields = {}
+        task.formatted_prompt = "test"
+
+        result = strategy.invoke(task, basic_context)
+
+        assert result.response is None
+        assert result.executed is False
+        assert result.recovery_metadata is not None
+        assert result.recovery_metadata.reprompt is not None
+        assert result.recovery_metadata.reprompt.passed is False
+
+    def test_reprompt_exhaustion_with_retry_returns_not_executed(self, basic_context):
+        """_invoke_with_retry_and_reprompt returns executed=False when reprompt exhausted."""
+        from agent_actions.processing.recovery.retry import RetryService
+
+        retry_service = MagicMock(spec=RetryService)
+        reprompt_service = MagicMock()
+        reprompt_service.execute.return_value = RepromptResult(
+            response=[{"_parse_error": "Failed to parse JSON"}],
+            executed=True,
+            attempts=2,
+            passed=False,
+            validation_name="check_json",
+            exhausted=True,
+            parse_error_count=2,
+        )
+
+        strategy = OnlineStrategy(retry_service=retry_service, reprompt_service=reprompt_service)
+        task = MagicMock()
+        task.should_execute = True
+        task.is_passthrough = False
+        task.passthrough_fields = {}
+        task.formatted_prompt = "test"
+
+        result = strategy.invoke(task, basic_context)
+
+        assert result.response is None
+        assert result.executed is False
+
+    def test_successful_reprompt_still_returns_response(self, basic_context):
+        """Non-exhausted reprompt returns the actual response normally."""
+        reprompt_service = MagicMock()
+        reprompt_service.execute.return_value = RepromptResult(
+            response=[{"field": "value"}],
+            executed=True,
+            attempts=2,
+            passed=True,
+            validation_name="check_json",
+            exhausted=False,
+        )
+
+        strategy = OnlineStrategy(reprompt_service=reprompt_service)
+        task = MagicMock()
+        task.should_execute = True
+        task.is_passthrough = False
+        task.passthrough_fields = {}
+        task.formatted_prompt = "test"
+
+        result = strategy.invoke(task, basic_context)
+
+        assert result.response == [{"field": "value"}]
+        assert result.executed is True
+
+
+class TestProcessRecordRepromptExhaustion:
+    """process_record must produce EXHAUSTED status for reprompt exhaustion."""
+
+    def test_reprompt_exhaustion_produces_exhausted_result(self):
+        """When invocation returns executed=False with reprompt metadata, result is EXHAUSTED."""
+        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response=None,
+            executed=False,
+            recovery=RecoveryMetadata(
+                reprompt=RepromptMetadata(
+                    attempts=3,
+                    passed=False,
+                    validation="check_json",
+                    parse_error_count=3,
+                )
+            ),
+        )
+
+        agent_config = {"name": "test_action", "intent": "test"}
+        strategy = OnlineLLMStrategy(
+            agent_config, "test_action", invocation_strategy=mock_invocation
+        )
+        context = ProcessingContext(
+            agent_config=agent_config, agent_name="test_action", record_index=0
+        )
+
+        with patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_tp:
+            mock_prepared = MagicMock()
+            mock_prepared.source_guid = "sg-1"
+            mock_prepared.source_snapshot = None
+            mock_prepared.original_content = {"field1": "val1"}
+            mock_prepared.guard_status = None
+            mock_tp.return_value.prepare.return_value = mock_prepared
+
+            result = strategy.process_record(
+                {"content": {"field1": "val1"}, "source_guid": "sg-1"},
+                context,
+                skip_guard=False,
+            )
+
+        assert result.status == ProcessingStatus.EXHAUSTED
+        assert result.data is not None
+        assert len(result.data) == 1
+        assert result.data[0].get("_tombstone") is True
+
+    def test_reprompt_exhaustion_not_success(self):
+        """Reprompt exhaustion must never produce SUCCESS status."""
+        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response=None,
+            executed=False,
+            recovery=RecoveryMetadata(
+                reprompt=RepromptMetadata(
+                    attempts=2,
+                    passed=False,
+                    validation="check_json",
+                    parse_error_count=2,
+                )
+            ),
+        )
+
+        agent_config = {"name": "test_action", "intent": "test"}
+        strategy = OnlineLLMStrategy(
+            agent_config, "test_action", invocation_strategy=mock_invocation
+        )
+        context = ProcessingContext(
+            agent_config=agent_config, agent_name="test_action", record_index=0
+        )
+
+        with patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_tp:
+            mock_prepared = MagicMock()
+            mock_prepared.source_guid = "sg-1"
+            mock_prepared.source_snapshot = None
+            mock_prepared.original_content = {"field1": "val1"}
+            mock_prepared.guard_status = None
+            mock_tp.return_value.prepare.return_value = mock_prepared
+
+            result = strategy.process_record(
+                {"content": {"field1": "val1"}, "source_guid": "sg-1"},
+                context,
+                skip_guard=False,
+            )
+
+        assert result.status != ProcessingStatus.SUCCESS
+
+    def test_reprompt_exhaustion_tombstone_reason_is_reprompt(self):
+        """Tombstone must carry _tombstone_reason='reprompt_exhausted', not 'retry_exhausted'."""
+        from agent_actions.processing.strategies.online_llm import OnlineLLMStrategy
+
+        mock_invocation = MagicMock()
+        mock_invocation.invoke.return_value = InvocationResult.immediate(
+            response=None,
+            executed=False,
+            recovery=RecoveryMetadata(
+                reprompt=RepromptMetadata(
+                    attempts=3,
+                    passed=False,
+                    validation="check_json",
+                    parse_error_count=3,
+                )
+            ),
+        )
+
+        agent_config = {"name": "test_action", "intent": "test"}
+        strategy = OnlineLLMStrategy(
+            agent_config, "test_action", invocation_strategy=mock_invocation
+        )
+        context = ProcessingContext(
+            agent_config=agent_config, agent_name="test_action", record_index=0
+        )
+
+        with patch("agent_actions.processing.strategies.online_llm.get_task_preparer") as mock_tp:
+            mock_prepared = MagicMock()
+            mock_prepared.source_guid = "sg-1"
+            mock_prepared.source_snapshot = None
+            mock_prepared.original_content = {"field1": "val1"}
+            mock_prepared.guard_status = None
+            mock_tp.return_value.prepare.return_value = mock_prepared
+
+            result = strategy.process_record(
+                {"content": {"field1": "val1"}, "source_guid": "sg-1"},
+                context,
+                skip_guard=False,
+            )
+
+        assert result.data[0]["_tombstone_reason"] == "reprompt_exhausted"


### PR DESCRIPTION
## Summary
- `_is_empty_output([{}])` returned `False` because `len([{}]) == 1` — empty dict responses were stored as SUCCESS with empty action namespaces, crashing downstream actions
- Reprompt exhaustion injected `[{}]` to avoid FAILED disposition loops, but this produced SUCCESS (not EXHAUSTED) in the online path because `write_record_dispositions` only runs in the batch path
- Strengthened `_is_empty_output` to detect lists of all-empty-dicts
- Routed reprompt exhaustion through `executed=False` so `online_llm.py` builds proper exhausted tombstones via `ExhaustedRecordBuilder` → `ProcessingResult.exhausted()` → `DISPOSITION_EXHAUSTED`
- Removed the dead `[{}]` injection in `reprompt.py`
- Added `REPROMPT_EXHAUSTED` reason constant and wired it into tombstones so reprompt vs retry exhaustion is distinguishable in stored records

## Files changed
- `agent_actions/processing/strategies/online_llm.py` — `_is_empty_output` + exhaustion branch widened
- `agent_actions/processing/invocation/online.py` — reprompt exhaustion returns `None, False`
- `agent_actions/processing/recovery/reprompt.py` — removed `[{}]` injection
- `agent_actions/processing/record_helpers.py` — `build_exhausted_tombstone` accepts `reason` param
- `agent_actions/record/reasons.py` — `REPROMPT_EXHAUSTED` constant
- Tests: 6 new tests for `_is_empty_output`, 5 new regression tests for reprompt exhaustion disposition

## Verification
- 7454 tests pass, 2 skipped
- `ruff check` clean, `ruff format --check` clean
- `_is_empty_output([{}])` now returns `True`
- Reprompt exhaustion produces `ProcessingStatus.EXHAUSTED` with `_tombstone_reason="reprompt_exhausted"`