### PR TITLE
fix: config module hardening — YAML type safety, dead code removal

### DIFF
--- a/agent_actions/config/ARCHITECTURE.md
+++ b/agent_actions/config/ARCHITECTURE.md
@@ -231,17 +231,8 @@ EnvironmentConfig
   │   ├── anthropic_api_key
   │   └── gemini_api_key
   │
-  ├── Runtime settings
-  │   ├── agent_actions_env    (development/staging/production)
-  │   ├── default_api_timeout  (1-600 seconds, default 120)
-  │   ├── default_max_retries  (0-10, default 3)
-  │   ├── default_batch_size   (1-10000, default 100)
-  │   └── max_concurrency      (1-100, default 10)
-  │
-  └── Feature flags
-      ├── debug_logging           (default false)
-      ├── enable_parallel_processing (default true)
-      └── cache_ttl              (seconds, default 300)
+  └── Runtime settings
+      └── agent_actions_env    (development/staging/production)
 
 model_config: extra="ignore"
   Unknown env vars are silently ignored — EnvironmentConfig only
@@ -361,7 +352,7 @@ ProcessorFactory uses both:
 | `di/application.py` | `ApplicationContainer` — top-level bootstrap, creates `ActionRunner` with all deps |
 | `di/types.py` | `DIConfig`, `LoggingConfig`, `ProcessorsConfig`, `ServicesConfig` typed dicts |
 | `factory.py` | `application_container_context()` context manager, `create_action_runner()` convenience function |
-| `interfaces.py` | `ILoader`, `IProcessor`, `IGenerator`, `IDataLoader`, `ISourceDataLoader`, `IDataProcessor` ABCs with async mixins; `ProcessingMode` enum |
+| `interfaces.py` | `ILoader`, `IProcessor`, `IGenerator`, `IDataLoader`, `ISourceDataLoader`, `IDataProcessor` interface ABCs |
 
 ### Project Lifecycle
 | File | Role |

--- a/agent_actions/config/_MANIFEST.md
+++ b/agent_actions/config/_MANIFEST.md
@@ -108,7 +108,7 @@ Key Functions
 | `ConfigManager.load_configs` | `agent_config/{workflow}.yml` | Reads | `tool_path` |
 | `ConfigManager._resolve_dotenv` | `.env` | Reads | — |
 
-**Internal only**: `ActionKind`, `VersionMode`, `VersionConfig`, `MergePattern`, `VersionConsumptionConfig`, `RetryConfig`, `RepromptConfig`, `HitlConfig`, `PathType`, `PathConfig`, `PathManagerError`, `ProjectRootNotFoundError`, `PathManagerValidationError`, `ProcessingMode`, `IAsyncCapable`, `ILoader`, `IProcessor`, `IGenerator`, `IDataLoader`, `ISourceDataLoader`, `IDataProcessor`, `Granularity`, `RunMode`, `ContextScopeDict`, `GuardConfigDict`, `WhereClauseDict`, `HitlConfigDict`, `ActionConfigDict`, `ActionEntryDict`, `ActionConfigMap`, `ProjectPaths`, `StorageDefaults`, `LockDefaults`, `OllamaDefaults`, `ApiDefaults`, `SeedDataDefaults`, `PromptDefaults`, `DocsDefaults` -- no direct project surface.
+**Internal only**: `ActionKind`, `VersionMode`, `VersionConfig`, `MergePattern`, `VersionConsumptionConfig`, `RetryConfig`, `RepromptConfig`, `HitlConfig`, `PathType`, `PathConfig`, `PathManagerError`, `ProjectRootNotFoundError`, `PathManagerValidationError`, `ILoader`, `IProcessor`, `IGenerator`, `IDataLoader`, `ISourceDataLoader`, `IDataProcessor`, `Granularity`, `RunMode`, `ContextScopeDict`, `GuardConfigDict`, `WhereClauseDict`, `HitlConfigDict`, `ActionConfigDict`, `ActionEntryDict`, `ActionConfigMap`, `ProjectPaths`, `StorageDefaults`, `LockDefaults`, `OllamaDefaults`, `ApiDefaults`, `SeedDataDefaults`, `PromptDefaults`, `DocsDefaults` -- no direct project surface.
 
 ## Dependencies
 

