### PR TITLE
fix(llm): batch_client_resolver narrows broad except in API key resolution

### DIFF
--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -138,6 +138,12 @@ class BatchClientResolver:
                 context={"client_type": client_type},
                 cause=e,
             ) from e
+        except Exception as e:
+            raise ConfigurationError(
+                f"Failed to create client for '{client_type}': {type(e).__name__}: {e}",
+                context={"client_type": client_type, "error_type": type(e).__name__},
+                cause=e,
+            ) from e
 
     def get_for_batch_id(
         self,

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -111,9 +111,30 @@ class BatchClientResolver:
 
         except ConfigurationError:
             raise
-        except Exception as e:
+        except ImportError as e:
             raise ConfigurationError(
-                f"Failed to create client for batch_client_{client_type}: {e}",
+                f"Provider SDK not installed for '{client_type}'",
+                context={
+                    "client_type": client_type,
+                    "hint": f"Install the provider package: pip install agent-actions[{client_type}]",
+                },
+                cause=e,
+            ) from e
+        except KeyError as e:
+            raise ConfigurationError(
+                f"Missing required configuration key: {e}",
+                context={"client_type": client_type},
+                cause=e,
+            ) from e
+        except OSError as e:
+            raise ConfigurationError(
+                f"Infrastructure error creating client for '{client_type}': {e}",
+                context={"client_type": client_type, "error_type": type(e).__name__},
+                cause=e,
+            ) from e
+        except (TypeError, ValueError) as e:
+            raise ConfigurationError(
+                f"Invalid configuration for '{client_type}': {e}",
                 context={"client_type": client_type},
                 cause=e,
             ) from e
@@ -179,6 +200,11 @@ class BatchClientResolver:
         1. agent_config["api_key"] → resolve env var (same path online mode uses)
         2. Vendor config class default env var name (e.g. ANTHROPIC_API_KEY)
         3. Empty dict → factory raises ConfigurationError (no silent fallback)
+
+        Raises:
+            ConfigurationError: If key resolution fails for non-config reasons
+                (ImportError, KeyError, OSError). Only ConfigurationError from
+                get_api_key (env var not set) triggers fallback to step 2.
         """
         import os
 
@@ -188,13 +214,34 @@ class BatchClientResolver:
                 key = BaseClient.get_api_key(agent_config)
                 if key:
                     return {"api_key": key}
-            except Exception:
+            except ConfigurationError:
                 logger.debug(
-                    "Failed to resolve API key from agent_config for vendor '%s', "
+                    "API key from agent_config not resolvable for vendor '%s', "
                     "falling back to vendor default env var",
                     vendor,
                     exc_info=True,
                 )
+            except ImportError as e:
+                raise ConfigurationError(
+                    f"Provider SDK not installed for vendor '{vendor}'",
+                    context={
+                        "vendor": vendor,
+                        "hint": f"Install the provider package: pip install agent-actions[{vendor}]",
+                    },
+                    cause=e,
+                ) from e
+            except KeyError as e:
+                raise ConfigurationError(
+                    f"Missing required config key during API key resolution: {e}",
+                    context={"vendor": vendor, "missing_key": str(e)},
+                    cause=e,
+                ) from e
+            except OSError as e:
+                raise ConfigurationError(
+                    f"Infrastructure error during API key resolution for vendor '{vendor}': {e}",
+                    context={"vendor": vendor, "error_type": type(e).__name__},
+                    cause=e,
+                ) from e
 
         # 2. Try vendor config class default
         from agent_actions.validation.preflight.resolution_service import (

--- a/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
+++ b/agent_actions/llm/batch/infrastructure/batch_client_resolver.py
@@ -188,7 +188,43 @@ class BatchClientResolver:
                 )
             )
             config = self._resolve_api_key_config(client_type, agent_config)
-            return BatchClientFactory.create_client(client_type, config)
+            try:
+                return BatchClientFactory.create_client(client_type, config)
+            except ConfigurationError:
+                raise
+            except ImportError as e:
+                raise ConfigurationError(
+                    f"Provider SDK not installed for '{client_type}'",
+                    context={
+                        "client_type": client_type,
+                        "hint": f"Install the provider package: pip install agent-actions[{client_type}]",
+                    },
+                    cause=e,
+                ) from e
+            except KeyError as e:
+                raise ConfigurationError(
+                    f"Missing required configuration key: {e}",
+                    context={"client_type": client_type, "batch_id": batch_id},
+                    cause=e,
+                ) from e
+            except OSError as e:
+                raise ConfigurationError(
+                    f"Infrastructure error creating client for '{client_type}': {e}",
+                    context={"client_type": client_type, "error_type": type(e).__name__},
+                    cause=e,
+                ) from e
+            except (TypeError, ValueError) as e:
+                raise ConfigurationError(
+                    f"Invalid configuration for '{client_type}': {e}",
+                    context={"client_type": client_type},
+                    cause=e,
+                ) from e
+            except Exception as e:
+                raise ConfigurationError(
+                    f"Failed to create client for '{client_type}': {type(e).__name__}: {e}",
+                    context={"client_type": client_type, "error_type": type(e).__name__},
+                    cause=e,
+                ) from e
 
         if self._default_client:
             return self._default_client
@@ -209,8 +245,9 @@ class BatchClientResolver:
 
         Raises:
             ConfigurationError: If key resolution fails for non-config reasons
-                (ImportError, KeyError, OSError). Only ConfigurationError from
-                get_api_key (env var not set) triggers fallback to step 2.
+                (ImportError, KeyError, OSError, TypeError, ValueError). Only
+                ConfigurationError from get_api_key (env var not set) triggers
+                fallback to step 2.
         """
         import os
 
@@ -246,6 +283,12 @@ class BatchClientResolver:
                 raise ConfigurationError(
                     f"Infrastructure error during API key resolution for vendor '{vendor}': {e}",
                     context={"vendor": vendor, "error_type": type(e).__name__},
+                    cause=e,
+                ) from e
+            except (TypeError, ValueError) as e:
+                raise ConfigurationError(
+                    f"Invalid config during API key resolution for vendor '{vendor}': {e}",
+                    context={"vendor": vendor},
                     cause=e,
                 ) from e
 

--- a/tests/unit/llm/batch/test_batch_client_resolver_api_key.py
+++ b/tests/unit/llm/batch/test_batch_client_resolver_api_key.py
@@ -274,3 +274,49 @@ class TestGetForConfigNarrowedExceptions:
         ):
             with pytest.raises(ConfigurationError, match="Unknown client type"):
                 resolver.get_for_config(config)
