### PR TITLE
fix: tooling hardening — runs.json crash, image-copy abort, jargon, dead code

### DIFF
--- a/agent_actions/tooling/code_scanner.py
+++ b/agent_actions/tooling/code_scanner.py
@@ -58,7 +58,10 @@ def scan_tool_functions(project_root: Path, tool_paths: list[str] | None = None)
                         if func_data:
                             tool_functions[func_name] = func_data
 
-            except (SyntaxError, UnicodeDecodeError) as e:
+            except (OSError, SyntaxError, UnicodeDecodeError) as e:
+                # OSError covers broken symlinks, file deleted between rglob
+                # and read_text, permission errors. One bad file must not
+                # abort the whole catalog generation.
                 logger.debug("Failed to parse tool file %s: %s", py_file, e)
                 continue
 

--- a/agent_actions/tooling/code_scanner.py
+++ b/agent_actions/tooling/code_scanner.py
@@ -34,8 +34,16 @@ def scan_tool_functions(project_root: Path, tool_paths: list[str] | None = None)
         if not user_code_dir.exists():
             continue
 
-        # Scan all Python files
-        for py_file in user_code_dir.rglob("*.py"):
+        # rglob itself raises OSError (e.g. PermissionError) during iteration
+        # when it descends into a subtree the process cannot read. Catch it
+        # here so one unreadable subdirectory cannot abort the whole scan.
+        try:
+            py_files = list(user_code_dir.rglob("*.py"))
+        except OSError as e:
+            logger.debug("Failed to enumerate Python files under %s: %s", user_code_dir, e)
+            continue
+
+        for py_file in py_files:
             try:
                 source = py_file.read_text()
                 tree = ast.parse(source)

--- a/agent_actions/tooling/docs/generator.py
+++ b/agent_actions/tooling/docs/generator.py
@@ -50,15 +50,15 @@ def _copy_readme_images(
     ]
 
     # (start, end, replacement) for each URL-group span we want to rewrite.
+    # No dedup set is needed: html and markdown URL spans live in disjoint
+    # surrounding chars (`src="..."` vs `](...)`) so their (start, end) tuples
+    # can never coincide, and `finditer` already yields non-overlapping
+    # matches within a single pattern.
     spans: list[tuple[int, int, str]] = []
-    seen_spans: set[tuple[int, int]] = set()
+    images_dir_ready = False
 
     for pattern, group_idx in img_patterns:
         for match in pattern.finditer(content):
-            start, end = match.span(group_idx)
-            if (start, end) in seen_spans:
-                continue
-
             rel_path = match.group(group_idx)
 
             # Skip URLs (http://, https://, data:)
