### PR TITLE
fix: input module hardening — 5 confirmed findings

### DIFF
--- a/agent_actions/input/loaders/tabular.py
+++ b/agent_actions/input/loaders/tabular.py
@@ -38,6 +38,12 @@ class TabularLoader(BaseLoader[list[dict[str, Any]]]):
                     context=error_context,
                 )
             rows = list(csv.DictReader(content_str.splitlines()))
+            if not rows:
+                logger.warning(
+                    "Tabular loader produced 0 records from %s "
+                    "(empty file or header-only). Downstream pipeline will run as a no-op.",
+                    file_path or "<inline content>",
+                )
             return rows
         except csv.Error as e:
             operation = f"parsing CSV from {file_path or 'content string'}"

--- a/agent_actions/input/loaders/udf.py
+++ b/agent_actions/input/loaders/udf.py
@@ -1,5 +1,6 @@
 """UDF discovery and validation."""
 
+import hashlib
 import importlib.util
 import sys
 from pathlib import Path
@@ -7,6 +8,19 @@ from typing import Any
 
 from agent_actions.errors import DuplicateFunctionError, UDFLoadError
 from agent_actions.utils.udf_management.registry import UDF_REGISTRY, get_udf
+
+
+def _project_scope_prefix(user_code_path: Path) -> str:
+    """Build a project-scoped sys.modules prefix from the user code path.
+
+    Two projects with the same module-relative path (e.g. ``tools/query.py``)
+    must produce distinct ``sys.modules`` keys; otherwise the second project's
+    discover_udfs silently inherits the first project's already-loaded module.
+    A short hash of the resolved absolute path provides that scoping.
+    """
+    resolved = str(user_code_path.resolve())
+    project_hash = hashlib.blake2b(resolved.encode("utf-8"), digest_size=6).hexdigest()
+    return f"agent_actions._udfs.{project_hash}"
 
 
 def discover_tool_files(tool_dir: Path) -> list[Path]:
@@ -51,21 +65,23 @@ def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
         )
 
     python_files = discover_tool_files(user_code_path)
+    scoped_prefix = _project_scope_prefix(user_code_path)
 
     for py_file in python_files:
         try:
             relative_path = py_file.relative_to(user_code_path)
             module_name = str(relative_path.with_suffix("")).replace("/", ".").replace("\\", ".")
+            scoped_module_name = f"{scoped_prefix}.{module_name}"
 
-            if f"agent_actions._udfs.{module_name}" in sys.modules:
+            if scoped_module_name in sys.modules:
                 continue
 
             # Keep original module loading logic to preserve exception behavior
             # (DuplicateFunctionError must bubble up directly)
-            spec = importlib.util.spec_from_file_location(module_name, py_file)
+            spec = importlib.util.spec_from_file_location(scoped_module_name, py_file)
             if spec and spec.loader:
                 module = importlib.util.module_from_spec(spec)
-                sys.modules[f"agent_actions._udfs.{module_name}"] = module
+                sys.modules[scoped_module_name] = module
                 spec.loader.exec_module(module)
 
         except DuplicateFunctionError:

--- a/agent_actions/input/preprocessing/chunking/field_chunking.py
+++ b/agent_actions/input/preprocessing/chunking/field_chunking.py
@@ -196,7 +196,7 @@ class FieldChunker:
         if strategy_name == "preserve_original":
             return PreserveOriginalStrategy()
         if strategy_name == "truncate":
-            return TruncateStrategy()
+            return TruncateStrategy(truncate_at=self.config.truncate_at)
         if strategy_name == "skip":
             return SkipStrategy()
         if strategy_name == "error":

--- a/agent_actions/input/preprocessing/chunking/strategies/fallback_strategies.py
+++ b/agent_actions/input/preprocessing/chunking/strategies/fallback_strategies.py
@@ -63,6 +63,14 @@ class PreserveOriginalStrategy(FallbackStrategy):
 class TruncateStrategy(FallbackStrategy):
     """Fallback strategy that truncates content to fit within specified limits."""
 
