### PR TITLE
fix(prompt): render save and scope parsing surface their failures

### DIFF
--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -1,9 +1,13 @@
 """Field reference parsing and action name extraction utilities."""
 
+import logging
+
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
 from agent_actions.utils.template_escape import escape_jinja_in_inline_code
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "parse_field_reference",
@@ -130,14 +134,16 @@ def extract_action_names_from_template(template: str | None) -> set:
     Extract unique action names referenced in a Jinja2 template.
 
     Parses template AST to extract namespace names, excluding variables scoped
-    by {% for %}, {% set %}, and {% macro %} constructs. Returns empty set
-    if the template has syntax errors (broken templates fail at render time).
+    by {% for %}, {% set %}, and {% macro %} constructs. Logs a warning and
+    returns empty set on Jinja2 syntax errors (syntax errors are caught at
+    render time; this function is a best-effort dependency extractor).
 
     Args:
         template: Jinja2 template string
 
     Returns:
-        Set of action names (potential upstream dependencies) referenced in template
+        Set of action names (potential upstream dependencies) referenced in template.
+        Empty set if the template has syntax errors (a warning is logged).
 
     Example:
         template = "{{ summarize_page_content.summary }} and {{ source.text }}"
@@ -154,7 +160,15 @@ def extract_action_names_from_template(template: str | None) -> set:
     try:
         env = Environment()
         ast = env.parse(escape_jinja_in_inline_code(template))
-    except TemplateSyntaxError:
+    except TemplateSyntaxError as e:
+        logger.warning(
+            "Jinja2 syntax error in template scope extraction (line %s): %s — "
+            "scope dependencies may be incomplete; the syntax error will surface at render time. "
+            "Template snippet: %.200s",
+            e.lineno,
+            e.message,
+            template,
+        )
         return set()
 
     referenced_actions: set[str] = set()

