### PR TITLE
refactor: make delete_metadata a proper backend contract (spec 551)

### DIFF
--- a/.changes/unreleased/Under the Hood-20260614-551000.yaml
+++ b/.changes/unreleased/Under the Hood-20260614-551000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Make delete_metadata and delete_metadata_prefix required on StorageBackend — future backends must implement metadata deletion"
+time: 2026-06-14T05:51:00.000000Z

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -219,14 +219,13 @@ class StorageBackend(ABC):
         """Load a metadata value by key. Returns None if not found."""
         ...
 
-    def delete_metadata(self, key: str) -> bool:  # noqa: B027
-        """Delete a metadata key. Returns True if deleted.
+    def delete_metadata(self, key: str) -> bool:
+        """Delete a metadata key. Returns True if deleted."""
+        raise NotImplementedError(f"{type(self).__name__} must implement delete_metadata()")
 
-        Backends that support metadata deletion should override.
-        SQLiteBackend uses SQL DELETE; other backends may use their
-        native key-removal operation.
-        """
-        return False
+    def delete_metadata_prefix(self, prefix: str) -> int:
+        """Delete all metadata keys starting with prefix. Returns count deleted."""
+        raise NotImplementedError(f"{type(self).__name__} must implement delete_metadata_prefix()")
 
     def _extract_delta(
         self, record: dict[str, Any], action_name: str, *, is_first_action: bool = False
@@ -626,11 +625,11 @@ class StorageBackend(ABC):
         """Delete traces for an action, or all if action_name is None."""
         return 0
 
-    def clear_batch_state(self, action_name: str) -> None:  # noqa: B027
-        """Delete all batch state (registry, recovery, context) for an action.
-
-        Default is no-op. Backends override to clean up batch coordination data.
-        """
+    def clear_batch_state(self, action_name: str) -> None:
+        """Delete all batch state (registry, recovery, context) for an action."""
+        self.delete_metadata(f"batch_registry:{action_name}")
+        self.delete_metadata_prefix(f"recovery_state:{action_name}:")
+        self.delete_metadata_prefix(f"batch_context:{action_name}:")
 
     def scan_data(self, preview_limit: int = 20) -> dict[str, Any] | None:
         """Return stats and preview records for the docs scanner.

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -492,12 +492,6 @@ class SQLiteBackend(StorageBackend):
             except sqlite3.OperationalError:
                 return 0
 
-    def clear_batch_state(self, action_name: str) -> None:
-        """Delete all batch state for an action."""
-        self.delete_metadata(f"batch_registry:{action_name}")
-        self.delete_metadata_prefix(f"recovery_state:{action_name}:")
-        self.delete_metadata_prefix(f"batch_context:{action_name}:")
-
     def write_source(
         self,
         relative_path: str,

--- a/tests/unit/storage/test_sqlite_backend.py
+++ b/tests/unit/storage/test_sqlite_backend.py
@@ -672,3 +672,70 @@ class TestSchemaEnforcement:
         data = backend2.read_target("node1", "file.json")
         assert data[0]["id"] == 1
         backend2.close()
+
+
+class TestMetadataDeletion:
+    """Test delete_metadata, delete_metadata_prefix, and clear_batch_state on SQLiteBackend."""
+
+    @pytest.fixture
+    def backend(self, tmp_path):
+        db_path = tmp_path / "agent_io" / "test.db"
+        backend = SQLiteBackend(str(db_path), "test_workflow")
+        backend.initialize()
+        yield backend
+        backend.close()
+
+    def test_delete_metadata_removes_key(self, backend):
+        """delete_metadata returns True and removes the key."""
+        backend._save_metadata_raw("my_key", "my_value")
+        assert backend.load_metadata("my_key") == "my_value"
+
+        deleted = backend.delete_metadata("my_key")
+        assert deleted is True
+        assert backend.load_metadata("my_key") is None
+
+    def test_delete_metadata_returns_false_when_key_missing(self, backend):
+        """delete_metadata returns False when the key does not exist."""
+        deleted = backend.delete_metadata("nonexistent")
+        assert deleted is False
+
+    def test_delete_metadata_prefix_matches_prefix(self, backend):
+        """delete_metadata_prefix deletes keys starting with prefix, returns count."""
+        backend._save_metadata_raw("prefix:A", "1")
+        backend._save_metadata_raw("prefix:B", "2")
+        backend._save_metadata_raw("other:C", "3")
+
+        count = backend.delete_metadata_prefix("prefix:")
+        assert count == 2
+        assert backend.load_metadata("prefix:A") is None
+        assert backend.load_metadata("prefix:B") is None
+        assert backend.load_metadata("other:C") == "3"
+
+    def test_delete_metadata_prefix_returns_zero_when_no_match(self, backend):
+        """delete_metadata_prefix returns 0 when nothing matches."""
+        backend._save_metadata_raw("some_key", "value")
+        count = backend.delete_metadata_prefix("nomatch:")
+        assert count == 0
+        assert backend.load_metadata("some_key") == "value"
+
+    def test_clear_batch_state_removes_all_batch_keys(self, backend):
+        """clear_batch_state wipes registry, recovery, and context keys for an action."""
+        action = "my_action"
+        backend._save_metadata_raw(f"batch_registry:{action}", "reg")
+        backend._save_metadata_raw(f"recovery_state:{action}:file1", "rec1")
+        backend._save_metadata_raw(f"recovery_state:{action}:file2", "rec2")
+        backend._save_metadata_raw(f"batch_context:{action}:ctx1", "ctx1")
+        backend._save_metadata_raw("unrelated_key", "stay")
+
+        backend.clear_batch_state(action)
+
+        assert backend.load_metadata(f"batch_registry:{action}") is None
+        assert backend.load_metadata(f"recovery_state:{action}:file1") is None
+        assert backend.load_metadata(f"recovery_state:{action}:file2") is None
+        assert backend.load_metadata(f"batch_context:{action}:ctx1") is None
+        assert backend.load_metadata("unrelated_key") == "stay"
+
+    def test_clear_batch_state_is_idempotent(self, backend):
+        """clear_batch_state does not raise when there is nothing to delete."""
+        backend.clear_batch_state("nonexistent_action")
+        # Should not raise; no assertions needed beyond reaching this line.

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -862,6 +862,12 @@ class TestGetFailedItems:
             def load_metadata(self, *a, **kw):
                 return None
 
+            def delete_metadata(self, key):
+                return False
+
+            def delete_metadata_prefix(self, prefix):
+                return 0
+
             def get_disposition(self, action_name, record_id=None, disposition=None):
                 return [
                     {


### PR DESCRIPTION
## Summary
- `delete_metadata`: changed from silent no-op (returns `False`) to `raise NotImplementedError` — future backends must implement metadata deletion
- `delete_metadata_prefix`: added to `StorageBackend` base class with `raise NotImplementedError`
- `clear_batch_state`: implemented on the base class using `delete_metadata` + `delete_metadata_prefix`, removing the redundant `SQLiteBackend` override (identical logic)
- `FakeBackend` in `test_circuit_breaker.py`: implements both new required methods

## Why
The no-op default meant non-SQLite backends silently failed to delete metadata. `RecoveryStateManager.delete()` and `BatchContextManager.delete_batch_context_map()` call `delete_metadata` directly — stale recovery state would persist and the next run would incorrectly resume recovery.

## Verification
- `pytest` → 7488 passed, 2 skipped
- `ruff check` → all checks passed
- `ruff format --check` → 954 files already formatted

## Files changed
| File | Change |
|------|--------|
| `storage/backend.py` | `delete_metadata` raises, `delete_metadata_prefix` added, `clear_batch_state` implemented |
| `storage/backends/sqlite_backend.py` | Removed redundant `clear_batch_state` override |
| `tests/unit/workflow/test_circuit_breaker.py` | `FakeBackend` implements both methods |