### PR TITLE
fix(docs): footer gap on short pages + sidebar collapse

### DIFF
--- a/docs.agent-actions/src/css/custom.css
+++ b/docs.agent-actions/src/css/custom.css
@@ -212,7 +212,8 @@ body::before {
 [class*="docItemWrapper"] {
   background: transparent !important;
 }
-.main-wrapper { min-height: 100vh; }
+/* min-height lives on #__docusaurus (Docusaurus's own flex layout).
+   Do NOT set it here — it pushes the footer below the fold on short pages. */
 
 /* ---- Doc layout: one solid surface for the entire row ----
    The docRoot holds sidebar + main + TOC as a single opaque band.

--- a/docs.agent-actions/src/theme/DocSidebar/_AgacTree.tsx
+++ b/docs.agent-actions/src/theme/DocSidebar/_AgacTree.tsx
@@ -118,7 +118,7 @@ export default function AgacTree({sidebar, className, onNavigate}: any): JSX.Ele
                 to={item.href}
                 className={cls}
                 onClick={() => {
-                  if (collapsible && !isOpen) toggle(key, true);
+                  if (collapsible) toggle(key, isOpen);
                   if (onNavigate) onNavigate();
                 }}>
                 {inner}


### PR DESCRIPTION
## Summary
- **Footer**: Removed `min-height: 100vh` from `.main-wrapper` in `custom.css`. This was forcing the content area to fill the viewport, pushing the footer below the fold on short pages. Docusaurus's built-in flex layout (`#__docusaurus` with `min-height: 100vh` + `.main-wrapper` with `flex: 1`) already provides correct sticky-footer behavior.
- **Sidebar**: Fixed the click handler for href-categories in `_AgacTree.tsx`. The `!isOpen` guard meant the toggle only fired when a category was closed → it could open but never collapse. Removed the guard so it toggles both directions, matching the pure-category handler.

## Verification
- `npm run build` passes with no errors
- Footer now flows after content on short pages (no viewport-pinning gap)
- Sidebar sub-categories under Reference (CLI, Context, Data I/O, etc.) can expand and collapse on click