### PR TITLE
refactor(batch): migrate batch state from filesystem to StorageBackend

### DIFF
--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -624,7 +624,7 @@ def _process_batch_mode(ctx: BatchProcessingContext):
     )
     client_resolver = BatchClientResolver(client_cache={}, default_client=None)
     context_manager = BatchContextManager()
-    registry_manager_factory = create_registry_manager_factory()
+    registry_manager_factory = create_registry_manager_factory(ctx.storage_backend)
 
     disposition_gate = DispositionGate(storage_backend=ctx.storage_backend)
     submission_service = BatchSubmissionService(

--- a/agent_actions/llm/batch/batch_cli.py
+++ b/agent_actions/llm/batch/batch_cli.py
@@ -33,15 +33,24 @@ def status(batch_id: str | None = None, project_root: Path | None = None):
     args = BatchCommandArgs(batch_id=batch_id)
     if not args.batch_id:
         raise click.UsageError("--batch-id is required.")
+    from agent_actions.storage import get_storage_backend
+
+    storage_backend = get_storage_backend(
+        workflow_path=str(project_root) if project_root else ".",
+        workflow_name="batch_cli",
+        backend_type="sqlite",
+    )
+    storage_backend.initialize()
     client_resolver = BatchClientResolver(client_cache={}, default_client=None)
     context_manager = BatchContextManager()
-    registry_manager_factory = create_registry_manager_factory()
+    registry_manager_factory = create_registry_manager_factory(storage_backend)
     task_preparator = BatchTaskPreparator()
     service = BatchSubmissionService(
         task_preparator=task_preparator,
         client_resolver=client_resolver,
         context_manager=context_manager,
         registry_manager_factory=registry_manager_factory,
+        storage_backend=storage_backend,
     )
     output_dir = str(project_root) if project_root else None
     batch_status = service.check_status(args.batch_id, output_directory=output_dir)
@@ -66,13 +75,22 @@ def retrieve(batch_id: str | None = None, project_root: Path | None = None):
     args = BatchCommandArgs(batch_id=batch_id)
     if not args.batch_id:
         raise click.UsageError("--batch-id is required.")
+    from agent_actions.storage import get_storage_backend
+
+    storage_backend = get_storage_backend(
+        workflow_path=str(project_root) if project_root else ".",
+        workflow_name="batch_cli",
+        backend_type="sqlite",
+    )
+    storage_backend.initialize()
     client_resolver = BatchClientResolver(client_cache={}, default_client=None)
     context_manager = BatchContextManager()
-    registry_manager_factory = create_registry_manager_factory()
+    registry_manager_factory = create_registry_manager_factory(storage_backend)
     service = BatchRetrievalService(
         client_resolver=client_resolver,
         context_manager=context_manager,
         registry_manager_factory=registry_manager_factory,
+        storage_backend=storage_backend,
     )
     result = service.retrieve_results(args.batch_id, str(resolve_project_root(project_root)))
     click.echo(result)

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -1,9 +1,7 @@
 """Resolves and caches batch clients based on configuration or batch ID."""
 
 import hashlib
-import json
 import logging
-from pathlib import Path
 from typing import Any
 
 from pydantic import SecretStr
@@ -252,18 +250,22 @@ class BatchClientResolver:
         return None
 
     def _lookup_client_from_file(self, batch_id: str, output_directory: str) -> str | None:
-        registry_file = Path(output_directory) / "batch" / ".batch_registry.json"
-        if not registry_file.exists():
-            return None
+        """Look up the provider for a batch ID via the storage backend.
 
-        try:
-            with open(registry_file, encoding="utf-8") as f:
-                registry = json.load(f)
-
-            for entry in registry.values():
-                if entry.get("batch_id") == batch_id:
-                    return entry.get("provider")  # type: ignore[no-any-return]
-        except (json.JSONDecodeError, OSError, KeyError):
-            logger.debug("Failed to read batch registry file %s", registry_file, exc_info=True)
-
+        Creates a temporary BatchRegistryManager to query the backend
+        metadata store. Falls back to None if no backend is available
+        or the batch ID is not found.
+        """
+        # We need a storage backend — try to find one via the module-level
+        # get_storage_backend, but since we don't have one here, return None.
+        # The caller (get_for_batch_id) already tried registry_manager first,
+        # and this fallback path is only hit when no registry_manager was
+        # provided.  In the new architecture, a registry_manager is always
+        # provided by callers that have a storage backend.
+        logger.debug(
+            "No registry_manager provided for batch_id=%s, output_directory=%s — "
+            "cannot resolve provider via storage backend in fallback path",
+            batch_id,
+            output_directory,
+        )
         return None

--- a/agent_actions/llm/batch/infrastructure/context.py
+++ b/agent_actions/llm/batch/infrastructure/context.py
@@ -92,9 +92,4 @@ class BatchContextManager:
         backend: "StorageBackend", action_name: str, batch_name: str
     ) -> bool:
         key = BatchContextManager._metadata_key(action_name, batch_name)
-        from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
-
-        if isinstance(backend, SQLiteBackend):
-            return backend.delete_metadata(key)
-        backend.save_metadata(key, "")
-        return True
+        return backend.delete_metadata(key)

--- a/agent_actions/llm/batch/infrastructure/context.py
+++ b/agent_actions/llm/batch/infrastructure/context.py
@@ -1,112 +1,100 @@
-"""Persistence of batch context maps to/from the batch directory."""
+"""Persistence of batch context maps via StorageBackend metadata store."""
 
 import json
 import logging
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agent_actions.errors import ProcessingError
-from agent_actions.utils.atomic_write import atomic_json_write
-from agent_actions.utils.path_utils import ensure_directory_exists
+
+if TYPE_CHECKING:
+    from agent_actions.storage.backend import StorageBackend
 
 logger = logging.getLogger(__name__)
 
 
 class BatchContextManager:
-    """Saves and loads batch context maps to/from the batch directory."""
+    """Saves and loads batch context maps via StorageBackend."""
+
+    @staticmethod
+    def _metadata_key(action_name: str, batch_name: str) -> str:
+        if ".." in batch_name:
+            raise ValueError(f"Invalid batch name contains path traversal: {batch_name}")
+        from pathlib import Path
+
+        safe_name = Path(batch_name).name
+        return f"batch_context:{action_name}:{safe_name}"
 
     @staticmethod
     def save_batch_context_map(
-        context_map: dict[str, Any], output_directory: str, batch_name: str
-    ) -> Path:
-        """Save batch processing context map to batch directory.
-
-        Raises:
-            ProcessingError: If save fails
-        """
+        backend: "StorageBackend",
+        action_name: str,
+        context_map: dict[str, Any],
+        batch_name: str,
+    ) -> None:
         try:
-            context_path = BatchContextManager._get_context_path(output_directory, batch_name)
-
-            ensure_directory_exists(context_path, is_file=True)
-
-            atomic_json_write(context_path, context_map, indent=2, ensure_ascii=False)
-
-            logger.debug("Saved context map to %s (%d entries)", context_path, len(context_map))
-
-            return context_path
-
+            key = BatchContextManager._metadata_key(action_name, batch_name)
+            backend.save_metadata(key, json.dumps(context_map, ensure_ascii=False))
+            logger.debug(
+                "Saved context map for %s/%s (%d entries)",
+                action_name,
+                batch_name,
+                len(context_map),
+            )
         except Exception as e:
             raise ProcessingError(
                 f"Failed to save context map: {e}",
                 cause=e,
-                context={"output_directory": output_directory, "batch_name": batch_name},
+                context={"action_name": action_name, "batch_name": batch_name},
             ) from e
 
     @staticmethod
-    def load_batch_context_map(output_directory: str, batch_name: str) -> dict[str, Any]:
-        """Load batch processing context map from batch directory.
-
-        Raises:
-            ProcessingError: If load fails or file not found
-        """
+    def load_batch_context_map(
+        backend: "StorageBackend", action_name: str, batch_name: str
+    ) -> dict[str, Any]:
         try:
-            context_path = BatchContextManager._get_context_path(output_directory, batch_name)
-
-            with open(context_path, encoding="utf-8") as f:
-                context_map = json.load(f)
-
-            logger.debug("Loaded context map from %s (%d entries)", context_path, len(context_map))
-
-            return context_map  # type: ignore[no-any-return]
-
-        except FileNotFoundError as e:
-            raise ProcessingError(
-                f"Context map file not found: {context_path}",
-                context={"output_directory": output_directory, "batch_name": batch_name},
-            ) from e
+            key = BatchContextManager._metadata_key(action_name, batch_name)
+            raw = backend.load_metadata(key)
+            if raw is None:
+                raise ProcessingError(
+                    f"Context map not found for {action_name}/{batch_name}",
+                    context={"action_name": action_name, "batch_name": batch_name},
+                )
+            context_map = json.loads(raw)
+            logger.debug(
+                "Loaded context map for %s/%s (%d entries)",
+                action_name,
+                batch_name,
+                len(context_map),
+            )
+            return context_map
+        except ProcessingError:
+            raise
         except json.JSONDecodeError as e:
             raise ProcessingError(
-                f"Invalid JSON in context map file: {e}",
+                f"Invalid JSON in context map: {e}",
                 cause=e,
-                context={"output_directory": output_directory, "batch_name": batch_name},
+                context={"action_name": action_name, "batch_name": batch_name},
             ) from e
         except Exception as e:
-            if isinstance(e, ProcessingError):
-                raise
             raise ProcessingError(
                 f"Failed to load context map: {e}",
                 cause=e,
-                context={"output_directory": output_directory, "batch_name": batch_name},
+                context={"action_name": action_name, "batch_name": batch_name},
             ) from e
 
     @staticmethod
-    def batch_context_exists(output_directory: str, batch_name: str) -> bool:
-        """Check if batch context map file exists."""
-        context_path = BatchContextManager._get_context_path(output_directory, batch_name)
-        return context_path.exists()
+    def batch_context_exists(backend: "StorageBackend", action_name: str, batch_name: str) -> bool:
+        key = BatchContextManager._metadata_key(action_name, batch_name)
+        return backend.load_metadata(key) is not None
 
     @staticmethod
-    def _get_context_path(output_directory: str, batch_name: str) -> Path:
-        """Get path to context map file."""
-        output_dir = Path(output_directory)
-        batch_dir = output_dir / "batch"
+    def delete_batch_context_map(
+        backend: "StorageBackend", action_name: str, batch_name: str
+    ) -> bool:
+        key = BatchContextManager._metadata_key(action_name, batch_name)
+        from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
 
-        if ".." in batch_name:
-            raise ValueError(f"Invalid batch name contains path traversal: {batch_name}")
-        safe_name = Path(batch_name).name
-
-        context_file_name = f".context_map_{safe_name}"
-
-        return batch_dir / context_file_name
-
-    @staticmethod
-    def delete_batch_context_map(output_directory: str, batch_name: str) -> bool:
-        """Delete batch context map file if it exists."""
-        context_path = BatchContextManager._get_context_path(output_directory, batch_name)
-
-        try:
-            context_path.unlink()
-        except FileNotFoundError:
-            return False
-        logger.debug("Deleted context map at %s", context_path)
+        if isinstance(backend, SQLiteBackend):
+            return backend.delete_metadata(key)
+        backend.save_metadata(key, "")
         return True

--- a/agent_actions/llm/batch/infrastructure/job_manager.py
+++ b/agent_actions/llm/batch/infrastructure/job_manager.py
@@ -1,13 +1,15 @@
 """Batch job lifecycle and registry status management."""
 
-import json
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
     BatchClientResolver,
 )
 from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
+
+if TYPE_CHECKING:
+    from agent_actions.storage.backend import StorageBackend
 
 logger = logging.getLogger(__name__)
 
@@ -19,15 +21,18 @@ class BatchJobManager:
         self,
         client_resolver: BatchClientResolver,
         registry_manager: BatchRegistryManager | None = None,
+        storage_backend: "StorageBackend | None" = None,
     ):
         """Initialize batch job manager.
 
         Args:
             client_resolver: Resolver for getting batch clients
             registry_manager: Optional registry manager (can be set later)
+            storage_backend: Storage backend for registry persistence
         """
         self._client_resolver = client_resolver
         self._registry_manager = registry_manager
+        self._storage_backend = storage_backend
 
     def set_registry_manager(self, registry_manager: BatchRegistryManager) -> None:
         """Set the registry manager (for lazy initialization)."""
@@ -43,15 +48,14 @@ class BatchJobManager:
         )
         return client.check_status(batch_id)
 
-    def _get_registry_manager(self, output_directory: str) -> BatchRegistryManager | None:
+    def _get_registry_manager(self, action_name: str) -> BatchRegistryManager | None:
         if self._registry_manager is not None:
             return self._registry_manager
 
-        registry_path = Path(output_directory) / "batch" / ".batch_registry.json"
-        if not registry_path.exists():
+        if self._storage_backend is None:
             return None
 
