### PR TITLE
revert: move target_data source of truth back to SQLite

### DIFF
--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import csv
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -17,6 +16,7 @@ from agent_actions.logging.events import (
 from agent_actions.processing.error_handling import ProcessorErrorHandlerMixin
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.path_safety import assert_path_contained
+from agent_actions.utils.path_utils import ensure_directory_exists
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -132,7 +132,10 @@ class FileWriter(ProcessorErrorHandlerMixin):
 
             self.storage_backend.write_target(self.action_name, relative_path, data)
 
-            return len(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+            ensure_directory_exists(file_path, is_file=True)
+            atomic_json_write(file_path, data)
+
+            return file_path.stat().st_size
 
         self._execute_write("Write target file", do_write)
 

--- a/agent_actions/storage/__init__.py
+++ b/agent_actions/storage/__init__.py
@@ -30,10 +30,7 @@ def get_storage_backend(
 
     workflow_dir = Path(workflow_path)
     db_path = workflow_dir / "agent_io" / "store" / f"{workflow_name}.db"
-    target_dir = workflow_dir / "agent_io" / "target"
-    backend = backend_class.create(
-        db_path=str(db_path), workflow_name=workflow_name, target_dir=str(target_dir)
-    )
+    backend = backend_class.create(db_path=str(db_path), workflow_name=workflow_name)
 
     return backend
 

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -20,8 +20,6 @@ from agent_actions.storage.backend import (
     DispositionRow,
     StorageBackend,
 )
-from agent_actions.utils.atomic_write import atomic_json_write
-from agent_actions.utils.path_safety import assert_path_contained
 
 logger = logging.getLogger(__name__)
 
@@ -170,11 +168,10 @@ class SQLiteBackend(StorageBackend):
     # Restrictive as defense-in-depth; all SQL is parameterized.
     _VALID_IDENTIFIER_CHARS = set(string.ascii_letters + string.digits + "_-./ ")
 
-    def __init__(self, db_path: str, workflow_name: str, target_dir: str | None = None):
+    def __init__(self, db_path: str, workflow_name: str):
         """Initialize SQLite backend."""
         self.db_path = Path(db_path)
         self.workflow_name = workflow_name
-        self.target_dir: Path | None = Path(target_dir) if target_dir else None
         self._connection: sqlite3.Connection | None = None
         self._lock = (
             threading.RLock()
@@ -187,17 +184,15 @@ class SQLiteBackend(StorageBackend):
         Required kwargs:
             db_path: Path to the SQLite database file.
             workflow_name: Name of the workflow.
-            target_dir: Path to agent_io/target directory.
         """
         db_path = kwargs.pop("db_path")
         workflow_name = kwargs.pop("workflow_name")
-        target_dir = kwargs.pop("target_dir", None)
         if kwargs:
             raise ConfigValidationError(
                 f"Unknown kwargs for SQLiteBackend: {list(kwargs)}",
                 context={"unknown_kwargs": list(kwargs)},
             )
-        return cls(str(db_path), workflow_name, target_dir=str(target_dir) if target_dir else None)
+        return cls(str(db_path), workflow_name)
 
     def _validate_identifier(self, name: str, field: str) -> str:
         """Validate and POSIX-normalize an identifier to prevent injection.
@@ -318,22 +313,12 @@ class SQLiteBackend(StorageBackend):
                 )
 
     def write_target(self, action_name: str, relative_path: str, data: list[dict[str, Any]]) -> str:
-        """Write target data to filesystem and metadata to DB."""
+        """Write target data for a specific node."""
         action_name = self._validate_identifier(action_name, "action_name")
         relative_path = self._validate_identifier(relative_path, "relative_path")
 
+        data_json = json.dumps(data, ensure_ascii=False)
         record_count = len(data)
-
-        if self.target_dir is None:
-            raise ValueError(
-                f"Cannot write target data without target_dir configured "
-                f"({action_name}/{relative_path})"
-            )
-
-        file_path = self.target_dir / action_name / relative_path
-        assert_path_contained(file_path, self.target_dir)
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_json_write(file_path, data)
 
         with self._lock:
             cursor = self.connection.cursor()
@@ -342,9 +327,9 @@ class SQLiteBackend(StorageBackend):
                     """
                     INSERT OR REPLACE INTO target_data
                     (action_name, relative_path, data, record_count, created_at)
-                    VALUES (?, ?, '[]', ?, CURRENT_TIMESTAMP)
+                    VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
                     """,
-                    (action_name, relative_path, record_count),
+                    (action_name, relative_path, data_json, record_count),
                 )
                 self.connection.commit()
                 logger.debug(
@@ -369,33 +354,25 @@ class SQLiteBackend(StorageBackend):
                 raise
 
     def _read_target_raw(self, action_name: str, relative_path: str) -> list[dict[str, Any]]:
-        """Read raw target data from the filesystem.
+        """Read raw target data from SQLite.
 
         Raises:
             FileNotFoundError: If no data exists for the given path.
         """
         action_name = self._validate_identifier(action_name, "action_name")
         relative_path = self._validate_identifier(relative_path, "relative_path")
-
-        if self.target_dir is None:
-            raise FileNotFoundError(
-                f"No target_dir configured — cannot read {action_name}/{relative_path}"
+        with self._lock:
+            cursor = self.connection.cursor()
+            cursor.execute(
+                "SELECT data FROM target_data WHERE action_name = ? AND relative_path = ?",
+                (action_name, relative_path),
             )
+            row = cursor.fetchone()
 
-        file_path = self.target_dir / action_name / relative_path
-        assert_path_contained(file_path, self.target_dir)
-        try:
-            result: list[dict[str, Any]] = json.loads(file_path.read_text(encoding="utf-8"))
-        except FileNotFoundError:
-            raise FileNotFoundError(
-                f"No target data found for {action_name}/{relative_path}"
-            ) from None
+        if row is None:
+            raise FileNotFoundError(f"No target data found for {action_name}/{relative_path}")
 
-        if not isinstance(result, list):
-            raise FileNotFoundError(
-                f"Target data at {action_name}/{relative_path} is not a list "
-                f"(got {type(result).__name__})"
-            )
+        result: list[dict[str, Any]] = json.loads(row["data"])
         return result
 
     def write_source(
@@ -508,16 +485,10 @@ class SQLiteBackend(StorageBackend):
         offset: int = 0,
         relative_path: str | None = None,
     ) -> dict[str, Any]:
-        """Preview target data for a node with pagination.
-
-        Reads file metadata from DB, actual data from filesystem.
-        """
+        """Preview target data for a node with pagination."""
         action_name = self._validate_identifier(action_name, "action_name")
         if relative_path is not None:
             relative_path = self._validate_identifier(relative_path, "relative_path")
-
-        if self.target_dir is None:
-            raise ValueError("Cannot preview target data without target_dir configured")
 
         limit = min(max(1, limit), 1000)
         offset = max(0, offset)
@@ -528,7 +499,7 @@ class SQLiteBackend(StorageBackend):
             cursor.execute(
                 """
                 SELECT relative_path,
-                       COALESCE(record_count, 0) as record_count
+                       COALESCE(record_count, json_array_length(data)) as record_count
                 FROM target_data
                 WHERE action_name = ?
                 ORDER BY relative_path
@@ -537,58 +508,60 @@ class SQLiteBackend(StorageBackend):
             )
             file_metadata = cursor.fetchall()
 
-        files = [row["relative_path"] for row in file_metadata]
+            files = [row["relative_path"] for row in file_metadata]
 
-        if relative_path:
-            if relative_path not in files:
-                return {
-                    "records": [],
-                    "total_count": 0,
-                    "action_name": action_name,
-                    "files": files,
-                    "error": f"File '{relative_path}' not found for node '{action_name}'",
-                }
-            file_metadata = [row for row in file_metadata if row["relative_path"] == relative_path]
+            if relative_path:
+                if relative_path not in files:
+                    return {
+                        "records": [],
+                        "total_count": 0,
+                        "action_name": action_name,
+                        "files": files,
+                        "error": f"File '{relative_path}' not found for node '{action_name}'",
+                    }
+                file_metadata = [
+                    row for row in file_metadata if row["relative_path"] == relative_path
+                ]
 
-        total_count = sum(row["record_count"] for row in file_metadata)
+            total_count = sum(row["record_count"] for row in file_metadata)
 
-        paginated_records: list[dict[str, Any]] = []
-        skipped = 0
-        collected = 0
+            paginated_records: list[dict[str, Any]] = []
+            skipped = 0
+            collected = 0
 
-        for row in file_metadata:
-            if collected >= limit:
-                break
+            for row in file_metadata:
+                if collected >= limit:
+                    break
 
-            file_path = row["relative_path"]
-            file_record_count = row["record_count"]
+                file_path = row["relative_path"]
+                file_record_count = row["record_count"]
 
-            if skipped + file_record_count <= offset:
-                skipped += file_record_count
-                continue
-
-            fs_path = self.target_dir / action_name / file_path
-            try:
-                records = json.loads(fs_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                continue
-
-            if not isinstance(records, list):
-                continue
-
-            for record in records:
-                if skipped < offset:
-                    skipped += 1
+                if skipped + file_record_count <= offset:
+                    skipped += file_record_count
                     continue
 
-                if collected < limit:
-                    if isinstance(record, dict):
-                        paginated_records.append({**record, "_file": file_path})
+                cursor.execute(
+                    "SELECT data FROM target_data WHERE action_name = ? AND relative_path = ?",
+                    (action_name, file_path),
+                )
+                data_row = cursor.fetchone()
+                if not data_row:
+                    continue
+
+                records = json.loads(data_row["data"])
+                for record in records:
+                    if skipped < offset:
+                        skipped += 1
+                        continue
+
+                    if collected < limit:
+                        if isinstance(record, dict):
+                            paginated_records.append({**record, "_file": file_path})
+                        else:
+                            paginated_records.append({"_file": file_path, "_value": record})
+                        collected += 1
                     else:
-                        paginated_records.append({"_file": file_path, "_value": record})
-                    collected += 1
-                else:
-                    break
+                        break
 
         return {
             "records": paginated_records,

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -105,9 +105,7 @@ def scan_workflow_data(project_root: Path) -> dict[str, Any]:
             workflow_name = db_file.stem
 
             try:
-                data = scan_sqlite_readonly(
-                    db_file, workflow_name, target_dir=agent_io_dir / "target"
-                )
+                data = scan_sqlite_readonly(db_file, workflow_name)
                 if data is not None:
                     workflow_data[workflow_name] = data
             except (OSError, sqlite3.Error) as e:
@@ -144,9 +142,7 @@ def _unwrap_record_content(record: dict, action_name: str) -> dict:
     return record
 
 
-def scan_sqlite_readonly(
-    db_file: Path, workflow_name: str, target_dir: Path | None = None
-) -> dict[str, Any] | None:
+def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | None:
     """Open a workflow SQLite DB read-only and extract stats + preview data.
 
     Uses a direct sqlite3 connection in read-only mode so that scanning
@@ -217,25 +213,27 @@ def scan_sqlite_readonly(
             )
             files = [row["relative_path"] for row in cursor.fetchall()]
 
-            # Preview: read from filesystem (source of truth).
-            # Cap at 20 flattened records.
+            # Preview: iterate the cursor lazily so we never load every
+            # data blob into memory.  Cap at 20 flattened records.
+            cursor.execute(
+                "SELECT relative_path, data FROM target_data WHERE action_name = ?",
+                (action_name,),
+            )
             records: list[dict] = []
-            for file_path in files:
+            for target_row in cursor:
                 if len(records) >= 20:
                     break
-                if target_dir is None:
-                    break
-                fs_path = target_dir / action_name / file_path
                 try:
-                    row_data = _json.loads(fs_path.read_text(encoding="utf-8"))
-                except (ValueError, _json.JSONDecodeError, OSError):
+                    row_data = _json.loads(target_row["data"])
+                except (ValueError, _json.JSONDecodeError):
                     logger.debug(
-                        "Skipping unreadable target file %s/%s/%s",
+                        "Skipping malformed JSON in %s node %s, file %s",
                         workflow_name,
                         action_name,
-                        file_path,
+                        target_row["relative_path"],
                     )
                     continue
+                file_path = target_row["relative_path"]
                 if isinstance(row_data, list):
                     for item in row_data:
                         if len(records) >= 20:

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -286,21 +286,8 @@ class AgentWorkflow:
             except Exception as e:
                 logger.warning("Failed to clear stored data for %s: %s", action_name, e)
 
-            # Clear target output files from filesystem (rglob for nested paths,
-            # but skip batch/ — batch artifacts have their own cleanup below)
-            action_target_dir = target_dir / action_name
-            batch_dir = action_target_dir / "batch"
-            if action_target_dir.is_dir():
-                for json_file in action_target_dir.rglob("*.json"):
-                    if batch_dir in json_file.parents or json_file.parent == batch_dir:
-                        continue
-                    try:
-                        json_file.unlink()
-                        logger.debug("Removed target file: %s", json_file)
-                    except OSError as e:
-                        logger.warning("Failed to remove %s: %s", json_file, e)
-
             # Batch artifacts live on disk, not in the DB
+            batch_dir = target_dir / action_name / "batch"
             if batch_dir.is_dir():
                 for pattern in [
                     ".recovery_state_*.json",

--- a/tests/integration/test_batch_content_materialization.py
+++ b/tests/integration/test_batch_content_materialization.py
@@ -108,12 +108,7 @@ def context_map(upstream_record) -> dict[str, Any]:
 
 @pytest.fixture
 def sqlite_backend(tmp_path) -> SQLiteBackend:
-    target_dir = tmp_path / "target"
-    backend = SQLiteBackend(
-        str(tmp_path / "test.db"),
-        workflow_name="test_workflow",
-        target_dir=str(target_dir),
-    )
+    backend = SQLiteBackend(str(tmp_path / "test.db"), workflow_name="test_workflow")
     backend.initialize()
     return backend
 
@@ -192,10 +187,10 @@ class TestBatchToDBPipeline:
         output = _process_batch([batch_result], context_map, action_config, str(tmp_path))
 
         writer = FileWriter(
-            str(tmp_path / "target" / "verify_answer" / "out.json"),
+            str(tmp_path / "out.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
-            output_directory=str(tmp_path / "target" / "verify_answer"),
+            output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
@@ -225,10 +220,10 @@ class TestBatchToDBPipeline:
 
         output = _process_batch(records, context_map, action_config, str(tmp_path))
         writer = FileWriter(
-            str(tmp_path / "target" / "verify_answer" / "batch.json"),
+            str(tmp_path / "batch.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
-            output_directory=str(tmp_path / "target" / "verify_answer"),
+            output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
@@ -265,10 +260,10 @@ class TestVersionedBatchContent:
 
         output = _process_batch([result], context_map, config, str(tmp_path), "verify_answer_1")
         writer = FileWriter(
-            str(tmp_path / "target" / "verify_answer_1" / "out.json"),
+            str(tmp_path / "out.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer_1",
-            output_directory=str(tmp_path / "target" / "verify_answer_1"),
+            output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
@@ -318,10 +313,10 @@ class TestPartialBatchFailure:
 
         output = _process_batch(batch_results, context_map, action_config, str(tmp_path))
         writer = FileWriter(
-            str(tmp_path / "target" / "verify_answer" / "partial.json"),
+            str(tmp_path / "partial.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
-            output_directory=str(tmp_path / "target" / "verify_answer"),
+            output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
@@ -341,12 +336,12 @@ class TestDiskMaterialization:
     ):
         output = _process_batch([batch_result], context_map, action_config, str(tmp_path))
 
-        output_file = tmp_path / "target" / "verify_answer" / "target.json"
+        output_file = tmp_path / "target.json"
         writer = FileWriter(
             str(output_file),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
-            output_directory=str(tmp_path / "target" / "verify_answer"),
+            output_directory=str(tmp_path),
         )
         writer.write_target(output)
 
@@ -424,10 +419,10 @@ class TestProviderParseChain:
 
         output = _process_batch([batch_result], context_map, action_config, str(tmp_path))
         writer = FileWriter(
-            str(tmp_path / "target" / "verify_answer" / "ollama.json"),
+            str(tmp_path / "ollama.json"),
             storage_backend=sqlite_backend,
             action_name="verify_answer",
-            output_directory=str(tmp_path / "target" / "verify_answer"),
+            output_directory=str(tmp_path),
         )
         writer.write_target(output)
 

--- a/tests/integration/test_storage_backend_integration.py
+++ b/tests/integration/test_storage_backend_integration.py
@@ -9,7 +9,6 @@ Tests the full storage backend lifecycle including:
 """
 
 import tempfile
-import threading
 from pathlib import Path
 
 import pytest
@@ -18,30 +17,27 @@ from agent_actions.storage.backend import NODE_LEVEL_RECORD_ID
 from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
 
-def _make_backend(tmpdir: str, workflow_name: str = "test_workflow") -> SQLiteBackend:
-    """Create a backend with target_dir set for filesystem reads."""
-    db_path = Path(tmpdir) / "test.db"
-    target_dir = Path(tmpdir) / "target"
-    return SQLiteBackend(str(db_path), workflow_name, target_dir=str(target_dir))
-
-
 class TestSQLiteBackendLifecycle:
     """Test SQLite backend initialization and cleanup."""
 
     def test_creates_database_file_on_initialize(self):
         """Backend creates database file when initialized."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            backend = _make_backend(tmpdir)
+            db_path = Path(tmpdir) / "test_workflow" / "agent_io" / "test.db"
+
+            backend = SQLiteBackend(str(db_path), "test_workflow")
             backend.initialize()
 
-            assert backend.db_path.exists()
+            assert db_path.exists()
             assert backend.backend_type == "sqlite"
             backend.close()
 
     def test_creates_tables_on_initialize(self):
         """Backend creates source_data and target_data tables."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            backend = _make_backend(tmpdir)
+            db_path = Path(tmpdir) / "test.db"
+
+            backend = SQLiteBackend(str(db_path), "test_workflow")
             backend.initialize()
 
             # Verify tables exist
@@ -56,7 +52,9 @@ class TestSQLiteBackendLifecycle:
     def test_context_manager_cleanup(self):
         """Context manager properly closes connection."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir) as backend:
+            db_path = Path(tmpdir) / "test.db"
+
+            with SQLiteBackend(str(db_path), "test_workflow") as backend:
                 backend.initialize()
                 # Connection is active inside context
                 assert backend._connection is not None
@@ -72,7 +70,8 @@ class TestTargetDataOperations:
     def backend(self):
         """Create and initialize a test backend."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            backend = _make_backend(tmpdir)
+            db_path = Path(tmpdir) / "test.db"
+            backend = SQLiteBackend(str(db_path), "test_workflow")
             backend.initialize()
             yield backend
             backend.close()
@@ -167,7 +166,8 @@ class TestSourceDataOperations:
     def backend(self):
         """Create and initialize a test backend."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            backend = _make_backend(tmpdir)
+            db_path = Path(tmpdir) / "test.db"
+            backend = SQLiteBackend(str(db_path), "test_workflow")
             backend.initialize()
             yield backend
             backend.close()
@@ -255,7 +255,8 @@ class TestPreviewAndStats:
     def backend_with_data(self):
         """Create backend with sample data."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            backend = _make_backend(tmpdir)
+            db_path = Path(tmpdir) / "test.db"
+            backend = SQLiteBackend(str(db_path), "test_workflow")
             backend.initialize()
 
             # Add sample target data
@@ -417,7 +418,9 @@ class TestConcurrencyAndResilience:
     def test_multiple_writes_to_same_node(self):
         """Multiple sequential writes to same node work correctly."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir) as backend:
+            db_path = Path(tmpdir) / "test.db"
+
+            with SQLiteBackend(str(db_path), "test_workflow") as backend:
                 backend.initialize()
 
                 # Multiple writes to same node, different files
@@ -437,7 +440,9 @@ class TestConcurrencyAndResilience:
     def test_handles_unicode_data(self):
         """Backend correctly handles unicode data."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir) as backend:
+            db_path = Path(tmpdir) / "test.db"
+
+            with SQLiteBackend(str(db_path), "test_workflow") as backend:
                 backend.initialize()
 
                 test_data = [
@@ -456,7 +461,9 @@ class TestConcurrencyAndResilience:
     def test_handles_large_records(self):
         """Backend handles large JSON records."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir) as backend:
+            db_path = Path(tmpdir) / "test.db"
+
+            with SQLiteBackend(str(db_path), "test_workflow") as backend:
                 backend.initialize()
 
                 # Create a large record (~1MB of text)
@@ -472,9 +479,11 @@ class TestConcurrencyAndResilience:
 
     def test_concurrent_writes_from_multiple_threads(self):
         """Concurrent writes from multiple threads don't cause transaction errors."""
+        import threading
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            backend = _make_backend(tmpdir)
+            db_path = Path(tmpdir) / "test.db"
+            backend = SQLiteBackend(str(db_path), "test_workflow")
             backend.initialize()
 
             errors = []
@@ -534,7 +543,8 @@ class TestBackendTypeProperty:
     def test_backend_type_returns_sqlite(self):
         """SQLiteBackend returns 'sqlite' as backend_type."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            backend = _make_backend(tmpdir)
+            db_path = Path(tmpdir) / "test.db"
+            backend = SQLiteBackend(str(db_path), "test_workflow")
 
             assert backend.backend_type == "sqlite"
             backend.close()
@@ -546,7 +556,9 @@ class TestWorkflowIntegration:
     def test_action_chain_data_flow(self):
         """Simulates data flowing through action chain."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 # Action 1: Extract - writes target data
@@ -584,7 +596,9 @@ class TestWorkflowIntegration:
     def test_parallel_actions_write_to_different_nodes(self):
         """Parallel actions can write to different nodes."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 # Simulate parallel writes from different actions
@@ -616,7 +630,9 @@ class TestWorkflowIntegration:
     def test_merge_pattern_combines_upstream_data(self):
         """Merge pattern can read from multiple upstream nodes."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 # Two parallel upstream actions
@@ -649,7 +665,9 @@ class TestDispositionLifecycle:
     def test_passthrough_lifecycle(self):
         """Passthrough disposition can be set, queried, and cleared."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 # 1. Set passthrough disposition
@@ -673,7 +691,9 @@ class TestDispositionLifecycle:
     def test_skip_disposition_lifecycle(self):
         """Skip disposition works end-to-end."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 # Set skip disposition
@@ -690,7 +710,9 @@ class TestDispositionLifecycle:
     def test_multiple_nodes_independent(self):
         """Dispositions for different nodes are independent."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 backend.set_disposition("node_a", NODE_LEVEL_RECORD_ID, "passthrough")
@@ -708,7 +730,9 @@ class TestDispositionLifecycle:
     def test_per_record_dispositions(self):
         """Individual record dispositions work alongside node-level ones."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 # Node-level
@@ -732,7 +756,9 @@ class TestDispositionLifecycle:
     def test_disposition_stats_in_storage_stats(self):
         """Storage stats include disposition count."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with _make_backend(tmpdir, "my_workflow") as backend:
+            db_path = Path(tmpdir) / "workflow.db"
+
+            with SQLiteBackend(str(db_path), "my_workflow") as backend:
                 backend.initialize()
 
                 # Write some target data and dispositions

--- a/tests/manual/smoke_test/checks/lineage.py
+++ b/tests/manual/smoke_test/checks/lineage.py
@@ -109,44 +109,39 @@ class LineageCheck(Check):
             with sqlite3.connect(str(db_path)) as conn:
                 conn.row_factory = sqlite3.Row
 
-                # Get action names from DB metadata
-                action_names_rows = conn.execute(
-                    "SELECT DISTINCT action_name FROM target_data ORDER BY action_name"
+                rows = conn.execute(
+                    "SELECT action_name, data FROM target_data ORDER BY action_name"
                 ).fetchall()
 
-                if not action_names_rows:
+                if not rows:
                     results.append(CheckResult(True, "lineage", "no target data to verify"))
                     return results
 
-                # --- Phase 1: Collect all records from filesystem ---
+                # --- Phase 1: Collect all records and build index ---
                 all_target_ids: set[str] = set()
                 action_records: dict[str, list[tuple[int, dict]]] = {}
 
-                for action_row in action_names_rows:
-                    action_name = action_row["action_name"]
-                    action_dir = ctx.target_dir / action_name
-                    if not action_dir.is_dir():
+                for row in rows:
+                    action_name = row["action_name"]
+                    try:
+                        data = json.loads(row["data"])
+                    except (json.JSONDecodeError, TypeError):
+                        results.append(
+                            CheckResult(False, f"lineage({action_name}): parse", "bad JSON")
+                        )
                         continue
-                    for json_file in sorted(action_dir.glob("*.json")):
-                        try:
-                            data = json.loads(json_file.read_text(encoding="utf-8"))
-                        except (json.JSONDecodeError, TypeError, OSError):
-                            results.append(
-                                CheckResult(False, f"lineage({action_name}): parse", "bad JSON")
-                            )
+
+                    records = data if isinstance(data, list) else [data]
+                    indexed = []
+                    for idx, record in enumerate(records):
+                        if not isinstance(record, dict):
                             continue
+                        indexed.append((idx, record))
+                        tid = record.get("target_id")
+                        if isinstance(tid, str) and tid:
+                            all_target_ids.add(tid)
 
-                        records = data if isinstance(data, list) else [data]
-                        indexed = []
-                        for idx, record in enumerate(records):
-                            if not isinstance(record, dict):
-                                continue
-                            indexed.append((idx, record))
-                            tid = record.get("target_id")
-                            if isinstance(tid, str) and tid:
-                                all_target_ids.add(tid)
-
-                        action_records.setdefault(action_name, []).extend(indexed)
+                    action_records.setdefault(action_name, []).extend(indexed)
 
                 total_records = sum(len(recs) for recs in action_records.values())
 

--- a/tests/manual/smoke_test/checks/schema_conformance.py
+++ b/tests/manual/smoke_test/checks/schema_conformance.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from pathlib import Path
 
 import yaml
 
@@ -103,29 +102,28 @@ class SchemaConformance(Check):
                 if not required_fields:
                     continue
 
-                # Discover action names (including versioned: _1, _2, _3)
-                action_names_to_check = [action_name]
                 cursor = conn.execute(
-                    "SELECT DISTINCT action_name FROM target_data WHERE action_name = ?",
+                    "SELECT data FROM target_data WHERE action_name = ?",
                     (action_name,),
                 )
-                if not cursor.fetchall():
-                    action_names_to_check = sorted(
+                rows = cursor.fetchall()
+
+                # Check versioned action names (e.g., classify_severity_1, _2, _3)
+                if not rows:
+                    for v_name in sorted(
                         a for a in all_db_actions if a.startswith(f"{action_name}_")
-                    )
+                    ):
+                        rows.extend(
+                            conn.execute(
+                                "SELECT data FROM target_data WHERE action_name = ?",
+                                (v_name,),
+                            ).fetchall()
+                        )
 
                 if action_name in skipped_actions:
                     continue
 
-                # Read target data from filesystem
-                target_files: list[tuple[str, str]] = []
-                for a_name in action_names_to_check:
-                    action_dir = ctx.target_dir / a_name
-                    if action_dir.is_dir():
-                        for f in sorted(action_dir.glob("*.json")):
-                            target_files.append((a_name, str(f)))
-
-                if not target_files:
+                if not rows:
                     if action_name in excused_actions:
                         continue
                     results.append(
@@ -140,9 +138,9 @@ class SchemaConformance(Check):
 
                 schema_actions_checked += 1
 
-                for _, file_path in target_files:
+                for row in rows:
                     try:
-                        data = json.loads(Path(file_path).read_text(encoding="utf-8"))
+                        data = json.loads(row[0])
                         records = data if isinstance(data, list) else [data]
                         for record in records:
                             if not isinstance(record, dict):
@@ -158,12 +156,12 @@ class SchemaConformance(Check):
                                     else "all required fields present",
                                 )
                             )
-                    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+                    except (json.JSONDecodeError, UnicodeDecodeError):
                         results.append(
                             CheckResult(
                                 passed=False,
                                 name=f"schema({action_name})",
-                                message="failed to parse target data file",
+                                message="failed to parse target_data JSON",
                             )
                         )
 

--- a/tests/unit/storage/test_delete_target.py
+++ b/tests/unit/storage/test_delete_target.py
@@ -12,8 +12,7 @@ class TestDeleteTarget:
     def backend(self, tmp_path):
         """Create a fresh SQLite backend for testing."""
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
@@ -39,8 +38,7 @@ class TestDeleteTarget:
     def test_works_with_real_sqlite_backend(self, tmp_path):
         """Full roundtrip: write, verify, delete, verify gone."""
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
-        backend = SQLiteBackend(str(db_path), "wf", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "wf")
         backend.initialize()
 
         try:

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -43,8 +43,7 @@ class TestSQLiteBackend:
     def backend(self, tmp_path):
         """Create a fresh SQLite backend for testing."""
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
@@ -52,8 +51,7 @@ class TestSQLiteBackend:
     def test_initialize_creates_tables(self, tmp_path):
         """Test that initialize creates required tables."""
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
 
         # Check tables exist
@@ -187,8 +185,7 @@ class TestSQLiteBackend:
         """Test that backend works as context manager."""
         db_path = tmp_path / "agent_io" / "test.db"
 
-        target_dir = tmp_path / "agent_io" / "target"
-        with SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir)) as backend:
+        with SQLiteBackend(str(db_path), "test_workflow") as backend:
             backend.initialize()
             backend.write_target("node_1", "file.json", [{"id": 1}])
 
@@ -211,8 +208,7 @@ class TestDispositionMethods:
     def backend(self, tmp_path):
         """Create a fresh SQLite backend for testing."""
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
@@ -357,8 +353,7 @@ class TestValidation:
     def backend(self, tmp_path):
         """Create a fresh SQLite backend for testing."""
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
@@ -415,8 +410,7 @@ class TestWriteSourceDropGuard:
     @pytest.fixture
     def backend(self, tmp_path):
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
@@ -456,14 +450,13 @@ class TestPreviewTargetNullRecordCount:
     @pytest.fixture
     def backend(self, tmp_path):
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
 
-    def test_null_record_count_uses_zero(self, backend):
-        """preview_target uses COALESCE(record_count, 0) when record_count IS NULL."""
+    def test_null_record_count_uses_json_length(self, backend):
+        """preview_target computes correct count from JSON when record_count IS NULL."""
         import json
 
         records = [{"id": 1}, {"id": 2}, {"id": 3}]
@@ -476,8 +469,8 @@ class TestPreviewTargetNullRecordCount:
         backend.connection.commit()
 
         result = backend.preview_target("node_1")
-        assert result["total_count"] == 0  # NULL record_count → COALESCE → 0
-        assert result["files"] == ["legacy.json"]
+        assert result["total_count"] == 3
+        assert len(result["records"]) == 3
 
 
 class TestGetStorageStatsNullRecordCount:
@@ -486,8 +479,7 @@ class TestGetStorageStatsNullRecordCount:
     @pytest.fixture
     def backend(self, tmp_path):
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
@@ -529,8 +521,7 @@ class TestSetDispositionRecordIdValidation:
     @pytest.fixture
     def backend(self, tmp_path):
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         yield backend
         backend.close()
@@ -578,8 +569,7 @@ class TestCloseThreadSafety:
     def test_double_close_is_safe(self, tmp_path):
         """Calling close() twice does not raise."""
         db_path = tmp_path / "agent_io" / "test.db"
-        target_dir = tmp_path / "agent_io" / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
         backend.close()
         backend.close()  # Should not raise
@@ -668,8 +658,7 @@ class TestSchemaEnforcement:
     def test_correct_schema_not_dropped(self, tmp_path):
         """Table with all columns is left intact on initialize()."""
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
-        backend = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend = SQLiteBackend(str(db_path), "test_workflow")
         backend.initialize()
 
         # Write some data
@@ -677,7 +666,7 @@ class TestSchemaEnforcement:
 
         # Re-initialize — data should survive
         backend.close()
-        backend2 = SQLiteBackend(str(db_path), "test_workflow", target_dir=str(target_dir))
+        backend2 = SQLiteBackend(str(db_path), "test_workflow")
         backend2.initialize()
 
         data = backend2.read_target("node1", "file.json")

--- a/tests/unit/tooling/test_data_scanners.py
+++ b/tests/unit/tooling/test_data_scanners.py
@@ -310,9 +310,7 @@ class TestExtractActionMetricsEnrichment:
 # ---------------------------------------------------------------------------
 
 
-def _create_test_db(
-    db_path: Path, *, with_traces: bool = False, target_dir: Path | None = None
-) -> None:
+def _create_test_db(db_path: Path, *, with_traces: bool = False) -> None:
     """Create a minimal SQLite DB with source/target data and optionally prompt_trace."""
     conn = sqlite3.connect(str(db_path))
     conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")
@@ -321,21 +319,13 @@ def _create_test_db(
         "(action_name TEXT, relative_path TEXT, data TEXT, record_count INTEGER)"
     )
     # Insert one target record with known source_guid and target_id
-    records_list = [
-        {"source_guid": "guid-001", "target_id": "tid-001", "issue_type": "bug", "lineage": []}
-    ]
-    record = json.dumps(records_list)
+    record = json.dumps(
+        [{"source_guid": "guid-001", "target_id": "tid-001", "issue_type": "bug", "lineage": []}]
+    )
     conn.execute(
         "INSERT INTO target_data VALUES (?, ?, ?, ?)",
         ("classify", "issues.json", record, 1),
     )
-
-    # Write filesystem file for the scanner to read
-    if target_dir is not None:
-        fs_path = target_dir / "classify" / "issues.json"
-        fs_path.parent.mkdir(parents=True, exist_ok=True)
-        fs_path.write_text(record)
-
     # Insert a source row for count
     conn.execute(
         "INSERT INTO source_data VALUES (?, ?, ?)",
@@ -389,10 +379,9 @@ class TestScanSqliteReadonlyTraceAttachment:
 
     def test_trace_attached_when_table_exists(self, tmp_path):
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
-        _create_test_db(db_path, with_traces=True, target_dir=target_dir)
+        _create_test_db(db_path, with_traces=True)
 
-        result = scan_sqlite_readonly(db_path, "test_workflow", target_dir=target_dir)
+        result = scan_sqlite_readonly(db_path, "test_workflow")
         assert result is not None
         records = result["nodes"]["classify"]["preview"]
         assert len(records) == 1
@@ -408,10 +397,9 @@ class TestScanSqliteReadonlyTraceAttachment:
     def test_no_trace_when_table_missing(self, tmp_path):
         """Old DBs without prompt_trace table should not crash."""
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
-        _create_test_db(db_path, with_traces=False, target_dir=target_dir)
+        _create_test_db(db_path, with_traces=False)
 
-        result = scan_sqlite_readonly(db_path, "test_workflow", target_dir=target_dir)
+        result = scan_sqlite_readonly(db_path, "test_workflow")
         assert result is not None
         records = result["nodes"]["classify"]["preview"]
         assert len(records) == 1
@@ -420,7 +408,6 @@ class TestScanSqliteReadonlyTraceAttachment:
     def test_no_trace_when_no_matching_target_id(self, tmp_path):
         """Records without target_id should not get traces."""
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")
         conn.execute(
@@ -445,12 +432,8 @@ class TestScanSqliteReadonlyTraceAttachment:
         )
         conn.commit()
         conn.close()
-        # Write filesystem file
-        fs_path = target_dir / "act" / "f.json"
-        fs_path.parent.mkdir(parents=True, exist_ok=True)
-        fs_path.write_text(record)
 
-        result = scan_sqlite_readonly(db_path, "test_wf", target_dir=target_dir)
+        result = scan_sqlite_readonly(db_path, "test_wf")
         assert result is not None
         records = result["nodes"]["act"]["preview"]
         assert len(records) == 1
@@ -459,8 +442,7 @@ class TestScanSqliteReadonlyTraceAttachment:
     def test_latest_attempt_wins(self, tmp_path):
         """When multiple attempts exist, only the latest is attached."""
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
-        _create_test_db(db_path, with_traces=True, target_dir=target_dir)
+        _create_test_db(db_path, with_traces=True)
 
         # Add a second attempt with different response
         conn = sqlite3.connect(str(db_path))
@@ -484,7 +466,7 @@ class TestScanSqliteReadonlyTraceAttachment:
         conn.commit()
         conn.close()
 
-        result = scan_sqlite_readonly(db_path, "test_workflow", target_dir=target_dir)
+        result = scan_sqlite_readonly(db_path, "test_workflow")
         records = result["nodes"]["classify"]["preview"]
         trace = records[0]["_trace"]
         assert trace["attempt"] == 1
@@ -553,7 +535,6 @@ class TestScanSqliteNamespaceUnwrap:
     def test_preview_records_show_action_fields(self, tmp_path):
         """Preview records should have unwrapped content for the action."""
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")
         conn.execute(
@@ -567,19 +548,15 @@ class TestScanSqliteNamespaceUnwrap:
                 "classify": {"genre": "fiction"},
             },
         }
-        record_json = json.dumps([namespaced_record])
         conn.execute(
             "INSERT INTO target_data VALUES (?, ?, ?, ?)",
-            ("extract", "data.json", record_json, 1),
+            ("extract", "data.json", json.dumps([namespaced_record]), 1),
         )
         conn.execute("INSERT INTO source_data VALUES (?, ?, ?)", ("g1", "data.json", "{}"))
         conn.commit()
         conn.close()
-        fs_path = target_dir / "extract" / "data.json"
-        fs_path.parent.mkdir(parents=True, exist_ok=True)
-        fs_path.write_text(record_json)
 
-        result = scan_sqlite_readonly(db_path, "test_wf", target_dir=target_dir)
+        result = scan_sqlite_readonly(db_path, "test_wf")
         records = result["nodes"]["extract"]["preview"]
         assert len(records) == 1
         # content should be unwrapped to show extract's fields
@@ -589,7 +566,6 @@ class TestScanSqliteNamespaceUnwrap:
     def test_flat_content_records_unchanged(self, tmp_path):
         """Records without namespaced content pass through unchanged."""
         db_path = tmp_path / "test.db"
-        target_dir = tmp_path / "target"
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE source_data (source_guid TEXT, relative_path TEXT, data TEXT)")
         conn.execute(
@@ -600,19 +576,15 @@ class TestScanSqliteNamespaceUnwrap:
             "source_guid": "g1",
             "content": {"genre": "fiction", "confidence": 0.9},
         }
-        record_json = json.dumps([flat_record])
         conn.execute(
             "INSERT INTO target_data VALUES (?, ?, ?, ?)",
-            ("classify", "data.json", record_json, 1),
+            ("classify", "data.json", json.dumps([flat_record]), 1),
         )
         conn.execute("INSERT INTO source_data VALUES (?, ?, ?)", ("g1", "data.json", "{}"))
         conn.commit()
         conn.close()
-        fs_path = target_dir / "classify" / "data.json"
-        fs_path.parent.mkdir(parents=True, exist_ok=True)
-        fs_path.write_text(record_json)
 
-        result = scan_sqlite_readonly(db_path, "test_wf", target_dir=target_dir)
+        result = scan_sqlite_readonly(db_path, "test_wf")
         records = result["nodes"]["classify"]["preview"]
         assert len(records) == 1
         assert records[0]["content"] == {"genre": "fiction", "confidence": 0.9}

--- a/tests/workflow/test_stale_completion_verification.py
+++ b/tests/workflow/test_stale_completion_verification.py
@@ -220,9 +220,7 @@ class TestSQLiteBackendThreadSafeReads:
     def test_list_target_files_acquires_lock(self, tmp_path):
         from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
-        backend = SQLiteBackend(
-            str(tmp_path / "test.db"), "test_workflow", target_dir=str(tmp_path / "target")
-        )
+        backend = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
         backend.initialize()
         backend.write_target(
             "action_a", "out.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}]
@@ -244,20 +242,30 @@ class TestSQLiteBackendThreadSafeReads:
 
         assert "locked" in acquired, "list_target_files must acquire _lock"
 
-    def test_read_target_reads_from_filesystem(self, tmp_path):
+    def test_read_target_acquires_lock(self, tmp_path):
         from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
-        backend = SQLiteBackend(
-            str(tmp_path / "test.db"), "test_workflow", target_dir=str(tmp_path / "target")
-        )
+        backend = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
         backend.initialize()
         backend.write_target(
             "action_a", "out.json", [{"_state": "processed", "_state_schema_version": 1, "id": 1}]
         )
 
-        result = backend.read_target("action_a", "out.json")
-        assert len(result) == 1
-        assert result[0]["id"] == 1
+        acquired = []
+        original_lock = backend._lock
+
+        class TrackingLock:
+            def __enter__(self_inner):
+                acquired.append("locked")
+                return original_lock.__enter__()
+
+            def __exit__(self_inner, *args):
+                return original_lock.__exit__(*args)
+
+        with patch.object(backend, "_lock", TrackingLock()):
+            backend.read_target("action_a", "out.json")
+
+        assert "locked" in acquired, "read_target must acquire _lock"
 
     def test_concurrent_reads_return_correct_data(self, tmp_path):
         """Multiple threads reading simultaneously must all return correct data."""
@@ -265,9 +273,7 @@ class TestSQLiteBackendThreadSafeReads:
 
         from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
-        backend = SQLiteBackend(
-            str(tmp_path / "test.db"), "test_workflow", target_dir=str(tmp_path / "target")
-        )
+        backend = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
         backend.initialize()
         backend.write_target(
             "upstream",
@@ -320,9 +326,7 @@ class TestSQLiteBackendRemainingReadLocks:
     def _setup_backend(self, tmp_path):
         from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
-        backend = SQLiteBackend(
-            str(tmp_path / "test.db"), "test_workflow", target_dir=str(tmp_path / "target")
-        )
+        backend = SQLiteBackend(str(tmp_path / "test.db"), "test_workflow")
         backend.initialize()
         return backend
 


### PR DESCRIPTION
## Summary
- Reverts #677 (filesystem source of truth for target_data)
- The split data plane (DB for metadata, filesystem for data) breaks the pluggable backend contract — swapping to Postgres still requires local filesystem target/ files
- The backend should be self-contained: one backend, one source of truth

## What this restores
- `write_target` stores full JSON blob in SQLite `data` column
- `_read_target_raw` reads from SQLite
- `preview_target` reads from SQLite
- Data scanners read from SQLite
- No `target_dir` parameter on SQLiteBackend

## Verification
- 7455 tests pass, 2 skipped