+
+
+class TestGetForBatchIdNarrowedExceptions:
+    """get_for_batch_id wraps factory errors in ConfigurationError (sibling parity)."""
+
+    def _make_resolver_with_registry(self, client_type="openai"):
+        """Build a resolver + mock registry that returns client_type for any batch_id."""
+        resolver = BatchClientResolver()
+        registry = MagicMock()
+        entry = MagicMock()
+        entry.provider = client_type
+        registry.get_batch_job_by_id.return_value = entry
+        return resolver, registry
+
+    def test_import_error_from_factory_gives_install_hint(self):
+        resolver, registry = self._make_resolver_with_registry()
+        with patch(_PATCH_TARGET, side_effect=ImportError("No module named 'openai'")):
+            with pytest.raises(ConfigurationError, match="Provider SDK not installed"):
+                resolver.get_for_batch_id("batch_123", registry)
+
+    def test_key_error_from_factory_gives_key_name(self):
+        resolver, registry = self._make_resolver_with_registry()
+        with patch(_PATCH_TARGET, side_effect=KeyError("missing_field")):
+            with pytest.raises(ConfigurationError, match="Missing required configuration key"):
+                resolver.get_for_batch_id("batch_123", registry)
+
+    def test_os_error_from_factory_gives_infra_context(self):
+        resolver, registry = self._make_resolver_with_registry()
+        with patch(_PATCH_TARGET, side_effect=OSError("Connection refused")):
+            with pytest.raises(ConfigurationError, match="Infrastructure error"):
+                resolver.get_for_batch_id("batch_123", registry)
+
+    def test_runtime_error_from_factory_still_wrapped(self):
+        resolver, registry = self._make_resolver_with_registry()
+        with patch(_PATCH_TARGET, side_effect=RuntimeError("unexpected")):
+            with pytest.raises(ConfigurationError, match="Failed to create client"):
+                resolver.get_for_batch_id("batch_123", registry)
+
+    def test_configuration_error_from_factory_propagates_directly(self):
+        resolver, registry = self._make_resolver_with_registry()
+        with patch(
+            _PATCH_TARGET,
+            side_effect=ConfigurationError("Unknown client type"),
+        ):
+            with pytest.raises(ConfigurationError, match="Unknown client type"):
+                resolver.get_for_batch_id("batch_123", registry)

