### PR TITLE
fix(processing): record without source_guid no longer silently skipped from disposition writes

### DIFF
--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -645,7 +645,7 @@ def collect_results_from_processing_results(
                     )
                 )
             elif storage_backend and result.source_guid is None:
-                failed_items = result.data if result.data else output[-1:]
+                failed_items = result.data or []
                 if failed_items:
                     input_snapshot_str = _serialize_snapshot(
                         result.source_snapshot or result.input_record
@@ -658,6 +658,12 @@ def collect_results_from_processing_results(
                         reason=result.error or "processing_error",
                         input_snapshot=input_snapshot_str,
                         detail=result.error,
+                    )
+                else:
+                    logger.warning(
+                        "[%s] FAILED result has no source_guid and no data — "
+                        "disposition not written (risk of reprocessing on next run)",
+                        action_name,
                     )
 
         elif status == ProcessingStatus.FILTERED:
@@ -682,11 +688,21 @@ def collect_results_from_processing_results(
                     )
                 )
             elif storage_backend and result.source_guid is None:
-                logger.warning(
-                    "[%s] FILTERED result has no source_guid — "
-                    "disposition not written (risk of reprocessing on next run)",
-                    action_name,
-                )
+                filtered_data = result.data or []
+                if filtered_data:
+                    _per_item_dispositions(
+                        pending_dispositions,
+                        action_name,
+                        filtered_data,
+                        DISPOSITION_FILTERED,
+                        reason=result.skip_reason or GUARD_FILTER,
+                    )
+                else:
+                    logger.warning(
+                        "[%s] FILTERED result has no source_guid and no data — "
+                        "disposition not written (risk of reprocessing on next run)",
+                        action_name,
+                    )
 
         elif status == ProcessingStatus.UNPROCESSED:
             data = result.data or []
@@ -919,11 +935,29 @@ class ResultCollector:
                         detail=er.error,
                     )
                 else:
-                    logger.warning(
-                        "[%s] Exhausted result has no source_guid — "
-                        "disposition not written (on_exhausted=raise)",
-                        agent_name,
-                    )
+                    er_data = er.data or []
+                    if er_data:
+                        input_snapshot_str = _serialize_snapshot(
+                            er.source_snapshot or er.input_record
+                        )
+                        for item in er_data:
+                            item_guid = item.get("source_guid")
+                            if item_guid:
+                                _safe_set_disposition(
+                                    storage_backend,
+                                    agent_name,
+                                    item_guid,
+                                    DISPOSITION_EXHAUSTED,
+                                    reason=f"exhausted_after_{_get_retry_attempts(er)}_attempts",
+                                    input_snapshot=input_snapshot_str,
+                                    detail=er.error,
+                                )
+                    else:
+                        logger.warning(
+                            "[%s] Exhausted result has no source_guid and no data — "
+                            "disposition not written (on_exhausted=raise)",
+                            agent_name,
+                        )
 
         first = exhausted_results[0]
         raise AgentActionsError(

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -190,6 +190,40 @@ def _serialize_snapshot(source: dict[str, Any] | None) -> str | None:
         return None
 
 
+def _per_item_dispositions(
+    pending: list[DispositionRow],
+    action_name: str,
+    data: list[dict[str, Any]],
+    disposition: str,
+    reason: str | None = None,
+    input_snapshot: str | None = None,
+    detail: str | None = None,
+) -> int:
+    """Write per-item dispositions when the result-level source_guid is None.
+
+    FILE-mode results bundle multiple records into one ProcessingResult with
+    source_guid=None.  Individual data items carry their own source_guid.
+
+    Returns the count of items that had a usable source_guid.
+    """
+    written = 0
+    for item in data:
+        item_guid = item.get("source_guid")
+        if item_guid:
+            pending.append(
+                (action_name, item_guid, disposition, reason, None, input_snapshot, detail)
+            )
+            written += 1
+    if not written and data:
+        logger.warning(
+            "[%s] %d data item(s) but none carry source_guid — "
+            "dispositions not written (risk of reprocessing on next run)",
+            action_name,
+            len(data),
+        )
+    return written
+
+
 def _safe_set_disposition(
     backend: "StorageBackend",
     action_name: str,
@@ -251,6 +285,13 @@ def write_record_dispositions(
     for item in items:
         source_guid = item.get("source_guid")
         if not source_guid:
+            logger.warning(
+                "[%s] Batch output item missing source_guid — "
+                "disposition not written (risk of reprocessing on next run). "
+                "Item keys: %s",
+                action_name,
+                sorted(item.keys())[:10],
+            )
             continue
         metadata = item.get("metadata", {})
 
@@ -418,6 +459,14 @@ def collect_results_from_processing_results(
                             None,
                         )
                     )
+                elif storage_backend and result.source_guid is None and data:
+                    _per_item_dispositions(
+                        pending_dispositions,
+                        action_name,
+                        data,
+                        DISPOSITION_FAILED,
+                        reason=PARSE_ERROR,
+                    )
                 continue
 
             if data:
@@ -449,24 +498,12 @@ def collect_results_from_processing_results(
                     )
                 )
             elif storage_backend and result.source_guid is None and data:
-                # FILE-mode results have source_guid=None on the result level
-                # but individual items carry their own source_guid.  Write
-                # per-item dispositions so DispositionGate can carry them
-                # forward on retry.
-                for item in data:
-                    item_guid = item.get("source_guid")
-                    if item_guid:
-                        pending_dispositions.append(
-                            (
-                                action_name,
-                                item_guid,
-                                DISPOSITION_SUCCESS,
-                                None,
-                                None,
-                                None,
-                                None,
-                            )
-                        )
+                _per_item_dispositions(
+                    pending_dispositions,
+                    action_name,
+                    data,
+                    DISPOSITION_SUCCESS,
+                )
 
         elif status == ProcessingStatus.SKIPPED:
             data = result.data or []
@@ -503,6 +540,14 @@ def collect_results_from_processing_results(
                         None,
                     )
                 )
