### PR TITLE
fix: storage module architectural review — cache leak, silent no-ops, inverted dep

### DIFF
--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -455,7 +455,7 @@ class StorageBackend(ABC):
         """Get storage statistics (record counts, DB size, per-node breakdown)."""
         ...
 
-    def set_disposition(  # noqa: B027
+    def set_disposition(
         self,
         action_name: str,
         record_id: str,
@@ -472,6 +472,7 @@ class StorageBackend(ABC):
                 Implementations SHOULD truncate to a reasonable limit (recommended 10KB).
             detail: Extended error message or context for the disposition.
         """
+        raise NotImplementedError
         # No-op: subclass must override to persist dispositions.
 
     def set_dispositions_batch(
@@ -525,7 +526,7 @@ class StorageBackend(ABC):
         """Delete matching disposition records. Returns count deleted."""
         return 0
 
-    def save_checkpoint_records(  # noqa: B027
+    def save_checkpoint_records(
         self,
         action_name: str,
         relative_path: str,
@@ -536,6 +537,7 @@ class StorageBackend(ABC):
         Used for incremental checkpointing during online processing.
         Uses INSERT OR REPLACE keyed on (action_name, relative_path, source_guid).
         """
+        raise NotImplementedError
 
     def read_checkpoint_records(
         self,

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -49,6 +49,16 @@ VALID_DISPOSITIONS = frozenset(d.value for d in Disposition)
 # filtered (predicate), deferred (in-flight HITL/batch).
 FAILURE_DISPOSITIONS = frozenset({DISPOSITION_FAILED, DISPOSITION_EXHAUSTED})
 
+TERMINAL_DISPOSITIONS = frozenset(
+    {
+        DISPOSITION_SUCCESS,
+        DISPOSITION_FILTERED,
+        DISPOSITION_SKIPPED,
+        DISPOSITION_PASSTHROUGH,
+        DISPOSITION_EXHAUSTED,
+    }
+)
+
 # Dispositions cleared when resuming an interrupted (RUNNING) action.
 # Includes DEFERRED because in-flight batch/HITL items must be re-submitted.
 # Excludes SUCCESS, PASSTHROUGH, FILTERED, SKIPPED so that checkpointed

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -209,11 +209,8 @@ class SQLiteBackend(StorageBackend):
         """Create a read-only instance for scanning. Do not call initialize()."""
         import urllib.parse
 
-        instance = cls.__new__(cls)
-        StorageBackend.__init__(instance)
-        instance.db_path = Path(db_path)
-        instance.workflow_name = instance.db_path.stem
-        instance._lock = threading.RLock()
+        db_path = Path(db_path)
+        instance = cls(str(db_path), db_path.stem)
         instance._readonly = True
 
         posix_path = instance.db_path.as_posix()

--- a/agent_actions/storage/backends/sqlite_backend.py
+++ b/agent_actions/storage/backends/sqlite_backend.py
@@ -761,9 +761,7 @@ class SQLiteBackend(StorageBackend):
             )
         # Cap input_snapshot at 10KB to prevent storage bloat.
         if input_snapshot and len(input_snapshot) > 10240:
-            input_snapshot = (
-                '{"__truncated__": true, "partial": ' + json.dumps(input_snapshot[:8192]) + "}"
-            )
+            input_snapshot = json.dumps({"__truncated__": True, "partial": input_snapshot[:8192]})
         return action_name, record_id, relative_path, input_snapshot
 
     def set_disposition(
@@ -945,10 +943,10 @@ class SQLiteBackend(StorageBackend):
 
     def get_terminal_record_ids(self, action_name: str) -> set[str]:
         """Return record_ids with any gate-terminal disposition for an action."""
-        from agent_actions.processing.disposition_gate import GATE_TERMINAL_DISPOSITIONS
+        from agent_actions.storage.backend import TERMINAL_DISPOSITIONS
 
         action_name = self._validate_identifier(action_name, "action_name")
-        terminal = tuple(GATE_TERMINAL_DISPOSITIONS)
+        terminal = tuple(TERMINAL_DISPOSITIONS)
         placeholders = ",".join("?" * len(terminal))
         sql = (
             f"SELECT DISTINCT record_id FROM record_disposition "
@@ -1734,7 +1732,7 @@ class SQLiteBackend(StorageBackend):
             }
 
     def close(self) -> None:
-        """Close the database connection."""
+        """Close the database connection and clear caches."""
         with self._lock:
             if self._connection is not None:
                 try:
@@ -1752,3 +1750,4 @@ class SQLiteBackend(StorageBackend):
                     )
                 finally:
                     self._connection = None
+        super().close()


### PR DESCRIPTION
## Summary

Architectural review of `agent_actions/storage/` (4 files, 2484 lines) using code-review agent. 5 findings fixed:

- **close() cache leak**: `SQLiteBackend.close()` never called `super().close()` — reconstruction/execution/dependency caches survived close, returning stale data on reuse
- **Silent no-ops → NotImplementedError**: `set_disposition` and `save_checkpoint_records` were silent pass in base class — a new backend that forgot to implement them would silently lose all disposition and checkpoint data
- **Inverted dependency**: `get_terminal_record_ids` imported from `processing.disposition_gate` — storage layer should not import from its consumer. Added `TERMINAL_DISPOSITIONS` to `storage.backend`
- **Fragile create_readonly**: Used `__new__` + manual setup bypassing `__init__`. Now uses proper `__init__` call
- **JSON string concatenation**: Input snapshot truncation built JSON by concatenation instead of `json.dumps()`

## Verification

- 7495 tests pass
- `ruff check` / `ruff format` clean
- 5/5 consensus review via Pi + Ollama (local, zero cost)