### PR TITLE
refactor(storage): DB as single source of truth — eliminate redundant FS writes

### DIFF
--- a/agent_actions/logging/events/handlers/run_results.py
+++ b/agent_actions/logging/events/handlers/run_results.py
@@ -122,8 +122,8 @@ class RunResultsCollector:
         if not self.output_dir:
             return
 
-        target_dir = self.output_dir / "target"
-        target_dir.mkdir(parents=True, exist_ok=True)
+        logs_dir = self.output_dir / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
 
         output = {
             "metadata": self._metadata,
@@ -134,7 +134,7 @@ class RunResultsCollector:
             "tokens": self._total_tokens,
         }
 
-        output_path = target_dir / "run_results.json"
+        output_path = logs_dir / "run_results.json"
         atomic_json_write(output_path, output, indent=2, default=str)
 
     def _handle_workflow_start(self, event: BaseEvent) -> None:

--- a/agent_actions/logging/factory.py
+++ b/agent_actions/logging/factory.py
@@ -140,7 +140,7 @@ class LoggerFactory:
 
         if output_dir:
             output_path = Path(output_dir)
-            log_file = output_path / "target" / "events.json"
+            log_file = output_path / "logs" / "events.json"
             json_handler = JSONFileHandler(
                 file_path=log_file,
                 min_level=EventLevel.DEBUG,
@@ -148,7 +148,7 @@ class LoggerFactory:
             )
             manager.register(json_handler)
 