--- a/agent_actions/config/environment.py
+++ b/agent_actions/config/environment.py
@@ -14,16 +14,6 @@ class Environment(str, Enum):
     PRODUCTION = "production"
 
 
-class LogLevel(str, Enum):
-    """Supported log levels."""
-
-    DEBUG = "DEBUG"
-    INFO = "INFO"
-    WARNING = "WARNING"
-    ERROR = "ERROR"
-    CRITICAL = "CRITICAL"
-
-
 class EnvironmentConfig(BaseSettings):
     """Environment configuration loaded from environment variables with validation.
 
@@ -45,22 +35,6 @@ class EnvironmentConfig(BaseSettings):
     agent_actions_env: Environment = Field(
         default=Environment.DEVELOPMENT, description="Application environment setting"
     )
-    default_api_timeout: int = Field(
-        default=120, ge=1, le=600, description="Default timeout for API requests in seconds"
-    )
-    default_max_retries: int = Field(
-        default=3, ge=0, le=10, description="Maximum retries for API requests"
-    )
-    debug_logging: bool = Field(default=False, description="Enable debug logging")
-    cache_ttl: int = Field(default=300, ge=0, description="Cache TTL in seconds (0 to disable)")
-    default_batch_size: int = Field(
-        default=100, ge=1, le=10000, description="Default batch size for processing"
-    )
-    enable_parallel_processing: bool = Field(default=True, description="Enable parallel processing")
-    max_concurrency: int = Field(
-        default=10, ge=1, le=100, description="Maximum number of concurrent operations"
-    )
-    database_url: str | None = Field(default=None, description="Database connection URL")
 
     @field_validator("openai_api_key", "anthropic_api_key", "gemini_api_key", mode="before")
     @classmethod
@@ -72,18 +46,6 @@ class EnvironmentConfig(BaseSettings):
                 raise ValueError("API key must be at least 10 characters long")
         return v
 
-    @field_validator("database_url")
-    @classmethod
-    def validate_database_url(cls, v):
-        """Validate database URL format if provided."""
-        if v is not None:
-            valid_prefixes = ("postgresql://", "mysql://", "sqlite:///")
-            if not v.startswith(valid_prefixes):
-                raise ValueError(
-                    "Database URL must start with postgresql://, mysql://, or sqlite:///"
-                )
-        return v
-
     def is_development(self) -> bool:
         """Check if running in development environment."""
         return self.agent_actions_env == Environment.DEVELOPMENT
@@ -92,13 +54,5 @@ class EnvironmentConfig(BaseSettings):
         """Check if running in production environment."""
         return self.agent_actions_env == Environment.PRODUCTION
 
-    def get_log_level(self) -> LogLevel:
-        """Get appropriate log level based on environment and debug setting."""
-        if self.debug_logging:
-            return LogLevel.DEBUG
-        if self.is_development():
-            return LogLevel.INFO
-        return LogLevel.WARNING
 
-
-__all__ = ["EnvironmentConfig", "Environment", "LogLevel"]
+__all__ = ["EnvironmentConfig", "Environment"]

--- a/agent_actions/config/interfaces.py
+++ b/agent_actions/config/interfaces.py
@@ -1,51 +1,22 @@
 """Common interfaces for processors."""
 
 import asyncio
-from abc import ABC, abstractmethod
-from enum import Enum
+from abc import abstractmethod
 from typing import Generic, TypeVar
 
 # Generic type variable for interfaces
 T = TypeVar("T")
 
 
-class ProcessingMode(Enum):
-    """Execution strategy for individual components (loaders, processors, generators).
-
-    This enum controls *how* a single component runs: synchronously, asynchronously,
-    or auto-detected.  Values: SYNC, ASYNC, AUTO.
-
-    Not to be confused with ``config.types.RunMode`` which controls the
-    *pipeline-level* dispatch mode (ONLINE vs BATCH).
-    """
-
-    SYNC = "sync"
-    ASYNC = "async"
-    AUTO = "auto"  # Choose based on system capabilities and data size
-
-
-# Base interfaces
-class IAsyncCapable(ABC):
-    """Interface for components that support async operations."""
-
-    @abstractmethod
-    def supports_async(self) -> bool:
-        """Return True if this component supports async operations."""
-
-    @abstractmethod
-    def get_processing_mode(self) -> ProcessingMode:
-        """Return the preferred processing mode for this component."""
-
-
-class ILoader(IAsyncCapable):
+class ILoader:
     """Base interface for all loaders."""
 
 
-class IProcessor(IAsyncCapable):
+class IProcessor:
     """Base interface for all processors."""
 
 
-class IGenerator(IAsyncCapable):
+class IGenerator:
     """Base interface for all generators."""
 
 

--- a/agent_actions/config/manager.py
+++ b/agent_actions/config/manager.py
@@ -41,8 +41,6 @@ class ConfigManager:
         self.tool_path: list[str] | None = None
         self.template_dir = str(resolve_project_root(project_root) / "templates")
         self.environment_config: EnvironmentConfig | None = None
-        self.workflow_config: Any = None
-        self.pipeline_config: Any = None
 
     def _load_single_config(self, config_path: str, config_type: str) -> dict[str, Any]:
         """Load and parse a single config file with template rendering.
