### PR TITLE
fix: output module hardening

### DIFF
--- a/agent_actions/output/response/context_data.py
+++ b/agent_actions/output/response/context_data.py
@@ -10,12 +10,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from agent_actions.errors import ConfigValidationError
 from agent_actions.output.response.loader import SchemaLoader
 from agent_actions.utils.constants import SCHEMA_KEY, SCHEMA_NAME_KEY
 
 from .dispatch_injection import _resolve_dispatch_in_schema
-from .vendor_compilation import compile_unified_schema
+from .vendor_compilation import SUPPORTED_VENDORS, compile_unified_schema
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +139,12 @@ def _compile_schema_for_vendor(
     schema_name: str,
 ) -> dict[str, Any] | list[dict[str, Any]] | None:
     """
-    Compile schema for specific vendor with error handling.
+    Compile schema for specific vendor.
+
+    Pre-validates the vendor against the known-supported set so unknown vendors
+    return None (schema dropped) without invoking compile_unified_schema. This
+    keeps the catch surface narrow: any ConfigValidationError raised inside
+    compile_unified_schema is a real validation failure and propagates.
 
     Args:
         base_schema: Unified schema dict
@@ -150,12 +154,11 @@ def _compile_schema_for_vendor(
     Returns:
         Compiled schema or None if vendor doesn't support schemas
     """
-    try:
-        return compile_unified_schema(base_schema, vendor)
-    except ConfigValidationError:
+    if vendor.lower() not in SUPPORTED_VENDORS:
         logger.info(
             "Vendor '%s' does not support schema validation. Schema '%s' will be ignored.",
             vendor,
             schema_name,
         )
         return None
+    return compile_unified_schema(base_schema, vendor)

--- a/agent_actions/output/response/dispatch_injection.py
+++ b/agent_actions/output/response/dispatch_injection.py
@@ -7,7 +7,7 @@ Handles recursive dispatch_task() resolution and injection into schema structure
 import logging
 from typing import Any
 
