### PR TITLE
fix: CLI module hardening — 7 P0/P1 findings

### DIFF
--- a/agent_actions/cli/dispositions.py
+++ b/agent_actions/cli/dispositions.py
@@ -69,7 +69,7 @@ class DispositionsCommand:
         table.add_column("Success", justify="right", style="green")
         table.add_column("Failed", justify="right", style="red")
         table.add_column("Exhausted", justify="right", style="red")
-        table.add_column("Quarantined", justify="right", style="yellow")
+        table.add_column("Unprocessed", justify="right", style="yellow")
         table.add_column("Passthrough", justify="right", style="dim")
         table.add_column("Filtered", justify="right", style="dim")
         table.add_column("Total", justify="right", style="bold")

--- a/agent_actions/cli/init.py
+++ b/agent_actions/cli/init.py
@@ -93,8 +93,10 @@ def _list_remote_examples() -> list[dict[str, str]]:
             readme_bytes = _github_request(readme_url)
             first_line = readme_bytes.decode("utf-8", errors="replace").strip().splitlines()[0]
             desc = first_line.lstrip("# ").strip()
-        except (click.ClickException, IndexError):
+        except IndexError:
             pass
+        except click.ClickException as exc:
+            logger.warning("Could not fetch README for example '%s': %s", name, exc.message)
         results.append({"name": name, "description": desc})
     return results
 
@@ -228,8 +230,12 @@ class InitCommand:
                         dir=str(self.project_dir.parent),
                     )
                 )
-                shutil.rmtree(backup_dir)
-                self.project_dir.rename(backup_dir)
+                # Move existing project INTO the temp dir (which mkdtemp already
+                # created atomically).  The old code deleted the temp dir first,
+                # opening a TOCTOU race where another process could reclaim the
+                # path between rmtree and rename.
+                target = backup_dir / self.project_dir.name
+                self.project_dir.rename(target)
             self.project_dir.mkdir(exist_ok=self.args.force)
             if backup_dir and backup_dir.exists():
                 try:
@@ -238,7 +244,12 @@ class InitCommand:
                     logger.warning("Failed to clean up backup %s: %s", backup_dir, cleanup_err)
         except OSError as e:
             if backup_dir and backup_dir.exists() and not self.project_dir.exists():
