### PR TITLE
feat: clean up batch JSONL files after processing (spec 550)

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260614-550000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260614-550000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Clean up batch JSONL files after processing — input files deleted after provider upload, result files deleted after parsing, --fresh deletes remaining batch artifacts"
+time: 2026-06-14T05:50:00.000000Z

--- a/agent_actions/llm/providers/batch_base.py
+++ b/agent_actions/llm/providers/batch_base.py
@@ -136,7 +136,12 @@ class BaseBatchClient(ABC):
         batch_dir = self._get_batch_directory(output_directory)
         input_file = self._prepare_batch_input_file(tasks, batch_dir, batch_name)
         logger.info("Submitting batch with %s tasks to %s...", len(tasks), self.__class__.__name__)
-        return self._submit_to_provider_api(input_file, batch_name)
+        result = self._submit_to_provider_api(input_file, batch_name)
+        try:
+            input_file.unlink(missing_ok=True)
+        except OSError:
+            logger.debug("Could not delete batch input file: %s", input_file)
+        return result
 
     def check_status(self, batch_id: str) -> str:
         """Check the status of a batch job (Template Method)."""
@@ -168,10 +173,15 @@ class BaseBatchClient(ABC):
 
         raw_results = _fetch_safe()
 
-        # Optionally write to file
+        # Write to file, parse, then clean up
         if output_directory:
             result_file_path = self._write_results_to_file(batch_id, raw_results, output_directory)
-            return self._read_jsonl_file(result_file_path)
+            results = self._read_jsonl_file(result_file_path)
+            try:
+                result_file_path.unlink(missing_ok=True)
+            except OSError:
+                logger.debug("Could not delete batch result file: %s", result_file_path)
+            return results
 
         batch_results = []
         lines = raw_results.decode("utf-8").strip().split("\n")

--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -275,6 +275,7 @@ class AgentWorkflow:
         """Clear stored results, dispositions, status, and event logs for a fresh run."""
         project_root = self.config.resolve_project_root()
 
+        target_dir = project_root / "agent_io" / "target"
         for action_name in self.execution_order:
             try:
                 self.storage_backend.delete_target(action_name)
@@ -284,6 +285,15 @@ class AgentWorkflow:
                 self.storage_backend.clear_batch_state(action_name)
             except Exception as e:
                 logger.warning("Failed to clear stored data for %s: %s", action_name, e)
+
+            batch_dir = target_dir / action_name / "batch"
+            if batch_dir.is_dir():
+                for f in batch_dir.iterdir():
+                    if f.suffix in (".jsonl", ".json"):
+                        try:
+                            f.unlink(missing_ok=True)
+                        except OSError:
+                            logger.debug("Could not delete batch artifact: %s", f)
 
         try:
             self.storage_backend.clear_source_data()
@@ -295,7 +305,6 @@ class AgentWorkflow:
         # JSONFileHandler opens lazily, so deleting between handler init
         # and first event write is safe.
         logs_dir = project_root / "agent_io" / "logs"
-        target_dir = project_root / "agent_io" / "target"
         for events_file in ("events.json", "errors.json"):
             for search_dir in (logs_dir, target_dir):
                 try:

--- a/tests/unit/llm/test_batch_jsonl_cleanup.py
+++ b/tests/unit/llm/test_batch_jsonl_cleanup.py
@@ -1,0 +1,131 @@
+"""Tests for batch JSONL file cleanup after upload and retrieval.
+
+Verifies that input JSONL files are deleted after successful provider upload
+and result JSONL files are deleted after successful parsing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_actions.llm.providers.batch_base import BaseBatchClient
+
+
+class _StubBatchClient(BaseBatchClient):
+    """Minimal concrete implementation for testing base class cleanup."""
+
+    vendor_type = "stub"
+
+    def _prepare_batch_input_file(self, tasks, batch_dir, batch_name):
+        return self._write_jsonl_file(tasks, batch_dir, batch_name, "stub")
+
+    def _submit_to_provider_api(self, input_file, batch_name):
+        return ("batch_123", "validating")
+
+    def _fetch_status(self, batch_id):
+        return "completed"
+
+    def _normalize_status(self, raw_status):
+        return raw_status
+
+    def _fetch_raw_results(self, batch_id):
+        result = {
+            "custom_id": "id1",
+            "response": {"body": {"choices": [{"message": {"content": '"hello"'}}]}},
+        }
+        return (json.dumps(result) + "\n").encode()
+
+    def _parse_result(self, raw_result):
+        from agent_actions.llm.providers.batch_base import BatchResult
+
+        return BatchResult(
+            custom_id=raw_result.get("custom_id", "unknown"),
+            content="hello",
+            success=True,
+        )
+
+    def _get_result_file_name(self, batch_id):
+        return f"{batch_id}_results.jsonl"
+
+    def _get_default_model(self):
+        return "stub-model"
+
+    def format_task_for_provider(self, *args, **kwargs):
+        return {}
+
+    def _extract_content_from_response(self, response):
+        return response
+
+    def _extract_error_from_response(self, response):
+        return None
+
+    def _extract_metadata_from_response(self, response):
+        return {}
+
+    def _extract_usage_from_response(self, response):
+        return {}
+
+
+class TestInputJsonlCleanup:
+    """Input JSONL file must be deleted after successful provider upload."""
+
+    def test_input_file_deleted_after_submit(self, tmp_path: Path):
+        client = _StubBatchClient()
+        output_dir = str(tmp_path / "agent_io" / "target" / "extract")
+
+        client.submit_batch(
+            tasks=[{"custom_id": "1", "body": {}}],
+            batch_name="extract",
+            output_directory=output_dir,
+        )
+
+        batch_dir = tmp_path / "agent_io" / "target" / "extract" / "batch"
+        jsonl_files = list(batch_dir.glob("*_batch_input.jsonl"))
+        assert jsonl_files == [], f"Input JSONL not cleaned up: {jsonl_files}"
+
+    def test_input_file_created_then_deleted(self, tmp_path: Path):
+        """Verify the file IS created during submission (not skipped entirely)."""
+        created_files: list[Path] = []
+        original_submit = _StubBatchClient._submit_to_provider_api
+
+        def spy_submit(self, input_file, batch_name):
+            created_files.append(input_file)
+            assert input_file.exists(), "Input file should exist before upload"
+            return original_submit(self, input_file, batch_name)
+
+        client = _StubBatchClient()
+        output_dir = str(tmp_path / "agent_io" / "target" / "extract")
+
+        with patch.object(_StubBatchClient, "_submit_to_provider_api", spy_submit):
+            client.submit_batch(
+                tasks=[{"custom_id": "1", "body": {}}],
+                batch_name="extract",
+                output_directory=output_dir,
+            )
+
+        assert len(created_files) == 1
+        assert not created_files[0].exists(), "Input file should be deleted after upload"
+
+
+class TestResultJsonlCleanup:
+    """Result JSONL file must be deleted after successful parsing."""
+
+    def test_result_file_deleted_after_retrieve(self, tmp_path: Path):
+        client = _StubBatchClient()
+        output_dir = str(tmp_path / "agent_io" / "target" / "extract")
+        (tmp_path / "agent_io" / "target" / "extract" / "batch").mkdir(parents=True)
+
+        results = client.retrieve_results("batch_123", output_dir)
+
+        assert len(results) == 1
+        batch_dir = tmp_path / "agent_io" / "target" / "extract" / "batch"
+        jsonl_files = list(batch_dir.glob("*_results.jsonl"))
+        assert jsonl_files == [], f"Result JSONL not cleaned up: {jsonl_files}"
+
+    def test_retrieve_without_output_dir_skips_file_write(self):
+        """When no output_directory, results parsed from memory — no file to clean."""
+        client = _StubBatchClient()
+        results = client.retrieve_results("batch_123")
+        assert len(results) == 1

--- a/tests/unit/workflow/test_fresh_run_cleanup.py
+++ b/tests/unit/workflow/test_fresh_run_cleanup.py
@@ -7,7 +7,6 @@ the existing target_data/disposition/prompt_trace cleanup.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -148,3 +147,60 @@ class TestFreshRunExistingBehavior:
 
         assert not (logs_dir / "events.json").exists()
         assert not (logs_dir / "errors.json").exists()
+
+
+class TestFreshRunClearsBatchJsonlFiles:
+    """--fresh must delete batch JSONL/JSON artifacts from target/{action}/batch/."""
+
+    def test_jsonl_files_deleted(self, tmp_path: Path):
+        batch_dir = tmp_path / "agent_io" / "target" / "extract" / "batch"
+        batch_dir.mkdir(parents=True)
+        (batch_dir / "extract_openai_batch_input.jsonl").write_text("{}")
+        (batch_dir / "batch_abc123_results.jsonl").write_text("{}")
+
+        stub = _make_coordinator_stub(tmp_path, ["extract"])
+        stub._clear_for_fresh_run()
+
+        assert not (batch_dir / "extract_openai_batch_input.jsonl").exists()
+        assert not (batch_dir / "batch_abc123_results.jsonl").exists()
+
+    def test_json_files_deleted(self, tmp_path: Path):
+        """Anthropic writes .json input files, not .jsonl."""
+        batch_dir = tmp_path / "agent_io" / "target" / "classify" / "batch"
+        batch_dir.mkdir(parents=True)
+        (batch_dir / "classify_anthropic_batch_input.json").write_text("{}")
+
+        stub = _make_coordinator_stub(tmp_path, ["classify"])
+        stub._clear_for_fresh_run()
+
+        assert not (batch_dir / "classify_anthropic_batch_input.json").exists()
+
+    def test_non_json_files_preserved(self, tmp_path: Path):
+        """Non-JSON/JSONL files in batch/ are not deleted."""
+        batch_dir = tmp_path / "agent_io" / "target" / "extract" / "batch"
+        batch_dir.mkdir(parents=True)
+        (batch_dir / "notes.txt").write_text("keep me")
+
+        stub = _make_coordinator_stub(tmp_path, ["extract"])
+        stub._clear_for_fresh_run()
+
+        assert (batch_dir / "notes.txt").exists()
+
+    def test_no_batch_dir_no_error(self, tmp_path: Path):
+        """Actions without a batch/ directory don't cause errors."""
+        stub = _make_coordinator_stub(tmp_path, ["online_action"])
+        stub._clear_for_fresh_run()
+
+    def test_multiple_actions_cleaned(self, tmp_path: Path):
+        for action in ("a1", "a2"):
+            batch_dir = tmp_path / "agent_io" / "target" / action / "batch"
+            batch_dir.mkdir(parents=True)
+            (batch_dir / f"{action}_input.jsonl").write_text("{}")
+
+        stub = _make_coordinator_stub(tmp_path, ["a1", "a2"])
+        stub._clear_for_fresh_run()
+
+        for action in ("a1", "a2"):
+            assert not (
+                tmp_path / "agent_io" / "target" / action / "batch" / f"{action}_input.jsonl"
+            ).exists()