-            errors_file = output_path / "target" / "errors.json"
+            errors_file = output_path / "logs" / "errors.json"
             errors_handler = JSONFileHandler(
                 file_path=errors_file,
                 min_level=EventLevel.ERROR,

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -16,7 +17,6 @@ from agent_actions.logging.events import (
 from agent_actions.processing.error_handling import ProcessorErrorHandlerMixin
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.path_safety import assert_path_contained
-from agent_actions.utils.path_utils import ensure_directory_exists
 
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
@@ -109,7 +109,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
         self._execute_write("Write staging file", do_write)
 
     def write_target(self, data: list[dict[str, Any]]) -> None:
-        """Write data to storage backend and materialize to disk."""
+        """Write data to storage backend (DB is the single source of truth)."""
 
         def do_write() -> int:
             if self.storage_backend is None or self.action_name is None:
@@ -132,18 +132,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
 
             self.storage_backend.write_target(self.action_name, relative_path, data)
 
-            # Strip _delta_mode before disk write — it's a storage-layer
-            # internal that must not leak to filesystem files.
-            clean_data = [
-                {k: v for k, v in record.items() if k != "_delta_mode"}
-                if isinstance(record, dict) and "_delta_mode" in record
-                else record
-                for record in data
-            ]
-            ensure_directory_exists(file_path, is_file=True)
-            atomic_json_write(file_path, clean_data)
-
-            return file_path.stat().st_size
+            return len(json.dumps(data, default=str).encode())
 
         self._execute_write("Write target file", do_write)
 

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -617,6 +617,13 @@ class StorageBackend(ABC):
         """Delete traces for an action, or all if action_name is None."""
         return 0
 
+    def scan_data(self, preview_limit: int = 20) -> dict[str, Any] | None:
+        """Return stats and preview records for the docs scanner.
+
+        Default returns None. Backends override to provide scan capability.
+        """
+        return None
+
     def clear_source_data(self) -> None:
         """Delete all rows from the source_data table."""
         raise NotImplementedError(f"{type(self).__name__} must implement clear_source_data()")

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -203,6 +203,35 @@ class SQLiteBackend(StorageBackend):
             )
         return cls(str(db_path), workflow_name)
 
+    @classmethod
+    def create_readonly(cls, db_path: str | Path) -> "SQLiteBackend":
+        """Create a read-only instance for scanning. Do not call initialize()."""
+        import urllib.parse
+
+        instance = cls.__new__(cls)
+        StorageBackend.__init__(instance)
+        instance.db_path = Path(db_path)
+        instance.workflow_name = instance.db_path.stem
+        instance._lock = threading.RLock()
+        instance._readonly = True
+
+        posix_path = instance.db_path.as_posix()
+        if not posix_path.startswith("/"):
+            posix_path = "/" + posix_path
+        encoded_path = urllib.parse.quote(posix_path, safe="/:")
+
+        ro_uri = f"file://{encoded_path}?mode=ro"
+        try:
+            conn = sqlite3.connect(ro_uri, uri=True)
+            conn.row_factory = sqlite3.Row
+            conn.execute("SELECT 1 FROM sqlite_master LIMIT 1")
+        except sqlite3.OperationalError:
+            conn = sqlite3.connect(f"file://{encoded_path}?immutable=1", uri=True)
+            conn.row_factory = sqlite3.Row
+
+        instance._connection = conn
+        return instance
+
     def _validate_identifier(self, name: str, field: str) -> str:
         """Validate and POSIX-normalize an identifier to prevent injection.
 
@@ -249,6 +278,8 @@ class SQLiteBackend(StorageBackend):
 
     def initialize(self) -> None:
         """Create connection, enforce schema, create tables and indexes."""
+        if getattr(self, "_readonly", False):
+            raise RuntimeError("Cannot initialize a read-only backend instance.")
         with self._lock:
             self._open_connection()
             cursor = self.connection.cursor()
@@ -421,12 +452,15 @@ class SQLiteBackend(StorageBackend):
     def load_metadata(self, key: str) -> str | None:
         """Load a metadata value by key. Returns None if not found."""
         with self._lock:
-            cursor = self.connection.cursor()
-            cursor.execute(
-                "SELECT value FROM workflow_metadata WHERE key = ?",
-                (key,),
-            )
-            row = cursor.fetchone()
+            try:
+                cursor = self.connection.cursor()
+                cursor.execute(
+                    "SELECT value FROM workflow_metadata WHERE key = ?",
+                    (key,),
+                )
+                row = cursor.fetchone()
+            except sqlite3.OperationalError:
+                return None
         return row["value"] if row else None
 
     def write_source(
@@ -1567,6 +1601,122 @@ class SQLiteBackend(StorageBackend):
                     e,
                     extra={"workflow_name": self.workflow_name},
                 )
+
+    def scan_data(self, preview_limit: int = 20) -> dict[str, Any] | None:
+        """Return stats and preview records for the docs scanner."""
+        with self._lock:
+            cursor = self._connection.cursor()
+
+            cursor.execute("SELECT COUNT(*) as count FROM source_data")
+            source_count = cursor.fetchone()["count"]
+
+            cursor.execute(
+                "SELECT action_name, COALESCE(SUM(record_count), 0) as count "
+                "FROM target_data GROUP BY action_name ORDER BY action_name"
+            )
+            node_counts = {row["action_name"]: row["count"] for row in cursor.fetchall()}
+
+            cursor.execute("SELECT SUM(record_count) as count FROM target_data")
+            row = cursor.fetchone()
+            target_count = row["count"] if row["count"] else 0
+
+            db_size = self.db_path.stat().st_size if self.db_path.exists() else 0
+
+            nodes: dict[str, Any] = {}
+            for action_name, record_count in node_counts.items():
+                cursor.execute(
+                    "SELECT DISTINCT relative_path FROM target_data "
+                    "WHERE action_name = ? ORDER BY relative_path",
+                    (action_name,),
+                )
+                files = [r["relative_path"] for r in cursor.fetchall()]
+
+                records: list[dict[str, Any]] = []
+                for rp in files:
+                    if len(records) >= preview_limit:
+                        break
+                    try:
+                        data = self._read_target_raw(action_name, rp)
+                        if not isinstance(data, list):
+                            data = [data] if data else []
+                        if data and isinstance(data[0], dict) and "_delta_mode" in data[0]:
+                            data = self._reconstruct_from_deltas(action_name, rp, data)
+                        for item in data:
+                            if len(records) >= preview_limit:
+                                break
+                            content = item.get("content")
+                            if isinstance(content, dict) and action_name in content:
+                                ns = content[action_name]
+                                if isinstance(ns, dict):
+                                    item = {**item, "content": ns}
+                                elif ns is None:
+                                    item = {**item, "content": {}}
+                            records.append({**item, "_file": rp})
+                    except (FileNotFoundError, json.JSONDecodeError):
+                        pass
+
+                # Attach prompt traces
+                try:
+                    tid_map: dict[str, list[dict[str, Any]]] = {}
+                    for rec in records:
+                        tid = rec.get("target_id")
+                        if tid:
+                            tid_map.setdefault(tid, []).append(rec)
+                    if tid_map:
+                        placeholders = ",".join("?" for _ in tid_map)
+                        cursor.execute(
+                            f"SELECT record_id, compiled_prompt, llm_context, "
+                            f"response_text, model_name, model_vendor, run_mode, "
+                            f"prompt_length, response_length, attempt "
+                            f"FROM prompt_trace "
+                            f"WHERE action_name = ? AND record_id IN ({placeholders})"
+                            f" ORDER BY attempt DESC",
+                            [action_name, *tid_map.keys()],
+                        )
+                        seen: set[str] = set()
+                        for trace_row in cursor:
+                            rid = trace_row["record_id"]
+                            if rid in seen:
+                                continue
+                            seen.add(rid)
+                            trace_data = {
+                                "compiled_prompt": trace_row["compiled_prompt"],
+                                "llm_context": trace_row["llm_context"],
+                                "response_text": trace_row["response_text"],
+                                "model_name": trace_row["model_name"],
+                                "model_vendor": trace_row["model_vendor"],
+                                "run_mode": trace_row["run_mode"],
+                                "prompt_length": trace_row["prompt_length"],
+                                "response_length": trace_row["response_length"],
+                                "attempt": trace_row["attempt"],
+                            }
+                            for rec in tid_map.get(rid, []):
+                                rec["_trace"] = trace_data
+                except sqlite3.OperationalError:
+                    pass
+
+                nodes[action_name] = {
+                    "record_count": record_count,
+                    "files": files,
+                    "preview": records,
+                }
+
+            if db_size < 1024:
+                size_human = f"{db_size} B"
+            elif db_size < 1024 * 1024:
+                size_human = f"{db_size / 1024:.1f} KB"
+            elif db_size < 1024 * 1024 * 1024:
+                size_human = f"{db_size / (1024 * 1024):.1f} MB"
+            else:
+                size_human = f"{db_size / (1024 * 1024 * 1024):.1f} GB"
+
+            return {
+                "db_path": str(self.db_path),
+                "db_size": size_human,
+                "source_count": source_count,
+                "target_count": target_count,
+                "nodes": nodes,
+            }
 
     def close(self) -> None:
         """Close the database connection."""

--- a/agent_actions/tooling/docs/scanner/__init__.py
+++ b/agent_actions/tooling/docs/scanner/__init__.py
@@ -36,7 +36,6 @@ from .data_scanners import (
     scan_prompts,
     scan_runs,
     scan_schemas,
-    scan_sqlite_readonly,
     scan_workflow_data,
 )
 
@@ -54,7 +53,6 @@ __all__ = [
     "scan_prompts",
     "scan_schemas",
     "scan_workflow_data",
-    "scan_sqlite_readonly",
     "scan_runs",
     "scan_logs",
     "extract_action_metrics",

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -90,6 +90,8 @@ def scan_schemas(project_root: Path) -> dict[str, Any]:
 
 def scan_workflow_data(project_root: Path) -> dict[str, Any]:
     """Scan project for SQLite target databases and export preview data."""
+    from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
     workflow_data = {}
     artefact_dir = project_root / "artefact"
 
@@ -105,223 +107,17 @@ def scan_workflow_data(project_root: Path) -> dict[str, Any]:
             workflow_name = db_file.stem
 
             try:
-                data = scan_sqlite_readonly(db_file, workflow_name)
-                if data is not None:
-                    workflow_data[workflow_name] = data
+                backend = SQLiteBackend.create_readonly(db_file)
+                try:
+                    data = backend.scan_data()
+                    if data is not None:
+                        workflow_data[workflow_name] = data
+                finally:
+                    backend.close()
             except (OSError, sqlite3.Error) as e:
                 logger.warning("Failed to scan workflow DB %s: %s", db_file, e, exc_info=True)
 
     return workflow_data
-
-
-def _unwrap_record_content(record: dict, action_name: str) -> dict:
-    """Unwrap namespaced content for a specific action.
-
-    With the additive model, record["content"] is
-    {"action_a": {...}, "action_b": {...}, ...}. Replace it with the
-    specific action's fields so consumers see actual output data.
-    """
-    content = record.get("content")
-    if not isinstance(content, dict):
-        return record
-    if action_name in content:
-        ns = content[action_name]
-        if ns is None:
-            # Guard-skipped — null namespace
-            return {**record, "content": {}}
-        if isinstance(ns, dict):
-            return {**record, "content": ns}
-        return {**record, "content": {action_name: ns}}
-    # Check if content looks namespaced (values are dicts/None = bus model)
-    # vs flat (values are strings/numbers = legacy or pre-namespace data)
-    looks_namespaced = any(isinstance(v, (dict, type(None))) for v in content.values())
-    if looks_namespaced:
-        # Namespaced but this action missing — guard-skipped without null marker
-        return {**record, "content": {}}
-    # Flat legacy content — pass through as-is
-    return record
-
-
-def scan_sqlite_readonly(db_file: Path, workflow_name: str) -> dict[str, Any] | None:
-    """Open a workflow SQLite DB read-only and extract stats + preview data.
-
-    Uses a direct sqlite3 connection in read-only mode so that scanning
-    never modifies the database (safe on read-only mounts/checkouts).
-
-    Tries ``mode=ro`` first so WAL data from active writers is visible.
-    Falls back to ``immutable=1`` when the filesystem is truly read-only
-    (``mode=ro`` still attempts WAL sidecar writes and raises
-    ``OperationalError`` on read-only mounts).
-    """
-    import json as _json
-    import sqlite3
-
-    # Percent-encode the path so that # and ? in directory names
-    # are treated as path bytes, not URI fragment/query separators.
-    import urllib.parse
-
-    # as_posix() ensures forward slashes on all platforms (Windows included).
-    posix_path = db_file.as_posix()
-    # Guarantee the path starts with / so file://{path} always has an
-    # empty URI authority.  Unix paths already start with /; Windows
-    # drive paths (C:/...) do not; UNC paths (//server/...) are fine.
-    if not posix_path.startswith("/"):
-        posix_path = "/" + posix_path
-    encoded_path = urllib.parse.quote(posix_path, safe="/:")
-
-    # mode=ro sees live WAL data; immutable=1 skips WAL but works on
-    # read-only filesystems.  Try the richer mode first.
-    ro_uri = f"file://{encoded_path}?mode=ro"
-    try:
-        conn = sqlite3.connect(ro_uri, uri=True)
-        conn.row_factory = sqlite3.Row
-        # Probe to surface WAL sidecar errors early.
-        conn.execute("SELECT 1 FROM sqlite_master LIMIT 1")
-    except sqlite3.OperationalError:
-        conn = sqlite3.connect(f"file://{encoded_path}?immutable=1", uri=True)
-        conn.row_factory = sqlite3.Row
-    try:
-        cursor = conn.cursor()
-
-        # Source count
-        cursor.execute("SELECT COUNT(*) as count FROM source_data")
-        source_count = cursor.fetchone()["count"]
-
-        # Target counts per node — COALESCE guards against NULL record_count rows
-        cursor.execute(
-            "SELECT action_name, COALESCE(SUM(record_count), 0) as count "
-            "FROM target_data GROUP BY action_name ORDER BY action_name"
-        )
-        node_counts = {row["action_name"]: row["count"] for row in cursor.fetchall()}
-
-        # Total target count
-        cursor.execute("SELECT SUM(record_count) as count FROM target_data")
-        row = cursor.fetchone()
-        target_count = row["count"] if row["count"] else 0
-
-        # DB size
-        db_size = db_file.stat().st_size if db_file.exists() else 0
-
-        # Preview records per node
-        nodes = {}
-        for action_name, record_count in node_counts.items():
-            # Collect ALL files for this action (no limit)
-            cursor.execute(
-                "SELECT DISTINCT relative_path FROM target_data "
-                "WHERE action_name = ? ORDER BY relative_path",
-                (action_name,),
-            )
-            files = [row["relative_path"] for row in cursor.fetchall()]
-
-            # Preview: iterate the cursor lazily so we never load every
-            # data blob into memory.  Cap at 20 flattened records.
-            cursor.execute(
-                "SELECT relative_path, data FROM target_data WHERE action_name = ?",
-                (action_name,),
-            )
-            records: list[dict] = []
-            for target_row in cursor:
-                if len(records) >= 20:
-                    break
-                try:
-                    row_data = _json.loads(target_row["data"])
-                except (ValueError, _json.JSONDecodeError):
-                    logger.debug(
-                        "Skipping malformed JSON in %s node %s, file %s",
-                        workflow_name,
-                        action_name,
-                        target_row["relative_path"],
-                    )
-                    continue
-                file_path = target_row["relative_path"]
-                if isinstance(row_data, list):
-                    for item in row_data:
-                        if len(records) >= 20:
-                            break
-                        if isinstance(item, dict):
-                            item = _unwrap_record_content(item, action_name)
-                            records.append({**item, "_file": file_path})
-                        else:
-                            records.append({"_file": file_path, "_value": item})
-                elif isinstance(row_data, dict):
-                    row_data = _unwrap_record_content(row_data, action_name)
-                    records.append({**row_data, "_file": file_path})
-                else:
-                    records.append({"_file": file_path, "_value": row_data})
-            nodes[action_name] = {
-                "record_count": record_count,
-                "files": files,
-                "preview": records,
-            }
-
-        # Attach prompt traces to preview records (if table exists).
-        # The prompt_trace table was added in v0.1.6; older DBs won't have it.
-        # Traces are keyed by target_id (unique per record per stage).
-        try:
-            for action_name, node_data in nodes.items():
-                # Map target_id → list of records
-                tid_map: dict[str, list[dict]] = {}
-                for rec in node_data["preview"]:
-                    tid = rec.get("target_id")
-                    if tid:
-                        tid_map.setdefault(tid, []).append(rec)
-
-                if not tid_map:
-                    continue
-
-                placeholders = ",".join("?" for _ in tid_map)
-                cursor.execute(
-                    f"SELECT record_id, compiled_prompt, llm_context, "
-                    f"response_text, model_name, model_vendor, run_mode, "
-                    f"prompt_length, response_length, attempt "
-                    f"FROM prompt_trace "
-                    f"WHERE action_name = ? AND record_id IN ({placeholders})"
-                    f" ORDER BY attempt DESC",
-                    [action_name, *tid_map.keys()],
-                )
-                seen: set[str] = set()
-                for trace_row in cursor:
-                    rid = trace_row["record_id"]
-                    if rid in seen:
-                        continue
-                    seen.add(rid)
-                    trace_data = {
-                        "compiled_prompt": trace_row["compiled_prompt"],
-                        "llm_context": trace_row["llm_context"],
-                        "response_text": trace_row["response_text"],
-                        "model_name": trace_row["model_name"],
-                        "model_vendor": trace_row["model_vendor"],
-                        "run_mode": trace_row["run_mode"],
-                        "prompt_length": trace_row["prompt_length"],
-                        "response_length": trace_row["response_length"],
-                        "attempt": trace_row["attempt"],
-                    }
-                    for rec in tid_map.get(rid, []):
-                        rec["_trace"] = trace_data
-        except sqlite3.OperationalError:
-            logger.debug("No prompt_trace table in %s — skipping trace attachment", db_file)
-
-        # Format size
-        if db_size < 1024:
-            size_human = f"{db_size} B"
-        elif db_size < 1024 * 1024:
-            size_human = f"{db_size / 1024:.1f} KB"
-        elif db_size < 1024 * 1024 * 1024:
-            size_human = f"{db_size / (1024 * 1024):.1f} MB"
-        elif db_size < 1024 * 1024 * 1024 * 1024:
-            size_human = f"{db_size / (1024 * 1024 * 1024):.1f} GB"
-        else:
-            size_human = f"{db_size / (1024 * 1024 * 1024 * 1024):.1f} TB"
-
-        return {
-            "db_path": str(db_file),
-            "db_size": size_human,
-            "source_count": source_count,
-            "target_count": target_count,
-            "nodes": nodes,
-        }
-    finally:
-        conn.close()
 
 
 def scan_runs(project_root: Path) -> dict[str, Any]:
@@ -337,10 +133,6 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
         if artefact_dir in agent_io_dir.parents or agent_io_dir == artefact_dir:
             continue
 
-        target_dir = agent_io_dir / "target"
-        if not target_dir.exists():
-            continue
-
         # Extract workflow name from path (parent of agent_io is workflow dir)
         workflow_dir = agent_io_dir.parent
         # Get the workflow name from agent_config if possible
@@ -354,8 +146,19 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
         if not workflow_name:
             workflow_name = workflow_dir.name
 
+        logs_dir = agent_io_dir / "logs"
+        target_dir = agent_io_dir / "target"
+
+        def _resolve_log_file(
+            name: str, _logs: Path = logs_dir, _target: Path = target_dir
+        ) -> Path:
+            path = _logs / name
+            if path.exists():
+                return path
+            return _target / name
+
         # Load run_results.json for latest run metadata
-        run_results_path = target_dir / "run_results.json"
+        run_results_path = _resolve_log_file("run_results.json")
         latest_run = None
         if run_results_path.exists():
             try:
@@ -365,7 +168,7 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
                 logger.debug("Failed to load run_results %s: %s", run_results_path, e)
 
         # Load events.json for detailed execution data
-        events_path = target_dir / "events.json"
+        events_path = _resolve_log_file("events.json")
         action_metrics = {}
         runtime_warnings: list[dict[str, Any]] = []
         if events_path.exists():
@@ -388,7 +191,7 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
                 )
 
         # Load .manifest.json for execution plan and per-action status
-        manifest_path = target_dir / ".manifest.json"
+        manifest_path = _resolve_log_file(".manifest.json")
         manifest_data = None
         if manifest_path.exists():
             try:

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -311,8 +311,9 @@ class AgentWorkflow:
 
         # JSONFileHandler opens lazily, so deleting between handler init
         # and first event write is safe.
+        logs_dir = project_root / "agent_io" / "logs"
         for events_file in ("events.json", "errors.json"):
-            events_path = target_dir / events_file
+            events_path = logs_dir / events_file
             try:
                 events_path.unlink(missing_ok=True)
             except OSError as e:

--- a/agent_actions/workflow/managers/loop.py
+++ b/agent_actions/workflow/managers/loop.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections import defaultdict
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -19,18 +17,6 @@ if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class JsonLoadParams:
-    """Parameters for loading JSON from file."""
-
-    json_file: Path
-    outputs: list
-    corrupted_files: list
-    output_dir: Path
-    operation: str
-    add_source_file: bool = False
 
 
 class VersionOutputCorrelator:
@@ -89,19 +75,8 @@ class VersionOutputCorrelator:
         version_filenames = set()
 
         for version_agent in version_sources:
-            if self.storage_backend is not None:
-                outputs, filenames = self._load_from_storage_backend(version_agent)
-                if outputs:
-                    version_outputs[version_agent] = outputs
-                    version_filenames.update(filenames)
-                    continue
-
-            version_idx = self._find_agent_index(version_agent)
-            if version_idx is None:
-                continue
-            version_output_dir = self.agent_folder / "target" / version_agent
-            if version_output_dir.exists():
-                outputs, filenames = self._load_agent_outputs_with_filenames(version_output_dir)
+            outputs, filenames = self._load_from_storage_backend(version_agent)
+            if outputs:
                 version_outputs[version_agent] = outputs
                 version_filenames.update(filenames)
 
@@ -110,6 +85,10 @@ class VersionOutputCorrelator:
     def _load_from_storage_backend(self, version_agent: str) -> tuple[list[dict[str, Any]], set]:
         """Load outputs from storage backend for a version agent."""
         if self.storage_backend is None:
+            logger.warning(
+                "No storage backend configured — cannot load version outputs for %s",
+                version_agent,
+            )
             return [], set()
 
         outputs = []
@@ -189,115 +168,6 @@ class VersionOutputCorrelator:
         except (OSError, ValueError, KeyError) as e:
             logger.exception("Error preparing correlated input for %s: %s", agent_name, e)
             return None
-
-    def _find_agent_index(self, agent_name: str) -> int | None:
-        """Return 0 if the agent has data in storage or filesystem, None otherwise."""
-        if self.storage_backend is not None:
-            try:
-                target_files = self.storage_backend.list_target_files(agent_name)
-                if target_files:
-                    return 0
-            except Exception as e:
-                logger.debug("Failed to list target files for %s: %s", agent_name, e, exc_info=True)
-
-        target_dir = self.agent_folder / "target"
-        if not target_dir.exists():
-            return None
-        agent_dir = target_dir / agent_name
-        if agent_dir.exists() and agent_dir.is_dir():
-            return 0
-        return None
-
-    def _load_json_from_file(self, params: JsonLoadParams):
-        """Load JSON from a file and handle errors."""
-        try:
-            with open(params.json_file, encoding="utf-8") as f:
-                data = json.load(f)
-                if params.add_source_file:
-                    if isinstance(data, list):
-                        for record in data:
-                            record["_source_file"] = params.json_file.name
-                        params.outputs.extend(data)
-                    else:
-                        data["_source_file"] = params.json_file.name
-                        params.outputs.append(data)
-                elif isinstance(data, list):
-                    params.outputs.extend(data)
-                else:
-                    params.outputs.append(data)
-        except json.JSONDecodeError as e:
-            logger.warning(
-                "Skipping corrupted JSON file in version output",
-                extra={
-                    "operation": params.operation,
-                    "file": str(params.json_file),
-                    "output_dir": str(params.output_dir),
-                    "error": str(e),
-                    "line": e.lineno if hasattr(e, "lineno") else None,
-                },
-            )
-            params.corrupted_files.append(str(params.json_file.name))
-        except OSError as e:
-            logger.error(
-                "Failed to read version output file",
-                extra={
-                    "operation": params.operation,
-                    "file": str(params.json_file),
-                    "output_dir": str(params.output_dir),
-                    "error": str(e),
-                },
-            )
-            params.corrupted_files.append(str(params.json_file.name))
-        except (ValueError, TypeError, UnicodeDecodeError) as e:
-            logger.exception(
-                "Unexpected error loading version output file",
-                extra={
-                    "operation": params.operation,
-                    "file": str(params.json_file),
-                    "output_dir": str(params.output_dir),
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                },
-            )
-            params.corrupted_files.append(str(params.json_file.name))
-
-    def _load_agent_outputs_with_filenames(
-        self, output_dir: Path
-    ) -> tuple[list[dict[str, Any]], set]:
-        """Load all JSON outputs with filenames."""
-        outputs: list[dict[str, Any]] = []
-        filenames = set()
-        corrupted_files: list[str] = []
-
-        for json_file in output_dir.glob("*.json"):
-            before_count = len(outputs)
-            self._load_json_from_file(
-                JsonLoadParams(
-                    json_file=json_file,
-                    outputs=outputs,
-                    corrupted_files=corrupted_files,
-                    output_dir=output_dir,
-                    operation="load_version_outputs_with_filenames",
-                    add_source_file=True,
-                )
-            )
-            if len(outputs) > before_count:
-                filenames.add(json_file.name)
-
-        if corrupted_files:
-            logger.warning(
-                "Skipped %d corrupted files in version output",
-                len(corrupted_files),
-                extra={
-                    "operation": "load_loop_outputs_with_filenames",
-                    "output_dir": str(output_dir),
-                    "corrupted_count": len(corrupted_files),
-                    "corrupted_files": corrupted_files,
-                    "loaded_count": len(outputs),
-                },
-            )
-
-        return (outputs, filenames)
 
     def _build_correlation_groups(
         self, version_outputs: dict[str, list[dict[str, Any]]]
@@ -385,9 +255,8 @@ class VersionOutputCorrelator:
 
         if self.storage_backend is not None and action_name:
             try:
-                for record in cleaned_data:
-                    record["_delta_mode"] = "full"
-                self.storage_backend.write_target(action_name, filename, cleaned_data)
+                tagged_data = [{**r, "_delta_mode": "full"} for r in cleaned_data]
+                self.storage_backend.write_target(action_name, filename, tagged_data)
                 logger.debug(
                     "Wrote %d correlated records to storage backend for %s/%s",
                     len(cleaned_data),
@@ -400,6 +269,8 @@ class VersionOutputCorrelator:
                     action_name,
                     e,
                 )
+            output_file = output_dir / filename
+            self._create_correlation_source_data(output_file, cleaned_data)
         else:
             output_file = output_dir / filename
             atomic_json_write(output_file, cleaned_data, indent=2)

--- a/agent_actions/workflow/managers/manifest.py
+++ b/agent_actions/workflow/managers/manifest.py
@@ -33,7 +33,8 @@ class ManifestManager:
         """Initialize manifest manager."""
         self.agent_io_path = Path(agent_io_path)
         self.target_dir = self.agent_io_path / "target"
-        self.manifest_path = self.target_dir / MANIFEST_FILENAME
+        self.logs_dir = self.agent_io_path / "logs"
+        self.manifest_path = self.logs_dir / MANIFEST_FILENAME
         self._manifest: dict[str, Any] | None = None
         self._lock = threading.RLock()
 
@@ -113,8 +114,7 @@ class ManifestManager:
                     "error": None,
                 }
 
-            # Ensure target directory exists and save
-            self.target_dir.mkdir(parents=True, exist_ok=True)
+            self.logs_dir.mkdir(parents=True, exist_ok=True)
             self._save_manifest()
             logger.debug("Initialized manifest for workflow %s", workflow_name)
 

--- a/agent_actions/workflow/managers/output.py
+++ b/agent_actions/workflow/managers/output.py
@@ -63,22 +63,7 @@ class ActionOutputManager:
         self._version_consumption_map: dict | None = None
         self._version_consumption_lock = threading.Lock()
 
-    def _load_json_files(self, json_files: list[Path], agent_output: dict[str, Any]) -> list[Any]:
-        """Load data from JSON files."""
-        outputs = []
-        for json_file in json_files:
-            try:
-                with open(json_file, encoding="utf-8") as f:
-                    data = json.load(f)
-                    if isinstance(data, list):
-                        outputs.extend(data)
-                    else:
-                        outputs.append(data)
-            except (OSError, ValueError, TypeError) as file_error:
-                agent_output["errors"].append(f"Failed to read {json_file.name}: {file_error}")
-        return outputs
-
-    def _process_agent_output(self, output_dir: Path, prev_agent_name: str) -> dict[str, Any]:
+    def _process_agent_output(self, prev_agent_name: str) -> dict[str, Any]:
         """Process output directory for a single action."""
         agent_output = {
             "data": [],
@@ -92,12 +77,6 @@ class ActionOutputManager:
         outputs, backend_files = self._load_outputs_from_backend(prev_agent_name)
         if backend_files:
             agent_output["output_files"] = backend_files
-
-        if not outputs and output_dir.exists():
-            json_files = list(output_dir.glob("*.json"))
-            agent_output["output_files"] = [str(f.name) for f in json_files]
-            if json_files:
-                outputs = self._load_json_files(json_files, agent_output)
 
         agent_output["data"] = outputs
         agent_output["output_count"] = len(outputs)
@@ -129,10 +108,9 @@ class ActionOutputManager:
 
         for i in range(current_idx):
             prev_agent_name = self.execution_order[i]
-            output_dir = self.agent_folder / "target" / prev_agent_name
 
             try:
-                agent_output = self._process_agent_output(output_dir, prev_agent_name)
+                agent_output = self._process_agent_output(prev_agent_name)
                 previous_outputs[prev_agent_name] = agent_output["data"]
                 previous_outputs[f"{prev_agent_name}_meta"] = agent_output
 
@@ -143,7 +121,6 @@ class ActionOutputManager:
                     error_msg,
                     extra={
                         "prev_agent_name": prev_agent_name,
-                        "output_dir": str(output_dir),
                         "operation": "load_previous_outputs",
                     },
                 )

--- a/tests/core/graph/test_version_correlator.py
+++ b/tests/core/graph/test_version_correlator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 from agent_actions.workflow.coordinator import AgentWorkflow
 from agent_actions.workflow.managers.loop import VersionOutputCorrelator
 
@@ -20,9 +21,18 @@ class TestVersionOutputCorrelator:
             yield Path(tmpdir)
 
     @pytest.fixture
-    def correlator(self, temp_agent_folder):
-        """Create a VersionOutputCorrelator instance."""
-        return VersionOutputCorrelator(temp_agent_folder)
+    def storage_backend(self, temp_agent_folder):
+        """Create a SQLite backend for testing."""
+        db_path = temp_agent_folder / "store" / "test.db"
+        backend = SQLiteBackend.create(db_path=str(db_path), workflow_name="test")
+        backend.initialize()
+        yield backend
+        backend.close()
+
+    @pytest.fixture
+    def correlator(self, temp_agent_folder, storage_backend):
+        """Create a VersionOutputCorrelator instance with storage backend."""
+        return VersionOutputCorrelator(temp_agent_folder, storage_backend=storage_backend)
 
     @pytest.fixture
     def sample_execution_order(self):
@@ -90,42 +100,39 @@ class TestVersionOutputCorrelator:
         }
         assert "validate_quiz" not in consumption_map
 
-    def test_filename_preservation(self, correlator, temp_agent_folder):
+    def test_filename_preservation(self, correlator, storage_backend, temp_agent_folder):
         """Test that original filenames are preserved during correlation."""
-        loop_dirs = []
         test_filename = "Azure_AI_Questions.json"
         for i in range(1, 4):
-            # Use simple directory names (no node_X_ prefix)
-            loop_dir = temp_agent_folder / "target" / f"generate_distractors_{i}"
-            loop_dir.mkdir(parents=True)
-            loop_dirs.append(loop_dir)
+            action_name = f"generate_distractors_{i}"
             test_data = [
                 {
                     "source_guid": "test-guid-1",
                     "version_correlation_id": "test-corr-1",
                     "target_id": "target-1",
-                    "content": {
-                        f"generate_distractors_{i}": {f"distractor_{i}": f"Wrong answer {i}"}
-                    },
+                    "_state": "processed",
+                    "_state_schema_version": 1,
+                    "content": {action_name: {f"distractor_{i}": f"Wrong answer {i}"}},
                 }
             ]
-            with open(loop_dir / test_filename, "w") as f:
-                json.dump(test_data, f)
+            storage_backend._write_target_raw(action_name, test_filename, test_data)
         result_dir = correlator.prepare_correlated_input(
             "reconstruct_options",
             ["generate_distractors_1", "generate_distractors_2", "generate_distractors_3"],
             4,
         )
-        output_file = Path(result_dir) / test_filename
-        assert output_file.exists(), f"Expected file {test_filename} not found"
+        assert result_dir is not None, "prepare_correlated_input returned None"
+        target_files = storage_backend.list_target_files("reconstruct_options")
+        assert test_filename in target_files, f"Expected {test_filename} in backend target files"
         source_file = temp_agent_folder / "source" / test_filename
         assert source_file.exists(), f"Source file {test_filename} not created"
 
-    def test_correlation_source_includes_lineage(self, correlator, temp_agent_folder):
+    def test_correlation_source_includes_lineage(
+        self, correlator, storage_backend, temp_agent_folder
+    ):
         """Source file created by correlation must include lineage for downstream enrichment."""
         for i in range(1, 3):
-            loop_dir = temp_agent_folder / "target" / f"scorer_{i}"
-            loop_dir.mkdir(parents=True)
+            action_name = f"scorer_{i}"
             test_data = [
                 {
                     "source_guid": "guid-1",
@@ -133,11 +140,12 @@ class TestVersionOutputCorrelator:
                     "target_id": "tid-1",
                     "node_id": f"node_{i}_abc",
                     "lineage": ["node_0_root", f"node_{i}_abc"],
-                    "content": {f"scorer_{i}": {f"score_{i}": 8}},
+                    "_state": "processed",
+                    "_state_schema_version": 1,
+                    "content": {action_name: {f"score_{i}": 8}},
                 }
             ]
-            with open(loop_dir / "data.json", "w") as f:
-                json.dump(test_data, f)
+            storage_backend._write_target_raw(action_name, "data.json", test_data)
 
         correlator.prepare_correlated_input("aggregate", ["scorer_1", "scorer_2"], 3)
 
@@ -152,28 +160,26 @@ class TestVersionOutputCorrelator:
         assert len(record["lineage"]) >= 2
         assert "node_0_root" in record["lineage"]
 
-    def test_partial_record_handling(self, correlator, temp_agent_folder):
+    def test_partial_record_handling(self, correlator, storage_backend, temp_agent_folder):
         """Test that records missing from some loops are still included."""
-        # Use simple directory names (no node_X_ prefix)
-        loop1_dir = temp_agent_folder / "target" / "distractor_1"
-        loop2_dir = temp_agent_folder / "target" / "distractor_2"
-        loop3_dir = temp_agent_folder / "target" / "distractor_3"
-        for dir in [loop1_dir, loop2_dir, loop3_dir]:
-            dir.mkdir(parents=True)
+        lifecycle = {"_state": "processed", "_state_schema_version": 1}
         data_loop1 = [
             {
                 "source_guid": "guid-1",
                 "version_correlation_id": "corr-1",
+                **lifecycle,
                 "content": {"distractor_1": {"field_1": "value1"}},
             },
             {
                 "source_guid": "guid-2",
                 "version_correlation_id": "corr-2",
+                **lifecycle,
                 "content": {"distractor_1": {"field_1": "value2"}},
             },
             {
                 "source_guid": "guid-3",
                 "version_correlation_id": "corr-3",
+                **lifecycle,
                 "content": {"distractor_1": {"field_1": "value3"}},
             },
         ]
@@ -181,11 +187,13 @@ class TestVersionOutputCorrelator:
             {
                 "source_guid": "guid-1",
                 "version_correlation_id": "corr-1",
+                **lifecycle,
                 "content": {"distractor_2": {"field_2": "value1"}},
             },
             {
                 "source_guid": "guid-2",
                 "version_correlation_id": "corr-2",
+                **lifecycle,
                 "content": {"distractor_2": {"field_2": "value2"}},
             },
         ]
@@ -193,21 +201,18 @@ class TestVersionOutputCorrelator:
             {
                 "source_guid": "guid-1",
                 "version_correlation_id": "corr-1",
+                **lifecycle,
                 "content": {"distractor_3": {"field_3": "value1"}},
-            }
+            },
         ]
-        with open(loop1_dir / "data.json", "w") as f:
-            json.dump(data_loop1, f)
-        with open(loop2_dir / "data.json", "w") as f:
-            json.dump(data_loop2, f)
-        with open(loop3_dir / "data.json", "w") as f:
-            json.dump(data_loop3, f)
+        storage_backend._write_target_raw("distractor_1", "data.json", data_loop1)
+        storage_backend._write_target_raw("distractor_2", "data.json", data_loop2)
+        storage_backend._write_target_raw("distractor_3", "data.json", data_loop3)
         result_dir = correlator.prepare_correlated_input(
             "consumer", ["distractor_1", "distractor_2", "distractor_3"], 4
         )
-        output_file = Path(result_dir) / "data.json"
-        with open(output_file) as f:
-            correlated_data = json.load(f)
+        assert result_dir is not None
+        correlated_data = storage_backend.read_target("consumer", "data.json")
         assert len(correlated_data) == 3
         record1 = next(r for r in correlated_data if r["source_guid"] == "guid-1")
         # Version namespaces are now nested, not prefixed
@@ -229,47 +234,40 @@ class TestVersionOutputCorrelator:
         assert "distractor_3" not in record3["content"]
         assert record3["content"]["distractor_1"]["field_1"] == "value3"
 
-    def test_multiple_file_correlation(self, correlator, temp_agent_folder):
+    def test_multiple_file_correlation(self, correlator, storage_backend, temp_agent_folder):
         """Test correlation when loop agents produce multiple files."""
-        # Use simple directory names (no node_X_ prefix)
-        loop1_dir = temp_agent_folder / "target" / "processor_1"
-        loop2_dir = temp_agent_folder / "target" / "processor_2"
-        loop1_dir.mkdir(parents=True)
-        loop2_dir.mkdir(parents=True)
+        lifecycle = {"_state": "processed", "_state_schema_version": 1}
         files = ["questions.json", "answers.json", "metadata.json"]
         for filename in files:
             data1 = [
                 {
                     "source_guid": f"{filename}-guid-1",
                     "version_correlation_id": f"{filename}-corr-1",
+                    **lifecycle,
                     "content": {"processor_1": {"loop1_data": f"data_from_{filename}"}},
                 }
             ]
-            with open(loop1_dir / filename, "w") as f:
-                json.dump(data1, f)
             data2 = [
                 {
                     "source_guid": f"{filename}-guid-1",
                     "version_correlation_id": f"{filename}-corr-1",
+                    **lifecycle,
                     "content": {"processor_2": {"loop2_data": f"data_from_{filename}"}},
                 }
             ]
-            with open(loop2_dir / filename, "w") as f:
-                json.dump(data2, f)
+            storage_backend._write_target_raw("processor_1", filename, data1)
+            storage_backend._write_target_raw("processor_2", filename, data2)
         result_dir = correlator.prepare_correlated_input(
             "aggregator", ["processor_1", "processor_2"], 3
         )
+        assert result_dir is not None
         for filename in files:
-            output_file = Path(result_dir) / filename
-            assert output_file.exists(), f"File {filename} not correlated"
-            with open(output_file) as f:
-                data = json.load(f)
-                assert len(data) == 1
-                # Version namespaces are now nested, not prefixed
-                assert "processor_1" in data[0]["content"]
-                assert "processor_2" in data[0]["content"]
-                assert data[0]["content"]["processor_1"]["loop1_data"] == f"data_from_{filename}"
-                assert data[0]["content"]["processor_2"]["loop2_data"] == f"data_from_{filename}"
+            data = storage_backend.read_target("aggregator", filename)
+            assert len(data) == 1
+            assert "processor_1" in data[0]["content"]
+            assert "processor_2" in data[0]["content"]
+            assert data[0]["content"]["processor_1"]["loop1_data"] == f"data_from_{filename}"
+            assert data[0]["content"]["processor_2"]["loop2_data"] == f"data_from_{filename}"
 
     def test_correlate_by_source_record(self, correlator):
         """Test the correlation logic for merging records with prefixed field names."""
@@ -364,32 +362,31 @@ class TestVersionOutputCorrelatorIntegration:
     def test_integration_with_agent_workflow(self, mock_agent_workflow):
         """Test integration with AgentWorkflow's _setup_correlation_if_needed."""
         workflow, agent_folder = mock_agent_workflow
-        correlator = VersionOutputCorrelator(agent_folder)
+        db_path = agent_folder / "store" / "test.db"
+        backend = SQLiteBackend.create(db_path=str(db_path), workflow_name="test")
+        backend.initialize()
+        correlator = VersionOutputCorrelator(agent_folder, storage_backend=backend)
         workflow.version_correlator = correlator
+        lifecycle = {"_state": "processed", "_state_schema_version": 1}
         for i in range(1, 4):
-            # Use simple directory names (no node_X_ prefix)
-            loop_dir = agent_folder / "target" / f"loop_{i}"
-            loop_dir.mkdir(parents=True)
+            action_name = f"loop_{i}"
             data = [
                 {
                     "source_guid": "test-guid",
                     "version_correlation_id": "test-corr",
-                    "content": {f"loop_{i}": {f"field_{i}": f"value_{i}"}},
+                    **lifecycle,
+                    "content": {action_name: {f"field_{i}": f"value_{i}"}},
                 }
             ]
-            with open(loop_dir / "output.json", "w") as f:
-                json.dump(data, f)
+            backend._write_target_raw(action_name, "output.json", data)
         result = correlator.prepare_correlated_input("consumer", ["loop_1", "loop_2", "loop_3"], 4)
         assert result is not None
-        output_file = Path(result) / "output.json"
-        assert output_file.exists()
-        with open(output_file) as f:
-            data = json.load(f)
-            assert len(data) == 1
-            # Content is nested by agent name (not flattened)
-            assert data[0]["content"]["loop_1"]["field_1"] == "value_1"
-            assert data[0]["content"]["loop_2"]["field_2"] == "value_2"
-            assert data[0]["content"]["loop_3"]["field_3"] == "value_3"
+        data = backend.read_target("consumer", "output.json")
+        assert len(data) == 1
+        assert data[0]["content"]["loop_1"]["field_1"] == "value_1"
+        assert data[0]["content"]["loop_2"]["field_2"] == "value_2"
+        assert data[0]["content"]["loop_3"]["field_3"] == "value_3"
+        backend.close()
 
 
 class TestLoopCorrelatorWithSequentialMode:
@@ -402,147 +399,140 @@ class TestLoopCorrelatorWithSequentialMode:
             yield Path(tmpdir)
 
     @pytest.fixture
-    def correlator(self, temp_agent_folder):
-        """Create a VersionOutputCorrelator instance."""
-        return VersionOutputCorrelator(temp_agent_folder)
+    def storage_backend(self, temp_agent_folder):
+        """Create a SQLite backend for testing."""
+        db_path = temp_agent_folder / "store" / "test.db"
+        backend = SQLiteBackend.create(db_path=str(db_path), workflow_name="test")
+        backend.initialize()
+        yield backend
+        backend.close()
 
-    def test_sequential_loop_correlation_works(self, correlator, temp_agent_folder):
+    @pytest.fixture
+    def correlator(self, temp_agent_folder, storage_backend):
+        """Create a VersionOutputCorrelator instance with storage backend."""
+        return VersionOutputCorrelator(temp_agent_folder, storage_backend=storage_backend)
+
+    def test_sequential_loop_correlation_works(
+        self, correlator, storage_backend, temp_agent_folder
+    ):
         """Test that correlator works correctly with sequential loop outputs."""
+        lifecycle = {"_state": "processed", "_state_schema_version": 1}
         for i in range(1, 4):
-            # Use simple directory names (no node_X_ prefix)
-            loop_dir = temp_agent_folder / "target" / f"refine_{i}"
-            loop_dir.mkdir(parents=True)
+            action_name = f"refine_{i}"
             test_data = [
                 {
                     "source_guid": f"test-{i}",
                     "version_correlation_id": f"test-corr-{i}",
-                    "content": {f"refine_{i}": {"iteration": i, "data": f"refined_data_{i}"}},
+                    **lifecycle,
+                    "content": {action_name: {"iteration": i, "data": f"refined_data_{i}"}},
                 }
             ]
-            with open(loop_dir / "output.json", "w") as f:
-                json.dump(test_data, f)
+            storage_backend._write_target_raw(action_name, "output.json", test_data)
         result_dir = correlator.prepare_correlated_input(
             "aggregate", ["refine_1", "refine_2", "refine_3"], 4
         )
         assert result_dir is not None
-        output_file = Path(result_dir) / "output.json"
-        assert output_file.exists()
-        with open(output_file) as f:
-            data = json.load(f)
-            assert len(data) == 3
-            # Content is nested by agent name
-            # Extract iteration values from nested namespaces
-            iterations = set()
-            for item in data:
-                for _agent_name, content in item["content"].items():
-                    if isinstance(content, dict) and "iteration" in content:
-                        iterations.add(content["iteration"])
-            assert iterations == {1, 2, 3}
+        data = storage_backend.read_target("aggregate", "output.json")
+        assert len(data) == 3
+        iterations = set()
+        for item in data:
+            for _agent_name, content in item["content"].items():
+                if isinstance(content, dict) and "iteration" in content:
+                    iterations.add(content["iteration"])
+        assert iterations == {1, 2, 3}
 
-    def test_partial_sequential_failure_correlation(self, correlator, temp_agent_folder):
+    def test_partial_sequential_failure_correlation(
+        self, correlator, storage_backend, temp_agent_folder
+    ):
         """Test correlation when some sequential iterations fail."""
+        lifecycle = {"_state": "processed", "_state_schema_version": 1}
         for i in range(1, 3):
-            loop_dir = temp_agent_folder / "target" / f"process_{i}"
-            loop_dir.mkdir(parents=True)
+            action_name = f"process_{i}"
             test_data = [
                 {
                     "source_guid": "test-guid",
                     "version_correlation_id": "test-corr",
-                    "content": {f"process_{i}": {f"field_{i}": f"value_{i}"}},
+                    **lifecycle,
+                    "content": {action_name: {f"field_{i}": f"value_{i}"}},
                 }
             ]
-            with open(loop_dir / "result.json", "w") as f:
-                json.dump(test_data, f)
+            storage_backend._write_target_raw(action_name, "result.json", test_data)
         result_dir = correlator.prepare_correlated_input(
             "consumer", ["process_1", "process_2", "process_3"], 4
         )
         assert result_dir is not None
-        output_file = Path(result_dir) / "result.json"
-        if output_file.exists():
-            with open(output_file) as f:
-                data = json.load(f)
-                assert len(data) <= 2
-                if len(data) > 0:
-                    # Content is nested by agent name
-                    content = data[0]["content"]
-                    # Check that process_1 or process_2 namespace exists
-                    assert "process_1" in content or "process_2" in content
+        data = storage_backend.read_target("consumer", "result.json")
+        assert len(data) <= 2
+        if len(data) > 0:
+            content = data[0]["content"]
+            assert "process_1" in content or "process_2" in content
 
-    def test_sequential_loop_with_mixed_metadata(self, correlator, temp_agent_folder):
+    def test_sequential_loop_with_mixed_metadata(
+        self, correlator, storage_backend, temp_agent_folder
+    ):
         """Test correlation when sequential loop agents have loop_mode metadata."""
+        lifecycle = {"_state": "processed", "_state_schema_version": 1}
         for i in range(1, 4):
-            loop_dir = temp_agent_folder / "target" / f"step_{i}"
-            loop_dir.mkdir(parents=True)
+            action_name = f"step_{i}"
             test_data = [
                 {
                     "source_guid": "test-guid",
                     "version_correlation_id": "test-corr",
                     "loop_mode": "sequential",
                     "version_number": i,
-                    "content": {f"step_{i}": {"step": i, "result": f"step_{i}_result"}},
+                    **lifecycle,
+                    "content": {action_name: {"step": i, "result": f"step_{i}_result"}},
                 }
             ]
-            with open(loop_dir / "data.json", "w") as f:
-                json.dump(test_data, f)
+            storage_backend._write_target_raw(action_name, "data.json", test_data)
         result_dir = correlator.prepare_correlated_input("final", ["step_1", "step_2", "step_3"], 4)
         assert result_dir is not None
-        output_file = Path(result_dir) / "data.json"
-        assert output_file.exists()
-        with open(output_file) as f:
-            data = json.load(f)
-            assert len(data) == 1
-            # Content is nested by agent name
-            content = data[0]["content"]
-            # Check that step namespaces exist with expected values
-            step_values = []
-            for i in range(1, 4):
-                if f"step_{i}" in content and isinstance(content[f"step_{i}"], dict):
-                    step_values.append(content[f"step_{i}"].get("step"))
-            assert any(v in [1, 2, 3] for v in step_values if v is not None)
+        data = storage_backend.read_target("final", "data.json")
+        assert len(data) == 1
+        content = data[0]["content"]
+        step_values = []
+        for i in range(1, 4):
+            if f"step_{i}" in content and isinstance(content[f"step_{i}"], dict):
+                step_values.append(content[f"step_{i}"].get("step"))
+        assert any(v in [1, 2, 3] for v in step_values if v is not None)
 
-    def test_sequential_vs_parallel_correlation_same_behavior(self, correlator, temp_agent_folder):
+    def test_sequential_vs_parallel_correlation_same_behavior(
+        self, correlator, storage_backend, temp_agent_folder
+    ):
         """Test that correlation behavior is identical for sequential and parallel loops."""
+        lifecycle = {"_state": "processed", "_state_schema_version": 1}
         for i in range(1, 3):
-            loop_dir = temp_agent_folder / "target" / f"seq_{i}"
-            loop_dir.mkdir(parents=True)
+            action_name = f"seq_{i}"
             test_data = [
                 {
                     "source_guid": "guid-1",
                     "version_correlation_id": "corr-1",
                     "loop_mode": "sequential",
-                    "content": {f"seq_{i}": {f"seq_field_{i}": f"seq_value_{i}"}},
+                    **lifecycle,
+                    "content": {action_name: {f"seq_field_{i}": f"seq_value_{i}"}},
                 }
             ]
-            with open(loop_dir / "output.json", "w") as f:
-                json.dump(test_data, f)
-        for i in range(3, 5):
-            loop_dir = temp_agent_folder / "target" / f"par_{i - 2}"
-            loop_dir.mkdir(parents=True)
+            storage_backend._write_target_raw(action_name, "output.json", test_data)
+        for i in range(1, 3):
+            action_name = f"par_{i}"
             test_data = [
                 {
                     "source_guid": "guid-2",
                     "version_correlation_id": "corr-2",
                     "loop_mode": "parallel",
-                    "content": {f"par_{i - 2}": {f"par_field_{i - 2}": f"par_value_{i - 2}"}},
+                    **lifecycle,
+                    "content": {action_name: {f"par_field_{i}": f"par_value_{i}"}},
                 }
             ]
-            with open(loop_dir / "output.json", "w") as f:
-                json.dump(test_data, f)
+            storage_backend._write_target_raw(action_name, "output.json", test_data)
         seq_result = correlator.prepare_correlated_input("seq_consumer", ["seq_1", "seq_2"], 5)
         par_result = correlator.prepare_correlated_input("par_consumer", ["par_1", "par_2"], 6)
         assert seq_result is not None
         assert par_result is not None
-        seq_file = Path(seq_result) / "output.json"
-        par_file = Path(par_result) / "output.json"
-        assert seq_file.exists()
-        assert par_file.exists()
-        with open(seq_file) as f:
-            seq_data = json.load(f)
-        with open(par_file) as f:
-            par_data = json.load(f)
+        seq_data = storage_backend.read_target("seq_consumer", "output.json")
+        par_data = storage_backend.read_target("par_consumer", "output.json")
         assert len(seq_data) == 1
         assert len(par_data) == 1
-        # Content is nested by agent name
         assert "seq_1" in seq_data[0]["content"]
         assert seq_data[0]["content"]["seq_1"]["seq_field_1"] == "seq_value_1"
         assert "seq_2" in seq_data[0]["content"]
@@ -560,9 +550,11 @@ class TestVersionCorrelatorSourceProtection:
         """Test that sparse correlation outputs don't overwrite rich source data."""
         with tempfile.TemporaryDirectory() as tmpdir:
             agent_folder = Path(tmpdir)
-            correlator = VersionOutputCorrelator(agent_folder)
+            db_path = agent_folder / "store" / "test.db"
+            backend = SQLiteBackend.create(db_path=str(db_path), workflow_name="test")
+            backend.initialize()
+            correlator = VersionOutputCorrelator(agent_folder, storage_backend=backend)
 
-            # Setup: Create rich source data with many fields
             source_dir = agent_folder / "agent_io" / "source"
             source_dir.mkdir(parents=True)
             source_file = source_dir / "data.json"
@@ -578,15 +570,10 @@ class TestVersionCorrelatorSourceProtection:
                     "created_at": "2024-01-01",
                     "tags": ["important"],
                 }