+            elif storage_backend and result.source_guid is None and data:
+                _per_item_dispositions(
+                    pending_dispositions,
+                    action_name,
+                    data,
+                    DISPOSITION_PASSTHROUGH,
+                    reason=result.skip_reason or GUARD_SKIP,
+                )
 
         elif status == ProcessingStatus.EXHAUSTED:
             data = result.data or []
@@ -538,6 +583,19 @@ def collect_results_from_processing_results(
                         input_snapshot_str,
                         result.error,
                     )
+                )
+            elif storage_backend and result.source_guid is None and data:
+                input_snapshot_str = _serialize_snapshot(
+                    result.source_snapshot or result.input_record
+                )
+                _per_item_dispositions(
+                    pending_dispositions,
+                    action_name,
+                    data,
+                    DISPOSITION_EXHAUSTED,
+                    reason=f"exhausted_after_{attempts}_attempts",
+                    input_snapshot=input_snapshot_str,
+                    detail=result.error,
                 )
 
         elif status == ProcessingStatus.FAILED:
@@ -586,6 +644,21 @@ def collect_results_from_processing_results(
                         result.error,
                     )
                 )
+            elif storage_backend and result.source_guid is None:
+                failed_items = result.data if result.data else output[-1:]
+                if failed_items:
+                    input_snapshot_str = _serialize_snapshot(
+                        result.source_snapshot or result.input_record
+                    )
+                    _per_item_dispositions(
+                        pending_dispositions,
+                        action_name,
+                        failed_items,
+                        DISPOSITION_FAILED,
+                        reason=result.error or "processing_error",
+                        input_snapshot=input_snapshot_str,
+                        detail=result.error,
+                    )
 
         elif status == ProcessingStatus.FILTERED:
             logger.debug("Collected FILTERED result source_guid=%s", result.source_guid)
@@ -607,6 +680,12 @@ def collect_results_from_processing_results(
                         None,
                         None,
                     )
+                )
+            elif storage_backend and result.source_guid is None:
+                logger.warning(
+                    "[%s] FILTERED result has no source_guid — "
+                    "disposition not written (risk of reprocessing on next run)",
+                    action_name,
                 )
 
         elif status == ProcessingStatus.UNPROCESSED:
@@ -654,6 +733,14 @@ def collect_results_from_processing_results(
                         None,
                     )
                 )
+            elif storage_backend and result.source_guid is None and data:
+                _per_item_dispositions(
+                    pending_dispositions,
+                    action_name,
+                    data,
+                    DISPOSITION_UNPROCESSED,
+                    reason=result.skip_reason or UNPROCESSED,
+                )
 
         elif status == ProcessingStatus.DEFERRED:
             task_id = result.task_id or ""
