### PR TITLE
fix(prompt): render save and scope parsing surface their failures

### DIFF
--- a/agent_actions/llm/realtime/services/invocation.py
+++ b/agent_actions/llm/realtime/services/invocation.py
@@ -66,8 +66,11 @@ def _resolve_client(model_vendor: str) -> Any:
                     "install_command": f"uv pip install {package}",
                 },
             ) from err
-        CLIENT_REGISTRY.setdefault(model_vendor, cls)  # atomic under CPython GIL
-        return CLIENT_REGISTRY[model_vendor]  # return whatever won the race
+        # Replace lazy "module:Class" string with the resolved class so
+        # subsequent lookups skip the import. Plain assignment, not setdefault:
+        # the key already exists (with a string), so setdefault would no-op.
+        CLIENT_REGISTRY[model_vendor] = cls
+        return cls
     return entry
 
 

--- a/agent_actions/prompt/context/scope_inference.py
+++ b/agent_actions/prompt/context/scope_inference.py
@@ -249,8 +249,29 @@ def infer_dependencies(
 
     try:
         raw_prompt = PromptFormatter.get_raw_prompt(action_config)
-        if raw_prompt:
+    except Exception as e:
+        logger.debug(
+            "Prompt retrieval failed for template inference on '%s': %s",
+            action_name,
+            e,
+            exc_info=True,
+        )
+        raw_prompt = None
+
+    if raw_prompt:
+        from jinja2.exceptions import TemplateSyntaxError
+
+        try:
             template_actions = extract_action_names_from_template(raw_prompt)
+        except TemplateSyntaxError as e:
+            logger.warning(
+                "Template syntax error during scope inference for '%s' (line %s): %s — "
+                "context_scope inference skipped; the syntax error will surface at render time.",
+                action_name,
+                e.lineno,
+                e.message,
+            )
+        else:
             # Only add template-referenced actions that are valid workflow actions
             valid_template_actions = template_actions & set(workflow_actions)
             if valid_template_actions - referenced_actions:
@@ -259,13 +280,6 @@ def infer_dependencies(
                     f"from template: {valid_template_actions - referenced_actions}"
                 )
             referenced_actions = referenced_actions | valid_template_actions
-    except Exception as e:
-        logger.debug(
-            "Prompt retrieval failed for template inference on '%s': %s",
-            action_name,
-            e,
-            exc_info=True,
-        )
 
     # 2b. Identify wildcard actions from context_scope
     wildcard_actions = set()

--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -134,16 +134,20 @@ def extract_action_names_from_template(template: str | None) -> set:
     Extract unique action names referenced in a Jinja2 template.
 
     Parses template AST to extract namespace names, excluding variables scoped
-    by {% for %}, {% set %}, and {% macro %} constructs. Logs a warning and
-    returns empty set on Jinja2 syntax errors (syntax errors are caught at
-    render time; this function is a best-effort dependency extractor).
+    by {% for %}, {% set %}, and {% macro %} constructs.
 
     Args:
         template: Jinja2 template string
 
     Returns:
         Set of action names (potential upstream dependencies) referenced in template.
-        Empty set if the template has syntax errors (a warning is logged).
+        Empty set when template is None, empty, or not a string.
+
+    Raises:
+        TemplateSyntaxError: If the template has a Jinja2 syntax error. A warning
+            is logged before the exception propagates so the caller has diagnostic
+            context (line number, message, template snippet). Callers that want
+            best-effort extraction must catch this explicitly.
 
     Example:
         template = "{{ summarize_page_content.summary }} and {{ source.text }}"

--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -1,9 +1,13 @@
 """Field reference parsing and action name extraction utilities."""
 
+import logging
+
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events.io_events import ContextFieldSkippedEvent
 from agent_actions.utils.constants import SPECIAL_NAMESPACES
 from agent_actions.utils.template_escape import escape_jinja_in_inline_code
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "parse_field_reference",
@@ -130,14 +134,16 @@ def extract_action_names_from_template(template: str | None) -> set:
     Extract unique action names referenced in a Jinja2 template.
 
     Parses template AST to extract namespace names, excluding variables scoped
-    by {% for %}, {% set %}, and {% macro %} constructs. Returns empty set
-    if the template has syntax errors (broken templates fail at render time).
+    by {% for %}, {% set %}, and {% macro %} constructs. Logs a warning and
+    returns empty set on Jinja2 syntax errors (syntax errors are caught at
+    render time; this function is a best-effort dependency extractor).
 
     Args:
         template: Jinja2 template string
 
     Returns:
-        Set of action names (potential upstream dependencies) referenced in template
+        Set of action names (potential upstream dependencies) referenced in template.
+        Empty set if the template has syntax errors (a warning is logged).
 
     Example:
         template = "{{ summarize_page_content.summary }} and {{ source.text }}"
@@ -154,7 +160,15 @@ def extract_action_names_from_template(template: str | None) -> set:
     try:
         env = Environment()
         ast = env.parse(escape_jinja_in_inline_code(template))
-    except TemplateSyntaxError:
+    except TemplateSyntaxError as e:
+        logger.warning(
+            "Jinja2 syntax error in template scope extraction (line %s): %s — "
+            "scope dependencies may be incomplete; the syntax error will surface at render time. "
+            "Template snippet: %.200s",
+            e.lineno,
+            e.message,
+            template,
+        )
         return set()
 
     referenced_actions: set[str] = set()

--- a/agent_actions/prompt/context/scope_parsing.py
+++ b/agent_actions/prompt/context/scope_parsing.py
@@ -163,13 +163,12 @@ def extract_action_names_from_template(template: str | None) -> set:
     except TemplateSyntaxError as e:
         logger.warning(
             "Jinja2 syntax error in template scope extraction (line %s): %s — "
-            "scope dependencies may be incomplete; the syntax error will surface at render time. "
             "Template snippet: %.200s",
             e.lineno,
             e.message,
             template,
         )
-        return set()
+        raise
 
     referenced_actions: set[str] = set()
 

--- a/agent_actions/prompt/render_workflow.py
+++ b/agent_actions/prompt/render_workflow.py
@@ -75,22 +75,21 @@ def _save_failed_render(rendered_yaml_content, workflow_name, project_root: Path
         project_root: Optional project root directory
 
     Returns:
-        Error message string or empty string if save fails
+        Error message string with path to saved file
+
+    Raises:
+        OSError: If the file cannot be written (disk full, permissions, etc.)
     """
     cache_dir = (
         resolve_project_root(project_root) / ".agent-actions" / "cache" / "rendered_workflows"
     )
     cache_dir.mkdir(parents=True, exist_ok=True)
     failed_render_path = cache_dir / f"{workflow_name}_failed.yml"
-    try:
-        with open(failed_render_path, "w", encoding="utf-8") as f:
-            f.write(rendered_yaml_content)
-        return (
-            f"\nRendered output saved to: {failed_render_path}\n"
-            f"Debug with: agac render {workflow_name}"
-        )
-    except OSError:
-        return ""
+    with open(failed_render_path, "w", encoding="utf-8") as f:
+        f.write(rendered_yaml_content)
+    return (
+        f"\nRendered output saved to: {failed_render_path}\nDebug with: agac render {workflow_name}"
+    )
 
 
 def _resolve_prompt_fields(item, project_root: Path | None = None):
@@ -575,9 +574,13 @@ def render_pipeline_with_templates(
         data = yaml.safe_load(rendered_yaml_content)
     except yaml.YAMLError as e:
         mark = getattr(e, "problem_mark", None)
-        saved_file_msg = _save_failed_render(
-            rendered_yaml_content, Path(yaml_path).stem, project_root=project_root
-        )
+        try:
+            saved_file_msg = _save_failed_render(
+                rendered_yaml_content, Path(yaml_path).stem, project_root=project_root
+            )
+        except OSError as save_err:
+            logger.warning("Could not save failed render output for debugging: %s", save_err)
+            saved_file_msg = ""
         raise ConfigurationError(
             f"Error parsing YAML after template rendering{saved_file_msg}",
             context={

--- a/agent_actions/validation/preflight/resolution_service.py
+++ b/agent_actions/validation/preflight/resolution_service.py
@@ -352,6 +352,8 @@ class WorkflowResolutionService:
         warnings: list[StaticTypeWarning],
     ) -> None:
         """Validate that seed field references in templates match loaded seed data."""
+        from jinja2.exceptions import TemplateSyntaxError
+
         from agent_actions.validation.static_analyzer.reference_extractor import (
             ReferenceExtractor,
         )
@@ -360,7 +362,22 @@ class WorkflowResolutionService:
 
         for action_name, config in self.action_configs.items():
             effective_config = self._resolve_prompt_for_extraction(config)
-            requirements = ref_extractor.extract_from_agent(effective_config)
+            try:
+                requirements = ref_extractor.extract_from_agent(effective_config)
+            except TemplateSyntaxError as exc:
+                errors.append(
+                    StaticTypeError(
+                        message=f"Template syntax error in '{action_name}': {exc.message} (line {exc.lineno})",
+                        location=FieldLocation(
+                            agent_name=action_name,
+                            config_field="prompt",
+                            line_number=exc.lineno,
+                        ),
+                        referenced_agent=action_name,
+                        referenced_field="",
+                    )
+                )
+                continue
             seed_refs = [r for r in requirements if r.source_agent == "seed"]
             if not seed_refs:
                 continue

--- a/agent_actions/validation/static_analyzer/field_flow_analyzer.py
+++ b/agent_actions/validation/static_analyzer/field_flow_analyzer.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .data_flow_graph import DataFlowGraph, DataFlowNode
-from .errors import StaticValidationResult
+from .errors import FieldLocation, StaticTypeError, StaticValidationResult
 
 
 @dataclass
@@ -168,9 +168,19 @@ class FieldFlowAnalyzer:
         """Get complete field flow for the entire workflow."""
         try:
             execution_order = self.graph.topological_sort()
-        except ValueError:
-            # Circular dependency - use whatever order we have
-            execution_order = list(self.graph.nodes.keys())
+        except ValueError as exc:
+            self.validation_result.add_error(
+                StaticTypeError(
+                    message=str(exc),
+                    location=FieldLocation(
+                        agent_name=self.workflow_name,
+                        config_field="dependencies",
+                    ),
+                    referenced_agent="",
+                    referenced_field="",
+                )
+            )
+            raise
 
         actions = []
         for action_name in execution_order:

--- a/agent_actions/validation/static_analyzer/field_flow_analyzer.py
+++ b/agent_actions/validation/static_analyzer/field_flow_analyzer.py
@@ -229,12 +229,26 @@ class FieldFlowAnalyzer:
         return self._build_action_flow_info(node)
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert full analysis to dictionary for JSON serialization."""
-        flow = self.get_full_flow()
+        """Convert full analysis to dictionary for JSON serialization.
+
+        On a cyclic workflow get_full_flow() raises ValueError (the cycle is
+        recorded as a StaticTypeError on validation_result). The serialized
+        output reports is_valid=False with an empty flow plus the validation
+        errors so consumers can render the cycle without crashing.
+        """
+        try:
+            flow_dict = self.get_full_flow().to_dict()
+        except ValueError:
+            flow_dict = {
+                "workflow_name": self.workflow_name,
+                "actions": [],
+                "execution_order": [],
+                "field_lineages": {},
+            }
         return {
             "workflow": self.workflow_name,
             "is_valid": self.validation_result.is_valid,
-            "flow": flow.to_dict(),
+            "flow": flow_dict,
             "validation": self.validation_result.to_dict(),
         }
 

--- a/agent_actions/validation/static_analyzer/reference_extractor.py
+++ b/agent_actions/validation/static_analyzer/reference_extractor.py
@@ -344,12 +344,23 @@ class ReferenceExtractor:
         self,
         workflow_config: dict[str, Any],
     ) -> dict[str, list[InputRequirement]]:
-        """Extract references from all actions in a workflow."""
+        """Extract references from all actions in a workflow.
+
+        A TemplateSyntaxError in one action's template does not abort the whole
+        workflow extraction: the failing action gets an empty requirements list
+        and a warning is logged by _extract_jinja_references. Static-analysis
+        callers that need to surface the syntax error explicitly should iterate
+        actions themselves and catch TemplateSyntaxError per-action.
+        """
         requirements: dict[str, list[InputRequirement]] = {}
 
         actions = workflow_config.get("actions", [])
         for action in actions:
             name = action.get("name", "unknown")
-            requirements[name] = self.extract_from_agent(action)
+            try:
+                requirements[name] = self.extract_from_agent(action)
+            except TemplateSyntaxError:
+                # Per-action failure isolated; warning already logged at parse site.
+                requirements[name] = []
 
         return requirements

--- a/agent_actions/validation/static_analyzer/reference_extractor.py
+++ b/agent_actions/validation/static_analyzer/reference_extractor.py
@@ -1,5 +1,6 @@
 """Extract field references from action configurations."""
 
+import logging
 import re
 from typing import Any
 
@@ -10,6 +11,8 @@ from agent_actions.utils.constants import SPECIAL_NAMESPACES
 from agent_actions.utils.template_escape import escape_jinja_in_inline_code
 
 from .data_flow_graph import InputRequirement
+
+logger = logging.getLogger(__name__)
 
 
 class ReferenceExtractor:
@@ -146,9 +149,14 @@ class ReferenceExtractor:
 
         try:
             ast = self._parse(template)
-        except TemplateSyntaxError:
-            # If template has syntax errors, fall back to empty (simple patterns will catch it)
-            return references
+        except TemplateSyntaxError as e:
+            logger.warning(
+                "Jinja2 syntax error in template (line %s): %s — Template snippet: %.200s",
+                e.lineno,
+                e.message,
+                template,
+            )
+            raise
 
         self._walk_ast(ast, references, local_vars=set())
         return references

--- a/agent_actions/validation/static_analyzer/reference_extractor.py
+++ b/agent_actions/validation/static_analyzer/reference_extractor.py
@@ -365,10 +365,13 @@ class ReferenceExtractor:
         """Extract references from all actions in a workflow.
 
         A TemplateSyntaxError in one action's template does not abort the whole
-        workflow extraction: the failing action gets an empty requirements list
-        and a warning is logged by _extract_jinja_references. Static-analysis
-        callers that need to surface the syntax error explicitly should iterate
-        actions themselves and catch TemplateSyntaxError per-action.
+        workflow extraction: the failing action gets its partial regex-only
+        requirements (the ones _extract_from_template collected before the Jinja
+        parse failed, attached to the exception as .partial_requirements). A
+        warning is logged at the parse site so the failure is operator-visible.
+        Static-analysis callers that need to surface the syntax error
+        explicitly should iterate actions themselves and catch TemplateSyntaxError
+        per-action.
         """
         requirements: dict[str, list[InputRequirement]] = {}
 
@@ -377,8 +380,9 @@ class ReferenceExtractor:
             name = action.get("name", "unknown")
             try:
                 requirements[name] = self.extract_from_agent(action)
-            except TemplateSyntaxError:
-                # Per-action failure isolated; warning already logged at parse site.
-                requirements[name] = []
+            except TemplateSyntaxError as exc:
+                # Preserve partial regex-extracted requirements; the warning
+                # is already logged at the parse site.
+                requirements[name] = list(getattr(exc, "partial_requirements", []))
 
         return requirements

--- a/agent_actions/validation/static_analyzer/reference_extractor.py
+++ b/agent_actions/validation/static_analyzer/reference_extractor.py
@@ -93,24 +93,19 @@ class ReferenceExtractor:
         _agent_name: str,
         location: str,
     ) -> list[InputRequirement]:
-        """Extract references from Jinja2 template using AST parsing."""
+        """Extract references from Jinja2 template using AST parsing.
+
+        Regex-based simple-brace patterns ({action.name.field}, {name.field}) are
+        collected first so they survive a Jinja2 TemplateSyntaxError. The Jinja2
+        AST pass runs last; if it raises, the requirements collected by the
+        regex pass are returned (a warning is logged at the parse site) so the
+        downstream graph still sees the simple-brace references.
+        """
         requirements: list[InputRequirement] = []
         seen: set[str] = set()
 
-        jinja_refs = self._extract_jinja_references(template)
-        for source, field, raw_ref in jinja_refs:
-            ref_key = f"{source}.{field}"
-            if ref_key not in seen:
-                seen.add(ref_key)
-                requirements.append(
-                    InputRequirement(
-                        source_agent=source,
-                        field_path=field,
-                        raw_reference=raw_ref,
-                        location=location,
-                    )
-                )
-
+        # Regex passes first — independent of Jinja2 parsing, so they survive
+        # a syntax error in the template.
         for match in self.SIMPLE_ACTION_PATTERN.finditer(template):
             source = match.group(1)
             field = match.group(2)
@@ -137,6 +132,29 @@ class ReferenceExtractor:
                         source_agent=source,
                         field_path=field,
                         raw_reference=match.group(0),
+                        location=location,
+                    )
+                )
+
+        # Jinja2 AST pass last — re-raises TemplateSyntaxError so callers that
+        # want to surface the error (e.g. WorkflowStaticAnalyzer) can record it.
+        # Regex requirements collected above are attached to the exception so
+        # callers that want best-effort extraction can use them.
+        try:
+            jinja_refs = self._extract_jinja_references(template)
+        except TemplateSyntaxError as exc:
+            exc.partial_requirements = requirements  # type: ignore[attr-defined]
+            raise
+
+        for source, field, raw_ref in jinja_refs:
+            ref_key = f"{source}.{field}"
+            if ref_key not in seen:
+                seen.add(ref_key)
+                requirements.append(
+                    InputRequirement(
+                        source_agent=source,
+                        field_path=field,
+                        raw_reference=raw_ref,
                         location=location,
                     )
                 )

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -473,19 +473,20 @@ class WorkflowStaticAnalyzer:
             try:
                 template_namespaces = extract_action_names_from_template(template)
             except TemplateSyntaxError as exc:
-                # Record the syntax error here too. _build_graph also catches it
-                # during _add_agent_node, but that path can be bypassed when the
-                # template is added after build or read from a different field;
-                # recording defensively guarantees the failure reaches the
-                # validation result instead of being silently dropped. Dedupe
-                # so the normal path (already recorded by _build_graph) is not
-                # double-reported.
+                # Record the syntax error here too. _add_agent_node also catches
+                # it during graph build, but that path can be bypassed when the
+                # template is read from a different field; recording defensively
+                # guarantees the failure reaches the validation result. Append
+                # to the local `errors` list (returned from this method) — NOT
+                # self._build_errors, which analyze() has already consumed by
+                # this step. Dedupe against errors already on self._build_errors
+                # so the normal path is not double-reported.
                 already_recorded = any(
                     err.location.agent_name == name and err.location.config_field == "prompt"
                     for err in self._build_errors
                 )
                 if not already_recorded:
-                    self._build_errors.append(
+                    errors.append(
                         StaticTypeError(
                             message=(
                                 f"Template syntax error in '{name}': {exc.message} "

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -226,24 +226,12 @@ class WorkflowStaticAnalyzer:
         # Add special source node (always available)
         self._add_source_node()
 
-        # Add action nodes from actions
+        # Add action nodes from actions. _add_agent_node handles its own
+        # TemplateSyntaxError so a stub node is still added to the graph
+        # (downstream references then resolve, instead of cascading "missing
+        # node" errors that hide the real syntax-error root cause).
         for action_config in actions:
-            try:
-                self._add_agent_node(action_config)
-            except TemplateSyntaxError as exc:
-                action_name = action_config.get("name", "unknown")
-                self._build_errors.append(
-                    StaticTypeError(
-                        message=f"Template syntax error in '{action_name}': {exc.message} (line {exc.lineno})",
-                        location=FieldLocation(
-                            agent_name=action_name,
-                            config_field="prompt",
-                            line_number=exc.lineno,
-                        ),
-                        referenced_agent=action_name,
-                        referenced_field="",
-                    )
-                )
+            self._add_agent_node(action_config)
 
         # Build edges from input requirements
         self.graph.build_edges_from_requirements()
@@ -1714,13 +1702,28 @@ class WorkflowStaticAnalyzer:
         # Extract output schema
         output_schema = self.schema_extractor.extract_schema(action_config, self.schema_loader)
 
-        # Extract input schema (pass reference_extractor for LLM template analysis)
-        input_schema = self.schema_extractor.extract_input_schema(
-            action_config, self.reference_extractor
-        )
+        # Catch template syntax errors from BOTH the input-schema and the
+        # input-requirements extraction paths. Both walk the prompt via
+        # ReferenceExtractor and raise the same exception; catching once at
+        # this layer keeps the partial-requirements fallback in one place.
+        syntax_error: TemplateSyntaxError | None = None
 
-        # Extract input requirements (field references)
-        input_requirements = self.reference_extractor.extract_from_agent(action_config)
+        try:
+            input_schema = self.schema_extractor.extract_input_schema(
+                action_config, self.reference_extractor
+            )
+        except TemplateSyntaxError as exc:
+            syntax_error = exc
+            input_schema = InputSchema()
+
+        try:
+            input_requirements = self.reference_extractor.extract_from_agent(action_config)
+        except TemplateSyntaxError as exc:
+            # Prefer the earlier syntax_error (from input_schema) so we record
+            # only one error per action. Use partial regex results if any.
+            if syntax_error is None:
+                syntax_error = exc
+            input_requirements = list(getattr(exc, "partial_requirements", []))
 
         # Use auto-inferred dependency model
         from agent_actions.prompt.context.scope_inference import infer_dependencies
@@ -1756,6 +1759,26 @@ class WorkflowStaticAnalyzer:
         )
 
         self.graph.add_node(node)
+
+        # Record the syntax error AFTER the node is added so downstream
+        # references resolve to a real (if partial) node, avoiding spurious
+        # "missing node" errors that would mask the root cause.
+        if syntax_error is not None:
+            self._build_errors.append(
+                StaticTypeError(
+                    message=(
+                        f"Template syntax error in '{name}': {syntax_error.message} "
+                        f"(line {syntax_error.lineno})"
+                    ),
+                    location=FieldLocation(
+                        agent_name=name,
+                        config_field="prompt",
+                        line_number=syntax_error.lineno,
+                    ),
+                    referenced_agent=name,
+                    referenced_field="",
+                )
+            )
 
     def get_graph(self) -> DataFlowGraph:
         """Return the data flow graph for inspection.

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -112,10 +112,6 @@ class WorkflowStaticAnalyzer:
         Returns:
             StaticValidationResult with errors and warnings
         """
-        # Reset per-run state so reusing an analyzer instance does not
-        # accumulate errors from previous analyze() calls.
-        self._build_errors = []
-
         # Step 0: Validate context_scope BEFORE normalization so diagnostic
         # hints can inspect the raw YAML values (null, wrong type, orphaned
         # directives). Normalization in Step 0b converts null → {} which would
@@ -220,6 +216,10 @@ class WorkflowStaticAnalyzer:
         """Build the data flow graph from workflow config."""
         if self._built:
             return
+
+        # Reset error buffer so a rebuild produces a fresh list rather than
+        # appending to errors from a prior partial state.
+        self._build_errors = []
 
         actions = self.workflow_config.get("actions", [])
 
@@ -484,8 +484,35 @@ class WorkflowStaticAnalyzer:
             # (source, version, seed, workflow, loop are already filtered)
             try:
                 template_namespaces = extract_action_names_from_template(template)
-            except TemplateSyntaxError:
-                continue  # syntax error already recorded in _build_graph via _build_errors
+            except TemplateSyntaxError as exc:
+                # Record the syntax error here too. _build_graph also catches it
+                # during _add_agent_node, but that path can be bypassed when the
+                # template is added after build or read from a different field;
+                # recording defensively guarantees the failure reaches the
+                # validation result instead of being silently dropped. Dedupe
+                # so the normal path (already recorded by _build_graph) is not
+                # double-reported.
+                already_recorded = any(
+                    err.location.agent_name == name and err.location.config_field == "prompt"
+                    for err in self._build_errors
+                )
+                if not already_recorded:
+                    self._build_errors.append(
+                        StaticTypeError(
+                            message=(
+                                f"Template syntax error in '{name}': {exc.message} "
+                                f"(line {exc.lineno})"
+                            ),
+                            location=FieldLocation(
+                                agent_name=name,
+                                config_field="prompt",
+                                line_number=exc.lineno,
+                            ),
+                            referenced_agent=name,
+                            referenced_field="",
+                        )
+                    )
+                continue
 
             # Also filter FRAMEWORK_NAMESPACES for safety
             template_namespaces -= FRAMEWORK_NAMESPACES

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -112,6 +112,10 @@ class WorkflowStaticAnalyzer:
         Returns:
             StaticValidationResult with errors and warnings
         """
+        # Reset per-run state so reusing an analyzer instance does not
+        # accumulate errors from previous analyze() calls.
+        self._build_errors = []
+
         # Step 0: Validate context_scope BEFORE normalization so diagnostic
         # hints can inspect the raw YAML values (null, wrong type, orphaned
         # directives). Normalization in Step 0b converts null → {} which would

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -7,6 +7,8 @@ similar to TypeScript's compile-time type checking.
 import logging
 from typing import Any
 
+from jinja2.exceptions import TemplateSyntaxError
+
 from agent_actions.errors import ConfigurationError
 from agent_actions.guards.consolidated_guard import GuardBehavior
 from agent_actions.input.context.normalizer import (
@@ -102,6 +104,7 @@ class WorkflowStaticAnalyzer:
 
         self.graph = DataFlowGraph()
         self._built = False
+        self._build_errors: list[StaticTypeError] = []
 
     def analyze(self) -> StaticValidationResult:
         """Perform static analysis of the workflow.
@@ -133,6 +136,24 @@ class WorkflowStaticAnalyzer:
         # Step 1: Build data flow graph
         self._build_graph()
 
+        # Step 1b: Check for circular dependencies
+        cycle_errors: list[StaticTypeError] = []
+        try:
+            self.graph.topological_sort()
+        except ValueError as exc:
+            workflow_name = self.workflow_config.get("name", "workflow")
+            cycle_errors.append(
+                StaticTypeError(
+                    message=str(exc),
+                    location=FieldLocation(
+                        agent_name=workflow_name,
+                        config_field="dependencies",
+                    ),
+                    referenced_agent="",
+                    referenced_field="",
+                )
+            )
+
         # Step 2: Expand wildcard field references (namespace.* → concrete fields)
         expansion_errors = self._expand_wildcards()
 
@@ -140,6 +161,10 @@ class WorkflowStaticAnalyzer:
         checker = StaticTypeChecker(self.graph, self.external_action_names)
         result = checker.check_all()
 
+        for error in cycle_errors:
+            result.add_error(error)
+        for error in self._build_errors:
+            result.add_error(error)
         for error in expansion_errors:
             result.add_error(error)
 
@@ -218,7 +243,22 @@ class WorkflowStaticAnalyzer:
 
         # Add action nodes from actions
         for action_config in actions:
-            self._add_agent_node(action_config)
+            try:
+                self._add_agent_node(action_config)
+            except TemplateSyntaxError as exc:
+                action_name = action_config.get("name", "unknown")
+                self._build_errors.append(
+                    StaticTypeError(
+                        message=f"Template syntax error in '{action_name}': {exc.message} (line {exc.lineno})",
+                        location=FieldLocation(
+                            agent_name=action_name,
+                            config_field="prompt",
+                            line_number=exc.lineno,
+                        ),
+                        referenced_agent=action_name,
+                        referenced_field="",
+                    )
+                )
 
         # Build edges from input requirements
         self.graph.build_edges_from_requirements()
@@ -457,7 +497,10 @@ class WorkflowStaticAnalyzer:
 
             # Extract non-special namespace references from template
             # (source, version, seed, workflow, loop are already filtered)
-            template_namespaces = extract_action_names_from_template(template)
+            try:
+                template_namespaces = extract_action_names_from_template(template)
+            except TemplateSyntaxError:
+                continue  # syntax error already recorded in _build_graph via _build_errors
 
             # Also filter FRAMEWORK_NAMESPACES for safety
             template_namespaces -= FRAMEWORK_NAMESPACES
@@ -1851,11 +1894,8 @@ class WorkflowStaticAnalyzer:
         return "\n".join(lines)
 
     def _get_execution_order(self) -> list[str]:
-        """Get execution order, falling back to node keys if cycle detected."""
-        try:
-            return self.graph.topological_sort()
-        except ValueError:
-            return list(self.graph.nodes.keys())
+        """Get execution order; raises ValueError if a cycle is detected."""
+        return self.graph.topological_sort()
 
     def _build_agent_references(self, node: DataFlowNode) -> list[dict[str, str]]:
         """Build references list for an action node."""

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -140,33 +140,14 @@ class WorkflowStaticAnalyzer:
         # Step 1: Build data flow graph
         self._build_graph()
 
-        # Step 1b: Check for circular dependencies
-        cycle_errors: list[StaticTypeError] = []
-        try:
-            self.graph.topological_sort()
-        except ValueError as exc:
-            workflow_name = self.workflow_config.get("name", "workflow")
-            cycle_errors.append(
-                StaticTypeError(
-                    message=str(exc),
-                    location=FieldLocation(
-                        agent_name=workflow_name,
-                        config_field="dependencies",
-                    ),
-                    referenced_agent="",
-                    referenced_field="",
-                )
-            )
-
         # Step 2: Expand wildcard field references (namespace.* → concrete fields)
         expansion_errors = self._expand_wildcards()
 
-        # Step 3: Run type checker
+        # Step 3: Run type checker. Cycle detection happens inside check_all()
+        # via graph.topological_sort() — no need to duplicate the check here.
         checker = StaticTypeChecker(self.graph, self.external_action_names)
         result = checker.check_all()
 
-        for error in cycle_errors:
-            result.add_error(error)
         for error in self._build_errors:
             result.add_error(error)
         for error in expansion_errors:
@@ -1923,14 +1904,22 @@ class WorkflowStaticAnalyzer:
         """Get a summary of data flow in the workflow.
 
         Returns:
-            Dict with nodes, edges, and execution order
+            Dict with nodes, edges, and execution order. On a cyclic workflow,
+            execution_order is empty and the dict carries a "cycle_error" entry
+            with the topological-sort message so consumers can render the cycle
+            instead of crashing.
         """
         if not self._built:
             self._build_graph()
 
-        execution_order = self._get_execution_order()
+        cycle_error: str | None = None
+        try:
+            execution_order = self._get_execution_order()
+        except ValueError as exc:
+            execution_order = []
+            cycle_error = str(exc)
 
-        return {
+        summary: dict[str, Any] = {
             "agents": [
                 self._build_agent_info(node)
                 for name, node in self.graph.nodes.items()
@@ -1944,6 +1933,9 @@ class WorkflowStaticAnalyzer:
                 for edge in self.graph.edges
             ],
         }
+        if cycle_error is not None:
+            summary["cycle_error"] = cycle_error
+        return summary
 
     @classmethod
     def from_workflow_file(

--- a/agent_actions/workflow/schema_service.py
+++ b/agent_actions/workflow/schema_service.py
@@ -152,12 +152,16 @@ class WorkflowSchemaService:
             return self._validation_result
 
     def get_execution_order(self) -> list[str]:
-        """Return topological execution order of actions, excluding special namespaces."""
-        try:
-            order = self.graph.topological_sort()
-        except ValueError:
-            order = list(self.graph.nodes.keys())
+        """Return topological execution order of actions, excluding special namespaces.
 
+        Raises:
+            ValueError: If the workflow contains a circular dependency. Callers
+                should call validate() first — preflight surfaces the cycle as a
+                StaticTypeError. The previous silent fallback to dict-key order
+                was removed because it let cyclic workflows run in arbitrary
+                order, masking the real configuration bug.
+        """
+        order = self.graph.topological_sort()
         return [name for name in order if not self.graph.is_special_namespace(name)]
 
     def get_downstream_actions(self, action_name: str) -> list[str]:

--- a/agent_actions/workflow/schema_service.py
+++ b/agent_actions/workflow/schema_service.py
@@ -170,15 +170,31 @@ class WorkflowSchemaService:
         return sorted(node.name for node in downstream_nodes)
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert full analysis to dictionary for JSON serialization."""
+        """Convert full analysis to dictionary for JSON serialization.
+
+        On a cyclic workflow get_execution_order() raises ValueError (the cycle
+        is recorded as a StaticTypeError on the validation result). The
+        serialized output reports is_valid=False with an empty execution_order
+        and a "cycle_error" key, so consumers can render the cycle without
+        crashing.
+        """
         validation = self.validate()
-        return {
+        cycle_error: str | None = None
+        try:
+            execution_order = self.get_execution_order()
+        except ValueError as exc:
+            execution_order = []
+            cycle_error = str(exc)
+        out: dict[str, Any] = {
             "workflow_name": self.workflow_name,
             "is_valid": validation.is_valid,
-            "execution_order": self.get_execution_order(),
+            "execution_order": execution_order,
             "actions": {name: schema.to_dict() for name, schema in self.get_all_schemas().items()},
             "validation": validation.to_dict(),
         }
+        if cycle_error is not None:
+            out["cycle_error"] = cycle_error
+        return out
 
     @staticmethod
     def _lookup_in_properties(

--- a/tests/services/test_workflow_schema_service.py
+++ b/tests/services/test_workflow_schema_service.py
@@ -544,3 +544,31 @@ class TestFromActionConfigs:
         )
         extractor = service._analyzer.schema_extractor
         assert extractor._get_tool_schemas() == {}
+
+
+class TestWorkflowSchemaServiceCycleHandling:
+    """Cyclic workflows must surface the cycle, not silently sort in dict-key order."""
+
+    CYCLIC_ACTIONS = {
+        "action_a": {"context_scope": {"observe": ["action_b.out_b"]}},
+        "action_b": {"context_scope": {"observe": ["action_a.out_a"]}},
+    }
+
+    def test_get_execution_order_raises_value_error_on_cycle(self):
+        """Silent fallback to dict-key order is gone — cycles must raise."""
+        import pytest
+
+        service = WorkflowSchemaService.from_action_configs("cyclic_wf", self.CYCLIC_ACTIONS)
+        with pytest.raises(ValueError, match="Circular dependency"):
+            service.get_execution_order()
+
+    def test_to_dict_degrades_gracefully_on_cycle(self):
+        """to_dict must not crash — returns degraded result with cycle_error."""
+        service = WorkflowSchemaService.from_action_configs("cyclic_wf", self.CYCLIC_ACTIONS)
+        out = service.to_dict()
+
+        assert out["is_valid"] is False
+        assert out["execution_order"] == []
+        assert "cycle_error" in out
+        assert "Circular dependency" in out["cycle_error"]
+        assert "validation" in out

--- a/tests/unit/llm/batch/test_batch_timeout.py
+++ b/tests/unit/llm/batch/test_batch_timeout.py
@@ -27,6 +27,7 @@ class TestWaitForBatchCompletionTimeout:
             0,  # first while check
             0,  # first current_time
             100,  # second while check — exceeds timeout
+            100,  # elapsed calculation after loop
         ]
         mock_time.sleep = MagicMock()
 

--- a/tests/unit/llm/test_client_resolution.py
+++ b/tests/unit/llm/test_client_resolution.py
@@ -1,0 +1,67 @@
+"""Regression: _resolve_client replaces lazy import strings with resolved classes.
+
+The CLIENT_REGISTRY holds lazy "module:Class" strings for external SDK providers
+so the CLI does not crash if a provider's SDK is missing. _resolve_client must
+import the module on first use and return the resolved class.
+
+Bug regression: _resolve_client previously used dict.setdefault to cache the
+resolved class, but setdefault is a no-op when the key already exists — so the
+original lazy string was never replaced, and callers received the string back.
+Downstream code then called .invoke() on a str, producing
+"'str' object has no attribute 'invoke'" at run time.
+"""
+
+import copy
+
+import pytest
+
+from agent_actions.llm.realtime.services.invocation import (
+    CLIENT_REGISTRY,
+    _resolve_client,
+)
+
+_ORIGINAL_REGISTRY = copy.copy(CLIENT_REGISTRY)
+
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    yield
+    CLIENT_REGISTRY.clear()
+    CLIENT_REGISTRY.update(_ORIGINAL_REGISTRY)
+
+
+class TestResolveClientLazyImport:
+    """_resolve_client must return a class, never the lazy import string."""
+
+    @pytest.mark.parametrize(
+        "vendor",
+        ["openai", "ollama_local", "ollama_cloud", "anthropic", "gemini", "cohere", "groq"],
+    )
+    def test_lazy_vendor_resolves_to_class_not_string(self, vendor):
+        """Each lazy-loaded provider resolves to an importable class with .invoke."""
+        # Force lazy state: restore the string entry before resolving.
+        CLIENT_REGISTRY[vendor] = _ORIGINAL_REGISTRY[vendor]
+        assert isinstance(CLIENT_REGISTRY[vendor], str), "precondition: starts as lazy string"
+
+        resolved = _resolve_client(vendor)
+
+        assert not isinstance(resolved, str), (
+            f"_resolve_client returned the lazy string for {vendor!r} — "
+            "calling .invoke() on a str would fail at runtime"
+        )
+        assert hasattr(resolved, "invoke"), f"resolved client for {vendor!r} must expose .invoke()"
+
+    def test_resolve_caches_class_in_registry(self):
+        """After resolution, the registry entry is the class (subsequent calls skip the import)."""
+        CLIENT_REGISTRY["openai"] = _ORIGINAL_REGISTRY["openai"]
+        _resolve_client("openai")
+        assert not isinstance(CLIENT_REGISTRY["openai"], str), (
+            "registry should hold the resolved class after first call"
+        )
+
+    def test_eager_internal_clients_returned_directly(self):
+        """tool/agac-provider/hitl are pre-loaded classes, returned as-is."""
+        for vendor in ("tool", "agac-provider", "hitl"):
+            entry = CLIENT_REGISTRY[vendor]
+            assert not isinstance(entry, str), f"{vendor} should be an eagerly loaded class"
+            assert _resolve_client(vendor) is entry

--- a/tests/unit/prompt/test_save_failed_render_propagates_oserror.py
+++ b/tests/unit/prompt/test_save_failed_render_propagates_oserror.py
@@ -1,0 +1,82 @@
+"""Regression: _save_failed_render propagates OSError instead of swallowing it.
+
+Finding #7: render_workflow.py:92 — OSError on render save was silently returned
+as "" (empty string). Callers had no way to detect the failure. The fix removes
+the silent fallback so OSError propagates, and the caller logs a warning while
+still raising the original ConfigurationError.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.prompt.render_workflow import _save_failed_render
+
+
+class TestSaveFailedRenderPropagatesOSError:
+    """_save_failed_render must raise OSError, not return ''."""
+
+    def test_oserror_on_write_propagates(self, tmp_path):
+        """OSError during file write is not caught — it propagates to caller."""
+        read_only_dir = tmp_path / "readonly"
+        read_only_dir.mkdir()
+        read_only_dir.chmod(0o444)
+
+        with patch(
+            "agent_actions.prompt.render_workflow.resolve_project_root",
+            return_value=read_only_dir,
+        ):
+            with pytest.raises(OSError):
+                _save_failed_render("bad yaml", "test_workflow", project_root=read_only_dir)
+
+        read_only_dir.chmod(0o755)
+
+    def test_successful_save_returns_path_message(self, tmp_path):
+        """When save succeeds, returns message with file path and debug command."""
+        with patch(
+            "agent_actions.prompt.render_workflow.resolve_project_root",
+            return_value=tmp_path,
+        ):
+            result = _save_failed_render("bad yaml", "my_workflow", project_root=tmp_path)
+
+        assert "my_workflow_failed.yml" in result
+        assert "agac render my_workflow" in result
+
+
+class TestRenderPipelineYamlParseErrorWithSaveFailure:
+    """When YAML parse fails AND save fails, ConfigurationError is still raised."""
+
+    def test_yaml_error_raised_even_if_save_fails(self, tmp_path):
+        """ConfigurationError from YAML parse is not lost when debug save fails."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.prompt.render_workflow import render_pipeline_with_templates
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+
+        yaml_file = tmp_path / "bad.yml"
+        yaml_file.write_text("name: test\nprompt: hello", encoding="utf-8")
+
+        config_content = "name: test\nbad_yaml: [unclosed"
+        yaml_file.write_text(config_content, encoding="utf-8")
+
+        with patch(
+            "agent_actions.prompt.render_workflow._save_failed_render",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(ConfigurationError, match="Error parsing YAML"):
+                render_pipeline_with_templates(yaml_file, templates_dir, project_root=tmp_path)
+
+    def test_yaml_error_includes_save_path_when_save_succeeds(self, tmp_path):
+        """ConfigurationError message includes debug file path on successful save."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.prompt.render_workflow import render_pipeline_with_templates
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+
+        yaml_file = tmp_path / "bad.yml"
+        yaml_file.write_text("bad_yaml: [unclosed", encoding="utf-8")
+
+        with pytest.raises(ConfigurationError, match="Rendered output saved to"):
+            render_pipeline_with_templates(yaml_file, templates_dir, project_root=tmp_path)

--- a/tests/unit/prompt/test_scope_inference_template_syntax.py
+++ b/tests/unit/prompt/test_scope_inference_template_syntax.py
@@ -1,0 +1,77 @@
+"""Regression: scope_inference catches TemplateSyntaxError explicitly.
+
+After extract_action_names_from_template was changed to raise TemplateSyntaxError
+on bad templates (instead of returning an empty set), the broad `except Exception`
+in scope_inference would mis-categorize the syntax error as "Prompt retrieval
+failed." The fix narrows the handler: prompt retrieval and template parsing get
+distinct except blocks with distinct log messages.
+"""
+
+import logging
+
+import pytest
+
+from agent_actions.prompt.context.scope_inference import infer_dependencies
+
+
+@pytest.fixture(autouse=True)
+def _enable_propagate():
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = original
+
+
+_SCOPE_INFERENCE_LOGGER = "agent_actions.prompt.context.scope_inference"
+
+
+class TestScopeInferenceTemplateSyntaxError:
+    """Template syntax errors during scope inference log a specific warning."""
+
+    def test_template_syntax_error_logs_scope_warning_not_prompt_warning(self, caplog):
+        """Bad template surfaces a 'Template syntax error during scope inference' warning."""
+        action_config = {
+            "name": "downstream",
+            "prompt": "{% if broken %} {{ upstream.field }}",
+            "context_scope": {},
+        }
+        workflow_actions = ["upstream", "downstream"]
+
+        with caplog.at_level(logging.WARNING, logger=_SCOPE_INFERENCE_LOGGER):
+            input_sources, context_sources = infer_dependencies(
+                action_config, workflow_actions, action_name="downstream", validate=False
+            )
+            result = set(input_sources) | set(context_sources)
+
+        assert isinstance(result, set)
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        scope_warnings = [r for r in warning_records if "scope inference" in r.message.lower()]
+        assert len(scope_warnings) >= 1, (
+            "expected a scope-inference warning for the bad template; "
+            f"got messages: {[r.message for r in warning_records]}"
+        )
+        assert "downstream" in scope_warnings[0].message
+        prompt_warnings = [r for r in warning_records if "prompt retrieval" in r.message.lower()]
+        assert not prompt_warnings, (
+            "syntax error must not be mis-categorized as a prompt retrieval failure"
+        )
+
+    def test_valid_template_no_warning(self, caplog):
+        """Well-formed templates produce no syntax warning."""
+        action_config = {
+            "name": "downstream",
+            "prompt": "Summary: {{ upstream.summary }}",
+            "context_scope": {},
+        }
+        workflow_actions = ["upstream", "downstream"]
+
+        with caplog.at_level(logging.WARNING, logger=_SCOPE_INFERENCE_LOGGER):
+            input_sources, context_sources = infer_dependencies(
+                action_config, workflow_actions, action_name="downstream", validate=False
+            )
+            result = set(input_sources) | set(context_sources)
+
+        assert "upstream" in result
+        syntax_warnings = [r for r in caplog.records if "syntax error" in r.message.lower()]
+        assert syntax_warnings == []

--- a/tests/unit/prompt/test_scope_parsing_template_syntax_error.py
+++ b/tests/unit/prompt/test_scope_parsing_template_syntax_error.py
@@ -1,0 +1,96 @@
+"""Regression: extract_action_names_from_template logs warning on Jinja2 syntax errors.
+
+Finding #8: scope_parsing.py:157 — TemplateSyntaxError was caught and returned
+as empty set with no logging. Callers received an empty set
+indistinguishable from "template has no action references", causing
+wrong context to be built silently. The fix logs a warning with
+diagnostics so the failure is visible in logs.
+"""
+
+import logging
+
+import pytest
+
+from agent_actions.prompt.context.scope_parsing import extract_action_names_from_template
+
+_LOGGER_NAME = "agent_actions.prompt.context.scope_parsing"
+
+
+@pytest.fixture(autouse=True)
+def _enable_propagate():
+    """Ensure the agent_actions logger propagates to root so caplog captures records."""
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = original
+
+
+class TestTemplateSyntaxErrorLogsWarning:
+    """TemplateSyntaxError must log a warning, not fail silently."""
+
+    def test_unclosed_block_logs_warning(self, caplog):
+        """Unclosed Jinja2 block tag logs a warning and returns empty set."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = extract_action_names_from_template("{% if foo %} no endif")
+
+        assert result == set()
+        assert len(caplog.records) == 1
+        assert "syntax error" in caplog.records[0].message.lower()
+
+    def test_unclosed_variable_logs_warning(self, caplog):
+        """Unclosed variable expression logs a warning and returns empty set."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = extract_action_names_from_template("{{ unclosed_var")
+
+        assert result == set()
+        assert len(caplog.records) == 1
+
+    def test_warning_includes_template_snippet(self, caplog):
+        """Warning message includes the template content for diagnostics."""
+        template = "{% if broken %} {{ action.field }}"
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            extract_action_names_from_template(template)
+
+        assert len(caplog.records) == 1
+        assert template[:50] in caplog.records[0].message
+
+    def test_warning_includes_line_number(self, caplog):
+        """Warning message includes the line number of the syntax error."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            extract_action_names_from_template("{% if broken %}")
+
+        assert len(caplog.records) == 1
+        assert "line" in caplog.records[0].message.lower()
+
+    def test_no_warning_on_valid_template(self, caplog):
+        """Valid templates produce no warnings."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            extract_action_names_from_template("{{ action.field }}")
+
+        assert len(caplog.records) == 0
+
+
+class TestValidTemplatesBehaviorUnchanged:
+    """Valid templates still return correct action name sets after the fix."""
+
+    def test_valid_template_returns_actions(self):
+        """Standard template with action references returns them."""
+        result = extract_action_names_from_template("{{ summarize.text }} and {{ extract.facts }}")
+        assert result == {"summarize", "extract"}
+
+    def test_empty_template_returns_empty_set(self):
+        """Empty or None template returns empty set (not an error)."""
+        assert extract_action_names_from_template("") == set()
+        assert extract_action_names_from_template(None) == set()
+
+    def test_template_without_actions_returns_empty_set(self):
+        """Template with only special namespaces returns empty set."""
+        result = extract_action_names_from_template("{{ source.text }}")
+        assert result == set()
+
+    def test_for_loop_scoped_vars_excluded(self):
+        """Variables introduced by {% for %} are excluded from action names."""
+        template = "{% for item in items %}{{ item.name }}{% endfor %}"
+        result = extract_action_names_from_template(template)
+        assert "item" not in result

--- a/tests/unit/prompt/test_scope_parsing_template_syntax_error.py
+++ b/tests/unit/prompt/test_scope_parsing_template_syntax_error.py
@@ -1,15 +1,15 @@
-"""Regression: extract_action_names_from_template logs warning on Jinja2 syntax errors.
+"""Regression: extract_action_names_from_template raises on Jinja2 syntax errors.
 
-Finding #8: scope_parsing.py:157 — TemplateSyntaxError was caught and returned
-as empty set with no logging. Callers received an empty set
-indistinguishable from "template has no action references", causing
-wrong context to be built silently. The fix logs a warning with
-diagnostics so the failure is visible in logs.
+Finding #8 (updated): scope_parsing.py:157 — TemplateSyntaxError was caught and
+returned as empty set. The fix re-raises the exception so callers are forced to
+handle it explicitly rather than silently receiving an empty set indistinguishable
+from "template has no action references".
 """
 
 import logging
 
 import pytest
+from jinja2.exceptions import TemplateSyntaxError
 
 from agent_actions.prompt.context.scope_parsing import extract_action_names_from_template
 
@@ -26,31 +26,32 @@ def _enable_propagate():
     aa_logger.propagate = original
 
 
-class TestTemplateSyntaxErrorLogsWarning:
-    """TemplateSyntaxError must log a warning, not fail silently."""
+class TestTemplateSyntaxErrorRaisesAndLogs:
+    """TemplateSyntaxError must raise and log a warning, not return empty set."""
 
-    def test_unclosed_block_logs_warning(self, caplog):
-        """Unclosed Jinja2 block tag logs a warning and returns empty set."""
+    def test_unclosed_block_raises_and_logs_warning(self, caplog):
+        """Unclosed Jinja2 block tag raises TemplateSyntaxError and logs a warning."""
         with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
-            result = extract_action_names_from_template("{% if foo %} no endif")
+            with pytest.raises(TemplateSyntaxError):
+                extract_action_names_from_template("{% if foo %} no endif")
 
-        assert result == set()
         assert len(caplog.records) == 1
         assert "syntax error" in caplog.records[0].message.lower()
 
-    def test_unclosed_variable_logs_warning(self, caplog):
-        """Unclosed variable expression logs a warning and returns empty set."""
+    def test_unclosed_variable_raises_and_logs_warning(self, caplog):
+        """Unclosed variable expression raises TemplateSyntaxError and logs a warning."""
         with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
-            result = extract_action_names_from_template("{{ unclosed_var")
+            with pytest.raises(TemplateSyntaxError):
+                extract_action_names_from_template("{{ unclosed_var")
 
-        assert result == set()
         assert len(caplog.records) == 1
 
     def test_warning_includes_template_snippet(self, caplog):
         """Warning message includes the template content for diagnostics."""
         template = "{% if broken %} {{ action.field }}"
         with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
-            extract_action_names_from_template(template)
+            with pytest.raises(TemplateSyntaxError):
+                extract_action_names_from_template(template)
 
         assert len(caplog.records) == 1
         assert template[:50] in caplog.records[0].message
@@ -58,7 +59,8 @@ class TestTemplateSyntaxErrorLogsWarning:
     def test_warning_includes_line_number(self, caplog):
         """Warning message includes the line number of the syntax error."""
         with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
-            extract_action_names_from_template("{% if broken %}")
+            with pytest.raises(TemplateSyntaxError):
+                extract_action_names_from_template("{% if broken %}")
 
         assert len(caplog.records) == 1
         assert "line" in caplog.records[0].message.lower()

--- a/tests/unit/validation/test_resolution_service.py
+++ b/tests/unit/validation/test_resolution_service.py
@@ -228,6 +228,59 @@ class TestSeedFileChecks:
         seed_errors = [e for e in result.errors if "seed" in e.message.lower()]
         assert len(seed_errors) == 0
 
+    def test_malformed_template_records_error_not_crash(self, tmp_path, monkeypatch):
+        """Malformed template in a seed-path action produces a StaticTypeError, not a crash."""
+        monkeypatch.setenv("AA_SKIP_ENV_VALIDATION", "1")
+        # _resolve_seed_data_dir returns non-None only when seed_data/ exists on disk
+        agent_config = tmp_path / "agent_config"
+        agent_config.mkdir()
+        (tmp_path / "seed_data").mkdir()
+        workflow_path = str(agent_config / "workflow.yml")
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "broken_action": {
+                    "prompt": "{{ unclosed_var",
+                    "context_scope": {"seed_path": {"data": "some_value"}},
+                },
+            },
+            workflow_config_path=workflow_path,
+        )
+        result = svc.resolve_all()
+
+        syntax_errors = [
+            e
+            for e in result.errors
+            if "broken_action" in e.message and "syntax" in e.message.lower()
+        ]
+        assert len(syntax_errors) == 1
+        assert syntax_errors[0].location.agent_name == "broken_action"
+
+    def test_good_action_not_affected_by_sibling_malformed_template(self, tmp_path, monkeypatch):
+        """A syntax error in one action's template does not block seed-ref checks for others."""
+        monkeypatch.setenv("AA_SKIP_ENV_VALIDATION", "1")
+        agent_config = tmp_path / "agent_config"
+        agent_config.mkdir()
+        (tmp_path / "seed_data").mkdir()
+        workflow_path = str(agent_config / "workflow.yml")
+
+        svc = WorkflowResolutionService(
+            action_configs={
+                "broken_action": {
+                    "prompt": "{{ unclosed_var",
+                    "context_scope": {"seed_path": {"data": "v"}},
+                },
+                "good_action": {
+                    "prompt": "{{ source.field }}",
+                },
+            },
+            workflow_config_path=workflow_path,
+        )
+        result = svc.resolve_all()
+
+        good_action_errors = [e for e in result.errors if e.location.agent_name == "good_action"]
+        assert len(good_action_errors) == 0
+
     def test_seed_data_dir_missing_graceful_skip(self, tmp_path):
         """When seed_data directory doesn't exist, gracefully skip (no errors)."""
         project = tmp_path / "project"

--- a/tests/validation/static_analyzer/test_field_flow_analyzer.py
+++ b/tests/validation/static_analyzer/test_field_flow_analyzer.py
@@ -271,3 +271,17 @@ class TestFieldFlowAnalyzerCycleDetection:
             analyzer.get_full_flow()
 
         assert result.errors[0].location.agent_name == "my_workflow"
+
+    def test_to_dict_returns_degraded_result_on_cycle(self):
+        """to_dict must not crash on a cyclic workflow — serializes the error instead."""
+        graph = self._make_cyclic_graph()
+        result = StaticValidationResult()
+        analyzer = FieldFlowAnalyzer(graph, result, "my_workflow")
+
+        out = analyzer.to_dict()
+
+        assert out["workflow"] == "my_workflow"
+        assert out["is_valid"] is False
+        assert out["flow"]["actions"] == []
+        assert out["flow"]["execution_order"] == []
+        assert any("Circular dependency" in e["message"] for e in out["validation"]["errors"])

--- a/tests/validation/static_analyzer/test_field_flow_analyzer.py
+++ b/tests/validation/static_analyzer/test_field_flow_analyzer.py
@@ -213,3 +213,61 @@ class TestFieldFlowAnalyzer:
         assert lineage is not None
         assert lineage.producer == "extractor"
         assert lineage.field_name == "summary"
+
+
+class TestFieldFlowAnalyzerCycleDetection:
+    """Circular dependency must raise ValueError and record a validation error."""
+
+    def _make_cyclic_graph(self):
+        graph = DataFlowGraph()
+        graph.add_node(
+            DataFlowNode(
+                name="action_a",
+                agent_kind=ActionKind.LLM,
+                output_schema=OutputSchema(schema_fields={"out_a"}),
+                dependencies={"action_b"},
+            )
+        )
+        graph.add_node(
+            DataFlowNode(
+                name="action_b",
+                agent_kind=ActionKind.LLM,
+                output_schema=OutputSchema(schema_fields={"out_b"}),
+                dependencies={"action_a"},
+            )
+        )
+        return graph
+
+    def test_get_full_flow_raises_on_cycle(self):
+        """get_full_flow raises ValueError when a circular dependency is present."""
+        graph = self._make_cyclic_graph()
+        result = StaticValidationResult()
+        analyzer = FieldFlowAnalyzer(graph, result, "cyclic_workflow")
+
+        with pytest.raises(ValueError, match="Circular dependency"):
+            analyzer.get_full_flow()
+
+    def test_cycle_recorded_in_validation_result(self):
+        """get_full_flow adds a StaticTypeError to the validation result on cycle."""
+        graph = self._make_cyclic_graph()
+        result = StaticValidationResult()
+        analyzer = FieldFlowAnalyzer(graph, result, "cyclic_workflow")
+
+        with pytest.raises(ValueError):
+            analyzer.get_full_flow()
+
+        assert not result.is_valid
+        assert len(result.errors) == 1
+        assert "Circular dependency" in result.errors[0].message
+        assert result.errors[0].location.config_field == "dependencies"
+
+    def test_cycle_error_names_the_workflow(self):
+        """The validation error names the workflow so the user knows where to look."""
+        graph = self._make_cyclic_graph()
+        result = StaticValidationResult()
+        analyzer = FieldFlowAnalyzer(graph, result, "my_workflow")
+
+        with pytest.raises(ValueError):
+            analyzer.get_full_flow()
+
+        assert result.errors[0].location.agent_name == "my_workflow"

--- a/tests/validation/static_analyzer/test_reference_extractor.py
+++ b/tests/validation/static_analyzer/test_reference_extractor.py
@@ -1,6 +1,12 @@
 """Tests for the reference extractor."""
 
+import logging
+
+import pytest
+
 from agent_actions.validation.static_analyzer import ReferenceExtractor
+
+_LOGGER_NAME = "agent_actions.validation.static_analyzer.reference_extractor"
 
 
 class TestReferenceExtractor:
@@ -425,3 +431,72 @@ class TestReferenceExtractor:
         assert "key" not in agent_names
         assert "value" not in agent_names
         assert "extractor" in agent_names
+
+
+class TestReferenceExtractorTemplateSyntaxError:
+    """TemplateSyntaxError must raise, not return empty refs."""
+
+    def setup_method(self):
+        self.extractor = ReferenceExtractor()
+
+    def _enable_propagate(self):
+        aa_logger = logging.getLogger("agent_actions")
+        original = aa_logger.propagate
+        aa_logger.propagate = True
+        return original
+
+    def test_syntax_error_raises_and_logs_warning(self, caplog):
+        """Broken template raises TemplateSyntaxError and logs a warning."""
+        from jinja2.exceptions import TemplateSyntaxError
+
+        original = self._enable_propagate()
+        try:
+            config = {
+                "name": "agent",
+                "prompt": "{% if broken %} {{ action.extractor.data }}",
+            }
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                with pytest.raises(TemplateSyntaxError):
+                    self.extractor.extract_from_agent(config)
+
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert len(warning_records) >= 1
+            assert "syntax error" in warning_records[0].message.lower()
+        finally:
+            logging.getLogger("agent_actions").propagate = original
+
+    def test_syntax_error_warning_includes_template_snippet(self, caplog):
+        """Warning includes the template text for diagnostics."""
+        from jinja2.exceptions import TemplateSyntaxError
+
+        original = self._enable_propagate()
+        try:
+            config = {
+                "name": "agent",
+                "prompt": "{{ unclosed_var",
+            }
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                with pytest.raises(TemplateSyntaxError):
+                    self.extractor.extract_from_agent(config)
+
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert len(warning_records) >= 1
+            assert "unclosed_var" in warning_records[0].message
+        finally:
+            logging.getLogger("agent_actions").propagate = original
+
+    def test_valid_template_no_warning(self, caplog):
+        """Valid templates produce no warnings."""
+        original = self._enable_propagate()
+        try:
+            config = {
+                "name": "agent",
+                "prompt": "{{ action.extractor.data }}",
+            }
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                self.extractor.extract_from_agent(config)
+
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert len(warning_records) == 0
+        finally:
+            logging.getLogger("agent_actions").propagate = original

--- a/tests/validation/static_analyzer/test_workflow_static_analyzer.py
+++ b/tests/validation/static_analyzer/test_workflow_static_analyzer.py
@@ -1332,6 +1332,25 @@ class TestCycleDetection:
         cycle_errors = [e for e in result.errors if "Circular dependency" in e.message]
         assert cycle_errors[0].location.config_field == "dependencies"
 
+    def test_circular_dependency_error_is_not_duplicated(self):
+        """Only one Circular dependency error is recorded — no duplicate from a removed pre-check."""
+        result = WorkflowStaticAnalyzer(self._cyclic_workflow()).analyze()
+        cycle_errors = [e for e in result.errors if "Circular dependency" in e.message]
+        assert len(cycle_errors) == 1, (
+            f"expected exactly one cycle error, got {len(cycle_errors)}: "
+            f"{[e.message for e in cycle_errors]}"
+        )
+
+    def test_get_data_flow_summary_returns_degraded_on_cycle(self):
+        """get_data_flow_summary surfaces the cycle without crashing."""
+        analyzer = WorkflowStaticAnalyzer(self._cyclic_workflow())
+        summary = analyzer.get_data_flow_summary()
+
+        assert summary["execution_order"] == []
+        assert "cycle_error" in summary
+        assert "Circular dependency" in summary["cycle_error"]
+        assert {a["name"] for a in summary["agents"]} == {"action_a", "action_b"}
+
 
 class TestTemplateSyntaxErrorSurfaces:
     """Template syntax errors must appear in the validation result, not be swallowed."""

--- a/tests/validation/static_analyzer/test_workflow_static_analyzer.py
+++ b/tests/validation/static_analyzer/test_workflow_static_analyzer.py
@@ -1392,3 +1392,53 @@ class TestTemplateSyntaxErrorSurfaces:
         # But good_action is not blamed for it
         good_action_errors = [e for e in result.errors if e.location.agent_name == "good_action"]
         assert len(good_action_errors) == 0
+
+    def test_scope_coverage_only_syntax_error_reaches_result(self):
+        """Syntax error only triggered in _check_template_scope_coverage still reaches result.
+
+        Regression: _check_template_scope_coverage was appending to
+        self._build_errors, but analyze() consumes _build_errors BEFORE the
+        coverage check runs. The append went nowhere — the error was silently
+        dropped. The fix appends to the method's local `errors` list (returned
+        and added to result by the caller).
+        """
+        from unittest.mock import patch
+
+        from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+            WorkflowStaticAnalyzer,
+        )
+
+        wf = {
+            "name": "wf",
+            "actions": [
+                {
+                    "name": "a",
+                    "prompt": "Hello",
+                    "context_scope": {"observe": ["source.*"]},
+                },
+            ],
+        }
+        analyzer = WorkflowStaticAnalyzer(wf)
+
+        # Build the graph normally (no syntax error during _add_agent_node)
+        analyzer._build_graph()
+        prev_build_errors = list(analyzer._build_errors)
+
+        # Then force the coverage check to see a TemplateSyntaxError, simulating
+        # the "different field" path the defensive recording is meant to catch.
+        from jinja2.exceptions import TemplateSyntaxError as _TSE
+
+        def _raise(template, *args, **kwargs):
+            raise _TSE("simulated", lineno=1)
+
+        with patch(
+            "agent_actions.prompt.context.scope_parsing.extract_action_names_from_template",
+            side_effect=_raise,
+        ):
+            coverage_errors = analyzer._check_template_scope_coverage()
+
+        assert any("Template syntax error in 'a'" in e.message for e in coverage_errors), (
+            "expected coverage check to return the syntax error in its local errors list"
+        )
+        # And _build_errors was not mutated (analyze() already consumed it)
+        assert analyzer._build_errors == prev_build_errors

--- a/tests/validation/static_analyzer/test_workflow_static_analyzer.py
+++ b/tests/validation/static_analyzer/test_workflow_static_analyzer.py
@@ -1295,3 +1295,81 @@ class TestPreflightFieldValidation:
             and ("Cannot validate" in issue.message or "Cannot verify" in issue.message)
         ]
         assert len(schema_issues) >= 1
+
+
+class TestCycleDetection:
+    """Circular dependencies must fail preflight, not silently use arbitrary order."""
+
+    def _cyclic_workflow(self):
+        return {
+            "name": "cyclic_wf",
+            "actions": [
+                {
+                    "name": "action_a",
+                    "context_scope": {"observe": ["action_b.out_b"]},
+                },
+                {
+                    "name": "action_b",
+                    "context_scope": {"observe": ["action_a.out_a"]},
+                },
+            ],
+        }
+
+    def test_circular_dependency_fails_validation(self):
+        """analyze() returns is_valid=False when a circular dependency exists."""
+        result = WorkflowStaticAnalyzer(self._cyclic_workflow()).analyze()
+        assert not result.is_valid
+
+    def test_circular_dependency_error_message(self):
+        """The validation error names the cycle so the user can identify it."""
+        result = WorkflowStaticAnalyzer(self._cyclic_workflow()).analyze()
+        cycle_errors = [e for e in result.errors if "Circular dependency" in e.message]
+        assert len(cycle_errors) >= 1
+
+    def test_circular_dependency_error_location(self):
+        """The cycle error is located in the workflow's dependencies config field."""
+        result = WorkflowStaticAnalyzer(self._cyclic_workflow()).analyze()
+        cycle_errors = [e for e in result.errors if "Circular dependency" in e.message]
+        assert cycle_errors[0].location.config_field == "dependencies"
+
+
+class TestTemplateSyntaxErrorSurfaces:
+    """Template syntax errors must appear in the validation result, not be swallowed."""
+
+    def _workflow_with_bad_template(self):
+        return {
+            "name": "bad_template_wf",
+            "actions": [
+                {
+                    "name": "broken_action",
+                    "prompt": "{{ unclosed_var",
+                },
+                {
+                    "name": "good_action",
+                    "prompt": "{{ source.field }}",
+                    "context_scope": {"observe": ["source.*"]},
+                },
+            ],
+        }
+
+    def test_template_syntax_error_fails_validation(self):
+        """analyze() returns is_valid=False when a template has a syntax error."""
+        result = WorkflowStaticAnalyzer(self._workflow_with_bad_template()).analyze()
+        assert not result.is_valid
+
+    def test_template_syntax_error_names_action(self):
+        """The validation error names the action with the bad template."""
+        result = WorkflowStaticAnalyzer(self._workflow_with_bad_template()).analyze()
+        syntax_errors = [e for e in result.errors if "broken_action" in e.message]
+        assert len(syntax_errors) >= 1
+        assert syntax_errors[0].location.agent_name == "broken_action"
+
+    def test_good_action_not_affected_by_sibling_syntax_error(self):
+        """A syntax error in one action does not prevent other actions from being analyzed."""
+        result = WorkflowStaticAnalyzer(self._workflow_with_bad_template()).analyze()
+        # The broken action error is present
+        syntax_errors = [e for e in result.errors if "broken_action" in e.message]
+        assert len(syntax_errors) >= 1
+        # But good_action is not blamed for it
+        good_action_errors = [e for e in result.errors if e.location.agent_name == "good_action"]
+        assert len(good_action_errors) == 0


### PR DESCRIPTION
## Summary

Contract 554 (Findings #7/#8) plus the cascading fixes required to make the integration tip green:

- **Finding #7 (HIGH):** `_save_failed_render` no longer swallows `OSError`. The caller logs a warning and still raises the original `ConfigurationError`, so disk-full / permission failures are visible instead of silently collapsing the debug-save path to `""`.
- **Finding #8 (MEDIUM):** `extract_action_names_from_template` now raises `TemplateSyntaxError` (via cherry-pick of PR #716). Callers (`scope_inference`, `_check_template_scope_coverage`, `resolution_service`, `_build_graph`) catch it per-action and record the failure in the validation result rather than letting it propagate as an empty set.
- **Smoke blocker (HIGH, framework):** `_resolve_client` was returning the lazy `"module:Class"` import string instead of the resolved class — `dict.setdefault` is a no-op when the key already exists, so the lazy entry was never replaced. Downstream `client.invoke(...)` then crashed with `'str' object has no attribute 'invoke'` on first LLM call for any external provider. Replaced with plain assignment + regression test covering all 10 registry entries.
- **Sibling pickup:** Pi-consensus correctly flagged the silent `TemplateSyntaxError` swallow at `validation/static_analyzer/reference_extractor.py:149`. That sibling lived behind PR #716 (already merged to main, not yet on integration). Cherry-picked it here so the integration tip carries both fixes together.

## What the consensus review surfaced (and how it's addressed)

Six rounds of pi-consensus on this branch. Every blocker was addressed with code + tests:

| Blocker | Fix |
|---|---|
| `_resolve_client` returned a string instead of a class | `tests/unit/llm/test_client_resolution.py` (9 cases) |
| Sibling swallow in `reference_extractor.py:149` | Cherry-picked #716 |
| Stale docstring on `extract_action_names_from_template` | Docstring rewritten to document the `Raises:` contract |
| Public cycle APIs (`to_dict`, `get_data_flow_summary`) crashed on cycles | Wrapped to return degraded result + `cycle_error` key |
| `WorkflowSchemaService.get_execution_order` silent fallback to dict-key order | Removed, raises `ValueError`; `to_dict` degrades |
| `WorkflowSchemaService.to_dict` crashed on cyclic workflows | Same wrap-and-degrade pattern |
| `_build_errors` reset wiped lazy-build errors | Reset moved into `_build_graph` after the early-return |
| `_check_template_scope_coverage` appended to consumed `_build_errors` | Append to local `errors` (returned to caller) |
| Syntax error in `_add_agent_node` dropped the entire action from the graph | Stub node created with partial regex requirements; error recorded after add |
| `_extract_from_template` lost simple-brace `{action.field}` references on Jinja syntax error | Regex pass moved before Jinja pass; partial requirements attached to the exception |
| `extract_from_workflow` discarded partial requirements | Now uses `partial_requirements` from the exception |
| Misleading 'prompt retrieval failed' on Jinja syntax errors in `scope_inference` | Split the handlers: dedicated `TemplateSyntaxError` warning with line number |
| Duplicate cycle errors from redundant Step-1b check | Removed; `StaticTypeChecker.check_all` already records the cycle |

## Verification

- ruff format + ruff check clean
- pytest: 7501 passed, 2 skipped (full suite)
- 30+ new regression tests across `tests/unit/prompt/`, `tests/unit/llm/`, `tests/services/`, and `tests/validation/static_analyzer/`
- Smoke: framework `'str' object has no attribute 'invoke'` bug fixed (the qanalabs smoke now executes 5 actions instead of failing at the first one). Remaining smoke failure is downstream in the qanalabs UDF `flatten_canonical_questions` — the LLM returned empty arrays from `extract_raw_qa_*`, which the UDF treats as a hard failure. That is content/model behavior, not framework code.

## Files changed

- `agent_actions/prompt/context/scope_parsing.py` (Finding #8 docstring + raise)
- `agent_actions/prompt/context/scope_inference.py` (dedicated `TemplateSyntaxError` handling)
- `agent_actions/prompt/render_workflow.py` (Finding #7)
- `agent_actions/llm/realtime/services/invocation.py` (`_resolve_client` smoke fix)
- `agent_actions/workflow/schema_service.py` (cycle propagation + `to_dict` degrade)
- `agent_actions/validation/static_analyzer/reference_extractor.py` (#716 + partial-requirements)
- `agent_actions/validation/static_analyzer/workflow_static_analyzer.py` (#716 + stub-node + dedup)
- `agent_actions/validation/static_analyzer/field_flow_analyzer.py` (#716 + cycle degrade)
- `agent_actions/validation/preflight/resolution_service.py` (#716 caller fix)
- `tests/...` (regression coverage for every fix above)