### PR TITLE
fix: logging module hardening — credential redaction, error routing, resource leaks

### DIFF
--- a/agent_actions/logging/core/handlers/bridge.py
+++ b/agent_actions/logging/core/handlers/bridge.py
@@ -63,8 +63,6 @@ class LoggingBridgeHandler(logging.Handler):
             self._event_manager.fire(event)
 
         except Exception:
-            # Don't let bridge errors break the application
-            # Fall back to default handling
             self.handleError(record)
 
     def _extract_category(self, logger_name: str) -> str:

--- a/agent_actions/logging/core/handlers/json_file.py
+++ b/agent_actions/logging/core/handlers/json_file.py
@@ -96,12 +96,16 @@ class JSONFileHandler:
             self._file = open(self.file_path, "a", encoding="utf-8")
             self._current_size = self.file_path.stat().st_size if self.file_path.exists() else 0
 
-        for event_dict in self._buffer:
-            line = json.dumps(event_dict, default=str) + "\n"
-            self._file.write(line)
-            self._current_size += len(line.encode("utf-8"))
-
-        self._buffer.clear()
+        written = 0
+        try:
+            for event_dict in self._buffer:
+                line = json.dumps(event_dict, default=str) + "\n"
+                self._file.write(line)
+                self._current_size += len(line.encode("utf-8"))
+                written += 1
+        finally:
+            if written > 0:
+                del self._buffer[:written]
 
     def _rotate(self) -> None:
         """Rotate the log file (must hold lock)."""

--- a/agent_actions/logging/core/manager.py
+++ b/agent_actions/logging/core/manager.py
@@ -74,6 +74,12 @@ class EventManager:
         with cls._lock:
             if cls._instance is not None:
                 cls._instance.flush()
+                for handler in cls._instance._handlers:
+                    if hasattr(handler, "close"):
+                        try:
+                            handler.close()
+                        except Exception:
+                            pass
                 cls._instance._handlers.clear()
                 cls._instance._filters.clear()
                 cls._instance._context.clear()

--- a/agent_actions/logging/errors/formatters/api.py
+++ b/agent_actions/logging/errors/formatters/api.py
@@ -19,7 +19,11 @@ class APIErrorFormatter(ErrorFormatter):
 
         message_lower = message.lower()
         api_patterns = [
-            "api",
+            "api error",
+            "api request",
+            "api call",
+            "api returned",
+            "api rate",
             "connection",
             "network",
             "timeout",

--- a/agent_actions/logging/errors/formatters/authentication.py
+++ b/agent_actions/logging/errors/formatters/authentication.py
@@ -10,6 +10,9 @@ class AuthenticationErrorFormatter(ErrorFormatter):
     """Handles authentication errors."""
 
     def can_handle(self, exc: Exception, root: Exception, message: str) -> bool:
+        if isinstance(exc, PermissionError) or isinstance(root, PermissionError):
+            return False
+
         exc_names = [type(exc).__name__, type(root).__name__]
 
         if any("Auth" in name for name in exc_names):

--- a/agent_actions/logging/errors/formatters/configuration.py
+++ b/agent_actions/logging/errors/formatters/configuration.py
@@ -46,10 +46,17 @@ class ConfigurationErrorFormatter(ErrorFormatter):
             return self._format_missing_env_var_error(message, context)
 
         if "schema validation" in message.lower():
+            from agent_actions.errors import SchemaValidationError
+
+            details = "The configuration format is invalid"
+            if isinstance(root, SchemaValidationError) and hasattr(root, "format_user_message"):
+                details = root.format_user_message()
+            elif isinstance(exc, SchemaValidationError) and hasattr(exc, "format_user_message"):
+                details = exc.format_user_message()
             return UserError(
                 category="Configuration Error",
                 title="Schema validation failed",
-                details="The configuration format is invalid",
+                details=details,
                 fix="Check your YAML/JSON syntax and required fields",
                 context=context,
                 docs_url="https://docs.runagac.com/config/schema",

--- a/agent_actions/logging/errors/formatters/function.py
+++ b/agent_actions/logging/errors/formatters/function.py
@@ -10,9 +10,17 @@ from .base import ErrorFormatter
 class FunctionNotFoundFormatter(ErrorFormatter):
     """Handles function/UDF not found errors with helpful suggestions."""
 
+    _HANDLED_NAMES = frozenset(
+        {
+            "FunctionNotFoundError",
+            "DuplicateFunctionError",
+            "UDFLoadError",
+        }
+    )
+
     def can_handle(self, exc: Exception, root: Exception, message: str) -> bool:
-        exc_names = [type(exc).__name__, type(root).__name__]
-        if "FunctionNotFoundError" in exc_names:
+        exc_names = {type(exc).__name__, type(root).__name__}
+        if exc_names & self._HANDLED_NAMES:
             return True
 
         if "function" in message.lower() and "not found" in message.lower():

--- a/agent_actions/logging/errors/formatters/model.py
+++ b/agent_actions/logging/errors/formatters/model.py
@@ -16,6 +16,12 @@ class ModelErrorFormatter(ErrorFormatter):
             "unsupported model",
             "invalid model",
             "model not found",
+            "model_not_found",
+            "model_not_found_error",
+            "not available in your region",
+            "unknown model",
+            "model unavailable",
+            "model decommissioned",
         ]
         return any(pattern in message_lower for pattern in model_patterns)
 

--- a/agent_actions/logging/events/formatters.py
+++ b/agent_actions/logging/events/formatters.py
@@ -86,15 +86,16 @@ class AgentActionsFormatter:
         skipped = event.data.get("actions_skipped", 0)
         failed = event.data.get("actions_failed", 0)
 
-        ok = self._status("OK") if completed > 0 else "OK"
-        part = self._status("PARTIAL") if partial > 0 else "PARTIAL"
-        skip = self._status("SKIP") if skipped > 0 else "SKIP"
-        err = self._status("ERROR") if failed > 0 else "ERROR"
+        parts = [f"{ts}Completed in {elapsed:.2f}s"]
+        parts.append(f"{completed} {self._status('OK')}" if completed > 0 else f"{completed} OK")
+        if partial > 0:
+            parts.append(f"{partial} {self._status('PARTIAL')}")
+        if skipped > 0:
+            parts.append(f"{skipped} {self._status('SKIP')}")
+        if failed > 0:
+            parts.append(f"{failed} {self._status('ERROR')}")
 
-        return (
-            f"{ts}Completed in {elapsed:.2f}s | {completed} {ok} | "
-            f"{partial} {part} | {skipped} {skip} | {failed} {err}"
-        )
+        return " | ".join(parts)
 
     def _format_workflow_failed(self, event: BaseEvent) -> str:
         ts = self._timestamp(event)

--- a/agent_actions/logging/factory.py
+++ b/agent_actions/logging/factory.py
@@ -120,6 +120,7 @@ class LoggerFactory:
             "WARN": EventLevel.WARN,
             "WARNING": EventLevel.WARN,
             "ERROR": EventLevel.ERROR,
+            "CRITICAL": EventLevel.ERROR,
         }
         console_level = level_map.get(console_level_str.upper(), EventLevel.INFO)
 
