### PR TITLE
fix(processing): batch FILE tool missing-record warnings with actionable guidance

### DIFF
--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -108,11 +108,6 @@ class FileToolStrategy:
                 for input_record in records:
                     rid = input_record.get("source_guid")
                     if rid and rid not in output_guids:
-                        logger.warning(
-                            "Tool '%s' did not return record %s — producing passthrough tombstone",
-                            context.agent_name,
-                            rid,
-                        )
                         missing_results.append(
                             ProcessingResult.unprocessed(
                                 data=[
@@ -127,6 +122,37 @@ class FileToolStrategy:
                                 source_guid=rid,
                                 input_record=input_record,
                             )
+                        )
+
+                if missing_results:
+                    n_missing = len(missing_results)
+                    n_total = len(records)
+                    n_output = len(structured_data)
+                    ratio = n_missing / n_total if n_total > 0 else 0
+
+                    if ratio > 0.5:
+                        logger.warning(
+                            "Tool '%s' did not return %d of %d input records "
+                            "(produced %d outputs). "
+                            "If this is a many-to-one tool (N inputs -> M outputs), "
+                            "use a list for source_index to map all inputs:\n"
+                            '  FileUDFResult(outputs=[{"source_index": [0, 1, 2, ...], "data": ...}])\n'
+                            "Unmapped records will be passed through as tombstones.",
+                            context.agent_name,
+                            n_missing,
+                            n_total,
+                            n_output,
+                        )
+                    else:
+                        missing_guids = [r.source_guid for r in missing_results if r.source_guid]
+                        logger.warning(
+                            "Tool '%s' did not return %d of %d records — "
+                            "producing passthrough tombstones. "
+                            "Missing source_guids: %s",
+                            context.agent_name,
+                            n_missing,
+                            n_total,
+                            missing_guids[:10],
                         )
 
             result = ProcessingResult.success(

--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -96,11 +96,6 @@ class FileToolStrategy:
 
             is_expansion = len(structured_data) > len(records)
 
-            # Detect missing records — tool dropped input without output.
-            # Skip for expansion tools (N→M, M>N) where output GUIDs
-            # legitimately differ from input GUIDs.
-            # Also skip when synthetic records exist (source_mapping contains
-            # None) — we can't determine which inputs a synthetic consumed.
             has_synthetic = source_mapping and any(v is None for v in source_mapping.values())
             missing_results: list[ProcessingResult] = []
             if not is_expansion and not has_synthetic:
@@ -128,7 +123,7 @@ class FileToolStrategy:
                     n_missing = len(missing_results)
                     n_total = len(records)
                     n_output = len(structured_data)
-                    ratio = n_missing / n_total if n_total > 0 else 0
+                    ratio = n_missing / n_total
 
                     if ratio > 0.5:
                         logger.warning(

--- a/tests/unit/processing/test_tool_missing_record_detection.py
+++ b/tests/unit/processing/test_tool_missing_record_detection.py
@@ -197,6 +197,56 @@ class TestToolMissingRecordDetection:
         assert "dropper_tool" in stderr
         assert "r2" in stderr
 
+    def test_high_drop_ratio_logs_many_to_one_guidance(self, capsys):
+        """When >50% of records are missing, log guidance about source_index lists."""
+        records = _make_records("r1", "r2", "r3", "r4", "r5")
+        context = _make_context("batch_tool")
+        context.source_data = records
+
+        # Tool returns 1 output for 5 inputs — 80% missing
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [TrackedItem({"v": 1}, source_index=0)],
+                True,
+            ),
+        ):
+            FileToolStrategy().invoke(records, context)
+
+        stderr = capsys.readouterr().err
+        assert "batch_tool" in stderr
+        assert "4 of 5" in stderr
+        assert "many-to-one" in stderr
+        assert "source_index" in stderr
+        # No per-record spam
+        assert stderr.count("did not return") == 1
+
+    def test_low_drop_ratio_logs_summary_with_guids(self, capsys):
+        """When <=50% of records are missing, log summary with missing GUIDs."""
+        records = _make_records("r1", "r2", "r3", "r4")
+        context = _make_context("filter_tool")
+        context.source_data = records
+
+        # Tool drops r3 — 25% missing
+        with patch(
+            "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+            return_value=(
+                [
+                    TrackedItem({"v": 1}, source_index=0),
+                    TrackedItem({"v": 2}, source_index=1),
+                    TrackedItem({"v": 4}, source_index=3),
+                ],
+                True,
+            ),
+        ):
+            FileToolStrategy().invoke(records, context)
+
+        stderr = capsys.readouterr().err
+        assert "filter_tool" in stderr
+        assert "1 of 4" in stderr
+        assert "r3" in stderr
+        assert "many-to-one" not in stderr
+
     def test_synthetic_record_no_false_positives(self):
         """Tool merging N inputs into synthetic output — no false tombstones."""
         records = _make_records("r1", "r2")


### PR DESCRIPTION
## Summary
- Replace per-record warning spam (N identical log lines) with a single batched summary when FILE-mode tools drop input records
- When >50% of records are unmapped: log guidance about using `source_index` as a list for many-to-one tools (`FileUDFResult(outputs=[{"source_index": [0, 1, 2, ...], ...}])`)
- When <=50% are unmapped: log a compact summary with the first 10 missing GUIDs for debugging
- Tombstone creation logic is unchanged — only log output differs

## Verification
- All 10 tests in `test_tool_missing_record_detection.py` pass (8 existing + 2 new)
- Full suite: 7455 passed, 2 skipped
- `ruff check` and `ruff format --check` clean
- `grep "many-to-one tool" file_tool.py` → 1 match (guidance present)
- `grep "producing passthrough tombstone\"," file_tool.py` → 0 matches (per-record spam removed)