@@ -64,7 +62,18 @@ class ConfigManager:
             config_data = render_pipeline_with_templates(
                 config_path, self.template_dir, project_root=self.project_root
             )
-            loaded: dict[str, Any] = yaml.safe_load(config_data)
+            loaded = yaml.safe_load(config_data)
+            if not isinstance(loaded, dict):
+                config_name = Path(config_path).name
+                raise ConfigurationError(
+                    f"{config_type.capitalize()} config '{config_name}' must be a YAML mapping, "
+                    f"got {type(loaded).__name__}",
+                    context={
+                        "config_path": str(config_path),
+                        "operation": f"load_{config_type}_config",
+                        "parsed_type": type(loaded).__name__,
+                    },
+                )
             fire_event(ConfigLoadEvent(config_file=str(config_path), config_type=config_type))
             return loaded
         except TemplateRenderingError as e:
@@ -129,22 +138,14 @@ class ConfigManager:
             logger.info("No tool_path configured; defaulting to 'tools/'")
 
     def find_agent_name(self, config: dict[str, Any]) -> str:
-        """
-        Find the name of the agent from the configuration.
-
-        Args:
-            config: Agent configuration dictionary
-
-        Returns:
-            str: Name of the agent
-        """
+        """Find the name of the agent from the configuration."""
+        if not isinstance(config, dict) or not config:
+            raise ConfigurationError(
+                "Cannot find agent name: configuration is empty or not a mapping",
+                context={"config_type": type(config).__name__},
+            )
         if "name" in config and "actions" in config:
             return str(config["name"])
-        if not config:
-            raise ConfigurationError(
-                "Cannot find agent name: configuration is empty",
-                context={"config_keys": list(config.keys())},
-            )
         return str(next(iter(config)))
 
     def validate_agent_name(self) -> None:
@@ -363,14 +364,6 @@ class ConfigManager:
         env_path = Path(root) / ".env"
         return env_path if env_path.is_file() else None
 
-    def get_agent_config(self, agent_type: str) -> AgentConfig | None:
-        """Get typed agent configuration by agent type."""
-        return self.agent_configs.get(agent_type)
-
-    def get_all_agent_configs(self) -> dict[str, AgentConfig]:
-        """Get all typed agent configurations."""
-        return self.agent_configs.copy()
-
     def get_all_agent_configs_as_dicts(self) -> dict[str, dict[str, Any]]:
         """Get all agent configurations as dictionaries for backward compatibility."""
         result = {}
@@ -418,72 +411,3 @@ class ConfigManager:
 
             result[agent_type] = config_dict
         return result