-            ]  # 8 fields
+            ]
             source_file.write_text(json.dumps(rich_source_data))
 
-            # Setup version outputs that will be correlated
-            target_dir = agent_folder / "agent_io" / "target" / "consumer"
-            target_dir.mkdir(parents=True)
-
-            version1_dir = agent_folder / "target" / "action_1"
-            version1_dir.mkdir(parents=True)
+            lifecycle = {"_state": "processed", "_state_schema_version": 1}
             version1_output = [
                 {
                     "source_guid": "guid-1",
@@ -594,13 +581,10 @@ class TestVersionCorrelatorSourceProtection:
                     "node_id": "node-1",
                     "version_correlation_id": "corr-1",
                     "lineage": [],
+                    **lifecycle,
                     "content": {"action_1": {"result": "v1"}},
                 }
             ]
-            (version1_dir / "data.json").write_text(json.dumps(version1_output))
-
-            version2_dir = agent_folder / "target" / "action_2"
-            version2_dir.mkdir(parents=True)
             version2_output = [
                 {
                     "source_guid": "guid-1",
@@ -608,27 +592,25 @@ class TestVersionCorrelatorSourceProtection:
                     "node_id": "node-1",
                     "version_correlation_id": "corr-1",
                     "lineage": [],
+                    **lifecycle,
                     "content": {"action_2": {"result": "v2"}},
                 }
             ]