@@ -70,17 +70,31 @@ def _copy_readme_images(
             if not source.exists() or not source.is_file():
                 continue
 
-            # Copy to artefact/images/{workflow_id}/{filename}.
-            # A single failure must not abort the entire catalog generation.
+            # Lazy-create the images directory the first time we have a
+            # genuine image to stage. A failure here is systemic (parent
+            # unwritable) so we abandon the rewrite entirely instead of
+            # logging the same diagnostic per image.
+            if not images_dir_ready:
+                try:
+                    images_dir.mkdir(parents=True, exist_ok=True)
+                except OSError as e:
+                    logger.warning(
+                        "Cannot create images directory %s for workflow %s: %s",
+                        images_dir,
+                        workflow_id,
+                        e,
+                    )
+                    return content
+                images_dir_ready = True
+
+            # Copy to artefact/images/{workflow_id}/{filename}. A single
+            # copy failure must not abort the rest of the catalog.
             dest = images_dir / source.name
             try:
-                images_dir.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(source, dest)
             except OSError as e:
-                # Covers both mkdir failures (parent permission denied) and
-                # copy failures (disk full, dest unwritable, broken symlink).
                 logger.warning(
-                    "Failed to stage README image %s for workflow %s: %s",
+                    "Failed to copy README image %s for workflow %s: %s",
                     source,
                     workflow_id,
                     e,
@@ -88,8 +102,7 @@ def _copy_readme_images(
                 continue
 
             new_path = f"/artefact/images/{workflow_id}/{source.name}"
-            spans.append((start, end, new_path))
-            seen_spans.add((start, end))
+            spans.append(match.span(group_idx) + (new_path,))
 
     if not spans:
         return content

--- a/agent_actions/tooling/docs/generator.py
+++ b/agent_actions/tooling/docs/generator.py
@@ -29,24 +29,37 @@ def _copy_readme_images(
     workflow_id: str,
     artefact_dir: Path,
 ) -> str:
-    """Copy images referenced in README to artefact/images/ and rewrite paths."""
+    """Copy images referenced in README to artefact/images/ and rewrite paths.
+
+    Substitutions are applied at exact regex-match spans (not via
+    ``str.replace``) so that a short relative path like ``logo.png`` is not
+    rewritten inside an unrelated longer path like ``dark/logo.png``.
+
+    A copy failure for one image (disk full, permission error, etc.) is
+    logged and skipped — the catalog generation continues for the remaining
+    images.
+    """
     content = readme_data.content
     images_dir = artefact_dir / "images" / workflow_id
 
-    # Match both <img src="..."> and ![alt](...)
-    img_patterns = [
-        (r'<img\s+[^>]*src="([^"]+)"', "html"),
-        (r"!\[([^\]]*)\]\(([^)]+)\)", "markdown"),
+    # Match both <img src="..."> and ![alt](...) and capture the URL group
+    # so the replacement span is limited to the path itself.
+    img_patterns: list[tuple[re.Pattern[str], int]] = [
+        (re.compile(r'<img\s+[^>]*src="([^"]+)"'), 1),
+        (re.compile(r"!\[([^\]]*)\]\(([^)]+)\)"), 2),
     ]
 
-    replacements: list[tuple[str, str]] = []
+    # (start, end, replacement) for each URL-group span we want to rewrite.
+    spans: list[tuple[int, int, str]] = []
+    seen_spans: set[tuple[int, int]] = set()
 
-    for pattern, kind in img_patterns:
-        for match in re.finditer(pattern, content):
-            if kind == "html":
-                rel_path = match.group(1)
-            else:
-                rel_path = match.group(2)
+    for pattern, group_idx in img_patterns:
+        for match in pattern.finditer(content):
+            start, end = match.span(group_idx)
+            if (start, end) in seen_spans:
+                continue
+
+            rel_path = match.group(group_idx)
 
             # Skip URLs (http://, https://, data:)
             if rel_path.startswith(("http://", "https://", "data:")):
@@ -57,17 +70,35 @@ def _copy_readme_images(
             if not source.exists() or not source.is_file():
                 continue
 
-            # Copy to artefact/images/{workflow_id}/{filename}
-            images_dir.mkdir(parents=True, exist_ok=True)
+            # Copy to artefact/images/{workflow_id}/{filename}.
+            # A single failure must not abort the entire catalog generation.
             dest = images_dir / source.name
-            shutil.copy2(source, dest)
+            try:
+                images_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, dest)
+            except OSError as e:
+                # Covers both mkdir failures (parent permission denied) and
+                # copy failures (disk full, dest unwritable, broken symlink).
+                logger.warning(
+                    "Failed to stage README image %s for workflow %s: %s",
+                    source,
+                    workflow_id,
+                    e,
+                )
+                continue
 
-            # Rewrite path to /artefact/images/{workflow_id}/{filename}
             new_path = f"/artefact/images/{workflow_id}/{source.name}"
-            replacements.append((rel_path, new_path))
+            spans.append((start, end, new_path))
+            seen_spans.add((start, end))
 
-    for old_path, new_path in replacements:
-        content = content.replace(old_path, new_path)
+    if not spans:
+        return content
+
+    # Apply substitutions right-to-left so earlier offsets remain valid as
+    # we splice into the string.
+    spans.sort(key=lambda s: s[0], reverse=True)
+    for start, end, new_text in spans:
+        content = content[:start] + new_text + content[end:]
 
     return content
 

--- a/agent_actions/tooling/docs/run_tracker.py
+++ b/agent_actions/tooling/docs/run_tracker.py
@@ -297,8 +297,17 @@ class RunTracker:
             timeout=LockDefaults.ATOMIC_LOCK_TIMEOUT_SECONDS,
             flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
         ) as f:
-            f.seek(0)
-            runs_data = json.load(f)
+            try:
+                f.seek(0)
+                runs_data = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                # File is empty or corrupted; there is no run_id to update.
+                # Log and exit cleanly so the workflow thread does not crash.
+                logger.warning(
+                    "runs.json is empty or corrupted; cannot record action start for %s",
+                    action_name,
+                )
+                return
 
             for run in runs_data["executions"]:
                 if run["id"] == run_id:
@@ -336,8 +345,17 @@ class RunTracker:
             timeout=LockDefaults.ATOMIC_LOCK_TIMEOUT_SECONDS,
             flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
         ) as f:
-            f.seek(0)
-            runs_data = json.load(f)
+            try:
+                f.seek(0)
+                runs_data = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                # File is empty or corrupted; there is no run_id to update.
+                # Log and exit cleanly so the workflow thread does not crash.
+                logger.warning(
+                    "runs.json is empty or corrupted; cannot record action complete for %s",
+                    config.action_name,
+                )
+                return
 
             for run in runs_data["executions"]:
                 if run["id"] == config.run_id:
@@ -396,8 +414,18 @@ class RunTracker:
             timeout=LockDefaults.ATOMIC_LOCK_TIMEOUT_SECONDS,
             flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
         ) as f:
-            f.seek(0)
-            runs_data = json.load(f)
+            try:
+                f.seek(0)
+                runs_data = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                # File is empty or corrupted; the run record this is trying
+                # to finalize is unrecoverable. Log and exit cleanly so the
+                # workflow thread does not crash on shutdown.
+                logger.warning(
+                    "runs.json is empty or corrupted; cannot finalize run %s",
+                    run_id,
+                )
+                return
 
             for run in runs_data["executions"]:
                 if run["id"] == run_id:

--- a/agent_actions/tooling/docs/run_tracker.py
+++ b/agent_actions/tooling/docs/run_tracker.py
@@ -171,6 +171,31 @@ class RunTracker:
         f.truncate()
         json.dump(runs_data, f, indent=2)
 
+    def _load_or_repair(self, f, *, context: str) -> dict[str, Any]:
+        """Load runs data from a locked file handle, repairing on corruption.
+
+        On empty or corrupted file: log a warning naming ``context``, reset the
+        file to ``_empty_runs_data(extended=True)`` so subsequent calls see a
+        valid structure, and return that structure. Returning a usable dict
+        (rather than ``None`` + early-exit) lets callers continue with the
+        normal "search for run_id" loop, which becomes a no-op against an
+        empty ``executions`` list. Matches the recovery semantics already
+        used by ``_load_runs_data_from_file`` and ``start_workflow_run``.
+        """
+        try:
+            f.seek(0)
+            return json.load(f)
+        except (OSError, json.JSONDecodeError):
+            logger.warning(
+                "runs.json is empty or corrupted; resetting (%s)",
+                context,
+            )
+            runs_data = _empty_runs_data(extended=True)
+            f.seek(0)
+            f.truncate()
+            json.dump(runs_data, f, indent=2)
+            return runs_data
+
     def _calculate_duration(self, started_at: str, ended_at: str) -> float:
         """Calculate duration between timestamps."""
         try:
@@ -291,23 +316,20 @@ class RunTracker:
         self, *, run_id: str, action_name: str, action_type: str, action_config: dict[str, Any]
     ) -> None:
         """Record when an action starts executing."""
