### PR TITLE
fix: utils module hardening — 9 findings (security, data integrity, robustness)

### DIFF
--- a/agent_actions/utils/file_utils.py
+++ b/agent_actions/utils/file_utils.py
@@ -13,9 +13,13 @@ def load_structured_file(path: Path) -> Any:
     """Load a JSON or YAML file based on its extension.
 
     Returns the parsed content.  Raises ``json.JSONDecodeError`` for
-    malformed JSON and ``yaml.YAMLError`` for malformed YAML.
+    malformed JSON, ``yaml.YAMLError`` for malformed YAML, and
+    ``ValueError`` for empty files.
     """
     with open(path, encoding="utf-8") as f:
         if path.suffix == ".json":
             return json.load(f)
-        return yaml.safe_load(f)
+        result = yaml.safe_load(f)
+        if result is None:
+            raise ValueError(f"Empty or null YAML file: {path}")
+        return result

--- a/agent_actions/utils/metadata/extractor.py
+++ b/agent_actions/utils/metadata/extractor.py
@@ -177,11 +177,12 @@ class MetadataExtractor:
         elif "prompt_tokens" in result and "completion_tokens" in result:
             result["total_tokens"] = result["prompt_tokens"] + result["completion_tokens"]
 
-        if hasattr(usage, "input_tokens"):
-            result["prompt_tokens"] = usage.input_tokens or 0
-        if hasattr(usage, "output_tokens"):
-            result["completion_tokens"] = usage.output_tokens or 0
-            if "prompt_tokens" in result:
+        if not result:
+            if hasattr(usage, "input_tokens"):
+                result["prompt_tokens"] = usage.input_tokens or 0
+            if hasattr(usage, "output_tokens"):
+                result["completion_tokens"] = usage.output_tokens or 0
+            if "prompt_tokens" in result and "completion_tokens" in result:
                 result["total_tokens"] = result["prompt_tokens"] + result["completion_tokens"]
 
         return result if result else None