-            (version2_dir / "data.json").write_text(json.dumps(version2_output))
+            backend._write_target_raw("action_1", "data.json", version1_output)
+            backend._write_target_raw("action_2", "data.json", version2_output)
 
-            # Run correlation (this will try to write sparse source data)
             result = correlator.prepare_correlated_input("consumer", ["action_1", "action_2"], 0)
-
             assert result is not None
 
-            # Verify: Rich source data should NOT be overwritten
             with open(source_file) as f:
                 final_source_data = json.load(f)
 
-            # Should still have rich data (8 fields), not sparse data (2 fields)
             assert len(final_source_data[0]) == 8, (
                 "Rich source data was overwritten by sparse correlation output!"
             )
             assert "page_content" in final_source_data[0], "page_content field lost!"
-            assert "title" in final_source_data[0], "title field lost!"
             assert final_source_data[0]["page_content"] == "Full page content here..."
+            backend.close()
 
     def test_correlation_richer_data_allowed(self):
         """Test that correlation outputs with MORE fields can update source."""

--- a/tests/integration/test_batch_content_materialization.py
+++ b/tests/integration/test_batch_content_materialization.py
@@ -4,7 +4,6 @@ Verifies that batch LLM results are injected into content.{action_name}
 and persisted to both the storage backend and the filesystem.
 """
 
-import json
 from typing import Any, cast
 
 import pytest
@@ -331,7 +330,7 @@ class TestPartialBatchFailure:
 
 
 class TestDiskMaterialization:
-    def test_target_json_materialized_on_disk(
+    def test_target_data_persisted_to_backend(
         self, action_config, batch_result, context_map, sqlite_backend, tmp_path
     ):
         output = _process_batch([batch_result], context_map, action_config, str(tmp_path))
@@ -345,11 +344,10 @@ class TestDiskMaterialization:
         )
         writer.write_target(output)
 
-        assert output_file.exists(), "Target file not materialized to disk"
+        assert not output_file.exists(), "Target file should not be written to disk"
 
-        with open(output_file) as f:
-            disk_data = json.load(f)
-        assert disk_data[0]["content"]["verify_answer"]["verified_answer"] == "C"
+        backend_data = sqlite_backend.read_target("verify_answer", "target.json")
+        assert backend_data[0]["content"]["verify_answer"]["verified_answer"] == "C"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_version_merge_lineage.py
+++ b/tests/integration/test_version_merge_lineage.py
@@ -13,23 +13,17 @@ import pytest
 
 from agent_actions.processing.enrichment import LineageEnricher
 from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 from agent_actions.workflow.managers.loop import VersionOutputCorrelator
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+LIFECYCLE = {"_state": "processed", "_state_schema_version": 1}
 
 
-def _write_version_outputs(agent_folder: Path, version_agents: dict):
-    """Write version agent output files to target directories.
-
-    version_agents: {"agent_name": [records...], ...}
-    """
+def _write_version_outputs_to_backend(backend, version_agents: dict):
+    """Write version agent output to the storage backend."""
     for agent_name, records in version_agents.items():
-        target_dir = agent_folder / "target" / agent_name
-        target_dir.mkdir(parents=True, exist_ok=True)
-        with open(target_dir / "data.json", "w") as f:
-            json.dump(records, f)
+        enriched = [{**r, **LIFECYCLE} for r in records]
+        backend._write_target_raw(agent_name, "data.json", enriched)
 
 
 def _load_source_data(agent_folder: Path, filename: str = "data.json") -> list[dict]:
@@ -54,13 +48,21 @@ class TestVersionMergeLineage:
         return tmp_path
 
     @pytest.fixture
-    def correlator(self, agent_folder):
-        return VersionOutputCorrelator(agent_folder)
+    def backend(self, agent_folder):
+        db_path = agent_folder / "store" / "test.db"
+        b = SQLiteBackend.create(db_path=str(db_path), workflow_name="test")
+        b.initialize()
+        yield b
+        b.close()
 
-    def test_merged_record_preserves_lineage(self, correlator, agent_folder):
+    @pytest.fixture
+    def correlator(self, agent_folder, backend):
+        return VersionOutputCorrelator(agent_folder, storage_backend=backend)
+
+    def test_merged_record_preserves_lineage(self, correlator, backend, agent_folder):
         """Merged record has union of all version agent lineages."""
-        _write_version_outputs(
-            agent_folder,
+        _write_version_outputs_to_backend(
+            backend,
             {
                 "score_quality_1": [
                     {
@@ -102,9 +104,7 @@ class TestVersionMergeLineage:
         )
         assert result_dir is not None
 
-        with open(Path(result_dir) / "data.json") as f:
-            merged_records = json.load(f)
-
+        merged_records = backend.read_target("aggregate_votes", "data.json")
         assert len(merged_records) == 1
         rec = merged_records[0]
         assert rec["source_guid"] == "sg-001"
@@ -113,10 +113,10 @@ class TestVersionMergeLineage:
         assert "score_quality_2_bbb" in rec["lineage"]
         assert "score_quality_3_ccc" in rec["lineage"]
 
-    def test_consuming_action_extends_merged_lineage(self, correlator, agent_folder):
+    def test_consuming_action_extends_merged_lineage(self, correlator, backend, agent_folder):
         """Consuming action's enricher extends merged lineage, not truncates."""