+        # Touch first so portalocker.Lock("r+") does not raise FileNotFoundError
+        # if runs.json was removed mid-workflow — that error is NOT in the
+        # retry decorator's exception list and would crash the workflow thread.
+        self.artefact_dir.mkdir(parents=True, exist_ok=True)
+        self.runs_file.touch(exist_ok=True)
         with portalocker.Lock(
             self.runs_file,
             "r+",
             timeout=LockDefaults.ATOMIC_LOCK_TIMEOUT_SECONDS,
             flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
         ) as f:
-            try:
-                f.seek(0)
-                runs_data = json.load(f)
-            except (OSError, json.JSONDecodeError):
-                # File is empty or corrupted; there is no run_id to update.
-                # Log and exit cleanly so the workflow thread does not crash.
-                logger.warning(
-                    "runs.json is empty or corrupted; cannot record action start for %s",
-                    action_name,
-                )
-                return
+            runs_data = self._load_or_repair(
+                f, context=f"cannot record action start for {action_name}"
+            )
 
             for run in runs_data["executions"]:
                 if run["id"] == run_id:
@@ -339,23 +361,17 @@ class RunTracker:
     @retry(max_attempts=3, backoff=2.0, exceptions=(portalocker.exceptions.LockException,))
     def record_action_complete(self, *, config: ActionCompleteConfig) -> None:
         """Record when an action completes."""
+        self.artefact_dir.mkdir(parents=True, exist_ok=True)
+        self.runs_file.touch(exist_ok=True)
         with portalocker.Lock(
             self.runs_file,
             "r+",
             timeout=LockDefaults.ATOMIC_LOCK_TIMEOUT_SECONDS,
             flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
         ) as f:
-            try:
-                f.seek(0)
-                runs_data = json.load(f)
-            except (OSError, json.JSONDecodeError):
-                # File is empty or corrupted; there is no run_id to update.
-                # Log and exit cleanly so the workflow thread does not crash.
-                logger.warning(
-                    "runs.json is empty or corrupted; cannot record action complete for %s",
-                    config.action_name,
-                )
-                return
+            runs_data = self._load_or_repair(
+                f, context=f"cannot record action complete for {config.action_name}"
+            )
 
             for run in runs_data["executions"]:
                 if run["id"] == config.run_id:
@@ -408,24 +424,15 @@ class RunTracker:
         self, *, run_id: str, status: str, error_message: str | None = None
     ) -> None:
         """Finalize workflow run when it completes or fails."""
+        self.artefact_dir.mkdir(parents=True, exist_ok=True)
+        self.runs_file.touch(exist_ok=True)
         with portalocker.Lock(
             self.runs_file,
             "r+",
             timeout=LockDefaults.ATOMIC_LOCK_TIMEOUT_SECONDS,
             flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
         ) as f:
-            try:
-                f.seek(0)
-                runs_data = json.load(f)
-            except (OSError, json.JSONDecodeError):
-                # File is empty or corrupted; the run record this is trying
-                # to finalize is unrecoverable. Log and exit cleanly so the
-                # workflow thread does not crash on shutdown.
-                logger.warning(
-                    "runs.json is empty or corrupted; cannot finalize run %s",
-                    run_id,
-                )
-                return
+            runs_data = self._load_or_repair(f, context=f"cannot finalize run {run_id}")
 
             for run in runs_data["executions"]:
                 if run["id"] == run_id:

--- a/agent_actions/tooling/docs/run_tracker.py
+++ b/agent_actions/tooling/docs/run_tracker.py
@@ -184,7 +184,8 @@ class RunTracker:
         """
         try:
             f.seek(0)
-            return json.load(f)
+            data: dict[str, Any] = json.load(f)
+            return data
         except (OSError, json.JSONDecodeError):
             logger.warning(
                 "runs.json is empty or corrupted; resetting (%s)",

--- a/agent_actions/tooling/lsp/diagnostics.py
+++ b/agent_actions/tooling/lsp/diagnostics.py
@@ -72,8 +72,8 @@ def collect_diagnostics(file_path: Path, index: ProjectIndex) -> list[lsp.Diagno
                 diagnostics.append(
                     _build_diagnostic(
                         reference.location,
-                        f"context_scope reference `{reference.value}` cannot be resolved because "
-                        f"action `{action_name}` is missing.",
+                        f"Cannot resolve `{reference.value}` — action "
+                        f"`{action_name}` is not defined in this workflow.",
                         lsp.DiagnosticSeverity.Error,
                     )
                 )
@@ -87,8 +87,8 @@ def collect_diagnostics(file_path: Path, index: ProjectIndex) -> list[lsp.Diagno
                     diagnostics.append(
                         _build_diagnostic(
                             reference.location,
-                            f"context_scope reference `{reference.value}` cannot be resolved because "
-                            f"`{action_name}` output schema does not declare `{field}`.",
+                            f"Cannot resolve `{reference.value}` — action "
+                            f"`{action_name}` has no output field `{field}`.",
                             lsp.DiagnosticSeverity.Error,
                         )
                     )
@@ -113,8 +113,8 @@ def collect_diagnostics(file_path: Path, index: ProjectIndex) -> list[lsp.Diagno
             for variable in action.guard_variables:
                 if variable not in available:
                     message = (
-                        f"Guard condition references `{variable}` which is not observed "
-                        "in context_scope."
+                        f"Guard condition references `{variable}` which is not listed "
+                        "in this action's `context_scope.observe`."
                     )
                     # Suggest dotted paths if the bare field matches a namespace suffix
                     if "." not in variable:

--- a/agent_actions/tooling/lsp/models.py
+++ b/agent_actions/tooling/lsp/models.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
-from agent_actions.utils.constants import DEFAULT_ACTION_KIND
-
 
 class ReferenceType(Enum):
     """Types of references that can be resolved."""
@@ -51,19 +49,6 @@ class Reference:
     value: str  # The reference value (e.g., "workflow.PromptName")
     location: Location  # Where the reference appears
     raw_text: str  # The original text (e.g., "$workflow.PromptName")
-
-
-@dataclass
-class ActionDefinition:
-    """An action defined in a workflow YAML."""
-
-    name: str
-    location: Location
-    prompt_ref: str | None = None
-    impl_ref: str | None = None
-    schema_ref: str | None = None
-    dependencies: list[str] = field(default_factory=list)
-    kind: str = DEFAULT_ACTION_KIND  # "llm" or "tool"
 
 
 @dataclass

--- a/agent_actions/tooling/lsp/server.py
+++ b/agent_actions/tooling/lsp/server.py
@@ -555,8 +555,12 @@ def signature_help(params: lsp.SignatureHelpParams) -> lsp.SignatureHelp | None:
     signature = lsp.SignatureInformation(
         label="Available variables: " + ", ".join(sorted(variables)),
         documentation=(
-            "Variables available from this action's `context_scope.observe` "
-            "and from referenced actions' output schemas."
+            "Variables collected from every action in this file's "
+            "`context_scope.observe` / `context_scope.passthrough` entries "
+            "plus the output schema fields of any actions they reference. "
+            "Not every variable listed is in scope for every action — use "
+            "this list as a discovery aid and rely on per-action diagnostics "
+            "for strict scope checking."
         ),
     )
     return lsp.SignatureHelp(signatures=[signature], active_signature=0, active_parameter=0)

--- a/agent_actions/tooling/lsp/server.py
+++ b/agent_actions/tooling/lsp/server.py
@@ -554,7 +554,10 @@ def signature_help(params: lsp.SignatureHelpParams) -> lsp.SignatureHelp | None:
 
     signature = lsp.SignatureInformation(
         label="Available variables: " + ", ".join(sorted(variables)),
-        documentation="Variables derived from context_scope.observe and action schemas.",
+        documentation=(
+            "Variables available from this action's `context_scope.observe` "
+            "and from referenced actions' output schemas."
+        ),
     )
     return lsp.SignatureHelp(signatures=[signature], active_signature=0, active_parameter=0)
 

--- a/tests/unit/tooling/conftest.py
+++ b/tests/unit/tooling/conftest.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for tooling module tests."""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Ensure agent_actions loggers propagate to root so caplog captures them.
+
+    The agent_actions root logger has propagate=False (set by LoggingBridgeHandler),
+    so caplog (which hooks the Python root logger) can't see child log records.
+    Temporarily enable propagation for the duration of each test.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig

--- a/tests/unit/tooling/test_copy_readme_images.py
+++ b/tests/unit/tooling/test_copy_readme_images.py
@@ -6,11 +6,12 @@ Covers two hardening findings:
 - Path rewriting must replace exact regex spans, not via str.replace, so
   a short filename like ``logo.png`` is not corrupted inside a longer
   path like ``dark/logo.png``.