+    def __init__(self, truncate_at: int = 50000):
+        """Configure the per-field truncation cap used on chunking failure.
+
+        ``truncate_at`` mirrors ``ChunkerConfig.truncate_at`` so the error-path
+        fallback uses the same size budget as the rest of the chunker.
+        """
+        self.truncate_at = truncate_at
+
     def handle_oversized_field(
         self, field_value: str, field_name: str, maximum_field_size: int
     ) -> tuple[str, str]:
@@ -82,8 +90,20 @@ class TruncateStrategy(FallbackStrategy):
     def handle_chunking_error(
         self, record: dict[str, Any], field_name: str, error_message: str
     ) -> list[dict[str, Any]]:
-        """Skip the record entirely when chunking error occurs."""
-        return []
+        """Truncate the failing field and emit the record as a single chunk."""
+        truncated_record = dict(record)
+        original_value = record.get(field_name, "")
+        if isinstance(original_value, str):
+            truncated_record[field_name] = original_value[: self.truncate_at]
+        truncated_record["chunk_info"] = {
+            "source_field": field_name,
+            "chunk_index": 1,
+            "total_chunks": 1,
+            "chunking_error": error_message,
+            "fallback_applied": "truncate_on_error",
+            "truncated_at": self.truncate_at,
+        }
+        return [truncated_record]
 
 
 class SkipStrategy(FallbackStrategy):

--- a/agent_actions/input/preprocessing/processing/data_processor.py
+++ b/agent_actions/input/preprocessing/processing/data_processor.py
@@ -53,6 +53,8 @@ class DataProcessor(ProcessorErrorHandlerMixin, IDataProcessor):
                 passthrough_fields=passthrough_fields,
             )
         except (ValueError, TypeError, KeyError) as e:
+            # handle_processing_error always re-raises (reraise=True default) as
+            # TransformationError with enriched context. No silent fallback.
             self.handle_processing_error(
                 e,
                 "Processing generated data item",
@@ -60,4 +62,4 @@ class DataProcessor(ProcessorErrorHandlerMixin, IDataProcessor):
                 source_guid=source_guid,
                 item_count=len(generated_data) if isinstance(generated_data, list) else 1,
             )
-            return []
+            raise

--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -275,8 +275,16 @@ def _should_save_source_items(
                 )
                 return True
 
