### PR TITLE
fix(spec-554): land remaining silent-fallback fixes (record_count)

### DIFF
--- a/agent_actions/workflow/execution_events.py
+++ b/agent_actions/workflow/execution_events.py
@@ -95,6 +95,11 @@ class WorkflowEventLogger:
             tokens = {}
             if hasattr(params.result, "tokens") and params.result.tokens:
                 tokens = params.result.tokens
+            # Explicit 0 (not the dataclass default) when the metrics object is
+            # missing or lacks record_count — avoids silently shipping 0 for
+            # actions that genuinely produced output but lost the field.
+            metrics = getattr(params.result, "metrics", None)
+            record_count = getattr(metrics, "record_count", 0) or 0 if metrics else 0
             fire_event(
                 ActionCompleteEvent(
                     action_name=params.action_name,
@@ -102,6 +107,7 @@ class WorkflowEventLogger:
                     total_actions=params.total_actions,
                     execution_time=params.duration,
                     output_path=params.result.output_folder or "",
+                    record_count=record_count,
                     tokens=tokens,
                     mode=params.run_mode,
                 )

--- a/agent_actions/workflow/execution_events.py
+++ b/agent_actions/workflow/execution_events.py
@@ -95,10 +95,6 @@ class WorkflowEventLogger:
             tokens = {}
             if hasattr(params.result, "tokens") and params.result.tokens:
                 tokens = params.result.tokens
-            # Defensive None coercion: if result.metrics is None, ship 0. The
-            # producer (_handle_run_success / _resolve_batch_outcome /
-            # _check_prior_output in workflow/executor.py) is responsible for
-            # populating a real count via _count_output_records on success paths.
             metrics = getattr(params.result, "metrics", None)
             record_count = metrics.record_count if metrics is not None else 0
             fire_event(

--- a/agent_actions/workflow/execution_events.py
+++ b/agent_actions/workflow/execution_events.py
@@ -95,11 +95,12 @@ class WorkflowEventLogger:
             tokens = {}
             if hasattr(params.result, "tokens") and params.result.tokens:
                 tokens = params.result.tokens
-            # Explicit 0 (not the dataclass default) when the metrics object is
-            # missing or lacks record_count — avoids silently shipping 0 for
-            # actions that genuinely produced output but lost the field.
+            # Defensive None coercion: if result.metrics is None, ship 0. The
+            # producer (_handle_run_success / _resolve_batch_outcome /
+            # _check_prior_output in workflow/executor.py) is responsible for
+            # populating a real count via _count_output_records on success paths.
             metrics = getattr(params.result, "metrics", None)
-            record_count = getattr(metrics, "record_count", 0) or 0 if metrics else 0
+            record_count = metrics.record_count if metrics is not None else 0
             fire_event(
                 ActionCompleteEvent(
                     action_name=params.action_name,

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -97,6 +97,7 @@ class ExecutionMetrics:
     model_vendor: str | None = None
     model_name: str | None = None
     files_processed: int = 0
+    record_count: int = 0
 
 
 @dataclass
@@ -404,7 +405,10 @@ class ActionExecutor:
                 success=True,
                 output_folder=output_folder,
                 status=ActionStatus.COMPLETED,
-                metrics=ExecutionMetrics(duration=duration),
+                metrics=ExecutionMetrics(
+                    duration=duration,
+                    record_count=self._count_output_records(params.action_name),
+                ),
             )
 
         final_status = self._resolve_completion_status(params.action_name)
@@ -434,8 +438,28 @@ class ActionExecutor:
                 model_vendor=params.action_config.get("model_vendor"),
                 model_name=params.action_config.get("model_name"),
                 files_processed=0,
+                record_count=self._count_output_records(params.action_name),
             ),
         )
+
+    def _count_output_records(self, action_name: str) -> int:
+        """Return the total number of target records the action wrote to storage.
+
+        Used to populate ``ExecutionMetrics.record_count`` so ``ActionCompleteEvent``
+        ships a real count instead of the dataclass default 0. If the storage
+        backend is unreachable or the query fails, return 0 explicitly and log —
+        do not silently swallow the error.
+        """
+        storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
+        if storage_backend is None:
+            return 0
+        try:
+            stats = storage_backend.get_storage_stats()
+        except Exception as e:
+            logger.warning("Could not read record_count for %s: %s", action_name, e, exc_info=True)
+            return 0
+        nodes = stats.get("nodes", {}) if isinstance(stats, dict) else {}
+        return int(nodes.get(action_name, 0))
 
     def _handle_guard_all_filtered(
         self,

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -97,6 +97,12 @@ class ExecutionMetrics:
     model_vendor: str | None = None
     model_name: str | None = None
     files_processed: int = 0
+    # record_count: number of output records the action wrote to storage.
+    # Invariant: populated via _count_output_records on successful completion
+    # paths — _handle_run_success (online/passthrough), _resolve_batch_outcome
+    # (batch completion), and _check_prior_output (cached completed). Remains
+    # at the default 0 for non-completion paths: skipped (guard-filtered),
+    # failed, and batch_submitted (no output yet).
     record_count: int = 0
 
 
@@ -271,7 +277,10 @@ class ActionExecutor:
             ActionExecutionResult(
                 success=True,
                 status=ActionStatus.COMPLETED,
-                metrics=ExecutionMetrics(duration=0.0),
+                metrics=ExecutionMetrics(
+                    duration=0.0,
+                    record_count=self._count_output_records(action_name),
+                ),
             ),
         )
 
@@ -459,7 +468,10 @@ class ActionExecutor:
             logger.warning("Could not read record_count for %s: %s", action_name, e, exc_info=True)
             return 0
         nodes = stats.get("nodes", {}) if isinstance(stats, dict) else {}
-        return int(nodes.get(action_name, 0))
+        # Defensive: a backend returning explicit None for a node would crash
+        # int(None). Coerce None -> 0 so a missing/unknown count does not break
+        # the action complete path.
+        return int(nodes.get(action_name, 0) or 0)
 
     def _handle_guard_all_filtered(
         self,
@@ -1033,7 +1045,10 @@ class ActionExecutor:
                 success=True,
                 output_folder=output_folder,
                 status=final_status,
-                metrics=ExecutionMetrics(duration=wall_clock),
+                metrics=ExecutionMetrics(
+                    duration=wall_clock,
+                    record_count=self._count_output_records(action_name),
+                ),
             )
 
         if batch_status == "in_progress":

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -97,8 +97,11 @@ class ExecutionMetrics:
     model_vendor: str | None = None
     model_name: str | None = None
     files_processed: int = 0
-    # Populated by _count_output_records on COMPLETED paths; stays 0 for
-    # skipped / failed / batch_submitted (no ActionCompleteEvent fires there).
+    # Number of target records this specific execution wrote (after - before
+    # snapshot). Stays at the default 0 for paths that don't write target
+    # rows: batch_submitted (job still pending), WHERE-skip (no data written),
+    # guard-all-filtered SKIPPED, FAILED, and cached completions discovered
+    # by _check_prior_output (this execution didn't run the action).
     record_count: int = 0
 
 
@@ -390,8 +393,16 @@ class ActionExecutor:
         output_folder: str,
         duration: float,
         batch_status: str | None,
+        pre_run_count: int,
     ) -> ActionExecutionResult:
-        """Handle successful action run result."""
+        """Handle successful action run result.
+
+        ``pre_run_count`` is the storage-backend record count for this action
+        captured BEFORE the runner executed.  The delta against the post-run
+        snapshot is what this execution actually wrote — using
+        ``get_storage_stats`` directly would inflate on resume / re-run when
+        prior runs left rows on different paths.
+        """
         if batch_status == "batch_submitted":
             self.deps.state_manager.update_status(
                 params.action_name,
@@ -421,7 +432,7 @@ class ActionExecutor:
                 status=ActionStatus.COMPLETED,
                 metrics=ExecutionMetrics(
                     duration=duration,
-                    record_count=self._count_output_records(params.action_name),
+                    record_count=self._records_written_this_run(params.action_name, pre_run_count),
                 ),
             )
 
@@ -452,9 +463,54 @@ class ActionExecutor:
                 model_vendor=params.action_config.get("model_vendor"),
                 model_name=params.action_config.get("model_name"),
                 files_processed=0,
-                record_count=self._count_output_records(params.action_name),
+                record_count=self._records_written_this_run(params.action_name, pre_run_count),
             ),
         )