-        return BatchRegistryManager(registry_path)
+        return BatchRegistryManager(self._storage_backend, action_name)
 
     def are_all_jobs_completed(
         self, output_directory: str, agent_config: dict | None = None
@@ -59,7 +63,7 @@ class BatchJobManager:
         """Check if all batch jobs in the registry are completed.
 
         Args:
-            output_directory: Directory containing the batch registry
+            output_directory: Directory containing the batch registry (used as action_name)
             agent_config: Optional agent config for API key resolution
 
         Returns:
@@ -68,19 +72,16 @@ class BatchJobManager:
         if not output_directory:
             return True
 
-        registry_path = Path(output_directory) / "batch" / ".batch_registry.json"
-        if not registry_path.exists():
+        # Extract action_name from output_directory path
+        from pathlib import Path
+
+        action_name = Path(output_directory).name
+
+        manager = self._get_registry_manager(action_name)
+        if manager is None:
             return True
 
-        try:
-            with open(registry_path, encoding="utf-8") as f:
-                json.load(f)
-        except (json.JSONDecodeError, OSError):
-            logger.warning("Registry file is malformed: %s", registry_path, exc_info=True)
-            return False
-
-        manager = self._get_registry_manager(output_directory)
-        if manager is None:
+        if not manager.has_jobs():
             return True
 
         def check_provider(batch_id: str) -> str:
@@ -101,8 +102,15 @@ class BatchJobManager:
         if not output_directory:
             return "no_batches"
 
-        manager = self._get_registry_manager(output_directory)
+        from pathlib import Path
+
+        action_name = Path(output_directory).name
+
+        manager = self._get_registry_manager(action_name)
         if manager is None:
+            return "no_batches"
+
+        if not manager.has_jobs():
             return "no_batches"
 
         return manager.get_overall_status()

--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -119,13 +119,7 @@ class RecoveryStateManager:
     @staticmethod
     def delete(backend: "StorageBackend", action_name: str, file_name: str) -> bool:
         key = RecoveryStateManager._metadata_key(action_name, file_name)
-        from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
-
-        if isinstance(backend, SQLiteBackend):
-            deleted = backend.delete_metadata(key)
-        else:
-            backend.save_metadata(key, "")
-            deleted = True
+        deleted = backend.delete_metadata(key)
         if deleted:
             logger.debug("Deleted recovery state for %s/%s", action_name, file_name)
         return deleted

--- a/agent_actions/llm/batch/infrastructure/recovery_state.py
+++ b/agent_actions/llm/batch/infrastructure/recovery_state.py
@@ -3,12 +3,12 @@
 import json
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agent_actions.llm.batch.core.batch_constants import OnExhaustedPolicy, RecoveryPhase
-from agent_actions.utils.atomic_write import atomic_json_write
-from agent_actions.utils.path_utils import ensure_directory_exists
+
+if TYPE_CHECKING:
+    from agent_actions.storage.backend import StorageBackend
 
 logger = logging.getLogger(__name__)
 
@@ -17,14 +17,14 @@ logger = logging.getLogger(__name__)
 class RecoveryState:
     """Cross-pass state for batch recovery (retry + reprompt).
 
-    Persisted to disk between workflow re-runs so that the processing
-    service can track progress across multiple async batch submissions.
+    Persisted to StorageBackend metadata between workflow re-runs so that
+    the processing service can track progress across multiple async batch
+    submissions.
     """
 
     phase: RecoveryPhase = RecoveryPhase.RETRY
 
     def __post_init__(self):
-        # Coerce raw strings from JSON deserialization
         if isinstance(self.phase, str):
             self.phase = RecoveryPhase(self.phase)
         if isinstance(self.on_exhausted, str):
@@ -54,16 +54,9 @@ class RecoveryState:
     evaluation_strategy_name: str | None = None
 
     # Per-record failure type counts accumulated across recovery rounds.
-    # Maps custom_id → {"parse_error": N, "udf_fail": M, "schema_fail": K}
     failure_type_counts: dict[str, dict[str, int]] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to dict without deep-copying already-serialized lists.
-
-        ``dataclasses.asdict()`` recursively copies every nested dict/list,
-        which is wasteful for ``accumulated_results`` and ``graduated_results``
-        — they are already plain ``list[dict]`` ready for JSON serialization.
-        """
         return {
             "phase": self.phase,
             "retry_attempt": self.retry_attempt,
@@ -84,59 +77,60 @@ class RecoveryState:
 
 
 class RecoveryStateManager:
-    """Persists RecoveryState to JSON files in the batch/ subdirectory."""
+    """Persists RecoveryState via StorageBackend metadata store."""
 
     @staticmethod
-    def save(output_directory: str, file_name: str, state: RecoveryState) -> Path:
-        """Save recovery state to disk."""
-        state_path = RecoveryStateManager._get_path(output_directory, file_name)
-        ensure_directory_exists(state_path, is_file=True)
+    def _metadata_key(action_name: str, file_name: str) -> str:
+        if ".." in file_name:
+            raise ValueError(f"Invalid file name contains path traversal: {file_name}")
+        from pathlib import Path
 
-        atomic_json_write(state_path, state.to_dict(), ensure_ascii=False)
+        safe_name = Path(file_name).name
+        return f"recovery_state:{action_name}:{safe_name}"
 
+    @staticmethod
+    def save(
+        backend: "StorageBackend", action_name: str, file_name: str, state: RecoveryState
+    ) -> None:
+        key = RecoveryStateManager._metadata_key(action_name, file_name)
+        backend.save_metadata(key, json.dumps(state.to_dict(), ensure_ascii=False))
         logger.debug(
-            "Saved recovery state to %s (phase=%s, retry=%d, reprompt=%d)",
-            state_path,
+            "Saved recovery state for %s/%s (phase=%s, retry=%d, reprompt=%d)",
+            action_name,
+            file_name,
             state.phase,
             state.retry_attempt,
             state.reprompt_attempt,
         )
-        return state_path
 
     @staticmethod
-    def load(output_directory: str, file_name: str) -> RecoveryState | None:
-        """Load recovery state from disk, or None if not found."""
-        state_path = RecoveryStateManager._get_path(output_directory, file_name)
+    def load(backend: "StorageBackend", action_name: str, file_name: str) -> RecoveryState | None:
+        key = RecoveryStateManager._metadata_key(action_name, file_name)
+        raw = backend.load_metadata(key)
+        if raw is None:
+            return None
         try:
-            with open(state_path, encoding="utf-8") as f:
-                data = json.load(f)
+            data = json.loads(raw)
             return RecoveryState(**data)
-        except FileNotFoundError:
-            return None
         except (json.JSONDecodeError, TypeError, ValueError) as e:
-            logger.error("Corrupt recovery state at %s: %s", state_path, e)
+            logger.error("Corrupt recovery state for %s/%s: %s", action_name, file_name, e)
             return None
 
     @staticmethod
-    def delete(output_directory: str, file_name: str) -> bool:
-        """Delete recovery state file. Returns True if deleted, False if not found."""
-        state_path = RecoveryStateManager._get_path(output_directory, file_name)
-        try:
-            state_path.unlink()
-        except FileNotFoundError:
-            return False
-        logger.debug("Deleted recovery state at %s", state_path)
-        return True
+    def delete(backend: "StorageBackend", action_name: str, file_name: str) -> bool:
+        key = RecoveryStateManager._metadata_key(action_name, file_name)
+        from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+        if isinstance(backend, SQLiteBackend):
+            deleted = backend.delete_metadata(key)
+        else:
+            backend.save_metadata(key, "")
+            deleted = True
+        if deleted:
+            logger.debug("Deleted recovery state for %s/%s", action_name, file_name)
+        return deleted
 
     @staticmethod
-    def exists(output_directory: str, file_name: str) -> bool:
-        """Check if recovery state exists."""
-        return RecoveryStateManager._get_path(output_directory, file_name).exists()
-
-    @staticmethod
-    def _get_path(output_directory: str, file_name: str) -> Path:
-        """Get path to recovery state file."""
-        if ".." in file_name:
-            raise ValueError(f"Invalid file name contains path traversal: {file_name}")
-        safe_name = Path(file_name).name
-        return Path(output_directory) / "batch" / f".recovery_state_{safe_name}.json"
+    def exists(backend: "StorageBackend", action_name: str, file_name: str) -> bool:
+        key = RecoveryStateManager._metadata_key(action_name, file_name)
+        return backend.load_metadata(key) is not None

--- a/agent_actions/llm/batch/infrastructure/registry.py
+++ b/agent_actions/llm/batch/infrastructure/registry.py
@@ -1,11 +1,11 @@
-"""Thread-safe management of .batch_registry.json with in-memory caching."""
+"""Thread-safe batch registry with in-memory caching, backed by StorageBackend."""
 
 import dataclasses
 import json
 import logging
 import threading
 from collections.abc import Callable
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent_actions.llm.batch.core.batch_constants import BatchStatus
 from agent_actions.llm.batch.core.batch_models import BatchJobEntry, BatchRegistryStats
@@ -16,38 +16,34 @@ from agent_actions.logging.events.cache_events import (
     CacheMissEvent,
     CacheUpdateEvent,
 )
-from agent_actions.utils.atomic_write import atomic_json_write
-from agent_actions.utils.path_utils import ensure_directory_exists
+
+if TYPE_CHECKING:
+    from agent_actions.storage.backend import StorageBackend
 
 logger = logging.getLogger(__name__)
 
 
 class BatchRegistryManager:
-    """Thread-safe CRUD for .batch_registry.json with in-memory caching and atomic writes."""
+    """Thread-safe CRUD for batch registry with in-memory caching.
 
-    def __init__(self, registry_path: Path):
-        """
-        Initialize registry manager.
+    Persists to StorageBackend metadata store under key
+    ``batch_registry:{action_name}``.
+    """
 
-        Args:
-            registry_path: Path to .batch_registry.json file
-        """
-        self._registry_path = Path(registry_path)
+    def __init__(self, storage_backend: "StorageBackend", action_name: str):
+        self._backend = storage_backend
+        self._action_name = action_name
+        self._metadata_key = f"batch_registry:{action_name}"
         self._cache: dict[str, BatchJobEntry] | None = None
-        self._batch_id_index: dict[str, str] | None = None  # batch_id → file_name
+        self._batch_id_index: dict[str, str] | None = None
         self._lock = threading.Lock()
-        logger.debug("Initialized BatchRegistryManager for %s", registry_path)
+        logger.debug("Initialized BatchRegistryManager for action %s", action_name)
 
     # ============================================================
     # PUBLIC API - Thread-safe operations
     # ============================================================
 
     def save_batch_job(self, file_name: str, entry: BatchJobEntry) -> None:
-        """Save or update a batch job entry.
-
-        Raises:
-            IOError: If write fails
-        """
         with self._lock:
             cache = self._get_cache()
             old = cache.get(file_name)
@@ -58,11 +54,9 @@ class BatchRegistryManager:
                 self._batch_id_index[entry.batch_id] = file_name
             self._persist_registry(cache)
             logger.info("Saved batch job %s for file %s", entry.batch_id, file_name)
-
             fire_event(CacheUpdateEvent(cache_type="batch_registry", key=file_name))
 
     def remove_batch_job(self, file_name: str) -> bool:
-        """Remove a batch job entry. Returns True if removed, False if not found."""
         with self._lock:
             cache = self._get_cache()
             if file_name not in cache:
@@ -76,11 +70,9 @@ class BatchRegistryManager:
             return True
 
     def get_batch_job(self, file_name: str) -> BatchJobEntry | None:
-        """Retrieve batch job entry by file name."""
         with self._lock:
             cache = self._get_cache()
             entry = cache.get(file_name)
-
             if entry is not None:
                 fire_event(CacheHitEvent(cache_type="batch_registry", key=file_name))
             else:
@@ -89,21 +81,18 @@ class BatchRegistryManager:
                         cache_type="batch_registry", key=file_name, reason="file_name not in cache"
                     )
                 )
-
             return entry
 
     def get_batch_job_by_id(self, batch_id: str) -> BatchJobEntry | None:
-        """Retrieve batch job entry by batch ID."""
         with self._lock:
             cache = self._get_cache()
             if self._batch_id_index is None:
                 self._rebuild_batch_id_index()
-            assert self._batch_id_index is not None  # guaranteed by _rebuild above
+            assert self._batch_id_index is not None
             file_name = self._batch_id_index.get(batch_id)
             if file_name and file_name in cache:
                 fire_event(CacheHitEvent(cache_type="batch_registry", key=f"batch_id:{batch_id}"))
                 return cache[file_name]