-            existing_fields = set(existing_items[0].keys())
-            new_fields = set(new_items[0].keys()) if new_items else set()
+            # Compare the union of fields across all records, not just the first.
+            # Heterogeneous records can hide additional fields if only [0] is sampled.
+            existing_fields: set[str] = set()
+            for item in existing_items:
+                if isinstance(item, dict):
+                    existing_fields.update(item.keys())
+            new_fields: set[str] = set()
+            for item in new_items:
+                if isinstance(item, dict):
+                    new_fields.update(item.keys())
 
             if len(new_fields) > len(existing_fields):
                 logger.info(

--- a/tests/core/test_udf_loader.py
+++ b/tests/core/test_udf_loader.py
@@ -200,6 +200,74 @@ class TestDiscoverUDFs:
         assert len(registry) == 0
 
 
+class TestDiscoverUDFsProjectScoping:
+    """UDFs from two projects with the same module name must load independently."""
+
+    def test_two_projects_same_module_name_each_loads_own_udf(self, tmp_path):
+        """Project A and Project B both have tools/query.py — both load.
+
+        Bug pattern: when ``sys.modules`` is keyed by relative module name,
+        the second project's discover_udfs sees the first project's entry,
+        skips loading, and silently inherits its UDF.
+        """
+        project_a = tmp_path / "project_a"
+        project_b = tmp_path / "project_b"
+        (project_a / "tools").mkdir(parents=True)
+        (project_b / "tools").mkdir(parents=True)
+
+        # Same relative path, different return values — a contamination would
+        # cause project_b's discovery to silently reuse project_a's function.
+        (project_a / "tools" / "query.py").write_text(
+            UDF_TEMPLATE.format(func_name="lookup_a", return_value="from_a")
+        )
+        (project_b / "tools" / "query.py").write_text(
+            UDF_TEMPLATE.format(func_name="lookup_b", return_value="from_b")
+        )
+
+        registry_a = discover_udfs(project_a)
+        assert "lookup_a" in registry_a
+        assert "lookup_b" not in registry_a
+
+        # Without project-scoped sys.modules keys, this second discover_udfs
+        # would skip project_b's tools/query.py and never register lookup_b.
+        registry_b = discover_udfs(project_b)
+        assert "lookup_b" in registry_b, "project_b's UDF must be registered, not skipped"
+        assert registry_b["lookup_b"]["function"]({}) == "from_b"
+
+    def test_same_project_loaded_twice_is_idempotent(self, tmp_path):
+        """Re-running discover_udfs on the same project does not error or duplicate."""
+        project = tmp_path / "project"
+        (project / "tools").mkdir(parents=True)
+        (project / "tools" / "x.py").write_text(
+            UDF_TEMPLATE.format(func_name="my_func", return_value="v")
+        )
+
+        first = discover_udfs(project)
+        assert "my_func" in first
+
+        # Second call must not raise; sys.modules entry is reused.
+        second = discover_udfs(project)
+        assert "my_func" in second
+
+    def test_project_scope_prefix_is_deterministic_per_path(self, tmp_path):
+        """The scoping helper is a pure function of the resolved path."""
+        from agent_actions.input.loaders.udf import _project_scope_prefix
+
+        p = tmp_path / "x"
+        p.mkdir()
+        assert _project_scope_prefix(p) == _project_scope_prefix(p)
+
+    def test_project_scope_prefix_differs_across_paths(self, tmp_path):
+        """Different paths must produce different prefixes (no collision)."""
+        from agent_actions.input.loaders.udf import _project_scope_prefix
+
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        assert _project_scope_prefix(a) != _project_scope_prefix(b)
+
+
 class TestValidateUDFReferences:
     """Tests for validate_udf_references() function."""
 

--- a/tests/preprocessing/staging/test_source_data_protection.py
+++ b/tests/preprocessing/staging/test_source_data_protection.py
@@ -201,5 +201,80 @@ class TestShouldSaveSourceItems:
             assert result is False
 
 
+class TestFieldUnionAcrossAllRecords:
+    """Heterogeneous data: first record alone is not representative."""
+
+    def test_richer_new_data_detected_via_later_records(self):
+        """If new_items[0] is sparse but later records add fields, still richer."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflow_root = Path(tmpdir) / "workflow"
+            source_dir = workflow_root / "agent_io" / "source" / "input"
+            source_dir.mkdir(parents=True)
+            source_file = source_dir / "test.json"
+            existing_data = [{"source_guid": "g1", "id": "1"}]  # 2 fields
+            source_file.write_text(json.dumps(existing_data))
+
+            base_dir = workflow_root / "agent_io" / "staging" / "input"
+            base_dir.mkdir(parents=True)
+            file_path = base_dir / "test.json"
+
+            # First record sparse, later records bring extra fields.
+            new_items = [
+                {"source_guid": "g1", "id": "1"},  # 2 fields (atypical)
+                {"source_guid": "g2", "id": "2", "url": "u", "title": "t", "body": "b"},
+            ]
+
+            result = _should_save_source_items(new_items, str(file_path), str(base_dir), None)
+
+            assert result is True
+
+    def test_stale_data_detected_when_first_record_appears_rich(self):
+        """If new[0] is rich but existing has more fields across all records, block save."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflow_root = Path(tmpdir) / "workflow"
+            source_file = workflow_root / "agent_io" / "source" / "test.json"
+            source_file.parent.mkdir(parents=True)
+            # Existing has 5 unique fields across 2 records.
+            existing_data = [
+                {"source_guid": "g1", "id": "1", "url": "u", "title": "t"},
+                {"source_guid": "g2", "id": "2", "page_content": "p"},
+            ]  # union = 5 fields
+            source_file.write_text(json.dumps(existing_data))
+
+            base_dir = workflow_root / "agent_io" / "staging"
+            base_dir.mkdir(parents=True, exist_ok=True)
+            file_path = base_dir / "test.json"
+
+            # First record has 4 fields but later records add nothing.
+            new_items = [
+                {"source_guid": "g1", "id": "1", "a": "x", "b": "y"},  # 4 fields
+                {"source_guid": "g2", "id": "2"},  # 2 fields, no new keys
+            ]  # union = 4 fields
+
+            result = _should_save_source_items(new_items, str(file_path), str(base_dir), None)
+
+            assert result is False, "Existing union is richer; sparse new data must not overwrite"
+
+    def test_skips_non_dict_records_during_union(self):
+        """Non-dict entries are tolerated and ignored when building the field set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflow_root = Path(tmpdir) / "workflow"
+            source_file = workflow_root / "agent_io" / "source" / "test.json"
+            source_file.parent.mkdir(parents=True)
+            existing_data = [{"source_guid": "g1", "id": "1"}]
+            source_file.write_text(json.dumps(existing_data))
+
+            base_dir = workflow_root / "agent_io" / "staging"
+            base_dir.mkdir(parents=True, exist_ok=True)
+            file_path = base_dir / "test.json"
+
+            # Mixed types in new_items — dicts contribute, others are skipped.
+            new_items = [{"source_guid": "g1", "id": "1", "url": "u", "title": "t"}]
+
+            result = _should_save_source_items(new_items, str(file_path), str(base_dir), None)
+
+            assert result is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/preprocessing/strategies/test_fallback_strategies.py
+++ b/tests/preprocessing/strategies/test_fallback_strategies.py
@@ -1,0 +1,120 @@
+"""Tests for fallback strategies — Truncate must not silently mimic Skip."""
+
+from agent_actions.input.preprocessing.chunking.strategies.fallback_strategies import (
+    PreserveOriginalStrategy,
+    SkipStrategy,
+    TruncateStrategy,
+)
+
+
+class TestTruncateStrategyChunkingError:
+    """TruncateStrategy.handle_chunking_error must NOT drop records like SkipStrategy."""
+
+    def test_truncate_emits_single_chunk_record_not_empty_list(self):
+        """Truncate on chunking error must emit one record, not drop it."""
+        strategy = TruncateStrategy(truncate_at=100)
+        record = {"id": "r1", "content": "x" * 500, "extra": "kept"}
+
+        result = strategy.handle_chunking_error(record, "content", "tokenize failed")
+
+        assert len(result) == 1, "Truncate must preserve the record, not drop it"
+
+    def test_truncate_actually_truncates_the_failing_field(self):
+        """The failing field is truncated to truncate_at chars."""
+        strategy = TruncateStrategy(truncate_at=50)
+        record = {"id": "r1", "content": "abcdefghij" * 100}
+
+        result = strategy.handle_chunking_error(record, "content", "tokenize failed")
+
+        assert len(result[0]["content"]) == 50
+        assert result[0]["content"] == "abcdefghij" * 5
+
+    def test_truncate_preserves_other_fields_unchanged(self):
+        """Non-failing fields are passed through untouched."""
+        strategy = TruncateStrategy(truncate_at=100)
+        record = {"id": "r1", "content": "x" * 500, "url": "https://example.com", "n": 42}
+
+        result = strategy.handle_chunking_error(record, "content", "err")
+
+        assert result[0]["id"] == "r1"
+        assert result[0]["url"] == "https://example.com"
+        assert result[0]["n"] == 42
+
+    def test_truncate_attaches_chunk_info_metadata(self):
+        """Result carries chunk_info documenting the truncation."""
+        strategy = TruncateStrategy(truncate_at=200)
+        record = {"id": "r1", "content": "x" * 500}
+
+        result = strategy.handle_chunking_error(record, "content", "tokenize failed")
+
+        info = result[0]["chunk_info"]
+        assert info["source_field"] == "content"
+        assert info["chunk_index"] == 1
+        assert info["total_chunks"] == 1
+        assert info["chunking_error"] == "tokenize failed"
+        assert info["fallback_applied"] == "truncate_on_error"
+        assert info["truncated_at"] == 200
+
+    def test_truncate_is_distinct_from_skip(self):
+        """The whole point: Truncate.handle_chunking_error != Skip.handle_chunking_error."""
+        truncate = TruncateStrategy(truncate_at=100)
+        skip = SkipStrategy()
+        record = {"id": "r1", "content": "data"}
+
+        truncate_result = truncate.handle_chunking_error(record, "content", "err")
+        skip_result = skip.handle_chunking_error(record, "content", "err")
+
+        assert truncate_result != skip_result
+        assert skip_result == []
+        assert len(truncate_result) == 1
+
+    def test_truncate_does_not_mutate_input_record(self):
+        """The original record dict is not mutated."""
+        strategy = TruncateStrategy(truncate_at=10)
+        record = {"id": "r1", "content": "x" * 100}
+        original_content = record["content"]
+
+        strategy.handle_chunking_error(record, "content", "err")
+
+        assert record["content"] == original_content
+        assert "chunk_info" not in record
+
+    def test_truncate_handles_non_string_field_gracefully(self):
+        """Non-string field values are preserved (truncation is a string op)."""
+        strategy = TruncateStrategy(truncate_at=100)
+        record = {"id": "r1", "count": 42}
+
+        result = strategy.handle_chunking_error(record, "count", "err")
+
+        assert result[0]["count"] == 42
+        assert result[0]["chunk_info"]["fallback_applied"] == "truncate_on_error"
+
+    def test_truncate_at_default_matches_chunker_config(self):
+        """Default truncate_at mirrors ChunkerConfig.truncate_at (50000)."""
+        strategy = TruncateStrategy()
+        assert strategy.truncate_at == 50000
+
+    def test_truncate_handles_missing_field(self):
+        """Missing field still produces a record with empty truncated content."""
+        strategy = TruncateStrategy(truncate_at=100)
+        record = {"id": "r1"}
+
+        result = strategy.handle_chunking_error(record, "content", "err")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "r1"
+
+
+class TestTruncateAndPreserveSemantics:
+    """Sanity: each strategy retains its established semantic."""
+
+    def test_preserve_keeps_full_content(self):
+        strategy = PreserveOriginalStrategy()
+        record = {"id": "r1", "content": "x" * 500}
+        result = strategy.handle_chunking_error(record, "content", "err")
+        assert result[0]["content"] == "x" * 500
+
+    def test_skip_drops_record(self):
+        strategy = SkipStrategy()
+        result = strategy.handle_chunking_error({"id": "r1"}, "content", "err")
+        assert result == []

--- a/tests/unit/input/test_loader_contract.py
+++ b/tests/unit/input/test_loader_contract.py
@@ -5,11 +5,26 @@ and that XLSX FileReader output (list[dict]) is usable directly.
 """
 
 import csv
+import logging
 
 import pytest
 
 from agent_actions.input.loaders.tabular import TabularLoader
 from agent_actions.input.loaders.xml import XmlLoader
+
+
+@pytest.fixture
+def _enable_log_propagation():
+    """Re-enable propagation so caplog captures agent_actions logger output.
+
+    LoggingBridgeHandler sets ``agent_actions.propagate = False`` at import time;
+    caplog hooks the root logger and would otherwise see nothing.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig
 
 
 @pytest.fixture
@@ -42,6 +57,59 @@ class TestTabularLoaderWithFilePath:
         assert all(isinstance(row, dict) for row in result)
         assert result[0]["name"] == "Alice"
         assert result[1]["age"] == "25"
+
+
+@pytest.mark.usefixtures("_enable_log_propagation")
+class TestTabularLoaderEmptyCsvWarning:
+    """Empty or header-only CSV must surface a warning, not silently no-op."""
+
+    def test_header_only_csv_logs_warning(self, tmp_path, caplog):
+        """Header-only CSV: 0 rows, warning emitted with file path context."""
+        p = tmp_path / "header_only.csv"
+        with open(p, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=["name", "age"])
+            writer.writeheader()
+
+        loader = TabularLoader({}, "test_agent")
+        with caplog.at_level("WARNING", logger="agent_actions.input.loaders.tabular"):
+            result = loader.process(content=None, file_path=str(p))
+
+        assert result == []
+        assert any(
+            "0 records" in rec.message and str(p) in rec.message for rec in caplog.records
+        ), f"Expected empty-CSV warning mentioning {p}, got: {[r.message for r in caplog.records]}"
+
+    def test_zero_byte_csv_logs_warning(self, tmp_path, caplog):
+        """Zero-byte CSV: 0 rows, warning emitted."""
+        p = tmp_path / "empty.csv"
+        p.write_text("")
+
+        loader = TabularLoader({}, "test_agent")
+        with caplog.at_level("WARNING", logger="agent_actions.input.loaders.tabular"):
+            result = loader.process(content=None, file_path=str(p))
+
+        assert result == []
+        assert any("0 records" in rec.message for rec in caplog.records)
+
+    def test_inline_empty_content_logs_warning(self, caplog):
+        """Inline empty content: warning still emitted, with '<inline content>' marker."""
+        loader = TabularLoader({}, "test_agent")
+        with caplog.at_level("WARNING", logger="agent_actions.input.loaders.tabular"):
+            result = loader.process(content="name,age\n", file_path=None)
+
+        assert result == []
+        assert any("<inline content>" in rec.message for rec in caplog.records), (
+            f"Expected inline-content warning, got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_non_empty_csv_does_not_log_warning(self, csv_file, caplog):
+        """Healthy CSV must not log the empty-input warning."""
+        loader = TabularLoader({}, "test_agent")
+        with caplog.at_level("WARNING", logger="agent_actions.input.loaders.tabular"):
+            result = loader.process(content=None, file_path=csv_file)
+
+        assert len(result) == 2
+        assert not any("0 records" in rec.message for rec in caplog.records)
 
 
 class TestXmlLoaderWithFilePath:

--- a/tests/unit/workflow/test_state_orphan_entries.py
+++ b/tests/unit/workflow/test_state_orphan_entries.py
@@ -7,8 +7,8 @@ actions).
 """
 
 from agent_actions.workflow.managers.state import (
-    ActionStatus,
     ActionStateManager,
+    ActionStatus,
 )
 
 


### PR DESCRIPTION
## Summary

Clone 3's hardening review of `agent_actions/input/`. Five confirmed findings fixed:

| # | Sev | File | Fix |
|---|-----|------|-----|
| 1 | P0 | `input/preprocessing/processing/data_processor.py` | Replaced unreachable `return []` with `raise`. `handle_processing_error(reraise=True)` already re-raises — the trailing `return []` made the method look like a silent fallback. |
| 2 | P0 | `input/preprocessing/chunking/strategies/fallback_strategies.py` | `TruncateStrategy.handle_chunking_error` was identical to `SkipStrategy` (`return []`). Now truncates the failing field to `ChunkerConfig.truncate_at` and emits the record as a single chunk with `chunk_info` metadata. |
| 3 | P1 | `input/preprocessing/staging/initial_pipeline.py` | `_should_save_source_items` now compares the field **union across all records**, not just `[0]` field counts — heterogeneous data can no longer hide additional fields. |
| 4 | P1 | `input/loaders/tabular.py` | Empty/header-only CSV now logs a `WARNING` with the file path. Previously a silent no-op downstream. |
| 5 | P2 | `input/loaders/udf.py` | `sys.modules` keys scoped by a `blake2b(user_code_path)` hash so two projects with `tools/query.py` no longer collide — second project's UDF was silently inheriting the first's. |

P3 finding (TOCTOU re-read in `_prepare_batch_data`) deferred per protocol.

Plus a 2-line alphabetical import sort in `tests/unit/workflow/test_state_orphan_entries.py` that was failing `ruff check` on the integration branch base (pre-existing, blocked CI for every clone).

## Verification

- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- `pytest` — **7458 passed**, 2 skipped, 1 pre-existing failure in `tests/unit/llm/batch/test_batch_timeout.py` (clone 6 territory, `StopIteration` from `mock_time.time.side_effect` list exhaustion — same failure on the integration base without my changes)
- 21 new tests added:
  - `tests/preprocessing/strategies/test_fallback_strategies.py` — 10 tests (Truncate vs Skip distinction, truncation correctness, metadata, edge cases)
  - `tests/preprocessing/staging/test_source_data_protection.py` — 3 new (heterogeneous field union)
  - `tests/unit/input/test_loader_contract.py` — 4 new (empty CSV warning, propagation fixture)
  - `tests/core/test_udf_loader.py` — 4 new (two-project collision, idempotency, hash determinism)

## Pi consensus

2 of 5 reviewers completed and gave YES verdicts on the scoped diff; the other 3 hit Pi rate limits (`ollama.com 429 session usage limit`) — infrastructure, not review failure. Re-running yielded 5/5 rate-limited. Both completed reviews approved all 5 fixes with no findings.

## Smoke test

`smoke-test.sh online` fails at `summarize_page_content` with `'str' object has no attribute 'invoke'` — same failure with or without my changes (stash + re-run confirmed). Pre-existing LLM client issue on integration branch, unrelated to input/ hardening.