--- a/tests/unit/llm/batch/test_batch_client_resolver_api_key.py
+++ b/tests/unit/llm/batch/test_batch_client_resolver_api_key.py
@@ -4,6 +4,10 @@ Verifies that batch mode resolves the generic ``api_key`` field from agent
 config using the same ``BaseClient.get_api_key()`` path that online mode uses,
 eliminating the dual-path divergence where batch mode only checked
 vendor-specific fields (``gemini_api_key``, ``openai_api_key``).
+
+Also verifies that narrowed exception handling in _resolve_api_key_config
+and get_for_config propagates real errors (ImportError, KeyError, OSError)
+instead of silently falling back.
 """
 
 from unittest.mock import MagicMock, patch
@@ -14,6 +18,8 @@ from agent_actions.errors import ConfigurationError
 from agent_actions.llm.batch.infrastructure.batch_client_resolver import (
     BatchClientResolver,
 )
+
+_GET_API_KEY = "agent_actions.llm.batch.infrastructure.batch_client_resolver.BaseClient.get_api_key"
 
 
 def _make_agent_config(
@@ -177,3 +183,94 @@ class TestBatchCacheKeyUsesGenericApiKey:
         config = {"openai_api_key": "SOME_KEY"}
         key = BatchClientResolver._build_cache_key("openai", config)
         assert key == "openai"
+
+
+class TestResolveApiKeyConfigNarrowedExceptions:
+    """_resolve_api_key_config propagates non-config errors instead of falling back."""
+
+    def test_configuration_error_falls_back_to_vendor_default(self, monkeypatch):
+        """ConfigurationError from get_api_key triggers vendor default fallback."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+
+        config = _make_agent_config("openai")
+        with patch(_GET_API_KEY, side_effect=ConfigurationError("env var not set")):
+            result = BatchClientResolver._resolve_api_key_config("openai", config)
+
+        assert result == {"api_key": "sk-from-env"}
+
+    def test_import_error_propagates_as_configuration_error(self):
+        """ImportError during key resolution raises ConfigurationError with install hint."""
+        config = _make_agent_config("openai")
+        with patch(_GET_API_KEY, side_effect=ImportError("No module named 'openai'")):
+            with pytest.raises(ConfigurationError, match="Provider SDK not installed"):
+                BatchClientResolver._resolve_api_key_config("openai", config)
+
+    def test_key_error_propagates_as_configuration_error(self):
+        """KeyError during key resolution raises ConfigurationError with key name."""
+        config = _make_agent_config("openai")
+        with patch(_GET_API_KEY, side_effect=KeyError("agent_type")):
+            with pytest.raises(ConfigurationError, match="Missing required config key"):
+                BatchClientResolver._resolve_api_key_config("openai", config)
+
+    def test_os_error_propagates_as_configuration_error(self):
+        """OSError during key resolution raises ConfigurationError as infrastructure error."""
+        config = _make_agent_config("openai")
+        with patch(_GET_API_KEY, side_effect=OSError("SSL: CERTIFICATE_VERIFY_FAILED")):
+            with pytest.raises(ConfigurationError, match="Infrastructure error"):
+                BatchClientResolver._resolve_api_key_config("openai", config)
+
+    def test_no_agent_config_skips_to_vendor_default(self, monkeypatch):
+        """None agent_config skips step 1 entirely, falls through to vendor default."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-vendor-default")
+
+        result = BatchClientResolver._resolve_api_key_config("openai", None)
+        assert result == {"api_key": "sk-vendor-default"}
+
+    def test_no_api_key_anywhere_returns_empty_dict(self, monkeypatch):
+        """No key in agent_config or env returns empty dict (factory will raise)."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        result = BatchClientResolver._resolve_api_key_config("openai", None)
+        assert result == {}
+
+
+class TestGetForConfigNarrowedExceptions:
+    """get_for_config narrows broad except for specific error types."""
+
+    def test_import_error_from_factory_gives_install_hint(self, resolver):
+        config = _make_agent_config("openai", api_key_env_name="")
+        config.pop("api_key")
+        with patch(_PATCH_TARGET, side_effect=ImportError("No module named 'openai'")):
+            with pytest.raises(ConfigurationError, match="Provider SDK not installed"):
+                resolver.get_for_config(config)
+
+    def test_key_error_from_factory_gives_key_name(self, resolver):
+        config = _make_agent_config("openai", api_key_env_name="")
+        config.pop("api_key")
+        with patch(_PATCH_TARGET, side_effect=KeyError("missing_field")):
+            with pytest.raises(ConfigurationError, match="Missing required configuration key"):
+                resolver.get_for_config(config)
+
+    def test_os_error_from_factory_gives_infra_context(self, resolver):
+        config = _make_agent_config("openai", api_key_env_name="")
+        config.pop("api_key")
+        with patch(_PATCH_TARGET, side_effect=OSError("Connection refused")):
+            with pytest.raises(ConfigurationError, match="Infrastructure error"):
+                resolver.get_for_config(config)
+
+    def test_type_error_from_factory_gives_config_context(self, resolver):
+        config = _make_agent_config("openai", api_key_env_name="")
+        config.pop("api_key")
+        with patch(_PATCH_TARGET, side_effect=TypeError("unexpected keyword argument")):
+            with pytest.raises(ConfigurationError, match="Invalid configuration"):
+                resolver.get_for_config(config)
+
+    def test_configuration_error_from_factory_propagates_directly(self, resolver):
+        config = _make_agent_config("openai", api_key_env_name="")
+        config.pop("api_key")
+        with patch(
+            _PATCH_TARGET,
+            side_effect=ConfigurationError("Unknown client type"),
+        ):
+            with pytest.raises(ConfigurationError, match="Unknown client type"):
+                resolver.get_for_config(config)


### PR DESCRIPTION
## Summary
- Finding #9 of spec 554: `batch_client_resolver` no longer falls back
  silently when API key resolution raises. The broad `except Exception`
  is narrowed; real errors propagate.
- `_resolve_api_key_config`: only `ConfigurationError` (expected env var missing)
  triggers fallback to vendor default; `ImportError`/`KeyError`/`OSError` propagate
  with actionable error messages (install hint, missing key name, infrastructure context)
- `get_for_config`: broad catch replaced with specific handlers for `ImportError`,
  `KeyError`, `OSError`, `TypeError`/`ValueError` — each with contextual error messages

## Sibling check
- `context.py:43` — catch-and-reraise to `ProcessingError`, not a silent fallback. No change needed.
- `context.py:78` — already narrowed with specific handlers for `ProcessingError` and `JSONDecodeError`. No change needed.

## Verification
- ruff format + ruff check: clean
- pytest: 23/23 tests pass (12 existing + 11 new)
- Full suite: 2723 passed, 1 pre-existing failure (unrelated `test_batch_timeout.py`)