-                backup_dir.rename(self.project_dir)
+                # Restore: move the project back out of the backup dir.
+                target = backup_dir / self.project_dir.name
+                if target.exists():
+                    target.rename(self.project_dir)
+                else:
+                    backup_dir.rename(self.project_dir)
             raise FileSystemError(
                 "Failed to create project directory",
                 context={

--- a/agent_actions/cli/init.py
+++ b/agent_actions/cli/init.py
@@ -244,12 +244,8 @@ class InitCommand:
                     logger.warning("Failed to clean up backup %s: %s", backup_dir, cleanup_err)
         except OSError as e:
             if backup_dir and backup_dir.exists() and not self.project_dir.exists():
-                # Restore: move the project back out of the backup dir.
                 target = backup_dir / self.project_dir.name
-                if target.exists():
-                    target.rename(self.project_dir)
-                else:
-                    backup_dir.rename(self.project_dir)
+                target.rename(self.project_dir)
             raise FileSystemError(
                 "Failed to create project directory",
                 context={

--- a/agent_actions/cli/inspect_action.py
+++ b/agent_actions/cli/inspect_action.py
@@ -100,17 +100,21 @@ class ActionCommand(BaseInspectCommand):
         self.console.print(tree)
 
         ctx = info["context_scope"]
-        if ctx["observe"] or ctx["passthrough"]:
+        if ctx.get("observe") or ctx.get("passthrough") or ctx.get("drop"):
             self.console.print()
             scope_tree = Tree("[bold]Input Fields (from context_scope)[/bold]")
-            if ctx["observe"]:
+            if ctx.get("observe"):
                 obs = scope_tree.add("[cyan]observe:[/cyan]")
                 for f in ctx["observe"]:
                     obs.add(f"• {f}")
-            if ctx["passthrough"]:
+            if ctx.get("passthrough"):
                 pas = scope_tree.add("[cyan]passthrough:[/cyan]")
                 for f in ctx["passthrough"]:
                     pas.add(f"• {f}")
+            if ctx.get("drop"):
+                drp = scope_tree.add("[cyan]drop:[/cyan]")
+                for f in ctx["drop"]:
+                    drp.add(f"• {f}")
             self.console.print(scope_tree)
 
         output_fields = self._get_output_fields(

--- a/agent_actions/cli/inspect_base.py
+++ b/agent_actions/cli/inspect_base.py
@@ -44,11 +44,19 @@ class BaseInspectCommand:
         self.paths = paths
         filename = f"{self.agent_name}.yml"
         full_path = find_config_file(
-            self.agent_name, paths.agent_config_dir, filename, check_alternatives=True
+            self.agent_name,
+            paths.agent_config_dir,
+            filename,
+            check_alternatives=True,
+            project_root=project_root,
         )
 
         ConfigRenderingService().render_and_load_config(
-            self.agent_name, full_path, paths.template_dir, project_root=project_root
+            self.agent_name,
+            full_path,
+            paths.template_dir,
+            paths.rendered_workflows_dir,
+            project_root=project_root,
         )
 
         workflow = AgentWorkflow(
@@ -111,6 +119,7 @@ class BaseInspectCommand:
                 "context_scope": {
                     "observe": context_scope.get("observe", []),
                     "passthrough": context_scope.get("passthrough", []),
+                    "drop": context_scope.get("drop", []),
                 },
                 "has_primary_dependency": has_primary_dep,
                 "primary_dependency": action_config.get("primary_dependency"),
@@ -157,4 +166,6 @@ class BaseInspectCommand:
             fields.append(f"{field_ref} (observe)")
         for field_ref in ctx.get("passthrough", []):
             fields.append(f"{field_ref} (passthrough)")
+        for field_ref in ctx.get("drop", []):
+            fields.append(f"{field_ref} (drop)")
         return fields

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -8,6 +8,7 @@ the existing workflow execution engine for re-processing.
 import datetime
 import json
 import logging
+import traceback
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,7 @@ from agent_actions.storage.backend import (
     FAILURE_DISPOSITIONS,
     NODE_LEVEL_RECORD_ID,
 )
+from agent_actions.tooling.docs.run_tracker import RunTracker
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.validation.retry_validator import RetryCommandArgs
 
@@ -219,7 +221,34 @@ class RetryCommand:
         for action in downstream_actions:
             state_mgr.update_status(action, ActionStatus.PENDING)
 
-        workflow.run()
+        tracker = RunTracker(project_root=project_root)
+        run_id = tracker.start_workflow_run(
+            workflow_id=self.agent_name,
+            workflow_name=self.agent_name,
+            actions_total=len(workflow.execution_order),
+        )
+        workflow.services.core.action_executor.run_tracker = tracker
+        workflow.services.core.action_executor.run_id = run_id
+
+        status = "FAILED"
+        error_message = None
+        try:
+            workflow.run()
+            status = "SUCCESS"
+        except Exception:
+            error_message = traceback.format_exc()
+            raise
+        finally:
+            try:
+                tracker.finalize_workflow_run(
+                    run_id=run_id, status=status, error_message=error_message
+                )
+            except Exception as track_error:
+                logger.warning(
+                    "Could not finalize retry run tracking: %s",
+                    track_error,
+                    exc_info=True,
+                )
 
         # Retry completed successfully — delete the manifest.
         _delete_manifest(manifest_file)

--- a/agent_actions/cli/retry.py
+++ b/agent_actions/cli/retry.py
@@ -19,6 +19,7 @@ from rich.table import Table
 from agent_actions.cli.cli_decorators import handles_user_errors, requires_project
 from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
+from agent_actions.logging.factory import LoggerFactory
 from agent_actions.storage import get_storage_backend
 from agent_actions.storage.backend import (
     FAILURE_DISPOSITIONS,
@@ -230,11 +231,25 @@ class RetryCommand:
         workflow.services.core.action_executor.run_tracker = tracker
         workflow.services.core.action_executor.run_id = run_id
 
+        agent_folder = workflow.services.core.action_runner.get_action_folder(self.agent_name)
+        LoggerFactory.initialize(
+            output_dir=agent_folder,
+            workflow_name=self.agent_name,
+            invocation_id=run_id,
+            force=True,
+        )
+
         status = "FAILED"
         error_message = None
         try:
             workflow.run()
-            status = "SUCCESS"
+
+            if state_mgr.is_workflow_complete():
+                status = "SUCCESS"
+            elif state_mgr.is_workflow_done() and not state_mgr.has_any_failed():
+                status = "SUCCESS"
+            elif state_mgr.get_batch_submitted_actions(workflow.execution_order):
+                status = "PAUSED"
         except Exception:
             error_message = traceback.format_exc()
             raise
@@ -249,6 +264,11 @@ class RetryCommand:
                     track_error,
                     exc_info=True,
                 )
+
+            try:
+                LoggerFactory.flush()
+            except Exception as e:
+                logger.debug("Failed to flush event handlers: %s", e, exc_info=True)
 
         # Retry completed successfully — delete the manifest.
         _delete_manifest(manifest_file)

--- a/agent_actions/cli/run.py
+++ b/agent_actions/cli/run.py
@@ -117,7 +117,7 @@ class RunCommand:
                 snapshot = build_execution_snapshot(workflow, elapsed)
                 ExecutionRenderer(workflow.console).render(snapshot)
             except Exception as render_err:
-                logger.debug("Execution summary render failed: %s", render_err)
+                logger.warning("Execution summary render failed: %s", render_err, exc_info=True)
 
             state_mgr = workflow.services.core.state_manager
             execution_order = workflow.execution_order


### PR DESCRIPTION
## Summary
- **inspect_base**: add missing `project_root` and `rendered_workflows_dir` args to `find_config_file` / `render_and_load_config`, matching the canonical `workflow_loader.py` pattern — all 4 inspect subcommands were seeing structurally different workflow objects than run/retry
- **run.py**: escalate execution summary render failure from `logger.debug` to `logger.warning` with traceback — render failures were silently swallowed
- **retry.py**: wire `RunTracker` into retry execution (create tracker, `start_workflow_run`, wire into `action_executor`, `finalize_workflow_run` in finally) — retry runs were invisible to docs history
- **init.py**: eliminate TOCTOU race in `_create_project_directory` by renaming into the mkdtemp dir instead of deleting it first
- **dispositions.py**: fix column header from "Quarantined" to "Unprocessed" to match actual `DISPOSITION_UNPROCESSED` value
- **inspect_base**: add `drop` key to `context_scope` output and `_get_input_fields` — drop rules were invisible in inspect output
- **init.py**: log warning on network errors in `_list_remote_examples` instead of silently swallowing via `except: pass`

## Verification
- `ruff check` — clean
- `ruff format --check` — clean
- `pytest` — 7495 passed, 2 skipped
- 5/5 independent consensus-review agents approved all fixes unanimously