-
-    def create_pipeline_config(self, pipeline_data: dict[str, Any]) -> Any:
-        """Create a typed pipeline configuration from dictionary data."""
-        from agent_actions.workflow.pipeline import PipelineConfig as _PipelineConfig
-
-        try:
-            self.pipeline_config = _PipelineConfig.model_validate(pipeline_data)  # type: ignore[attr-defined]
-            return self.pipeline_config
-        except ValidationError as e:
-            raise ConfigurationError(
-                "Invalid pipeline configuration",
-                context={
-                    "pipeline_name": pipeline_data.get("name", "unknown"),
-                    "operation": "create_pipeline_config",
-                },
-                cause=e,
-            ) from e
-
-    def validate_all_configs(self) -> None:
-        """Validate all loaded configurations."""
-        from agent_actions.output.response.config_schema import AgentConfig
-
-        if not self.environment_config:
-            self.load_environment_config()
-        for agent_type, config in self.agent_configs.items():
-            try:
-                AgentConfig.model_validate(config.model_dump())
-            except ValidationError as e:
-                raise ConfigurationError(
-                    "Agent configuration is invalid",
-                    context={"agent_type": agent_type, "operation": "validate_all_configs"},
-                    cause=e,
-                ) from e
-
-    def get_configuration_summary(self) -> dict[str, Any]:
-        """Get a summary of all loaded configurations."""
-        project_name = None
-        if self.project_root is not None:
-            try:
-                from agent_actions.config.path_config import get_project_name
-
-                project_name = get_project_name(self.project_root)
-            except (OSError, ConfigValidationError) as exc:
-                logger.debug("Could not retrieve project_name for summary: %s", exc)
-
-        return {
-            "project": {
-                "name": project_name,
-            },
-            "environment": {
-                "loaded": self.environment_config is not None,
-                "env": (
-                    self.environment_config.agent_actions_env if self.environment_config else None
-                ),
-            },
-            "agents": {
-                "count": len(self.agent_configs),
-                "types": list(self.agent_configs.keys()),
-                "execution_order": self.execution_order,
-            },
-            "workflow": {
-                "loaded": self.workflow_config is not None,
-                "name": getattr(self.workflow_config, "name", None),
-            },
-            "pipeline": {
-                "loaded": self.pipeline_config is not None,
-                "name": getattr(self.pipeline_config, "name", None),
-            },
-        }

--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -9,6 +9,14 @@ from agent_actions.config.types import Granularity, RunMode
 from agent_actions.guards import GuardParser, parse_guard_config
 
 
+def _validate_bool_or_mapping(v: Any, field_name: str, usage_hint: str) -> Any:
+    if v is False or v is None:
+        return None
+    if v is True:
+        raise ValueError(f"{field_name}: true is not valid; {usage_hint}")
+    return v
+
+
 class ActionKind(str, Enum):
     """Types of actions in the workflow."""
 
@@ -286,26 +294,18 @@ class ActionConfig(BaseModel):
     @field_validator("retry", mode="before")
     @classmethod
     def validate_retry(cls, v):
-        """Accept false (disable) but reject true (ambiguous — use mapping)."""
-        if v is False or v is None:
-            return None
-        if v is True:
-            raise ValueError("retry: true is not valid; use retry: {max_attempts: N} or omit")
-        return v
+        return _validate_bool_or_mapping(v, "retry", "use retry: {max_attempts: N} or omit")
 
     @field_validator("reprompt", mode="before")
     @classmethod
     def validate_reprompt(cls, v):
-        """Accept false (disable) but reject true (ambiguous — use mapping)."""
-        if v is False or v is None:
-            return None
-        if v is True:
-            raise ValueError(
-                "reprompt: true is not valid. Use one of:\n"
-                "  reprompt: {on_schema_mismatch: reprompt}  # schema validates (no UDF needed)\n"
-                "  reprompt: {validation: fn_name}            # custom UDF validates"
-            )
-        return v
+        return _validate_bool_or_mapping(
+            v,
+            "reprompt",
+            "Use one of:\n"
+            "  reprompt: {on_schema_mismatch: reprompt}  # schema validates (no UDF needed)\n"
+            "  reprompt: {validation: fn_name}            # custom UDF validates",
+        )
 
     @model_validator(mode="after")
     def validate_kind_requirements(self):
@@ -402,26 +402,18 @@ class DefaultsConfig(BaseModel):
     @field_validator("retry", mode="before")
     @classmethod
     def validate_retry(cls, v):