--- a/agent_actions/utils/module_loader.py
+++ b/agent_actions/utils/module_loader.py
@@ -89,9 +89,12 @@ def load_module_from_path(
                     if spec and spec.loader:
                         module = importlib.util.module_from_spec(spec)
 
-                        # CRITICAL: Register in sys.modules BEFORE execution
-                        # This ensures decorators can find the module
-                        sys.modules[f"agent_actions._udfs.{module_name}"] = module
+                        # Register in sys.modules BEFORE execution so
+                        # decorators can find the module.  Use module_name
+                        # (not cache_key) to stay consistent with udf.py's
+                        # deduplication guard.
+                        sys_modules_key = f"agent_actions._udfs.{module_name}"
+                        sys.modules[sys_modules_key] = module
 
                         if execute:
                             try:
@@ -100,7 +103,7 @@ def load_module_from_path(
                                 # Module file found but its code is broken.
                                 # Clean up and block fallback so a different
                                 # same-named package doesn't silently replace it.
-                                sys.modules.pop(f"agent_actions._udfs.{module_name}", None)
+                                sys.modules.pop(sys_modules_key, None)
                                 logger.warning(
                                     "Failed to execute module %s from %s: %s",
                                     module_name,

--- a/agent_actions/utils/passthrough_builder.py
+++ b/agent_actions/utils/passthrough_builder.py
@@ -62,13 +62,13 @@ class PassthroughItemBuilder:
         if "metadata" not in processed_item:
             processed_item["metadata"] = {}
 
+        if mode not in ("online", "batch"):
+            raise ValueError(f"Invalid passthrough mode '{mode}' — must be 'online' or 'batch'")
+
         if mode == "online":
             processed_item["metadata"]["reason"] = reason
-            flag_name = PassthroughItemBuilder._reason_to_legacy_flag(reason)
-            processed_item["metadata"][flag_name] = True
-        else:
-            flag_name = PassthroughItemBuilder._reason_to_legacy_flag(reason)
-            processed_item["metadata"][flag_name] = True
+        flag_name = PassthroughItemBuilder._reason_to_legacy_flag(reason)
+        processed_item["metadata"][flag_name] = True
 
         processed_item["metadata"]["agent_type"] = "tombstone"
         processed_item["_tombstone"] = True

--- a/agent_actions/utils/tools_resolver.py
+++ b/agent_actions/utils/tools_resolver.py
@@ -12,6 +12,47 @@ from agent_actions.utils.project_root import find_project_root
 
 logger = logging.getLogger(__name__)
 
+_FORBIDDEN_MODULES = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "importlib",
+        "ctypes",
+        "code",
+        "codeop",
+        "compile",
+        "compileall",
+        "socket",
+        "http",
+        "ftplib",
+        "smtplib",
+        "telnetlib",
+        "pickle",
+        "shelve",
+        "marshal",
+        "builtins",
+        "__builtin__",
+        "signal",
+        "multiprocessing",
+        "threading",
+    }
+)
+
+
+def _validate_module_path(module_path: str) -> None:
+    """Reject module paths that contain traversal or resolve to dangerous stdlib modules."""
+    if ".." in module_path or module_path.startswith("/"):
+        raise ConfigValidationError(
+            f"module_path '{module_path}' contains path traversal — must be a dotted Python name"
+        )
+    top_level = module_path.split(".")[0]
+    if top_level in _FORBIDDEN_MODULES:
+        raise ConfigValidationError(
+            f"module_path '{module_path}' resolves to a restricted module '{top_level}'"
+        )
+
 
 def anchor_to_project_root(path: str) -> str:
     """Anchor a relative path to the project root, or return as-is if absolute."""
@@ -66,13 +107,12 @@ def resolve_tools_path(agent_config: dict[str, Any]) -> str | None:
                         with open(resolved, encoding="utf-8") as f:
                             tool_config = yaml.safe_load(f)
                             if tool_config and "module_path" in tool_config:
-                                module_path = tool_config["module_path"]
+                                module_path = str(tool_config["module_path"])
+                                _validate_module_path(module_path)
                                 logger.debug(
                                     "Resolved tools_path from OpenAI tool config: %s", module_path
                                 )
-                                # module_path is a Python module name (e.g. "my.module"),
-                                # not a filesystem path — skip anchor_to_project_root.
-                                return cast(str, module_path)
+                                return module_path
                     except (
                         yaml.YAMLError,
                         FileNotFoundError,

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -1,5 +1,7 @@
 """Passthrough strategies for pre-computed passthrough_fields."""
 
+import copy
+
 from .base import IPassthroughTransformStrategy, ensure_dict_output
 
 
@@ -33,13 +35,13 @@ class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
 
         Returns flat action output dicts — RecordEnvelope handles wrapping.
         """
+        pt = passthrough_fields or {}
         result = []
         for item in data:
             if isinstance(item, dict) and "content" in item and isinstance(item["content"], dict):
-                merged_content = {**item["content"], **(passthrough_fields or {})}
-                result.append(merged_content)
+                result.append({**item["content"], **copy.deepcopy(pt)})
             elif isinstance(item, dict):
-                result.append({**item, **(passthrough_fields or {})})
+                result.append({**item, **copy.deepcopy(pt)})
             else:
                 result.append(ensure_dict_output(item))
         return result
@@ -75,11 +77,11 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
 
         Returns flat action output dicts — RecordEnvelope handles wrapping.
         """
+        pt = passthrough_fields or {}
         merged = []
         for item in data:
             if isinstance(item, dict):
-                merged_item = {**item, **(passthrough_fields or {})}
-                merged.append(merged_item)
+                merged.append({**item, **copy.deepcopy(pt)})
             else:
                 merged.append(ensure_dict_output(item))
         return merged

--- a/agent_actions/utils/udf_management/registry.py
+++ b/agent_actions/utils/udf_management/registry.py
@@ -69,11 +69,11 @@ def udf_tool(
 
             if func_name_lower in UDF_REGISTRY:
                 existing = UDF_REGISTRY[func_name_lower]
-                new_file = inspect.getfile(f)
-                # Allow if it's the same file being imported via different module paths
-                # This happens when tools_path subdirectories are added to sys.path
+                try:
+                    new_file = inspect.getfile(f)
+                except TypeError:
+                    new_file = f"<builtin:{f.__module__}>"
                 if existing["file"] == new_file:
-                    # Same file, different import path - return existing function
                     return cast(Callable, existing["function"])
                 raise DuplicateFunctionError(
                     function_name=f.__name__,
@@ -83,11 +83,16 @@ def udf_tool(
                     new_file=new_file,
                 )
 
+            try:
+                source_file = inspect.getfile(f)
+            except TypeError:
+                source_file = f"<builtin:{f.__module__}>"
+
             UDF_REGISTRY[func_name_lower] = {
                 "function": f,
                 "module": f.__module__,
                 "name": f.__name__,
-                "file": inspect.getfile(f),
+                "file": source_file,
                 "docstring": f.__doc__,
                 "signature": inspect.signature(f),
                 "granularity": granularity,

--- a/agent_actions/utils/udf_management/tooling.py
+++ b/agent_actions/utils/udf_management/tooling.py
@@ -21,7 +21,7 @@ def load_user_defined_function(module_name: str, function_name: str) -> Callable
         module_name,
         module_path=None,
         execute=True,
-        fallback_import=True,
+        fallback_import=False,
         cache=True,
     )
     if module is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,10 +121,13 @@ def wire_batch_disposition_delegate(backend: MagicMock) -> None:
 def _reset_global_singletons():
     """Prevent singleton state from leaking between tests."""
     from agent_actions.logging.factory import LoggerFactory
+    from agent_actions.utils.correlation.version_id import VersionIdGenerator
     from agent_actions.utils.path_utils import reset_path_manager
 
     reset_path_manager()
     LoggerFactory.reset()
+    VersionIdGenerator.clear()
     yield
     reset_path_manager()
     LoggerFactory.reset()  # cascades to EventManager.reset()
+    VersionIdGenerator.clear()

--- a/tests/unit/output/test_loader.py
+++ b/tests/unit/output/test_loader.py
@@ -37,14 +37,14 @@ class TestSchemaLoaderLoadSchema:
         assert isinstance(result, dict)
         assert result["name"] == "TestSchema"
 
-    def test_empty_yaml_returns_none(self, tmp_path):
-        """An empty YAML file produces yaml.safe_load -> None; loader returns that."""
+    def test_empty_yaml_raises(self, tmp_path):
+        """An empty YAML file raises ValueError."""
         _write_project_config(tmp_path)
         schema_dir = tmp_path / "schema"
         schema_dir.mkdir()
         (schema_dir / "Empty.yml").write_text("")
-        result = SchemaLoader.load_schema("Empty", project_root=tmp_path)
-        assert result is None
+        with pytest.raises(ValueError, match="Empty or null YAML file"):
+            SchemaLoader.load_schema("Empty", project_root=tmp_path)
 
     def test_recursive_search_finds_nested_schema(self, tmp_path):
         _write_project_config(tmp_path)

--- a/tests/utilities/test_tools_resolver.py
+++ b/tests/utilities/test_tools_resolver.py
@@ -32,9 +32,8 @@ class TestToolsResolver:
 
     def test_openai_format(self, tmp_path):
         """Test OpenAI tool calling format."""
-        # Create tool config file
         tool_config_path = tmp_path / "tool_config.yaml"
-        tool_config_path.write_text(f"module_path: {tmp_path}")
+        tool_config_path.write_text("module_path: my.tools.module")
 
         agent_config = {
             "tools": [{"type": "function", "function": {"file": str(tool_config_path)}}],
@@ -46,7 +45,7 @@ class TestToolsResolver:
             return_value=tmp_path,
         ):
             resolved = resolve_tools_path(agent_config)
-        assert resolved == str(tmp_path), f"Expected module_path from tool config, got {resolved}"
+        assert resolved == "my.tools.module"
 
     def test_no_tools_configured(self):
         """Test that missing tools returns None."""


### PR DESCRIPTION
## Summary

**Security (P0):**
- **tooling.py**: disable `fallback_import` to prevent stdlib hijack via UDF module names like `os` or `subprocess`
- **tools_resolver.py**: validate `module_path` from YAML configs — reject path traversal (`..`, `/`) and block dangerous stdlib modules via `_FORBIDDEN_MODULES` frozenset
- **file_utils.py**: raise `ValueError` on empty/null YAML instead of returning `None` that crashes callers with misleading `AttributeError`

**Data integrity (P1):**
- **precomputed.py**: deep-copy `passthrough_fields` to prevent mutable aliasing across output items
- **extractor.py**: try OpenAI token fields first, fall back to Anthropic only if OpenAI produced nothing — prevents silent overwrite when both attribute sets are present
- **module_loader.py**: keep `sys.modules` key as `module_name` (not `cache_key`) to stay consistent with `udf.py` deduplication guard

**Robustness (P2):**
- **registry.py**: guard `inspect.getfile` with `try/except TypeError` for frozen/built-in modules
- **passthrough_builder.py**: raise `ValueError` on unknown mode instead of silent batch fallback, deduplicate shared flag logic
- **conftest.py**: add `VersionIdGenerator.clear()` to autouse fixture to prevent cross-test state leaks

## Verification
- `ruff check` — clean
- `ruff format --check` — clean
- `pytest` — 7495 passed, 2 skipped
- 5/5 independent consensus-review agents approved all fixes
- `/code-review high` — 3 findings caught and fixed (sys.modules key mismatch with udf.py, deepcopy hoisting, extractor dual-attribute handling)
- Smoke test (`./smoke-test.sh online`) — passed, 52 actions clean