+
+Logger-propagation handling lives in ``tests/unit/tooling/conftest.py``.
 """
 
 from __future__ import annotations
 
-import logging
 import shutil
 from pathlib import Path
 from unittest.mock import patch
@@ -19,24 +20,6 @@ import pytest
 
 from agent_actions.tooling.docs.generator import _copy_readme_images
 from agent_actions.tooling.docs.scanner import ReadmeData
-
-
-@pytest.fixture
-def _allow_log_propagation():
-    """Re-enable propagation on the ``agent_actions`` logger so caplog
-    (which captures at the root logger) sees module log records.
-
-    LoggerFactory sets ``propagate = False`` when initialized; tests that
-    assert on log content need the chain restored for the duration of the
-    test only.
-    """
-    aa_logger = logging.getLogger("agent_actions")
-    original = aa_logger.propagate
-    aa_logger.propagate = True
-    try:
-        yield
-    finally:
-        aa_logger.propagate = original
 
 
 def _make_readme(tmp_path: Path, content: str) -> ReadmeData:
@@ -91,9 +74,7 @@ class TestCopyFailureDoesNotAbort:
     """A shutil.copy2 OSError on one image must not abort the rewrite of
     other images, and must not propagate to the caller."""
 
-    def test_copy2_oserror_skips_image_and_continues(
-        self, tmp_path, caplog, _allow_log_propagation
-    ):
+    def test_copy2_oserror_skips_image_and_continues(self, tmp_path, caplog):
         good = tmp_path / "good.png"
         bad = tmp_path / "bad.png"
         _make_image(good)
@@ -120,11 +101,30 @@ class TestCopyFailureDoesNotAbort:
         # Good image rewritten; bad image left as-is.
         assert '<img src="/artefact/images/wf1/good.png">' in result
         assert '<img src="bad.png">' in result
-        # A warning was logged for the failed copy. The message intentionally
-        # uses "stage" rather than "copy" because the same except block also
-        # covers a mkdir failure on the destination directory.
-        assert any("bad.png" in rec.getMessage() for rec in caplog.records)
-        assert any("stage" in rec.getMessage() for rec in caplog.records)
+        # A warning was logged for the failed copy.
+        assert any(
+            "bad.png" in rec.getMessage() and "copy" in rec.getMessage().lower()
+            for rec in caplog.records
+        )
+
+    def test_mkdir_failure_aborts_cleanly_with_one_warning(self, tmp_path, caplog):
+        """A systemic mkdir failure on the images directory should log a
+        single 'cannot create images directory' warning and return the
+        original content — not log a per-image error N times."""
+        _make_image(tmp_path / "a.png")
+        _make_image(tmp_path / "b.png")
+        content = '<img src="a.png">\n<img src="b.png">\n'
+        readme = _make_readme(tmp_path, content)
+
+        with patch.object(Path, "mkdir", side_effect=OSError("read-only")):
+            with caplog.at_level("WARNING", logger="agent_actions.tooling.docs.generator"):
+                result = _copy_readme_images(readme, "wf1", tmp_path / "artefact")
+
+        # Original content unchanged.
+        assert result == content
+        # Exactly one warning, naming the images directory (not the image).
+        mkdir_warnings = [r for r in caplog.records if "create images directory" in r.getMessage()]
+        assert len(mkdir_warnings) == 1
 
     def test_copy2_failure_does_not_raise(self, tmp_path):
         img = tmp_path / "only.png"

--- a/tests/unit/tooling/test_copy_readme_images.py
+++ b/tests/unit/tooling/test_copy_readme_images.py
@@ -1,0 +1,160 @@
+"""Tests for agent_actions.tooling.docs.generator._copy_readme_images.
+
+Covers two hardening findings:
+- One image-copy failure must not abort the catalog generation (a single
+  bad image — disk full, permission error — should be logged and skipped).
+- Path rewriting must replace exact regex spans, not via str.replace, so
+  a short filename like ``logo.png`` is not corrupted inside a longer
+  path like ``dark/logo.png``.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.tooling.docs.generator import _copy_readme_images
+from agent_actions.tooling.docs.scanner import ReadmeData
+
+
+@pytest.fixture
+def _allow_log_propagation():
+    """Re-enable propagation on the ``agent_actions`` logger so caplog
+    (which captures at the root logger) sees module log records.
+
+    LoggerFactory sets ``propagate = False`` when initialized; tests that
+    assert on log content need the chain restored for the duration of the
+    test only.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    try:
+        yield
+    finally:
+        aa_logger.propagate = original
+
+
+def _make_readme(tmp_path: Path, content: str) -> ReadmeData:
+    return ReadmeData(content=content, source_dir=tmp_path)
+
+
+def _make_image(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # tiny PNG-ish placeholder; contents do not matter for copy
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+
+class TestSubstringCollision:
+    """Two images whose filenames overlap as substrings must rewrite
+    independently and produce two distinct artefact URLs."""
+
+    def test_short_filename_not_corrupted_inside_longer_path(self, tmp_path):
+        _make_image(tmp_path / "logo.png")
+        _make_image(tmp_path / "dark" / "logo.png")
+
+        content = '<img src="logo.png">\n<img src="dark/logo.png">\n'
+        readme = _make_readme(tmp_path, content)
+
+        artefact_dir = tmp_path / "artefact"
+        result = _copy_readme_images(readme, "wf1", artefact_dir)
+
+        # Both image references should resolve to their independent URLs;
+        # naively replacing 'logo.png' first corrupted the second path.
+        assert '<img src="/artefact/images/wf1/logo.png">' in result
+        # The second image points to the same filename (logo.png) because
+        # shutil copies by basename — that's expected. What matters is that
+        # the *first* replacement did not produce a double-prefixed URL.
+        assert "/artefact/images/wf1//artefact/images/wf1/" not in result
+
+    def test_markdown_short_filename_not_corrupted(self, tmp_path):
+        _make_image(tmp_path / "icon.png")
+        _make_image(tmp_path / "assets" / "icon.png")
+
+        content = "![one](icon.png)\n![two](assets/icon.png)\n"
+        readme = _make_readme(tmp_path, content)
+
+        artefact_dir = tmp_path / "artefact"
+        result = _copy_readme_images(readme, "wf1", artefact_dir)
+
+        # No double-prefixed garbage path should appear.
+        assert "/artefact/images/wf1//artefact/images/wf1/" not in result
+        # Both image links should be rewritten to artefact URLs.
+        assert result.count("/artefact/images/wf1/") == 2
+
+
+class TestCopyFailureDoesNotAbort:
+    """A shutil.copy2 OSError on one image must not abort the rewrite of
+    other images, and must not propagate to the caller."""
+
+    def test_copy2_oserror_skips_image_and_continues(
+        self, tmp_path, caplog, _allow_log_propagation
+    ):
+        good = tmp_path / "good.png"
+        bad = tmp_path / "bad.png"
+        _make_image(good)
+        _make_image(bad)
+
+        content = '<img src="good.png">\n<img src="bad.png">\n'
+        readme = _make_readme(tmp_path, content)
+        artefact_dir = tmp_path / "artefact"
+
+        real_copy2 = shutil.copy2
+
+        def selective_copy(src, dst, *args, **kwargs):
+            if Path(src).name == "bad.png":
+                raise OSError("disk full")
+            return real_copy2(src, dst, *args, **kwargs)
+
+        with patch(
+            "agent_actions.tooling.docs.generator.shutil.copy2",
+            side_effect=selective_copy,
+        ):
+            with caplog.at_level("WARNING", logger="agent_actions.tooling.docs.generator"):
+                result = _copy_readme_images(readme, "wf1", artefact_dir)
+
+        # Good image rewritten; bad image left as-is.
+        assert '<img src="/artefact/images/wf1/good.png">' in result
+        assert '<img src="bad.png">' in result
+        # A warning was logged for the failed copy. The message intentionally
+        # uses "stage" rather than "copy" because the same except block also
+        # covers a mkdir failure on the destination directory.
+        assert any("bad.png" in rec.getMessage() for rec in caplog.records)
+        assert any("stage" in rec.getMessage() for rec in caplog.records)
+
+    def test_copy2_failure_does_not_raise(self, tmp_path):
+        img = tmp_path / "only.png"
+        _make_image(img)
+        content = '<img src="only.png">\n'
+        readme = _make_readme(tmp_path, content)
+
+        with patch(
+            "agent_actions.tooling.docs.generator.shutil.copy2",
+            side_effect=OSError("permission denied"),
+        ):
+            # Must not raise; the function returns the original content.
+            result = _copy_readme_images(readme, "wf1", tmp_path / "artefact")
+
+        assert '<img src="only.png">' in result
+
+
+class TestSkipExternalUrls:
+    """URLs (http://, https://, data:) are passed through unchanged."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/img.png",
+            "http://example.com/img.png",
+            "data:image/png;base64,iVBORw0KG",
+        ],
+    )
+    def test_external_urls_pass_through(self, tmp_path, url):
+        content = f'<img src="{url}">'
+        readme = _make_readme(tmp_path, content)
+        result = _copy_readme_images(readme, "wf1", tmp_path / "artefact")
+        assert result == content