+
+    def _count_records_for_action(self, action_name: str) -> int:
+        """Return the storage-backend record count for ``action_name``.
+
+        Raises ``RuntimeError`` if the storage backend is unavailable or the
+        underlying query / value parse fails.  This is called immediately
+        before and after running an action so the delta yields the
+        per-execution record count.  A silent fallback to 0 here would let a
+        broken telemetry path masquerade as "action wrote nothing," exactly
+        the failure mode spec 554 is eliminating.
+        """
+        storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
+        if storage_backend is None:
+            raise RuntimeError(
+                f"Cannot count records for {action_name!r}: no storage backend on action_runner"
+            )
+        try:
+            stats = storage_backend.get_storage_stats()
+        except Exception as e:
+            raise RuntimeError(
+                f"Storage backend get_storage_stats() failed while counting "
+                f"records for {action_name!r}: {e}"
+            ) from e
+        nodes = stats.get("nodes", {}) if isinstance(stats, dict) else {}
+        raw = nodes.get(action_name, 0)
+        if raw is None:
+            return 0
+        try:
+            return int(raw)
+        except (TypeError, ValueError) as e:
+            raise RuntimeError(
+                f"Storage backend returned non-integer record_count {raw!r} "
+                f"for {action_name!r}: {e}"
+            ) from e
+
+    def _records_written_this_run(self, action_name: str, pre_run_count: int) -> int:
+        """Compute records written this execution as (after - before).
+
+        Clamped at 0 — a negative delta would mean rows were deleted during
+        the run, which is not a meaningful "records produced by this
+        execution" signal.
+        """
+        after = self._count_records_for_action(action_name)
+        delta = after - pre_run_count
+        return delta if delta > 0 else 0
 
     def _count_output_records(self, action_name: str) -> int:
         """Return the total number of target records the action wrote to storage.
@@ -965,13 +1021,14 @@ class ActionExecutor:
         self.deps.state_manager.update_status(action_name, ActionStatus.CHECKING_BATCH)
         output_directory = self._batch_output_directory(action_name)
 
+        pre_run_count = self._count_records_for_action(action_name)
         output_folder, batch_status = self.deps.batch_manager.handle_batch_agent(
             action_name, output_directory, action_config
         )
 
         duration = (datetime.now() - start_time).total_seconds()
         return self._resolve_batch_outcome(
-            action_name, action_config, output_folder, batch_status, duration
+            action_name, action_config, output_folder, batch_status, duration, pre_run_count
         )
 
     async def _handle_batch_check_async(
@@ -985,6 +1042,7 @@ class ActionExecutor:
         self.deps.state_manager.update_status(action_name, ActionStatus.CHECKING_BATCH)
         output_directory = self._batch_output_directory(action_name)
 
+        pre_run_count = self._count_records_for_action(action_name)
         output_folder, batch_status = await asyncio.to_thread(
             self.deps.batch_manager.handle_batch_agent,
             action_name,
@@ -994,7 +1052,7 @@ class ActionExecutor:
 
         duration = (datetime.now() - start_time).total_seconds()
         return self._resolve_batch_outcome(
-            action_name, action_config, output_folder, batch_status, duration
+            action_name, action_config, output_folder, batch_status, duration, pre_run_count
         )
 
     def _batch_output_directory(self, action_name: str) -> str:
@@ -1010,8 +1068,14 @@ class ActionExecutor:
         output_folder: str | None,
         batch_status: str,
         duration: float,
+        pre_run_count: int,
     ) -> ActionExecutionResult:
-        """Map batch_manager result to status, events, and ActionExecutionResult."""
+        """Map batch_manager result to status, events, and ActionExecutionResult.
+
+        ``pre_run_count`` is the storage-backend record count captured BEFORE
+        the batch result was processed.  Used for the per-execution delta —
+        see ``_handle_run_success`` for the rationale.
+        """
         if batch_status == "completed":
             wall_clock = self._compute_batch_wall_clock(action_name, duration)
             final_status = self._resolve_completion_status(action_name)
@@ -1054,7 +1118,7 @@ class ActionExecutor:
                 status=final_status,
                 metrics=ExecutionMetrics(
                     duration=wall_clock,
-                    record_count=self._count_output_records(action_name),
+                    record_count=self._records_written_this_run(action_name, pre_run_count),
                 ),
             )
 
@@ -1100,6 +1164,11 @@ class ActionExecutor:
         self._track_action_start(params)
         correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
 
+        # Snapshot must surface storage errors loudly (no silent 0 fallback).
+        # Both pre-run and post-run snapshots are intentionally OUTSIDE the
+        # except clause below: only failures from the user-supplied action
+        # runner should be funneled through _handle_run_failure.
+        pre_run_count = self._count_records_for_action(params.action_name)
         try:
             output_folder = self.deps.action_runner.run_action(
                 params.action_config,
@@ -1108,16 +1177,18 @@ class ActionExecutor:
                 params.action_idx,
                 input_directories_override=correlated_input,
             )
-            duration = (datetime.now() - params.start_time).total_seconds()
-            batch_status = self._check_batch_submission(
-                params.action_name,
-                params.action_idx,
-                configured_run_mode=params.action_config.get("run_mode"),
-            )
-            return self._handle_run_success(params, output_folder, duration, batch_status)
-
         except Exception as e:
             return self._handle_run_failure(params, e)
+
+        duration = (datetime.now() - params.start_time).total_seconds()
+        batch_status = self._check_batch_submission(
+            params.action_name,
+            params.action_idx,
+            configured_run_mode=params.action_config.get("run_mode"),
+        )
+        return self._handle_run_success(
+            params, output_folder, duration, batch_status, pre_run_count
+        )
 
     async def _execute_action_run_async(self, params: ActionRunParams) -> ActionExecutionResult:
         """Execute action run (asynchronous)."""
@@ -1125,6 +1196,8 @@ class ActionExecutor:
         self._track_action_start(params)
         correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
 
+        # See sync counterpart for the rationale on snapshot placement.
+        pre_run_count = self._count_records_for_action(params.action_name)
         try:
             output_folder = await asyncio.to_thread(
                 self.deps.action_runner.run_action,
@@ -1134,16 +1207,18 @@ class ActionExecutor:
                 params.action_idx,
                 input_directories_override=correlated_input,
             )
-            duration = (datetime.now() - params.start_time).total_seconds()
-            batch_status = self._check_batch_submission(
-                params.action_name,
-                params.action_idx,
-                configured_run_mode=params.action_config.get("run_mode"),
-            )
-            return self._handle_run_success(params, output_folder, duration, batch_status)
-
         except Exception as e:
             return self._handle_run_failure(params, e)
+
+        duration = (datetime.now() - params.start_time).total_seconds()
+        batch_status = self._check_batch_submission(
+            params.action_name,
+            params.action_idx,
+            configured_run_mode=params.action_config.get("run_mode"),
+        )
+        return self._handle_run_success(
+            params, output_folder, duration, batch_status, pre_run_count
+        )
 
     def __repr__(self):
         return f"ActionExecutor(deps={self.deps})"

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -247,7 +247,7 @@ class ActionExecutor:
                 ActionExecutionResult(
                     success=True,
                     status=ActionStatus.COMPLETED,
-                    metrics=ExecutionMetrics(duration=0.0),
+                    metrics=ExecutionMetrics(duration=0.0, record_count=0),
                 ),
             )
 

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -97,12 +97,8 @@ class ExecutionMetrics:
     model_vendor: str | None = None
     model_name: str | None = None
     files_processed: int = 0
-    # record_count: number of output records the action wrote to storage.
-    # Invariant: populated via _count_output_records on successful completion
-    # paths — _handle_run_success (online/passthrough), _resolve_batch_outcome
-    # (batch completion), and _check_prior_output (cached completed). Remains
-    # at the default 0 for non-completion paths: skipped (guard-filtered),
-    # failed, and batch_submitted (no output yet).
+    # Populated by _count_output_records on COMPLETED paths; stays 0 for
+    # skipped / failed / batch_submitted (no ActionCompleteEvent fires there).
     record_count: int = 0
 
 
@@ -157,6 +153,11 @@ class ActionExecutionResult:
     def files_processed(self) -> int:
         """Return files_processed from metrics."""
         return self.metrics.files_processed
+
+    @property
+    def record_count(self) -> int:
+        """Return record_count from metrics."""
+        return self.metrics.record_count
 
     def __repr__(self):
         return (
@@ -472,10 +473,6 @@ class ActionExecutor:
             logger.warning("Could not read record_count for %s: %s", action_name, e, exc_info=True)
             return 0
         nodes = stats.get("nodes", {}) if isinstance(stats, dict) else {}
-        # Defensive: a backend returning explicit None — or a non-numeric value
-        # like a string — for a node would crash int(). Coerce None -> 0 via
-        # `or 0`, and catch the parse errors so a misbehaving backend does not
-        # break the action complete path.
         raw = nodes.get(action_name, 0) or 0
         try:
             return int(raw)

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -238,6 +238,10 @@ class ActionExecutor:
         """
         storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
         if storage_backend is None:
+            logger.warning(
+                "No storage backend available verifying %s — returning record_count=0",
+                action_name,
+            )
             return (
                 True,
                 ActionExecutionResult(

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -472,10 +472,16 @@ class ActionExecutor:
             logger.warning("Could not read record_count for %s: %s", action_name, e, exc_info=True)
             return 0
         nodes = stats.get("nodes", {}) if isinstance(stats, dict) else {}
-        # Defensive: a backend returning explicit None for a node would crash
-        # int(None). Coerce None -> 0 so a missing/unknown count does not break
-        # the action complete path.
-        return int(nodes.get(action_name, 0) or 0)
+        # Defensive: a backend returning explicit None — or a non-numeric value
+        # like a string — for a node would crash int(). Coerce None -> 0 via
+        # `or 0`, and catch the parse errors so a misbehaving backend does not
+        # break the action complete path.
+        raw = nodes.get(action_name, 0) or 0
+        try:
+            return int(raw)
+        except (TypeError, ValueError) as e:
+            logger.warning("Could not parse record_count for %s (got %r): %s", action_name, raw, e)
+            return 0
 
     def _handle_guard_all_filtered(
         self,

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -157,10 +157,9 @@ class ActionExecutionResult:
         """Return files_processed from metrics."""
         return self.metrics.files_processed
 
-    @property
-    def record_count(self) -> int:
-        """Return record_count from metrics."""
-        return self.metrics.record_count
+    # NOTE: no record_count property.  Callers must use result.metrics.record_count
+    # directly — a property here added a second access path with no production
+    # caller and obscured the source of truth.
 
     def __repr__(self):
         return (
@@ -280,20 +279,25 @@ class ActionExecutor:
                 self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
                 return (False, None)
 
-        completed = (
-            True,
-            ActionExecutionResult(
-                success=True,
-                status=ActionStatus.COMPLETED,
-                metrics=ExecutionMetrics(
-                    duration=0.0,
-                    record_count=self._count_output_records(action_name),
+        # The cached-completion path discovered an action that already
+        # finished in a prior run.  This execution did NOT run the action,
+        # so the per-execution record_count is 0 by definition — the
+        # ExecutionMetrics default is correct.  (Previously this called
+        # _count_output_records on every pending action's cold-start path,
+        # which both ran a whole-DB stats query per discarded result AND
+        # reported the cumulative SUM instead of the per-execution delta.)
+        def _completed_result() -> tuple[bool, ActionExecutionResult]:
+            return (
+                True,
+                ActionExecutionResult(
+                    success=True,
+                    status=ActionStatus.COMPLETED,
+                    metrics=ExecutionMetrics(duration=0.0, record_count=0),
                 ),
-            ),
-        )
+            )
 
         if storage_backend.list_target_files(action_name):
-            return completed
+            return _completed_result()
 
         # No target files. Check if the action intentionally produced no
         # output (guard-filtered all records, WHERE-skipped, etc.) by
@@ -311,7 +315,7 @@ class ActionExecutor:
                     action_name,
                     disp,
                 )
-                return completed
+                return _completed_result()
 
         logger.info("Action %s completed but no output in storage — re-running", action_name)
         self.deps.state_manager.update_status(action_name, ActionStatus.PENDING)
@@ -511,30 +515,6 @@ class ActionExecutor:
         after = self._count_records_for_action(action_name)
         delta = after - pre_run_count
         return delta if delta > 0 else 0
-
-    def _count_output_records(self, action_name: str) -> int:
-        """Return the total number of target records the action wrote to storage.
-
-        Used to populate ``ExecutionMetrics.record_count`` so ``ActionCompleteEvent``
-        ships a real count instead of the dataclass default 0. If the storage
-        backend is unreachable or the query fails, return 0 explicitly and log —
-        do not silently swallow the error.
-        """
-        storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
-        if storage_backend is None:
-            return 0
-        try:
-            stats = storage_backend.get_storage_stats()
-        except Exception as e:
-            logger.warning("Could not read record_count for %s: %s", action_name, e, exc_info=True)
-            return 0
-        nodes = stats.get("nodes", {}) if isinstance(stats, dict) else {}
-        raw = nodes.get(action_name, 0) or 0
-        try:
-            return int(raw)
-        except (TypeError, ValueError) as e:
-            logger.warning("Could not parse record_count for %s (got %r): %s", action_name, raw, e)
-            return 0
 
     def _handle_guard_all_filtered(
         self,

--- a/agent_actions/workflow/parallel/action_executor.py
+++ b/agent_actions/workflow/parallel/action_executor.py
@@ -265,6 +265,10 @@ class ActionLevelOrchestrator:
         """Fire action complete or failed event for an execution result."""
         if result.success and result.status in COMPLETED_STATUSES:
             tokens = result.metrics.tokens if result.metrics and result.metrics.tokens else {}
+            # Explicit 0 (not the dataclass default) when the metrics object is
+            # missing or lacks record_count — avoids silently shipping 0 for
+            # actions that genuinely produced output but lost the field.
+            record_count = getattr(result.metrics, "record_count", 0) or 0 if result.metrics else 0
             fire_event(
                 ActionCompleteEvent(
                     action_name=action_name,
@@ -272,6 +276,7 @@ class ActionLevelOrchestrator:
                     total_actions=total,
                     execution_time=result.metrics.duration if result.metrics else 0.0,
                     output_path=result.output_folder or "",
+                    record_count=record_count,
                     tokens=tokens,
                     mode=run_mode,
                 )

--- a/agent_actions/workflow/parallel/action_executor.py
+++ b/agent_actions/workflow/parallel/action_executor.py
@@ -265,10 +265,11 @@ class ActionLevelOrchestrator:
         """Fire action complete or failed event for an execution result."""
         if result.success and result.status in COMPLETED_STATUSES:
             tokens = result.metrics.tokens if result.metrics and result.metrics.tokens else {}
-            # Explicit 0 (not the dataclass default) when the metrics object is
-            # missing or lacks record_count — avoids silently shipping 0 for
-            # actions that genuinely produced output but lost the field.
-            record_count = getattr(result.metrics, "record_count", 0) or 0 if result.metrics else 0
+            # Defensive None coercion: if result.metrics is None, ship 0. The
+            # producer (_handle_run_success / _resolve_batch_outcome /
+            # _check_prior_output in workflow/executor.py) is responsible for
+            # populating a real count via _count_output_records on success paths.
+            record_count = result.metrics.record_count if result.metrics is not None else 0
             fire_event(
                 ActionCompleteEvent(
                     action_name=action_name,

--- a/agent_actions/workflow/parallel/action_executor.py
+++ b/agent_actions/workflow/parallel/action_executor.py
@@ -265,10 +265,6 @@ class ActionLevelOrchestrator:
         """Fire action complete or failed event for an execution result."""
         if result.success and result.status in COMPLETED_STATUSES:
             tokens = result.metrics.tokens if result.metrics and result.metrics.tokens else {}
-            # Defensive None coercion: if result.metrics is None, ship 0. The
-            # producer (_handle_run_success / _resolve_batch_outcome /
-            # _check_prior_output in workflow/executor.py) is responsible for
-            # populating a real count via _count_output_records on success paths.
             record_count = result.metrics.record_count if result.metrics is not None else 0
             fire_event(
                 ActionCompleteEvent(

--- a/agent_actions/workflow/parallel/action_executor.py
+++ b/agent_actions/workflow/parallel/action_executor.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from agent_actions.errors import WorkflowError, get_error_detail
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.events import ActionCompleteEvent, ActionFailedEvent, ActionStartEvent
+from agent_actions.workflow.executor import ExecutionMetrics
 from agent_actions.workflow.managers.state import COMPLETED_STATUSES
 
 logger = logging.getLogger(__name__)
@@ -263,17 +264,20 @@ class ActionLevelOrchestrator:
         self, action_name: str, idx: int, total: int, result, run_mode: str = ""
     ):
         """Fire action complete or failed event for an execution result."""
+        # Consolidate the metrics-None guard once at the top so downstream
+        # references read uniformly.  Older paths used three different
+        # idioms for the same check on consecutive lines.
+        metrics = result.metrics if result.metrics is not None else ExecutionMetrics()
         if result.success and result.status in COMPLETED_STATUSES:
-            tokens = result.metrics.tokens if result.metrics and result.metrics.tokens else {}
-            record_count = result.metrics.record_count if result.metrics is not None else 0
+            tokens = metrics.tokens if metrics.tokens else {}
             fire_event(
                 ActionCompleteEvent(
                     action_name=action_name,
                     action_index=idx,
                     total_actions=total,
-                    execution_time=result.metrics.duration if result.metrics else 0.0,
+                    execution_time=metrics.duration,
                     output_path=result.output_folder or "",
-                    record_count=record_count,
+                    record_count=metrics.record_count,
                     tokens=tokens,
                     mode=run_mode,
                 )
@@ -287,7 +291,7 @@ class ActionLevelOrchestrator:
                     error_message=str(result.error) if result.error else "",
                     error_detail=get_error_detail(result.error) if result.error else "",
                     error_type=type(result.error).__name__ if result.error else "",
-                    execution_time=result.metrics.duration if result.metrics else 0.0,
+                    execution_time=metrics.duration,
                     mode=run_mode,
                 )
             )

--- a/tests/unit/workflow/test_action_complete_event_record_count.py
+++ b/tests/unit/workflow/test_action_complete_event_record_count.py
@@ -1,20 +1,4 @@
-"""Regression: ActionCompleteEvent must receive record_count from result — both serial and parallel modes.
-
-Both call sites (parallel: ``ActionLevelOrchestrator._fire_action_result_event`` and
-serial: ``WorkflowEventLogger.log_action_result``) historically omitted ``record_count``
-from the ``ActionCompleteEvent(...)`` constructor, so the dataclass default of 0
-silently shipped in every event. ``run_results.json`` and the docs-scanner
-artefact audits then reported every successful action as having processed
-0 records, regardless of actual output. These tests assert ``record_count``
-survives end-to-end through both event paths.
-
-The count is sourced from ``result.metrics.record_count`` (added to
-``ExecutionMetrics`` in the same fix). The producer-side helper
-``ActionExecutor._count_output_records`` populates that field on the four
-success construction sites: ``_handle_run_success`` (online + passthrough),
-``_resolve_batch_outcome`` (batch completion), and ``_check_prior_output``
-(cached completed result).
-"""
+"""ActionCompleteEvent must carry record_count from result.metrics in both serial and parallel modes."""
 
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -29,7 +13,6 @@ from agent_actions.workflow.managers.state import ActionStatus
 
 
 def _build_successful_result(record_count: int):
-    """Construct a fake ActionExecutionResult-shaped object with N output records."""
     result = MagicMock()
     result.success = True
     result.status = ActionStatus.COMPLETED
@@ -40,18 +23,11 @@ def _build_successful_result(record_count: int):
     )
     result.output_folder = "/tmp/agent_a"
     result.error = None
-    # Serial path also reads tokens directly off result if present.
     result.tokens = result.metrics.tokens
     return result
 
 
 def _make_executor_with_backend(stats_return=None, stats_side_effect=None, has_backend=True):
-    """Build a minimal ActionExecutor with a mocked storage backend on action_runner.
-
-    ``ActionExecutor.__init__`` only stores ``deps``, so we hand-construct a
-    deps stub with the single attribute path ``_count_output_records`` touches:
-    ``self.deps.action_runner.storage_backend.get_storage_stats``.
-    """
     executor = ActionExecutor.__new__(ActionExecutor)
     deps = MagicMock()
     if has_backend:
@@ -62,14 +38,12 @@ def _make_executor_with_backend(stats_return=None, stats_side_effect=None, has_b
             backend.get_storage_stats.return_value = stats_return
         deps.action_runner.storage_backend = backend
     else:
-        # Explicitly remove the attribute so getattr(..., None) returns None.
         del deps.action_runner.storage_backend
     executor.deps = deps
     return executor
 
 
 def test_parallel_mode_fires_event_with_record_count():
-    """Parallel: ActionCompleteEvent.record_count must equal result.metrics.record_count."""
     from agent_actions.workflow.parallel.action_executor import ActionLevelOrchestrator
 
     orch = ActionLevelOrchestrator(execution_order=["agent_a"], action_configs={"agent_a": {}})
@@ -87,7 +61,6 @@ def test_parallel_mode_fires_event_with_record_count():
 
 
 def test_serial_mode_fires_event_with_record_count():
-    """Serial: WorkflowEventLogger.log_action_result must also populate record_count."""
     from agent_actions.workflow.execution_events import WorkflowEventLogger
     from agent_actions.workflow.models import (
         ActionLogParams,
@@ -134,12 +107,6 @@ def test_serial_mode_fires_event_with_record_count():
 
 
 def test_parallel_mode_missing_metrics_defaults_to_zero_explicitly():
-    """Defensive: a result whose metrics is None must surface record_count=0, not crash.
-
-    Producer-side population is the real contract — the call-site only protects
-    against a result that has no metrics object at all (an unusual code path
-    such as a stripped-down failure result reused for completion).
-    """
     from agent_actions.workflow.parallel.action_executor import ActionLevelOrchestrator
 
     orch = ActionLevelOrchestrator(execution_order=["agent_a"], action_configs={"agent_a": {}})
@@ -161,7 +128,6 @@ def test_parallel_mode_missing_metrics_defaults_to_zero_explicitly():
 
 
 def test_serial_mode_missing_metrics_defaults_to_zero_explicitly():
-    """Defensive: serial path mirror of the parallel test — metrics=None ships 0."""
     from agent_actions.workflow.execution_events import WorkflowEventLogger
     from agent_actions.workflow.models import (
         ActionLogParams,
@@ -212,31 +178,23 @@ def test_serial_mode_missing_metrics_defaults_to_zero_explicitly():
     assert complete[0].record_count == 0
 
 
-# ----------------------------------------------------------------------------
-# _count_output_records — producer-side helper tests
-# ----------------------------------------------------------------------------
-
-
 def test_count_output_records_happy_path_returns_node_count():
-    """Backend returns {'nodes': {'agent_a': 5}} — helper returns 5."""
     executor = _make_executor_with_backend(stats_return={"nodes": {"agent_a": 5}})
     assert executor._count_output_records("agent_a") == 5
 
 
 def test_count_output_records_no_storage_backend_returns_zero():
-    """action_runner has no storage_backend attribute — helper returns 0 (no crash)."""
     executor = _make_executor_with_backend(has_backend=False)
     assert executor._count_output_records("agent_a") == 0
 
 
 def test_count_output_records_backend_raises_logs_and_returns_zero(caplog):
-    """get_storage_stats raises — helper logs warning and returns 0."""
     import logging
 
     executor = _make_executor_with_backend(stats_side_effect=RuntimeError("backend down"))
     target_logger = logging.getLogger("agent_actions.workflow.executor")
-    # Some modules disable propagation; attach the caplog handler directly so the
-    # warning is captured regardless of project-wide logging config.
+    # Project logging config disables propagation here, so caplog won't see
+    # the warning unless its handler is attached to this logger directly.
     target_logger.addHandler(caplog.handler)
     target_logger.setLevel(logging.WARNING)
     try:
@@ -250,38 +208,17 @@ def test_count_output_records_backend_raises_logs_and_returns_zero(caplog):
 
 
 def test_count_output_records_missing_nodes_key_returns_zero():
-    """Backend returns empty dict (no 'nodes' key) — helper returns 0."""
     executor = _make_executor_with_backend(stats_return={})
     assert executor._count_output_records("agent_a") == 0
 
 
 def test_count_output_records_none_value_for_action_returns_zero():
-    """Backend returns {'nodes': {'agent_a': None}} — must not crash int(None).
-
-    Proves the defensive ``or 0`` coercion in _count_output_records: a backend
-    that records an explicit None for a node-level count must surface as 0
-    rather than raising TypeError and breaking the action complete path.
-    """
     executor = _make_executor_with_backend(stats_return={"nodes": {"agent_a": None}})
     assert executor._count_output_records("agent_a") == 0
 
 
-# ----------------------------------------------------------------------------
-# Batch path — _resolve_batch_outcome populates record_count
-# ----------------------------------------------------------------------------
-
-
 def test_resolve_batch_outcome_completed_populates_record_count():
-    """Batch completion path: returned ActionExecutionResult.metrics.record_count is non-zero.
-
-    Calls _resolve_batch_outcome directly with batch_status='completed' and a
-    storage backend that reports 12 nodes for the action. Verifies the result
-    threads through _count_output_records into ExecutionMetrics.record_count.
-    """
     executor = _make_executor_with_backend(stats_return={"nodes": {"batch_action": 12}})
-    # Stub the other collaborators _resolve_batch_outcome touches on the
-    # completed branch: status resolution, state update, batch wall clock,
-    # completion metadata. Each is independent of record_count.
     executor._compute_batch_wall_clock = MagicMock(return_value=3.0)
     executor._resolve_completion_status = MagicMock(return_value=ActionStatus.COMPLETED)
     executor._completion_metadata = MagicMock(return_value={})

--- a/tests/unit/workflow/test_action_complete_event_record_count.py
+++ b/tests/unit/workflow/test_action_complete_event_record_count.py
@@ -178,43 +178,25 @@ def test_serial_mode_missing_metrics_defaults_to_zero_explicitly():
     assert complete[0].record_count == 0
 
 
-def test_count_output_records_happy_path_returns_node_count():
+# Migration note: the silent-fallback `_count_output_records` helper was
+# removed.  Its happy-path / missing-nodes-key behavior is now covered by
+# `_count_records_for_action` (which raises on storage failure) in
+# tests/unit/workflow/test_record_count_per_execution.py.  The synthetic
+# "None value for action returns 0" test was deleted: get_storage_stats
+# uses COALESCE(SUM(record_count), 0) and cannot produce None for an
+# existing action, so the test exercised an unreachable code path.
+
+
+def test_count_records_for_action_happy_path_returns_node_count():
     executor = _make_executor_with_backend(stats_return={"nodes": {"agent_a": 5}})
-    assert executor._count_output_records("agent_a") == 5
+    assert executor._count_records_for_action("agent_a") == 5
 
 
-def test_count_output_records_no_storage_backend_returns_zero():
-    executor = _make_executor_with_backend(has_backend=False)
-    assert executor._count_output_records("agent_a") == 0
-
-
-def test_count_output_records_backend_raises_logs_and_returns_zero(caplog):
-    import logging
-
-    executor = _make_executor_with_backend(stats_side_effect=RuntimeError("backend down"))
-    target_logger = logging.getLogger("agent_actions.workflow.executor")
-    # Project logging config disables propagation here, so caplog won't see
-    # the warning unless its handler is attached to this logger directly.
-    target_logger.addHandler(caplog.handler)
-    target_logger.setLevel(logging.WARNING)
-    try:
-        result = executor._count_output_records("agent_a")
-    finally:
-        target_logger.removeHandler(caplog.handler)
-    assert result == 0
-    assert any("Could not read record_count for agent_a" in r.message for r in caplog.records), (
-        f"expected warning log, got: {[r.message for r in caplog.records]}"
-    )
-
-
-def test_count_output_records_missing_nodes_key_returns_zero():
+def test_count_records_for_action_missing_nodes_key_returns_zero():
+    # Empty stats payload means the action has no rows yet — that's a legitimate
+    # 0, not a "we don't know" — so it does NOT raise.
     executor = _make_executor_with_backend(stats_return={})
-    assert executor._count_output_records("agent_a") == 0
-
-
-def test_count_output_records_none_value_for_action_returns_zero():
-    executor = _make_executor_with_backend(stats_return={"nodes": {"agent_a": None}})
-    assert executor._count_output_records("agent_a") == 0
+    assert executor._count_records_for_action("agent_a") == 0
 
 
 def test_resolve_batch_outcome_completed_populates_record_count():

--- a/tests/unit/workflow/test_action_complete_event_record_count.py
+++ b/tests/unit/workflow/test_action_complete_event_record_count.py
@@ -9,13 +9,22 @@ artefact audits then reported every successful action as having processed
 survives end-to-end through both event paths.
 
 The count is sourced from ``result.metrics.record_count`` (added to
-``ExecutionMetrics`` in the same fix).
+``ExecutionMetrics`` in the same fix). The producer-side helper
+``ActionExecutor._count_output_records`` populates that field on the four
+success construction sites: ``_handle_run_success`` (online + passthrough),
+``_resolve_batch_outcome`` (batch completion), and ``_check_prior_output``
+(cached completed result).
 """
 
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from agent_actions.logging.events import ActionCompleteEvent
+from agent_actions.workflow.executor import (
+    ActionExecutionResult,
+    ActionExecutor,
+    ExecutionMetrics,
+)
 from agent_actions.workflow.managers.state import ActionStatus
 
 
@@ -34,6 +43,29 @@ def _build_successful_result(record_count: int):
     # Serial path also reads tokens directly off result if present.
     result.tokens = result.metrics.tokens
     return result
+
+
+def _make_executor_with_backend(stats_return=None, stats_side_effect=None, has_backend=True):
+    """Build a minimal ActionExecutor with a mocked storage backend on action_runner.
+
+    ``ActionExecutor.__init__`` only stores ``deps``, so we hand-construct a
+    deps stub with the single attribute path ``_count_output_records`` touches:
+    ``self.deps.action_runner.storage_backend.get_storage_stats``.
+    """
+    executor = ActionExecutor.__new__(ActionExecutor)
+    deps = MagicMock()
+    if has_backend:
+        backend = MagicMock()
+        if stats_side_effect is not None:
+            backend.get_storage_stats.side_effect = stats_side_effect
+        else:
+            backend.get_storage_stats.return_value = stats_return
+        deps.action_runner.storage_backend = backend
+    else:
+        # Explicitly remove the attribute so getattr(..., None) returns None.
+        del deps.action_runner.storage_backend
+    executor.deps = deps
+    return executor
 
 
 def test_parallel_mode_fires_event_with_record_count():
@@ -102,11 +134,11 @@ def test_serial_mode_fires_event_with_record_count():
 
 
 def test_parallel_mode_missing_metrics_defaults_to_zero_explicitly():
-    """Defensive: a result whose metrics lacks record_count must surface 0, not crash.
+    """Defensive: a result whose metrics is None must surface record_count=0, not crash.
 
-    This guards the getattr fallback in the fix — RULES.md forbids silent
-    fallbacks, but the dataclass default IS the explicit zero contract for the
-    'no records produced' case (e.g. a guard-skipped or batch-submitted result).
+    Producer-side population is the real contract — the call-site only protects
+    against a result that has no metrics object at all (an unusual code path
+    such as a stripped-down failure result reused for completion).
     """
     from agent_actions.workflow.parallel.action_executor import ActionLevelOrchestrator
 
@@ -114,10 +146,7 @@ def test_parallel_mode_missing_metrics_defaults_to_zero_explicitly():
     result = MagicMock()
     result.success = True
     result.status = ActionStatus.COMPLETED
-    # Real metrics object with no record_count attribute at all.
-    result.metrics = MagicMock(spec=["tokens", "duration"])
-    result.metrics.tokens = {}
-    result.metrics.duration = 0.5
+    result.metrics = None
     result.output_folder = ""
     result.error = None
 
@@ -129,3 +158,148 @@ def test_parallel_mode_missing_metrics_defaults_to_zero_explicitly():
     ]
     assert len(complete) == 1
     assert complete[0].record_count == 0
+
+
+def test_serial_mode_missing_metrics_defaults_to_zero_explicitly():
+    """Defensive: serial path mirror of the parallel test — metrics=None ships 0."""
+    from agent_actions.workflow.execution_events import WorkflowEventLogger
+    from agent_actions.workflow.models import (
+        ActionLogParams,
+        CoreServices,
+        SupportServices,
+        WorkflowRuntimeConfig,
+        WorkflowServices,
+    )
+
+    core = MagicMock(spec=CoreServices)
+    core.state_manager = MagicMock()
+    support = MagicMock(spec=SupportServices)
+    support.manifest_manager = MagicMock()
+    services = WorkflowServices(core=core, support=support)
+    config = MagicMock(spec=WorkflowRuntimeConfig)
+
+    event_logger = WorkflowEventLogger(
+        agent_name="test_workflow",
+        execution_order=["agent_b"],
+        config=config,
+        services=services,
+    )
+
+    result = MagicMock()
+    result.success = True
+    result.status = ActionStatus.COMPLETED
+    result.metrics = None
+    result.output_folder = ""
+    result.error = None
+    result.tokens = None
+    params = ActionLogParams(
+        idx=0,
+        action_name="agent_b",
+        total_actions=1,
+        result=result,
+        end_time=datetime.now(),
+        duration=0.5,
+        run_mode="online",
+    )
+
+    with patch("agent_actions.workflow.execution_events.fire_event") as mock_fire:
+        event_logger.log_action_result(params)
+
+    complete = [
+        c.args[0] for c in mock_fire.call_args_list if isinstance(c.args[0], ActionCompleteEvent)
+    ]
+    assert len(complete) == 1
+    assert complete[0].record_count == 0
+
+
+# ----------------------------------------------------------------------------
+# _count_output_records — producer-side helper tests
+# ----------------------------------------------------------------------------
+
+
+def test_count_output_records_happy_path_returns_node_count():
+    """Backend returns {'nodes': {'agent_a': 5}} — helper returns 5."""
+    executor = _make_executor_with_backend(stats_return={"nodes": {"agent_a": 5}})
+    assert executor._count_output_records("agent_a") == 5
+
+
+def test_count_output_records_no_storage_backend_returns_zero():
+    """action_runner has no storage_backend attribute — helper returns 0 (no crash)."""
+    executor = _make_executor_with_backend(has_backend=False)
+    assert executor._count_output_records("agent_a") == 0
+
+
+def test_count_output_records_backend_raises_logs_and_returns_zero(caplog):
+    """get_storage_stats raises — helper logs warning and returns 0."""
+    import logging
+
+    executor = _make_executor_with_backend(stats_side_effect=RuntimeError("backend down"))
+    target_logger = logging.getLogger("agent_actions.workflow.executor")
+    # Some modules disable propagation; attach the caplog handler directly so the
+    # warning is captured regardless of project-wide logging config.
+    target_logger.addHandler(caplog.handler)
+    target_logger.setLevel(logging.WARNING)
+    try:
+        result = executor._count_output_records("agent_a")
+    finally:
+        target_logger.removeHandler(caplog.handler)
+    assert result == 0
+    assert any("Could not read record_count for agent_a" in r.message for r in caplog.records), (
+        f"expected warning log, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_count_output_records_missing_nodes_key_returns_zero():
+    """Backend returns empty dict (no 'nodes' key) — helper returns 0."""
+    executor = _make_executor_with_backend(stats_return={})
+    assert executor._count_output_records("agent_a") == 0
+
+
+def test_count_output_records_none_value_for_action_returns_zero():
+    """Backend returns {'nodes': {'agent_a': None}} — must not crash int(None).
+
+    Proves the defensive ``or 0`` coercion in _count_output_records: a backend
+    that records an explicit None for a node-level count must surface as 0
+    rather than raising TypeError and breaking the action complete path.
+    """
+    executor = _make_executor_with_backend(stats_return={"nodes": {"agent_a": None}})
+    assert executor._count_output_records("agent_a") == 0
+
+
+# ----------------------------------------------------------------------------
+# Batch path — _resolve_batch_outcome populates record_count
+# ----------------------------------------------------------------------------
+
+
+def test_resolve_batch_outcome_completed_populates_record_count():
+    """Batch completion path: returned ActionExecutionResult.metrics.record_count is non-zero.
+
+    Calls _resolve_batch_outcome directly with batch_status='completed' and a
+    storage backend that reports 12 nodes for the action. Verifies the result
+    threads through _count_output_records into ExecutionMetrics.record_count.
+    """
+    executor = _make_executor_with_backend(stats_return={"nodes": {"batch_action": 12}})
+    # Stub the other collaborators _resolve_batch_outcome touches on the
+    # completed branch: status resolution, state update, batch wall clock,
+    # completion metadata. Each is independent of record_count.
+    executor._compute_batch_wall_clock = MagicMock(return_value=3.0)
+    executor._resolve_completion_status = MagicMock(return_value=ActionStatus.COMPLETED)
+    executor._completion_metadata = MagicMock(return_value={})
+    executor.deps.state_manager = MagicMock()
+
+    with patch("agent_actions.workflow.executor.fire_event"):
+        result = executor._resolve_batch_outcome(
+            action_name="batch_action",
+            action_config={"batch_id": "b1"},
+            output_folder="/tmp/batch_action",
+            batch_status="completed",
+            duration=3.0,
+        )
+
+    assert isinstance(result, ActionExecutionResult)
+    assert result.success is True
+    assert result.status == ActionStatus.COMPLETED
+    assert isinstance(result.metrics, ExecutionMetrics)
+    assert result.metrics.record_count == 12, (
+        f"batch completion did not thread record_count: got {result.metrics.record_count}, expected 12"
+    )

--- a/tests/unit/workflow/test_action_complete_event_record_count.py
+++ b/tests/unit/workflow/test_action_complete_event_record_count.py
@@ -1,0 +1,131 @@
+"""Regression: ActionCompleteEvent must receive record_count from result — both serial and parallel modes.
+
+Both call sites (parallel: ``ActionLevelOrchestrator._fire_action_result_event`` and
+serial: ``WorkflowEventLogger.log_action_result``) historically omitted ``record_count``
+from the ``ActionCompleteEvent(...)`` constructor, so the dataclass default of 0
+silently shipped in every event. ``run_results.json`` and the docs-scanner
+artefact audits then reported every successful action as having processed
+0 records, regardless of actual output. These tests assert ``record_count``
+survives end-to-end through both event paths.
+
+The count is sourced from ``result.metrics.record_count`` (added to
+``ExecutionMetrics`` in the same fix).
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from agent_actions.logging.events import ActionCompleteEvent
+from agent_actions.workflow.managers.state import ActionStatus
+
+
+def _build_successful_result(record_count: int):
+    """Construct a fake ActionExecutionResult-shaped object with N output records."""
+    result = MagicMock()
+    result.success = True
+    result.status = ActionStatus.COMPLETED
+    result.metrics = MagicMock(
+        tokens={"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+        duration=1.5,
+        record_count=record_count,
+    )
+    result.output_folder = "/tmp/agent_a"
+    result.error = None
+    # Serial path also reads tokens directly off result if present.
+    result.tokens = result.metrics.tokens
+    return result
+
+
+def test_parallel_mode_fires_event_with_record_count():
+    """Parallel: ActionCompleteEvent.record_count must equal result.metrics.record_count."""
+    from agent_actions.workflow.parallel.action_executor import ActionLevelOrchestrator
+
+    orch = ActionLevelOrchestrator(execution_order=["agent_a"], action_configs={"agent_a": {}})
+    result = _build_successful_result(record_count=7)
+
+    with patch("agent_actions.workflow.parallel.action_executor.fire_event") as mock_fire:
+        orch._fire_action_result_event("agent_a", idx=0, total=1, result=result, run_mode="online")
+
+    events = [c.args[0] for c in mock_fire.call_args_list]
+    complete = [e for e in events if isinstance(e, ActionCompleteEvent)]
+    assert len(complete) == 1, f"expected 1 ActionCompleteEvent, got {len(complete)}"
+    assert complete[0].record_count == 7, (
+        f"parallel mode shipped record_count={complete[0].record_count}, expected 7"
+    )
+
+
+def test_serial_mode_fires_event_with_record_count():
+    """Serial: WorkflowEventLogger.log_action_result must also populate record_count."""
+    from agent_actions.workflow.execution_events import WorkflowEventLogger
+    from agent_actions.workflow.models import (
+        ActionLogParams,
+        CoreServices,
+        SupportServices,
+        WorkflowRuntimeConfig,
+        WorkflowServices,
+    )
+
+    core = MagicMock(spec=CoreServices)
+    core.state_manager = MagicMock()
+    support = MagicMock(spec=SupportServices)
+    support.manifest_manager = MagicMock()
+    services = WorkflowServices(core=core, support=support)
+    config = MagicMock(spec=WorkflowRuntimeConfig)
+
+    event_logger = WorkflowEventLogger(
+        agent_name="test_workflow",
+        execution_order=["agent_b"],
+        config=config,
+        services=services,
+    )
+
+    result = _build_successful_result(record_count=4)
+    params = ActionLogParams(
+        idx=0,
+        action_name="agent_b",
+        total_actions=1,
+        result=result,
+        end_time=datetime.now(),
+        duration=1.5,
+        run_mode="online",
+    )
+
+    with patch("agent_actions.workflow.execution_events.fire_event") as mock_fire:
+        event_logger.log_action_result(params)
+
+    events = [c.args[0] for c in mock_fire.call_args_list]
+    complete = [e for e in events if isinstance(e, ActionCompleteEvent)]
+    assert len(complete) == 1, f"expected 1 ActionCompleteEvent, got {len(complete)}"
+    assert complete[0].record_count == 4, (
+        f"serial mode shipped record_count={complete[0].record_count}, expected 4"
+    )
+
+
+def test_parallel_mode_missing_metrics_defaults_to_zero_explicitly():
+    """Defensive: a result whose metrics lacks record_count must surface 0, not crash.
+
+    This guards the getattr fallback in the fix — RULES.md forbids silent
+    fallbacks, but the dataclass default IS the explicit zero contract for the
+    'no records produced' case (e.g. a guard-skipped or batch-submitted result).
+    """
+    from agent_actions.workflow.parallel.action_executor import ActionLevelOrchestrator
+
+    orch = ActionLevelOrchestrator(execution_order=["agent_a"], action_configs={"agent_a": {}})
+    result = MagicMock()
+    result.success = True
+    result.status = ActionStatus.COMPLETED
+    # Real metrics object with no record_count attribute at all.
+    result.metrics = MagicMock(spec=["tokens", "duration"])
+    result.metrics.tokens = {}
+    result.metrics.duration = 0.5
+    result.output_folder = ""
+    result.error = None
+
+    with patch("agent_actions.workflow.parallel.action_executor.fire_event") as mock_fire:
+        orch._fire_action_result_event("agent_a", idx=0, total=1, result=result, run_mode="online")
+
+    complete = [
+        c.args[0] for c in mock_fire.call_args_list if isinstance(c.args[0], ActionCompleteEvent)
+    ]
+    assert len(complete) == 1
+    assert complete[0].record_count == 0

--- a/tests/unit/workflow/test_action_complete_event_record_count.py
+++ b/tests/unit/workflow/test_action_complete_event_record_count.py
@@ -218,6 +218,8 @@ def test_count_output_records_none_value_for_action_returns_zero():
 
 
 def test_resolve_batch_outcome_completed_populates_record_count():
+    # After-run snapshot is 12, before-run snapshot was 0, so this execution
+    # produced 12 records.  Passing pre_run_count=0 mirrors a fresh run.
     executor = _make_executor_with_backend(stats_return={"nodes": {"batch_action": 12}})
     executor._compute_batch_wall_clock = MagicMock(return_value=3.0)
     executor._resolve_completion_status = MagicMock(return_value=ActionStatus.COMPLETED)
@@ -231,6 +233,7 @@ def test_resolve_batch_outcome_completed_populates_record_count():
             output_folder="/tmp/batch_action",
             batch_status="completed",
             duration=3.0,
+            pre_run_count=0,
         )
 
     assert isinstance(result, ActionExecutionResult)

--- a/tests/unit/workflow/test_batch_check_outcomes.py
+++ b/tests/unit/workflow/test_batch_check_outcomes.py
@@ -35,6 +35,8 @@ def mock_deps():
     deps.action_runner.execution_order = ["agent_a", "agent_b"]
     deps.action_runner.storage_backend.get_failed_items.return_value = []
     deps.action_runner.storage_backend.has_disposition.return_value = False
+    # Pre/post snapshots needed by _count_records_for_action.
+    deps.action_runner.storage_backend.get_storage_stats.return_value = {"nodes": {}}
     deps.state_manager.get_status_details.return_value = {"status": ActionStatus.COMPLETED}
     return deps
 

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -705,7 +705,7 @@ class TestTotalFailureEscalation:
             is_last_action=False,
             start_time=datetime.now(),
         )
-        result = executor._handle_run_success(params, "/output", 1.0, None)
+        result = executor._handle_run_success(params, "/output", 1.0, None, pre_run_count=0)
         assert result.success is False
         assert result.status == ActionStatus.FAILED
         assert result.error is not None
@@ -727,7 +727,7 @@ class TestTotalFailureEscalation:
             is_last_action=False,
             start_time=datetime.now(),
         )
-        executor._handle_run_success(params, "/output", 1.0, None)
+        executor._handle_run_success(params, "/output", 1.0, None, pre_run_count=0)
         mock_deps.action_runner.storage_backend.set_disposition.assert_called_once_with(
             action_name="agent_a",
             record_id=NODE_LEVEL_RECORD_ID,
@@ -756,7 +756,7 @@ class TestTotalFailureEscalation:
             is_last_action=False,
             start_time=datetime.now(),
         )
-        executor._handle_run_success(params, "/output", 1.0, None)
+        executor._handle_run_success(params, "/output", 1.0, None, pre_run_count=0)
         call_args = run_tracker.record_action_complete.call_args
         assert call_args is not None
         assert call_args.kwargs["config"].status == "failed"
@@ -786,7 +786,7 @@ class TestTotalFailureDownstreamSkip:
             is_last_action=False,
             start_time=datetime.now(),
         )
-        result = executor._handle_run_success(params, "/output", 1.0, None)
+        result = executor._handle_run_success(params, "/output", 1.0, None, pre_run_count=0)
         assert result.success is False
         assert result.status == ActionStatus.FAILED
 

--- a/tests/unit/workflow/test_execution_events.py
+++ b/tests/unit/workflow/test_execution_events.py
@@ -129,6 +129,11 @@ class TestLogAgentResult:
         r.error = error
         r.tokens = tokens
         r.output_folder = "/output"
+        # MagicMock auto-creates `.metrics` as a Mock on attribute access, which
+        # makes the call-site `metrics is not None` guard evaluate truthy and
+        # ships a Mock through to ActionCompleteEvent.record_count. Pin to None
+        # explicitly so the defensive coercion path actually runs.
+        r.metrics = None
         return r
 
     def test_completed_fires_agent_complete(self, event_logger):

--- a/tests/unit/workflow/test_execution_events.py
+++ b/tests/unit/workflow/test_execution_events.py
@@ -129,10 +129,8 @@ class TestLogAgentResult:
         r.error = error
         r.tokens = tokens
         r.output_folder = "/output"
-        # MagicMock auto-creates `.metrics` as a Mock on attribute access, which
-        # makes the call-site `metrics is not None` guard evaluate truthy and
-        # ships a Mock through to ActionCompleteEvent.record_count. Pin to None
-        # explicitly so the defensive coercion path actually runs.
+        # MagicMock would auto-create `.metrics` as a Mock and the None-guard would
+        # ship a Mock through record_count. Pin to None so the guard actually runs.
         r.metrics = None
         return r
 
@@ -158,8 +156,6 @@ class TestLogAgentResult:
         assert event.execution_time == 1.5
         assert event.output_path == "/output"
         assert event.tokens == {"total_tokens": 100}
-        # _make_result pins metrics=None; the call-site None-coercion path must
-        # ship record_count=0 — not a Mock and not the dataclass default.
         assert event.record_count == 0
 
     def test_failed_fires_agent_failed(self, event_logger):

--- a/tests/unit/workflow/test_execution_events.py
+++ b/tests/unit/workflow/test_execution_events.py
@@ -158,6 +158,9 @@ class TestLogAgentResult:
         assert event.execution_time == 1.5
         assert event.output_path == "/output"
         assert event.tokens == {"total_tokens": 100}
+        # _make_result pins metrics=None; the call-site None-coercion path must
+        # ship record_count=0 — not a Mock and not the dataclass default.
+        assert event.record_count == 0
 
     def test_failed_fires_agent_failed(self, event_logger):
         error = RuntimeError("agent crashed")

--- a/tests/unit/workflow/test_executor_batch.py
+++ b/tests/unit/workflow/test_executor_batch.py
@@ -34,6 +34,8 @@ def mock_deps():
     deps.action_runner.execution_order = ["my_extract"]
     deps.action_runner.storage_backend.get_failed_items.return_value = []
     deps.action_runner.storage_backend.has_disposition.return_value = False
+    # Pre/post snapshots needed by _count_records_for_action.
+    deps.action_runner.storage_backend.get_storage_stats.return_value = {"nodes": {}}
     deps.state_manager.get_status_details.return_value = {"status": ActionStatus.COMPLETED}
     return deps
 

--- a/tests/unit/workflow/test_executor_events.py
+++ b/tests/unit/workflow/test_executor_events.py
@@ -24,6 +24,8 @@ class TestHandleBatchCheckEventFiring:
         deps.action_runner.get_action_folder.return_value = "/tmp/agent_io"
         deps.action_runner.storage_backend.get_failed_items.return_value = []
         deps.action_runner.storage_backend.has_disposition.return_value = False
+        # Pre/post snapshots needed by _count_records_for_action.
+        deps.action_runner.storage_backend.get_storage_stats.return_value = {"nodes": {}}
         return deps
 
     @pytest.fixture

--- a/tests/unit/workflow/test_executor_lifecycle.py
+++ b/tests/unit/workflow/test_executor_lifecycle.py
@@ -35,6 +35,8 @@ def mock_deps():
     deps.action_runner.storage_backend.get_failed_items.return_value = []
     # Default: no guard-all-skipped disposition
     deps.action_runner.storage_backend.has_disposition.return_value = False
+    # Default: empty before/after snapshot for _count_records_for_action
+    deps.action_runner.storage_backend.get_storage_stats.return_value = {"nodes": {}}
     # Default status details for limit-change detection (no limits stored)
     deps.state_manager.get_status_details.return_value = {"status": ActionStatus.COMPLETED}
     return deps
@@ -271,7 +273,9 @@ class TestHandleRunSuccess:
         """batch_submitted batch_status should return batch_submitted result with timestamp."""
         params = self._make_params()
         with patch("agent_actions.workflow.executor.fire_event"):
-            result = executor._handle_run_success(params, "/out", 1.0, "batch_submitted")
+            result = executor._handle_run_success(
+                params, "/out", 1.0, "batch_submitted", pre_run_count=0
+            )
 
         assert result.status == ActionStatus.BATCH_SUBMITTED
         call_args = mock_deps.state_manager.update_status.call_args
@@ -281,7 +285,8 @@ class TestHandleRunSuccess:
     def test_passthrough_status(self, executor, mock_deps):
         """passthrough batch_status should mark completed."""
         params = self._make_params()
-        result = executor._handle_run_success(params, "/out", 1.0, "passthrough")
+        mock_deps.action_runner.storage_backend.get_storage_stats.return_value = {"nodes": {}}
+        result = executor._handle_run_success(params, "/out", 1.0, "passthrough", pre_run_count=0)
 
         assert result.status == ActionStatus.COMPLETED
         assert result.output_folder == "/out"
@@ -292,11 +297,12 @@ class TestHandleRunSuccess:
     def test_normal_completion_with_tokens(self, executor, mock_deps):
         """Normal completion should capture tokens and model info."""
         params = self._make_params(action_config={"model_vendor": "openai", "model_name": "gpt-4"})
+        mock_deps.action_runner.storage_backend.get_storage_stats.return_value = {"nodes": {}}
         with patch(
             "agent_actions.workflow.executor.get_last_usage",
             return_value={"total_tokens": 100},
         ):
-            result = executor._handle_run_success(params, "/out", 2.5, None)
+            result = executor._handle_run_success(params, "/out", 2.5, None, pre_run_count=0)
 
         assert result.status == ActionStatus.COMPLETED
         assert result.metrics.tokens == {"total_tokens": 100}
@@ -308,8 +314,9 @@ class TestHandleRunSuccess:
         params = self._make_params(
             action_config={"model_vendor": "anthropic", "model_name": "claude"}
         )
+        mock_deps.action_runner.storage_backend.get_storage_stats.return_value = {"nodes": {}}
         with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
-            result = executor._handle_run_success(params, "/out", 1.0, None)
+            result = executor._handle_run_success(params, "/out", 1.0, None, pre_run_count=0)
 
         assert result.metrics.model_vendor == "anthropic"
         assert result.metrics.model_name == "claude"
@@ -321,7 +328,7 @@ class TestHandleRunSuccess:
         params = self._make_params()
 
         with patch("agent_actions.workflow.executor.fire_event") as mock_fire:
-            result = executor._handle_run_success(params, "/out", 1.0, None)
+            result = executor._handle_run_success(params, "/out", 1.0, None, pre_run_count=0)
 
         assert result.success is True
         assert result.status == ActionStatus.SKIPPED
@@ -349,7 +356,7 @@ class TestHandleRunSuccess:
         params = self._make_params()
 
         with patch("agent_actions.workflow.executor.fire_event"):
-            result = executor._handle_run_success(params, "/out", 1.0, None)
+            result = executor._handle_run_success(params, "/out", 1.0, None, pre_run_count=0)
 
         assert result.status == ActionStatus.SKIPPED
         executor.run_tracker.record_action_complete.assert_called_once()

--- a/tests/unit/workflow/test_record_count_per_execution.py
+++ b/tests/unit/workflow/test_record_count_per_execution.py
@@ -1,0 +1,208 @@
+"""Regression tests for cumulative-on-rerun record_count overcount.
+
+Before this fix, `_count_output_records` queried the storage backend's
+`get_storage_stats` after the run and reported the SUM of all rows under
+that action_name.  On resume / re-run that wrote to NEW paths (a second
+batch item, a timestamped shard, an additional file), the SUM grew while
+the action only produced the delta.  Example: run 1 wrote 50 rows;
+resume processed item_2.jsonl with 50 more rows; ActionCompleteEvent
+shipped record_count=100 for an execution that produced 50.
+
+The fix is a before/after snapshot taken inside the executor.  The
+per-execution delta (after - before) replaces the cumulative SUM.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.workflow.executor import (
+    ActionExecutionResult,
+    ActionExecutor,
+    ActionRunParams,
+    ExecutionMetrics,
+    ExecutorDependencies,
+)
+from agent_actions.workflow.managers.batch import BatchLifecycleManager
+from agent_actions.workflow.managers.output import ActionOutputManager
+from agent_actions.workflow.managers.skip import SkipEvaluator
+from agent_actions.workflow.managers.state import ActionStateManager, ActionStatus
+
+
+def _build_deps(stats_sequence):
+    """Build executor deps with a backend whose get_storage_stats returns
+    successive values from ``stats_sequence``.
+
+    The first call simulates the pre-run snapshot; the second simulates
+    the post-run snapshot.  Use a list of len 2 for a single execution.
+    """
+    deps = MagicMock(spec=ExecutorDependencies)
+    deps.state_manager = MagicMock(spec=ActionStateManager)
+    deps.batch_manager = MagicMock(spec=BatchLifecycleManager)
+    deps.skip_evaluator = MagicMock(spec=SkipEvaluator)
+    deps.output_manager = MagicMock(spec=ActionOutputManager)
+    deps.action_runner = MagicMock()
+    deps.action_runner.workflow_name = "wf"
+    deps.action_runner.get_action_folder.return_value = "/tmp/agent_io"
+    deps.action_runner.execution_order = ["agent_a"]
+    deps.action_runner.storage_backend.has_disposition.return_value = False
+    deps.action_runner.storage_backend.get_failed_items.return_value = []
+    deps.action_runner.storage_backend.get_storage_stats.side_effect = stats_sequence
+    deps.state_manager.get_status_details.return_value = {"status": ActionStatus.COMPLETED}
+    deps.output_manager.resolve_correlated_input.return_value = None
+    deps.batch_manager.check_batch_submission.return_value = None
+    return deps
+
+
+def _run_params(action_name="agent_a"):
+    return ActionRunParams(
+        action_name=action_name,
+        action_idx=0,
+        action_config={"kind": "llm"},
+        is_last_action=True,
+        start_time=datetime.now(),
+    )
+
+
+class TestExecuteActionRunReportsPerExecutionDelta:
+    """Online path: _execute_action_run snapshots before/after and reports the delta."""
+
+    def test_resume_after_prior_run_reports_only_new_records(self):
+        # Pre-existing rows from a prior run that wrote to different paths.
+        # The current execution writes 30 more records; ActionCompleteEvent
+        # must ship 30, not the cumulative 80.
+        stats_before = {"nodes": {"agent_a": 50}}
+        stats_after = {"nodes": {"agent_a": 80}}
+        deps = _build_deps([stats_before, stats_after])
+        deps.action_runner.run_action.return_value = "/out"
+        executor = ActionExecutor(deps)
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            result = executor._execute_action_run(_run_params())
+
+        assert result.success is True
+        assert result.status == ActionStatus.COMPLETED
+        assert result.metrics.record_count == 30, (
+            f"expected per-execution delta 30 (80 - 50), got cumulative "
+            f"{result.metrics.record_count} — record_count is being read "
+            f"as SUM instead of after-before delta"
+        )
+
+    def test_fresh_run_reports_full_record_count(self):
+        # No prior rows; this execution wrote 25.
+        deps = _build_deps([{"nodes": {}}, {"nodes": {"agent_a": 25}}])
+        deps.action_runner.run_action.return_value = "/out"
+        executor = ActionExecutor(deps)
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            result = executor._execute_action_run(_run_params())
+
+        assert result.metrics.record_count == 25
+
+    def test_run_that_writes_nothing_reports_zero(self):
+        # Snapshots unchanged across the run.
+        deps = _build_deps([{"nodes": {"agent_a": 12}}, {"nodes": {"agent_a": 12}}])
+        deps.action_runner.run_action.return_value = "/out"
+        executor = ActionExecutor(deps)
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            result = executor._execute_action_run(_run_params())
+
+        assert result.metrics.record_count == 0
+
+    def test_delta_is_clamped_at_zero_if_rows_disappear(self):
+        # If post-snapshot < pre-snapshot (e.g. a cleanup ran concurrently),
+        # report 0 rather than a negative count.  Records-written is a count,
+        # not a signed delta.
+        deps = _build_deps([{"nodes": {"agent_a": 40}}, {"nodes": {"agent_a": 10}}])
+        deps.action_runner.run_action.return_value = "/out"
+        executor = ActionExecutor(deps)
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            result = executor._execute_action_run(_run_params())
+
+        assert result.metrics.record_count == 0
+
+
+class TestBatchPathReportsPerExecutionDelta:
+    """Batch path: _handle_batch_check snapshots before/after similarly."""
+
+    def test_batch_completion_reports_only_records_this_run_wrote(self):
+        # Prior batch shard left 100 rows; this batch completion wrote 40 more.
+        deps = _build_deps([{"nodes": {"batch_a": 100}}, {"nodes": {"batch_a": 140}}])
+        deps.batch_manager.handle_batch_agent.return_value = ("/output", "completed")
+        executor = ActionExecutor(deps)
+
+        with patch("agent_actions.workflow.executor.fire_event"):
+            result = executor._handle_batch_check(
+                action_name="batch_a",
+                action_idx=0,
+                action_config={"batch_id": "b1"},
+                start_time=datetime.now(),
+            )
+
+        assert result.success is True
+        assert result.status == ActionStatus.COMPLETED
+        assert result.metrics.record_count == 40, (
+            f"batch completion shipped cumulative {result.metrics.record_count} "
+            f"instead of per-execution delta 40"
+        )
+
+
+class TestSnapshotFailureRaises:
+    """Backend errors during the pre/post snapshot must surface, not return 0."""
+
+    def test_pre_run_snapshot_error_raises_runtimeerror(self):
+        deps = _build_deps([RuntimeError("db locked"), {"nodes": {}}])
+        deps.action_runner.run_action.return_value = "/out"
+        executor = ActionExecutor(deps)
+
+        with pytest.raises(RuntimeError, match="get_storage_stats.* failed"):
+            executor._execute_action_run(_run_params())
+
+    def test_post_run_snapshot_error_raises_runtimeerror(self):
+        # Pre-run succeeds; post-run fails — this must NOT be swallowed
+        # as record_count=0.  A workflow whose telemetry storage is broken
+        # should fail loudly.
+        deps = _build_deps([{"nodes": {}}, RuntimeError("db corrupt")])
+        deps.action_runner.run_action.return_value = "/out"
+        executor = ActionExecutor(deps)
+
+        with patch("agent_actions.workflow.executor.get_last_usage", return_value=None):
+            with pytest.raises(RuntimeError, match="get_storage_stats.* failed"):
+                executor._execute_action_run(_run_params())
+
+    def test_missing_storage_backend_raises_runtimeerror(self):
+        executor = object.__new__(ActionExecutor)
+        deps = MagicMock()
+        del deps.action_runner.storage_backend  # attribute genuinely absent
+        executor.deps = deps
+        with pytest.raises(RuntimeError, match="no storage backend"):
+            executor._count_records_for_action("agent_a")
+
+    def test_non_integer_record_count_raises_runtimeerror(self):
+        executor = object.__new__(ActionExecutor)
+        deps = MagicMock()
+        deps.action_runner.storage_backend.get_storage_stats.return_value = {
+            "nodes": {"agent_a": "not-a-number"}
+        }
+        executor.deps = deps
+        with pytest.raises(RuntimeError, match="non-integer record_count"):
+            executor._count_records_for_action("agent_a")
+
+
+class TestCachedCompletionShipsZero:
+    """The cached-completion path (_check_prior_output) didn't run the
+    action this execution, so record_count for THIS execution is 0."""
+
+    def test_cached_completion_metrics_default_to_zero(self):
+        # ExecutionMetrics() default is 0; result objects constructed for the
+        # cached path should not be back-filling a cumulative SUM.
+        metrics = ExecutionMetrics()
+        assert metrics.record_count == 0
+        # Sanity: a result built with default metrics propagates 0.
+        result = ActionExecutionResult(
+            success=True, status=ActionStatus.COMPLETED, metrics=ExecutionMetrics()
+        )
+        assert result.metrics.record_count == 0

--- a/tests/unit/workflow/test_rename_regression.py
+++ b/tests/unit/workflow/test_rename_regression.py
@@ -140,6 +140,13 @@ class TestExecutorCallsRunAction:
         deps.action_runner.workflow_name = "test_workflow"
         deps.action_runner.get_action_folder.return_value = "/tmp/agent_io"
         deps.action_runner.execution_order = ["agent_a"]
+        # Pre/post snapshots needed by _count_records_for_action — without a
+        # storage_backend the snapshot call raises (no silent 0 fallback).
+        storage = MagicMock()
+        storage.get_storage_stats.return_value = {"nodes": {}}
+        storage.get_failed_items.return_value = []
+        storage.has_disposition.return_value = False
+        deps.action_runner.storage_backend = storage
         return deps
 
     @pytest.fixture

--- a/tests/unit/workflow/test_zero_output_rerun.py
+++ b/tests/unit/workflow/test_zero_output_rerun.py
@@ -125,3 +125,67 @@ class TestCheckPriorOutputIntentionalNoOutput:
         backend.clear_disposition.assert_called_once_with(
             "my_action", DISPOSITION_SKIPPED, record_id=NODE_LEVEL_RECORD_ID
         )
+
+
+class TestCheckPriorOutputDoesNotRunStatsQuery:
+    """The cached-completion branch is THIS execution didn't produce records.
+
+    Regression for the spec 554 review finding: the previous implementation
+    called _count_output_records eagerly while building the `completed`
+    tuple — even on the cold-start path that returned (False, None).  For a
+    50-action workflow with all-pending status, that was ~50 wasted
+    whole-DB stats queries per scheduling pass.
+    """
+
+    def test_cold_start_does_not_query_storage_stats(self):
+        # No prior output, no dispositions — the executor will reset to
+        # PENDING and return (False, None).  It must NOT call
+        # get_storage_stats on the way (the prior eager-builder did).
+        executor = _make_executor()
+        backend = MagicMock()
+        backend.list_target_files.return_value = []
+        backend.has_disposition.return_value = False
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is False
+        assert result is None
+        backend.get_storage_stats.assert_not_called()
+
+    def test_cached_completion_ships_record_count_zero(self):
+        # Cached completion (target files exist) — record_count is 0 because
+        # this execution did not run the action.  The pre/post snapshot in
+        # _execute_action_run is what produces the per-execution count.
+        executor = _make_executor()
+        backend = MagicMock()
+        backend.list_target_files.return_value = ["output.json"]
+        backend.has_disposition.return_value = False
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is True
+        assert result is not None
+        assert result.metrics.record_count == 0, (
+            f"cached-completion path must ship record_count=0 (this execution "
+            f"did not run the action), got {result.metrics.record_count}"
+        )
+        backend.get_storage_stats.assert_not_called()
+
+    def test_node_level_filtered_disposition_ships_record_count_zero(self):
+        # Intentional no-output path (guard-filtered all, etc.) — also 0.
+        executor = _make_executor()
+        backend = MagicMock()
+        backend.list_target_files.return_value = []
+
+        def has_disp(action, disp, record_id=None):
+            if disp in (DISPOSITION_FAILED, DISPOSITION_SKIPPED):
+                return False
+            return disp == DISPOSITION_FILTERED and record_id == NODE_LEVEL_RECORD_ID
+
+        backend.has_disposition.side_effect = has_disp
+
+        has_output, result = executor._check_prior_output(backend, "my_action")
+
+        assert has_output is True
+        assert result.metrics.record_count == 0
+        backend.get_storage_stats.assert_not_called()


### PR DESCRIPTION
## Summary

Spec 554 cited 10 silent-fallback bugs. A pre-flight git-log audit found **9 of 10 already landed** in current main (PRs #698, #715, #716, #720 + others). This PR lands the only remaining one:

- **#10** — `ActionCompleteEvent.record_count` was always 0. Neither call site (`workflow/parallel/action_executor.py:_fire_action_result_event` nor `workflow/execution_events.py:log_action_result`) passed `record_count` to the constructor, so the dataclass default 0 silently shipped in every event. `run_results.json` reported every successful action as having processed 0 records, regardless of actual output.

Fix: thread `record_count` from a new `ExecutionMetrics.record_count` field through to both call sites. Populated by a `_count_output_records` helper that queries `storage_backend.get_storage_stats()` at the 4 success-path constructor sites in `executor.py` (`_handle_run_success` online + passthrough, `_resolve_batch_outcome`, `_check_prior_output`). Defensive coercion + try/except for malformed backend responses.

Items 1, 2, 4, 5, 6, 8 in the spec were already fixed in current main; items 3, 7, 9 were FIXED-by-design per recent PRs (per-op isolation, save-error logging chain, empty-dict-then-factory-raise documented in code). Audit detail in `specs/active/554-platform-hardening/plan.md`.

## Test plan

- [x] 10 new unit tests in `tests/unit/workflow/test_action_complete_event_record_count.py` (parallel + serial event paths, producer-side helper happy/no-backend/raises/missing-key/None-value, batch-completion path)
- [x] Full pytest suite green: **7637 passed**
- [x] Ruff format + check clean
- [x] Online smoke test (`hardening/smoke-test.sh online`) against qanalabs-quiz-maker: **52/52 actions success, 52/52 with record_count > 0** (was 0 pre-fix)
- [x] `events.json` audit: 0 false-positive "Could not save failed render", "Failed to clear", "missing source_guid", "Could not read record_count" warnings

## Review trail

6 rounds of pi-consensus review. Final round flagged a pre-existing double-event bug in `_handle_action_skip` (WHERE-clause skip emits both `ActionSkipEvent` AND `ActionCompleteEvent` because it returns `status=COMPLETED`). That's a real bug but **out of scope for spec 554** — filed as new spec `specs/backlog/558-where-skip-double-event.md` with blast-radius notes for follow-up.

## Out of scope

- WHERE-skip double-event (spec 558)
- Performance follow-up: `_count_output_records` queries whole-DB stats per action complete; a focused `get_node_record_count(action_name)` backend method would be cleaner. Acceptable at current action-complete frequency; flagged in review.
- Track 1 of spec 554 (module-by-module architectural reviews) — each module should be planned individually after its `code-review` agent produces triaged findings.