-        """Accept false (disable) but reject true (ambiguous — use mapping)."""
-        if v is False or v is None:
-            return None
-        if v is True:
-            raise ValueError("retry: true is not valid; use retry: {max_attempts: N} or omit")
-        return v
+        return _validate_bool_or_mapping(v, "retry", "use retry: {max_attempts: N} or omit")
 
     @field_validator("reprompt", mode="before")
     @classmethod
     def validate_reprompt(cls, v):
-        """Accept false (disable) but reject true (ambiguous — use mapping)."""
-        if v is False or v is None:
-            return None
-        if v is True:
-            raise ValueError(
-                "reprompt: true is not valid. Use one of:\n"
-                "  reprompt: {on_schema_mismatch: reprompt}  # schema validates (no UDF needed)\n"
-                "  reprompt: {validation: fn_name}            # custom UDF validates"
-            )
-        return v
+        return _validate_bool_or_mapping(
+            v,
+            "reprompt",
+            "Use one of:\n"
+            "  reprompt: {on_schema_mismatch: reprompt}  # schema validates (no UDF needed)\n"
+            "  reprompt: {validation: fn_name}            # custom UDF validates",
+        )
 
 
 class WorkflowConfig(BaseModel):

--- a/agent_actions/input/loaders/base.py
+++ b/agent_actions/input/loaders/base.py
@@ -9,7 +9,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-from agent_actions.config.interfaces import IDataLoader, ProcessingMode
+from agent_actions.config.interfaces import IDataLoader
 from agent_actions.config.types import ActionEntryDict
 from agent_actions.processing.error_handling import ProcessorErrorHandlerMixin
 
@@ -66,14 +66,6 @@ class BaseLoader(ProcessorErrorHandlerMixin, IDataLoader, ABC, Generic[T]):
         self.agent_config = agent_config
         self.agent_name = agent_name
         self.logger = logging.getLogger(__name__)
-
-    def supports_async(self) -> bool:
-        """Return True if this loader supports async operations."""
-        return True
-
-    def get_processing_mode(self) -> ProcessingMode:
-        """Return AUTO processing mode."""
-        return ProcessingMode.AUTO
 
     def load_file(self, file_path: str) -> str:
         """Safely load a file's content with retry logic."""

--- a/agent_actions/input/loaders/source_data.py
+++ b/agent_actions/input/loaders/source_data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from agent_actions.config.interfaces import ISourceDataLoader, ProcessingMode
+from agent_actions.config.interfaces import ISourceDataLoader
 from agent_actions.errors import DependencyError
 
 if TYPE_CHECKING:
@@ -26,14 +26,6 @@ class SourceDataLoader(ISourceDataLoader):
         if storage_backend is None:
             raise DependencyError("SourceDataLoader", "storage_backend")
         self.storage_backend = storage_backend
-
-    def supports_async(self) -> bool:
-        """Return True as this loader supports async operations."""
-        return True
-
-    def get_processing_mode(self) -> ProcessingMode:
-        """Return AUTO processing mode."""
-        return ProcessingMode.AUTO
 
     def load_source_data(self, source_relative_path: str) -> list[dict]:
         """Load source data from the storage backend."""

--- a/agent_actions/input/preprocessing/processing/data_processor.py
+++ b/agent_actions/input/preprocessing/processing/data_processor.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 
 from agent_actions.config.di.container import registry
-from agent_actions.config.interfaces import IDataProcessor, ProcessingMode
+from agent_actions.config.interfaces import IDataProcessor
 from agent_actions.errors import TransformationError
 from agent_actions.processing.error_handling import ProcessorErrorHandlerMixin
 from agent_actions.processing.helpers import transform_with_passthrough
@@ -26,14 +26,6 @@ class DataProcessor(ProcessorErrorHandlerMixin, IDataProcessor):
     def __init__(self, agent_config: dict):
         super().__init__()
         self.agent_config = agent_config
