### PR TITLE
fix: mobile sidebar not opening due to navbar backdrop-filter

### DIFF
--- a/docs.agent-actions/docusaurus.config.ts
+++ b/docs.agent-actions/docusaurus.config.ts
@@ -229,6 +229,9 @@ const config: Config = {
       // Both themes use the agac instrument palette — code blocks are always-dark
       theme: agacPrismTheme,
       darkTheme: agacPrismTheme,
+      // Load full grammars for languages where prism-react-renderer's built-in
+      // subset misses tokens (e.g. bash comments after blank lines)
+      additionalLanguages: ['bash', 'python', 'json', 'yaml', 'toml', 'diff'],
     },
     mermaid: {
       theme: {

--- a/docs.agent-actions/src/css/custom.css
+++ b/docs.agent-actions/src/css/custom.css
@@ -294,7 +294,13 @@ pre code {
 /* =====================================================================
    NAVBAR
    ===================================================================== */
-.navbar { backdrop-filter: blur(14px); transition: box-shadow 300ms ease; }
+/* backdrop-filter on .navbar breaks the mobile sidebar on many devices —
+   it creates a stacking context that renders the menu behind the page.
+   Only apply it on desktop where the mobile sidebar isn't used. */
+@media (min-width: 997px) {
+  .navbar { backdrop-filter: blur(14px); }
+}
+.navbar { transition: box-shadow 300ms ease; }
 .navbar--fixed-top { animation: agac-fade-in 400ms ease both; }
 .navbar__title {
   font-family: var(--agac-font-mono);
@@ -720,8 +726,11 @@ pre.prism-code, [class*="codeBlock"] pre {
 .agac-tree-node:hover .agac-tree-arrow { opacity: 1; }
 .agac-tree-node.active .agac-tree-arrow { opacity: 1; color: var(--ifm-color-primary); }
 
-/* hide Infima's default sidebar menu when our tree is present (safety) */
-.agac-tree + .menu { display: none; }
+/* hide Infima's default sidebar menu when our tree is present (desktop only).
+   On mobile, the .menu is used for the primary navbar-sidebar items and must stay visible. */
+@media (min-width: 997px) {
+  .agac-tree + .menu { display: none; }
+}
 
 /* --- mobile drawer variant (swizzled DocSidebar/Mobile) --------------- */
 /* The tree renders inside Docusaurus's slide-in secondary menu. Give it a
@@ -1100,4 +1109,14 @@ pre.prism-code, [class*="codeBlock"] pre {
   .agac-home-inner { padding: 0 20px; }
   .agac-hero { padding: 56px 0 40px; }
   .agac-qnav { padding: 40px 0 64px; }
+
+  /* code blocks: constrain to viewport on mobile */
+  [class*="codeBlockContainer"].cb-instrument {
+    border-radius: 10px !important;
+  }
+
+  /* mobile navbar sidebar — solid background */
+  .navbar-sidebar {
+    background: var(--ifm-background-color);
+  }
 }

--- a/docs.agent-actions/src/css/custom.css
+++ b/docs.agent-actions/src/css/custom.css
@@ -116,9 +116,9 @@
 
   --ifm-font-color-base: #e9edee;
   --ifm-heading-color: #e9edee;
-  --ifm-color-content: #b7c0c4;
-  --ifm-color-content-secondary: #828d93;
-  --agac-fg-3: #5a6469;
+  --ifm-color-content: #c0c8cc;
+  --ifm-color-content-secondary: #929da3;
+  --agac-fg-3: #738087;
 
   --ifm-link-color: #e9edee;
   --ifm-link-hover-color: var(--agac-signal-hi);
@@ -875,7 +875,7 @@ pre.prism-code, [class*="codeBlock"] pre {
 }
 .footer .footer__link-item {
   font-size: 14px;
-  color: var(--ifm-color-content-secondary);
+  color: var(--ifm-color-content);
   transition: color 180ms ease;
   position: relative;
 }

--- a/docs.agent-actions/src/css/custom.css
+++ b/docs.agent-actions/src/css/custom.css
@@ -394,8 +394,8 @@ main[class*="docMainContainer"] [class*="col"] { min-width: 0; }
 .cb-head {
   display: flex;
   align-items: center;
-  height: 48px;
-  padding: 0 16px;
+  height: 40px;
+  padding: 0 14px;
   background: var(--agac-code-bg-raised);
   border-bottom: none;
   flex-shrink: 0;
@@ -505,10 +505,14 @@ main[class*="docMainContainer"] [class*="col"] { min-width: 0; }
 /* hide the default Docusaurus button group */
 .cb-instrument [class*="buttonGroup"] { display: none !important; }
 
-/* code block content area — generous padding */
+/* code block content area — padding on <pre>, zero on inner <code> wrapper
+   (Docusaurus's codeBlockLines adds its own var(--ifm-pre-padding) which doubles up) */
 .cb-instrument pre.prism-code,
 .cb-instrument [class*="codeBlock"] pre {
-  padding: 20px 24px !important;
+  padding: 10px 14px !important;
+}
+.cb-instrument [class*="codeBlockLines"] {
+  padding: 0 !important;
 }
 
 /* code blocks fade in */
@@ -601,7 +605,7 @@ pre.prism-code, [class*="codeBlock"] pre {
 .table-of-contents .table-of-contents__link {
   position: relative;
   padding-left: 24px;
-  color: var(--ifm-color-content-secondary);
+  color: var(--ifm-color-content);
   transition: color 150ms ease, padding-left 150ms ease;
 }
 .table-of-contents .table-of-contents__link:hover { padding-left: 28px; }
@@ -612,11 +616,11 @@ pre.prism-code, [class*="codeBlock"] pre {
   top: 50%;
   width: 14px;
   height: 1px;
-  background: var(--ifm-color-emphasis-300);
+  background: var(--agac-fg-3);
   transition: width 160ms ease, background 160ms ease;
 }
 .table-of-contents__link:hover { color: var(--ifm-font-color-base); }
-.table-of-contents .table-of-contents__link--active { color: var(--ifm-color-primary); }
+.table-of-contents .table-of-contents__link--active { color: var(--ifm-color-primary); font-weight: 500; }
 .table-of-contents .table-of-contents__link--active::before { background: var(--ifm-color-primary); width: 22px; }
 /* "# on this page" cap */
 .table-of-contents::before {
@@ -626,7 +630,7 @@ pre.prism-code, [class*="codeBlock"] pre {
   font-size: 10.5px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-content-secondary);
   padding-left: 24px;
   margin-bottom: 12px;
 }
@@ -1110,10 +1114,26 @@ pre.prism-code, [class*="codeBlock"] pre {
   .agac-hero { padding: 56px 0 40px; }
   .agac-qnav { padding: 40px 0 64px; }
 
-  /* code blocks: constrain to viewport on mobile */
+  /* code blocks on mobile: tighter padding, slight margin from edges */
   [class*="codeBlockContainer"].cb-instrument {
     border-radius: 10px !important;
+    margin-left: 4px;
+    margin-right: 4px;
   }
+  .cb-instrument pre.prism-code,
+  .cb-instrument [class*="codeBlock"] pre {
+    padding: 14px 14px !important;
+  }
+  .cb-head {
+    height: 40px;
+    padding: 0 12px;
+  }
+  .cb-lights { gap: 6px; }
+  .cb-light { width: 11px; height: 11px; }
+  .cb-head-name { font-size: 12px; padding: 0 8px; }
+  .cb-head-chip { font-size: 9px; padding: 3px 7px; }
+  .cb-head-btn { height: 26px; padding: 0 8px; font-size: 11px; }
+  .cb-head-btn-label { font-size: 11px; }
 
   /* mobile navbar sidebar — solid background */
   .navbar-sidebar {

--- a/docs.agent-actions/src/css/custom.css
+++ b/docs.agent-actions/src/css/custom.css
@@ -57,9 +57,9 @@
 
   --ifm-font-color-base: #11181c;
   --ifm-heading-color: #11181c;
-  --ifm-color-content: #3a444a;
-  --ifm-color-content-secondary: #687077;
-  --agac-fg-3: #98a0a6;
+  --ifm-color-content: #2c353b;
+  --ifm-color-content-secondary: #556068;
+  --agac-fg-3: #8a9298;
 
   --ifm-link-color: #11181c;
   --ifm-link-hover-color: var(--agac-signal-dim);
@@ -71,9 +71,9 @@
   --ifm-navbar-link-hover-color: #11181c;
 
   --ifm-toc-border-color: #dde2df;
-  --ifm-color-emphasis-100: #e9ecea;
-  --ifm-color-emphasis-200: #dde2df;
-  --ifm-color-emphasis-300: #c6cdc8;
+  --ifm-color-emphasis-100: #e4e8e6;
+  --ifm-color-emphasis-200: #d4dad6;
+  --ifm-color-emphasis-300: #b8c0bb;
 
   /* always-dark code blocks — override Infima's light-mode pre background
      so the v4 @layer system doesn't revert our dark panels to #f6f7f8.
@@ -96,7 +96,7 @@
   --ifm-menu-color-background-active: transparent;
   --ifm-menu-color-background-hover: transparent;
 
-  --agac-grid-line: rgba(11, 14, 16, 0.055);
+  --agac-grid-line: rgba(11, 14, 16, 0.09);
 }
 
 /* =====================================================================
@@ -129,9 +129,9 @@
   --ifm-navbar-link-hover-color: #e9edee;
 
   --ifm-toc-border-color: #1d242a;
-  --ifm-color-emphasis-100: #161c21;
-  --ifm-color-emphasis-200: #1d242a;
-  --ifm-color-emphasis-300: #2b343b;
+  --ifm-color-emphasis-100: #181f25;
+  --ifm-color-emphasis-200: #252e36;
+  --ifm-color-emphasis-300: #354050;
 
   --ifm-blockquote-color: #828d93;
   --ifm-blockquote-border-color: #2b343b;

--- a/docs.agent-actions/src/pages/index.tsx
+++ b/docs.agent-actions/src/pages/index.tsx
@@ -84,7 +84,7 @@ export default function Home(): JSX.Element {
             <div className="agac-hero-grid">
               <div>
                 <div className="agac-eyebrow"><span className="dot"></span> v{version} · YAML-native agent orchestration</div>
-                <h1 className="agac-hero-title">One action tips.<br />The rest <span className="sig">cascade.</span></h1>
+                <h1 className="agac-hero-title">One action falls.<br />The rest <span className="sig">cascade.</span></h1>
                 <p className="agac-hero-sub">
                   agent-actions is an agentic workflow engine that runs in your terminal.
                   Define an LLM pipeline in YAML — the engine handles orchestration,

--- a/docs.agent-actions/src/theme/DocSidebar/Mobile/index.tsx
+++ b/docs.agent-actions/src/theme/DocSidebar/Mobile/index.tsx
@@ -1,35 +1,33 @@
 /**
  * Swizzled: @theme/DocSidebar/Mobile
- * Renders the agent-actions ASCII file-tree inside Docusaurus's slide-in mobile
- * drawer, instead of Infima's default <menu> list.
- *
- * Drop in at:  src/theme/DocSidebar/Mobile/index.tsx
- *
- * Same shared <AgacTree> the desktop rail uses — so the look, routing, active
- * state, and collapse behaviour all match. `onNavigate` closes the drawer when
- * the user taps a doc link (categories that toggle keep the drawer open).
- *
- * Loosely typed on purpose so `docusaurus build` (Babel) never trips.
+ * Renders the agent-actions ASCII file-tree in the mobile drawer.
+ * Matches the default Docusaurus pattern exactly, just swaps DocSidebarItems for AgacTree.
  */
 import React from 'react';
 import {
   NavbarSecondaryMenuFiller,
-  useNavbarMobileSidebar,
-} from '@docusaurus/theme-common/internal';
+  type NavbarSecondaryMenuComponent,
+} from '@docusaurus/theme-common';
+import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
 import AgacTree from '../_AgacTree';
+import type {Props} from '@theme/DocSidebar/Mobile';
 
-function DocSidebarMobileSecondaryMenu({sidebar}: any): JSX.Element {
+const DocSidebarMobileSecondaryMenu: NavbarSecondaryMenuComponent<Props> = ({
+  sidebar,
+  path,
+}) => {
   const mobileSidebar = useNavbarMobileSidebar();
   return (
     <AgacTree
       sidebar={sidebar}
+      path={path}
       className="agac-tree--mobile"
       onNavigate={() => mobileSidebar.toggle()}
     />
   );
-}
+};
 
-function DocSidebarMobile(props: any): JSX.Element {
+function DocSidebarMobile(props: Props) {
   return (
     <NavbarSecondaryMenuFiller
       component={DocSidebarMobileSecondaryMenu}


### PR DESCRIPTION
## Summary
- **Root cause**: `backdrop-filter: blur(14px)` on `.navbar` creates a stacking context that renders the mobile sidebar behind the page content — a known Docusaurus issue
- Scope `backdrop-filter` to desktop only (`min-width: 997px`)
- Scope `.agac-tree + .menu { display: none }` to desktop so mobile primary menu items stay visible
- Fix Mobile sidebar swizzle: proper TypeScript types, correct `NavbarSecondaryMenuFiller` import path, pass `path` prop
- Mobile code blocks get `border-radius: 10px`, sidebar gets solid background

## Verification
- Mobile: hamburger menu opens, shows primary items, tapping "Documentation" shows AgacTree sidebar
- Desktop: navbar blur effect still works, sidebar renders correctly