@@ -680,6 +767,12 @@ def collect_results_from_processing_results(
                         None,
                         None,
                     )
+                )
+            elif storage_backend and result.source_guid is None:
+                logger.warning(
+                    "[%s] DEFERRED result has no source_guid — "
+                    "disposition not written (risk of reprocessing on next run)",
+                    action_name,
                 )
 
         else:
@@ -824,6 +917,12 @@ class ResultCollector:
                         reason=f"exhausted_after_{_get_retry_attempts(er)}_attempts",
                         input_snapshot=input_snapshot_str,
                         detail=er.error,
+                    )
+                else:
+                    logger.warning(
+                        "[%s] Exhausted result has no source_guid — "
+                        "disposition not written (on_exhausted=raise)",
+                        agent_name,
                     )
 
         first = exhausted_results[0]

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -940,6 +940,7 @@ class ResultCollector:
                         input_snapshot_str = _serialize_snapshot(
                             er.source_snapshot or er.input_record
                         )
+                        written = 0
                         for item in er_data:
                             item_guid = item.get("source_guid")
                             if item_guid:
@@ -952,6 +953,15 @@ class ResultCollector:
                                     input_snapshot=input_snapshot_str,
                                     detail=er.error,
                                 )
+                                written += 1
+                        if not written:
+                            logger.warning(
+                                "[%s] %d exhausted data item(s) but none carry "
+                                "source_guid — dispositions not written "
+                                "(on_exhausted=raise)",
+                                agent_name,
+                                len(er_data),
+                            )
                     else:
                         logger.warning(
                             "[%s] Exhausted result has no source_guid and no data — "

--- a/tests/unit/core/test_result_collector.py
+++ b/tests/unit/core/test_result_collector.py
@@ -269,6 +269,79 @@ def test_result_collector_on_exhausted_raise_writes_disposition_before_raising()
     )
 
 