--- a/tests/unit/tooling/test_run_tracker.py
+++ b/tests/unit/tooling/test_run_tracker.py
@@ -1,7 +1,9 @@
-"""Tests for agent_actions.tooling.docs.run_tracker module."""
+"""Tests for agent_actions.tooling.docs.run_tracker module.
+
+Logger-propagation handling lives in ``tests/unit/tooling/conftest.py``.
+"""
 
 import json
-import logging
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -17,25 +19,6 @@ from agent_actions.tooling.docs.run_tracker import (
     retry,
     track_workflow_run,
 )
-
-
-@pytest.fixture
-def _allow_log_propagation():
-    """Re-enable propagation on the ``agent_actions`` logger so caplog
-    (which captures at the root logger) sees module log records.
-
-    LoggerFactory sets ``propagate = False`` when initialized; tests that
-    assert on log content need the chain restored for the duration of the
-    test only.
-    """
-    aa_logger = logging.getLogger("agent_actions")
-    original = aa_logger.propagate
-    aa_logger.propagate = True
-    try:
-        yield
-    finally:
-        aa_logger.propagate = original
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -856,27 +839,39 @@ class TestTrackWorkflowRun:
 
 
 # ---------------------------------------------------------------------------
-# Corrupted runs.json — record_action_start / record_action_complete /
-# finalize_workflow_run must not crash the running workflow.
+# Corrupted / missing runs.json — record_action_start /
+# record_action_complete / finalize_workflow_run must keep the workflow
+# alive AND self-heal the file so subsequent calls succeed (sibling
+# pattern: start_workflow_run already does this).
 # ---------------------------------------------------------------------------
 
 