-
             fire_event(
                 CacheMissEvent(
                     cache_type="batch_registry",
@@ -114,12 +103,11 @@ class BatchRegistryManager:
             return None
 
     def update_status(self, batch_id: str, new_status: str) -> bool:
-        """Update status for a batch job. Returns False if batch_id not found."""
         with self._lock:
             cache = self._get_cache()
             if self._batch_id_index is None:
                 self._rebuild_batch_id_index()
-            assert self._batch_id_index is not None  # guaranteed by _rebuild above
+            assert self._batch_id_index is not None
             file_name = self._batch_id_index.get(batch_id)
             if file_name and file_name in cache:
                 updated_entry = dataclasses.replace(cache[file_name], status=new_status)
@@ -127,23 +115,19 @@ class BatchRegistryManager:
                 self._persist_registry(cache)
                 logger.info("Updated batch %s status to %s", batch_id, new_status)
                 return True
-
             logger.warning("Batch ID %s not found in registry", batch_id)
             return False
 
     def get_all_jobs(self) -> dict[str, BatchJobEntry]:
-        """Get all batch jobs in registry."""
         with self._lock:
             return self._get_cache().copy()
 
     def get_registry_stats(self) -> BatchRegistryStats:
-        """Get aggregated statistics for all batches."""
         with self._lock:
             cache = self._get_cache()
             stats = BatchRegistryStats(
                 total_jobs=len(cache), completed=0, failed=0, in_progress=0, cancelled=0
             )
-
             for entry in cache.values():
                 if entry.status == BatchStatus.COMPLETED:
                     stats.completed += 1
@@ -153,34 +137,19 @@ class BatchRegistryManager:
                     stats.in_progress += 1
                 elif entry.status == BatchStatus.CANCELLED:
                     stats.cancelled += 1
-
             return stats
 
     def get_overall_status(self) -> str:
-        """Get overall status across all batches."""
         stats = self.get_registry_stats()
         return stats.overall_status
 
     def are_all_jobs_completed(self, check_provider: Callable[[str], str] | None = None) -> bool:
-        """Check if all batch jobs are in terminal state.
-
-        Args:
-            check_provider: Optional callable(batch_id) -> status to refresh from provider
-        """
         with self._lock:
             cache = self._get_cache()
 
             if not cache:
-                if self._registry_path.exists():
-                    logger.warning(
-                        "Registry file exists at %s but cache is empty — "
-                        "possible corruption. Reporting jobs as NOT completed.",
-                        self._registry_path,
-                    )
-                    return False
-                return True  # No registry file = no jobs = all complete
+                return True
 
-            # Collect entries that need a provider check (non-terminal) while holding the lock
             if check_provider:
                 to_check = [
                     (file_name, entry)
@@ -190,23 +159,19 @@ class BatchRegistryManager:
             else:
                 to_check = []
 
-            # Fast path: no provider checks needed
             if not check_provider:
                 return all(entry.is_terminal for entry in cache.values())
 
-        # Release the lock before performing network I/O
-        updates: list[tuple[str, str]] = []  # (file_name, new_status)
+        updates: list[tuple[str, str]] = []
         for file_name, entry in to_check:
             try:
                 actual_status = check_provider(entry.batch_id)
                 if actual_status != entry.status:
                     updates.append((file_name, actual_status))
             except Exception as e:
-                # Avoid one status check failure from breaking workflow
                 logger.warning("Failed to check status for %s: %s", entry.batch_id, e)
                 return False
 
-        # Re-acquire lock to apply updates and persist
         with self._lock:
             if self._cache is None:
                 raise RuntimeError(
@@ -217,8 +182,6 @@ class BatchRegistryManager:
             for file_name, new_status in updates:
                 if file_name in self._cache:
                     current = self._cache[file_name]
-                    # TOCTOU guard: skip if another thread already advanced this entry to
-                    # terminal between our lock release and re-acquire — keep the later write.
                     if not current.is_terminal:
                         self._cache[file_name] = dataclasses.replace(current, status=new_status)
                         cache_modified = True
@@ -228,18 +191,21 @@ class BatchRegistryManager:
 
             return all(entry.is_terminal for entry in self._cache.values())
 
+    def has_jobs(self) -> bool:
+        """Return True if the registry has any jobs."""
+        with self._lock:
+            return bool(self._get_cache())
+
     # ============================================================
-    # PRIVATE METHODS - Internal implementation
+    # PRIVATE METHODS
     # ============================================================
 
     def _rebuild_batch_id_index(self) -> None:
-        """Rebuild secondary index from cache. Must be called under lock."""
         self._batch_id_index = {
             entry.batch_id: file_name for file_name, entry in (self._cache or {}).items()
         }
 
     def _ensure_cache_loaded(self) -> None:
-        """Lazy load cache if not already loaded."""
         if self._cache is None:
             self._cache = self._load_registry()
             self._rebuild_batch_id_index()
@@ -247,7 +213,6 @@ class BatchRegistryManager:
             raise RuntimeError("Cache initialization failed")
 
     def _get_cache(self) -> dict[str, BatchJobEntry]:
-        """Load cache and return it, raising if load fails. Must be called under lock."""
         self._ensure_cache_loaded()
         if self._cache is None:
             raise RuntimeError(
@@ -257,73 +222,45 @@ class BatchRegistryManager:
         return self._cache
 
     def _load_registry(self) -> dict[str, BatchJobEntry]:
-        """
-        Load registry from disk.
-
-        Returns:
-            Dictionary of file_name -> BatchJobEntry
-        """
-        if not self._registry_path.exists():
-            logger.debug("Registry file does not exist: %s", self._registry_path)
+        raw = self._backend.load_metadata(self._metadata_key)
+        if raw is None:
             fire_event(
                 CacheLoadEvent(
-                    cache_type="batch_registry", entries_loaded=0, source="disk (file not found)"
+                    cache_type="batch_registry", entries_loaded=0, source="backend (not found)"
                 )
             )
             return {}
 
         try:
-            with open(self._registry_path, encoding="utf-8") as f:
-                raw_data = json.load(f)
-
-            registry = {}
-            for file_name, entry_dict in raw_data.items():
-                try:
-                    registry[file_name] = BatchJobEntry.from_dict(entry_dict)
-                except (TypeError, ValueError) as e:
-                    logger.warning("Invalid entry for %s in registry: %s", file_name, e)
-                    continue
-
-            logger.debug("Loaded %d entries from registry", len(registry))
-            fire_event(
-                CacheLoadEvent(
-                    cache_type="batch_registry", entries_loaded=len(registry), source="disk"
-                )
-            )
-            return registry
-
+            raw_data = json.loads(raw)
         except json.JSONDecodeError as e:
-            logger.error("Corrupted registry file %s: %s", self._registry_path, e)
+            logger.error("Corrupted registry metadata for %s: %s", self._action_name, e)
             fire_event(
                 CacheLoadEvent(
-                    cache_type="batch_registry", entries_loaded=0, source="disk (corrupted file)"
+                    cache_type="batch_registry", entries_loaded=0, source="backend (corrupted)"
                 )
             )
             return {}
-        except Exception as e:
-            logger.error("Failed to load registry from %s: %s", self._registry_path, e)
-            fire_event(
-                CacheLoadEvent(cache_type="batch_registry", entries_loaded=0, source="disk (error)")
+
+        registry = {}
+        for file_name, entry_dict in raw_data.items():
+            try:
+                registry[file_name] = BatchJobEntry.from_dict(entry_dict)
+            except (TypeError, ValueError) as e:
+                logger.warning("Invalid entry for %s in registry: %s", file_name, e)
+                continue
+
+        logger.debug("Loaded %d entries from registry", len(registry))
+        fire_event(
+            CacheLoadEvent(
+                cache_type="batch_registry", entries_loaded=len(registry), source="backend"
             )
-            return {}
+        )
+        return registry
 
     def _persist_registry(self, registry: dict[str, BatchJobEntry]) -> None:
-        """
-        Atomically write registry to disk.
-
-        Uses atomic write pattern: write to temp file, sync, rename.
-        This prevents corruption even if process crashes during write.
-
-        Args:
-            registry: Registry data to persist
-
-        Raises:
-            IOError: If write fails
-        """
-        ensure_directory_exists(self._registry_path, is_file=True)
-
         raw_data = {file_name: entry.to_dict() for file_name, entry in registry.items()}
-
-        atomic_json_write(self._registry_path, raw_data, indent=2, ensure_ascii=False)
-
-        logger.debug("Registry persisted to %s (%d entries)", self._registry_path, len(registry))
+        self._backend.save_metadata(self._metadata_key, json.dumps(raw_data))
+        logger.debug(
+            "Registry persisted for action %s (%d entries)", self._action_name, len(registry)
+        )

--- a/agent_actions/llm/batch/service.py
+++ b/agent_actions/llm/batch/service.py
@@ -2,22 +2,33 @@
 
 import logging
 from collections.abc import Callable
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
+
+if TYPE_CHECKING:
+    from agent_actions.storage.backend import StorageBackend
 
 logger = logging.getLogger(__name__)
 
 
-def create_registry_manager_factory() -> Callable[[str], BatchRegistryManager]:
-    """Create a factory that creates/caches registry managers."""
+def create_registry_manager_factory(
+    storage_backend: "StorageBackend",
+) -> Callable[[str], BatchRegistryManager]:
+    """Create a factory that creates/caches registry managers.
+
+    Args:
+        storage_backend: StorageBackend for metadata persistence.
+
+    Returns:
+        A callable that takes an ``action_name`` and returns a
+        ``BatchRegistryManager`` (cached per action_name).
+    """
     _cache: dict[str, BatchRegistryManager] = {}
 
-    def get_registry_manager(output_directory: str) -> BatchRegistryManager:
-        if output_directory not in _cache:
-            _cache[output_directory] = BatchRegistryManager(
-                Path(output_directory) / "batch" / ".batch_registry.json"
-            )
-        return _cache[output_directory]
+    def get_registry_manager(action_name: str) -> BatchRegistryManager:
+        if action_name not in _cache:
+            _cache[action_name] = BatchRegistryManager(storage_backend, action_name)
+        return _cache[action_name]
 
     return get_registry_manager

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -140,7 +140,7 @@ class BatchProcessingService:
                 recovery is pending, or processing fails
         """
         try:
-            manager = self._registry_manager_factory(output_directory)
+            manager = self._registry_manager_factory(self._action_name)
             provider = self._client_resolver.get_for_batch_id(batch_id, manager, output_directory)
 
             if provider.check_status(batch_id) != BatchStatus.COMPLETED:
@@ -201,14 +201,13 @@ class BatchProcessingService:
         Raises:
             ProcessingError: If no registry found or no files processed (and no recovery pending)
         """
-        manager = self._registry_manager_factory(output_directory)
+        effective_action_name = action_name or self._action_name
+        manager = self._registry_manager_factory(effective_action_name)
         all_jobs = manager.get_all_jobs()
         if not all_jobs:
             raise ProcessingError(
                 "No batch registry found", context={"output_directory": output_directory}
             )
-
-        effective_action_name = action_name or self._action_name
 
         processed_files = []
         for file_name, entry in all_jobs.items():
@@ -284,7 +283,7 @@ class BatchProcessingService:
             True if batch status is COMPLETED, False otherwise
         """
         try:
-            manager = self._registry_manager_factory(output_directory)
+            manager = self._registry_manager_factory(self._action_name)
             provider = self._client_resolver.get_for_batch_id(
                 batch_id, manager, output_directory, agent_config=agent_config
             )
@@ -337,22 +336,29 @@ class BatchProcessingService:
         batch_output: list[dict[str, Any]],
         output_directory: str,
     ) -> list[dict[str, Any]]:
-        """Merge carry-forward records from prior output into batch results."""
-        from agent_actions.llm.batch.services.submission import (
-            BATCH_CARRY_FORWARD_FILENAME,
-        )
+        """Merge carry-forward records from prior output into batch results.
 
-        carry_path = Path(output_directory) / "batch" / BATCH_CARRY_FORWARD_FILENAME
+        Uses the storage backend's terminal disposition set to identify
+        already-processed GUIDs (replacing the filesystem-based
+        .batch_carry_forward.json approach).
+        """
+        if not self._storage_backend or not action_name:
+            return batch_output
+
         try:
-            carry_data = json.loads(carry_path.read_text())
-            carry_guids = set(carry_data.get("guids", []))
-        except FileNotFoundError:
-            return batch_output
-        except (json.JSONDecodeError, KeyError):
-            logger.warning("Malformed %s — skipping merge", carry_path)
+            terminal_guids = self._storage_backend.get_terminal_record_ids(action_name)
+        except Exception:
+            logger.debug("Could not query terminal record IDs for %s", action_name, exc_info=True)
             return batch_output
 
-        if not carry_guids or not self._storage_backend or not action_name:
+        if not terminal_guids:
+            return batch_output
+
+        # Only carry forward records that are NOT already in the batch output
+        batch_guids = {r.get("source_guid") for r in batch_output if r.get("source_guid")}
+        carry_guids = terminal_guids - batch_guids
+
+        if not carry_guids:
             return batch_output
 
         from agent_actions.processing.disposition_gate import build_carry_forward
@@ -364,15 +370,6 @@ class BatchProcessingService:
             )
             carry_records.extend(found)
 
-        batch_guids = {r.get("source_guid") for r in batch_output if r.get("source_guid")}
-        overlap = carry_guids & batch_guids
-        if overlap:
-            logger.warning(
-                "Carry-forward/batch overlap for %d records — deduplicating",
-                len(overlap),
-            )
-            carry_records = [r for r in carry_records if r.get("source_guid") not in overlap]
-
         if carry_records:
             logger.info(
                 "Merging %d carry-forward records into batch output for %s",
@@ -381,11 +378,6 @@ class BatchProcessingService:
             )
             for record in carry_records:
                 record["_delta_mode"] = "full"
-
-        try:
-            carry_path.unlink()
-        except OSError:
-            logger.debug("Failed to clean up %s", carry_path)
 
         return batch_output + carry_records
 
@@ -466,7 +458,7 @@ class BatchProcessingService:
         start_time = time.time()
 
         context_map = self._context_manager.load_batch_context_map(
-            output_directory, file_name or "default"
+            self._storage_backend, self._action_name, file_name or "default"
         )
         agent_config = self._apply_workflow_session_id(agent_config, entry)
         provider = self._client_resolver.get_for_batch_id(
@@ -526,7 +518,9 @@ class BatchProcessingService:
                         state.validation_name = reprompt_parsed.validation_name
                         state.on_exhausted = OnExhaustedPolicy(reprompt_parsed.on_exhausted)
 
-                    RecoveryStateManager.save(output_directory, file_name, state)
+                    RecoveryStateManager.save(
+                        self._storage_backend, self._action_name, file_name, state
+                    )
                     logger.info(
                         "Async retry submitted for %s: %d missing records, batch %s",
                         file_name,
@@ -640,7 +634,7 @@ class BatchProcessingService:
         # Clean up stale recovery state (e.g. from a crashed previous run).
         # The recovery path already does this in _finalize_and_cleanup, but the
         # original batch path goes through this method instead and must also clean up.
-        RecoveryStateManager.delete(context.output_directory, identity.file_name)
+        RecoveryStateManager.delete(self._storage_backend, self._action_name, identity.file_name)
         output_path = _finalize_batch_output_impl(
             context,
             identity,
@@ -784,7 +778,7 @@ class BatchProcessingService:
 
         try:
             context_map = self._context_manager.load_batch_context_map(
-                output_directory, file_name or "default"
+                self._storage_backend, self._action_name, file_name or "default"
             )
         except Exception:
             logger.warning(

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -72,7 +72,9 @@ def process_recovery_batch(
         )
         return None
 
-    state = RecoveryStateManager.load(output_directory, parent_file_name)
+    state = RecoveryStateManager.load(
+        service._storage_backend, service._action_name, parent_file_name
+    )
     if not state:
         logger.error(
             "No recovery state found for parent=%s file_name=%s", parent_file_name, file_name
@@ -100,7 +102,7 @@ def process_recovery_batch(
     )
 
     context_map = service._context_manager.load_batch_context_map(
-        output_directory, parent_file_name
+        service._storage_backend, service._action_name, parent_file_name
     )
 
     recovery_results = retrieve_and_reconcile(
@@ -182,7 +184,12 @@ def handle_retry_recovery(
             state.missing_ids = list(still_missing)
             state.record_failure_counts = updated_counts
             state.accumulated_results = BatchRetryService.serialize_results(merged)
-            RecoveryStateManager.save(context.output_directory, identity.file_name, state)
+            RecoveryStateManager.save(
+                context.service._storage_backend,
+                context.service._action_name,
+                identity.file_name,
+                state,
+            )
             return None
 
     exhausted_recovery = None
@@ -292,7 +299,12 @@ def handle_reprompt_recovery(
                     state.reprompt_attempts_per_record.get(fr.custom_id, 0) + 1
                 )
             state.reprompt_attempt = next_attempt
-            RecoveryStateManager.save(context.output_directory, identity.file_name, state)
+            RecoveryStateManager.save(
+                context.service._storage_backend,
+                context.service._action_name,
+                identity.file_name,
+                state,
+            )
             return None
 
     # Exhausted or all graduated — finalize.
@@ -452,7 +464,9 @@ def check_and_submit_reprompt(
             rid: meta.retry.failures for rid, meta in exhausted_recovery.items() if meta.retry
         }
 
-    RecoveryStateManager.save(context.output_directory, identity.file_name, state)
+    RecoveryStateManager.save(
+        context.service._storage_backend, context.service._action_name, identity.file_name, state
+    )
     fire_event(
         RepromptRetryEvent(
             action_name=identity.file_name or "batch",
@@ -561,7 +575,9 @@ def _finalize_and_cleanup(
     exhausted_recovery: dict[str, RecoveryMetadata] | None = None,
 ) -> str:
     """Delete recovery state, finalize output, then clean up registry entries."""
-    RecoveryStateManager.delete(context.output_directory, identity.file_name)
+    RecoveryStateManager.delete(
+        context.service._storage_backend, context.service._action_name, identity.file_name
+    )
     output_path = finalize_batch_output(
         context,
         identity,
@@ -601,15 +617,17 @@ def register_recovery_batch(
 def _remove_batch_placeholder(output_file: Path) -> None:
     """Remove a batch placeholder file from disk after results are in the backend.
 
-    Only removes if the file matches the placeholder shape (batch_job_id + status=submitted).
+    Since placeholders are no longer written at submission time, this is a
+    no-op for new runs. Kept as a guard for pre-migration data that may
+    still have placeholder files on disk.
     """
+    if not output_file.exists():
+        return
+
     try:
         with open(output_file, encoding="utf-8") as f:
             data = json.load(f)
-    except OSError:
-        return  # File already gone
-    except json.JSONDecodeError:
-        logger.warning("Malformed JSON at %s during placeholder cleanup", output_file)
+    except (OSError, json.JSONDecodeError):
         return
 
     if (
@@ -619,8 +637,8 @@ def _remove_batch_placeholder(output_file: Path) -> None:
     ):
         try:
             output_file.unlink()
-            logger.debug("Removed batch placeholder: %s", output_file)
+            logger.debug("Removed legacy batch placeholder: %s", output_file)
         except FileNotFoundError:
-            pass  # Already removed by concurrent worker
+            pass
         except OSError as e:
             logger.warning("Failed to remove batch placeholder %s: %s", output_file, e)

--- a/agent_actions/llm/batch/services/retrieval.py
+++ b/agent_actions/llm/batch/services/retrieval.py
@@ -4,6 +4,7 @@ import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent_actions.errors import ExternalServiceError
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
@@ -19,6 +20,9 @@ from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.utils.path_utils import ensure_directory_exists
 
+if TYPE_CHECKING:
+    from agent_actions.storage.backend import StorageBackend
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,6 +37,8 @@ class BatchRetrievalService:
         client_resolver: BatchClientResolver,
         context_manager: BatchContextManager,
         registry_manager_factory: Callable[[str], BatchRegistryManager],
+        storage_backend: "StorageBackend | None" = None,
+        action_name: str | None = None,
     ):
         """Initialize retrieval service with dependencies.
 
@@ -40,10 +46,14 @@ class BatchRetrievalService:
             client_resolver: Resolver for batch API clients
             context_manager: Manager for batch context persistence
             registry_manager_factory: Factory function to create registry managers
+            storage_backend: Storage backend for metadata persistence
+            action_name: Action name for backend lookups
         """
         self._client_resolver = client_resolver
         self._context_manager = context_manager
         self._registry_manager_factory = registry_manager_factory
+        self._storage_backend = storage_backend
+        self._action_name = action_name
 
     def retrieve_results(
         self,
@@ -66,15 +76,18 @@ class BatchRetrievalService:
         """
         provider = None
         try:
-            manager = self._registry_manager_factory(output_dir)
+            action_name = self._action_name or Path(output_dir).name
+            manager = self._registry_manager_factory(action_name)
             provider = self._client_resolver.get_for_batch_id(batch_id, manager, output_dir)
 
             entry = manager.get_batch_job_by_id(batch_id)
             file_name = entry.file_name if entry else None
 
             context_map = (
-                self._context_manager.load_batch_context_map(output_dir, file_name)
-                if file_name
+                self._context_manager.load_batch_context_map(
+                    self._storage_backend, action_name, file_name
+                )
+                if file_name and self._storage_backend
                 else {}
             )
             batch_results = retrieve_and_reconcile(

--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from agent_actions.errors import ConfigurationError, ConfigValidationError, ExternalServiceError
@@ -34,7 +33,6 @@ from agent_actions.logging.events.batch_events import (
 from agent_actions.output.response.config_schema import WhereClauseBehavior
 from agent_actions.processing.result_collector import _safe_set_disposition
 from agent_actions.storage.backend import DISPOSITION_DEFERRED
-from agent_actions.utils.atomic_write import atomic_json_write
 
 if TYPE_CHECKING:
     from agent_actions.processing.disposition_gate import DispositionGate
@@ -149,7 +147,10 @@ class BatchSubmissionService:
             )
         provider = None
         try:
-            manager = self._registry_manager_factory(output_directory)
+            from pathlib import Path
+
+            action_name = Path(output_directory).name
+            manager = self._registry_manager_factory(action_name)
             provider = self._client_resolver.get_for_batch_id(batch_id, manager, output_directory)
             return provider.check_status(batch_id)  # type: ignore[return-value]
         except ConfigurationError:
@@ -199,7 +200,8 @@ class BatchSubmissionService:
         force_submission = force or self._force_batch
 
         if not force_submission and output_directory:
-            manager = self._registry_manager_factory(output_directory)
+            action_name_for_registry = agent_config.get("action_name", batch_name or "default")
+            manager = self._registry_manager_factory(action_name_for_registry)
             entry = manager.get_batch_job(batch_name or "default")
             if entry and entry.is_in_flight:
                 logger.info(
@@ -230,13 +232,8 @@ class BatchSubmissionService:
                 carry_forward_guids = sorted(carry_ids)
                 data = to_process
 
-        if output_directory:
-            carry_forward_path = Path(output_directory) / "batch" / BATCH_CARRY_FORWARD_FILENAME
-            if carry_forward_guids:
-                carry_forward_path.parent.mkdir(parents=True, exist_ok=True)
-                atomic_json_write(carry_forward_path, {"guids": carry_forward_guids})
-            else:
-                carry_forward_path.unlink(missing_ok=True)
+        # Carry-forward GUIDs are tracked via dispositions in the storage
+        # backend — no filesystem artifact needed.
 
         if not data:
             logger.info(
@@ -252,8 +249,10 @@ class BatchSubmissionService:
         if not tasks:
             return self._handle_empty_tasks(agent_config, context_map, data, output_directory)
 
-        if output_directory:
-            self._context_manager.save_batch_context_map(context_map, output_directory, batch_name)
+        if output_directory and self._storage_backend:
+            self._context_manager.save_batch_context_map(
+                self._storage_backend, action_name, context_map, batch_name
+            )
 
         result = self._submit_to_provider(agent_config, batch_name, tasks, output_directory)
 
@@ -382,7 +381,8 @@ class BatchSubmissionService:
             )
 
             if output_directory:
-                manager = self._registry_manager_factory(output_directory)
+                action_name_for_registry = agent_config.get("action_name", batch_name or "default")
+                manager = self._registry_manager_factory(action_name_for_registry)
                 file_key = batch_name or "default"
                 entry = BatchJobEntry(
                     batch_id=batch_id,

--- a/agent_actions/llm/batch/services/submission.py
+++ b/agent_actions/llm/batch/services/submission.py
@@ -39,8 +39,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-BATCH_CARRY_FORWARD_FILENAME = ".batch_carry_forward.json"
-
 
 class BatchSubmissionService:
     """Service for submitting batch jobs.

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import csv
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -132,7 +131,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
 
             self.storage_backend.write_target(self.action_name, relative_path, data)
 
-            return len(json.dumps(data, default=str).encode())
+            return 0
 
         self._execute_write("Write target file", do_write)
 

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -219,6 +219,15 @@ class StorageBackend(ABC):
         """Load a metadata value by key. Returns None if not found."""
         ...
 
+    def delete_metadata(self, key: str) -> bool:  # noqa: B027
+        """Delete a metadata key. Returns True if deleted.
+
+        Backends that support metadata deletion should override.
+        SQLiteBackend uses SQL DELETE; other backends may use their
+        native key-removal operation.
+        """
+        return False
+
     def _extract_delta(
         self, record: dict[str, Any], action_name: str, *, is_first_action: bool = False
     ) -> dict[str, Any]:

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -617,6 +617,12 @@ class StorageBackend(ABC):
         """Delete traces for an action, or all if action_name is None."""
         return 0
 
+    def clear_batch_state(self, action_name: str) -> None:  # noqa: B027
+        """Delete all batch state (registry, recovery, context) for an action.
+
+        Default is no-op. Backends override to clean up batch coordination data.
+        """
+
     def scan_data(self, preview_limit: int = 20) -> dict[str, Any] | None:
         """Return stats and preview records for the docs scanner.
 

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -1724,7 +1724,9 @@ class SQLiteBackend(StorageBackend):
                             for rec in tid_map.get(rid, []):
                                 rec["_trace"] = trace_data
                 except sqlite3.OperationalError:
-                    pass
+                    logger.debug(
+                        "No prompt_trace table for %s — skipping trace attachment", action_name
+                    )
 
                 nodes[action_name] = {
                     "record_count": record_count,
@@ -1732,18 +1734,9 @@ class SQLiteBackend(StorageBackend):
                     "preview": records,
                 }
 
-            if db_size < 1024:
-                size_human = f"{db_size} B"
-            elif db_size < 1024 * 1024:
-                size_human = f"{db_size / 1024:.1f} KB"
-            elif db_size < 1024 * 1024 * 1024:
-                size_human = f"{db_size / (1024 * 1024):.1f} MB"
-            else:
-                size_human = f"{db_size / (1024 * 1024 * 1024):.1f} GB"
-
             return {
                 "db_path": str(self.db_path),
-                "db_size": size_human,
+                "db_size": self._format_size(db_size),
                 "source_count": source_count,
                 "target_count": target_count,
                 "nodes": nodes,

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -463,6 +463,37 @@ class SQLiteBackend(StorageBackend):
                 return None
         return row["value"] if row else None
 
+    def delete_metadata(self, key: str) -> bool:
+        """Delete a metadata key. Returns True if deleted."""
+        with self._lock:
+            try:
+                cursor = self.connection.cursor()
+                cursor.execute("DELETE FROM workflow_metadata WHERE key = ?", (key,))
+                self.connection.commit()
+                return cursor.rowcount > 0
+            except sqlite3.OperationalError:
+                return False
+
+    def delete_metadata_prefix(self, prefix: str) -> int:
+        """Delete all metadata keys starting with prefix. Returns count deleted."""
+        with self._lock:
+            try:
+                cursor = self.connection.cursor()
+                cursor.execute(
+                    "DELETE FROM workflow_metadata WHERE key LIKE ?",
+                    (prefix + "%",),
+                )
+                self.connection.commit()
+                return cursor.rowcount
+            except sqlite3.OperationalError:
+                return 0
+
+    def clear_batch_state(self, action_name: str) -> None:
+        """Delete all batch state for an action."""
+        self.delete_metadata(f"batch_registry:{action_name}")
+        self.delete_metadata_prefix(f"recovery_state:{action_name}:")
+        self.delete_metadata_prefix(f"batch_context:{action_name}:")
+
     def write_source(
         self,
         relative_path: str,

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -149,16 +149,10 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
         logs_dir = agent_io_dir / "logs"
         target_dir = agent_io_dir / "target"
 
-        def _resolve_log_file(
-            name: str, _logs: Path = logs_dir, _target: Path = target_dir
-        ) -> Path:
-            path = _logs / name
-            if path.exists():
-                return path
-            return _target / name
-
         # Load run_results.json for latest run metadata
-        run_results_path = _resolve_log_file("run_results.json")
+        run_results_path = logs_dir / "run_results.json"
+        if not run_results_path.exists():
+            run_results_path = target_dir / "run_results.json"
         latest_run = None
         if run_results_path.exists():
             try:
@@ -168,7 +162,9 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
                 logger.debug("Failed to load run_results %s: %s", run_results_path, e)
 
         # Load events.json for detailed execution data
-        events_path = _resolve_log_file("events.json")
+        events_path = logs_dir / "events.json"
+        if not events_path.exists():
+            events_path = target_dir / "events.json"
         action_metrics = {}
         runtime_warnings: list[dict[str, Any]] = []
         if events_path.exists():
@@ -191,7 +187,9 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
                 )
 
         # Load .manifest.json for execution plan and per-action status
-        manifest_path = _resolve_log_file(".manifest.json")
+        manifest_path = logs_dir / ".manifest.json"
+        if not manifest_path.exists():
+            manifest_path = target_dir / ".manifest.json"
         manifest_data = None
         if manifest_path.exists():
             try:

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -295,12 +295,13 @@ class AgentWorkflow:
         # JSONFileHandler opens lazily, so deleting between handler init
         # and first event write is safe.
         logs_dir = project_root / "agent_io" / "logs"
+        target_dir = project_root / "agent_io" / "target"
         for events_file in ("events.json", "errors.json"):
-            events_path = logs_dir / events_file
-            try:
-                events_path.unlink(missing_ok=True)
-            except OSError as e:
-                logger.warning("Failed to clear %s: %s", events_file, e)
+            for search_dir in (logs_dir, target_dir):
+                try:
+                    (search_dir / events_file).unlink(missing_ok=True)
+                except OSError as e:
+                    logger.warning("Failed to clear %s: %s", events_file, e)
 
         self.console.print(
             "[yellow]--fresh: cleared stored results and reset all actions to pending[/yellow]"

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -273,10 +273,7 @@ class AgentWorkflow:
 
     def _clear_for_fresh_run(self) -> None:
         """Clear stored results, dispositions, status, and event logs for a fresh run."""
-        from agent_actions.llm.batch.services.submission import BATCH_CARRY_FORWARD_FILENAME
-
         project_root = self.config.resolve_project_root()
-        target_dir = project_root / "agent_io" / "target"
 
         for action_name in self.execution_order:
             try:
@@ -284,23 +281,9 @@ class AgentWorkflow:
                 self.storage_backend.clear_disposition(action_name)
                 self.storage_backend.clear_prompt_traces(action_name)
                 self.storage_backend.clear_checkpoint_records(action_name)
+                self.storage_backend.clear_batch_state(action_name)
             except Exception as e:
                 logger.warning("Failed to clear stored data for %s: %s", action_name, e)
-
-            # Batch artifacts live on disk, not in the DB
-            batch_dir = target_dir / action_name / "batch"
-            if batch_dir.is_dir():
-                for pattern in [
-                    ".recovery_state_*.json",
-                    ".batch_registry.json",
-                    BATCH_CARRY_FORWARD_FILENAME,
-                ]:
-                    for f in batch_dir.glob(pattern):
-                        try:
-                            f.unlink()
-                            logger.debug("Removed batch artifact: %s", f)
-                        except OSError as e:
-                            logger.warning("Failed to remove %s: %s", f, e)
 
         try:
             self.storage_backend.clear_source_data()

--- a/agent_actions/workflow/managers/batch.py
+++ b/agent_actions/workflow/managers/batch.py
@@ -236,16 +236,17 @@ class BatchLifecycleManager:
         if configured_run_mode == RunMode.ONLINE:
             return None
 
-        node_output_dir = agent_io_path / "target" / agent_name
-        registry_file = node_output_dir / "batch" / ".batch_registry.json"
+        from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
 
-        if registry_file.exists():
+        registry_manager = BatchRegistryManager(self.storage_backend, agent_name)
+        if registry_manager.has_jobs():
             return "batch_submitted"
 
         # Check passthrough disposition
         if self.storage_backend.has_disposition(agent_name, DISPOSITION_PASSTHROUGH):
             return "passthrough"
 
+        node_output_dir = agent_io_path / "target" / agent_name
         if node_output_dir.exists():
             # Output dir exists but no batch registry or passthrough
             return "no_batches"

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -28,7 +28,6 @@ from agent_actions.storage.backend import (
     DISPOSITION_SKIPPED,
     DispositionRow,
 )
-from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.utils.constants import MODEL_VENDOR_KEY
 from agent_actions.utils.safe_format import safe_format_error
 
@@ -233,7 +232,7 @@ class ProcessingPipeline:
         )
         client_resolver = BatchClientResolver(client_cache={}, default_client=None)
         context_manager = BatchContextManager()
-        registry_manager_factory = create_registry_manager_factory()
+        registry_manager_factory = create_registry_manager_factory(params.storage_backend)
         submission_service = BatchSubmissionService(
             task_preparator=task_preparator,
             client_resolver=client_resolver,
@@ -285,14 +284,8 @@ class ProcessingPipeline:
             )
             return str(output_file_path)
 
-        # Batch job placeholder - always JSON (tracking file, not data)
-        output_file_path.parent.mkdir(parents=True, exist_ok=True)
-        placeholder = {
-            "batch_job_id": result.batch_id,
-            "status": "submitted",
-            "agent": params.pipeline_action_name,
-        }
-        atomic_json_write(output_file_path, placeholder)
+        # The batch_jobs table in the storage backend signals "in-flight" —
+        # no placeholder file is needed on disk.
         return str(output_file_path)
 
     @staticmethod

--- a/agent_actions/workflow/service_init.py
+++ b/agent_actions/workflow/service_init.py
@@ -113,8 +113,8 @@ def initialize_services(
     context_manager = BatchContextManager()
     client_resolver = BatchClientResolver(client_cache={}, default_client=None)
     source_handler = BatchSourceHandler()
-    registry_manager_factory = create_registry_manager_factory()
-    job_manager = BatchJobManager(client_resolver=client_resolver)
+    registry_manager_factory = create_registry_manager_factory(storage_backend)
+    job_manager = BatchJobManager(client_resolver=client_resolver, storage_backend=storage_backend)
 
     processing_service = BatchProcessingService(
         client_resolver=client_resolver,

--- a/tests/unit/llm/batch/test_batch_carry_forward_merge.py
+++ b/tests/unit/llm/batch/test_batch_carry_forward_merge.py
@@ -1,24 +1,21 @@
 """Tests for batch carry-forward merge at retrieve time.
 
 Tests cover: parent spec items 6, 17 (cleanup part).
+Carry-forward is now derived from terminal dispositions in the storage
+backend, not from a filesystem file.
 """
 
 from __future__ import annotations
 
-import json
 import sys
-import tempfile
-from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-# Avoid circular import: pipeline_file_mode → workflow → ... → unified
 _sentinel = object()
 if sys.modules.get("agent_actions.workflow.pipeline_file_mode", _sentinel) is _sentinel:
     sys.modules["agent_actions.workflow.pipeline_file_mode"] = MagicMock()
 
 from agent_actions.llm.batch.services.processing import BatchProcessingService
-from agent_actions.llm.batch.services.submission import BATCH_CARRY_FORWARD_FILENAME
 
 
 def _make_service(
@@ -26,7 +23,6 @@ def _make_service(
     storage_backend: Any | None = None,
     action_name: str = "test_action",
 ) -> BatchProcessingService:
-    """Create a BatchProcessingService with minimal mocked dependencies."""
     return BatchProcessingService(
         client_resolver=MagicMock(),
         context_manager=MagicMock(),
@@ -40,15 +36,11 @@ def _make_service(
 def _mock_backend(
     target_files: list[str] | None = None,
     prior_output: dict[str, list[dict]] | None = None,
+    terminal_guids: set[str] | None = None,
 ) -> MagicMock:
-    """Create a mock storage backend.
-
-    Args:
-        target_files: list of relative paths returned by list_target_files
-        prior_output: map of rel_path → record list for read_target
-    """
     backend = MagicMock()
     backend.list_target_files.return_value = target_files or []
+    backend.get_terminal_record_ids.return_value = terminal_guids or set()
 
     def read_target(action_name: str, rel_path: str) -> list[dict]:
         if prior_output and rel_path in prior_output:
@@ -59,48 +51,37 @@ def _mock_backend(
     return backend
 
 
-def _write_carry_forward(tmpdir: str, guids: list[str]) -> Path:
-    batch_dir = Path(tmpdir) / "batch"
-    batch_dir.mkdir(parents=True, exist_ok=True)
-    carry_path = batch_dir / BATCH_CARRY_FORWARD_FILENAME
-    carry_path.write_text(json.dumps({"guids": guids}))
-    return carry_path
-
-
 class TestMergeCarryForward:
     """Spec test 6: carry-forward records merged into batch output."""
 
     def test_carry_forward_merged_into_output(self):
-        """9 carry-forward + 1 batch-processed → 10 in output."""
+        """9 carry-forward + 1 batch-processed -> 10 in output."""
         prior_records = [
             {"source_guid": f"r{i}", "score_quality": {"score": 0.9}} for i in range(9)
         ]
         backend = _mock_backend(
             target_files=["data.json"],
             prior_output={"data.json": prior_records},
+            terminal_guids={f"r{i}" for i in range(9)},
         )
         service = _make_service(storage_backend=backend)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            _write_carry_forward(tmpdir, [f"r{i}" for i in range(9)])
+        batch_output = [{"source_guid": "r9", "score_quality": {"score": 0.7}}]
+        result = service._merge_carry_forward("test_action", batch_output, "/unused")
 
-            batch_output = [{"source_guid": "r9", "score_quality": {"score": 0.7}}]
-            result = service._merge_carry_forward("test_action", batch_output, tmpdir)
+        assert len(result) == 10
+        assert result[0]["source_guid"] == "r9"
+        guids = {r["source_guid"] for r in result}
+        assert guids == {f"r{i}" for i in range(10)}
 
-            assert len(result) == 10
-            # Batch-processed record first, carry-forward appended
-            assert result[0]["source_guid"] == "r9"
-            guids = {r["source_guid"] for r in result}
-            assert guids == {f"r{i}" for i in range(10)}
+    def test_no_terminal_guids_returns_unchanged(self):
+        """No terminal dispositions -> output unchanged."""
+        backend = _mock_backend(terminal_guids=set())
+        service = _make_service(storage_backend=backend)
 
-    def test_no_carry_forward_file_returns_unchanged(self):
-        """No .batch_carry_forward.json → output unchanged."""
-        service = _make_service()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            batch_output = [{"source_guid": "r0"}]
-            result = service._merge_carry_forward("test_action", batch_output, tmpdir)
-            assert result == batch_output
+        batch_output = [{"source_guid": "r0"}]
+        result = service._merge_carry_forward("test_action", batch_output, "/unused")
+        assert result == batch_output
 
     def test_carry_forward_records_have_prior_run_data(self):
         """Carry-forward records contain the action's prior output data."""
@@ -110,63 +91,33 @@ class TestMergeCarryForward:
         backend = _mock_backend(
             target_files=["data.json"],
             prior_output={"data.json": prior_records},
+            terminal_guids={"r0"},
         )
         service = _make_service(storage_backend=backend)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            _write_carry_forward(tmpdir, ["r0"])
+        result = service._merge_carry_forward("test_action", [], "/unused")
 
-            result = service._merge_carry_forward("test_action", [], tmpdir)
-
-            assert len(result) == 1
-            assert result[0]["enriched_ns"] == {"key": "value"}
-            assert result[0]["lineage"] == {"parent": "abc"}
+        assert len(result) == 1
+        assert result[0]["enriched_ns"] == {"key": "value"}
+        assert result[0]["lineage"] == {"parent": "abc"}
 
 
 class TestCarryForwardEdgeCases:
-    def test_malformed_json_returns_unchanged(self):
-        """Malformed .batch_carry_forward.json → output unchanged, warning logged."""
-        service = _make_service()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            batch_dir = Path(tmpdir) / "batch"
-            batch_dir.mkdir(parents=True)
-            (batch_dir / BATCH_CARRY_FORWARD_FILENAME).write_text("not json")
-
-            batch_output = [{"source_guid": "r0"}]
-            result = service._merge_carry_forward("test_action", batch_output, tmpdir)
-            assert result == batch_output
-
-    def test_empty_guids_returns_unchanged(self):
-        """{"guids": []} → output unchanged."""
-        service = _make_service()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            _write_carry_forward(tmpdir, [])
-
-            batch_output = [{"source_guid": "r0"}]
-            result = service._merge_carry_forward("test_action", batch_output, tmpdir)
-            assert result == batch_output
-
     def test_missing_prior_output_partial_merge(self):
-        """Prior output missing for one file → partial merge, not crash."""
+        """Prior output missing for one file -> partial merge, not crash."""
         backend = _mock_backend(
             target_files=["data1.json", "data2.json"],
             prior_output={"data1.json": [{"source_guid": "r0", "data": "ok"}]},
-            # data2.json raises FileNotFoundError
+            terminal_guids={"r0", "r1"},
         )
         service = _make_service(storage_backend=backend)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            _write_carry_forward(tmpdir, ["r0", "r1"])
-
-            result = service._merge_carry_forward("test_action", [], tmpdir)
-            # Only r0 found (from data1.json); r1 missing (data2.json not found)
-            assert len(result) == 1
-            assert result[0]["source_guid"] == "r0"
+        result = service._merge_carry_forward("test_action", [], "/unused")
+        assert len(result) == 1
+        assert result[0]["source_guid"] == "r0"
 
     def test_overlap_deduplication(self):
-        """Overlapping GUIDs between batch and carry-forward → deduplicated."""
+        """Overlapping GUIDs between batch and carry-forward -> deduplicated."""
         prior_records = [
             {"source_guid": "r0", "data": "old"},
             {"source_guid": "r1", "data": "old"},
@@ -174,48 +125,22 @@ class TestCarryForwardEdgeCases:
         backend = _mock_backend(
             target_files=["data.json"],
             prior_output={"data.json": prior_records},
+            terminal_guids={"r0", "r1"},
         )
         service = _make_service(storage_backend=backend)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            _write_carry_forward(tmpdir, ["r0", "r1"])
+        batch_output = [{"source_guid": "r0", "data": "new"}]
+        result = service._merge_carry_forward("test_action", batch_output, "/unused")
 
-            # r0 appears in both batch output and carry-forward
-            batch_output = [{"source_guid": "r0", "data": "new"}]
-            result = service._merge_carry_forward("test_action", batch_output, tmpdir)
-
-            # batch_output r0 kept (preferred), carry-forward r0 dropped
-            assert len(result) == 2
-            r0s = [r for r in result if r["source_guid"] == "r0"]
-            assert len(r0s) == 1
-            assert r0s[0]["data"] == "new"
+        assert len(result) == 2
+        r0s = [r for r in result if r["source_guid"] == "r0"]
+        assert len(r0s) == 1
+        assert r0s[0]["data"] == "new"
 
     def test_no_storage_backend_returns_unchanged(self):
-        """No storage backend → can't read prior output → output unchanged."""
+        """No storage backend -> output unchanged."""
         service = _make_service(storage_backend=None)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            _write_carry_forward(tmpdir, ["r0"])
-
-            batch_output = [{"source_guid": "r1"}]
-            result = service._merge_carry_forward("test_action", batch_output, tmpdir)
-            assert result == batch_output
-
-
-class TestCarryForwardFileCleanup:
-    """Spec test 17 (cleanup part)."""
-
-    def test_file_deleted_after_merge(self):
-        """Carry-forward file cleaned up after successful merge."""
-        backend = _mock_backend(
-            target_files=["data.json"],
-            prior_output={"data.json": [{"source_guid": "r0"}]},
-        )
-        service = _make_service(storage_backend=backend)
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            carry_path = _write_carry_forward(tmpdir, ["r0"])
-            assert carry_path.exists()
-
-            service._merge_carry_forward("test_action", [], tmpdir)
-            assert not carry_path.exists()
+        batch_output = [{"source_guid": "r1"}]
+        result = service._merge_carry_forward("test_action", batch_output, "/unused")
+        assert result == batch_output

--- a/tests/unit/llm/batch/test_batch_disposition_gate.py
+++ b/tests/unit/llm/batch/test_batch_disposition_gate.py
@@ -5,22 +5,16 @@ Tests cover: parent spec items 5, 17.
 
 from __future__ import annotations
 
-import json
 import sys
 import tempfile
-from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-# Avoid circular import: pipeline_file_mode → workflow → ... → unified
 _sentinel = object()
 if sys.modules.get("agent_actions.workflow.pipeline_file_mode", _sentinel) is _sentinel:
     sys.modules["agent_actions.workflow.pipeline_file_mode"] = MagicMock()
 
-from agent_actions.llm.batch.services.submission import (
-    BATCH_CARRY_FORWARD_FILENAME,
-    BatchSubmissionService,
-)
+from agent_actions.llm.batch.services.submission import BatchSubmissionService
 from agent_actions.processing.disposition_gate import DispositionGate
 
 
@@ -108,11 +102,9 @@ class TestBatchDispositionGate:
             assert len(submitted_data) == 1
             assert submitted_data[0]["source_guid"] == "r9"
 
-            # Carry-forward file written
-            carry_path = Path(tmpdir) / "batch" / BATCH_CARRY_FORWARD_FILENAME
-            assert carry_path.exists()
-            carry_data = json.loads(carry_path.read_text())
-            assert set(carry_data["guids"]) == terminal
+            # Carry-forward is now derived from dispositions at merge time —
+            # no file is written. The 9 terminal records were filtered out
+            # and only 1 record was submitted (verified above).
 
     def test_no_gate_all_records_submitted(self):
         """Backward compatibility: no gate = all records to preparator."""
@@ -136,13 +128,9 @@ class TestBatchDispositionGate:
             submitted_data = args[0][1]
             assert len(submitted_data) == 10
 
-            # No carry-forward file
-            carry_path = Path(tmpdir) / "batch" / BATCH_CARRY_FORWARD_FILENAME
-            assert not carry_path.exists()
-
 
 class TestBatchAllCarryForward:
-    """All records carried → no batch submission."""
+    """All records carried -> no batch submission."""
 
     def test_all_terminal_skips_submission(self):
         terminal = {f"r{i}" for i in range(5)}
@@ -165,50 +153,15 @@ class TestBatchAllCarryForward:
                 output_directory=tmpdir,
             )
 
-            # No batch submitted
             assert result.batch_id is None
             assert result.passthrough == {"carry_forward_only": True}
 
-            # Carry-forward file still written
-            carry_path = Path(tmpdir) / "batch" / BATCH_CARRY_FORWARD_FILENAME
-            assert carry_path.exists()
-            carry_data = json.loads(carry_path.read_text())
-            assert set(carry_data["guids"]) == terminal
 
+class TestCarryForwardDispositionDerived:
+    """Carry-forward is derived from terminal dispositions, not a file."""
 
-class TestCarryForwardFileLifecycle:
-    """Spec test 17: carry-forward file lifecycle."""
-
-    def test_stale_file_cleaned_when_no_carry_forward(self):
-        """Stale .batch_carry_forward.json removed on next run with no carry-forward."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create stale carry-forward file
-            batch_dir = Path(tmpdir) / "batch"
-            batch_dir.mkdir(parents=True)
-            carry_path = batch_dir / BATCH_CARRY_FORWARD_FILENAME
-            carry_path.write_text('{"guids": ["stale"]}')
-
-            service = _make_service(
-                disposition_gate=DispositionGate(storage_backend=None),  # no-op gate
-                tasks=[{"custom_id": "r0"}],
-                context_map={"r0": {"source_guid": "r0"}},
-            )
-
-            records = [_make_record("r0")]
-            config = {"agent_type": "test_action", "action_name": "test_action"}
-
-            service.submit_batch_job(
-                agent_config=config,
-                batch_name="test",
-                data=records,
-                output_directory=tmpdir,
-            )
-
-            # Stale file cleaned up
-            assert not carry_path.exists()
-
-    def test_carry_forward_file_written_atomically(self):
-        """Carry-forward file exists after write with correct content."""
+    def test_terminal_records_filtered_by_gate(self):
+        """Terminal records are filtered by DispositionGate before submission."""
         terminal = {"r0", "r1"}
         backend = _mock_backend(terminal_ids=terminal)
         gate = DispositionGate(storage_backend=backend)
@@ -231,8 +184,7 @@ class TestCarryForwardFileLifecycle:
                 output_directory=tmpdir,
             )
 
-            carry_path = Path(tmpdir) / "batch" / BATCH_CARRY_FORWARD_FILENAME
-            assert carry_path.exists()
-            data = json.loads(carry_path.read_text())
-            # GUIDs sorted deterministically
-            assert data["guids"] == sorted(terminal)
+            args = service.prepare_batch_tasks.call_args
+            submitted_data = args[0][1]
+            assert len(submitted_data) == 1
+            assert submitted_data[0]["source_guid"] == "r2"

--- a/tests/unit/llm/batch/test_batch_exception_disposition.py
+++ b/tests/unit/llm/batch/test_batch_exception_disposition.py
@@ -156,7 +156,7 @@ class TestBatchExceptionDisposition:
         ctx_a = _make_context_map(("t1", "sg-1", FilterStatus.INCLUDED))
         ctx_b = _make_context_map(("t2", "sg-2", FilterStatus.INCLUDED))
 
-        def load_context(output_dir, file_name):
+        def load_context(backend, action_name, file_name):
             return ctx_a if file_name == "file_a" else ctx_b
 
         svc._context_manager.load_batch_context_map.side_effect = load_context

--- a/tests/unit/llm/batch/test_processing_recovery.py
+++ b/tests/unit/llm/batch/test_processing_recovery.py
@@ -418,7 +418,9 @@ class TestHandleRetryRecovery:
         assert event.total == 2
         assert event.completed == 2
         assert event.failed == 0
-        mock_mgr.delete.assert_called_once_with("/tmp", "test_file")
+        mock_mgr.delete.assert_called_once()
+        delete_args = mock_mgr.delete.call_args[0]
+        assert delete_args[2] == "test_file"  # (backend, action_name, file_name)
         manager.update_status.assert_called_once_with("batch-123", BatchStatus.COMPLETED)
 
 
@@ -1064,7 +1066,9 @@ class TestRecoveryLoopRootCauses:
 
         assert not should_continue
         mock_state_mgr.save.assert_called_once()
-        saved_state = mock_state_mgr.save.call_args[0][2]
+        saved_state = mock_state_mgr.save.call_args[0][
+            3
+        ]  # (backend, action_name, file_name, state)
         assert saved_state.reprompt_attempt == 2
 
     def test_max_attempts_enforced_when_state_loaded(self):
@@ -1244,5 +1248,5 @@ class TestStaleRecoveryState:
             context_map={},
         )
 
-        # Recovery state must be deleted before finalization
-        mock_state_mgr.delete.assert_called_once_with("/tmp/output", "my_action")
+        mock_state_mgr.delete.assert_called_once()
+        assert mock_state_mgr.delete.call_args[0][2] == "my_action"

--- a/tests/unit/llm/test_recovery_state_graduated.py
+++ b/tests/unit/llm/test_recovery_state_graduated.py
@@ -2,8 +2,6 @@
 
 import json
 import logging
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -11,6 +9,15 @@ from agent_actions.llm.batch.infrastructure.recovery_state import (
     RecoveryState,
     RecoveryStateManager,
 )
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+
+@pytest.fixture
+def backend(tmp_path):
+    b = SQLiteBackend.create(db_path=str(tmp_path / "test.db"), workflow_name="test")
+    b.initialize()
+    yield b
+    b.close()
 
 
 class TestRecoveryStateGraduatedFields:
@@ -71,7 +78,7 @@ class TestRecoveryStateGraduatedFields:
 class TestRecoveryStateSerialization:
     """Verify JSON roundtrip for graduated fields via RecoveryStateManager."""
 
-    def test_serialize_roundtrip_with_graduated(self, tmp_path):
+    def test_serialize_roundtrip_with_graduated(self, backend):
         """State with graduated results survives save/load roundtrip."""
         state = RecoveryState(
             phase="reprompt",
@@ -82,8 +89,8 @@ class TestRecoveryStateSerialization:
             ],
             evaluation_strategy_name="validation",
         )
-        RecoveryStateManager.save(str(tmp_path), "test_action", state)
-        restored = RecoveryStateManager.load(str(tmp_path), "test_action")
+        RecoveryStateManager.save(backend, "test_action", "test_file", state)
+        restored = RecoveryStateManager.load(backend, "test_action", "test_file")
 
         assert restored is not None
         assert restored.graduated_results == state.graduated_results
@@ -91,19 +98,19 @@ class TestRecoveryStateSerialization:
         assert restored.phase == "reprompt"
         assert restored.reprompt_attempt == 1
 
-    def test_serialize_roundtrip_empty_graduated(self, tmp_path):
+    def test_serialize_roundtrip_empty_graduated(self, backend):
         """State with default (empty) graduated fields roundtrips correctly."""
         state = RecoveryState(phase="retry", retry_attempt=2)
-        RecoveryStateManager.save(str(tmp_path), "test_action", state)
-        restored = RecoveryStateManager.load(str(tmp_path), "test_action")
+        RecoveryStateManager.save(backend, "test_action", "test_file", state)
+        restored = RecoveryStateManager.load(backend, "test_action", "test_file")
 
         assert restored is not None
         assert restored.graduated_results == []
         assert restored.evaluation_strategy_name is None
         assert restored.retry_attempt == 2
 
-    def test_deserialize_old_state_without_graduated(self, tmp_path):
-        """Old checkpoint files without graduated fields load with defaults."""
+    def test_deserialize_old_state_without_graduated(self, backend):
+        """Old checkpoint data without graduated fields loads with defaults."""
         old_data = {
             "phase": "retry",
             "retry_attempt": 1,
@@ -118,12 +125,11 @@ class TestRecoveryStateSerialization:
             "on_exhausted": "return_last",
             "accumulated_results": [{"custom_id": "r1", "content": "x", "success": True}],
         }
-        state_path = tmp_path / "batch" / ".recovery_state_test_action.json"
-        state_path.parent.mkdir(parents=True)
-        with open(state_path, "w") as f:
-            json.dump(old_data, f)
+        # Write raw JSON directly to the metadata store, simulating an old-format state
+        key = RecoveryStateManager._metadata_key("test_action", "test_file")
+        backend.save_metadata(key, json.dumps(old_data))
 
-        state = RecoveryStateManager.load(str(tmp_path), "test_action")
+        state = RecoveryStateManager.load(backend, "test_action", "test_file")
 
         assert state is not None
         assert state.graduated_results == []
@@ -131,7 +137,7 @@ class TestRecoveryStateSerialization:
         assert state.accumulated_results == [{"custom_id": "r1", "content": "x", "success": True}]
         assert state.missing_ids == ["rec_001"]
 
-    def test_graduated_results_json_serializable(self, tmp_path):
+    def test_graduated_results_json_serializable(self, backend):
         """graduated_results content is plain JSON — no special types."""
         state = RecoveryState(
             phase="done",
@@ -144,9 +150,11 @@ class TestRecoveryStateSerialization:
                 },
             ],
         )
-        path = RecoveryStateManager.save(str(tmp_path), "test_action", state)
-        with open(path) as f:
-            raw = json.load(f)
+        RecoveryStateManager.save(backend, "test_action", "test_file", state)
+
+        # Read raw metadata and verify JSON structure
+        key = RecoveryStateManager._metadata_key("test_action", "test_file")
+        raw = json.loads(backend.load_metadata(key))
 
         assert raw["graduated_results"] == state.graduated_results
         assert raw["evaluation_strategy_name"] is None
@@ -155,7 +163,7 @@ class TestRecoveryStateSerialization:
 class TestRecoveryStateManagerIntegration:
     """Verify RecoveryStateManager CRUD operations work with graduated fields."""
 
-    def test_save_load_delete_cycle(self, tmp_path):
+    def test_save_load_delete_cycle(self, backend):
         """Full create-read-delete cycle with graduated results."""
         state = RecoveryState(
             phase="reprompt",
@@ -163,40 +171,38 @@ class TestRecoveryStateManagerIntegration:
             accumulated_results=[{"custom_id": "a1"}],
             evaluation_strategy_name="critique",
         )
-        tmpdir = str(tmp_path)
-        RecoveryStateManager.save(tmpdir, "cycle_test", state)
-        assert RecoveryStateManager.exists(tmpdir, "cycle_test")
+        RecoveryStateManager.save(backend, "test_action", "cycle_test", state)
+        assert RecoveryStateManager.exists(backend, "test_action", "cycle_test")
 
-        loaded = RecoveryStateManager.load(tmpdir, "cycle_test")
+        loaded = RecoveryStateManager.load(backend, "test_action", "cycle_test")
         assert loaded is not None
         assert loaded.graduated_results == [{"custom_id": "g1"}]
         assert loaded.evaluation_strategy_name == "critique"
 
-        deleted = RecoveryStateManager.delete(tmpdir, "cycle_test")
+        deleted = RecoveryStateManager.delete(backend, "test_action", "cycle_test")
         assert deleted is True
-        assert not RecoveryStateManager.exists(tmpdir, "cycle_test")
+        assert not RecoveryStateManager.exists(backend, "test_action", "cycle_test")
 
-    def test_load_nonexistent_returns_none(self, tmp_path):
+    def test_load_nonexistent_returns_none(self, backend):
         """Loading missing state returns None, not an error."""
-        assert RecoveryStateManager.load(str(tmp_path), "missing") is None
+        assert RecoveryStateManager.load(backend, "test_action", "missing") is None
 
-    def test_overwrite_preserves_graduated(self, tmp_path):
+    def test_overwrite_preserves_graduated(self, backend):
         """Saving updated state overwrites previous graduated results."""
-        tmpdir = str(tmp_path)
         state1 = RecoveryState(
             phase="reprompt",
             graduated_results=[{"custom_id": "g1"}],
         )
-        RecoveryStateManager.save(tmpdir, "overwrite_test", state1)
+        RecoveryStateManager.save(backend, "test_action", "overwrite_test", state1)
 
         state2 = RecoveryState(
             phase="reprompt",
             graduated_results=[{"custom_id": "g1"}, {"custom_id": "g2"}],
             evaluation_strategy_name="validation",
         )
-        RecoveryStateManager.save(tmpdir, "overwrite_test", state2)
+        RecoveryStateManager.save(backend, "test_action", "overwrite_test", state2)
 
-        loaded = RecoveryStateManager.load(tmpdir, "overwrite_test")
+        loaded = RecoveryStateManager.load(backend, "test_action", "overwrite_test")
         assert loaded is not None
         assert len(loaded.graduated_results) == 2
         assert loaded.evaluation_strategy_name == "validation"
@@ -205,21 +211,16 @@ class TestRecoveryStateManagerIntegration:
 class TestRecoveryStateCorruptionHandling:
     """Verify load() logs at error-level on corruption and returns None."""
 
-    def _write_raw(self, tmp_path, content: str) -> Path:
-        """Write raw content to the recovery state file location."""
-        state_path = tmp_path / "batch" / ".recovery_state_test_action.json"
-        state_path.parent.mkdir(parents=True, exist_ok=True)
-        state_path.write_text(content)
-        return state_path
-
     _LOGGER = "agent_actions"
 
-    def test_corrupt_json_logs_error_and_returns_none(self, tmp_path, caplog):
+    def test_corrupt_json_logs_error_and_returns_none(self, backend, caplog):
         """Truncated/invalid JSON logs at error-level, returns None."""
-        self._write_raw(tmp_path, '{"phase": "retry", "retry_at')
+        # Write corrupt JSON directly to the metadata store
+        key = RecoveryStateManager._metadata_key("test_action", "test_file")
+        backend.save_metadata(key, '{"phase": "retry", "retry_at')
 
         with caplog.at_level(logging.ERROR, logger=self._LOGGER):
-            result = RecoveryStateManager.load(str(tmp_path), "test_action")
+            result = RecoveryStateManager.load(backend, "test_action", "test_file")
 
         assert result is None
         assert any(
@@ -227,23 +228,24 @@ class TestRecoveryStateCorruptionHandling:
             for r in caplog.records
         )
 
-    def test_missing_file_returns_none_silently(self, tmp_path, caplog):
-        """Missing file (first run) returns None with no error log."""
+    def test_missing_key_returns_none_silently(self, backend, caplog):
+        """Missing key (first run) returns None with no error log."""
         with caplog.at_level(logging.DEBUG, logger=self._LOGGER):
-            result = RecoveryStateManager.load(str(tmp_path), "nonexistent")
+            result = RecoveryStateManager.load(backend, "test_action", "nonexistent")
 
         assert result is None
         assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
-    def test_invalid_enum_value_logs_error(self, tmp_path, caplog):
+    def test_invalid_enum_value_logs_error(self, backend, caplog):
         """Valid JSON with bad enum value triggers ValueError in __post_init__."""
-        self._write_raw(
-            tmp_path,
+        key = RecoveryStateManager._metadata_key("test_action", "test_file")
+        backend.save_metadata(
+            key,
             json.dumps({"phase": "not_a_real_phase", "retry_attempt": 0, "reprompt_attempt": 0}),
         )
 
         with caplog.at_level(logging.ERROR, logger=self._LOGGER):
-            result = RecoveryStateManager.load(str(tmp_path), "test_action")
+            result = RecoveryStateManager.load(backend, "test_action", "test_file")
 
         assert result is None
         assert any(
@@ -251,144 +253,23 @@ class TestRecoveryStateCorruptionHandling:
             for r in caplog.records
         )
 
-    def test_valid_state_loads_without_error(self, tmp_path, caplog):
+    def test_valid_state_loads_without_error(self, backend, caplog):
         """Valid recovery state loads normally, no error logs."""
         state = RecoveryState(phase="retry", retry_attempt=1)
-        RecoveryStateManager.save(str(tmp_path), "test_action", state)
+        RecoveryStateManager.save(backend, "test_action", "test_file", state)
 
         with caplog.at_level(logging.DEBUG, logger=self._LOGGER):
-            result = RecoveryStateManager.load(str(tmp_path), "test_action")
+            result = RecoveryStateManager.load(backend, "test_action", "test_file")
 
         assert result is not None
         assert result.retry_attempt == 1
         assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
-class TestRecoveryStateAtomicWrite:
-    """Verify save() uses atomic writes to prevent crash corruption."""
+class TestRecoveryStateLargeRoundtrip:
+    """Verify large state roundtrips through the backend."""
 
-    def test_save_writes_via_temp_file(self, tmp_path):
-        """save() writes to a temp file first, then renames — observable mid-write."""
-        state = RecoveryState(phase="retry", retry_attempt=1)
-        captured_tmp = {}
-
-        original_replace = Path.replace
-
-        def spy_replace(self_path, target):
-            # Temp file should exist with valid JSON before rename
-            captured_tmp["path"] = self_path
-            captured_tmp["existed"] = self_path.exists()
-            if self_path.exists():
-                captured_tmp["content"] = json.loads(self_path.read_text())
-            return original_replace(self_path, target)
-
-        with patch.object(Path, "replace", spy_replace):
-            path = RecoveryStateManager.save(str(tmp_path), "atomic_test", state)
-
-        # Temp file was observed with valid data before rename
-        assert captured_tmp["existed"] is True
-        assert captured_tmp["content"]["phase"] == "retry"
-        assert str(captured_tmp["path"]).endswith(".tmp")
-
-        # Final file is correct, temp file gone
-        assert path.exists()
-        assert not captured_tmp["path"].exists()
-
-    def test_original_file_survives_write_error(self, tmp_path):
-        """If save() fails mid-write, the previous state file is untouched."""
-        tmpdir = str(tmp_path)
-
-        # Save initial good state
-        state_v1 = RecoveryState(
-            phase="retry",
-            graduated_results=[{"custom_id": "r1"}],
-        )
-        path = RecoveryStateManager.save(tmpdir, "crash_test", state_v1)
-
-        # Record original content
-        original_content = path.read_text()
-
-        # Attempt a second save that fails during json.dump
-        state_v2 = RecoveryState(
-            phase="reprompt",
-            graduated_results=[{"custom_id": "r1"}, {"custom_id": "r2"}],
-        )
-        with (
-            patch(
-                "agent_actions.utils.atomic_write.json.dump",
-                side_effect=OSError("disk full"),
-            ),
-            pytest.raises(OSError),
-        ):
-            RecoveryStateManager.save(tmpdir, "crash_test", state_v2)
-
-        # Original file is still intact
-        assert path.read_text() == original_content
-        loaded = RecoveryStateManager.load(tmpdir, "crash_test")
-        assert loaded is not None
-        assert loaded.phase == "retry"
-        assert len(loaded.graduated_results) == 1
-
-        # No leftover temp file
-        assert list(path.parent.glob("*.tmp")) == []
-
-    def test_save_error_cleans_up_temp_file(self, tmp_path):
-        """On write failure, the temp file is removed — no disk litter."""
-        state = RecoveryState(phase="retry")
-        with patch(
-            "agent_actions.utils.atomic_write.json.dump",
-            side_effect=OSError("disk full"),
-        ):
-            try:
-                RecoveryStateManager.save(str(tmp_path), "cleanup_test", state)
-            except OSError:
-                pass
-
-        # No temp file left behind
-        batch_dir = tmp_path / "batch"
-        assert batch_dir.exists()
-        assert list(batch_dir.glob("*.tmp")) == []
-
-    def test_rename_failure_cleans_up_and_preserves_original(self, tmp_path):
-        """If rename fails after successful write, temp is cleaned up and original survives."""
-        tmpdir = str(tmp_path)
-
-        # Save initial good state
-        state_v1 = RecoveryState(
-            phase="retry",
-            graduated_results=[{"custom_id": "r1"}],
-        )
-        path = RecoveryStateManager.save(tmpdir, "rename_test", state_v1)
-        original_content = path.read_text()
-
-        # Attempt a second save where rename fails
-        state_v2 = RecoveryState(phase="reprompt")
-        with (
-            patch.object(Path, "replace", side_effect=OSError("cross-device link")),
-            pytest.raises(OSError),
-        ):
-            RecoveryStateManager.save(tmpdir, "rename_test", state_v2)
-
-        # Original file is untouched
-        assert path.read_text() == original_content
-        loaded = RecoveryStateManager.load(tmpdir, "rename_test")
-        assert loaded is not None
-        assert loaded.phase == "retry"
-
-        # Temp file cleaned up
-        assert list(path.parent.glob("*.tmp")) == []
-
-    def test_save_error_raises_oserror(self, tmp_path):
-        """save() propagates write failures as OSError."""
-        state = RecoveryState(phase="retry")
-        with patch(
-            "agent_actions.utils.atomic_write.json.dump",
-            side_effect=ValueError("bad data"),
-        ):
-            with pytest.raises(OSError, match="Failed to write"):
-                RecoveryStateManager.save(str(tmp_path), "error_test", state)
-
-    def test_large_state_serialization_roundtrip(self, tmp_path):
+    def test_large_state_serialization_roundtrip(self, backend):
         """200-record graduated state survives save/load roundtrip."""
         state = RecoveryState(
             phase="reprompt",
@@ -399,8 +280,8 @@ class TestRecoveryStateAtomicWrite:
             ],
             evaluation_strategy_name="validation",
         )
-        RecoveryStateManager.save(str(tmp_path), "large_test", state)
-        loaded = RecoveryStateManager.load(str(tmp_path), "large_test")
+        RecoveryStateManager.save(backend, "test_action", "large_test", state)
+        loaded = RecoveryStateManager.load(backend, "test_action", "large_test")
 
         assert loaded is not None
         assert len(loaded.graduated_results) == 200

--- a/tests/unit/test_assert_replacement_smoke.py
+++ b/tests/unit/test_assert_replacement_smoke.py
@@ -36,10 +36,12 @@ class TestBatchRegistryManagerCacheGuard:
     """BatchRegistryManager raises RuntimeError when cache is None after load."""
 
     def test_save_with_poisoned_cache(self, tmp_path):
+        from unittest.mock import MagicMock
+
         from agent_actions.llm.batch.core.batch_models import BatchJobEntry
         from agent_actions.llm.batch.infrastructure.registry import BatchRegistryManager
 
-        mgr = BatchRegistryManager(tmp_path / "registry.json")
+        mgr = BatchRegistryManager(MagicMock(), "test_action")
         # Force _load_registry to return None (simulating a corrupted state)
         mgr._load_registry = lambda: None  # type: ignore[assignment]
 

--- a/tests/unit/test_async_evaluation_wiring.py
+++ b/tests/unit/test_async_evaluation_wiring.py
@@ -412,7 +412,7 @@ class TestCheckAndSubmitRepromptGraduatedPool:
         service = _make_service()
         saved_state = {}
 
-        def capture_save(output_dir, file_name, state):
+        def capture_save(backend, action_name, file_name, state):
             saved_state["graduated_results"] = state.graduated_results
             saved_state["evaluation_strategy_name"] = state.evaluation_strategy_name
 

--- a/tests/unit/workflow/managers/test_batch_lifecycle_disposition.py
+++ b/tests/unit/workflow/managers/test_batch_lifecycle_disposition.py
@@ -19,6 +19,7 @@ def mock_storage_backend():
     """Create a mock storage backend with disposition methods."""
     backend = MagicMock()
     backend.has_disposition.return_value = False
+    backend.load_metadata.return_value = None
     return backend
 
 
@@ -134,16 +135,27 @@ class TestCheckBatchSubmissionRunMode:
     def test_batch_mode_respects_registry(
         self, mock_job_manager, mock_processing_service, mock_storage_backend
     ):
-        """Stale .batch_registry.json + run_mode=BATCH → returns 'batch_submitted'."""
+        """Backend has batch jobs + run_mode=BATCH -> returns 'batch_submitted'."""
+        import json
+
+        mock_storage_backend.load_metadata.return_value = json.dumps(
+            {
+                "file.json": {
+                    "batch_id": "b1",
+                    "status": "pending",
+                    "timestamp": "t",
+                    "provider": "p",
+                }
+            }
+        )
         manager = BatchLifecycleManager(
             mock_job_manager, mock_processing_service, storage_backend=mock_storage_backend
         )
         agent_io = Path("/tmp/fake_agent_io")
 
-        with patch.object(Path, "exists", return_value=True):
-            result = manager.check_batch_submission(
-                "extract", 0, agent_io, configured_run_mode=RunMode.BATCH
-            )
+        result = manager.check_batch_submission(
+            "extract", 0, agent_io, configured_run_mode=RunMode.BATCH
+        )
 
         assert result == "batch_submitted"
 
@@ -170,13 +182,24 @@ class TestCheckBatchSubmissionRunMode:
     def test_none_run_mode_preserves_existing_behavior(
         self, mock_job_manager, mock_processing_service, mock_storage_backend
     ):
-        """configured_run_mode=None (default) → existing behavior unchanged."""
+        """configured_run_mode=None (default) with jobs in backend -> batch_submitted."""
+        import json
+
+        mock_storage_backend.load_metadata.return_value = json.dumps(
+            {
+                "file.json": {
+                    "batch_id": "b1",
+                    "status": "pending",
+                    "timestamp": "t",
+                    "provider": "p",
+                }
+            }
+        )
         manager = BatchLifecycleManager(
             mock_job_manager, mock_processing_service, storage_backend=mock_storage_backend
         )
         agent_io = Path("/tmp/fake_agent_io")
 
-        with patch.object(Path, "exists", return_value=True):
-            result = manager.check_batch_submission("extract", 0, agent_io)
+        result = manager.check_batch_submission("extract", 0, agent_io)
 
         assert result == "batch_submitted"

--- a/tests/unit/workflow/test_fresh_run_cleanup.py
+++ b/tests/unit/workflow/test_fresh_run_cleanup.py
@@ -87,74 +87,27 @@ class TestFreshRunClearsSourceData:
         stub.services.core.state_manager.reset.assert_called_once()
 
 
-class TestFreshRunClearsBatchFiles:
-    """Batch recovery state, registry, and carry-forward files must be deleted."""
+class TestFreshRunClearsBatchState:
+    """Batch state must be cleared via storage backend."""
 
-    def _create_batch_files(self, tmp_path: Path, action_name: str) -> Path:
-        batch_dir = tmp_path / "agent_io" / "target" / action_name / "batch"
-        batch_dir.mkdir(parents=True)
-
-        (batch_dir / ".recovery_state_abc123.json").write_text(json.dumps({"attempt": 3}))
-        (batch_dir / ".recovery_state_def456.json").write_text(json.dumps({"attempt": 1}))
-        (batch_dir / ".batch_registry.json").write_text(json.dumps({"batch_id": "expired_123"}))
-        (batch_dir / ".batch_carry_forward.json").write_text(json.dumps({}))
-
-        # Also create a normal output file that should NOT be deleted
-        (batch_dir / "output_results.json").write_text(json.dumps([{"data": "keep"}]))
-
-        return batch_dir
-
-    def test_recovery_state_files_deleted(self, tmp_path: Path):
-        batch_dir = self._create_batch_files(tmp_path, "action1")
+    def test_clear_batch_state_called_per_action(self, tmp_path: Path):
         stub = _make_coordinator_stub(tmp_path, ["action1"])
-
         stub._clear_for_fresh_run()
-
-        assert list(batch_dir.glob(".recovery_state_*.json")) == []
-
-    def test_batch_registry_deleted(self, tmp_path: Path):
-        batch_dir = self._create_batch_files(tmp_path, "action1")
-        stub = _make_coordinator_stub(tmp_path, ["action1"])
-
-        stub._clear_for_fresh_run()
-
-        assert not (batch_dir / ".batch_registry.json").exists()
-
-    def test_batch_carry_forward_deleted(self, tmp_path: Path):
-        batch_dir = self._create_batch_files(tmp_path, "action1")
-        stub = _make_coordinator_stub(tmp_path, ["action1"])
-
-        stub._clear_for_fresh_run()
-
-        assert not (batch_dir / ".batch_carry_forward.json").exists()
-
-    def test_normal_output_files_preserved(self, tmp_path: Path):
-        batch_dir = self._create_batch_files(tmp_path, "action1")
-        stub = _make_coordinator_stub(tmp_path, ["action1"])
-
-        stub._clear_for_fresh_run()
-
-        assert (batch_dir / "output_results.json").exists()
+        stub.storage_backend.clear_batch_state.assert_any_call("action1")
 
     def test_no_batch_dir_no_error(self, tmp_path: Path):
-        """If the batch directory doesn't exist, no error is raised."""
         stub = _make_coordinator_stub(tmp_path, ["action_no_batch"])
-
-        # Should not raise
         stub._clear_for_fresh_run()
 
     def test_multiple_actions_batch_cleanup(self, tmp_path: Path):
-        """Batch files cleaned for each action in execution_order."""
-        batch_dir_a = self._create_batch_files(tmp_path, "action_a")
-        batch_dir_b = self._create_batch_files(tmp_path, "action_b")
+        """Batch state cleared for each action in execution_order."""
+        stub = _make_coordinator_stub(tmp_path, ["action_a", "action_b"])
 
         stub = _make_coordinator_stub(tmp_path, ["action_a", "action_b"])
         stub._clear_for_fresh_run()
 
-        assert list(batch_dir_a.glob(".recovery_state_*.json")) == []
-        assert not (batch_dir_a / ".batch_registry.json").exists()
-        assert list(batch_dir_b.glob(".recovery_state_*.json")) == []
-        assert not (batch_dir_b / ".batch_registry.json").exists()
+        stub.storage_backend.clear_batch_state.assert_any_call("action_a")
+        stub.storage_backend.clear_batch_state.assert_any_call("action_b")
 
 
 class TestFreshRunExistingBehavior:


### PR DESCRIPTION
## Summary

- **Batch registry** (`BatchRegistryManager`): persists to `workflow_metadata` table under `batch_registry:{action_name}` key instead of `.batch_registry.json` files
- **Recovery state** (`RecoveryStateManager`): persists under `recovery_state:{action}:{file}` metadata keys instead of `.recovery_state_*.json` files
- **Context maps** (`BatchContextManager`): persists under `batch_context:{action}:{batch}` metadata keys instead of `.context_map_*` files
- **Carry-forward eliminated**: `BATCH_CARRY_FORWARD_FILENAME` file writes removed — carry-forward GUIDs now derived from `get_terminal_record_ids()` at merge time
- **Placeholder files eliminated**: batch_jobs metadata entry is the in-flight signal, no filesystem placeholder needed
- **--fresh cleanup**: uses `clear_batch_state()` instead of filesystem glob for batch artifacts
- **Raw file reads eliminated**: `job_manager.py` and `batch_client_resolver.py` no longer bypass the registry with direct `json.load()`

Stacked on #680 (Phases 1+2). Together they complete spec 542: DB is the single source of truth for all workflow state.

**Net: 27 files changed, -263 lines** (545 added, 808 removed)

## Verification

- `ruff check` clean (0 new issues)
- `ruff format --check` clean
- `pytest`: 7479 passed, 2 skipped