### PR DESCRIPTION
## Summary
- Delete input JSONL files immediately after successful provider upload — the provider has the data, the local file is ephemeral
- Delete result JSONL files immediately after parsing — results flow into memory then SQLite, the file is a write-through cache
- Delete remaining `.jsonl`/`.json` batch artifacts in `target/{action}/batch/` during `--fresh` cleanup
- CLI `batch retrieve` output file is NOT deleted — that's the user-requested artifact

## Why
Batch JSONL files accumulate across runs. A 50-action workflow running daily produces ~100 files/run. After 30 days: ~3000 orphaned files. No code reads these files after the initial upload/retrieval call completes.

## Files changed (2 production, 2 test)
| File | Change |
|------|--------|
| `llm/providers/batch_base.py` | Delete input JSONL after `_submit_to_provider_api`, delete result JSONL after `_read_jsonl_file` |
| `workflow/coordinator.py` | `_clear_for_fresh_run` globs and deletes `.jsonl`/`.json` in `target/{action}/batch/` |
| `tests/unit/llm/test_batch_jsonl_cleanup.py` | 4 new tests: input cleanup, result cleanup, no-output-dir path |
| `tests/unit/workflow/test_fresh_run_cleanup.py` | 5 new tests: JSONL deleted, JSON deleted, non-JSON preserved, no-dir safe, multi-action |

## Verification
- `pytest` → 7488 passed, 2 skipped (+9 new tests)
- `ruff check` → all checks passed
- `ruff format --check` → 954 files already formatted