### PR TITLE
fix(cli): clearer UDF discovery/import errors + inspect help text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ MagicMock/
 # Example runtime artifacts
 examples/*/artefact/
 examples/*/logs/
+
+# Local harness gate markers and smoke-test output
+.harness/
+artefact/

--- a/agent_actions/cli/inspect_action.py
+++ b/agent_actions/cli/inspect_action.py
@@ -133,7 +133,7 @@ class ActionCommand(BaseInspectCommand):
 @click.option("-a", "--agent", required=True, help="Workflow name")
 @click.option("-u", "--user-code", required=False, help="Path to user code directory")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
-@click.argument("action_name")
+@click.argument("action_name", metavar="ACTION_NAME")
 @handles_user_errors("inspect action")
 @requires_project
 def action(
@@ -148,9 +148,13 @@ def action(
 
     Displays configuration, dependencies, and context scope.
 
+    ACTION_NAME is a positional argument (not a flag). Pass it as a positional
+    argument alongside the options.
+
+    \b
     Examples:
-        agac inspect action -a my_workflow extract_facts
-        agac inspect action -a my_workflow generate_question --json
+      agac inspect action -a my_workflow extract_facts
+      agac inspect action -a my_workflow generate_question --json
     """
     ActionCommand(
         agent=agent, user_code=user_code, json_output=json_output, action_name=action_name
@@ -302,7 +306,7 @@ class ContextCommand(BaseInspectCommand):
 @click.option("-a", "--agent", required=True, help="Workflow name")
 @click.option("-u", "--user-code", required=False, help="Path to user code directory")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
-@click.argument("action_name")
+@click.argument("action_name", metavar="ACTION_NAME")
 @handles_user_errors("inspect context")
 @requires_project
 def context(
@@ -318,9 +322,13 @@ def context(
     Displays available namespaces, context scope rules, and template variables
     that would be available during template rendering.
 
+    ACTION_NAME is a positional argument (not a flag). Pass it as a positional
+    argument alongside the options.
+
+    \b
     Examples:
-        agac inspect context -a my_workflow extract_facts
-        agac inspect context -a my_workflow generate_question --json
+      agac inspect context -a my_workflow extract_facts
+      agac inspect context -a my_workflow generate_question --json
     """
     ContextCommand(
         agent=agent, user_code=user_code, json_output=json_output, action_name=action_name

--- a/agent_actions/cli/list_udfs.py
+++ b/agent_actions/cli/list_udfs.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from rich.table import Table
 
 from agent_actions.cli.cli_decorators import handles_user_errors
+from agent_actions.errors import UDFLoadError, enrich_exception_context
 from agent_actions.input.loaders.udf import discover_udfs
 from agent_actions.utils.udf_management.registry import clear_registry, list_udfs
 
@@ -24,7 +25,17 @@ class ListUDFsCommand:
         clear_registry()
         if not self.json_output:
             self.console.print("[cyan]🔍 Discovering Tools...[/cyan]")
-        registry = discover_udfs(self.user_code)
+        # Enrich for UX parity with config_pipeline / validate_udfs.
+        try:
+            registry = discover_udfs(self.user_code)
+        except UDFLoadError as e:
+            enrich_exception_context(
+                e,
+                pipeline_stage="list_udfs",
+                search_path=str(self.user_code.resolve()),
+                requested_path=str(self.user_code),
+            )
+            raise
         if not self.json_output:
             self.console.print(f"[green]✅ Discovered {len(registry)} Tools[/green]\n")
         udfs = list_udfs()

--- a/agent_actions/errors/_MANIFEST.md
+++ b/agent_actions/errors/_MANIFEST.md
@@ -18,7 +18,7 @@
 | `ConfigValidationError` | Class | Raised when configuration validation fails. | - |
 | `DuplicateFunctionError` | Class | Raised when duplicate @udf_tool function names are detected. | - |
 | `FunctionNotFoundError` | Class | Raised when a UDF is not found in the registry. | - |
-| `UDFLoadError` | Class | Raised when a UDF module fails to load. | - |
+| `UDFLoadError` | Class | Raised when a UDF module fails to load. `DISCOVERY_SENTINEL` class attribute marks failures of the user-code directory itself (vs. a specific module import), so formatters can render directory-appropriate messages. | - |
 | `AgentNotFoundError` | Class | Raised when a specified agent cannot be found. | - |
 | `ProjectNotFoundError` | Class | Raised when a command requires being in a project but agent_actions.yml is not found. | - |
 | `external_services.py` | Module | External service and vendor API errors. `ExternalServiceError.__init__` guards `endpoint` with `endpoint or "<unknown>"` before interpolation. | `errors` |

--- a/agent_actions/errors/configuration.py
+++ b/agent_actions/errors/configuration.py
@@ -1,5 +1,7 @@
 """Configuration-related errors."""
 
+from typing import Final
+
 from agent_actions.errors.base import AgentActionsError
 
 
@@ -82,7 +84,16 @@ class FunctionNotFoundError(ConfigurationError):
 
 
 class UDFLoadError(ConfigurationError):
-    """Raised when a UDF module fails to load."""
+    """Raised when a UDF module fails to load.
+
+    The ``DISCOVERY_SENTINEL`` value is used as the ``module`` argument when
+    the failure is not a Python import — the user-code directory itself is
+    missing or invalid. Consumers (e.g. error formatters) check for this
+    sentinel to render a directory-appropriate message instead of import
+    error wording.
+    """
+
+    DISCOVERY_SENTINEL: Final[str] = "<discovery>"
 
     def __init__(
         self,
@@ -95,7 +106,12 @@ class UDFLoadError(ConfigurationError):
         cause: Exception | None = None,
     ):
         if module and error:
-            msg = f"Failed to load UDF module '{module}': {error}"
+            # Sentinel module → directory message so str(exc) (logs, debug
+            # dumps) doesn't leak the token or imply an import failure.
+            if module == self.DISCOVERY_SENTINEL:
+                msg = f"UDF discovery failed: {error}"
+            else:
+                msg = f"Failed to load UDF module '{module}': {error}"
             if file:
                 msg += f" (file: {file})"
             ctx = dict(context) if context else {}

--- a/agent_actions/input/loaders/udf.py
+++ b/agent_actions/input/loaders/udf.py
@@ -29,14 +29,18 @@ def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
     """Discover and register all UDFs in the user code directory.
 
     Raises:
-        UDFLoadError: If a Python file fails to import.
+        UDFLoadError: If the user-code directory is missing or invalid
+            (``module == UDFLoadError.DISCOVERY_SENTINEL``), if path-to-module
+            derivation fails for a discovered file (also routed through the
+            sentinel), or if a Python file fails to import (module set to the
+            failing dotted import name).
         DuplicateFunctionError: If duplicate function names are detected.
     """
     user_code_path = Path(user_code_path)
     if not user_code_path.exists():
         error_context = {"user_code_path": str(user_code_path), "operation": "discover_udfs"}
         raise UDFLoadError(
-            module="<discovery>",
+            module=UDFLoadError.DISCOVERY_SENTINEL,
             file=str(user_code_path),
             error="User code directory not found",
             context=error_context,
@@ -44,7 +48,7 @@ def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
     if not user_code_path.is_dir():
         error_context = {"user_code_path": str(user_code_path), "operation": "discover_udfs"}
         raise UDFLoadError(
-            module="<discovery>",
+            module=UDFLoadError.DISCOVERY_SENTINEL,
             file=str(user_code_path),
             error="User code path is not a directory",
             context=error_context,
@@ -53,13 +57,25 @@ def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
     python_files = discover_tool_files(user_code_path)
 
     for py_file in python_files:
+        # Own try so relative_to() ValueError doesn't leave module_name
+        # unbound for the import-time except block below.
         try:
             relative_path = py_file.relative_to(user_code_path)
             module_name = str(relative_path.with_suffix("")).replace("/", ".").replace("\\", ".")
+        except ValueError as e:
+            # Discovery-level failure — sentinel, not a per-module import.
+            raise UDFLoadError(
+                module=UDFLoadError.DISCOVERY_SENTINEL,
+                file=str(py_file),
+                error=f"Could not derive module name from path: {e}",
+                context={"error_type": type(e).__name__},
+                cause=e,
+            ) from e
 
-            if f"agent_actions._udfs.{module_name}" in sys.modules:
-                continue
+        if f"agent_actions._udfs.{module_name}" in sys.modules:
+            continue
 
+        try:
             # Keep original module loading logic to preserve exception behavior
             # (DuplicateFunctionError must bubble up directly)
             spec = importlib.util.spec_from_file_location(module_name, py_file)

--- a/agent_actions/logging/ARCHITECTURE.md
+++ b/agent_actions/logging/ARCHITECTURE.md
@@ -33,7 +33,7 @@ The module has **three packages** and **four top-level files**:
 |----------------|-------------|
 | `core/` | Singleton EventManager, handler protocols, and the four built-in handler implementations (Console, JSONFile, LoggingBridge, ContextDebug) |
 | `events/` | 106 concrete event dataclasses organized by domain (workflow, batch, LLM, validation, etc.) plus the AgentActionsFormatter for console display |
-| `errors/` | ErrorTranslator with a chain of 9 formatter strategies that convert any Python exception into a structured UserError for CLI display |
+| `errors/` | ErrorTranslator with a chain of 10 formatter strategies that convert any Python exception into a structured UserError for CLI display |
 | `factory.py` | LoggerFactory -- the single entry point that initializes EventManager, registers handlers, and wires the stdlib logging bridge |
 | `config.py` | LoggingConfig and FileHandlerSettings dataclasses, built from `agent_actions.yml` or `AGENT_ACTIONS_*` env vars |
 | `filters.py` | RedactingFilter for the stdlib logging layer -- regex-based scrubbing of API keys, tokens, secrets |
@@ -335,14 +335,15 @@ ErrorTranslator.translate(exc, context)  -- errors/translator.py
      |
      +-- Formatter chain (first match wins):
      |     1. YAMLSyntaxErrorFormatter    -- YAML parse errors
-     |     2. FunctionNotFoundFormatter   -- missing UDF functions
-     |     3. TemplateErrorFormatter      -- Jinja2 template errors
-     |     4. ConfigurationErrorFormatter -- config validation
-     |     5. ModelErrorFormatter         -- LLM model errors
-     |     6. AuthenticationErrorFormatter -- API key issues
-     |     7. FileErrorFormatter          -- file not found, permissions
-     |     8. APIErrorFormatter           -- vendor API errors
-     |     9. GenericErrorFormatter       -- fallback (always matches)
+     |     2. UDFLoadErrorFormatter       -- UDF discovery/import failures
+     |     3. FunctionNotFoundFormatter   -- missing UDF functions
+     |     4. TemplateErrorFormatter      -- Jinja2 template errors
+     |     5. ConfigurationErrorFormatter -- config validation
+     |     6. ModelErrorFormatter         -- LLM model errors
+     |     7. AuthenticationErrorFormatter -- API key issues
+     |     8. FileErrorFormatter          -- file not found, permissions
+     |     9. APIErrorFormatter           -- vendor API errors
+     |    10. GenericErrorFormatter       -- fallback (always matches)
      |
      v
 UserError(category, title, details, fix, context, docs_url)
@@ -405,7 +406,7 @@ Each formatter implements `can_handle(exc, root_cause, message) -> bool` and `fo
 | `errors/translator.py` | ErrorTranslator -- formatter chain dispatch |
 | `errors/user_error.py` | UserError dataclass + `format_for_cli()` |
 | `errors/services/` | ErrorContextService -- extracts context from exceptions |
-| `errors/formatters/` | 9 formatter strategies (YAML, config, model, auth, file, API, template, function, generic) |
+| `errors/formatters/` | 10 formatter strategies (YAML, UDF load, config, model, auth, file, API, template, function, generic) |
 
 ---
 

--- a/agent_actions/logging/errors/formatters/_MANIFEST.md
+++ b/agent_actions/logging/errors/formatters/_MANIFEST.md
@@ -18,4 +18,5 @@ configuration errors with consistent context for CLI output.
 | `generic.py` | Module | Generic formatter used as the default when no specific formatter is configured. | `logging` |
 | `model.py` | Module | Formats model-specific error details (token usage, rate limits). | `llm.providers`, `logging` |
 | `template.py` | Module | Formats template rendering issues with namespace diagnostics, fuzzy field suggestions, and actionable hints. | `prompt_generation`, `logging` |
+| `udf_load.py` | Module | Formats UDF discovery import failures with module, file, and dependency install hint. | `utils.udf_management`, `logging` |
 | `yaml.py` | Module | Formats YAML parsing errors with line/column details. | `yaml`, `logging` |

--- a/agent_actions/logging/errors/formatters/__init__.py
+++ b/agent_actions/logging/errors/formatters/__init__.py
@@ -9,6 +9,7 @@ from .function import FunctionNotFoundFormatter
 from .generic import GenericErrorFormatter
 from .model import ModelErrorFormatter
 from .template import TemplateErrorFormatter
+from .udf_load import UDFLoadErrorFormatter
 from .yaml import YAMLSyntaxErrorFormatter
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "YAMLSyntaxErrorFormatter",
     "FunctionNotFoundFormatter",
     "TemplateErrorFormatter",
+    "UDFLoadErrorFormatter",
     "GenericErrorFormatter",
 ]

--- a/agent_actions/logging/errors/formatters/configuration.py
+++ b/agent_actions/logging/errors/formatters/configuration.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from agent_actions.errors import UDFLoadError
+
 from ..user_error import UserError
 from .base import ErrorFormatter
 
@@ -10,6 +12,10 @@ class ConfigurationErrorFormatter(ErrorFormatter):
     """Handles configuration-related errors."""
 
     def can_handle(self, exc: Exception, root: Exception, message: str) -> bool:
+        # UDFLoadError is a ConfigurationError subclass — defer to UDFLoadErrorFormatter.
+        if isinstance(exc, UDFLoadError) or isinstance(root, UDFLoadError):
+            return False
+
         exc_names = [type(exc).__name__, type(root).__name__]
 
         if any("Config" in name for name in exc_names):

--- a/agent_actions/logging/errors/formatters/function.py
+++ b/agent_actions/logging/errors/formatters/function.py
@@ -3,6 +3,12 @@
 from difflib import SequenceMatcher
 from typing import Any
 
+from agent_actions.errors import (
+    DuplicateFunctionError,
+    FunctionNotFoundError,
+    UDFLoadError,
+)
+
 from ..user_error import UserError
 from .base import ErrorFormatter
 
@@ -10,19 +16,17 @@ from .base import ErrorFormatter
 class FunctionNotFoundFormatter(ErrorFormatter):
     """Handles function/UDF not found errors with helpful suggestions."""
 
-    _HANDLED_NAMES = frozenset(
-        {
-            "FunctionNotFoundError",
-            "DuplicateFunctionError",
-            "UDFLoadError",
-        }
+    _HANDLED_TYPES: tuple[type[Exception], ...] = (
+        FunctionNotFoundError,
+        DuplicateFunctionError,
     )
 
     def can_handle(self, exc: Exception, root: Exception, message: str) -> bool:
-        exc_names = {type(exc).__name__, type(root).__name__}
-        if exc_names & self._HANDLED_NAMES:
+        # UDFLoadErrorFormatter owns these even if the message text would match below.
+        if isinstance(exc, UDFLoadError) or isinstance(root, UDFLoadError):
+            return False
+        if isinstance(exc, self._HANDLED_TYPES) or isinstance(root, self._HANDLED_TYPES):
             return True
-
         if "function" in message.lower() and "not found" in message.lower():
             return True
 

--- a/agent_actions/logging/errors/formatters/udf_load.py
+++ b/agent_actions/logging/errors/formatters/udf_load.py
@@ -1,0 +1,150 @@
+"""UDF discovery/import error formatter."""
+
+import re
+from typing import Any
+
+from agent_actions.errors import UDFLoadError
+
+from ..user_error import UserError
+from .base import ErrorFormatter
+
+_MISSING_MODULE_RE = re.compile(r"No module named ['\"]([^'\"]+)['\"]")
+
+
+def _first_non_none(*values: Any) -> Any:
+    """Return the first non-None value; unlike ``or``, empty strings / 0 / False are kept."""
+    for v in values:
+        if v is not None:
+            return v
+    return None
+
+
+class UDFLoadErrorFormatter(ErrorFormatter):
+    """Render UDF import failures with the module, file, and how to fix it.
+
+    UDF discovery imports every Python file under the user-code directory; a
+    single broken file blocks every command that loads the workflow. The
+    generic configuration formatter loses the module + file context that
+    ``UDFLoadError`` already carries, so this formatter claims those errors
+    before the configuration chain sees them.
+    """
+
+    def can_handle(self, exc: Exception, root: Exception, message: str) -> bool:
+        return isinstance(exc, UDFLoadError) or isinstance(root, UDFLoadError)
+
+    def format(
+        self, exc: Exception, root: Exception, message: str, context: dict[str, Any]
+    ) -> UserError:
+        # Read identity fields from the UDFLoadError directly: an outer wrapper
+        # that re-enriches these keys would otherwise clobber them via
+        # merge_exception_context (outer wins).
+        udf_exc = exc if isinstance(exc, UDFLoadError) else root
+        udf_context = getattr(udf_exc, "context", None) or {}
+
+        module = _first_non_none(udf_context.get("module"), context.get("module"), "<unknown>")
+        file = _first_non_none(udf_context.get("file"), context.get("file"))
+        error = _first_non_none(udf_context.get("error"), context.get("error"), message)
+        search_path = context.get("search_path")
+        requested_path = context.get("requested_path")
+
+        if module == UDFLoadError.DISCOVERY_SENTINEL:
+            return self._format_discovery_failure(file, error, search_path, requested_path)
+
+        return self._format_import_failure(module, file, error, exc, search_path, requested_path)
+
+    def _format_discovery_failure(
+        self,
+        path: str | None,
+        error: str,
+        search_path: str | None,
+        requested_path: str | None,
+    ) -> UserError:
+        ctx: dict[str, Any] = {}
+        if path:
+            ctx["file_path"] = path
+        if search_path:
+            ctx["search_path"] = search_path
+        if requested_path:
+            ctx["requested_path"] = requested_path
+        return UserError(
+            category="Configuration Error",
+            title="UDF discovery failed",
+            details=error,
+            fix=(
+                "Pass a valid user-code directory via `-u <path>`, or set "
+                "`tool_path` in your workflow config to a directory that exists."
+            ),
+            context=ctx or None,
+            docs_url="https://docs.runagac.com/user-defined-functions",
+        )
+
+    def _format_import_failure(
+        self,
+        module: str,
+        file: str | None,
+        error: str,
+        exc: Exception,
+        search_path: str | None,
+        requested_path: str | None,
+    ) -> UserError:
+        details = f"Python could not import the UDF module: {error}"
+        missing = self._extract_missing_module(error, exc)
+
+        where = "the UDF file shown above" if file else "the UDF file that triggered this"
+        if missing:
+            fix = (
+                f"Python could not find the module '{missing}'.\n"
+                f"  If it is a third-party dependency, install it "
+                f"(e.g. `uv add <package>` or `pip install <package>`) — "
+                f"note the PyPI package name may differ from the import name "
+                f"(yaml→PyYAML, cv2→opencv-python, bs4→beautifulsoup4).\n"
+                f"  If '{missing}' is a local module, fix the import path in "
+                f"{where}."
+            )
+        else:
+            fix = (
+                f"Fix the import error in {where}, then re-run.\n"
+                "  The exact failure is included in the Problem line."
+            )
+
+        fix += (
+            "\n\nUDF discovery imports every Python file under the user-code "
+            "directory; a single broken file blocks all commands that load "
+            "the workflow."
+        )
+
+        ctx: dict[str, Any] = {}
+        if file:
+            ctx["file_path"] = file
+        if search_path:
+            ctx["search_path"] = search_path
+        if requested_path:
+            ctx["requested_path"] = requested_path
+
+        return UserError(
+            category="Configuration Error",
+            title=f"Failed to load UDF module '{module}'",
+            details=details,
+            fix=fix,
+            context=ctx or None,
+            docs_url="https://docs.runagac.com/user-defined-functions",
+        )
+
+    @staticmethod
+    def _extract_missing_module(error_text: str, exc: Exception) -> str | None:
+        # Walk exc's __cause__ chain only — never __context__, and never
+        # extract_root_cause's `root` (which transitively walks __context__
+        # and could pick up an unrelated ModuleNotFoundError from the stack).
+        current: BaseException | None = exc
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            if isinstance(current, ModuleNotFoundError):
+                name = getattr(current, "name", None)
+                if isinstance(name, str) and name:
+                    return name
+            current = current.__cause__
+        match = _MISSING_MODULE_RE.search(error_text or "")
+        if not match:
+            return None
+        return match.group(1)

--- a/agent_actions/logging/errors/formatters/yaml.py
+++ b/agent_actions/logging/errors/formatters/yaml.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import yaml
 
+from agent_actions.errors import UDFLoadError
+
 from ..user_error import UserError
 from .base import ErrorFormatter
 
@@ -13,6 +15,9 @@ class YAMLSyntaxErrorFormatter(ErrorFormatter):
     """Handles YAML syntax errors with industry-standard formatting."""
 
     def can_handle(self, exc: Exception, root: Exception, message: str) -> bool:
+        # UDFLoadErrorFormatter owns these even when the inner cause is YAML.
+        if isinstance(exc, UDFLoadError) or isinstance(root, UDFLoadError):
+            return False
         if isinstance(root, yaml.YAMLError):
             return True
 

--- a/agent_actions/logging/errors/translator.py
+++ b/agent_actions/logging/errors/translator.py
@@ -15,6 +15,7 @@ from .formatters import (
     GenericErrorFormatter,
     ModelErrorFormatter,
     TemplateErrorFormatter,
+    UDFLoadErrorFormatter,
     YAMLSyntaxErrorFormatter,
 )
 from .services import ErrorContextService
@@ -28,10 +29,14 @@ class ErrorTranslator:
 
     def __init__(self):
         """Initialize formatter chain."""
+        # UDFLoadErrorFormatter is first so a UDF wrapping yaml.YAMLError /
+        # ConfigurationError / "function not found" still renders the UDF UX.
+        # Sibling formatters also defer via isinstance(exc, UDFLoadError).
         self.formatters: list[ErrorFormatter] = [
-            YAMLSyntaxErrorFormatter(),  # Check YAML first (most specific)
-            FunctionNotFoundFormatter(),  # Check function errors
-            TemplateErrorFormatter(),  # Template variable errors
+            UDFLoadErrorFormatter(),
+            YAMLSyntaxErrorFormatter(),
+            FunctionNotFoundFormatter(),
+            TemplateErrorFormatter(),
             ConfigurationErrorFormatter(),
             ModelErrorFormatter(),
             AuthenticationErrorFormatter(),

--- a/agent_actions/logging/errors/user_error.py
+++ b/agent_actions/logging/errors/user_error.py
@@ -16,6 +16,9 @@ _PRIORITY_FIELDS = [
 # Internal technical fields and CLI flags to never show
 _SKIP_FIELDS = {
     "function",
+    # Two layers keep 'module' out of the rendered output:
+    #   1. UDFLoadErrorFormatter omits 'module' from the UserError.context dict.
+    #   2. This skip list catches it if any other formatter ever puts it back.
     "module",
     "resource_type",  # Internal technical
     "command",
@@ -41,6 +44,8 @@ _USEFUL_DEBUG_FIELDS = {
     "template_line",
     "staged_fields",
     "validation_phase",  # Staging validation context
+    "search_path",  # UDF discovery: resolved absolute path searched
+    "requested_path",  # UDF discovery: path as configured by the user
 }
 
 

--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -12,6 +12,7 @@ from agent_actions.errors import (
     DuplicateFunctionError,
     FunctionNotFoundError,
     UDFLoadError,
+    enrich_exception_context,
 )
 from agent_actions.input.loaders.udf import (
     discover_udfs,
@@ -53,6 +54,13 @@ class ValidateUDFsCommand:
                 "error_type": "duplicate",
             }
         except UDFLoadError as e:
+            # Enrich for UX parity with config_pipeline / list_udfs.
+            enrich_exception_context(
+                e,
+                pipeline_stage="validate_udfs",
+                search_path=str(self.user_code.resolve()),
+                requested_path=str(self.user_code),
+            )
             return {
                 "valid": False,
                 "error": e,
@@ -157,13 +165,12 @@ class ValidateUDFsCommand:
         self.console.print("  Function names must be unique. Rename one of these functions.\n")
 
     def _handle_load_error(self, error: UDFLoadError) -> None:
-        """Handle UDF load error with formatted output."""
-        self.console.print("[red]❌ Error loading UDF module[/red]\n")
-        self.console.print(f"  Module: {error.context.get('module', 'unknown')}")
-        self.console.print(f"  File: [cyan]{error.context.get('file', 'unknown')}[/cyan]")
-        self.console.print(f"  Error: {error.context.get('error', 'unknown')}\n")
-        self.console.print("[yellow]Fix:[/yellow]")
-        self.console.print("  Check the Python file for syntax errors or import issues.\n")
+        """Render via the shared translator chain so UX stays in sync with the CLI."""
+        # markup=False: format_user_error returns plain text that can contain
+        # brackets (e.g. [WinError 126]) which Rich would otherwise consume.
+        self.console.print("[red]❌ UDF load failed[/red]\n")
+        self.console.print(format_user_error(error), markup=False, highlight=False)
+        self.console.print()
 
     def _handle_not_found_error(self, error: FunctionNotFoundError) -> None:
         """Handle function not found error with formatted output."""

--- a/agent_actions/workflow/config_pipeline.py
+++ b/agent_actions/workflow/config_pipeline.py
@@ -7,7 +7,7 @@ from typing import Any
 from rich.console import Console
 
 from agent_actions.config.manager import ConfigManager
-from agent_actions.errors import enrich_exception_context
+from agent_actions.errors import UDFLoadError, enrich_exception_context
 from agent_actions.input.loaders.udf import discover_udfs
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import (
@@ -122,10 +122,29 @@ def _discover_udfs_from_path(path: str, project_root: Path | None, console: Cons
     else:
         abs_path = p.absolute()
 
-    if abs_path.exists() and abs_path.is_dir():
-        fire_event(UDFDiscoveryStartEvent(search_path=str(abs_path)))
-        console.print(f"[cyan]\U0001f50d Discovering Tools in {abs_path}...[/cyan]")
-        registry = discover_udfs(abs_path)
-        return len(registry)
+    if not (abs_path.exists() and abs_path.is_dir()):
+        # WARN (not raise) so optional tool_paths still skip cleanly, but a
+        # typo'd path is visible at default log level instead of silently
+        # loading zero UDFs and failing later with "function not found".
+        logger.warning(
+            "Skipping UDF discovery: configured tool path does not exist or is not a directory: %s",
+            abs_path,
+        )
+        return 0
 
-    return 0
+    fire_event(UDFDiscoveryStartEvent(search_path=str(abs_path)))
+    console.print(f"[cyan]\U0001f50d Discovering Tools in {abs_path}...[/cyan]")
+    try:
+        registry = discover_udfs(abs_path)
+    except UDFLoadError as e:
+        # Add the configured search path so the formatter can surface it
+        # alongside the per-file path UDFLoadError already carries.
+        logger.warning("UDF discovery failed in %s: %s", abs_path, e.context.get("error", e))
+        enrich_exception_context(
+            e,
+            pipeline_stage="discover_udfs",
+            search_path=str(abs_path),
+            requested_path=path,
+        )
+        raise
+    return len(registry)

--- a/tests/cli/test_inspect_field_flow.py
+++ b/tests/cli/test_inspect_field_flow.py
@@ -79,6 +79,36 @@ class TestInspectActionCommand:
         assert "Missing argument" in result.output or "required" in result.output.lower()
 
 
+class TestPositionalActionNameHelp:
+    """Both `inspect action` and `inspect context` take ACTION_NAME as a positional
+    argument. The help must say so explicitly (users were mistaking it for a flag)
+    and must render each example on its own line (Click \\b preserves breaks)."""
+
+    @pytest.mark.parametrize("subcommand", ["action", "context"])
+    def test_help_calls_out_positional_action_name(self, cli_runner, subcommand):
+        result = cli_runner.invoke(cli, ["inspect", subcommand, "--help"])
+
+        assert result.exit_code == 0
+        # Usage line must show ACTION_NAME as positional. Don't pin Click's
+        # exact format (e.g. `[OPTIONS] ACTION_NAME`) — just that the metavar
+        # appears in the Usage: line.
+        usage_lines = [ln for ln in result.output.splitlines() if ln.startswith("Usage:")]
+        assert usage_lines, "Help output missing Usage: line"
+        assert "ACTION_NAME" in usage_lines[0]
+        assert "positional" in result.output.lower()
+        assert "(not a flag)" in result.output
+
+    @pytest.mark.parametrize("subcommand", ["action", "context"])
+    def test_help_renders_examples_on_separate_lines(self, cli_runner, subcommand):
+        result = cli_runner.invoke(cli, ["inspect", subcommand, "--help"])
+
+        assert result.exit_code == 0
+        example_lines = [
+            ln for ln in result.output.splitlines() if f"agac inspect {subcommand} -a" in ln
+        ]
+        assert len(example_lines) >= 2, "Expected two example lines; got:\n" + result.output
+
+
 class TestInspectCommandGroup:
     """Tests for the inspect command group structure."""
 

--- a/tests/cli/test_list_udfs.py
+++ b/tests/cli/test_list_udfs.py
@@ -1,0 +1,61 @@
+"""Tests for ListUDFsCommand.
+
+Locks in the UDFLoadError enrichment introduced so the formatter renders the
+same search_path / requested_path keys regardless of which CLI entry point
+(workflow init, validate-udfs, or list-udfs) surfaced the failure.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.cli.list_udfs import ListUDFsCommand
+from agent_actions.errors import UDFLoadError
+from agent_actions.utils.udf_management.registry import clear_registry
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """ListUDFsCommand.execute() calls clear_registry(); keep tests
+    independent of any UDFs registered by sibling modules."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+class TestListUDFsCommandEnrichment:
+    def test_udf_load_error_is_enriched_with_pipeline_context(self, tmp_path):
+        user_code = tmp_path / "tools"
+        user_code.mkdir()
+        raised = UDFLoadError(module="proj.bad", file="bad.py", error="boom")
+
+        cmd = ListUDFsCommand(str(user_code), json_output=True, verbose=False)
+        with patch("agent_actions.cli.list_udfs.discover_udfs", side_effect=raised):
+            with pytest.raises(UDFLoadError) as exc_info:
+                cmd.execute()
+
+        # Original identity is preserved.
+        assert exc_info.value.context["module"] == "proj.bad"
+        # Enrichment matches the keys validate_udfs / config_pipeline add, so
+        # UDFLoadErrorFormatter renders consistently across entry points.
+        assert exc_info.value.context["pipeline_stage"] == "list_udfs"
+        assert exc_info.value.context["search_path"] == str(user_code.resolve())
+        assert exc_info.value.context["requested_path"] == str(user_code)
+
+    def test_discovery_sentinel_error_propagates_with_enrichment(self, tmp_path):
+        user_code = tmp_path / "tools"
+        user_code.mkdir()
+        raised = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file=str(user_code),
+            error="User code directory not found",
+        )
+
+        cmd = ListUDFsCommand(str(user_code), json_output=True, verbose=False)
+        with patch("agent_actions.cli.list_udfs.discover_udfs", side_effect=raised):
+            with pytest.raises(UDFLoadError) as exc_info:
+                cmd.execute()
+
+        assert exc_info.value.context["module"] == UDFLoadError.DISCOVERY_SENTINEL
+        assert exc_info.value.context["pipeline_stage"] == "list_udfs"
+        assert exc_info.value.context["search_path"] == str(user_code.resolve())

--- a/tests/core/test_udf_loader.py
+++ b/tests/core/test_udf_loader.py
@@ -144,6 +144,33 @@ class TestDiscoverUDFs:
         assert "bad.py" in error.context["file"]
         assert "error" in error.context
 
+    def test_discover_udfs_wraps_relative_to_failure(self, tmp_path, monkeypatch):
+        """If Path.relative_to fails (symlink/Windows path quirks), the function
+        must not raise UnboundLocalError on `module_name`. It must surface a
+        typed UDFLoadError routed via the DISCOVERY_SENTINEL so the formatter
+        renders a directory-appropriate message instead of `pip install` hints."""
+        from pathlib import Path
+
+        user_code = tmp_path / "tools"
+        user_code.mkdir()
+        (user_code / "ok.py").write_text("x = 1\n")
+
+        original_relative_to = Path.relative_to
+
+        def fake_relative_to(self, *args, **kwargs):
+            if self.name == "ok.py":
+                raise ValueError("simulated relative_to failure")
+            return original_relative_to(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "relative_to", fake_relative_to)
+
+        with pytest.raises(UDFLoadError) as exc_info:
+            discover_udfs(user_code)
+        # Must surface as a typed UDFLoadError tagged as a discovery failure.
+        assert exc_info.value.context["module"] == UDFLoadError.DISCOVERY_SENTINEL
+        assert "ok.py" in exc_info.value.context["file"]
+        assert "module name" in exc_info.value.context["error"]
+
     def test_discover_udfs_does_not_mutate_sys_path(self, temp_user_code_dir):
         """Verify discover_udfs does not add user_code_path to sys.path."""
         import sys

--- a/tests/unit/error_formatters/test_configuration.py
+++ b/tests/unit/error_formatters/test_configuration.py
@@ -1,0 +1,62 @@
+"""Tests for ConfigurationErrorFormatter — specifically the UDFLoadError defer.
+
+UDFLoadError extends ConfigurationError, so the configuration formatter's name-
+based ``"Config" in exc_names`` match would otherwise claim UDF load errors and
+strip the module/file/install-hint context that UDFLoadErrorFormatter renders.
+The formatter has an explicit isinstance guard to defer; this file locks that
+behavior in so a future refactor can't silently regress.
+"""
+
+import pytest
+
+from agent_actions.errors import ConfigValidationError, UDFLoadError
+from agent_actions.logging.errors.formatters.configuration import (
+    ConfigurationErrorFormatter,
+)
+
+
+@pytest.fixture
+def formatter():
+    return ConfigurationErrorFormatter()
+
+
+class TestUDFLoadErrorDefer:
+    """ConfigurationErrorFormatter must never claim UDFLoadError, regardless of
+    chain ordering."""
+
+    def test_defers_when_udf_load_error_is_outer_exception(self, formatter):
+        exc = UDFLoadError(module="proj.bad", file="/proj/bad.py", error="boom")
+        assert not formatter.can_handle(exc, exc, str(exc))
+
+    def test_defers_when_udf_load_error_is_root_cause(self, formatter):
+        root = UDFLoadError(module="proj.bad", file="/proj/bad.py", error="boom")
+        wrapped = RuntimeError("workflow failed")
+        wrapped.__cause__ = root
+        assert not formatter.can_handle(wrapped, root, str(root))
+
+    def test_defers_for_discovery_sentinel_too(self, formatter):
+        exc = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        assert not formatter.can_handle(exc, exc, str(exc))
+
+    def test_defers_for_udf_load_error_subclass(self, formatter):
+        class CustomUDFLoadError(UDFLoadError):
+            pass
+
+        exc = CustomUDFLoadError(module="proj.bad", file="/x.py", error="boom")
+        assert not formatter.can_handle(exc, exc, str(exc))
+
+
+class TestStillClaimsOtherConfigurationErrors:
+    """Sanity: the defer must not regress the formatter's normal claims."""
+
+    def test_claims_config_validation_error(self, formatter):
+        exc = ConfigValidationError(reason="bad value", config_key="some.key")
+        assert formatter.can_handle(exc, exc, str(exc))
+
+    def test_claims_message_with_yaml_substring(self, formatter):
+        exc = ValueError("invalid yaml in config")
+        assert formatter.can_handle(exc, exc, str(exc))

--- a/tests/unit/error_formatters/test_function.py
+++ b/tests/unit/error_formatters/test_function.py
@@ -1,0 +1,114 @@
+"""Tests for FunctionNotFoundFormatter.
+
+Locks in the narrowed contract introduced when UDFLoadError was moved out to
+its own formatter: this one handles `FunctionNotFoundError` and
+`DuplicateFunctionError` only, and must NOT claim `UDFLoadError` even if the
+substring fallback would otherwise match.
+"""
+
+import pytest
+
+from agent_actions.errors import (
+    DuplicateFunctionError,
+    FunctionNotFoundError,
+    UDFLoadError,
+)
+from agent_actions.logging.errors.formatters.function import FunctionNotFoundFormatter
+
+
+@pytest.fixture
+def formatter():
+    return FunctionNotFoundFormatter()
+
+
+class TestCanHandle:
+    def test_claims_function_not_found_error(self, formatter):
+        exc = FunctionNotFoundError("Function 'foo' not found")
+        assert formatter.can_handle(exc, exc, str(exc))
+
+    def test_claims_duplicate_function_error(self, formatter):
+        exc = DuplicateFunctionError(function_name="foo")
+        assert formatter.can_handle(exc, exc, str(exc))
+
+    def test_claims_when_function_not_found_is_root_cause(self, formatter):
+        root = FunctionNotFoundError("Function 'foo' not found")
+        wrapped = RuntimeError("workflow failed")
+        wrapped.__cause__ = root
+        assert formatter.can_handle(wrapped, root, str(root))
+
+    def test_rejects_udf_load_error(self, formatter):
+        """UDFLoadErrorFormatter owns UDFLoadError — function formatter must defer."""
+        exc = UDFLoadError(module="proj.bad", file="/proj/bad.py", error="boom")
+        assert not formatter.can_handle(exc, exc, str(exc))
+
+    def test_rejects_udf_load_error_with_function_not_found_message(self, formatter):
+        """Substring fallback must not steal UDFLoadError even when the error text
+        contains 'function' + 'not found' (e.g. wrapped ImportError from a UDF that
+        references a missing symbol)."""
+        exc = UDFLoadError(
+            module="proj.bad",
+            file="/proj/bad.py",
+            error="cannot import function 'foo' from module — not found",
+        )
+        assert not formatter.can_handle(exc, exc, str(exc))
+
+    def test_rejects_udf_load_error_as_root_cause(self, formatter):
+        """Defers even when UDFLoadError is wrapped — protects against chain reorders."""
+        root = UDFLoadError(module="proj.bad", file="/proj/bad.py", error="boom")
+        wrapped = RuntimeError("workflow failed")
+        wrapped.__cause__ = root
+        assert not formatter.can_handle(wrapped, root, str(root))
+
+    def test_claims_untyped_error_with_function_not_found_message(self, formatter):
+        """Substring fallback still catches generic errors that name a missing function."""
+        exc = RuntimeError("function 'foo' not found in registry")
+        assert formatter.can_handle(exc, exc, str(exc))
+
+    def test_rejects_unrelated_error(self, formatter):
+        exc = ValueError("something else entirely")
+        assert not formatter.can_handle(exc, exc, str(exc))
+
+
+class TestFormat:
+    def test_renders_function_name_in_title(self, formatter):
+        exc = FunctionNotFoundError("Function 'extract_facts' not found")
+        result = formatter.format(exc, exc, str(exc), {"function_name": "extract_facts"})
+        assert result.title == "Function 'extract_facts' not found"
+
+    def test_renders_unknown_when_function_name_missing(self, formatter):
+        exc = FunctionNotFoundError("Function not found")
+        result = formatter.format(exc, exc, str(exc), {})
+        assert result.title == "Function 'unknown' not found"
+
+    def test_suggests_similar_function_when_available(self, formatter):
+        # _find_similar_functions matches via substring containment, so the
+        # target must be a sub/super-string of an available function.
+        exc = FunctionNotFoundError("Function 'extract' not found")
+        result = formatter.format(
+            exc,
+            exc,
+            str(exc),
+            {
+                "function_name": "extract",
+                "available_functions": ["extract_facts", "extract_links", "summarize"],
+            },
+        )
+        assert "Did you mean" in result.fix
+        assert "extract_facts" in result.fix
+
+    def test_lists_list_udfs_command_when_available_functions_known(self, formatter):
+        exc = FunctionNotFoundError("Function 'foo' not found")
+        result = formatter.format(
+            exc,
+            exc,
+            str(exc),
+            {"function_name": "foo", "available_functions": ["a", "b", "c"]},
+        )
+        assert "agac list-udfs" in result.fix
+        assert "3 available functions" in result.fix
+
+    def test_generic_fix_when_no_similar_and_no_available(self, formatter):
+        exc = FunctionNotFoundError("Function 'foo' not found")
+        result = formatter.format(exc, exc, str(exc), {"function_name": "foo"})
+        assert "@udf_tool decorator" in result.fix
+        assert "user_code directory" in result.fix

--- a/tests/unit/error_formatters/test_udf_load.py
+++ b/tests/unit/error_formatters/test_udf_load.py
@@ -1,0 +1,388 @@
+"""Tests for UDFLoadErrorFormatter."""
+
+import pytest
+
+from agent_actions.errors import UDFLoadError
+from agent_actions.logging.errors.formatters.udf_load import (
+    UDFLoadErrorFormatter,
+    _first_non_none,
+)
+from agent_actions.logging.errors.translator import ErrorTranslator
+
+
+@pytest.fixture
+def formatter():
+    return UDFLoadErrorFormatter()
+
+
+@pytest.fixture
+def udf_import_error():
+    cause = ModuleNotFoundError("No module named 'markdown2'")
+    cause.name = "markdown2"
+    return UDFLoadError(
+        module="run_thinkific_gen.apply_html_text",
+        file="/proj/tools/run_thinkific_gen/apply_html_text.py",
+        error="No module named 'markdown2'",
+        cause=cause,
+    )
+
+
+def _context_for(exc: UDFLoadError) -> dict:
+    """Approximate the per-exception slice of ErrorTranslator's merged context.
+
+    Only the exception's own ``.context`` dict is copied — the full
+    ``ErrorContextService.merge_exception_context`` also walks the chain and
+    pulls allowed typed attributes off the outer exception. For these tests the
+    UDFLoadError is the outer exception, so the simpler shape is sufficient.
+    """
+    return dict(exc.context or {})
+
+
+class TestCanHandle:
+    def test_claims_udf_load_error(self, formatter, udf_import_error):
+        assert formatter.can_handle(udf_import_error, udf_import_error, str(udf_import_error))
+
+    def test_claims_when_wrapped_as_root_cause(self, formatter, udf_import_error):
+        wrapped = RuntimeError("workflow load failed")
+        assert formatter.can_handle(wrapped, udf_import_error, str(udf_import_error))
+
+    def test_claims_subclass_via_isinstance(self, formatter):
+        class CustomUDFLoadError(UDFLoadError):
+            pass
+
+        exc = CustomUDFLoadError(module="x", file="/x.py", error="boom")
+        assert formatter.can_handle(exc, exc, str(exc))
+
+    def test_rejects_unrelated_error(self, formatter):
+        exc = ValueError("something else")
+        assert not formatter.can_handle(exc, exc, str(exc))
+
+
+class TestImportFailureFormatting:
+    def test_names_module_in_title(self, formatter, udf_import_error):
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        assert result.title == "Failed to load UDF module 'run_thinkific_gen.apply_html_text'"
+
+    def test_details_include_underlying_import_error(self, formatter, udf_import_error):
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        assert (
+            "Python could not import the UDF module: No module named 'markdown2'" in result.details
+        )
+
+    def test_file_path_surfaces_in_context(self, formatter, udf_import_error):
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        assert result.context["file_path"] == "/proj/tools/run_thinkific_gen/apply_html_text.py"
+
+    def test_module_key_omitted_from_context(self, formatter, udf_import_error):
+        # Two layers of defense: (1) the formatter does not put 'module' into
+        # ctx, and (2) UserError._SKIP_FIELDS lists 'module' so even if a
+        # future change forgets layer 1, it still won't render.
+        from agent_actions.logging.errors.user_error import _SKIP_FIELDS
+
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        assert "module" not in (result.context or {})  # layer 1
+        assert "module" in _SKIP_FIELDS  # layer 2
+
+    def test_fix_names_missing_module_and_install_command(self, formatter, udf_import_error):
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        assert "Python could not find the module 'markdown2'" in result.fix
+        assert "uv add" in result.fix
+        assert "pip install" in result.fix
+
+    def test_fix_warns_about_pypi_import_name_mismatch(self, formatter, udf_import_error):
+        # Real footgun: yaml→PyYAML, cv2→opencv-python — must not blindly suggest the import name.
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        assert "PyPI" in result.fix or "package name may differ" in result.fix
+
+    def test_fix_explains_blast_radius(self, formatter, udf_import_error):
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        assert "single broken file blocks" in result.fix
+
+    def test_dotted_submodule_preserved_in_missing_module_hint(self, formatter):
+        cause = ModuleNotFoundError("No module named 'google.cloud.storage'")
+        cause.name = "google.cloud.storage"
+        exc = UDFLoadError(
+            module="proj.tools.bad",
+            file="/proj/tools/bad.py",
+            error="No module named 'google.cloud.storage'",
+            cause=cause,
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        # Must NOT collapse to 'google' — real PyPI package is 'google-cloud-storage'.
+        assert "'google.cloud.storage'" in result.fix
+        assert "'google'" not in result.fix
+
+    def test_does_not_extract_unrelated_module_from_root(self, formatter):
+        """`root` (from extract_root_cause) may have fallen through
+        __context__ and picked up an unrelated ModuleNotFoundError. The
+        formatter must walk only the UDFLoadError's own __cause__ chain —
+        never `root` — so the user isn't told to `pip install <unrelated>`."""
+        udf_cause = ModuleNotFoundError("No module named 'markdown2'")
+        udf_cause.name = "markdown2"
+        udf_exc = UDFLoadError(
+            module="proj.bad",
+            file="/proj/bad.py",
+            error="No module named 'markdown2'",
+            cause=udf_cause,
+        )
+        unrelated = ModuleNotFoundError("No module named 'somewhere_else'")
+        unrelated.name = "somewhere_else"
+        # Simulate the translator handing in `unrelated` as the root (would
+        # happen if extract_root_cause walked __context__ past the UDF chain).
+        result = formatter.format(udf_exc, unrelated, str(udf_exc), _context_for(udf_exc))
+        # The UDF's own cause must win.
+        assert "Python could not find the module 'markdown2'" in result.fix
+        assert "somewhere_else" not in result.fix
+
+    def test_does_not_extract_module_reachable_only_via_root_context(self, formatter):
+        """Stronger version of the previous test: a UDFLoadError with NO
+        __cause__ chain (only message text) plus a `root` carrying a typed
+        ModuleNotFoundError must NOT inherit the root's module name. Without
+        the no-root guard, the regex fallback would still kick in on the
+        message text — but if the UDFLoadError's error string doesn't mention
+        the module name, root walking would be the only way for it to leak."""
+        # UDFLoadError where the error message has no quoted module hint.
+        udf_exc = UDFLoadError(
+            module="proj.bad",
+            file="/proj/bad.py",
+            error="some non-import failure: invalid state",
+        )
+        # extract_root_cause might surface this from elsewhere in the call
+        # stack via __context__ — must NOT be consulted.
+        sneaky_root = ModuleNotFoundError("No module named 'pwned'")
+        sneaky_root.name = "pwned"
+        result = formatter.format(udf_exc, sneaky_root, str(udf_exc), _context_for(udf_exc))
+        # No install hint; generic fix path.
+        assert "Python could not find the module" not in result.fix
+        assert "pwned" not in result.fix
+        assert "Fix the import error" in result.fix
+
+    def test_prefers_typed_name_attribute_over_message_regex(self, formatter):
+        # Localized / reworded ModuleNotFoundError messages still surface the missing name.
+        cause = ModuleNotFoundError("kein Modul namens 'markdown2' (translated message)")
+        cause.name = "markdown2"
+        exc = UDFLoadError(
+            module="proj.tools.bad",
+            file="/proj/tools/bad.py",
+            error="kein Modul namens 'markdown2' (translated message)",
+            cause=cause,
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert "Python could not find the module 'markdown2'" in result.fix
+
+    def test_non_import_error_gets_generic_fix(self, formatter):
+        exc = UDFLoadError(
+            module="proj.tools.bad",
+            file="/proj/tools/bad.py",
+            error="invalid syntax (bad.py, line 12)",
+            cause=SyntaxError("invalid syntax"),
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert "Fix the import error" in result.fix
+        assert "Python could not find the module" not in result.fix
+
+    def test_format_for_cli_lays_out_problem_file_and_fix(self, formatter, udf_import_error):
+        result = formatter.format(
+            udf_import_error,
+            udf_import_error,
+            str(udf_import_error),
+            _context_for(udf_import_error),
+        )
+        rendered = result.format_for_cli()
+        assert "Configuration Error: Failed to load UDF module" in rendered
+        assert "Problem: Python could not import the UDF module" in rendered
+        assert "File: /proj/tools/run_thinkific_gen/apply_html_text.py" in rendered
+        assert "Fix: Python could not find the module 'markdown2'" in rendered
+
+
+class TestDiscoveryFailureFormatting:
+    """The <discovery> sentinel signals a directory problem, not an import failure."""
+
+    def test_directory_not_found_uses_discovery_title(self, formatter):
+        exc = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert result.title == "UDF discovery failed"
+        # Sentinel must not leak into the title.
+        assert UDFLoadError.DISCOVERY_SENTINEL not in result.title
+
+    def test_directory_not_found_details_are_the_underlying_reason(self, formatter):
+        exc = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert result.details == "User code directory not found"
+        # Must not say "Python could not import" — there was nothing to import.
+        assert "import" not in result.details.lower()
+
+    def test_directory_not_found_suggests_fixing_path_not_imports(self, formatter):
+        exc = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert "user-code directory" in result.fix or "tool_path" in result.fix
+        assert "Fix the import error" not in result.fix
+        assert "not installed" not in result.fix
+
+    def test_directory_not_found_surfaces_path_in_context(self, formatter):
+        exc = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert result.context["file_path"] == "/no/such/dir"
+
+
+class TestFirstNonNone:
+    """Direct coverage for the explicit-None coalescing helper.
+
+    The formatter uses this instead of `or` so an empty-string `module`/`file`
+    isn't silently swallowed (which would mask an upstream bug). These tests
+    document and lock in those edge cases."""
+
+    def test_returns_first_non_none(self):
+        assert _first_non_none(None, "x", "y") == "x"
+
+    def test_all_none_returns_none(self):
+        assert _first_non_none(None, None, None) is None
+
+    def test_no_args_returns_none(self):
+        assert _first_non_none() is None
+
+    def test_empty_string_is_returned_not_skipped(self):
+        # Differs from `None or ""` (returns ""), `"" or "fallback"` (returns "fallback").
+        assert _first_non_none(None, "", "fallback") == ""
+
+    def test_zero_is_returned_not_skipped(self):
+        assert _first_non_none(None, 0, "fallback") == 0
+
+    def test_false_is_returned_not_skipped(self):
+        assert _first_non_none(None, False, "fallback") is False
+
+
+class TestRegistrationInTranslatorChain:
+    def test_translator_uses_udf_load_formatter(self, udf_import_error):
+        translator = ErrorTranslator()
+        result = translator.translate(udf_import_error)
+        assert result.title == "Failed to load UDF module 'run_thinkific_gen.apply_html_text'"
+        # Sanity: the install-hint surfaced (i.e. function/config formatters did not steal it).
+        assert "Python could not find the module 'markdown2'" in result.fix
+
+    def test_translator_routes_discovery_sentinel_through_udf_formatter(self):
+        # Full pipeline: ErrorContextService merges exc.context into the dict
+        # passed to format(), and the chain ordering puts UDFLoadErrorFormatter
+        # ahead of ConfigurationErrorFormatter (which would otherwise claim it).
+        exc = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        translator = ErrorTranslator()
+        result = translator.translate(exc)
+        assert result.title == "UDF discovery failed"
+        assert UDFLoadError.DISCOVERY_SENTINEL not in result.title
+        assert "user-code directory" in result.fix or "tool_path" in result.fix
+
+    def test_translator_walks_cause_chain_for_missing_module_name(self):
+        # End-to-end: UDFLoadError wraps ModuleNotFoundError via __cause__.
+        # The formatter must pull `name` off the cause through the chain, not
+        # rely on the message-text regex.
+        cause = ModuleNotFoundError("kein Modul namens 'PyYAML' (localized)")
+        cause.name = "PyYAML"
+        exc = UDFLoadError(
+            module="proj.tools.uses_yaml",
+            file="/proj/tools/uses_yaml.py",
+            error="kein Modul namens 'PyYAML' (localized)",
+            cause=cause,
+        )
+        translator = ErrorTranslator()
+        result = translator.translate(exc)
+        assert result.title == "Failed to load UDF module 'proj.tools.uses_yaml'"
+        assert "Python could not find the module 'PyYAML'" in result.fix
+
+    def test_translator_routes_udf_with_yaml_cause_through_udf_formatter(self):
+        """A UDF that loads malformed YAML at import time raises
+        UDFLoadError(cause=yaml.YAMLError). The chain must render the UDF
+        formatter (with module/file context), not the YAML formatter (which
+        would strip that context)."""
+        import yaml
+
+        yaml_err = None
+        try:
+            yaml.safe_load("a:\n  b: : :")  # malformed
+        except yaml.YAMLError as e:
+            yaml_err = e
+        assert yaml_err is not None
+
+        exc = UDFLoadError(
+            module="proj.uses_yaml",
+            file="/proj/tools/uses_yaml.py",
+            error=str(yaml_err),
+            cause=yaml_err,
+        )
+        translator = ErrorTranslator()
+        result = translator.translate(exc)
+        assert result.title == "Failed to load UDF module 'proj.uses_yaml'"
+        assert result.category == "Configuration Error"
+        assert "YAML syntax error" not in result.title
+
+    def test_translator_renders_pipeline_enrichment_keys(self):
+        # config_pipeline enriches with search_path / requested_path; those
+        # must surface in the CLI rendering, not just the merged-context dict.
+        from agent_actions.errors import enrich_exception_context
+
+        exc = UDFLoadError(module="proj.bad", file="bad.py", error="boom")
+        enrich_exception_context(
+            exc,
+            pipeline_stage="discover_udfs",
+            search_path="/abs/proj/tools",
+            requested_path="tools",
+        )
+        translator = ErrorTranslator()
+        result = translator.translate(exc)
+        rendered = result.format_for_cli()
+        assert "search_path: /abs/proj/tools" in rendered
+        assert "requested_path: tools" in rendered

--- a/tests/unit/error_formatters/test_yaml.py
+++ b/tests/unit/error_formatters/test_yaml.py
@@ -1,0 +1,61 @@
+"""Tests for YAMLSyntaxErrorFormatter.
+
+Locks in the UDFLoadError defer: even though a UDF that loads malformed YAML
+at import raises yaml.YAMLError (which YAMLSyntaxErrorFormatter normally
+claims via isinstance), the UDF wrapper must take precedence so the user
+sees the failing module/file context.
+"""
+
+import pytest
+import yaml
+
+from agent_actions.errors import UDFLoadError
+from agent_actions.logging.errors.formatters.yaml import YAMLSyntaxErrorFormatter
+
+
+@pytest.fixture
+def formatter():
+    return YAMLSyntaxErrorFormatter()
+
+
+@pytest.fixture
+def yaml_err():
+    try:
+        yaml.safe_load("a:\n  b: : :")
+    except yaml.YAMLError as e:
+        return e
+    raise AssertionError("expected YAMLError")
+
+
+class TestUDFLoadErrorDefer:
+    def test_defers_when_udf_load_error_is_outer_exception(self, formatter, yaml_err):
+        exc = UDFLoadError(
+            module="proj.uses_yaml",
+            file="/proj/uses_yaml.py",
+            error=str(yaml_err),
+            cause=yaml_err,
+        )
+        # root here is the yaml.YAMLError (what extract_root_cause would return).
+        assert not formatter.can_handle(exc, yaml_err, str(exc))
+
+    def test_defers_when_udf_load_error_is_root_cause(self, formatter, yaml_err):
+        udf = UDFLoadError(
+            module="proj.uses_yaml",
+            file="/proj/uses_yaml.py",
+            error=str(yaml_err),
+            cause=yaml_err,
+        )
+        wrapped = RuntimeError("workflow init failed")
+        wrapped.__cause__ = udf
+        assert not formatter.can_handle(wrapped, udf, str(udf))
+
+
+class TestStillClaimsRealYAMLErrors:
+    """Sanity: the defer must not regress the formatter's normal claims."""
+
+    def test_claims_plain_yaml_error(self, formatter, yaml_err):
+        assert formatter.can_handle(yaml_err, yaml_err, str(yaml_err))
+
+    def test_rejects_unrelated_error(self, formatter):
+        exc = ValueError("not a YAML problem")
+        assert not formatter.can_handle(exc, exc, str(exc))

--- a/tests/unit/workflow/test_config_pipeline_stage.py
+++ b/tests/unit/workflow/test_config_pipeline_stage.py
@@ -6,14 +6,19 @@ Covers:
 - agent name propagation
 - Exception without .context attribute
 - Exception with existing .context dict
+- UDFLoadError raised from _discover_udfs_from_path is enriched with the
+  searched and requested paths and re-raised typed.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agent_actions.errors import ConfigurationError
-from agent_actions.workflow.config_pipeline import _run_config_stage
+from agent_actions.errors import ConfigurationError, UDFLoadError
+from agent_actions.workflow.config_pipeline import (
+    _discover_udfs_from_path,
+    _run_config_stage,
+)
 
 
 def _make_manager(agent_name: str = "test_agent") -> MagicMock:
@@ -122,3 +127,44 @@ class TestRunConfigStage:
             _run_config_stage(fail, "load_configs", manager)
 
         assert exc_info.value.context["agent"] == "unknown"
+
+
+class TestDiscoverUDFsFromPathTypedHandling:
+    """_discover_udfs_from_path must wrap discover_udfs in a typed try/except
+    so UDFLoadError carries the configured path context — not just the
+    per-file path UDFLoadError already records — when bubbled up."""
+
+    def test_udf_load_error_is_enriched_with_search_path(self, tmp_path):
+        path_dir = tmp_path / "tools"
+        path_dir.mkdir()
+        console = MagicMock()
+        raised = UDFLoadError(module="proj.bad", file="bad.py", error="boom")
+
+        with patch("agent_actions.workflow.config_pipeline.discover_udfs", side_effect=raised):
+            with pytest.raises(UDFLoadError) as exc_info:
+                _discover_udfs_from_path(str(path_dir), None, console)
+
+        # Original identity preserved.
+        assert exc_info.value.context["module"] == "proj.bad"
+        # Pipeline context added so the formatter / logs can name the
+        # workflow-level search location.
+        assert exc_info.value.context["pipeline_stage"] == "discover_udfs"
+        assert exc_info.value.context["search_path"] == str(path_dir.resolve())
+        assert exc_info.value.context["requested_path"] == str(path_dir)
+
+    def test_discovery_sentinel_error_propagates_with_enrichment(self, tmp_path):
+        path_dir = tmp_path / "tools"
+        path_dir.mkdir()
+        console = MagicMock()
+        raised = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file=str(path_dir),
+            error="User code directory not found",
+        )
+
+        with patch("agent_actions.workflow.config_pipeline.discover_udfs", side_effect=raised):
+            with pytest.raises(UDFLoadError) as exc_info:
+                _discover_udfs_from_path(str(path_dir), None, console)
+
+        assert exc_info.value.context["module"] == UDFLoadError.DISCOVERY_SENTINEL
+        assert exc_info.value.context["search_path"] == str(path_dir.resolve())

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -164,6 +164,13 @@ class TestValidate:
 
         assert result["valid"] is False
         assert result["error_type"] == "load_error"
+        # Pipeline enrichment is in-place on the returned exception object —
+        # assert it directly so the formatter contract stays observable from
+        # tests, not just from rendered CLI output.
+        err = result["error"]
+        assert err.context["pipeline_stage"] == "validate_udfs"
+        assert err.context["search_path"] == str(Path(str(tmp_path)).resolve())
+        assert err.context["requested_path"] == str(tmp_path)
 
     @patch(_CLEAR_REGISTRY)
     @patch(_VALIDATE_REFS)
@@ -258,7 +265,9 @@ class TestExecute:
         assert any("Duplicate function name" in c for c in calls)
 
     @patch("agent_actions.validation.validate_udfs.fire_event")
-    def test_load_error_calls_handler(self, mock_fire, tmp_path):
+    def test_load_error_routes_through_shared_formatter(self, mock_fire, tmp_path):
+        """Delegates to format_user_error → UDFLoadErrorFormatter so the
+        validate-udfs UX stays in sync with the rest of the CLI."""
         cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
         cmd.console = MagicMock()
         load_err = UDFLoadError(module="bad", file="bad.py", error="SyntaxError")
@@ -268,8 +277,39 @@ class TestExecute:
 
         cmd.execute()
 
+        joined = "\n".join(str(c) for c in cmd.console.print.call_args_list)
+        # Marker line + canonical formatter output.
+        assert "UDF load failed" in joined
+        assert "Failed to load UDF module 'bad'" in joined
+        assert "Python could not import the UDF module: SyntaxError" in joined
+        assert "File: bad.py" in joined
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_discovery_sentinel_renders_directory_error_not_module_error(self, mock_fire, tmp_path):
+        """When discover_udfs signals the user-code dir is missing/invalid via
+        UDFLoadError.DISCOVERY_SENTINEL, the handler must render a directory-
+        appropriate message and never leak the sentinel string to the user."""
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        load_err = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        cmd.validate = MagicMock(
+            return_value={"valid": False, "error": load_err, "error_type": "load_error"}
+        )
+
+        cmd.execute()
+
         calls = [str(c) for c in cmd.console.print.call_args_list]
-        assert any("Error loading UDF" in c for c in calls)
+        joined = "\n".join(calls)
+        assert "UDF discovery failed" in joined
+        assert "/no/such/dir" in joined
+        assert "User code directory not found" in joined
+        assert UDFLoadError.DISCOVERY_SENTINEL not in joined
+        # Directory-fix wording, not import-error wording.
+        assert "user-code directory" in joined or "tool_path" in joined
 
     @patch("agent_actions.validation.validate_udfs.fire_event")
     def test_not_found_error_calls_handler(self, mock_fire, tmp_path):


### PR DESCRIPTION
## Summary

Splits `UDFLoadError` handling into a dedicated formatter so users see the failing module, file, and an install hint instead of a leaked `<discovery>` sentinel or a generic configuration error.

## What changed

**`UDFLoadError` (agent_actions/errors/configuration.py)**
- New `DISCOVERY_SENTINEL: Final[str]` class attribute signals failures that aren't Python imports (missing user-code directory, path-derivation errors), so consumers render directory-appropriate messages instead of "fix your imports" advice.
- `__init__` now produces a directory-shaped message (`"UDF discovery failed: …"`) when the sentinel is used, so `str(exc)` and logs don't leak the internal token.

**`UDFLoadErrorFormatter` (new — agent_actions/logging/errors/formatters/udf_load.py)**
- Two render paths: directory failure (`title="UDF discovery failed"`) vs import failure (`title="Failed to load UDF module '…'"`).
- Extracts the missing module from `ModuleNotFoundError.name` typed attribute, walked via `__cause__` only — never `__context__`, which can surface unrelated errors from the call stack.
- Install hint warns that PyPI names differ from import names (yaml→PyYAML, cv2→opencv-python, bs4→beautifulsoup4) and tells the user how to handle the local-module case.
- Forwards `search_path` / `requested_path` enrichment from the pipeline into the rendered context.

**Chain hardening (formatters/translator.py + sibling formatters)**
- `UDFLoadErrorFormatter` registered ahead of function/configuration formatters; both siblings now defer via explicit `isinstance(exc, UDFLoadError)` guards so chain reordering can't silently regress UDF rendering.
- `ConfigurationErrorFormatter` no longer claims `UDFLoadError` implicitly via the `ConfigurationError` base class.
- `FunctionNotFoundFormatter` migrated from string-name matching to typed `isinstance` checks; substring fallback kept for untyped errors.

**Discovery hardening (input/loaders/udf.py)**
- `discover_udfs()` no longer crashes with `UnboundLocalError` when `Path.relative_to` fails on symlink/Windows quirks — surfaces a typed `UDFLoadError` routed through the discovery sentinel.

**Pipeline consistency**
- `config_pipeline._discover_udfs_from_path`, `validate_udfs.validate`, and `list_udfs.execute` all enrich `UDFLoadError` with `pipeline_stage` / `search_path` / `requested_path` so the formatter renders the configured location across every entry point, not just the per-file path.
- `validate_udfs._handle_load_error` delegates to `format_user_error` (markup disabled so brackets in messages aren't consumed as Rich markup) instead of hand-rolling Rich output.

**CLI help (cli/inspect_action.py)**
- `agac inspect action` and `agac inspect context` declare `metavar="ACTION_NAME"` and explicitly call out the positional argument (users were mistaking it for a `--action` flag). Examples preserved on separate lines via Click's `\b`.

## Test plan

- [x] `pytest tests/` (7621 passed)
- [x] `ruff format --check` + `ruff check`
- [x] `harness ci` + `harness review` (6 consecutive consensus passes)
- [x] `harness smoke` end-to-end against qanalabs-quiz-maker (last run hit Ollama 429 session limit; prior runs passed)
- [x] 100+ new regression tests across:
  - `tests/unit/error_formatters/test_udf_load.py` — formatter behavior, sentinel routing, chain integration, pipeline enrichment, `__cause__` chain walking
  - `tests/unit/error_formatters/test_function.py` — `UDFLoadError` defer
  - `tests/unit/error_formatters/test_configuration.py` — `UDFLoadError` defer
  - `tests/cli/test_list_udfs.py`, `tests/cli/test_inspect_field_flow.py` — CLI help + enrichment
  - `tests/unit/workflow/test_config_pipeline_stage.py`, `tests/validation/test_validate_udfs.py` — typed try/except enrichment
  - `tests/core/test_udf_loader.py` — `relative_to` `ValueError` wrapping