-from agent_actions.errors import AgentActionsError
+from agent_actions.errors import ConfigValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,12 @@ def _inject_functions_into_schema(
 
     Returns:
         The processed schema with function outputs injected
+
+    Raises:
+        ConfigValidationError: If dispatch_task() resolution fails. Letting the
+            unresolved string flow to the LLM vendor produces opaque API errors
+            (or malformed output for permissive vendors); failing here surfaces
+            the misconfiguration at compile time with a clear error.
     """
     if isinstance(schema, dict):
         return {
@@ -46,27 +52,29 @@ def _inject_functions_into_schema(
             )
             for item in schema
         ]
-    if isinstance(schema, str):
-        if "dispatch_task(" in schema:
-            try:
-                from agent_actions.prompt.prompt_utils import PromptUtils
+    if isinstance(schema, str) and "dispatch_task(" in schema:
+        from agent_actions.prompt.prompt_utils import PromptUtils
 
-                return PromptUtils.process_dispatch_in_text(
-                    schema,
-                    tools_path=tools_path or "",
-                    context_data_str=context_data_str or "",
-                    agent_config=agent_config,
-                    captured_results=captured_results,
-                    preserve_type_on_exact_match=True,
-                )
-            except (ValueError, TypeError, KeyError, AgentActionsError) as e:
-                logger.warning(
-                    "dispatch_task resolution failed in schema — the unresolved string "
-                    "will be passed to the LLM vendor as-is, which may cause API errors: %s",
-                    e,
-                )
-                return schema
-        return schema
+        try:
+            return PromptUtils.process_dispatch_in_text(
+                schema,
+                tools_path=tools_path or "",
+                context_data_str=context_data_str or "",
+                agent_config=agent_config,
+                captured_results=captured_results,
+                preserve_type_on_exact_match=True,
+            )
+        except Exception as e:
+            raise ConfigValidationError(
+                f"dispatch_task() resolution failed in schema: {e}. "
+                "Check that the referenced UDF exists under tools/<workflow>/ and "
+                "that its signature matches the dispatch_task() call.",
+                context={
+                    "schema_fragment": schema,
+                    "tools_path": tools_path,
+                    "error_type": type(e).__name__,
+                },
+            ) from e
     return schema
 
 
@@ -88,14 +96,19 @@ def _resolve_dispatch_in_schema(
         captured_results: Dictionary to collect function outputs
 
     Returns:
-        Resolved schema (original if not a dispatch call or resolution fails)
+        Resolved schema (unchanged if it is not a dispatch_task string).
+
+    Raises:
+        ConfigValidationError: If dispatch_task() resolution fails. Same reasoning
+            as ``_inject_functions_into_schema``: silent fallback was masking
+            broken configs and producing opaque downstream API errors.
     """
     if not isinstance(schema, str) or "dispatch_task(" not in schema:
         return schema
 
-    try:
-        from agent_actions.prompt.prompt_utils import PromptUtils
+    from agent_actions.prompt.prompt_utils import PromptUtils
 
+    try:
         return PromptUtils.process_dispatch_in_text(
             schema,
             tools_path=tools_path or "",
@@ -104,10 +117,14 @@ def _resolve_dispatch_in_schema(
             captured_results=captured_results,
             preserve_type_on_exact_match=True,
         )
-    except (ValueError, TypeError, KeyError, AgentActionsError) as e:
-        logger.warning(
-            "dispatch_task resolution failed in schema — the unresolved string "
-            "will be passed to the LLM vendor as-is, which may cause API errors: %s",
-            e,
-        )
-        return schema
+    except Exception as e:
+        raise ConfigValidationError(
+            f"dispatch_task() resolution failed in schema: {e}. "
+            "Check that the referenced UDF exists under tools/<workflow>/ and "
+            "that its signature matches the dispatch_task() call.",
+            context={
+                "schema_fragment": schema,
+                "tools_path": tools_path,
+                "error_type": type(e).__name__,
+            },
+        ) from e

--- a/agent_actions/output/response/dispatch_injection.py
+++ b/agent_actions/output/response/dispatch_injection.py
@@ -4,12 +4,9 @@ Dispatch and injection logic for schema processing.
 Handles recursive dispatch_task() resolution and injection into schema structures.
 """
 
-import logging
 from typing import Any
 
 from agent_actions.errors import ConfigValidationError
-
-logger = logging.getLogger(__name__)
 
 
 def _inject_functions_into_schema(

--- a/agent_actions/output/response/expander.py
+++ b/agent_actions/output/response/expander.py
@@ -400,15 +400,9 @@ class ActionExpander:
                     agent["version_mode"] = action.get("version_mode", "parallel")
                     agent["_version_context"] = version_ctx
 
-                # Check for explicit dependencies in action, defaulting to empty list
-                # This is handled inside _create_agent_from_action via inheritance,
-                # but we ensure it persists
                 created_agent = ActionExpander._create_agent_from_action(
                     action, defaults, agent, lambda x: x
                 )
-                if "dependencies" not in created_agent and "dependencies" in action:
-                    created_agent["dependencies"] = action["dependencies"]
-
                 agents.append(created_agent)
 
         return {workflow_name: agents}

--- a/agent_actions/output/response/schema_conversion.py
+++ b/agent_actions/output/response/schema_conversion.py
@@ -60,8 +60,40 @@ def _convert_json_schema_to_unified(json_schema: dict[str, Any]) -> dict[str, An
             ),
         )
 
-    # Check if array is required (default to True for backward compatibility)
-    is_required = json_schema.get("required", True)
+    # Determine whether this array field is required by its parent. The codebase
+    # convention is a boolean `required: true|false` at the top level — distinct
+    # from JSON Schema's standard `required: [...]` list (which belongs on the
+    # OBJECT containing this array, not on the array itself, and never reaches
+    # this function because top-level callers strip it).
+    #
+    # Reject misplaced lists explicitly: previously `required: ['fact', 'paraphrase']`
+    # was treated as a truthy boolean and the array was unconditionally required,
+    # hiding a config bug. Surface the mistake so the user moves it under `items`.
+    required_value = json_schema.get("required", True)
+    if isinstance(required_value, bool):
+        is_required = required_value
+    elif isinstance(required_value, list):
+        raise SchemaValidationError(
+            f"Array schema '{schema_name}' has a list at top-level 'required'. "
+            "A boolean is expected here (whether the array itself is required in "
+            "its parent). To declare which item properties are required, move the "
+            "list under 'items.required'.",
+            schema_name=schema_name,
+            validation_type="structure",
+            hint=(
+                "Replace `required: [field1, field2]` at the array level with "
+                "`required: true|false` (this array's requiredness), and put the "
+                "property-name list under `items: {required: [field1, field2]}`."
+            ),
+        )
+    else:
+        raise SchemaValidationError(
+            f"Array schema '{schema_name}' has invalid 'required' value of type "
+            f"{type(required_value).__name__}; expected a boolean.",
+            schema_name=schema_name,
+            validation_type="structure",
+            hint="Use `required: true` or `required: false` at the array level.",
+        )
 
     # Determine if items are objects or primitives
     item_type = items.get("type", "object")

--- a/agent_actions/output/response/vendor_compilation.py
+++ b/agent_actions/output/response/vendor_compilation.py
@@ -15,6 +15,23 @@ from .schema_conversion import _convert_json_schema_to_unified, compile_field
 
 logger = logging.getLogger(__name__)
 
+# Vendors with schema/tool-calling support. Caller `_compile_schema_for_vendor`
+# pre-checks this set so unknown vendors short-circuit to None without going
+# through `compile_unified_schema` — keeping the ConfigValidationError catch
+# surface narrow to genuine validation errors.
+SUPPORTED_VENDORS: frozenset[str] = frozenset(
+    {
+        "openai",
+        "anthropic",
+        "gemini",
+        "ollama_local",
+        "ollama_cloud",
+        "agac-provider",
+        "groq",
+        "cohere",
+    }
+)
+
 
 def compile_unified_schema(
     unified: dict[str, Any], target_system: str
@@ -105,16 +122,7 @@ def compile_unified_schema(
             f"Unknown target system: {target}",
             context={
                 "target_system": target,
-                "valid_systems": [
-                    "openai",
-                    "anthropic",
-                    "gemini",
-                    "ollama_local",
-                    "ollama_cloud",
-                    "agac-provider",
-                    "groq",
-                    "cohere",
-                ],
+                "valid_systems": sorted(SUPPORTED_VENDORS),
                 "operation": "compile_unified_schema",
             },
         )

--- a/agent_actions/output/writer.py
+++ b/agent_actions/output/writer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -44,8 +45,14 @@ class FileWriter(ProcessorErrorHandlerMixin):
         self.action_name = action_name
         self.output_directory = output_directory
 
-    def _execute_write(self, operation_name: str, write_fn: Callable[[], int]) -> None:
-        """Execute a write operation with event firing and error handling."""
+    def _execute_write(self, write_kind: str, write_fn: Callable[[], int]) -> None:
+        """Execute a write operation with event firing and error handling.
+
+        Args:
+            write_kind: Canonical kind ('staging', 'target', or 'source') used both for
+                logging context and so handle_file_error maps OSError → FileWriteError
+                (handle_file_error matches the literal 'write' against an allow-list).
+        """
         try:
             fire_event(
                 FileWriteStartedEvent(
@@ -64,13 +71,20 @@ class FileWriter(ProcessorErrorHandlerMixin):
                 )
             )
         except OSError as e:
-            self.handle_file_error(e, operation_name, self.file_path, file_type=self.file_type)
+            self.handle_file_error(
+                e,
+                "write",
+                self.file_path,
+                file_type=self.file_type,
+                write_kind=write_kind,
+            )
         except Exception as e:
             self.handle_processing_error(
                 e,
-                f"{operation_name} {self.file_path}",
+                f"Write {write_kind} file {self.file_path}",
                 file_path=self.file_path,
                 file_type=self.file_type,
+                write_kind=write_kind,
             )
 
     def write_staging(self, data: Any) -> None:
@@ -105,7 +119,7 @@ class FileWriter(ProcessorErrorHandlerMixin):
                 )
             return Path(self.file_path).stat().st_size
 
-        self._execute_write("Write staging file", do_write)
+        self._execute_write("staging", do_write)
 
     def write_target(self, data: list[dict[str, Any]]) -> None:
         """Write data to storage backend (DB is the single source of truth)."""
@@ -131,9 +145,13 @@ class FileWriter(ProcessorErrorHandlerMixin):
 
             self.storage_backend.write_target(self.action_name, relative_path, data)
 
-            return 0
+            # Approximate payload size as JSON byte length so FileWriteCompleteEvent
+            # carries a meaningful metric. The backend may store data in a different
+            # on-disk shape (e.g. SQLite rows), so this measures payload, not
+            # storage footprint — but it's accurate enough to spot empty writes.
+            return len(json.dumps(data, ensure_ascii=False).encode("utf-8"))
 
-        self._execute_write("Write target file", do_write)
+        self._execute_write("target", do_write)
 
     def write_source(self, data: Any) -> None:
         """Write data to source file in JSON format."""
@@ -143,4 +161,4 @@ class FileWriter(ProcessorErrorHandlerMixin):
             atomic_json_write(Path(self.file_path), data, indent=4)
             return Path(self.file_path).stat().st_size
 
-        self._execute_write("Write source file", do_write)
+        self._execute_write("source", do_write)

--- a/tests/core/parser/test_schema_array_conversion.py
+++ b/tests/core/parser/test_schema_array_conversion.py
@@ -329,8 +329,9 @@ class TestRequiredFieldTypeHandling:
         }
         with pytest.raises(SchemaValidationError) as exc_info:
             _convert_json_schema_to_unified(schema)
-        msg = str(exc_info.value)
-        assert "items.required" in msg or "items" in msg.lower()
+        # The remediation hint must specifically name `items.required` — the
+        # whole point of the error is to redirect the misplaced list there.
+        assert "items.required" in str(exc_info.value)
 
     def test_top_level_required_true_keeps_array_required(self):
         """`required: true` at array top-level marks the array required in its parent."""

--- a/tests/core/parser/test_schema_array_conversion.py
+++ b/tests/core/parser/test_schema_array_conversion.py
@@ -5,6 +5,9 @@ These tests verify that array schemas (JSON Schema format with type='array')
 are properly converted to the unified format and compile correctly for all vendors.
 """
 
+import pytest
+
+from agent_actions.errors import SchemaValidationError
 from agent_actions.output.response.schema import (
     _convert_json_schema_to_unified,
     compile_unified_schema,
@@ -308,3 +311,56 @@ class TestEdgeCases:
         props = result[0]["input_schema"]["properties"]
         assert "test" in props
         assert props["test"]["type"] == "array"
+
+
+class TestRequiredFieldTypeHandling:
+    """Top-level `required` on an array schema is a boolean flag; reject lists."""
+
+    def test_top_level_required_list_rejected(self):
+        """A list at top-level 'required' is misplaced (should live under 'items')."""
+        schema = {
+            "name": "candidate_facts_list",
+            "type": "array",
+            "required": ["fact", "paraphrase"],
+            "items": {
+                "type": "object",
+                "properties": {"fact": {"type": "string"}, "paraphrase": {"type": "string"}},
+            },
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            _convert_json_schema_to_unified(schema)
+        msg = str(exc_info.value)
+        assert "items.required" in msg or "items" in msg.lower()
+
+    def test_top_level_required_true_keeps_array_required(self):
+        """`required: true` at array top-level marks the array required in its parent."""
+        schema = {
+            "name": "required_array",
+            "type": "array",
+            "required": True,
+            "items": {"type": "string"},
+        }
+        result = compile_unified_schema(schema, "openai")
+        assert "required_array" in result["schema"].get("required", [])
+
+    def test_top_level_required_false_keeps_array_optional(self):
+        """`required: false` keeps the array out of the parent's required list."""
+        schema = {
+            "name": "optional_array",
+            "type": "array",
+            "required": False,
+            "items": {"type": "string"},
+        }
+        result = compile_unified_schema(schema, "openai")
+        assert "optional_array" not in result["schema"].get("required", [])
+
+    def test_top_level_required_invalid_type_rejected(self):
+        """A non-bool, non-list (e.g. dict/str) at top-level 'required' is rejected."""
+        schema = {
+            "name": "weird",
+            "type": "array",
+            "required": "yes",
+            "items": {"type": "string"},
+        }
+        with pytest.raises(SchemaValidationError):
+            _convert_json_schema_to_unified(schema)

--- a/tests/integration/test_schema_dispatch_audit.py
+++ b/tests/integration/test_schema_dispatch_audit.py
@@ -518,20 +518,19 @@ class TestDispatchInSchema:
         result = _resolve_dispatch_in_schema(schema_dict, None, "{}", {}, {})
         assert result == schema_dict
 
-    @patch("agent_actions.output.response.dispatch_injection.logger")
-    def test_dispatch_resolution_failure_warns(self, mock_logger):
-        """Failed dispatch_task() resolution logs WARNING (not silent DEBUG).
+    def test_dispatch_resolution_failure_raises(self):
+        """Failed dispatch_task() resolution must raise ConfigValidationError.
 
-        ConfigurationError (e.g., missing UDF module) is caught and logged.
+        Letting the unresolved string flow to the LLM vendor produces opaque
+        API errors at request time; failing here surfaces the misconfig at
+        schema-compile time with a clear, actionable message.
         """
         schema_str = 'dispatch_task("nonexistent_function")'
-        result = _resolve_dispatch_in_schema(schema_str, None, "{}", {}, {})
-        # Should return original string (unresolved)
-        assert result == schema_str
-        # Should log at WARNING level (not DEBUG)
-        mock_logger.warning.assert_called_once()
-        warning_msg = str(mock_logger.warning.call_args)
-        assert "dispatch_task resolution failed" in warning_msg
+        with pytest.raises(ConfigValidationError) as exc_info:
+            _resolve_dispatch_in_schema(schema_str, None, "{}", {}, {})
+        assert "dispatch_task() resolution failed" in str(exc_info.value)
+        # Context retains the offending fragment for downstream diagnostics.
+        assert exc_info.value.context.get("schema_fragment") == schema_str
 
     def test_recursive_injection_in_dict(self):
         """_inject_functions_into_schema recursively processes dict values."""
@@ -553,13 +552,12 @@ class TestDispatchInSchema:
         assert result["type"] == "string"
         assert result["description"] == "A text field"
 
-    @patch("agent_actions.output.response.dispatch_injection.logger")
-    def test_unresolved_dispatch_passes_through_to_vendor(self, mock_logger):
-        """Unresolved dispatch_task string flows through compilation without crash.
+    def test_unresolved_dispatch_raises_during_injection(self):
+        """Unresolved dispatch_task must raise at injection — never reach the vendor.
 
-        This is the critical unhappy path: dispatch_task fails → string passes
-        through → vendor compiler receives it. The compiled output should contain
-        the literal string, not crash.
+        Previously this silently passed an unresolved 'dispatch_task(...)' string
+        into the compiled schema, producing opaque LLM API errors. The contract
+        is now to fail fast at compile time.
         """
         schema_with_dispatch = {
             "name": "test",
@@ -568,51 +566,38 @@ class TestDispatchInSchema:
                 {"id": "dynamic_field", "type": 'dispatch_task("missing_fn")', "required": True},
             ],
         }
-        # _inject_functions_into_schema processes the dispatch_task string
-        # and returns it as-is when resolution fails
-        processed = _inject_functions_into_schema(schema_with_dispatch, None, None, None, {})
-        # The literal string survives into the schema
-        assert processed["fields"][1]["type"] == 'dispatch_task("missing_fn")'
+        with pytest.raises(ConfigValidationError) as exc_info:
+            _inject_functions_into_schema(schema_with_dispatch, None, None, None, {})
+        assert "dispatch_task() resolution failed" in str(exc_info.value)
 
-        # Vendor compilation still succeeds — it doesn't validate type values
-        compiled = compile_unified_schema(processed, "openai")
-        assert compiled is not None
-        props = compiled["schema"]["properties"]
-        assert props["dynamic_field"]["type"] == 'dispatch_task("missing_fn")'
-
-    @patch("agent_actions.output.response.dispatch_injection.logger")
-    def test_multiple_dispatch_failures_all_warned(self, mock_logger):
-        """Multiple failing dispatch_task calls each log a WARNING."""
+    def test_first_dispatch_failure_short_circuits(self):
+        """First failing dispatch_task() aborts the traversal with a raise."""
         schema = {
             "field_a": 'dispatch_task("missing_a")',
             "field_b": 'dispatch_task("missing_b")',
             "field_c": "regular_string",
         }
-        result = _inject_functions_into_schema(schema, None, None, None, {})
-        # Both dispatch strings survive (unresolved)
-        assert 'dispatch_task("missing_a")' in result["field_a"]
-        assert 'dispatch_task("missing_b")' in result["field_b"]
-        # Regular strings untouched
-        assert result["field_c"] == "regular_string"
+        with pytest.raises(ConfigValidationError):
+            _inject_functions_into_schema(schema, None, None, None, {})
 
-    @patch("agent_actions.output.response.dispatch_injection.logger")
-    def test_dispatch_task_in_nested_positions(self, mock_logger):
-        """dispatch_task in nested dict/list positions is recursively processed."""
+    def test_dispatch_task_in_nested_positions_raises(self):
+        """dispatch_task failures inside nested dict/list positions still raise."""
         schema = {
             "outer": {
                 "inner": 'dispatch_task("nested_fn")',
                 "list_field": ['dispatch_task("list_fn")', "normal"],
             }
         }
-        result = _inject_functions_into_schema(schema, None, None, None, {})
-        # Nested dispatch_task strings survive (unresolved but caught)
-        assert 'dispatch_task("nested_fn")' in result["outer"]["inner"]
-        assert 'dispatch_task("list_fn")' in result["outer"]["list_field"][0]
-        assert result["outer"]["list_field"][1] == "normal"
+        with pytest.raises(ConfigValidationError):
+            _inject_functions_into_schema(schema, None, None, None, {})
 
-    @patch("agent_actions.output.response.dispatch_injection.logger")
-    def test_dispatch_failure_full_pipeline(self, mock_logger):
-        """Full path: dispatch fails → WARNING → compiler produces output → all vendors handle it."""
+    def test_dispatch_failure_full_pipeline_raises(self):
+        """Full pipeline path: dispatch fails → ResponseSchemaCompiler.compile raises.
+
+        Replaces the prior 'compile silently produces an unresolved schema for
+        every vendor' contract. Vendors must never receive an unresolved
+        dispatch_task() string in a compiled schema.
+        """
         schema = {
             "name": "with_dispatch",
             "fields": [
@@ -620,7 +605,7 @@ class TestDispatchInSchema:
                 {"id": "broken", "type": 'dispatch_task("no_such_fn")', "required": False},
             ],
         }
-        compiler = ResponseSchemaCompiler(project_root=None, tools_path=None)
+        compiler = ResponseSchemaCompiler(project_root=None, tools_path="/tmp/_missing_tools")
         config = {"schema": schema, "name": "test_action"}
 
         for vendor in [
@@ -632,10 +617,8 @@ class TestDispatchInSchema:
             "groq",
             "cohere",
         ]:
-            compiled, _ = compiler.compile(config, vendor)
-            assert compiled is not None, (
-                f"{vendor} failed to compile schema with unresolved dispatch_task"
-            )
+            with pytest.raises(ConfigValidationError):
+                compiler.compile(config, vendor)
 
 
 # ===================================================================
@@ -643,23 +626,24 @@ class TestDispatchInSchema:
 # ===================================================================
 
 
-class TestDispatchWarningContent:
-    """Verify WARNING messages contain actionable information."""
+class TestDispatchErrorContent:
+    """Verify the raised ConfigValidationError carries actionable information."""
 
-    @patch("agent_actions.output.response.dispatch_injection.logger")
-    def test_warning_contains_function_name(self, mock_logger):
-        """WARNING message includes the failed function name for debugging."""
-        _resolve_dispatch_in_schema('dispatch_task("calculate_score")', None, "{}", {}, {})
-        mock_logger.warning.assert_called_once()
-        msg = str(mock_logger.warning.call_args)
-        assert "calculate_score" in msg or "dispatch_task" in msg
+    def test_error_contains_function_fragment(self):
+        """Raised error includes the offending dispatch_task() fragment."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            _resolve_dispatch_in_schema('dispatch_task("calculate_score")', None, "{}", {}, {})
+        assert (
+            "calculate_score" in str(exc_info.value)
+            or exc_info.value.context.get("schema_fragment", "").find("calculate_score") != -1
+        )
 
-    @patch("agent_actions.output.response.dispatch_injection.logger")
-    def test_warning_mentions_vendor_consequence(self, mock_logger):
-        """WARNING message explains the consequence (passed to vendor as-is)."""
-        _resolve_dispatch_in_schema('dispatch_task("missing")', None, "{}", {}, {})
-        msg = str(mock_logger.warning.call_args)
-        assert "vendor" in msg.lower() or "as-is" in msg.lower()
+    def test_error_message_explains_remediation(self):
+        """Error message points the user at the UDF directory and signature."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            _resolve_dispatch_in_schema('dispatch_task("missing")', None, "{}", {}, {})
+        msg = str(exc_info.value).lower()
+        assert "udf" in msg or "tools/" in msg
 
 
 # ===================================================================

--- a/tests/unit/security/test_security_drop_observe.py
+++ b/tests/unit/security/test_security_drop_observe.py
@@ -115,17 +115,19 @@ class TestAtomicWriteCleanup:
     """Verify tempfile is cleaned up on write failure."""
 
     def test_tempfile_cleaned_on_serialization_error(self, tmp_path):
-        from agent_actions.errors import ProcessingError
+        from agent_actions.errors import FileWriteError
         from agent_actions.output.writer import FileWriter
 
         output_file = tmp_path / "output.json"
         writer = FileWriter(str(output_file))
 
-        # Object that can't be serialized
+        # Object that can't be serialized — atomic_json_write wraps the
+        # JSON TypeError as OSError, which FileWriter must surface as
+        # FileWriteError (the canonical write-failure type).
         class Unserializable:
             pass
 
-        with pytest.raises(ProcessingError):
+        with pytest.raises(FileWriteError):
             writer.write_staging(Unserializable())
 
         # No leftover .tmp files (cleaned up in except block)


### PR DESCRIPTION
## Summary

Closes the 6 findings in `hardening/reviews/output-review.md` for `agent_actions/output/`.

| # | Sev | Fix |
|---|-----|-----|
| 1 | HIGH | `FileWriter._execute_write` now passes canonical `"write"` to `handle_file_error` so OSError maps to `FileWriteError` (was `ProcessingError`). Descriptive context preserved via `write_kind` kwarg. |
| 2 | HIGH | `_resolve_dispatch_in_schema` / `_inject_functions_into_schema` raise `ConfigValidationError` on `dispatch_task()` failure instead of warning and passing the unresolved string to the LLM vendor. |
| 3 | MEDIUM | `_convert_json_schema_to_unified` rejects a list at top-level `required` with `SchemaValidationError` (previously list was treated as truthy bool, making the array unconditionally required). |
| 4 | MEDIUM | `write_target` reports the JSON payload byte length on `FileWriteCompleteEvent` instead of 0. |
| 5 | MEDIUM | `_compile_schema_for_vendor` pre-validates against a `SUPPORTED_VENDORS` frozenset and no longer swallows `ConfigValidationError` from `compile_unified_schema`. |
| 6 | LOW | Removed dead dependency-key fallback in `ActionExpander` — `_create_agent_from_action` unconditionally assigns the key. |

## Verification

- `pytest`: **7498 passed, 2 skipped**
- `ruff format --check` / `ruff check` on changed paths: clean
- Pi consensus (first run, before quota hit): **3 YES + 2 UNCLEAR (0 NO)**. Reviewer 3's flagged in-method imports in `test_schema_array_conversion.py` were moved to module level.
- Pi re-run and online smoke test are both blocked by an **Ollama Cloud 429 session-limit** on the account — external rate-limit, not a code regression. Re-run when quota resets:
  ```
  cd ../../hardening && bash ./consensus-review-local.sh
  cd ../../hardening && bash ./smoke-test.sh online
  ```

## Test coverage added

- `tests/core/parser/test_schema_array_conversion.py::TestRequiredFieldTypeHandling` — list/bool/invalid-type rejection for top-level `required`.
- `tests/integration/test_schema_dispatch_audit.py` — replaced "warns and passes unresolved string through" tests with fail-fast assertions on `ConfigValidationError`. Error message must reference UDF/tools path.
- `tests/unit/security/test_security_drop_observe.py::test_tempfile_cleaned_on_serialization_error` — flipped from asserting `ProcessingError` (the bug) to `FileWriteError` (the correct type).