-        _write_version_outputs(
-            agent_folder,
+        _write_version_outputs_to_backend(
+            backend,
             {
                 "scorer_1": [
                     {
@@ -169,10 +169,10 @@ class TestVersionMergeLineage:
         # Must end with consumer's own node_id (not truncated to just this)
         assert len(lineage) > 1, "Lineage must not be truncated to [own_node_id]"
 
-    def test_merged_record_has_source_guid(self, correlator, agent_folder):
+    def test_merged_record_has_source_guid(self, correlator, backend, agent_folder):
         """Merged record source_guid is non-empty."""
-        _write_version_outputs(
-            agent_folder,
+        _write_version_outputs_to_backend(
+            backend,
             {
                 "v1": [
                     {
@@ -188,18 +188,17 @@ class TestVersionMergeLineage:
         )
 
         result_dir = correlator.prepare_correlated_input("consumer", ["v1"], 2)
-        with open(Path(result_dir) / "data.json") as f:
-            records = json.load(f)
-
+        assert result_dir is not None
+        records = backend.read_target("consumer", "data.json")
         assert records[0]["source_guid"] == "sg-abc"
 
         source_data = _load_source_data(agent_folder)
         assert source_data[0]["source_guid"] == "sg-abc"
 
-    def test_partial_merge_preserves_lineage(self, correlator, agent_folder):
+    def test_partial_merge_preserves_lineage(self, correlator, backend, agent_folder):
         """Missing versions don't break lineage on present versions."""
-        _write_version_outputs(
-            agent_folder,
+        _write_version_outputs_to_backend(
+            backend,
             {
                 "v1": [
                     {
@@ -234,9 +233,8 @@ class TestVersionMergeLineage:
         )
 
         result_dir = correlator.prepare_correlated_input("consumer", ["v1", "v2"], 3)
-        with open(Path(result_dir) / "data.json") as f:
-            records = json.load(f)
-
+        assert result_dir is not None
+        records = backend.read_target("consumer", "data.json")
         assert len(records) == 2
 
         # Record with both versions: full merged lineage
@@ -249,10 +247,10 @@ class TestVersionMergeLineage:
         rec2 = next(r for r in records if r["source_guid"] == "sg-002")
         assert rec2["lineage"] == ["root_001", "v1_bbb"]
 
-    def test_source_file_lineage_enables_enricher_chain(self, correlator, agent_folder):
+    def test_source_file_lineage_enables_enricher_chain(self, correlator, backend, agent_folder):
         """Source file with lineage lets enricher build correct chain for multiple records."""
-        _write_version_outputs(
-            agent_folder,
+        _write_version_outputs_to_backend(
+            backend,
             {
                 "gen_1": [
                     {

--- a/tests/logging/events/test_handlers/test_run_results_collector.py
+++ b/tests/logging/events/test_handlers/test_run_results_collector.py
@@ -95,7 +95,7 @@ class TestWorkflowEventHandling:
         assert collector._metadata["status"] == "success"
 
         # Should have written run_results.json
-        assert (temp_output_dir / "target" / "run_results.json").exists()
+        assert (temp_output_dir / "logs" / "run_results.json").exists()
 
     def test_handle_workflow_failed(self, collector, temp_output_dir):
         """Test WorkflowFailedEvent handling."""
@@ -234,11 +234,11 @@ class TestFlushAndOutput:
     """Tests for flush and output generation."""
 
     def test_flush_creates_target_directory(self, collector, temp_output_dir):
-        """Test that flush creates target directory."""
+        """Test that flush creates logs directory."""
         collector.handle(WorkflowStartEvent(workflow_name="test", action_count=0))
         collector.handle(WorkflowCompleteEvent(workflow_name="test"))
 
-        assert (temp_output_dir / "target").exists()
+        assert (temp_output_dir / "logs").exists()
 
     def test_flush_writes_run_results_json(self, collector, temp_output_dir):
         """Test that flush writes run_results.json."""
@@ -252,7 +252,7 @@ class TestFlushAndOutput:
         )
         collector.handle(WorkflowCompleteEvent(workflow_name="test", elapsed_time=10.0))
 
-        output_path = temp_output_dir / "target" / "run_results.json"
+        output_path = temp_output_dir / "logs" / "run_results.json"
         assert output_path.exists()
 
         with open(output_path) as f:
@@ -285,7 +285,7 @@ class TestFlushAndOutput:
             )
         )
 
-        output_path = temp_output_dir / "target" / "run_results.json"
+        output_path = temp_output_dir / "logs" / "run_results.json"
         with open(output_path) as f:
             data = json.load(f)
 
@@ -317,7 +317,7 @@ class TestFlushAndOutput:
 
         collector.handle(WorkflowCompleteEvent(workflow_name="test"))
 
-        output_path = temp_output_dir / "target" / "run_results.json"
+        output_path = temp_output_dir / "logs" / "run_results.json"
         with open(output_path) as f:
             data = json.load(f)
 

--- a/tests/orchestration/test_manifest_manager.py
+++ b/tests/orchestration/test_manifest_manager.py
@@ -57,7 +57,8 @@ class TestManifestManagerInitialization:
 
         assert manager.agent_io_path == temp_agent_io
         assert manager.target_dir == temp_agent_io / "target"
-        assert manager.manifest_path == temp_agent_io / "target" / MANIFEST_FILENAME
+        assert manager.logs_dir == temp_agent_io / "logs"
+        assert manager.manifest_path == temp_agent_io / "logs" / MANIFEST_FILENAME
 
     def test_init_accepts_string_path(self, temp_agent_io):
         """Should accept string path and convert to Path."""
@@ -127,13 +128,13 @@ class TestManifestInitialization:
         transform = manifest_manager.manifest["actions"]["transform"]
         assert transform["dependencies"] == ["extract"]
 
-    def test_creates_target_directory(self, manifest_manager, sample_workflow_data):
-        """Should create target directory if it doesn't exist."""
-        assert not manifest_manager.target_dir.exists()
+    def test_creates_logs_directory(self, manifest_manager, sample_workflow_data):
+        """Should create logs directory if it doesn't exist."""
+        assert not manifest_manager.logs_dir.exists()
 
         manifest_manager.initialize_manifest(**sample_workflow_data)
 
-        assert manifest_manager.target_dir.exists()
+        assert manifest_manager.logs_dir.exists()
 
     def test_custom_workflow_run_id(self, manifest_manager, sample_workflow_data):
         """Should accept custom workflow run ID."""

--- a/tests/unit/logging/test_atomic_write.py
+++ b/tests/unit/logging/test_atomic_write.py
@@ -31,7 +31,7 @@ class TestRunResultsAtomicWrite:
         """Happy path: flush() creates run_results.json."""
         handler = self._make_handler(tmp_path)
         handler.flush()
-        output = tmp_path / "target" / "run_results.json"
+        output = tmp_path / "logs" / "run_results.json"
         assert output.exists()
         data = json.loads(output.read_text())
         assert "metadata" in data
@@ -39,7 +39,7 @@ class TestRunResultsAtomicWrite:
     def test_flush_cleans_up_tmp_on_write_failure(self, tmp_path):
         """If json.dump raises inside atomic_json_write, temp file is cleaned up."""
         handler = self._make_handler(tmp_path)
-        (tmp_path / "target").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
         def boom(*args, **kwargs):
             raise TypeError("unserializable sentinel")
@@ -49,14 +49,14 @@ class TestRunResultsAtomicWrite:
                 handler.flush()
 
         # No orphaned .tmp files should remain in the target dir
-        target = tmp_path / "target"
+        target = tmp_path / "logs"
         tmp_files = list(target.glob("*.tmp"))
         assert tmp_files == [], f"Orphaned temp files found: {tmp_files}"
 
     def test_flush_cleans_up_tmp_on_rename_failure(self, tmp_path):
         """If rename raises inside atomic_json_write, temp file is cleaned up."""
         handler = self._make_handler(tmp_path)
-        (tmp_path / "target").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
         _orig = Path.replace
 
@@ -69,6 +69,6 @@ class TestRunResultsAtomicWrite:
             with pytest.raises(OSError, match="disk full"):
                 handler.flush()
 
-        target = tmp_path / "target"
+        target = tmp_path / "logs"
         tmp_files = list(target.glob("*.tmp"))
         assert tmp_files == [], f"Orphaned temp files found: {tmp_files}"

--- a/tests/unit/storage/test_delta_storage.py
+++ b/tests/unit/storage/test_delta_storage.py
@@ -1306,10 +1306,8 @@ class TestIssue7_PartitionedPipeline:
 class TestIssue8_FilesystemLeak:
     """_delta_mode must not appear in filesystem target files."""
 
-    def test_disk_file_has_no_delta_mode(self, tmp_path):
-        """FileWriter strips _delta_mode before writing to disk."""
-        from unittest.mock import MagicMock
-
+    def test_write_target_does_not_create_disk_file(self, tmp_path):
+        """FileWriter writes to backend only — no filesystem file created."""
         from agent_actions.output.writer import FileWriter
 
         backend = _make_backend(tmp_path)
@@ -1317,7 +1315,6 @@ class TestIssue8_FilesystemLeak:
         backend.initialize()
 
         output_dir = tmp_path / "target" / "expand_action"
-        output_dir.mkdir(parents=True, exist_ok=True)
         file_path = output_dir / "out.json"
 
         writer = FileWriter(
@@ -1338,10 +1335,11 @@ class TestIssue8_FilesystemLeak:
         ]
         writer.write_target(data)
 
-        # Read the disk file directly — must NOT have _delta_mode
-        disk_data = json.loads(file_path.read_text())
-        for record in disk_data:
-            assert "_delta_mode" not in record, "_delta_mode leaked to filesystem"
+        assert not file_path.exists(), "Target file should not be written to disk"
+
+        db_data = backend.read_target("expand_action", "out.json")
+        for record in db_data:
+            assert "_delta_mode" not in record, "_delta_mode leaked through read_target"
 
         backend.close()
 

--- a/tests/unit/test_prompt_pattern_regressions.py
+++ b/tests/unit/test_prompt_pattern_regressions.py
@@ -83,7 +83,7 @@ class TestLspIndexerReadError:
 
 
 # ---------------------------------------------------------------------------
-# I-2: COALESCE guards NULL record_count in scan_sqlite_readonly
+# I-2: COALESCE guards NULL record_count in scan_data
 # ---------------------------------------------------------------------------
 class TestScanSqliteCoalesce:
     def test_null_record_count_defaults_to_zero(self, tmp_path):
@@ -96,7 +96,6 @@ class TestScanSqliteCoalesce:
             "CREATE TABLE target_data "
             "(action_name TEXT, relative_path TEXT, data TEXT, record_count INTEGER)"
         )
-        # Insert row with NULL record_count
         conn.execute(
             "INSERT INTO target_data VALUES (?, ?, ?, ?)",
             ("my_action", "file.json", '{"x":1}', None),
@@ -108,13 +107,13 @@ class TestScanSqliteCoalesce:
         conn.commit()
         conn.close()
 
-        from agent_actions.tooling.docs.scanner.data_scanners import scan_sqlite_readonly
+        from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
-        result = scan_sqlite_readonly(db, "test_workflow")
+        backend = SQLiteBackend.create_readonly(db)
+        result = backend.scan_data()
+        backend.close()
         assert result is not None
-        # Per-node count must be 0 (not None) — this is where COALESCE applies
         assert result["nodes"]["my_action"]["record_count"] == 0
-        # Total target_count also guarded (separate SUM query)
         assert result["target_count"] == 0
 
 

--- a/tests/unit/tooling/test_data_scanners.py
+++ b/tests/unit/tooling/test_data_scanners.py
@@ -1,6 +1,6 @@
 """Tests for data scanners: scan_logs, extract_action_metrics, extract_runtime_warnings.
 
-Also covers scan_sqlite_readonly prompt trace attachment (spec 015)
+Also covers SQLiteBackend.scan_data() prompt trace attachment (spec 015)
 and namespace unwrapping (spec 092).
 """
 
@@ -10,12 +10,11 @@ import json
 import sqlite3
 from pathlib import Path
 
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 from agent_actions.tooling.docs.scanner.data_scanners import (
-    _unwrap_record_content,
     extract_action_metrics,
     extract_runtime_warnings,
     scan_logs,
-    scan_sqlite_readonly,
 )
 
 # ---------------------------------------------------------------------------
@@ -306,7 +305,7 @@ class TestExtractActionMetricsEnrichment:
 
 
 # ---------------------------------------------------------------------------
-# scan_sqlite_readonly — prompt trace attachment
+# SQLiteBackend.scan_data — prompt trace attachment
 # ---------------------------------------------------------------------------
 
 
@@ -374,14 +373,23 @@ def _create_test_db(db_path: Path, *, with_traces: bool = False) -> None:
     conn.close()
 
 
+def _scan_readonly(db_path: Path) -> dict | None:
+    """Helper: open a readonly backend, scan, and close."""
+    backend = SQLiteBackend.create_readonly(db_path)
+    try:
+        return backend.scan_data()
+    finally:
+        backend.close()
+
+
 class TestScanSqliteReadonlyTraceAttachment:
-    """Verify scan_sqlite_readonly joins prompt_trace to preview records."""
+    """Verify scan_data joins prompt_trace to preview records."""
 
     def test_trace_attached_when_table_exists(self, tmp_path):
         db_path = tmp_path / "test.db"
         _create_test_db(db_path, with_traces=True)
 
-        result = scan_sqlite_readonly(db_path, "test_workflow")
+        result = _scan_readonly(db_path)
         assert result is not None
         records = result["nodes"]["classify"]["preview"]
         assert len(records) == 1
@@ -399,7 +407,7 @@ class TestScanSqliteReadonlyTraceAttachment:
         db_path = tmp_path / "test.db"
         _create_test_db(db_path, with_traces=False)
 
-        result = scan_sqlite_readonly(db_path, "test_workflow")
+        result = _scan_readonly(db_path)
         assert result is not None
         records = result["nodes"]["classify"]["preview"]
         assert len(records) == 1
@@ -433,7 +441,7 @@ class TestScanSqliteReadonlyTraceAttachment:
         conn.commit()
         conn.close()
 
-        result = scan_sqlite_readonly(db_path, "test_wf")
+        result = _scan_readonly(db_path)
         assert result is not None
         records = result["nodes"]["act"]["preview"]
         assert len(records) == 1
@@ -466,71 +474,15 @@ class TestScanSqliteReadonlyTraceAttachment:
         conn.commit()
         conn.close()
 
-        result = scan_sqlite_readonly(db_path, "test_workflow")
+        result = _scan_readonly(db_path)
         records = result["nodes"]["classify"]["preview"]
         trace = records[0]["_trace"]
         assert trace["attempt"] == 1
         assert "retry" in trace["compiled_prompt"]
 
 
-# ---------------------------------------------------------------------------
-# _unwrap_record_content (spec 092)
-# ---------------------------------------------------------------------------
-
-
-class TestUnwrapRecordContent:
-    """Verify _unwrap_record_content extracts action-specific fields."""
-
-    def test_unwraps_namespaced_content(self):
-        record = {
-            "source_guid": "g1",
-            "content": {
-                "classify": {"genre": "fiction", "confidence": 0.9},
-                "summarize": {"summary": "A book"},
-            },
-            "node_id": "n1",
-        }
-        result = _unwrap_record_content(record, "classify")
-        assert result["content"] == {"genre": "fiction", "confidence": 0.9}
-        assert result["source_guid"] == "g1"
-        assert result["node_id"] == "n1"
-
-    def test_leaves_flat_content_unchanged(self):
-        """Pre-namespace records with flat content pass through."""
-        record = {"content": {"genre": "fiction"}, "source_guid": "g1"}
-        result = _unwrap_record_content(record, "classify")
-        assert result is record  # no copy needed
-
-    def test_no_content_key(self):
-        record = {"question": "What?"}
-        result = _unwrap_record_content(record, "classify")
-        assert result is record
-
-    def test_content_not_dict(self):
-        record = {"content": "plain string"}
-        result = _unwrap_record_content(record, "classify")
-        assert result is record
-
-    def test_action_value_not_dict(self):
-        """When content[action_name] is not a dict, wrap as {action_name: value}."""
-        record = {"content": {"classify": "not-a-dict"}}
-        result = _unwrap_record_content(record, "classify")
-        assert result["content"] == {"classify": "not-a-dict"}
-
-    def test_does_not_mutate_original(self):
-        """Unwrapping returns a new dict; the original is untouched."""
-        original_content = {
-            "classify": {"genre": "fiction"},
-            "summarize": {"summary": "..."},
-        }
-        record = {"source_guid": "g1", "content": original_content}
-        result = _unwrap_record_content(record, "classify")
-        assert result["content"] == {"genre": "fiction"}
-        assert record["content"] is original_content  # original unchanged
-
-
 class TestScanSqliteNamespaceUnwrap:
-    """Verify scan_sqlite_readonly unwraps namespaced content per action."""
+    """Verify scan_data unwraps namespaced content per action."""
 
     def test_preview_records_show_action_fields(self, tmp_path):
         """Preview records should have unwrapped content for the action."""
@@ -556,7 +508,7 @@ class TestScanSqliteNamespaceUnwrap:
         conn.commit()
         conn.close()
 
-        result = scan_sqlite_readonly(db_path, "test_wf")
+        result = _scan_readonly(db_path)
         records = result["nodes"]["extract"]["preview"]
         assert len(records) == 1
         # content should be unwrapped to show extract's fields
@@ -584,7 +536,7 @@ class TestScanSqliteNamespaceUnwrap:
         conn.commit()
         conn.close()
 
-        result = scan_sqlite_readonly(db_path, "test_wf")
+        result = _scan_readonly(db_path)
         records = result["nodes"]["classify"]["preview"]
         assert len(records) == 1
         assert records[0]["content"] == {"genre": "fiction", "confidence": 0.9}

--- a/tests/unit/workflow/managers/test_passthrough_output.py
+++ b/tests/unit/workflow/managers/test_passthrough_output.py
@@ -4,7 +4,6 @@ Verifies that _process_agent_output reads from backend before falling back
 to filesystem.
 """
 
-import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -64,8 +63,8 @@ class TestProcessAgentOutputBackend:
             execution_order=["extract", "transform"],
             action_status={"extract": {"status": "completed"}},
         )
-        output_dir = tmp_path / "target" / "extract"
-        result = mgr._process_agent_output(output_dir, "extract")
+
+        result = mgr._process_agent_output("extract")
 
         assert result["has_data"] is True
         assert result["output_count"] == 1
@@ -88,40 +87,34 @@ class TestProcessAgentOutputBackend:
             execution_order=["extract", "transform"],
             action_status={"extract": {"status": "completed"}},
         )
-        output_dir = tmp_path / "target" / "extract"
-        result = mgr._process_agent_output(output_dir, "extract")
+
+        result = mgr._process_agent_output("extract")
 
         assert result["output_files"] == ["batch_0.json", "batch_1.json"]
         assert result["output_count"] == 2
 
-    def test_falls_back_to_filesystem(self, tmp_path, make_manager, mock_storage_backend):
-        """When backend has no data, falls back to filesystem glob."""
+    def test_empty_backend_returns_empty(self, tmp_path, make_manager, mock_storage_backend):
+        """When backend has no data, returns empty — no filesystem fallback."""
         mock_storage_backend.list_target_files.return_value = []
-
-        output_dir = tmp_path / "target" / "extract"
-        output_dir.mkdir(parents=True)
-        (output_dir / "batch_0.json").write_text(json.dumps([{"id": "1", "val": "from_fs"}]))
 
         mgr = make_manager(
             execution_order=["extract", "transform"],
             action_status={"extract": {"status": "completed"}},
         )
-        result = mgr._process_agent_output(output_dir, "extract")
+        result = mgr._process_agent_output("extract")
 
-        assert result["has_data"] is True
-        assert result["data"][0]["val"] == "from_fs"
-        assert "batch_0.json" in result["output_files"]
+        assert result["has_data"] is False
+        assert result["data"] == []
 
     def test_both_empty_returns_empty(self, tmp_path, make_manager, mock_storage_backend):
         """When both backend and filesystem have no data, returns empty output."""
         mock_storage_backend.list_target_files.return_value = []
 
-        output_dir = tmp_path / "target" / "extract"
         mgr = make_manager(
             execution_order=["extract", "transform"],
             action_status={"extract": {"status": "completed"}},
         )
-        result = mgr._process_agent_output(output_dir, "extract")
+        result = mgr._process_agent_output("extract")
 
         assert result["has_data"] is False
         assert result["output_count"] == 0
@@ -138,8 +131,8 @@ class TestProcessAgentOutputBackend:
             execution_order=["extract", "transform"],
             action_status={"extract": {"status": "completed"}},
         )
-        output_dir = tmp_path / "target" / "extract"
-        mgr._process_agent_output(output_dir, "extract")
+
+        mgr._process_agent_output("extract")
 
         # Both disposition calls must include record_id=NODE_LEVEL_RECORD_ID
         disposition_calls = mock_storage_backend.get_disposition.call_args_list
@@ -147,21 +140,17 @@ class TestProcessAgentOutputBackend:
         for c in disposition_calls:
             assert c.kwargs.get("record_id") == NODE_LEVEL_RECORD_ID
 
-    def test_backend_exception_falls_back(self, tmp_path, make_manager, mock_storage_backend):
-        """When backend raises an exception, falls back to filesystem."""
+    def test_backend_exception_returns_empty(self, tmp_path, make_manager, mock_storage_backend):
+        """When backend raises an exception, returns empty data (no filesystem fallback)."""
         import sqlite3
 
         mock_storage_backend.list_target_files.side_effect = sqlite3.OperationalError("db locked")
-
-        output_dir = tmp_path / "target" / "extract"
-        output_dir.mkdir(parents=True)
-        (output_dir / "batch_0.json").write_text(json.dumps([{"id": "1", "val": "fallback"}]))
 
         mgr = make_manager(
             execution_order=["extract", "transform"],
             action_status={"extract": {"status": "completed"}},
         )
-        result = mgr._process_agent_output(output_dir, "extract")
+        result = mgr._process_agent_output("extract")
 
-        assert result["has_data"] is True
-        assert result["data"][0]["val"] == "fallback"
+        assert result["has_data"] is False
+        assert result["data"] == []

--- a/tests/unit/workflow/test_fresh_run_cleanup.py
+++ b/tests/unit/workflow/test_fresh_run_cleanup.py
@@ -187,13 +187,13 @@ class TestFreshRunExistingBehavior:
         stub.services.core.state_manager.reset.assert_called_once()
 
     def test_event_log_files_cleared(self, tmp_path: Path):
-        target_dir = tmp_path / "agent_io" / "target"
-        target_dir.mkdir(parents=True)
-        (target_dir / "events.json").write_text("[]")
-        (target_dir / "errors.json").write_text("[]")
+        logs_dir = tmp_path / "agent_io" / "logs"
+        logs_dir.mkdir(parents=True)
+        (logs_dir / "events.json").write_text("[]")
+        (logs_dir / "errors.json").write_text("[]")
 
         stub = _make_coordinator_stub(tmp_path, ["a1"])
         stub._clear_for_fresh_run()
 
-        assert not (target_dir / "events.json").exists()
-        assert not (target_dir / "errors.json").exists()
+        assert not (logs_dir / "events.json").exists()
+        assert not (logs_dir / "errors.json").exists()


### PR DESCRIPTION
## Summary

- **Remove redundant filesystem writes**: `FileWriter.write_target()` no longer writes `agent_io/target/{action}/*.json`. DB via StorageBackend is the single source of truth. Removes filesystem fallback paths and ~130 lines of dead code from `output.py` and `loop.py`.
- **Move log files**: `events.json`, `errors.json`, `run_results.json`, `.manifest.json` moved from `agent_io/target/` to `agent_io/logs/`. `scan_runs()` has backward-compat fallback for pre-migration directories.
- **Migrate docs scanner to StorageBackend**: `scan_sqlite_readonly()` (175 lines of raw SQLite) replaced by `SQLiteBackend.create_readonly()` + `scan_data()`. Fixes broken delta reconstruction in the docs site (post-spec-543), removes duplicated namespace unwrapping, and enables pluggable backends.

**Scope**: Phases 1+2 of spec 542 plus docs scanner migration. Phase 3 (batch state to DB) and Phase 4 (remove target/ entirely) are deferred — batch JSONL and batch state files still live on disk.

**Net: 22 files changed, -287 lines** (481 added, 768 removed)

## Verification

- `ruff check` clean (0 new issues)
- `ruff format --check` clean
- `pytest`: 7491 passed, 2 skipped
- Self-review addressed: legacy DB `load_metadata` guard, silent-empty warning for missing backend, in-place mutation fix