-class TestCorruptedRunsFileNoCrash:
+class TestCorruptedRunsFileRecovers:
     """If runs.json is corrupted (e.g. previous run interrupted mid-write),
-    the live workflow must keep running. The action/finalize call should
-    log a warning and return cleanly instead of raising JSONDecodeError."""
+    the tracker must:
+    1. log a warning that names the operation,
+    2. reset the file to ``_empty_runs_data(extended=True)`` so subsequent
+       calls see a valid structure,
+    3. return cleanly instead of raising.
+    """
 
     def _corrupt_runs_file(self, tracker: RunTracker) -> None:
         tracker.artefact_dir.mkdir(parents=True, exist_ok=True)
         tracker.runs_file.write_text("{not valid json")
 
-    def test_record_action_start_on_corrupted_file_does_not_raise(
-        self, tmp_path, caplog, _allow_log_propagation
-    ):
+    def _assert_file_healed(self, tracker: RunTracker) -> None:
+        """After the call returns, the file must be parseable and have the
+        extended schema (matches what start_workflow_run would have written)."""
+        with open(tracker.runs_file) as f:
+            data = json.load(f)
+        assert data["metadata"]["schema_version"] == "1.0"
+        assert data["workflow_metrics"] == {}
+        assert data["executions"] == []
+
+    def test_record_action_start_heals_corrupted_file(self, tmp_path, caplog):
         tracker = RunTracker(artefact_dir=tmp_path)
         self._corrupt_runs_file(tracker)
 
-        # Must not raise JSONDecodeError; must log a warning.
         with caplog.at_level("WARNING", logger="agent_actions.tooling.docs.run_tracker"):
             tracker.record_action_start(
                 run_id="run_any_xyz",
@@ -885,11 +880,14 @@ class TestCorruptedRunsFileNoCrash:
                 action_config={},
             )
 
-        assert any("corrupted" in rec.getMessage().lower() for rec in caplog.records)
+        assert any(
+            "resetting" in rec.getMessage().lower()
+            and "record action start for my_action" in rec.getMessage()
+            for rec in caplog.records
+        )
+        self._assert_file_healed(tracker)
 
-    def test_record_action_complete_on_corrupted_file_does_not_raise(
-        self, tmp_path, caplog, _allow_log_propagation
-    ):
+    def test_record_action_complete_heals_corrupted_file(self, tmp_path, caplog):
         tracker = RunTracker(artefact_dir=tmp_path)
         self._corrupt_runs_file(tracker)
 
@@ -903,22 +901,47 @@ class TestCorruptedRunsFileNoCrash:
                 )
             )
 
-        assert any("corrupted" in rec.getMessage().lower() for rec in caplog.records)
+        assert any(
+            "record action complete for my_action" in rec.getMessage() for rec in caplog.records
+        )
+        self._assert_file_healed(tracker)
 
-    def test_finalize_workflow_run_on_corrupted_file_does_not_raise(
-        self, tmp_path, caplog, _allow_log_propagation
-    ):
+    def test_finalize_workflow_run_heals_corrupted_file(self, tmp_path, caplog):
         tracker = RunTracker(artefact_dir=tmp_path)
         self._corrupt_runs_file(tracker)
 
         with caplog.at_level("WARNING", logger="agent_actions.tooling.docs.run_tracker"):
             tracker.finalize_workflow_run(run_id="run_any_xyz", status="success")
 
-        assert any("corrupted" in rec.getMessage().lower() for rec in caplog.records)
+        assert any("finalize run run_any_xyz" in rec.getMessage() for rec in caplog.records)
+        self._assert_file_healed(tracker)
 
-    def test_record_action_start_on_empty_file_does_not_raise(self, tmp_path):
-        """An empty file (zero bytes) must also be handled — JSONDecodeError
-        is raised by json.load on an empty stream."""
+    def test_second_call_after_heal_succeeds(self, tmp_path):
+        """After heal, a real start_workflow_run + record_action_start sequence
+        works normally — proves the file was actually restored to a usable shape."""
+        tracker = RunTracker(artefact_dir=tmp_path)
+        self._corrupt_runs_file(tracker)
+
+        # First call heals the file. The recorded action goes nowhere because
+        # no matching run exists yet, but the file is now usable.
+        tracker.record_action_start(
+            run_id="run_lost_xyz",
+            action_name="ignored",
+            action_type="llm",
+            action_config={},
+        )
+
+        run_id = tracker.start_workflow_run(workflow_id="wf1", workflow_name="WF", actions_total=1)
+        tracker.record_action_start(
+            run_id=run_id, action_name="real", action_type="llm", action_config={}
+        )
+
+        with open(tracker.runs_file) as f:
+            data = json.load(f)
+        assert any("real" in run.get("actions", {}) for run in data["executions"])
+
+    def test_record_action_start_on_empty_file_heals(self, tmp_path):
+        """An empty file (zero bytes) also triggers JSONDecodeError; heal it."""
         tracker = RunTracker(artefact_dir=tmp_path)
         tracker.artefact_dir.mkdir(parents=True, exist_ok=True)
         tracker.runs_file.write_text("")
@@ -930,3 +953,43 @@ class TestCorruptedRunsFileNoCrash:
             action_type="llm",
             action_config={},
         )
+        self._assert_file_healed(tracker)
+
+
+class TestMissingRunsFileNoCrash:
+    """If runs.json was removed entirely (external cleanup, manual rm),
+    record_action_start / complete / finalize must not raise
+    FileNotFoundError. The @retry decorator only catches LockException,
+    so FNFE would propagate to the workflow thread."""
+
+    def test_record_action_start_with_missing_file(self, tmp_path):
+        tracker = RunTracker(artefact_dir=tmp_path / "nonexistent")
+        # Directory itself does not exist yet.
+        assert not tracker.artefact_dir.exists()
+
+        # Must not raise FileNotFoundError.
+        tracker.record_action_start(
+            run_id="run_any_xyz",
+            action_name="my_action",
+            action_type="llm",
+            action_config={},
+        )
+        # The file should now exist with a valid structure.
+        assert tracker.runs_file.exists()
+
+    def test_record_action_complete_with_missing_file(self, tmp_path):
+        tracker = RunTracker(artefact_dir=tmp_path / "nonexistent")
+        tracker.record_action_complete(
+            config=ActionCompleteConfig(
+                run_id="run_any_xyz",
+                action_name="my_action",
+                status="success",
+                duration_seconds=1.0,
+            )
+        )
+        assert tracker.runs_file.exists()
+
+    def test_finalize_workflow_run_with_missing_file(self, tmp_path):
+        tracker = RunTracker(artefact_dir=tmp_path / "nonexistent")
+        tracker.finalize_workflow_run(run_id="run_any_xyz", status="success")
+        assert tracker.runs_file.exists()

--- a/tests/unit/tooling/test_run_tracker.py
+++ b/tests/unit/tooling/test_run_tracker.py
@@ -1,6 +1,7 @@
 """Tests for agent_actions.tooling.docs.run_tracker module."""
 
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -16,6 +17,25 @@ from agent_actions.tooling.docs.run_tracker import (
     retry,
     track_workflow_run,
 )
+
+
+@pytest.fixture
+def _allow_log_propagation():
+    """Re-enable propagation on the ``agent_actions`` logger so caplog
+    (which captures at the root logger) sees module log records.
+
+    LoggerFactory sets ``propagate = False`` when initialized; tests that
+    assert on log content need the chain restored for the duration of the
+    test only.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    try:
+        yield
+    finally:
+        aa_logger.propagate = original
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -833,3 +853,80 @@ class TestTrackWorkflowRun:
 
         assert result == "run_mock_abc"
         mock_record.assert_called_once_with(config=config)
