### PR TITLE
chore: bump version to 0.2.6

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.2.5"
+version = "0.2.6"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` and `agent_actions/__version__.py` from 0.2.5 → 0.2.6.

27 PRs since v0.2.5 — hardening sweep across most modules plus diagnostics polish:

- Module hardening across `cli`, `config`, `errors`, `guards`, `llm`, `logging`, `models`, `output`, `processing`, `prompt`, `record`, `storage`, `utils`, `validation`, `workflow`, `batch` — P0/P1 findings, silent fallbacks, resource leaks, credential redaction, fail-closed semantics
- Clearer UDF discovery/import errors + `agac inspect` help text (#720)
- Static analyzer surfaces circular deps + template syntax errors (#716)
- `render save` and scope parsing surface their failures (#715)
- Skills bundle condensed to 5 references + 2 helper scripts (#717)
- Tooling hardening — runs.json crash, image-copy abort (#706)
- Docs dashboard accuracy (#689, #691)

## Test plan

- [x] pyproject.toml + agent_actions/__version__.py both updated
- [x] No other 0.2.5 references in code
- [ ] CI green on merge → tag v0.2.6 and cut release