--- a/agent_actions/prompt/render_workflow.py
+++ b/agent_actions/prompt/render_workflow.py
@@ -75,22 +75,21 @@ def _save_failed_render(rendered_yaml_content, workflow_name, project_root: Path
         project_root: Optional project root directory
 
     Returns:
-        Error message string or empty string if save fails
+        Error message string with path to saved file
+
+    Raises:
+        OSError: If the file cannot be written (disk full, permissions, etc.)
     """
     cache_dir = (
         resolve_project_root(project_root) / ".agent-actions" / "cache" / "rendered_workflows"
     )
     cache_dir.mkdir(parents=True, exist_ok=True)
     failed_render_path = cache_dir / f"{workflow_name}_failed.yml"
-    try:
-        with open(failed_render_path, "w", encoding="utf-8") as f:
-            f.write(rendered_yaml_content)
-        return (
-            f"\nRendered output saved to: {failed_render_path}\n"
-            f"Debug with: agac render {workflow_name}"
-        )
-    except OSError:
-        return ""
+    with open(failed_render_path, "w", encoding="utf-8") as f:
+        f.write(rendered_yaml_content)
+    return (
+        f"\nRendered output saved to: {failed_render_path}\nDebug with: agac render {workflow_name}"
+    )
 
 
 def _resolve_prompt_fields(item, project_root: Path | None = None):
@@ -575,9 +574,13 @@ def render_pipeline_with_templates(
         data = yaml.safe_load(rendered_yaml_content)
     except yaml.YAMLError as e:
         mark = getattr(e, "problem_mark", None)
-        saved_file_msg = _save_failed_render(
-            rendered_yaml_content, Path(yaml_path).stem, project_root=project_root
-        )
+        try:
+            saved_file_msg = _save_failed_render(
+                rendered_yaml_content, Path(yaml_path).stem, project_root=project_root
+            )
+        except OSError as save_err:
+            logger.warning("Could not save failed render output for debugging: %s", save_err)
+            saved_file_msg = ""
         raise ConfigurationError(
             f"Error parsing YAML after template rendering{saved_file_msg}",
             context={

--- a/agent_actions/validation/static_analyzer/reference_extractor.py
+++ b/agent_actions/validation/static_analyzer/reference_extractor.py
@@ -1,10 +1,13 @@
 """Extract field references from action configurations."""
 
+import logging
 import re
 from typing import Any
 
 from jinja2 import Environment, nodes
 from jinja2.exceptions import TemplateSyntaxError
+
+logger = logging.getLogger(__name__)
 
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
 from agent_actions.utils.template_escape import escape_jinja_in_inline_code
@@ -146,8 +149,15 @@ class ReferenceExtractor:
 
         try:
             ast = self._parse(template)
-        except TemplateSyntaxError:
-            # If template has syntax errors, fall back to empty (simple patterns will catch it)
+        except TemplateSyntaxError as e:
+            logger.warning(
+                "Jinja2 syntax error in template reference extraction (line %s): %s — "
+                "references may be incomplete; the syntax error will surface at render time. "
+                "Template snippet: %.200s",
+                e.lineno,
+                e.message,
+                template,
+            )
             return references
 
         self._walk_ast(ast, references, local_vars=set())

--- a/tests/unit/prompt/test_save_failed_render_propagates_oserror.py
+++ b/tests/unit/prompt/test_save_failed_render_propagates_oserror.py
@@ -1,0 +1,82 @@
+"""Regression: _save_failed_render propagates OSError instead of swallowing it.
+
+Finding #7: render_workflow.py:92 — OSError on render save was silently returned
+as "" (empty string). Callers had no way to detect the failure. The fix removes
+the silent fallback so OSError propagates, and the caller logs a warning while
+still raising the original ConfigurationError.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.prompt.render_workflow import _save_failed_render
+
+
+class TestSaveFailedRenderPropagatesOSError:
+    """_save_failed_render must raise OSError, not return ''."""
+
+    def test_oserror_on_write_propagates(self, tmp_path):
+        """OSError during file write is not caught — it propagates to caller."""
+        read_only_dir = tmp_path / "readonly"
+        read_only_dir.mkdir()
+        read_only_dir.chmod(0o444)
+
+        with patch(
+            "agent_actions.prompt.render_workflow.resolve_project_root",
+            return_value=read_only_dir,
+        ):
+            with pytest.raises(OSError):
+                _save_failed_render("bad yaml", "test_workflow", project_root=read_only_dir)
+
+        read_only_dir.chmod(0o755)
+
+    def test_successful_save_returns_path_message(self, tmp_path):
+        """When save succeeds, returns message with file path and debug command."""
+        with patch(
+            "agent_actions.prompt.render_workflow.resolve_project_root",
+            return_value=tmp_path,
+        ):
+            result = _save_failed_render("bad yaml", "my_workflow", project_root=tmp_path)
+
+        assert "my_workflow_failed.yml" in result
+        assert "agac render my_workflow" in result
+
+
+class TestRenderPipelineYamlParseErrorWithSaveFailure:
+    """When YAML parse fails AND save fails, ConfigurationError is still raised."""
+
+    def test_yaml_error_raised_even_if_save_fails(self, tmp_path):
+        """ConfigurationError from YAML parse is not lost when debug save fails."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.prompt.render_workflow import render_pipeline_with_templates
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+
+        yaml_file = tmp_path / "bad.yml"
+        yaml_file.write_text("name: test\nprompt: hello", encoding="utf-8")
+
+        config_content = "name: test\nbad_yaml: [unclosed"
+        yaml_file.write_text(config_content, encoding="utf-8")
+
+        with patch(
+            "agent_actions.prompt.render_workflow._save_failed_render",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(ConfigurationError, match="Error parsing YAML"):
+                render_pipeline_with_templates(yaml_file, templates_dir, project_root=tmp_path)
+
+    def test_yaml_error_includes_save_path_when_save_succeeds(self, tmp_path):
+        """ConfigurationError message includes debug file path on successful save."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.prompt.render_workflow import render_pipeline_with_templates
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+
+        yaml_file = tmp_path / "bad.yml"
+        yaml_file.write_text("bad_yaml: [unclosed", encoding="utf-8")
+
+        with pytest.raises(ConfigurationError, match="Rendered output saved to"):
+            render_pipeline_with_templates(yaml_file, templates_dir, project_root=tmp_path)

--- a/tests/unit/prompt/test_scope_parsing_template_syntax_error.py
+++ b/tests/unit/prompt/test_scope_parsing_template_syntax_error.py
@@ -1,0 +1,96 @@
+"""Regression: extract_action_names_from_template logs warning on Jinja2 syntax errors.
+
+Finding #8: scope_parsing.py:157 — TemplateSyntaxError was caught and returned
+as empty set with no logging. Callers received an empty set
+indistinguishable from "template has no action references", causing
+wrong context to be built silently. The fix logs a warning with
+diagnostics so the failure is visible in logs.
+"""
+
+import logging
+
+import pytest
+
+from agent_actions.prompt.context.scope_parsing import extract_action_names_from_template
+
+_LOGGER_NAME = "agent_actions.prompt.context.scope_parsing"
+
+
+@pytest.fixture(autouse=True)
+def _enable_propagate():
+    """Ensure the agent_actions logger propagates to root so caplog captures records."""
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = original
+
+
+class TestTemplateSyntaxErrorLogsWarning:
+    """TemplateSyntaxError must log a warning, not fail silently."""
+
+    def test_unclosed_block_logs_warning(self, caplog):
+        """Unclosed Jinja2 block tag logs a warning and returns empty set."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = extract_action_names_from_template("{% if foo %} no endif")
+
+        assert result == set()
+        assert len(caplog.records) == 1
+        assert "syntax error" in caplog.records[0].message.lower()
+
+    def test_unclosed_variable_logs_warning(self, caplog):
+        """Unclosed variable expression logs a warning and returns empty set."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = extract_action_names_from_template("{{ unclosed_var")
+
+        assert result == set()
+        assert len(caplog.records) == 1
+
+    def test_warning_includes_template_snippet(self, caplog):
+        """Warning message includes the template content for diagnostics."""
+        template = "{% if broken %} {{ action.field }}"
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            extract_action_names_from_template(template)
+
+        assert len(caplog.records) == 1
+        assert template[:50] in caplog.records[0].message
+
+    def test_warning_includes_line_number(self, caplog):
+        """Warning message includes the line number of the syntax error."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            extract_action_names_from_template("{% if broken %}")
+
+        assert len(caplog.records) == 1
+        assert "line" in caplog.records[0].message.lower()
+
+    def test_no_warning_on_valid_template(self, caplog):
+        """Valid templates produce no warnings."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            extract_action_names_from_template("{{ action.field }}")
+
+        assert len(caplog.records) == 0
+
+
+class TestValidTemplatesBehaviorUnchanged:
+    """Valid templates still return correct action name sets after the fix."""
+
+    def test_valid_template_returns_actions(self):
+        """Standard template with action references returns them."""
+        result = extract_action_names_from_template("{{ summarize.text }} and {{ extract.facts }}")
+        assert result == {"summarize", "extract"}
+
+    def test_empty_template_returns_empty_set(self):
+        """Empty or None template returns empty set (not an error)."""
+        assert extract_action_names_from_template("") == set()
+        assert extract_action_names_from_template(None) == set()
+
+    def test_template_without_actions_returns_empty_set(self):
+        """Template with only special namespaces returns empty set."""
+        result = extract_action_names_from_template("{{ source.text }}")
+        assert result == set()
+
+    def test_for_loop_scoped_vars_excluded(self):
+        """Variables introduced by {% for %} are excluded from action names."""
+        template = "{% for item in items %}{{ item.name }}{% endfor %}"
+        result = extract_action_names_from_template(template)
+        assert "item" not in result

--- a/tests/validation/static_analyzer/test_reference_extractor.py
+++ b/tests/validation/static_analyzer/test_reference_extractor.py
@@ -1,6 +1,10 @@
 """Tests for the reference extractor."""
 
+import logging
+
 from agent_actions.validation.static_analyzer import ReferenceExtractor
+
+_LOGGER_NAME = "agent_actions.validation.static_analyzer.reference_extractor"
 
 
 class TestReferenceExtractor:
@@ -425,3 +429,67 @@ class TestReferenceExtractor:
         assert "key" not in agent_names
         assert "value" not in agent_names
         assert "extractor" in agent_names
+
+
+class TestReferenceExtractorTemplateSyntaxError:
+    """TemplateSyntaxError must log a warning, not fail silently."""
+
+    def setup_method(self):
+        self.extractor = ReferenceExtractor()
+
+    def _enable_propagate(self):
+        aa_logger = logging.getLogger("agent_actions")
+        original = aa_logger.propagate
+        aa_logger.propagate = True
+        return original
+
+    def test_syntax_error_logs_warning_and_returns_empty(self, caplog):
+        """Broken template logs warning and returns empty refs, not silent."""
+        original = self._enable_propagate()
+        try:
+            config = {
+                "name": "agent",
+                "prompt": "{% if broken %} {{ action.extractor.data }}",
+            }
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                refs = self.extractor.extract_from_agent(config)
+
+            assert refs == [] or all(r.location != "prompt" for r in refs)
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert len(warning_records) >= 1
+            assert "syntax error" in warning_records[0].message.lower()
+        finally:
+            logging.getLogger("agent_actions").propagate = original
+
+    def test_syntax_error_warning_includes_template_snippet(self, caplog):
+        """Warning includes the template text for diagnostics."""
+        original = self._enable_propagate()
+        try:
+            config = {
+                "name": "agent",
+                "prompt": "{{ unclosed_var",
+            }
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                self.extractor.extract_from_agent(config)
+
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert len(warning_records) >= 1
+            assert "unclosed_var" in warning_records[0].message
+        finally:
+            logging.getLogger("agent_actions").propagate = original
+
+    def test_valid_template_no_warning(self, caplog):
+        """Valid templates produce no warnings."""
+        original = self._enable_propagate()
+        try:
+            config = {
+                "name": "agent",
+                "prompt": "{{ action.extractor.data }}",
+            }
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                self.extractor.extract_from_agent(config)
+
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert len(warning_records) == 0
+        finally:
+            logging.getLogger("agent_actions").propagate = original


### PR DESCRIPTION
## Summary
- Finding #7 (HIGH): `_save_failed_render` no longer swallows `OSError` on disk write. The function propagates the error; the single caller catches it, logs a warning, and still raises the original `ConfigurationError` for the YAML parse failure.
- Finding #8 (MEDIUM): `extract_action_names_from_template` now logs a `WARNING` on Jinja2 syntax errors instead of silently returning `set()`. The warning includes line number, error message, and template snippet. Return type unchanged to preserve caller compatibility.
- Sibling fix: `reference_extractor._extract_jinja_references` gets the same warning-on-syntax-error treatment.

## Verification
- ruff check + ruff format: clean
- pytest: 7554 passed (16 new regression tests)
- judge: claude-consensus 5/5 YES
- smoke: qanalabs online pass (52 actions, 487s)