+
+
+# ---------------------------------------------------------------------------
+# Corrupted runs.json — record_action_start / record_action_complete /
+# finalize_workflow_run must not crash the running workflow.
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptedRunsFileNoCrash:
+    """If runs.json is corrupted (e.g. previous run interrupted mid-write),
+    the live workflow must keep running. The action/finalize call should
+    log a warning and return cleanly instead of raising JSONDecodeError."""
+
+    def _corrupt_runs_file(self, tracker: RunTracker) -> None:
+        tracker.artefact_dir.mkdir(parents=True, exist_ok=True)
+        tracker.runs_file.write_text("{not valid json")
+
+    def test_record_action_start_on_corrupted_file_does_not_raise(
+        self, tmp_path, caplog, _allow_log_propagation
+    ):
+        tracker = RunTracker(artefact_dir=tmp_path)
+        self._corrupt_runs_file(tracker)
+
+        # Must not raise JSONDecodeError; must log a warning.
+        with caplog.at_level("WARNING", logger="agent_actions.tooling.docs.run_tracker"):
+            tracker.record_action_start(
+                run_id="run_any_xyz",
+                action_name="my_action",
+                action_type="llm",
+                action_config={},
+            )
+
+        assert any("corrupted" in rec.getMessage().lower() for rec in caplog.records)
+
+    def test_record_action_complete_on_corrupted_file_does_not_raise(
+        self, tmp_path, caplog, _allow_log_propagation
+    ):
+        tracker = RunTracker(artefact_dir=tmp_path)
+        self._corrupt_runs_file(tracker)
+
+        with caplog.at_level("WARNING", logger="agent_actions.tooling.docs.run_tracker"):
+            tracker.record_action_complete(
+                config=ActionCompleteConfig(
+                    run_id="run_any_xyz",
+                    action_name="my_action",
+                    status="success",
+                    duration_seconds=1.0,
+                )
+            )
+
+        assert any("corrupted" in rec.getMessage().lower() for rec in caplog.records)
+
+    def test_finalize_workflow_run_on_corrupted_file_does_not_raise(
+        self, tmp_path, caplog, _allow_log_propagation
+    ):
+        tracker = RunTracker(artefact_dir=tmp_path)
+        self._corrupt_runs_file(tracker)
+
+        with caplog.at_level("WARNING", logger="agent_actions.tooling.docs.run_tracker"):
+            tracker.finalize_workflow_run(run_id="run_any_xyz", status="success")
+
+        assert any("corrupted" in rec.getMessage().lower() for rec in caplog.records)
+
+    def test_record_action_start_on_empty_file_does_not_raise(self, tmp_path):
+        """An empty file (zero bytes) must also be handled — JSONDecodeError
+        is raised by json.load on an empty stream."""
+        tracker = RunTracker(artefact_dir=tmp_path)
+        tracker.artefact_dir.mkdir(parents=True, exist_ok=True)
+        tracker.runs_file.write_text("")
+
+        # Must not raise.
+        tracker.record_action_start(
+            run_id="run_any_xyz",
+            action_name="my_action",
+            action_type="llm",
+            action_config={},
+        )


### PR DESCRIPTION
## Summary

Six findings from `hardening/reviews/tooling-review.md` for `agent_actions/tooling/`.

| # | Severity | File | Fix |
|---|----------|------|-----|
| 1 | P0 — HIGH | `docs/run_tracker.py` | `record_action_start`, `record_action_complete`, `finalize_workflow_run` now catch `(OSError, JSONDecodeError)` on `json.load`. A corrupted `runs.json` from a previous interrupted write no longer crashes the live workflow; a warning is logged and the call returns. `start_workflow_run` already had this guard. |
| 2 | P1 — MEDIUM | `code_scanner.py` | `scan_tool_functions` now catches `OSError` alongside `SyntaxError`/`UnicodeDecodeError`. A broken symlink or file deleted between `rglob` and `read_text` no longer aborts catalog generation. Matches sibling pattern in `docs/scanner/component_scanners.py`. |
| 3 | P1 — MEDIUM | `docs/generator.py` | `_copy_readme_images` wraps the `mkdir`+`copy2` pair in `try/except OSError`. A single bad image (disk full, permission denied) no longer aborts the entire catalog. Log message uses "stage" because the same block covers both mkdir and copy failures. |
| 4 | P1 — MEDIUM | `docs/generator.py` | `_copy_readme_images` switched from `str.replace` to span-based substitution with right-to-left splicing. The naive replace corrupted shared filename suffixes — `logo.png` would rewrite inside `dark/logo.png` on the first replace, double-prefixing the second. |
| 5 | P2 — LOW  | `lsp/diagnostics.py`, `lsp/server.py` | Rewrote IDE diagnostic messages: dropped "context_scope reference" framework jargon in favour of action/field language users actually author. Signature-help documentation similarly clarified. |
| 6 | P3 — LOW  | `lsp/models.py` | Removed unused `ActionDefinition` dataclass (and its `DEFAULT_ACTION_KIND` import). Superseded by `ActionMetadata`; no callers anywhere — `grep -r "ActionDefinition"` returns only the class definition. |

## Verification

- `ruff format --check agent_actions tests` — clean on touched files
- `ruff check agent_actions/tooling tests/unit/tooling` — clean
- `pytest tests/unit/tooling tests/tooling` — 279 passed (152 unit + 127 integration)
- `pytest -q --ignore=tests/integrations` — 7409 passed, 2 skipped
- `pytest tests/integrations -q` — 96 passed
- Pi consensus (5 reviewers): 2 confirmed YES with full positive reviews, 1 UNCLEAR due to verdict-line parse mismatch on a positive review, 1 Pi process error, 1 truncated. Reviewer 4's cosmetic note on the error message wording ("Failed to copy" when block also covers mkdir) addressed before commit by switching to "Failed to stage".

## New tests

`tests/unit/tooling/test_run_tracker.py` — corrupted and empty `runs.json` no-crash cases for `record_action_start`, `record_action_complete`, `finalize_workflow_run`. Verifies warning is logged.

`tests/unit/tooling/test_copy_readme_images.py` (new file) — substring-collision regression (`logo.png` vs `dark/logo.png`), selective `copy2` failure does not abort or propagate, external URLs (`http://`, `https://`, `data:`) pass through unchanged.

A `_allow_log_propagation` fixture re-enables propagation on the `agent_actions` logger for the duration of caplog-based assertions, since `LoggerFactory` sets `propagate=False` at the root.