### PR TITLE
docs(audits): consolidate 12 hardening review files into audits/

### DIFF
--- a/audits/INDEX.md
+++ b/audits/INDEX.md
@@ -1,0 +1,59 @@
+# Module Audits — Index
+
+Findings produced during the platform-hardening rounds. Each review records
+the state of one module at the time the review was conducted. The fixes
+those reviews motivated have shipped — the reviews themselves are kept here
+as the historical record of *why* the changes were made.
+
+Future module audits (track 2 of spec 554, and any later rounds) land in
+this same directory and follow the same shape.
+
+## Index
+
+| Module | Review | Findings | Fix PR | Round |
+|---|---|---|---|---|
+| `agent_actions/cli/`         | [cli-review.md](cli-review.md)               | 7  P0/P1 | [#699](https://github.com/Muizzkolapo/agent-actions/pull/699) | Hardening round 1 |
+| `agent_actions/utils/`       | [utils-review.md](utils-review.md)           | 6 mixed  | [#700](https://github.com/Muizzkolapo/agent-actions/pull/700) | Hardening round 1 |
+| `agent_actions/config/`      | [config-review.md](config-review.md)         | 5 mixed  | [#701](https://github.com/Muizzkolapo/agent-actions/pull/701) | Hardening round 1 |
+| `agent_actions/logging/`     | [logging-review.md](logging-review.md)       | 6 mixed  | [#702](https://github.com/Muizzkolapo/agent-actions/pull/702) | Hardening round 1 |
+| `agent_actions/validation/`  | [validation-review.md](validation-review.md) | 5 mixed  | [#703](https://github.com/Muizzkolapo/agent-actions/pull/703) | Hardening round 1 |
+| `agent_actions/guards/`      | [guards-review.md](guards-review.md)         | 4 mixed  | [#704](https://github.com/Muizzkolapo/agent-actions/pull/704) | Hardening round 1 |
+| `agent_actions/prompt/`      | [prompt-review.md](prompt-review.md)         | 6 mixed  | [#708](https://github.com/Muizzkolapo/agent-actions/pull/708) | Hardening round 2 |
+| `agent_actions/tooling/`     | [tooling-review.md](tooling-review.md)       | 6 mixed  | [#706](https://github.com/Muizzkolapo/agent-actions/pull/706) | Hardening round 2 |
+| `agent_actions/input/`       | [input-review.md](input-review.md)           | 6 mixed  | [#710](https://github.com/Muizzkolapo/agent-actions/pull/710) | Hardening round 2 |
+| `agent_actions/output/`      | [output-review.md](output-review.md)         | 6 mixed  | [#709](https://github.com/Muizzkolapo/agent-actions/pull/709) | Hardening round 2 |
+| `agent_actions/errors/`      | [errors-review.md](errors-review.md)         | 4 mixed  | [#707](https://github.com/Muizzkolapo/agent-actions/pull/707) | Hardening round 2 |
+| `agent_actions/models/`      | [models-review.md](models-review.md)         | 6 mixed  | [#705](https://github.com/Muizzkolapo/agent-actions/pull/705) | Hardening round 2 |
+
+## Modules still unreviewed (track 2 of spec 554)
+
+| Module | Status |
+|---|---|
+| `agent_actions/storage/`    | Queued — `audit-storage` contract |
+| `agent_actions/record/`     | Queued — `audit-record` contract |
+| `agent_actions/processing/` | Queued — `audit-processing` contract |
+| `agent_actions/llm/`        | Queued — `audit-llm` contract |
+| `agent_actions/workflow/`   | Queued — `audit-workflow` contract |
+
+## Review shape
+
+Each review follows roughly the same structure:
+
+```markdown
+# Code Review: agent_actions/<module>/
+
+**Date:** YYYY-MM-DD
+**Reviewer:** <who>
+**Files reviewed:** <count>
+
+## Findings
+
+### 1. <severity> — <title>
+- **File:** agent_actions/<module>/<file>.py:<line>
+- **Summary:** ...
+- **Failure scenario:** ...
+- **Severity:** P0/P1/P2/P3
+```
+
+The earliest reviews are looser; later reviews and all track-2 audits
+follow the shape defined in `harness/contracts/_AUDIT_SPEC.md`.

--- a/audits/cli-review.md
+++ b/audits/cli-review.md
@@ -1,0 +1,150 @@
+# Code Review: agent_actions/cli/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (4-angle parallel review + 1-vote verification)
+**Files reviewed:** 25 Python files
+**Verdict:** 14 CONFIRMED, 1 PLAUSIBLE, 2 REFUTED
+
+---
+
+## Findings (ranked by severity)
+
+### 1. CONFIRMED — inspect_base._load_workflow diverges from workflow_loader.load_workflow
+
+- **File:** `agent_actions/cli/inspect_base.py:46,50`
+- **Summary:** `_load_workflow` omits `project_root` arg on `find_config_file` and omits `output_dir` (rendered_workflows_dir) on `render_and_load_config`. All 4 inspect subcommands see a structurally different workflow object than run/retry.
+- **Failure scenario:** User runs `agac inspect graph` then `agac run`. Inspect resolves config from CWD instead of project root on fallback path. Inspect renders config in-memory only (no persisted rendered YAML), while run persists it. The two commands operate on different representations of the same workflow.
+- **Severity:** HIGH — silent behavioral divergence between inspect and run
+
+### 2. CONFIRMED — Execution summary render errors silently swallowed
+
+- **File:** `agent_actions/cli/run.py:119`
+- **Summary:** ExecutionRenderer wrapped in `except Exception` logged only at DEBUG level. If build_execution_snapshot raises (e.g., after partial initialization failure), user sees no post-run summary with no indication anything went wrong.
+- **Failure scenario:** After a workflow run, `build_execution_snapshot` raises AttributeError due to services structure change. User sees clean exit, no summary table, no error — appears as if run completed cleanly.
+- **Severity:** HIGH — silent fallback, merge-blocking anti-pattern
+
+### 3. CONFIRMED — Retry runs invisible to RunTracker/docs history
+
+- **File:** `agent_actions/cli/retry.py:222`
+- **Summary:** `workflow.run()` called without attaching a RunTracker. Unlike RunCommand which wires up RunTracker, retry runs are completely invisible to docs history and `tracker.finalize_workflow_run` is never called.
+- **Failure scenario:** User retries a failed workflow successfully. Docs server shows only the original failed run as the last entry. Run duration and outcome for the retry are never persisted.
+- **Severity:** HIGH — data integrity gap in run history
+
+### 4. CONFIRMED — init.py TOCTOU race in _create_project_directory
+
+- **File:** `agent_actions/cli/init.py:226`
+- **Summary:** `mkdtemp()` creates temp dir, immediately `rmtree()` deletes it, then `rename()` moves project into the deleted path. Between rmtree and rename, another process can occupy the path.
+- **Failure scenario:** `agac init --force existing_project` in a directory with concurrent file indexing. Another process creates backup_dir between rmtree and rename. rename fails with FileExistsError, and the project has already been moved away — user left with no project at either location.
+- **Severity:** MEDIUM — race condition, data loss risk
+
+### 5. CONFIRMED — dispositions.py column header mismatch
+
+- **File:** `agent_actions/cli/dispositions.py:95`
+- **Summary:** Table column header says "Quarantined" but displays `counts.get("unprocessed", 0)`. These are different disposition states.
+- **Failure scenario:** User runs `agac dispositions -a workflow`. The "Quarantined" column shows unprocessed count, not quarantined count. Records actually in quarantined state are misrepresented.
+- **Severity:** MEDIUM — misleading CLI output
+
+### 6. CONFIRMED — inspect_base._analyze_dependencies omits 'drop' from context_scope
+
+- **File:** `agent_actions/cli/inspect_base.py:110`
+- **Summary:** context_scope dict only includes 'observe' and 'passthrough' keys. The 'drop' key is omitted from `agac inspect action --json` output.
+- **Failure scenario:** User runs `agac inspect action --json` to analyze dependencies. Drop rules are invisible in the output. Downstream tooling parsing the JSON misses active drop rules.
+- **Severity:** MEDIUM — incomplete data in CLI output
+
+### 7. CONFIRMED — init.py silent network error swallowing
+
+- **File:** `agent_actions/cli/init.py:96`
+- **Summary:** README fetch errors caught as `except (click.ClickException, IndexError): pass` in `_list_remote_examples`. Network failures produce empty descriptions with no warning.
+- **Failure scenario:** User runs `agac example list` on intermittent connection. All examples show empty descriptions, no indication that fetching failed.
+- **Severity:** MEDIUM — silent fallback
+
+### 8. CONFIRMED — docs.py raises click.Abort instead of ClickException
+
+- **File:** `agent_actions/cli/docs.py:50`
+- **Summary:** On failure paths (no workflows found, serve_docs fails), raises `click.Abort()` which prints "Aborted!" instead of an actionable error message. Abort is for Ctrl-C, not application failures.
+- **Failure scenario:** User runs `agac docs` in empty project. Sees "No workflows found to document." followed by "Aborted!" — inconsistent with all other commands that raise ClickException.
+- **Severity:** MEDIUM — poor UX, inconsistent error handling
+
+### 9. CONFIRMED — docs.py run_tests dead in user projects
+
+- **File:** `agent_actions/cli/docs.py:58`
+- **Summary:** `run_tests` expects Playwright .js test files in project root that are never distributed to user projects. Command immediately aborts for all real users.
+- **Failure scenario:** User runs `agac docs test`, gets "Test files not found" and Aborted. Feature is discoverable via --help but non-functional outside framework development.
+- **Severity:** MEDIUM — dead command in user-facing CLI
+
+### 10. CONFIRMED — RunCommand uses click.echo while siblings use rich Console
+
+- **File:** `agent_actions/cli/run.py:37`
+- **Summary:** RunCommand uses `click.echo` throughout for status messages. All sibling commands (retry, status, dispositions, etc.) use rich Console. Inconsistent terminal output behavior.
+- **Failure scenario:** On narrow terminals, rich-rendered output from ExecutionRenderer adapts to width while click.echo status lines do not. Piped output mixes rich formatting with raw click.echo lines.
+- **Severity:** LOW — inconsistent output, no correctness impact
+
+### 11. CONFIRMED — cli_decorators.py project root message pollutes JSON output
+
+- **File:** `agent_actions/cli/cli_decorators.py:62`
+- **Summary:** `click.echo('📁 Project root: ...', err=True)` emitted unconditionally, even in `--json` mode. Tools capturing stderr see non-JSON content.
+- **Failure scenario:** CI script runs `agac inspect deps -a foo --json 2>&1 | jq '.'`. The project root line mixed into captured output causes jq to fail.
+- **Severity:** LOW — pollutes stderr for machine consumers
+
+### 12. CONFIRMED — Full AgentWorkflow constructed just to read execution_order
+
+- **File:** `agent_actions/cli/dispositions.py:48`
+- **Summary:** `load_workflow()` constructs full AgentWorkflow (storage backend, service graph) just to read `workflow.execution_order` — a static list from YAML config.
+- **Failure scenario:** User runs `agac dispositions -a workflow` that has never been run (no SQLite DB). Storage init may log misleading errors for a command that only needs config.
+- **Severity:** LOW — unnecessary overhead
+
+### 13. CONFIRMED — example.py/init.py YAML injection block duplicated
+
+- **File:** `agent_actions/cli/example.py:69` and `agent_actions/cli/init.py:422`
+- **Summary:** project_name YAML injection block (yaml.safe_load, set key, yaml.safe_dump, exception handling) is character-for-character identical in both files. No shared helper.
+- **Failure scenario:** Bug fix to injection logic in one file missed in the other. Two diverging code paths for the same operation.
+- **Severity:** LOW — duplication maintenance risk
+
+### 14. CONFIRMED — init.py downloads full repo tarball for single example
+
+- **File:** `agent_actions/cli/init.py:113`
+- **Summary:** `_fetch_example` downloads the entire repository tarball to extract one example subdirectory. On a misspelled name, a second full tarball request is also made.
+- **Failure scenario:** User on slow connection runs `agac example install contract_reviewer`. Downloads entire repo (potentially tens of MB) for one small directory. Misspelled name doubles the wasted bandwidth.
+- **Severity:** LOW — efficiency issue
+
+### 15. CONFIRMED — schema_renderer dead public API
+
+- **File:** `agent_actions/cli/renderers/schema_renderer.py:41`
+- **Summary:** `render_flow_tree` and `render_action_detail` are public methods with zero external callers. `render_action_detail` has no callers anywhere.
+- **Failure scenario:** Dead code accumulates drift. Method signatures and field assumptions diverge from the live schema without any test catching it.
+- **Severity:** LOW — dead code
+
+---
+
+## PLAUSIBLE findings
+
+### P1. Six command classes duplicate setup boilerplate
+
+- **Files:** `status.py, run.py, retry.py, dispositions.py, schema.py, preview.py`
+- **Summary:** Each independently does `Path(agent).stem`, `ProjectPathsFactory.create_project_paths()`, `Console()`. No shared base or factory.
+- **Cost:** New parameter to ProjectPathsFactory requires updating 6 call sites independently.
+
+---
+
+## REFUTED
+
+### R1. inspect.py backward-compat re-exports — REFUTED
+- Actively used by main.py and tests. Not dead code.
+
+### R2. compile.py alias duplication — REFUTED
+- Two separate Click commands with identical options is the expected alias pattern, not duplication on a single command.
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (behavioral divergence) | #1 (inspect vs run workflow objects) | Medium — unify via workflow_loader |
+| P0 (silent fallback) | #2 (execution summary swallowed) | Small — raise or log at warning |
+| P0 (data integrity) | #3 (retry no RunTracker) | Medium — wire RunTracker into retry |
+| P1 (data loss risk) | #4 (TOCTOU race) | Small — don't delete temp dir |
+| P1 (wrong output) | #5 (column mismatch), #6 (missing drop) | Small — fix column/add drop key |
+| P1 (silent fallback) | #7 (network swallowing) | Small — log warning on fetch failure |
+| P2 (UX consistency) | #8, #9, #10, #11 (Abort/echo/JSON/dead cmd) | Small each |
+| P3 (cleanup) | #12-#15 (overhead, duplication, dead code) | Varies |

--- a/audits/config-review.md
+++ b/audits/config-review.md
@@ -1,0 +1,136 @@
+# Code Review: agent_actions/config/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (4-angle parallel review + 1-vote verification)
+**Files reviewed:** 16 Python files
+**Verdict:** 8 CONFIRMED, 5 PLAUSIBLE, 1 REFUTED
+
+---
+
+## Findings (ranked by severity)
+
+### 1. CONFIRMED — find_agent_name crashes on empty YAML (TypeError before None guard)
+
+- **File:** `agent_actions/config/manager.py:141`
+- **Summary:** `find_agent_name` does `'name' in config` before the `if not config` guard. When yaml.safe_load returns None (empty or comment-only file), `'name' in None` raises TypeError.
+- **Failure scenario:** User creates a workflow YAML with only comments. yaml.safe_load returns None. `'name' in None` raises `TypeError: argument of type 'NoneType' is not iterable` — not a ConfigurationError, so no actionable message.
+- **Severity:** HIGH — crashes on valid empty file input
+
+### 2. CONFIRMED — _load_single_config returns None without dict guard
+
+- **File:** `agent_actions/config/manager.py:101`
+- **Summary:** `_load_single_config` return type is annotated `dict[str, Any]` but yaml.safe_load returns None for empty files. Callers like `validate_agent_name` pass None to `find_agent_name` which crashes (see finding #1).
+- **Failure scenario:** Empty YAML file -> None assigned to self.user_config -> validate_agent_name raises RuntimeError("load_configs() must be called") — a completely misleading error.
+- **Severity:** HIGH — misleading error message hides root cause
+
+### 3. CONFIRMED — List-typed YAML bypasses both branches in find_agent_name
+
+- **File:** `agent_actions/config/manager.py:143`
+- **Summary:** If YAML top-level is a list, `'name' in [...]` is False (searches values not keys), `not config` is False for non-empty list, falls through to `next(iter(config))` which returns first list element as agent name.
+- **Failure scenario:** YAML file with `- name: foo` parses to a list. find_agent_name returns the string `'name: foo'` as the agent name. Downstream ConfigurationError about name mismatch with filename.
+- **Severity:** HIGH — silent wrong behavior
+
+### 4. CONFIRMED — DIConfigurator.configure_container ignores config parameter
+
+- **File:** `agent_actions/config/di/configurator.py:21`
+- **Summary:** configure_container(config: DIConfig) accepts a full config dict but never reads any value from it. All environment-specific settings (parallel_processing, cache_enabled, batch_size, timeout, logging level) from ConfigurationProfile.production()/testing() are silently ignored.
+- **Failure scenario:** `ApplicationContainer.create_for_environment('production')` produces the exact same container as 'development'. Environment-specific tuning is impossible.
+- **Severity:** MEDIUM — config system promises environment-awareness it doesn't deliver
+
+### 5. CONFIRMED — Broad except Exception swallows infer_dependencies errors
+
+- **File:** `agent_actions/config/manager.py:326`
+- **Summary:** `determine_execution_order` wraps `infer_dependencies` in `except Exception`, silently falling back to explicit config.dependencies. Any bug in inference (KeyError, AttributeError) is swallowed.
+- **Failure scenario:** Malformed context_scope causes AttributeError in infer_dependencies. Warning logged but fallback uses empty/stale config.dependencies. Workflow runs in wrong order with silently incorrect outputs.
+- **Severity:** MEDIUM — silent fallback masks bugs
+
+### 6. CONFIRMED — Five dead public methods on ConfigManager
+
+- **File:** `agent_actions/config/manager.py:422,439,455`
+- **Summary:** `validate_all_configs`, `create_pipeline_config`, `get_configuration_summary`, `get_agent_config`, `get_all_agent_configs` have zero callers in the production codebase. `workflow_config` and `pipeline_config` attributes are never assigned.
+- **Failure scenario:** Dead code that accumulates drift. get_configuration_summary always reports workflow.loaded=False. create_pipeline_config references PipelineConfig that may not exist at the imported path.
+- **Severity:** MEDIUM — dead code / false API surface
+
+### 7. CONFIRMED — Tool path normalization duplicated from path_config.py
+
+- **File:** `agent_actions/config/manager.py:104`
+- **Summary:** load_configs re-implements tool_path normalization (str-vs-list, default to 'tools') already available in `path_config.py:get_tool_dirs`. Manager version has no path-traversal guard.
+- **Failure scenario:** If path-traversal protection is added to get_tool_dirs, manager.py's copy remains unprotected. Two code paths for the same logic, one less secure.
+- **Severity:** MEDIUM — duplication with security divergence risk
+
+### 8. CONFIRMED — IAsyncCapable interface never consumed by runtime
+
+- **File:** `agent_actions/config/interfaces.py:28`
+- **Summary:** `supports_async()` and `get_processing_mode()` are abstract on IAsyncCapable, forcing all concrete classes to implement them (always returning False/AUTO), but no runtime code ever calls these methods.
+- **Failure scenario:** ProcessingMode.AUTO/SYNC/ASYNC enum exists, 5+ classes implement the interface methods, but the runtime never consults them. Pure dead abstraction.
+- **Severity:** MEDIUM — dead interface tax on all implementations
+
+### 9. CONFIRMED — EnvironmentConfig validates fields nothing reads
+
+- **File:** `agent_actions/config/environment.py:27`
+- **Summary:** Fields database_url, max_concurrency, default_batch_size, cache_ttl, enable_parallel_processing, debug_logging, default_max_retries are validated on every startup but never read by any runtime code. Only `agent_actions_env` is ever accessed.
+- **Failure scenario:** User sets DATABASE_URL or MAX_CONCURRENCY in .env, gets ValidationError on malformed value, but the field has no effect even when valid. Debugging time wasted on phantom config.
+- **Severity:** MEDIUM — misleading config surface
+
+### 10. CONFIRMED — validate_retry/validate_reprompt duplicated across two models
+
+- **File:** `agent_actions/config/schema.py:286,402`
+- **Summary:** validate_retry and validate_reprompt field validators are character-for-character identical on ActionConfig and DefaultsConfig. Four methods, two copies.
+- **Failure scenario:** Change to validation logic in one model but not the other silently diverges behavior for workflow-level defaults vs per-action config.
+- **Severity:** LOW — duplication maintenance risk
+
+---
+
+## PLAUSIBLE findings (lower priority)
+
+### P1. Repeated YAML parsing — no cache on load_project_config
+
+- **File:** `agent_actions/config/path_config.py:16`
+- **Summary:** Every call to get_tool_dirs, get_schema_path, get_seed_data_path re-parses agent_actions.yml. Multiple calls per run, worse in LSP mode.
+- **Cost:** Redundant I/O, theoretical TOCTOU if file changes between reads.
+
+### P2. _check_permissions over-restricts with AND logic
+
+- **File:** `agent_actions/config/paths.py:218`
+- **Summary:** Requires both os.access() AND stat mode bits. ACL-based access that passes os.access but lacks matching stat bits is rejected.
+- **Cost:** False "not writable" errors on ACL-managed filesystems.
+
+### P3. get_schema_path ConfigValidationError uncaught in SchemaLoader
+
+- **File:** `agent_actions/config/path_config.py:182`
+- **Summary:** get_schema_path raises ConfigValidationError but output/response/loader.py callers don't catch it. Running from outside project dir propagates unhandled.
+- **Cost:** Raw stack trace instead of actionable error message.
+
+### P4. find_agent_name legacy format depends on dict insertion order
+
+- **File:** `agent_actions/config/manager.py:131`
+- **Summary:** Legacy format fallback uses `next(iter(config))` — relies on YAML parse order preserved in Python dict. Stable in practice but undocumented assumption.
+- **Cost:** Fragile if YAML preprocessing ever reorders keys.
+
+### P5. types.py _missing_ pattern duplication with schema.py
+
+- **File:** `agent_actions/config/types.py:14`
+- **Summary:** Granularity._missing_ and RunMode._missing_ duplicate the case-folding pattern from ActionKind._missing_ and VersionMode._missing_. Common Enum limitation.
+- **Cost:** Four identical methods across two files; drift risk is low.
+
+---
+
+## REFUTED
+
+### R1. factory.py context manager resource leak — REFUTED
+
+- **File:** `agent_actions/config/factory.py:37`
+- **Reason:** ApplicationContainer holds no OS resources. DependencyContainer has no __enter__/__exit__ or close(). The @contextmanager is cosmetic, not a resource lifecycle boundary. No actual leak.
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (crash/wrong behavior) | #1, #2, #3 (YAML handling) | Small — add type guard before key checks |
+| P1 (silent fallback) | #5 (broad except) | Small — narrow to specific exceptions |
+| P1 (dead config surface) | #4 (DIConfig ignored), #9 (EnvironmentConfig dead fields) | Medium — decide: implement or remove |
+| P2 (dead code) | #6 (dead methods), #8 (IAsyncCapable) | Small — delete dead code |
+| P2 (duplication) | #7 (tool path), #10 (validators) | Small — extract shared helpers |
+| P3 (nice to have) | P1-P5 (plausible findings) | Varies |

--- a/audits/errors-review.md
+++ b/audits/errors-review.md
@@ -1,0 +1,45 @@
+# Code Review: agent_actions/errors/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 11 Python files
+
+---
+
+## Findings
+
+### 1. CONFIRMED — Three dead exception classes never raised in production
+
+- **Files:** `processing.py:30` (SerializationError), `external_services.py:63` (LLMResponseParseError), `common.py:7` (InvalidParameterError)
+- **Summary:** All three are defined, exported, but never raised anywhere in production code. LLMResponseParseError is the most dangerous — its name implies it signals JSON parse failures, but the pipeline uses `_parse_error` dict markers instead.
+- **Failure scenario:** A caller catches `LLMResponseParseError` expecting it to fire on LLM parse failures. It never does. The guard silently does nothing.
+- **Severity:** MEDIUM — false API surface, misleading contracts
+
+### 2. CONFIRMED — Falsy coercion collapses empty list to None in ContextStructureError
+
+- **File:** `agent_actions/errors/preflight.py:187`
+- **Summary:** `actual_fields if actual_fields else None` collapses `[]` (known-empty context) to None (unknown context). User cannot distinguish "no fields loaded" from "fields unknown".
+- **Fix:** `actual_fields if actual_fields is not None else None`
+- **Severity:** MEDIUM — loses diagnostic information in error messages
+
+### 3. CONFIRMED — ConfigValidationError parameter name misleads callers
+
+- **File:** `agent_actions/errors/configuration.py:12`
+- **Summary:** First positional arg is named `message` but at 15+ call sites it's used as `config_key`. When `reason` is also provided, `message` doubles as a key — producing `'Configuration validation failed for "your_full_sentence": reason'`.
+- **Severity:** LOW — confusing API, latent bug for new callers
+
+### 4. CONFIRMED — Private cross-module import of _render_sections
+
+- **File:** `agent_actions/errors/validation.py:6`
+- **Summary:** `SchemaValidationError` imports `_render_sections` directly from `preflight.py` — an underscore-prefixed internal function with no export or stability guarantee.
+- **Severity:** LOW — fragile coupling
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P1 | #2 (falsy coercion) | Tiny — change condition |
+| P2 | #1 (dead exceptions) | Small — remove or wire up |
+| P3 | #3, #4 (naming, coupling) | Small cleanup |

--- a/audits/guards-review.md
+++ b/audits/guards-review.md
@@ -1,0 +1,47 @@
+# Code Review: agent_actions/guards/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 3 Python files + 1 caller (evaluator.py)
+
+---
+
+## Findings
+
+### 1. CONFIRMED — Silent fallback: UDF guard exceptions bypass guard protection
+
+- **File:** `agent_actions/input/preprocessing/filtering/evaluator.py:205`
+- **Summary:** `_evaluate_conditional_clause()` catches ValueError/TypeError/KeyError/AttributeError from UDF execution, logs at DEBUG only, returns None. evaluate() falls through to _evaluate_guard(), which returns GuardResult.passed() if no guard_config exists. A broken UDF guard silently becomes a no-op.
+- **Failure scenario:** UDF guard function has a bug (raises KeyError). Guard silently passes. Records that should be filtered proceed through the pipeline unprotected.
+- **Severity:** HIGH — silent fallback, guard fails open
+
+### 2. CONFIRMED — Cross-format default inconsistency for on_false
+
+- **File:** `agent_actions/guards/consolidated_guard.py:89`
+- **Summary:** `from_dict()` defaults missing `on_false` to "filter" for all guard types. `from_string()` defaults UDF strings to SKIP and SQL strings to FILTER. Dict-form UDF guard gets FILTER by default, which then hits ConfigurationError in expander_action_types.py.
+- **Failure scenario:** User writes `{"condition": "udf:validators.check"}` without `on_false`. Gets FILTER default. expander_action_types.py:33 raises ConfigurationError about FILTER not being valid for UDF guards — error message gives no hint the implicit default caused the problem.
+- **Severity:** MEDIUM — user-hostile trap
+
+### 3. CONFIRMED — Docstring falsely claims safe column names won't trigger validator
+
+- **File:** `agent_actions/guards/guard_parser.py:42`
+- **Summary:** parse() docstring says column names like 'file', 'input', 'vars', 'dir' "will not trigger the dangerous-pattern validator". They do — word-boundary regex matches standalone tokens.
+- **Failure scenario:** User writes `file == "pdf"` guard, gets ValidationError. Docstring said this would work.
+- **Severity:** MEDIUM — incorrect documentation causes user confusion
+
+### 4. CONFIRMED — Double parse in from_string()
+
+- **File:** `agent_actions/guards/consolidated_guard.py:96`
+- **Summary:** from_string() calls GuardParser.parse() for type detection, then cls() constructor calls parse() again. First result discarded.
+- **Severity:** LOW — dead work, no correctness impact
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (silent fallback) | #1 — UDF guard bypass | Medium — raise or log at warning, don't return None |
+| P1 (user trap) | #2 — on_false default inconsistency | Small — align defaults |
+| P1 (docs) | #3 — false docstring | Small — fix docstring or fix regex |
+| P3 | #4 — double parse | Small — pass parsed result through |

--- a/audits/input-review.md
+++ b/audits/input-review.md
@@ -1,0 +1,57 @@
+# Code Review: agent_actions/input/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 44 Python files
+
+---
+
+## Findings
+
+### 1. CONFIRMED — Silent empty-list return on transform error drops records
+
+- **File:** `agent_actions/input/preprocessing/processing/data_processor.py:55`
+- **Summary:** process_item catches ValueError/TypeError/KeyError, calls handle_processing_error (debug/info only), returns []. Records vanish from pipeline output with no user-visible signal.
+- **Severity:** HIGH — silent data loss
+
+### 2. CONFIRMED — TruncateStrategy.handle_chunking_error silently drops records like SkipStrategy
+
+- **File:** `agent_actions/input/preprocessing/chunking/strategies/fallback_strategies.py:83`
+- **Summary:** Class named "Truncate" but handle_chunking_error returns [] — identical to SkipStrategy. Users configuring `fallback_strategy: truncate` lose records silently.
+- **Severity:** HIGH — misdocumented behavior causes data loss
+
+### 3. CONFIRMED — _should_save_source_items compares only first record's field count
+
+- **File:** `agent_actions/input/preprocessing/staging/initial_pipeline.py:278`
+- **Summary:** Uses new_items[0] vs existing_items[0] for field count comparison. Heterogeneous data where record 0 is atypical causes permanent stale source data.
+- **Severity:** MEDIUM — stale data persisted across runs
+
+### 4. CONFIRMED — Empty CSV returns empty list with no warning
+
+- **File:** `agent_actions/input/loaders/tabular.py:40`
+- **Summary:** Header-only or zero-byte CSV → empty list → pipeline proceeds with 0 records → no warning, no error. User gets silent no-op run.
+- **Severity:** MEDIUM — silent no-op
+
+### 5. CONFIRMED — Global sys.modules UDF dedup causes stale UDF injection
+
+- **File:** `agent_actions/input/loaders/udf.py:60`
+- **Summary:** UDF with same module name from different project directories gets skipped if already in sys.modules. Second project silently inherits first project's UDF.
+- **Severity:** MEDIUM — cross-project state contamination
+
+### 6. CONFIRMED — CSV batch path TOCTOU re-reads file from disk
+
+- **File:** `agent_actions/input/preprocessing/staging/initial_pipeline.py:424`
+- **Summary:** _prepare_batch_data re-reads file via TabularLoader after FileReader already read it. File modification between reads produces inconsistent pipeline state.
+- **Severity:** LOW — race condition on file mutation
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (data loss) | #1 (transform error drops records), #2 (truncate = skip) | Small — raise or log warning, fix truncate behavior |
+| P1 (stale data) | #3 (first-record comparison) | Small — compare all or representative sample |
+| P1 (silent no-op) | #4 (empty CSV) | Small — warn on empty input |
+| P2 (state leak) | #5 (UDF dedup) | Medium — scope to project root |
+| P3 | #6 (TOCTOU) | Low priority |

--- a/audits/logging-review.md
+++ b/audits/logging-review.md
@@ -1,0 +1,130 @@
+# Code Review: agent_actions/logging/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (3-angle parallel review: core, errors, events)
+**Files reviewed:** ~40 Python files across 3 sub-packages
+
+---
+
+## Core Layer Findings
+
+### 1. CONFIRMED — RedactingFilter defined but never attached to any handler
+
+- **File:** `agent_actions/logging/filters.py:50-168`
+- **Summary:** RedactingFilter exists and is tested but never wired into any handler or logger. API keys and tokens in log messages flow unredacted through LoggingBridgeHandler to JSONFileHandler and are written to disk in plaintext.
+- **Failure scenario:** LLM provider logs debug message containing raw API key. Record passes through bridge unredacted. JSONFileHandler writes it to events.json. Any process with file read access recovers the credential.
+- **Severity:** HIGH — credential exposure in log files
+
+### 2. CONFIRMED — CRITICAL level missing from level_map, silently falls back to INFO
+
+- **File:** `agent_actions/logging/factory.py:117-124`
+- **Summary:** `level_map` dict has no 'CRITICAL' key. LoggingConfig allows CRITICAL. `level_map.get('CRITICAL', EventLevel.INFO)` returns INFO. Console shows everything instead of suppressing.
+- **Failure scenario:** Operator sets `AGENT_ACTIONS_LOG_LEVEL=CRITICAL` to suppress noise. Gets INFO-and-above flood instead.
+- **Severity:** HIGH — silent fallback, log level completely wrong
+
+### 3. CONFIRMED — EventManager.reset() leaks file descriptors
+
+- **File:** `agent_actions/logging/core/manager.py:72-81`
+- **Summary:** reset() and initialize(force=True) discard JSONFileHandler instances without calling close(). Open file handles leak until GC finalizes.
+- **Failure scenario:** Test suite calling reset() between runs. Force re-init in production. File descriptor exhaustion after many cycles.
+- **Severity:** MEDIUM — resource leak
+
+### 4. CONFIRMED — JSONFileHandler _flush_buffer doesn't clear buffer on write failure
+
+- **File:** `agent_actions/logging/core/handlers/json_file.py:87-104`
+- **Summary:** If write() raises (disk full), buffer is not cleared. Next flush retries same events against corrupt file handle. Duplicate records, partial lines.
+- **Failure scenario:** Disk fills mid-write. Buffer retained. Next flush duplicates events on same stale handle.
+- **Severity:** MEDIUM — data corruption on disk-full
+
+### 5. CONFIRMED — LoggingBridgeHandler.emit() swallows all exceptions via handleError()
+
+- **File:** `agent_actions/logging/core/handlers/bridge.py:65-68`
+- **Summary:** `except Exception: self.handleError(record)` — fires silently swallow downstream handler crashes. Events lost with no structured error or metric.
+- **Severity:** MEDIUM — silent fallback
+
+### 6. CONFIRMED — JSONFormatter is dead code
+
+- **File:** `agent_actions/logging/formatters.py:11-106`
+- **Summary:** Pipeline converts LogRecord → BaseEvent at the bridge. No downstream handler uses LogRecord. JSONFormatter has no production caller.
+- **Severity:** LOW — dead code
+
+---
+
+## Error Formatter Findings
+
+### 7. CONFIRMED — AuthenticationErrorFormatter misroutes filesystem PermissionError
+
+- **File:** `agent_actions/logging/errors/formatters/authentication.py:12`
+- **Summary:** Matches 'permission denied' substring. OS PermissionError (file permissions) hits before FileErrorFormatter in chain. User told "Invalid API key" when the fix is "check file permissions".
+- **Failure scenario:** Wrong OS permissions on config file → "Authentication Error: Invalid API key" instead of "check file permissions on /path/to/file".
+- **Severity:** HIGH — actively misleading error message
+
+### 8. CONFIRMED — APIErrorFormatter matches bare 'api' substring
+
+- **File:** `agent_actions/logging/errors/formatters/api.py:22`
+- **Summary:** Substring 'api' matches words like 'rapid', 'capital', 'therapist_agent', 'api_key'. Non-API errors misrouted.
+- **Failure scenario:** ValueError about 'api_key' config field → formatted as "API Error: Check your API key and network connection" instead of the actual config issue.
+- **Severity:** MEDIUM — false positive error classification
+
+### 9. CONFIRMED — SchemaValidationError rich context discarded by ConfigurationErrorFormatter
+
+- **File:** `agent_actions/logging/errors/formatters/configuration.py:49`
+- **Summary:** ConfigurationErrorFormatter matches SchemaValidationError by class name, returns generic one-liner. All structured data (missing_fields, extra_fields, type_errors, hint) thrown away. SchemaValidationError.format_user_message() already renders this correctly but is never called.
+- **Failure scenario:** Schema validation error with detailed field-level info → user sees "The configuration format is invalid — Check your YAML/JSON syntax".
+- **Severity:** MEDIUM — information destruction
+
+### 10. CONFIRMED — DuplicateFunctionError/UDFLoadError fall through to generic formatter
+
+- **File:** `agent_actions/logging/errors/translator.py:31`
+- **Summary:** Neither class name matches any formatter's pattern. Both get "Error during operation — Check your configuration". Rich structured messages (file locations, suggestions) are lost.
+- **Severity:** MEDIUM — important context discarded
+
+### 11. CONFIRMED — ModelErrorFormatter misses real provider error phrasing
+
+- **File:** `agent_actions/logging/errors/formatters/model.py:13`
+- **Summary:** Only matches 3 hardcoded substrings. Real provider responses ("model X does not exist", "not available in your region") miss. Falls to API or generic formatter.
+- **Severity:** MEDIUM — wrong error guidance
+
+### 12. CONFIRMED — _find_similar_functions no minimum length guard
+
+- **File:** `agent_actions/logging/errors/formatters/function.py:64`
+- **Summary:** Short names ('do', 'a') substring-match nearly every function. Suggestion list is noise.
+- **Severity:** LOW — noisy output
+
+---
+
+## Event System Findings
+
+### 13. CONFIRMED — '0 ERROR' appears on every successful workflow completion
+
+- **File:** `agent_actions/logging/events/formatters.py:89`
+- **Summary:** _format_workflow_complete unconditionally includes all labels. Clean run prints "3 OK | 0 PARTIAL | 1 SKIP | 0 ERROR". Literal string "ERROR" appears even on success.
+- **Failure scenario:** CI log scraping catches "ERROR" keyword on successful runs. Users confused by ERROR label on clean output.
+- **Severity:** MEDIUM — misleading output
+
+### 14. CONFIRMED — RunResultsCollector.get_summary() uses different keys than finalize_workflow expects
+
+- **File:** `agent_actions/logging/events/handlers/run_results.py:297`
+- **Summary:** Collector returns {success, skipped, error, running}. finalize_workflow expects {completed, completed_with_failures}. The live path uses state_manager.get_summary() (correct), but the inconsistent API is a trap.
+- **Severity:** MEDIUM — inconsistent API, silent zeros if misused
+
+### 15. CONFIRMED — Large batch of event types defined but never emitted
+
+- **Files:** Multiple across `batch_events.py`, `data_pipeline_events.py`, `initialization_events.py`
+- **Summary:** B011, B012, RP004, DT004, DT005, F003, F004, I004-I007, E001-E003, P002, P004 — all defined, exported, tested, but have zero emit sites in production code. Some annotated "not yet instrumented", others appear genuinely missed.
+- **Failure scenario:** Handlers/dashboards subscribing to these events see nothing. Partial batch failures, normalization, startup phases are unobservable.
+- **Severity:** MEDIUM — misleading event catalog, gaps in observability
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (security) | #1 (RedactingFilter unwired) | Small — attach filter to bridge |
+| P0 (wrong behavior) | #2 (CRITICAL level map), #7 (auth/permission misroute) | Small — add key, reorder chain |
+| P1 (misleading) | #8 (api substring), #9 (schema context discarded), #13 (0 ERROR output) | Medium — fix patterns, use format_user_message |
+| P1 (silent fallback) | #5 (bridge swallows), #10 (UDF errors generic) | Medium |
+| P2 (resource) | #3 (fd leak), #4 (buffer corruption) | Small — add close() calls, try/finally |
+| P2 (gaps) | #11 (model patterns), #14 (summary keys), #15 (dead events) | Varies |
+| P3 (dead code) | #6 (JSONFormatter), #12 (short name matching) | Small cleanup |

--- a/audits/models-review.md
+++ b/audits/models-review.md
@@ -1,0 +1,56 @@
+# Code Review: agent_actions/models/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 2 Python files + callers
+
+---
+
+## Findings
+
+### 1. CONFIRMED — Wrong FieldSource on input fields in schema_service
+
+- **File:** `agent_actions/workflow/schema_service.py:252,262`
+- **Summary:** All input fields (required and optional) are tagged `FieldSource.TOOL_OUTPUT`. That enum member describes output provenance (produced by UDF tool), not input provenance. Renderer ignores `.source` on inputs today.
+- **Failure scenario:** Future code branching on `input_field.source` gets TOOL_OUTPUT for every input field including LLM context-scope fields — produces incorrect formatting or dead-code paths.
+- **Severity:** MEDIUM — wrong data, silent today
+
+### 2. CONFIRMED — FieldInfo.to_dict() asymmetric key rename breaks round-trip
+
+- **File:** `agent_actions/models/action_schema.py:32`
+- **Summary:** Python attribute is `field_type` but to_dict() serializes as `"type"`. No round-trip possible — `FieldInfo(**d)` fails or uses default.
+- **Severity:** MEDIUM — serialization contract violation
+
+### 3. CONFIRMED — ActionKind.SEED is dead in runtime pipeline
+
+- **File:** `agent_actions/models/action_schema.py:44`
+- **Summary:** No DataFlowNode is ever assigned `agent_kind=SEED`. A SEED-kinded ActionSchema in schema_renderer falls through all branches silently with no label.
+- **Severity:** LOW — dead enum member
+
+### 4. CONFIRMED — ActionKind re-export shim with noqa suppression
+
+- **File:** `agent_actions/models/action_schema.py:9`
+- **Summary:** ActionKind imported from config/schema.py with `noqa: F401`. Move or rename in config/schema.py causes silently suppressed ImportError.
+- **Severity:** LOW — fragile re-export
+
+### 5. CONFIRMED — to_dict() redundantly recomputes derived properties
+
+- **File:** `agent_actions/models/action_schema.py:56`
+- **Summary:** available_outputs, dropped_outputs, required_inputs, optional_inputs are computed properties already derivable from output_fields/input_fields, but to_dict() also embeds them — double iteration, redundant keys.
+- **Severity:** LOW — unnecessary overhead
+
+### 6. CONFIRMED — Test docstring says "4 members" but enum has 5
+
+- **File:** `tests/unit/models/test_action_schema.py:16`
+- **Summary:** Stale docstring. Assertion is correct (== 5) but docstring contradicts.
+- **Severity:** LOW — stale docs
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P1 | #1 (wrong FieldSource), #2 (key rename) | Small — fix source assignment, fix key name |
+| P2 | #3 (dead SEED), #4 (re-export shim) | Small — remove or document |
+| P3 | #5, #6 (overhead, stale docs) | Tiny |

--- a/audits/output-review.md
+++ b/audits/output-review.md
@@ -1,0 +1,61 @@
+# Code Review: agent_actions/output/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 19 Python files
+
+---
+
+## Findings
+
+### 1. CONFIRMED — FileWriteError never raised — operation name mismatch
+
+- **File:** `agent_actions/output/writer.py:47-73`
+- **Summary:** handle_file_error checks `operation.lower() in ['write', 'save', 'create']` but operations passed are 'Write staging file', 'Write target file', etc. — none match. All OSError write failures raised as ProcessingError instead of FileWriteError.
+- **Failure scenario:** Disk full during write_target → ProcessingError raised → caller catching FileWriteError misses it → no retry or disk-full handling.
+- **Severity:** HIGH — wrong exception type for all file writes
+
+### 2. CONFIRMED — Silent fallback on dispatch_task() resolution failure
+
+- **File:** `agent_actions/output/response/dispatch_injection.py:61-68,107-113`
+- **Summary:** Resolution failures caught as (ValueError, TypeError, KeyError, AgentActionsError), raw unresolved dispatch_task() string passed to LLM vendor. Comment says "may cause API errors".
+- **Failure scenario:** Misconfigured dispatch_task → raw string 'dispatch_task(build_options)' sent as schema property → vendor rejects or produces malformed output.
+- **Severity:** HIGH — silent fallback, broken schema sent to API
+
+### 3. CONFIRMED — JSON Schema 'required' list treated as boolean
+
+- **File:** `agent_actions/output/response/schema_conversion.py:63-98`
+- **Summary:** `is_required = json_schema.get('required', True)` reads top-level 'required' which is a list of property names, not boolean. Non-empty list → truthy → always required. Empty list → falsy → never required.
+- **Failure scenario:** Array schema with `required: [fact, paraphrase]` → outer field unconditionally required regardless of intent.
+- **Severity:** MEDIUM — type confusion in schema compilation
+
+### 4. CONFIRMED — write_target always reports 0 bytes_written
+
+- **File:** `agent_actions/output/writer.py:110-136`
+- **Summary:** bytes_written hardcoded to 0 for target writes. FileWriteCompleteEvent always shows 0 bytes. Cannot distinguish normal write from data loss via metrics.
+- **Severity:** MEDIUM — broken observability
+
+### 5. CONFIRMED — ConfigValidationError swallowed as "vendor doesn't support schemas"
+
+- **File:** `agent_actions/output/response/context_data.py:153-161`
+- **Summary:** _compile_schema_for_vendor catches ConfigValidationError for both "vendor unsupported" and any future schema compilation logic error. Real validation errors silently drop the schema constraint.
+- **Severity:** MEDIUM — overly broad exception catch
+
+### 6. CONFIRMED — Dead dependency guard in expander
+
+- **File:** `agent_actions/output/response/expander.py:406-413`
+- **Summary:** Post-call check for missing 'dependencies' key is unreachable — _create_agent_from_action unconditionally sets it. Dead code providing false safety.
+- **Severity:** LOW — dead code
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (wrong type) | #1 (FileWriteError never raised) | Small — fix operation name matching |
+| P0 (silent fallback) | #2 (dispatch_task fallback) | Small — raise instead of warn |
+| P1 (type confusion) | #3 (required list/bool) | Medium — handle JSON Schema required correctly |
+| P1 (observability) | #4 (0 bytes) | Small — compute actual bytes |
+| P2 (broad catch) | #5 (ConfigValidationError) | Small — narrow exception type |
+| P3 | #6 (dead code) | Tiny — remove |

--- a/audits/prompt-review.md
+++ b/audits/prompt-review.md
@@ -1,0 +1,58 @@
+# Code Review: agent_actions/prompt/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 18 Python files
+
+---
+
+## Findings
+
+### 1. CONFIRMED — Silent fallback: null prompt resolves to generic "Process the following content"
+
+- **File:** `agent_actions/prompt/formatter.py:51`
+- **Summary:** `prompt: null` in YAML config bypasses empty-string guard (requires isinstance str), bypasses key-missing guard (key IS present), hits `if not raw_prompt` and silently returns generic prompt. LLM action runs with nonsense prompt.
+- **Severity:** HIGH — silent wrong behavior, no error
+
+### 2. CONFIRMED — Token limit guard bypassed for most providers
+
+- **File:** `agent_actions/prompt/message_builder.py:338`
+- **Summary:** Groq, Cohere, Gemini, and all non-json-mode paths omit `model_name=` from `MessageBuilder.build()`. Guard `if model_name is not None` never fires. Oversized prompts sent to provider without PromptTooLargeError preflight.
+- **Failure scenario:** 40k token prompt on mixtral-8x7b-32768 → sent without check → provider returns API error after network round-trip.
+- **Severity:** MEDIUM — missing preflight validation
+
+### 3. CONFIRMED — Skipped-dep re-render not guarded against second UndefinedError
+
+- **File:** `agent_actions/prompt/service.py:371`
+- **Summary:** After injecting _PermissiveNamespace for first missing dep, re-render happens outside inner except block. Second missing dep raises UndefinedError → surfaces as TemplateVariableError blaming user's template.
+- **Severity:** MEDIUM — misleading error message
+
+### 4. CONFIRMED — Seed namespace silently overwrites action named 'seed'
+
+- **File:** `agent_actions/prompt/context/scope_application.py:149`
+- **Summary:** Warning logged but overwrite proceeds. Upstream action named 'seed' loses its output namespace. LLM receives static seed data where computed output was expected.
+- **Severity:** MEDIUM — data corruption on namespace collision
+
+### 5. CONFIRMED — Dead code: _enrich_source_namespace
+
+- **File:** `agent_actions/prompt/context/scope_namespace.py:56`
+- **Summary:** Defined and tested but never called from production. Source namespace enrichment logic missing at runtime.
+- **Severity:** LOW — dead code with false test coverage
+
+### 6. CONFIRMED — Dead code: replace_field_references and helpers
+
+- **File:** `agent_actions/prompt/prompt_utils.py:207`
+- **Summary:** Entire bare-brace field substitution system ({source.field} syntax) unreachable from production. Tests pass but feature doesn't work end-to-end.
+- **Severity:** LOW — dead code, misleading tests
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (silent wrong behavior) | #1 (null prompt fallback) | Small — raise on None prompt |
+| P1 (missing validation) | #2 (token guard bypass) | Medium — pass model_name from all providers |
+| P1 (misleading error) | #3 (skipped-dep re-render) | Small — wrap re-render in try/except |
+| P2 (namespace collision) | #4 (seed overwrite) | Small — raise instead of warn+overwrite |
+| P3 (dead code) | #5, #6 | Small — remove |

--- a/audits/tooling-review.md
+++ b/audits/tooling-review.md
@@ -1,0 +1,59 @@
+# Code Review: agent_actions/tooling/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 21 Python files
+
+---
+
+## Findings
+
+### 1. CONFIRMED — RunTracker json.load crash on corrupted runs.json
+
+- **File:** `agent_actions/tooling/docs/run_tracker.py:301,340`
+- **Summary:** record_action_start and record_action_complete call json.load bare. @retry only catches LockException. JSONDecodeError from corrupted file crashes live workflow. Fix pattern already exists in start_workflow_run (line 244) which has try/except (OSError, JSONDecodeError).
+- **Failure scenario:** Previous run interrupted mid-write → runs.json corrupted → next run calls record_action_start → JSONDecodeError → workflow thread crashes.
+- **Severity:** HIGH — unhandled exception crashes live workflow
+
+### 2. CONFIRMED — code_scanner.py missing OSError catch on file read
+
+- **File:** `agent_actions/tooling/code_scanner.py:40`
+- **Summary:** scan_tool_functions catches SyntaxError and UnicodeDecodeError but not OSError. Broken symlink or deleted file between rglob and read_text crashes generate_docs.
+- **Severity:** MEDIUM — unhandled exception aborts docs generation
+
+### 3. CONFIRMED — shutil.copy2 failure aborts entire catalog generation
+
+- **File:** `agent_actions/tooling/docs/generator.py:62`
+- **Summary:** No try/except around image copy. Disk-full or permission error on one image aborts full generate_docs, leaving catalog.json unwritten.
+- **Severity:** MEDIUM — one bad image kills all docs
+
+### 4. CONFIRMED — Naive substring replacement corrupts image URLs
+
+- **File:** `agent_actions/tooling/docs/generator.py:69`
+- **Summary:** `content.replace(old_path, new_path)` — 'logo.png' matches inside 'dark/logo.png'. Two images sharing a filename suffix produce broken URLs in catalog.
+- **Failure scenario:** README with logo.png and dark/logo.png → first replace corrupts second path → both image links broken in rendered docs.
+- **Severity:** MEDIUM — broken documentation images
+
+### 5. CONFIRMED — Framework jargon in LSP diagnostic messages
+
+- **Files:** `agent_actions/tooling/lsp/diagnostics.py:75,90,117` and `server.py:557`
+- **Summary:** User-facing IDE diagnostics use internal terms: "context_scope reference", "Variables derived from context_scope.observe". Users never author these terms in their YAML.
+- **Severity:** LOW — poor UX in editor
+
+### 6. CONFIRMED — Dead ActionDefinition dataclass
+
+- **File:** `agent_actions/tooling/lsp/models.py:57`
+- **Summary:** Never imported or used anywhere. Superseded by ActionMetadata. Creates confusion for new contributors.
+- **Severity:** LOW — dead code
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (crash) | #1 (RunTracker json.load) | Small — add try/except like start_workflow_run |
+| P1 (robustness) | #2 (OSError), #3 (shutil.copy2) | Small — add exception guards |
+| P1 (correctness) | #4 (substring replacement) | Small — longest-first or regex |
+| P2 (UX) | #5 (jargon) | Small — rewrite messages |
+| P3 (dead code) | #6 | Tiny — delete |

--- a/audits/utils-review.md
+++ b/audits/utils-review.md
@@ -1,0 +1,103 @@
+# Code Review: agent_actions/utils/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (2-angle parallel review: top-level files + sub-packages)
+**Files reviewed:** ~40 Python files
+
+---
+
+## Findings (ranked by severity)
+
+### 1. CONFIRMED — UDF module loading allows stdlib/package hijacking
+
+- **File:** `agent_actions/utils/udf_management/tooling.py:11-43`
+- **Summary:** `load_user_defined_function` accepts unvalidated `module_name` passed to `load_module_from_path` with `fallback_import=True`. Module name 'os' or 'subprocess' resolves via standard importlib. No restriction that module must come from project's tools/ directory.
+- **Failure scenario:** agent_config.yml specifies `tool_module: os`, `tool_function: system`. Resolved via fallback import. UDF executor calls `os.system` with workflow-controlled arguments.
+- **Severity:** HIGH — security: arbitrary code execution via config
+
+### 2. CONFIRMED — Path traversal check validates wrong value in tools_resolver
+
+- **File:** `agent_actions/utils/tools_resolver.py:57`
+- **Summary:** Containment check validates the YAML tool config file path against safe_root, but then returns `module_path` (a Python dotted module name from inside that YAML) which is never validated. Crafted module_path bypasses the check.
+- **Failure scenario:** Tool config contains `module_path: ../../../../etc/secret_module`. File path check passes (the YAML file itself is inside the project). module_path escapes.
+- **Severity:** HIGH — security: path traversal check on wrong value
+
+### 3. CONFIRMED — Silent None from empty YAML in load_structured_file
+
+- **File:** `agent_actions/utils/file_utils.py:21`
+- **Summary:** `yaml.safe_load` returns None for empty files. `load_structured_file` propagates None without raising, despite callers expecting dict. SchemaLoader crashes with AttributeError at a location far from the empty file.
+- **Failure scenario:** Empty schema YAML file → None propagated → `schema_data['fields']` raises AttributeError with no indication the file was empty.
+- **Severity:** HIGH — misleading crash, root cause invisible
+
+### 4. CONFIRMED — Passthrough fields nested mutables shared across output items
+
+- **File:** `agent_actions/utils/transformation/strategies/precomputed.py:38-44`
+- **Summary:** `{**item["content"], **(passthrough_fields or {})}` spreads only top-level keys. Nested dicts/lists inside passthrough_fields are aliased across all output items. Mutation of one item corrupts all others.
+- **Failure scenario:** passthrough_fields = {'annotations': []}. Downstream enricher appends to one item's annotations → every item's annotations list grows.
+- **Severity:** MEDIUM — data corruption via mutable aliasing
+
+### 5. CONFIRMED — total_tokens silently overwritten in metadata extractor
+
+- **File:** `agent_actions/utils/metadata/extractor.py:180-185`
+- **Summary:** Two sequential attribute-family blocks (OpenAI-style then Anthropic-style). Second block unconditionally overwrites total_tokens. SDK object with both attribute families produces wrong usage counts.
+- **Failure scenario:** Wrapper object with both prompt_tokens=100 and input_tokens=0 → total_tokens set to 100, then overwritten to 0.
+- **Severity:** MEDIUM — wrong usage tracking
+
+### 6. CONFIRMED — sys.modules key mismatch on concurrent UDF loading failure
+
+- **File:** `agent_actions/utils/module_loader.py:94`
+- **Summary:** Module registered in sys.modules under `agent_actions._udfs.<name>` before execution. Cache uses different key `name:path`. Concurrent failure pops sys.modules entry that another thread's decorator is reading.
+- **Failure scenario:** Two threads load same UDF. Thread A fails, pops sys.modules entry. Thread B's decorator finds empty sys.modules, silently skips registration.
+- **Severity:** MEDIUM — race condition in UDF loading
+
+### 7. CONFIRMED — inspect.getfile() unhandled TypeError in udf_tool decorator
+
+- **File:** `agent_actions/utils/udf_management/registry.py:59-97`
+- **Summary:** Dedup check calls `inspect.getfile(f)` without guarding against TypeError on frozen/built-in/dynamic modules. Crashes at decoration time.
+- **Failure scenario:** UDF in .pyc-only distribution → TypeError at decoration → raw uncaught error with no user-friendly message.
+- **Severity:** MEDIUM — unhandled exception
+
+### 8. CONFIRMED — Unrecognized mode silently takes batch path in passthrough_builder
+
+- **File:** `agent_actions/utils/passthrough_builder.py:65`
+- **Summary:** `if mode == "online" / else` — any unrecognized mode string silently takes batch path. metadata['reason'] never set. Downstream KeyError on online pipeline.
+- **Failure scenario:** mode='ONLINE' (case mismatch) → batch path → KeyError when online pipeline reads metadata['reason'].
+- **Severity:** MEDIUM — silent fallback
+
+### 9. CONFIRMED — Class-level VersionIdGenerator registry leaks across sessions
+
+- **File:** `agent_actions/utils/correlation/version_id.py:15-16`
+- **Summary:** Process-global OrderedDict never isolated per test or per sequential workflow. Stale correlation IDs from session A visible in session B. Grows unboundedly until clear().
+- **Failure scenario:** Parametrized test reuses source_guid → gets stale correlation ID from prior test session.
+- **Severity:** MEDIUM — test pollution, potential production state leak
+
+### 10. CONFIRMED — FieldManager.add_metadata mutation contract inconsistency
+
+- **File:** `agent_actions/utils/field_management/manager.py:61-68`
+- **Summary:** add_metadata mutates in place but caller discards return value. Sibling ensure_required_fields copies first. Inconsistent mutation contracts.
+- **Severity:** LOW — code design inconsistency
+
+### 11. CONFIRMED — Double-checked locking race in get_path_manager
+
+- **File:** `agent_actions/utils/path_utils.py:23`
+- **Summary:** Outer None check outside lock. Concurrent set_path_manager write may not be visible. Documented race ("must be called before concurrent calls").
+- **Severity:** LOW — documented but unfixed race
+
+### 12. CONFIRMED — FileHandler.get_folder_after_agent_config is dead code
+
+- **File:** `agent_actions/utils/file_handler.py:67`
+- **Summary:** Zero callers in production code. Contains magic sentinel return value "(isfile)" that no caller handles.
+- **Severity:** LOW — dead code
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (security) | #1 (UDF stdlib hijack), #2 (path traversal wrong value) | Medium — add module allowlist/path validation |
+| P0 (crash) | #3 (empty YAML None) | Small — raise on None from yaml.safe_load |
+| P1 (data integrity) | #4 (mutable aliasing), #5 (token overwrite) | Small — deep copy passthrough, fix ordering |
+| P1 (concurrency) | #6 (sys.modules race) | Medium — unify cache key and sys.modules key |
+| P2 (robustness) | #7 (inspect TypeError), #8 (mode dispatch), #9 (registry leak) | Small each |
+| P3 (cleanup) | #10, #11, #12 | Small |

--- a/audits/validation-review.md
+++ b/audits/validation-review.md
@@ -1,0 +1,62 @@
+# Code Review: agent_actions/validation/
+
+**Date:** 2026-06-17
+**Reviewer:** Claude (single-angle deep review)
+**Files reviewed:** 48 Python files
+
+---
+
+## Findings
+
+### 1. CONFIRMED — _apply_context_scope reads nonexistent top-level keys, producing empty observe/drop sets
+
+- **File:** `agent_actions/validation/static_analyzer/schema_extractor.py:401`
+- **Summary:** Reads `config.get('observe')` and `config.get('drops')` from action top-level dict. These keys don't exist at the top level (they live under `context_scope`). All actions get empty observe_fields and dropped_fields. All downstream static checks (guard-nullable, drop-directive) produce zero findings.
+- **Failure scenario:** Action with `context_scope: { drop: [upstream.sensitive_field] }` → dropped_fields = set() → drop-directive check passes → guard using dropped field not caught.
+- **Severity:** HIGH — systematic false negatives in static analysis
+
+### 2. CONFIRMED — Unhandled TimeoutError from as_completed() in key_verifier
+
+- **File:** `agent_actions/validation/preflight/key_verifier.py:195`
+- **Summary:** `for future in as_completed(futures, timeout=7)` raises TimeoutError if slow probes exceed wall-clock limit. Not caught anywhere. Crashes entire preflight run.
+- **Failure scenario:** 4 vendor probes on slow DNS, each ~4.8s → as_completed timeout at 7s → unhandled TimeoutError → preflight crash → workflow won't start.
+- **Severity:** HIGH — unhandled exception crashes preflight
+
+### 3. CONFIRMED — Bare except Exception swallows prompt file errors in resolution_service
+
+- **File:** `agent_actions/validation/preflight/resolution_service.py:461`
+- **Summary:** `_resolve_prompt_for_extraction` catches all exceptions and returns original config string. Any prompt file error (YAML parse error, encoding error) silently skips template-level seed field validation.
+- **Failure scenario:** Prompt file has Jinja syntax error → swallowed → seed field references never validated → discovered only at runtime.
+- **Severity:** MEDIUM — silent fallback, validation bypass
+
+### 4. CONFIRMED — check_missing_dependencies() is dead code
+
+- **File:** `agent_actions/validation/static_analyzer/type_checker.py:243`
+- **Summary:** Method detects actions referencing upstream data without declaring dependency. Never called by WorkflowStaticAnalyzer.analyze(). Implicit dependency bugs never caught statically.
+- **Severity:** MEDIUM — validator exists but unused
+
+### 5. CONFIRMED — _check_api_keys() format-mismatch warnings list always empty
+
+- **File:** `agent_actions/validation/preflight/resolution_service.py:177`
+- **Summary:** Docstring says "Format mismatches are warnings" but the method body never populates the warnings list. Key-format validation promised but not implemented.
+- **Failure scenario:** Wrong API key in wrong env var (Groq key in ANTHROPIC_API_KEY) → no format warning → discovered at runtime.
+- **Severity:** MEDIUM — missing advertised validation
+
+### 6. CONFIRMED — output_field validator error message misleading for missing json_mode
+
+- **File:** `agent_actions/validation/action_validators/granularity_output_field_validator.py:53`
+- **Summary:** json_mode defaults to True when omitted. User with `output_field` but no explicit json_mode gets "output_field can only be used when json_mode is false" instead of a helpful message to add json_mode: false.
+- **Severity:** LOW — confusing error message
+
+---
+
+## Recommended fix priority
+
+| Priority | Findings | Effort |
+|----------|----------|--------|
+| P0 (systematic false negatives) | #1 (context_scope key mismatch) | Small — read from context_scope sub-dict |
+| P0 (crash) | #2 (TimeoutError unhandled) | Small — catch and degrade gracefully |
+| P1 (silent fallback) | #3 (prompt error swallowed) | Small — narrow catch or log at warning |
+| P1 (dead validator) | #4 (check_missing_dependencies) | Small — wire into analyze() |
+| P2 (missing feature) | #5 (format-mismatch warnings) | Medium — implement or remove docstring promise |
+| P3 (UX) | #6 (error message) | Small — improve message |


### PR DESCRIPTION
## Summary

Brings every shipped hardening review into the agent-actions repo at `audits/<module>-review.md`, alongside the code each review describes.

Previously, the 12 review files lived at `clone_N/hardening/reviews/done/` in the multi-clone orchestration layer — outside the repo. The fixes those reviews motivated all shipped (PRs #699–#710). This PR is documentation only — zero source / test changes.

`audits/INDEX.md` tabulates module → review → PR for fast lookup and lists the 5 modules still unreviewed (track 2 of spec 554: `storage`, `record`, `processing`, `llm`, `workflow`).

## Files

- `audits/INDEX.md` — module → review → PR table + remaining-modules list
- `audits/cli-review.md` — PR #699
- `audits/utils-review.md` — PR #700
- `audits/config-review.md` — PR #701
- `audits/logging-review.md` — PR #702
- `audits/validation-review.md` — PR #703
- `audits/guards-review.md` — PR #704
- `audits/prompt-review.md` — PR #708
- `audits/tooling-review.md` — PR #706
- `audits/input-review.md` — PR #710
- `audits/output-review.md` — PR #709
- `audits/errors-review.md` — PR #707
- `audits/models-review.md` — PR #705

## Verification

- 13 files added, +1023 lines, zero existing files modified
- No source / test / build / config changes — pure docs move