@@ -184,8 +185,11 @@ class LoggerFactory:
         # Event handlers will filter by level
         root_logger.setLevel(logging.DEBUG)
 
+        from agent_actions.logging.filters import RedactingFilter
+
         bridge = LoggingBridgeHandler(level=logging.DEBUG)
         root_logger.addHandler(bridge)
+        root_logger.addFilter(RedactingFilter())
 
         root_logger.propagate = False
 

--- a/tests/unit/logging/test_event_formatters.py
+++ b/tests/unit/logging/test_event_formatters.py
@@ -204,7 +204,7 @@ class TestWorkflowCompleteEvent:
         assert "2 [red]ERROR[/red]" in result
 
     @patch("agent_actions.logging.events.formatters.RICH_AVAILABLE", True)
-    def test_zero_counters_no_color_on_status(self):
+    def test_zero_counters_suppressed(self):
         fmt = AgentActionsFormatter(show_timestamp=False, use_color=True)
         event = _make_event(
             "WorkflowCompleteEvent",
@@ -216,11 +216,9 @@ class TestWorkflowCompleteEvent:
             },
         )
         result = fmt.format(event)
-        # When count is 0, status is plain text (no color markup)
         assert "0 OK" in result
-        assert "0 SKIP" in result
-        assert "0 ERROR" in result
-        assert "[green]" not in result
+        assert "SKIP" not in result
+        assert "ERROR" not in result
 
 
 class TestWorkflowFailedEvent:


### PR DESCRIPTION
## Summary

**Security (P0):**
- Wire `RedactingFilter` into logging bridge — API keys/tokens were flowing unredacted to log files
- Add `CRITICAL` to `level_map` — was silently falling back to INFO

**Error routing (P0/P1):**
- Exclude `PermissionError` from `AuthenticationErrorFormatter` — file permission errors were showing "Invalid API key"
- Tighten `APIErrorFormatter` from bare `"api"` substring to specific phrases
- Use `SchemaValidationError.format_user_message()` instead of generic one-liner
- Expand `FunctionNotFoundFormatter` to handle `DuplicateFunctionError`/`UDFLoadError`
- Add real provider error phrases to `ModelErrorFormatter`

**Resource management (P2):**
- Close handlers before clearing in `EventManager.reset()`
- Track written count in `JSONFileHandler` buffer flush — only successfully written events removed on failure

**UX (P1):**
- Suppress zero-count labels in workflow complete output — no more "0 ERROR" on successful runs

## Verification
- `ruff check` — clean
- `ruff format --check` — clean
- `pytest` — 7494 passed, 2 skipped
- Smoke test — passed, 52 actions clean
- Pi consensus — 4/5 YES (near consensus)