-
-    def supports_async(self) -> bool:
-        """Return whether this processor supports async operations."""
-        return True
-
-    def get_processing_mode(self) -> ProcessingMode:
-        """Return AUTO processing mode."""
-        return ProcessingMode.AUTO
 
     def process_item(
         self,

--- a/agent_actions/llm/batch/infrastructure/batch_data_loader.py
+++ b/agent_actions/llm/batch/infrastructure/batch_data_loader.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from agent_actions.config.interfaces import IDataLoader, ProcessingMode
+from agent_actions.config.interfaces import IDataLoader
 from agent_actions.input.loaders.base import read_file_with_retry
 from agent_actions.utils.path_safety import assert_path_contained
 
@@ -18,14 +18,6 @@ class BatchDataLoader(IDataLoader):
     centralised loader infrastructure, gaining automatic retry on
     transient I/O errors.
     """
-
-    def supports_async(self) -> bool:
-        """Return True as this loader supports async operations."""
-        return True
-
-    def get_processing_mode(self) -> ProcessingMode:
-        """Return AUTO processing mode to let system choose."""
-        return ProcessingMode.AUTO
 
     async def load_data_async(
         self, file_path: str, *, allowed_root: Path | None = None

--- a/agent_actions/prompt/data_generator.py
+++ b/agent_actions/prompt/data_generator.py
@@ -10,7 +10,7 @@ from agent_actions.config.types import ActionConfigDict, ActionEntryDict
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
 from agent_actions.config.di.container import registry
-from agent_actions.config.interfaces import IGenerator, ProcessingMode
+from agent_actions.config.interfaces import IGenerator
 from agent_actions.config.types import RunMode
 from agent_actions.errors import GenerationError
 from agent_actions.processing.enrichment import EnrichmentPipeline
@@ -47,14 +47,6 @@ class DataGenerator(IGenerator):
             agent_name=self.agent_name,
         )
         self._enrichment_pipeline = EnrichmentPipeline()
-
-    def supports_async(self) -> bool:
-        """Return True as this generator supports async operations."""
-        return True
-
-    def get_processing_mode(self) -> ProcessingMode:
-        """Return AUTO processing mode to let system choose."""
-        return ProcessingMode.AUTO
 
     def create_agent_with_data(
         self,

--- a/tests/unit/config/test_validator_contract.py
+++ b/tests/unit/config/test_validator_contract.py
@@ -15,13 +15,6 @@ class TestEnvironmentValidators:
             EnvironmentConfig(openai_api_key="short")
         assert "API key must be at least 10 characters" in str(exc_info.value)
 
-    def test_bad_database_url_raises_validation_error(self):
-        """Invalid DB URL prefix should be caught by Pydantic as ValidationError."""
-        with pytest.raises(ValidationError) as exc_info:
-            EnvironmentConfig(database_url="redis://localhost")
-        assert "Database URL must start with" in str(exc_info.value)
-
-
 class TestSchemaValidators:
     def test_invalid_guard_type_raises_validation_error(self):
         """Guard with invalid type should produce a Pydantic ValidationError."""

--- a/tests/unit/config/test_validator_contract.py
+++ b/tests/unit/config/test_validator_contract.py
@@ -15,6 +15,7 @@ class TestEnvironmentValidators:
             EnvironmentConfig(openai_api_key="short")
         assert "API key must be at least 10 characters" in str(exc_info.value)
 
+
 class TestSchemaValidators:
     def test_invalid_guard_type_raises_validation_error(self):
         """Guard with invalid type should produce a Pydantic ValidationError."""


### PR DESCRIPTION
## Summary
- **YAML handling (P0):** `_load_single_config` rejects non-dict YAML (None, list, scalar) with clear `ConfigurationError`. `find_agent_name` guards with `isinstance(config, dict)` before key checks.
- **Dead code removal (P2):** 5 dead `ConfigManager` methods, `IAsyncCapable` interface + `ProcessingMode` enum + 5 implementations, 7 dead `EnvironmentConfig` fields, dead `LogLevel` enum
- **Deduplication (P2):** Extract `_validate_bool_or_mapping` shared helper for retry/reprompt validators

## Verification
- `ruff check` — clean
- `ruff format --check` — clean
- `pytest` — 7494 passed, 2 skipped
- Smoke test (`./smoke-test.sh online`) — passed
- Pi consensus review — 4/5 YES (near consensus, flagged issue fixed)