### PR TITLE
fix: docs dashboard accuracy — version expansion + agent_io* search 

### DIFF
--- a/.changes/unreleased/Bug Fix-20260614-553000.yaml
+++ b/.changes/unreleased/Bug Fix-20260614-553000.yaml
@@ -1,3 +1,3 @@
 kind: Bug Fix
-body: "Fix missing edges in docs workflow graph when multiple workflows share action names"
+body: "Fix docs dashboard accuracy — expand versioned actions (43→52), search agent_io* directories for manifest/runs/logs"
 time: 2026-06-14T05:53:00.000000Z

--- a/agent_actions/tooling/docs/parser.py
+++ b/agent_actions/tooling/docs/parser.py
@@ -227,8 +227,8 @@ class WorkflowParser:
 
             workflow["actions"][action_name] = action
 
-        # Expand versioned actions: extract_raw_qa with versions.range=[1,2,3]
-        # becomes extract_raw_qa_1, extract_raw_qa_2, extract_raw_qa_3
+        # Expand versioned actions into concrete instances (e.g., action with
+        # versions.range=[1,2,3] becomes action_1, action_2, action_3)
         version_map: dict[str, list[str]] = {}
         expanded_actions: dict[str, Any] = {}
         for name, action in workflow["actions"].items():

--- a/agent_actions/tooling/docs/parser.py
+++ b/agent_actions/tooling/docs/parser.py
@@ -227,6 +227,34 @@ class WorkflowParser:
 
             workflow["actions"][action_name] = action
 
+        # Expand versioned actions: extract_raw_qa with versions.range=[1,2,3]
+        # becomes extract_raw_qa_1, extract_raw_qa_2, extract_raw_qa_3
+        version_map: dict[str, list[str]] = {}
+        expanded_actions: dict[str, Any] = {}
+        for name, action in workflow["actions"].items():
+            versions = action.get("versions")
+            if versions and isinstance(versions.get("range"), list):
+                version_range = versions["range"]
+                expanded_names = [f"{name}_{v}" for v in version_range]
+                version_map[name] = expanded_names
+                for v in version_range:
+                    versioned = {**action, "name": f"{name}_{v}"}
+                    versioned.pop("versions", None)
+                    expanded_actions[f"{name}_{v}"] = versioned
+            else:
+                expanded_actions[name] = action
+
+        if version_map:
+            for action in expanded_actions.values():
+                resolved_deps = []
+                for dep in action.get("dependencies", []):
+                    if dep in version_map:
+                        resolved_deps.extend(version_map[dep])
+                    else:
+                        resolved_deps.append(dep)
+                action["dependencies"] = resolved_deps
+            workflow["actions"] = expanded_actions
+
         return workflow
 
     @staticmethod

--- a/agent_actions/tooling/docs/scanner/data_scanners.py
+++ b/agent_actions/tooling/docs/scanner/data_scanners.py
@@ -95,7 +95,9 @@ def scan_workflow_data(project_root: Path) -> dict[str, Any]:
     workflow_data = {}
     artefact_dir = project_root / "artefact"
 
-    for agent_io_dir in project_root.rglob("agent_io"):
+    for agent_io_dir in sorted(project_root.rglob("agent_io*"), key=lambda p: p.name):
+        if not agent_io_dir.is_dir() or not agent_io_dir.name.startswith("agent_io"):
+            continue
         if artefact_dir in agent_io_dir.parents or agent_io_dir == artefact_dir:
             continue
 
@@ -127,7 +129,9 @@ def scan_runs(project_root: Path) -> dict[str, Any]:
     runs_data = {}
 
     # Find all agent_io directories
-    for agent_io_dir in project_root.rglob("agent_io"):
+    for agent_io_dir in sorted(project_root.rglob("agent_io*"), key=lambda p: p.name):
+        if not agent_io_dir.is_dir() or not agent_io_dir.name.startswith("agent_io"):
+            continue
         # Skip if inside artefact directory
         artefact_dir = project_root / "artefact"
         if artefact_dir in agent_io_dir.parents or agent_io_dir == artefact_dir:


### PR DESCRIPTION
## Summary
Two P0 fixes for incorrect data in the docs dashboard:

### 1. Expand versioned actions (43 → 52)
Actions with `versions: {range: [1,2,3]}` now expand into concrete versioned actions. Before: `extract_raw_qa` shown as 1 action. After: `extract_raw_qa_1`, `_2`, `_3` shown as 3 actions. Dependencies referencing base names resolve to all expanded names.

### 2. Fix agent_io directory search
`rglob("agent_io")` only matched directories named exactly `agent_io`, missing `agent_io_changed/` and other variants. Changed to `rglob("agent_io*")`. Fixes manifest, run_results, and event log scanning — resolves wrong workflow status ("paused" → "completed"), missing levels (0 → 36), missing runs (0 → actual count).

## Verification
```python
# Before: 43 actions, no manifest
# After: 52 actions, manifest found
from agent_actions.tooling.docs.parser import WorkflowParser
wf = WorkflowParser.parse_workflow('qanalabs_quiz_gen.yml')
len(wf['actions'])  # 52 (was 43)
```

- `pytest` → 7494 passed, 2 skipped
- `ruff check` → all checks passed