+def test_result_collector_on_exhausted_raise_file_mode_per_item():
+    """on_exhausted=raise writes per-item dispositions when source_guid is None."""
+    agent_config = {
+        "agent_type": "test_action",
+        "retry": {"on_exhausted": "raise"},
+    }
+    exhausted = ProcessingResult.exhausted(
+        error="Retry exhausted",
+        source_guid=None,
+        recovery_metadata=_retry_metadata(),
+        input_record={"target_id": "t-1"},
+    )
+    exhausted.data = [
+        {"source_guid": "item_1", "content": {}},
+        {"source_guid": "item_2", "content": {}},
+    ]
+
+    mock_backend = MagicMock()
+    mock_backend.set_disposition = MagicMock()
+    wire_batch_disposition_delegate(mock_backend)
+
+    with pytest.raises(AgentActionsError):
+        ResultCollector.collect_results(
+            [exhausted],
+            agent_config,
+            "test_agent",
+            is_first_stage=True,
+            storage_backend=mock_backend,
+        )
+
+    assert mock_backend.set_disposition.call_count == 2
+    guids = {c[0][1] for c in mock_backend.set_disposition.call_args_list}
+    assert guids == {"item_1", "item_2"}
+
+
+def test_result_collector_on_exhausted_raise_no_guid_warns(caplog):
+    """on_exhausted=raise warns when exhausted items have no source_guid."""
+    import logging
+
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+
+    agent_config = {
+        "agent_type": "test_action",
+        "retry": {"on_exhausted": "raise"},
+    }
+    exhausted = ProcessingResult.exhausted(
+        error="Retry exhausted",
+        source_guid=None,
+        recovery_metadata=_retry_metadata(),
+    )
+    exhausted.data = [{"content": {}}]
+
+    mock_backend = MagicMock()
+    mock_backend.set_disposition = MagicMock()
+    wire_batch_disposition_delegate(mock_backend)
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="agent_actions.processing.result_collector"):
+            with pytest.raises(AgentActionsError):
+                ResultCollector.collect_results(
+                    [exhausted],
+                    agent_config,
+                    "test_agent",
+                    is_first_stage=True,
+                    storage_backend=mock_backend,
+                )
+        assert any("none carry source_guid" in r.message for r in caplog.records)
+    finally:
+        aa_logger.propagate = orig
+
+
 def test_result_collector_on_exhausted_return_last_does_not_raise():
     """Test that on_exhausted=return_last (default) does not raise."""
     agent_config = {

--- a/tests/unit/core/test_result_collector_batch.py
+++ b/tests/unit/core/test_result_collector_batch.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
+
+import pytest
 
 from agent_actions.processing.result_collector import (
     collect_results_from_processing_results,
@@ -17,6 +20,16 @@ from agent_actions.storage.backend import (
     DISPOSITION_SUCCESS,
     DISPOSITION_UNPROCESSED,
 )
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Enable propagation so caplog captures agent_actions log records."""
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig
 
 
 def _mock_backend() -> MagicMock:
@@ -164,3 +177,165 @@ class TestBatchDispositionFlush:
         collect_results_from_processing_results(results, "action_A", storage_backend=backend)
         # set_disposition (single-record) should NOT be called — only set_dispositions_batch.
         backend.set_disposition.assert_not_called()
+
+
+class TestWriteRecordDispositionsWarning:
+    """write_record_dispositions logs a warning when batch items lack source_guid."""
+
+    def test_missing_source_guid_logs_warning(self, caplog):
+        """Batch items without source_guid log a warning instead of silent skip."""
+        from agent_actions.processing.result_collector import write_record_dispositions
+
+        backend = _mock_backend()
+        items = [
+            {"metadata": {}, "content": {"v": 1}},
+        ]
+        with caplog.at_level(logging.WARNING, logger="agent_actions.processing.result_collector"):
+            write_record_dispositions(backend, items, "action_A")
+        assert any("missing source_guid" in r.message for r in caplog.records)
+        backend.set_disposition.assert_not_called()
+
+    def test_items_with_source_guid_still_work(self):
+        """Batch items with source_guid are processed normally."""
+        from agent_actions.processing.result_collector import write_record_dispositions
+
+        backend = _mock_backend()
+        items = [
+            {"source_guid": "sg-1", "metadata": {}, "_state": "processed"},
+        ]
+        write_record_dispositions(backend, items, "action_A")
+        backend.set_disposition.assert_called_once()
+
+
+class TestPerItemDispositionFallback:
+    """When result.source_guid is None but data items carry their own source_guid,
+    dispositions must be written per-item to prevent infinite reprocessing."""
+
+    def test_skipped_per_item_dispositions(self):
+        """SKIPPED results with source_guid=None write per-item PASSTHROUGH dispositions."""
+        backend = _mock_backend()
+        result = ProcessingResult.skipped(
+            passthrough_data=None,
+            reason="guard_skip",
+            source_guid=None,
+        )
+        result.data = [
+            {"source_guid": "item_1", "content": {}},
+            {"source_guid": "item_2", "content": {}},
+        ]
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 2
+        assert all(t[2] == DISPOSITION_PASSTHROUGH for t in batch_arg)
+        assert {t[1] for t in batch_arg} == {"item_1", "item_2"}
+
+    def test_failed_per_item_dispositions(self):
+        """FAILED results with source_guid=None write per-item FAILED dispositions."""
+        backend = _mock_backend()
+        result = ProcessingResult.failed(error="timeout", source_guid=None)
+        result.data = [
+            {"source_guid": "item_1", "error": "timeout"},
+            {"source_guid": "item_2", "error": "timeout"},
+        ]
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 2
+        assert all(t[2] == DISPOSITION_FAILED for t in batch_arg)
+        assert {t[1] for t in batch_arg} == {"item_1", "item_2"}
+
+    def test_exhausted_per_item_dispositions(self):
+        """EXHAUSTED results with source_guid=None write per-item EXHAUSTED dispositions."""
+        backend = _mock_backend()
+        from agent_actions.processing.types import RecoveryMetadata, RetryMetadata
+
+        result = ProcessingResult.exhausted(
+            error="max_retries",
+            source_guid=None,
+            recovery_metadata=RecoveryMetadata(
+                retry=RetryMetadata(attempts=3, failures=3, succeeded=False, reason="max_retries")
+            ),
+        )
+        result.data = [
+            {"source_guid": "item_1", "content": {}},
+        ]
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 1
+        assert batch_arg[0][1] == "item_1"
+        assert batch_arg[0][2] == DISPOSITION_EXHAUSTED
+
+    def test_unprocessed_per_item_dispositions(self):
+        """UNPROCESSED results with source_guid=None write per-item UNPROCESSED dispositions."""
+        backend = _mock_backend()
+        result = ProcessingResult(
+            status=ProcessingStatus.UNPROCESSED,
+            data=[
+                {"source_guid": "item_1"},
+                {"source_guid": "item_2"},
+            ],
+            source_guid=None,
+            skip_reason="cascade_blocked",
+        )
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 2
+        assert all(t[2] == DISPOSITION_UNPROCESSED for t in batch_arg)
+        assert {t[1] for t in batch_arg} == {"item_1", "item_2"}
+
+    def test_parse_error_per_item_dispositions(self):
+        """Parse-error SUCCESS→FAILED with source_guid=None writes per-item FAILED dispositions."""
+        backend = _mock_backend()
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "item_1", "content": {"ns": {"_parse_error": "bad"}}},
+            ],
+            source_guid=None,
+        )
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 1
+        assert batch_arg[0][1] == "item_1"
+        assert batch_arg[0][2] == DISPOSITION_FAILED
+
+    def test_filtered_no_source_guid_logs_warning(self, caplog):
+        """FILTERED result with no source_guid logs a warning."""
+        backend = _mock_backend()
+        result = ProcessingResult(
+            status=ProcessingStatus.FILTERED,
+            data=[],
+            source_guid=None,
+        )
+        with caplog.at_level(logging.WARNING, logger="agent_actions.processing.result_collector"):
+            collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        assert any("FILTERED result has no source_guid" in r.message for r in caplog.records)
+        backend.set_dispositions_batch.assert_not_called()
+
+    def test_deferred_no_source_guid_logs_warning(self, caplog):
+        """DEFERRED result with no source_guid logs a warning."""
+        backend = _mock_backend()
+        result = ProcessingResult.deferred(task_id="task-1", source_guid=None)
+        with caplog.at_level(logging.WARNING, logger="agent_actions.processing.result_collector"):
+            collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        assert any("DEFERRED result has no source_guid" in r.message for r in caplog.records)
+        backend.set_dispositions_batch.assert_not_called()
+
+    def test_mixed_items_with_and_without_guid(self):
+        """Only items with source_guid get dispositions; those without are warned about."""
+        backend = _mock_backend()
+        result = ProcessingResult.success(
+            data=[
+                {"source_guid": "item_1", "content": {"v": 1}},
+                {"content": {"v": 2}},
+            ],
+            source_guid=None,
+        )
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 1
+        assert batch_arg[0][1] == "item_1"

--- a/tests/unit/core/test_result_collector_batch.py
+++ b/tests/unit/core/test_result_collector_batch.py
@@ -302,8 +302,27 @@ class TestPerItemDispositionFallback:
         assert batch_arg[0][1] == "item_1"
         assert batch_arg[0][2] == DISPOSITION_FAILED
 
-    def test_filtered_no_source_guid_logs_warning(self, caplog):
-        """FILTERED result with no source_guid logs a warning."""
+    def test_filtered_per_item_dispositions(self):
+        """FILTERED results with source_guid=None write per-item FILTERED dispositions."""
+        backend = _mock_backend()
+        result = ProcessingResult(
+            status=ProcessingStatus.FILTERED,
+            data=[
+                {"source_guid": "item_1"},
+                {"source_guid": "item_2"},
+            ],
+            source_guid=None,
+            skip_reason="guard_filter",
+        )
+        collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        backend.set_dispositions_batch.assert_called_once()
+        batch_arg = backend.set_dispositions_batch.call_args[0][0]
+        assert len(batch_arg) == 2
+        assert all(t[2] == DISPOSITION_FILTERED for t in batch_arg)
+        assert {t[1] for t in batch_arg} == {"item_1", "item_2"}
+
+    def test_filtered_no_data_no_source_guid_logs_warning(self, caplog):
+        """FILTERED result with no source_guid and no data logs a warning."""
         backend = _mock_backend()
         result = ProcessingResult(
             status=ProcessingStatus.FILTERED,
@@ -323,6 +342,15 @@ class TestPerItemDispositionFallback:
             collect_results_from_processing_results([result], "action_A", storage_backend=backend)
         assert any("DEFERRED result has no source_guid" in r.message for r in caplog.records)
         backend.set_dispositions_batch.assert_not_called()
+
+    def test_failed_no_data_no_source_guid_logs_warning(self, caplog):
+        """FAILED result with no source_guid and no data logs a warning."""
+        backend = _mock_backend()
+        result = ProcessingResult.failed(error="timeout", source_guid=None)
+        result.data = []
+        with caplog.at_level(logging.WARNING, logger="agent_actions.processing.result_collector"):
+            collect_results_from_processing_results([result], "action_A", storage_backend=backend)
+        assert any("FAILED result has no source_guid" in r.message for r in caplog.records)
 
     def test_mixed_items_with_and_without_guid(self):
         """Only items with source_guid get dispositions; those without are warned about."""

--- a/tests/unit/storage/test_delta_storage.py
+++ b/tests/unit/storage/test_delta_storage.py
@@ -1220,13 +1220,13 @@ class TestIssue7_PartitionedPipeline:
                     "source_guid": "g1",
                     "_state": "processed",
                     "_state_schema_version": 1,
-                    "content": {"source": {"x": 1}, "source": {"data": "raw"}},
+                    "content": {"source": {"x": 1, "data": "raw"}},
                 },
                 {
                     "source_guid": "g2",
                     "_state": "processed",
                     "_state_schema_version": 1,
-                    "content": {"source": {"x": 2}, "source": {"data": "raw2"}},
+                    "content": {"source": {"x": 2, "data": "raw2"}},
                 },
             ],
             is_first_action=True,
@@ -1241,8 +1241,7 @@ class TestIssue7_PartitionedPipeline:
                     "_state": "processed",
                     "_state_schema_version": 1,
                     "content": {
-                        "source": {"x": 1},
-                        "source": {"data": "raw"},
+                        "source": {"x": 1, "data": "raw"},
                         "branch_a": {"score": 5},
                     },
                 }
@@ -1258,8 +1257,7 @@ class TestIssue7_PartitionedPipeline:
                     "_state": "processed",
                     "_state_schema_version": 1,
                     "content": {
-                        "source": {"x": 2},
-                        "source": {"data": "raw2"},
+                        "source": {"x": 2, "data": "raw2"},
                         "branch_b": {"score": 8},
                     },
                 }
@@ -1275,8 +1273,7 @@ class TestIssue7_PartitionedPipeline:
                     "_state": "processed",
                     "_state_schema_version": 1,
                     "content": {
-                        "source": {"x": 1},
-                        "source": {"data": "raw"},
+                        "source": {"x": 1, "data": "raw"},
                         "branch_a": {"score": 5},
                         "merge": {"combined": "g1_result"},
                     },
@@ -1286,8 +1283,7 @@ class TestIssue7_PartitionedPipeline:
                     "_state": "processed",
                     "_state_schema_version": 1,
                     "content": {
-                        "source": {"x": 2},
-                        "source": {"data": "raw2"},
+                        "source": {"x": 2, "data": "raw2"},
                         "branch_b": {"score": 8},
                         "merge": {"combined": "g2_result"},
                     },


### PR DESCRIPTION
## Summary
- Finding #4 of spec 554: records lacking `source_guid` are no longer
  silently skipped from disposition writes. This was producing infinite
  reprocessing because the checkpoint never landed.
- Extracted `_per_item_dispositions()` helper to consolidate FILE-mode
  per-item fallback across all 7 status branches (was inline in SUCCESS only).
- All status branches (SUCCESS, SKIPPED, EXHAUSTED, FAILED, UNPROCESSED,
  FILTERED, parse-error) now write per-item dispositions when
  `result.source_guid is None` but data items carry their own `source_guid`.
- FILTERED and DEFERRED with no data + no guid log a warning.
- `write_record_dispositions` warns on batch items missing `source_guid`.
- `_handle_exhausted_policy` writes per-item dispositions for FILE-mode
  exhausted results under `on_exhausted=raise`.
- Fixed pre-existing duplicate dict key ruff errors in `test_delta_storage.py`.
- Sibling in `agent_actions/llm/batch/services/processing.py:724` documented
  as cross-clone issue (outside owned_paths).

## Verification
- ruff + pytest clean (7538 passed)
- judge: claude-consensus 5/5 YES
- smoke: qanalabs online pass (52 actions, 386s)