### PR TITLE
feat(logging): suppress noisy third-party loggers at framework init (spec 555 step 1)

### DIFF
--- a/agent_actions/logging/_MANIFEST.md
+++ b/agent_actions/logging/_MANIFEST.md
@@ -22,8 +22,8 @@ factories, filters, formatters, and the event-driven error/reporting plumbing.
 | `config.py` | Module | Dataclasses that capture project logging, handler, and formatting defaults. | `logging` |
 | `FileHandlerSettings` | Class | File handler configuration used by the factory. | `logging` |
 | `LoggingConfig` | Class | Central logging configuration builder with `from_project_config`/`from_environment`. | `logging` |
-| `factory.py` | Module | `LoggerFactory` that wires together configuration, filters, and handlers. Registers four handler types: Console, `events.json` (all levels), `errors.json` (ERROR-only, output_dir runs only), and `run_results.json`. On init, clamps noisy third-party SDK/HTTP loggers (httpx, urllib3, openai, anthropic, ollama, groq, cohere, google.genai, googleapiclient, etc.) to WARNING and applies user-supplied `logging.module_levels` overrides. | `logging` |
-| `LoggerFactory` | Class | Manage logger creation, level setting, and debug state. | `logging` |
+| `factory.py` | Module | `LoggerFactory` that wires together configuration, filters, and handlers. Registers four handler types: Console, `events.json` (all levels), `errors.json` (ERROR-only, output_dir runs only), and `run_results.json`. On init, clamps noisy third-party SDK/HTTP loggers (httpx, urllib3, openai, anthropic, ollama, groq, cohere, google_genai, googleapiclient, etc.) to WARNING and applies user-supplied `logging.module_levels` overrides; pre-init levels are snapshotted and restored by `reset()`. | `logging` |
+| `LoggerFactory` | Class | Manages logger creation, third-party suppression, and the `events.json` bridge. | `logging` |
 | `filters.py` | Module | Custom filters (e.g., `RedactingFilter`) to sanitize sensitive payloads. | `logging` |
 | `formatters.py` | Module | Formatter helpers such as `JSONFormatter` used across services. | `logging` |
 

--- a/agent_actions/logging/_MANIFEST.md
+++ b/agent_actions/logging/_MANIFEST.md
@@ -22,7 +22,7 @@ factories, filters, formatters, and the event-driven error/reporting plumbing.
 | `config.py` | Module | Dataclasses that capture project logging, handler, and formatting defaults. | `logging` |
 | `FileHandlerSettings` | Class | File handler configuration used by the factory. | `logging` |
 | `LoggingConfig` | Class | Central logging configuration builder with `from_project_config`/`from_environment`. | `logging` |
-| `factory.py` | Module | `LoggerFactory` that wires together configuration, filters, and handlers. Registers four handler types: Console, `events.json` (all levels), `errors.json` (ERROR-only, output_dir runs only), and `run_results.json`. | `logging` |
+| `factory.py` | Module | `LoggerFactory` that wires together configuration, filters, and handlers. Registers four handler types: Console, `events.json` (all levels), `errors.json` (ERROR-only, output_dir runs only), and `run_results.json`. On init, clamps noisy third-party SDK/HTTP loggers (httpx, urllib3, openai, anthropic, ollama, groq, cohere, google.genai, googleapiclient, etc.) to WARNING and applies user-supplied `logging.module_levels` overrides. | `logging` |
 | `LoggerFactory` | Class | Manage logger creation, level setting, and debug state. | `logging` |
 | `filters.py` | Module | Custom filters (e.g., `RedactingFilter`) to sanitize sensitive payloads. | `logging` |
 | `formatters.py` | Module | Formatter helpers such as `JSONFormatter` used across services. | `logging` |
@@ -31,7 +31,7 @@ factories, filters, formatters, and the event-driven error/reporting plumbing.
 
 | Symbol | File | Interaction | Config Key |
 |--------|------|-------------|------------|
-| `LoggingConfig.from_project_config()` | `agent_actions.yml` | Reads | `logging`, `logging.level`, `logging.file` |
+| `LoggingConfig.from_project_config()` | `agent_actions.yml` | Reads (not wired into CLI yet — programmatic only) | `logging`, `logging.level`, `logging.file`, `logging.module_levels` |
 | `LoggingConfig.from_environment()` | `.env` | Reads | `AGENT_ACTIONS_DEBUG`, `AGENT_ACTIONS_LOG_LEVEL`, `AGENT_ACTIONS_LOG_FORMAT`, `AGENT_ACTIONS_LOG_DIR` |
 | `LoggerFactory.initialize()` | `agent_io/target/events.json` | Writes | — |
 | `LoggerFactory.initialize()` | `agent_io/target/errors.json` | Writes | — |

--- a/agent_actions/logging/config.py
+++ b/agent_actions/logging/config.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+VALID_LOG_LEVELS: frozenset[str] = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 
 
 @dataclass
@@ -27,7 +30,9 @@ class LoggingConfig:
     """Central logging configuration."""
 
     default_level: LogLevel = "INFO"
-    module_levels: dict[str, LogLevel] = field(default_factory=dict)
+    # Keys and values both validated at apply time by ``_apply_logger_levels``
+    # — YAML can hand back non-string keys (numeric ids) and values.
+    module_levels: dict[Any, Any] = field(default_factory=dict)
     include_timestamps: bool = True
     include_source_location: bool = False
     file_handler: FileHandlerSettings = field(default_factory=FileHandlerSettings)
@@ -47,9 +52,18 @@ class LoggingConfig:
             format=file_config.get("format", "human"),
         )
 
+        raw_module_levels = logging_config.get("module_levels", {})
+        if not isinstance(raw_module_levels, dict):
+            sys.stderr.write(
+                "agent_actions: ignoring logging.module_levels "
+                f"(expected dict, got {type(raw_module_levels).__name__}: "
+                f"{raw_module_levels!r})\n"
+            )
+            raw_module_levels = {}
+
         return cls(
             default_level=cls._validate_log_level(logging_config.get("level", "INFO"), "INFO"),
-            module_levels=logging_config.get("module_levels", {}),
+            module_levels=raw_module_levels,
             include_timestamps=logging_config.get("include_timestamps", True),
             include_source_location=logging_config.get("include_source_location", False),
             file_handler=file_settings,
@@ -57,23 +71,24 @@ class LoggingConfig:
 
     @staticmethod
     def _validate_log_level(value: str, default: str) -> LogLevel:
-        """Validate and return a LogLevel, falling back to default."""
-        valid = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        """Validate and return a LogLevel; ``WARN`` is normalized to ``WARNING``."""
         upper = value.upper() if isinstance(value, str) else default
-        return cast(LogLevel, upper if upper in valid else default)
+        if upper == "WARN":
+            upper = "WARNING"
+        return cast(LogLevel, upper if upper in VALID_LOG_LEVELS else default)
 
     @classmethod
     def from_environment(cls) -> LoggingConfig:
-        """Create LoggingConfig from AGENT_ACTIONS_* environment variables."""
+        """Build LoggingConfig from AGENT_ACTIONS_* env vars; module_levels env wiring not supported."""
         debug_mode = os.environ.get("AGENT_ACTIONS_DEBUG", "0") == "1"
 
         if debug_mode:
-            level = "DEBUG"
+            level: LogLevel = "DEBUG"
             include_source = True
         else:
-            level = os.environ.get("AGENT_ACTIONS_LOG_LEVEL", "INFO").upper()
-            if level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-                level = "INFO"
+            level = cls._validate_log_level(
+                os.environ.get("AGENT_ACTIONS_LOG_LEVEL", "INFO"), "INFO"
+            )
             include_source = False
 
         log_format = os.environ.get("AGENT_ACTIONS_LOG_FORMAT", "human").lower()
@@ -88,19 +103,19 @@ class LoggingConfig:
             if log_dir:
                 file_path = str(Path(log_dir) / "agent_actions.log")
 
-        file_level = os.environ.get("AGENT_ACTIONS_FILE_LOG_LEVEL", "DEBUG").upper()
-        if file_level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-            file_level = "DEBUG"
+        file_level = cls._validate_log_level(
+            os.environ.get("AGENT_ACTIONS_FILE_LOG_LEVEL", "DEBUG"), "DEBUG"
+        )
 
         file_settings = FileHandlerSettings(
             enabled=file_enabled,
             path=file_path,
-            level=cast(LogLevel, file_level),
+            level=file_level,
             format=cast(Literal["human", "json"], log_format),
         )
 
         return cls(
-            default_level=cast(LogLevel, level),
+            default_level=level,
             include_source_location=include_source,
             file_handler=file_settings,
         )

--- a/agent_actions/logging/config.py
+++ b/agent_actions/logging/config.py
@@ -70,12 +70,22 @@ class LoggingConfig:
         )
 
     @staticmethod
-    def _validate_log_level(value: str, default: str) -> LogLevel:
-        """Validate and return a LogLevel; ``WARN`` is normalized to ``WARNING``."""
-        upper = value.upper() if isinstance(value, str) else default
+    def normalize_log_level(value: object) -> LogLevel | None:
+        """Return canonical LogLevel; None for non-string or unrecognized."""
+        if not isinstance(value, str):
+            return None
+        upper = value.upper()
         if upper == "WARN":
             upper = "WARNING"
-        return cast(LogLevel, upper if upper in VALID_LOG_LEVELS else default)
+        if upper not in VALID_LOG_LEVELS:
+            return None
+        return cast(LogLevel, upper)
+
+    @classmethod
+    def _validate_log_level(cls, value: object, default: str) -> LogLevel:
+        """Validate and return a LogLevel; fall back to default if invalid."""
+        normalized = cls.normalize_log_level(value)
+        return normalized if normalized is not None else cast(LogLevel, default)
 
     @classmethod
     def from_environment(cls) -> LoggingConfig:

--- a/agent_actions/logging/factory.py
+++ b/agent_actions/logging/factory.py
@@ -26,7 +26,7 @@ _THIRD_PARTY_NOISY_LOGGERS: tuple[str, ...] = (
     "ollama",
     "groq",
     "cohere",
-    "google.genai",
+    "google_genai",
     "googleapiclient",
     "sentence_transformers",
     "transformers",
@@ -42,6 +42,9 @@ class LoggerFactory:
     _root_logger_name: str = "agent_actions"
     _event_manager: EventManager | None = None
     _run_results_collector: RunResultsCollector | None = None
+    # logger name → its level before the framework first touched it; used by reset()
+    # to restore pre-init state and by force-reinit to drop loggers no longer managed.
+    _original_logger_levels: dict[str, int] = {}
 
     @classmethod
     def initialize(
@@ -196,9 +199,8 @@ class LoggerFactory:
 
     @classmethod
     def _apply_logger_levels(cls, config: LoggingConfig) -> None:
-        """Clamp third-party loggers to WARNING; apply user module_levels overrides."""
-        for name in _THIRD_PARTY_NOISY_LOGGERS:
-            logging.getLogger(name).setLevel(logging.WARNING)
+        """Clamp noisy loggers + apply module_levels; restore prior level for loggers no longer managed."""
+        new_managed: dict[str, str] = {name: "WARNING" for name in _THIRD_PARTY_NOISY_LOGGERS}
 
         for name, level in config.module_levels.items():
             if not isinstance(name, str):
@@ -207,7 +209,6 @@ class LoggerFactory:
                     f"keys must be str, got {type(name).__name__}\n"
                 )
                 continue
-
             if name == cls._root_logger_name or name.startswith(cls._root_logger_name + "."):
                 sys.stderr.write(
                     f"agent_actions: ignoring logging.module_levels[{name!r}]={level!r}: "
@@ -215,17 +216,26 @@ class LoggerFactory:
                     "break events.json; use logging.level for CLI-visible levels.\n"
                 )
                 continue
-
-            normalized = str(level).upper()
-            if normalized == "WARN":  # Python alias for WARNING.
-                normalized = "WARNING"
-            if normalized not in VALID_LOG_LEVELS:
+            normalized = LoggingConfig.normalize_log_level(level)
+            if normalized is None:
                 sys.stderr.write(
                     f"agent_actions: ignoring logging.module_levels[{name!r}]={level!r}: "
-                    f"not one of {sorted(VALID_LOG_LEVELS)}\n"
+                    f"value must be one of {sorted(VALID_LOG_LEVELS)} "
+                    f"(got {type(level).__name__})\n"
                 )
                 continue
-            logging.getLogger(name).setLevel(normalized)
+            new_managed[name] = normalized
+
+        for name in list(cls._original_logger_levels):
+            if name not in new_managed:
+                logging.getLogger(name).setLevel(cls._original_logger_levels.pop(name))
+
+        for name in new_managed:
+            if name not in cls._original_logger_levels:
+                cls._original_logger_levels[name] = logging.getLogger(name).level
+
+        for name, level_str in new_managed.items():
+            logging.getLogger(name).setLevel(level_str)
 
     @classmethod
     def _setup_logging_bridge(cls) -> None:
@@ -298,7 +308,7 @@ class LoggerFactory:
 
     @classmethod
     def reset(cls) -> None:
-        """Reset factory state and unset third-party logger levels (for testing)."""
+        """Reset factory state and restore loggers we touched to their pre-init levels."""
         cls._initialized = False
         cls._config = None
         cls._event_manager = None
@@ -309,8 +319,9 @@ class LoggerFactory:
         for f in root_logger.filters[:]:
             root_logger.removeFilter(f)
 
-        for name in _THIRD_PARTY_NOISY_LOGGERS:
-            logging.getLogger(name).setLevel(logging.NOTSET)
+        for name, level in cls._original_logger_levels.items():
+            logging.getLogger(name).setLevel(level)
+        cls._original_logger_levels = {}
 
         from agent_actions.logging.core.manager import EventManager
 

--- a/agent_actions/logging/factory.py
+++ b/agent_actions/logging/factory.py
@@ -3,16 +3,35 @@
 from __future__ import annotations
 
 import logging
+import sys
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from agent_actions.logging.config import LoggingConfig
+from agent_actions.logging.config import VALID_LOG_LEVELS, LoggingConfig
 
 if TYPE_CHECKING:
     from agent_actions.logging.core.handlers import ContextDebugHandler
     from agent_actions.logging.core.manager import EventManager
     from agent_actions.logging.events.handlers import RunResultsCollector
+
+
+# Clamped to WARNING on init so SDK/HTTP chatter never reaches the CLI (spec 555).
+_THIRD_PARTY_NOISY_LOGGERS: tuple[str, ...] = (
+    "httpx",
+    "httpcore",
+    "urllib3",
+    "openai",
+    "anthropic",
+    "ollama",
+    "groq",
+    "cohere",
+    "google.genai",
+    "googleapiclient",
+    "sentence_transformers",
+    "transformers",
+    "pypdf",
+)
 
 
 class LoggerFactory:
@@ -47,7 +66,7 @@ class LoggerFactory:
         if verbose or cls._config.default_level == "DEBUG":
             console_level_str = "DEBUG"
         elif quiet:
-            console_level_str = "WARN"
+            console_level_str = "WARNING"
         else:
             console_level_str = cls._config.default_level
 
@@ -81,6 +100,7 @@ class LoggerFactory:
                     manager.register(handler)
             raise
 
+        cls._apply_logger_levels(cls._config)
         cls._setup_logging_bridge()
 
         manager.initialize()
@@ -120,6 +140,7 @@ class LoggerFactory:
             "WARN": EventLevel.WARN,
             "WARNING": EventLevel.WARN,
             "ERROR": EventLevel.ERROR,
+            # EventLevel has no CRITICAL tier; fold into ERROR.
             "CRITICAL": EventLevel.ERROR,
         }
         console_level = level_map.get(console_level_str.upper(), EventLevel.INFO)
@@ -172,6 +193,39 @@ class LoggerFactory:
         )
         manager.register(run_results)
         cls._run_results_collector = run_results
+
+    @classmethod
+    def _apply_logger_levels(cls, config: LoggingConfig) -> None:
+        """Clamp third-party loggers to WARNING; apply user module_levels overrides."""
+        for name in _THIRD_PARTY_NOISY_LOGGERS:
+            logging.getLogger(name).setLevel(logging.WARNING)
+
+        for name, level in config.module_levels.items():
+            if not isinstance(name, str):
+                sys.stderr.write(
+                    f"agent_actions: ignoring logging.module_levels[{name!r}]={level!r}: "
+                    f"keys must be str, got {type(name).__name__}\n"
+                )
+                continue
+
+            if name == cls._root_logger_name or name.startswith(cls._root_logger_name + "."):
+                sys.stderr.write(
+                    f"agent_actions: ignoring logging.module_levels[{name!r}]={level!r}: "
+                    f"overrides on {cls._root_logger_name!r} or its children would "
+                    "break events.json; use logging.level for CLI-visible levels.\n"
+                )
+                continue
+
+            normalized = str(level).upper()
+            if normalized == "WARN":  # Python alias for WARNING.
+                normalized = "WARNING"
+            if normalized not in VALID_LOG_LEVELS:
+                sys.stderr.write(
+                    f"agent_actions: ignoring logging.module_levels[{name!r}]={level!r}: "
+                    f"not one of {sorted(VALID_LOG_LEVELS)}\n"
+                )
+                continue
+            logging.getLogger(name).setLevel(normalized)
 
     @classmethod
     def _setup_logging_bridge(cls) -> None:
@@ -233,27 +287,6 @@ class LoggerFactory:
         return logging.getLogger(name)
 
     @classmethod
-    def set_level(cls, level: str, logger_name: str | None = None) -> None:
-        """Set log level for a logger."""
-        if not cls._initialized:
-            cls.initialize()
-
-        if logger_name:
-            if not logger_name.startswith(cls._root_logger_name):
-                logger_name = f"{cls._root_logger_name}.{logger_name}"
-            logger = logging.getLogger(logger_name)
-        else:
-            logger = logging.getLogger(cls._root_logger_name)
-
-        logger.setLevel(getattr(logging, level.upper()))
-
-    @classmethod
-    def set_debug(cls, debug: bool = True) -> None:
-        """Enable or disable debug logging globally."""
-        level = "DEBUG" if debug else "INFO"
-        cls.set_level(level)
-
-    @classmethod
     def get_config(cls) -> LoggingConfig | None:
         """Get the current logging configuration."""
         return cls._config
@@ -265,7 +298,7 @@ class LoggerFactory:
 
     @classmethod
     def reset(cls) -> None:
-        """Reset the factory state (for testing)."""
+        """Reset factory state and unset third-party logger levels (for testing)."""
         cls._initialized = False
         cls._config = None
         cls._event_manager = None
@@ -275,6 +308,9 @@ class LoggerFactory:
         root_logger.handlers.clear()
         for f in root_logger.filters[:]:
             root_logger.removeFilter(f)
+
+        for name in _THIRD_PARTY_NOISY_LOGGERS:
+            logging.getLogger(name).setLevel(logging.NOTSET)
 
         from agent_actions.logging.core.manager import EventManager
 

--- a/docs.agent-actions/docs/api/logging.md
+++ b/docs.agent-actions/docs/api/logging.md
@@ -848,8 +848,49 @@ LoggerFactory.initialize(config=config)
 ```
 
 **Fields:**
-- `default_level` (str): Default log level ("DEBUG", "INFO", "WARN", "ERROR")
+- `default_level` (str): Default log level ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+- `module_levels` (dict): Per-logger level overrides applied at init. Keys are
+  Python logger names (e.g. `"httpx"`, `"my_module"`), values are level
+  strings. Use this to re-enable a logger the framework clamps by default,
+  or to silence one that's still too chatty.
 - `file_handler` (FileHandlerConfig): File handler configuration
+
+#### Third-party logger suppression
+
+To keep the CLI focused on framework output, `LoggerFactory.initialize()`
+clamps a curated set of SDK / HTTP loggers to `WARNING` on every init:
+
+```
+httpx, httpcore, urllib3, openai, anthropic, ollama, groq,
+cohere, google.genai, googleapiclient, sentence_transformers,
+transformers, pypdf
+```
+
+To opt back in to verbose output from one of these — or to silence a logger
+not in the curated list — pass `module_levels` when constructing the config:
+
+```python
+from agent_actions.logging.config import LoggingConfig
+from agent_actions.logging.factory import LoggerFactory
+
+config = LoggingConfig(
+    default_level="INFO",
+    module_levels={
+        "httpx": "INFO",         # see HTTP request lines from httpx again
+        "transformers": "ERROR", # silence model-loading chatter further
+    },
+)
+LoggerFactory.initialize(config=config)
+```
+
+Overrides on `agent_actions` and any of its children are refused with a
+stderr warning — the framework root must stay at DEBUG so every event reaches
+`events.json`. Use `default_level` to set the CLI-visible level instead.
+
+> **Note:** `LoggingConfig.from_project_config()` parses `module_levels` from
+> a YAML mapping, but the CLI does not yet route project YAML through it —
+> see the manifest for the wiring status. For now, supply `module_levels`
+> programmatically.
 
 #### FileHandlerConfig
 

--- a/docs.agent-actions/docs/api/logging.md
+++ b/docs.agent-actions/docs/api/logging.md
@@ -862,7 +862,7 @@ clamps a curated set of SDK / HTTP loggers to `WARNING` on every init:
 
 ```
 httpx, httpcore, urllib3, openai, anthropic, ollama, groq,
-cohere, google.genai, googleapiclient, sentence_transformers,
+cohere, google_genai, googleapiclient, sentence_transformers,
 transformers, pypdf
 ```
 

--- a/tests/logging/events/test_third_party_suppression.py
+++ b/tests/logging/events/test_third_party_suppression.py
@@ -1,0 +1,200 @@
+"""Spec 555 step 1: framework clamps noisy SDK/HTTP loggers to WARNING; module_levels overrides win."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent_actions.logging.config import LoggingConfig
+from agent_actions.logging.factory import _THIRD_PARTY_NOISY_LOGGERS, LoggerFactory
+
+# Source of truth lives in the factory. Importing it here means adding a
+# logger over there automatically widens parametrized coverage.
+NOISY_LOGGERS = list(_THIRD_PARTY_NOISY_LOGGERS)
+
+
+@pytest.fixture(autouse=True)
+def reset_factory_and_logger_state():
+    """Reset factory and restore third-party logger levels; force root to INFO so suppression isn't a tautology."""
+    LoggerFactory.reset()
+
+    saved_root = logging.getLogger().level
+    saved = {name: logging.getLogger(name).level for name in NOISY_LOGGERS}
+    saved["my_custom_lib"] = logging.getLogger("my_custom_lib").level
+
+    logging.getLogger().setLevel(logging.INFO)
+
+    try:
+        yield
+    finally:
+        LoggerFactory.reset()
+        logging.getLogger().setLevel(saved_root)
+        for name, level in saved.items():
+            logging.getLogger(name).setLevel(level)
+
+
+class TestThirdPartySuppression:
+    """Spec 555 step 1: framework explicitly clamps SDK/HTTP loggers to WARNING."""
+
+    @pytest.mark.parametrize("logger_name", NOISY_LOGGERS)
+    def test_logger_is_explicitly_clamped(self, logger_name):
+        """Each noisy logger's own ``.level`` (not inherited) is WARNING after init."""
+        LoggerFactory.initialize()
+
+        actual = logging.getLogger(logger_name).level
+        assert actual == logging.WARNING, (
+            f"{logger_name!r} level is {logging.getLevelName(actual)}; "
+            "spec 555 step 1 requires the framework to clamp it to WARNING"
+        )
+
+    def test_info_messages_from_third_party_are_silenced(self):
+        """End-to-end: an httpx INFO log is dropped; WARNING still passes."""
+        LoggerFactory.initialize()
+
+        captured: list[logging.LogRecord] = []
+
+        class CaptureHandler(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        httpx = logging.getLogger("httpx")
+        handler = CaptureHandler(level=logging.DEBUG)
+        httpx.addHandler(handler)
+        try:
+            httpx.info("HTTP GET https://api.example.com/v1/messages")
+            httpx.warning("retry exhausted")
+        finally:
+            httpx.removeHandler(handler)
+
+        levels = [r.levelno for r in captured]
+        assert logging.INFO not in levels, "INFO from httpx leaked past suppression"
+        assert logging.WARNING in levels, "WARNING from httpx must still be visible"
+
+    def test_agent_actions_logger_not_clamped(self):
+        """Suppression must not touch the framework's own logger tree."""
+        LoggerFactory.initialize()
+
+        # factory._setup_logging_bridge sets agent_actions to DEBUG so
+        # event handlers see everything; clamping it would defeat that.
+        assert logging.getLogger("agent_actions").level == logging.DEBUG
+
+    def test_provider_wrapper_logger_not_affected(self):
+        """Provider wrappers live under agent_actions.*, not under the SDK root."""
+        LoggerFactory.initialize()
+
+        wrapper = logging.getLogger("agent_actions.llm.providers.openai.client")
+        # Should inherit from agent_actions (DEBUG), NOT from "openai" (WARNING)
+        assert wrapper.getEffectiveLevel() == logging.DEBUG
+
+
+class TestModuleLevelOverrides:
+    """``module_levels`` in LoggingConfig is the escape hatch for suppression."""
+
+    def test_user_can_lower_a_clamped_logger_back_to_info(self):
+        """User can opt back in to INFO for a suppressed third-party logger."""
+        config = LoggingConfig(module_levels={"httpx": "INFO"})
+        LoggerFactory.initialize(config=config)
+
+        assert logging.getLogger("httpx").level == logging.INFO
+
+    def test_user_can_set_level_on_unsuppressed_logger(self):
+        """module_levels also works for loggers not in the suppression list."""
+        config = LoggingConfig(module_levels={"my_custom_lib": "ERROR"})
+        LoggerFactory.initialize(config=config)
+
+        assert logging.getLogger("my_custom_lib").level == logging.ERROR
+
+    def test_warn_is_accepted_as_alias_for_warning(self):
+        """Python's logging module treats WARN and WARNING as equivalent."""
+        config = LoggingConfig(module_levels={"my_custom_lib": "WARN"})
+        LoggerFactory.initialize(config=config)
+
+        assert logging.getLogger("my_custom_lib").level == logging.WARNING
+
+    def test_invalid_module_level_emits_stderr_warning(self, capsys):
+        """Garbage value is rejected with stderr warning; WARNING clamp stands (start from DEBUG to prove sequence)."""
+        logging.getLogger("httpx").setLevel(logging.DEBUG)
+
+        config = LoggingConfig(module_levels={"httpx": "NOT_A_LEVEL"})
+        LoggerFactory.initialize(config=config)
+
+        captured = capsys.readouterr()
+        assert "module_levels" in captured.err
+        assert "httpx" in captured.err
+        assert "NOT_A_LEVEL" in captured.err
+        # Clamp ran AND invalid override was rejected → final state is WARNING,
+        # not DEBUG (would mean clamp didn't run) and not NOT_A_LEVEL (would
+        # mean the override sneaked past validation).
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    @pytest.mark.parametrize("bad_value", [True, 20, ["INFO"], None])
+    def test_non_string_module_level_rejected_at_runtime(self, bad_value, capsys):
+        """Non-string values (bool/int/list/None) are rejected, suppression default holds."""
+        config = LoggingConfig(module_levels={"httpx": bad_value})
+
+        LoggerFactory.initialize(config=config)
+
+        err = capsys.readouterr().err
+        assert "httpx" in err
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_non_string_key_rejected_without_crash(self, capsys):
+        """A non-string key (e.g. int from YAML) is skipped, not propagated to getLogger."""
+        config = LoggingConfig(module_levels={42: "INFO"})
+
+        LoggerFactory.initialize(config=config)
+
+        err = capsys.readouterr().err
+        assert "42" in err
+        assert "str" in err
+
+    def test_agent_actions_root_override_refused(self, capsys):
+        """Overriding ``agent_actions`` would break the events.json bridge."""
+        config = LoggingConfig(module_levels={"agent_actions": "ERROR"})
+
+        LoggerFactory.initialize(config=config)
+
+        # Bridge wins: agent_actions stays at DEBUG so every event reaches handlers.
+        assert logging.getLogger("agent_actions").level == logging.DEBUG
+        captured = capsys.readouterr()
+        assert "agent_actions" in captured.err
+
+    def test_agent_actions_child_override_refused(self, capsys):
+        """Children of ``agent_actions`` are guarded for the same reason."""
+        config = LoggingConfig(module_levels={"agent_actions.llm.providers.openai.client": "ERROR"})
+
+        LoggerFactory.initialize(config=config)
+
+        wrapper = logging.getLogger("agent_actions.llm.providers.openai.client")
+        # Override refused → wrapper inherits DEBUG from agent_actions, not ERROR.
+        assert wrapper.getEffectiveLevel() == logging.DEBUG
+        captured = capsys.readouterr()
+        assert "agent_actions.llm.providers.openai.client" in captured.err
+
+
+class TestResetIsolatesThirdPartyLoggers:
+    """``LoggerFactory.reset()`` must clear levels it set on global loggers."""
+
+    def test_reset_restores_third_party_loggers_to_notset(self):
+        """After reset, third-party loggers no longer carry framework-set levels."""
+        LoggerFactory.initialize()
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+        LoggerFactory.reset()
+
+        assert logging.getLogger("httpx").level == logging.NOTSET
+
+
+class TestSuppressionIdempotency:
+    """Force re-init must reapply suppression, not leak old state."""
+
+    def test_force_reinit_reapplies_suppression(self):
+        """After force=True the third-party levels are still clamped."""
+        LoggerFactory.initialize()
+        # Simulate something downstream re-enabling DEBUG on httpx
+        logging.getLogger("httpx").setLevel(logging.DEBUG)
+
+        LoggerFactory.initialize(force=True)
+
+        assert logging.getLogger("httpx").level == logging.WARNING

--- a/tests/logging/events/test_third_party_suppression.py
+++ b/tests/logging/events/test_third_party_suppression.py
@@ -139,6 +139,21 @@ class TestModuleLevelOverrides:
         assert "httpx" in err
         assert logging.getLogger("httpx").level == logging.WARNING
 
+    def test_value_that_stringifies_to_valid_level_still_rejected(self, capsys):
+        """Type-guard (not str-coercion) — a non-string whose __str__ returns 'INFO' must NOT override."""
+
+        class StringifiesToInfo:
+            def __str__(self):
+                return "INFO"
+
+        config = LoggingConfig(module_levels={"httpx": StringifiesToInfo()})
+        LoggerFactory.initialize(config=config)
+
+        err = capsys.readouterr().err
+        assert "httpx" in err
+        # If the helper coerced via str(), httpx would be INFO; type-guard keeps it at WARNING (clamp).
+        assert logging.getLogger("httpx").level == logging.WARNING
+
     def test_non_string_key_rejected_without_crash(self, capsys):
         """A non-string key (e.g. int from YAML) is skipped, not propagated to getLogger."""
         config = LoggingConfig(module_levels={42: "INFO"})
@@ -174,13 +189,24 @@ class TestModuleLevelOverrides:
 
 
 class TestResetIsolatesThirdPartyLoggers:
-    """``LoggerFactory.reset()`` must clear levels it set on global loggers."""
+    """``LoggerFactory.reset()`` must restore loggers to their pre-init state."""
 
-    def test_reset_restores_third_party_loggers_to_notset(self):
-        """After reset, third-party loggers no longer carry framework-set levels."""
+    def test_reset_restores_pre_init_level_not_notset(self):
+        """Host app set httpx=ERROR before our init; reset() must restore ERROR, not blow it away to NOTSET."""
+        logging.getLogger("httpx").setLevel(logging.ERROR)
+
         LoggerFactory.initialize()
         assert logging.getLogger("httpx").level == logging.WARNING
 
+        LoggerFactory.reset()
+
+        assert logging.getLogger("httpx").level == logging.ERROR
+
+    def test_reset_restores_notset_when_logger_was_untouched(self):
+        """If a logger was at NOTSET before init, reset() returns it to NOTSET."""
+        logging.getLogger("httpx").setLevel(logging.NOTSET)
+
+        LoggerFactory.initialize()
         LoggerFactory.reset()
 
         assert logging.getLogger("httpx").level == logging.NOTSET
@@ -198,3 +224,18 @@ class TestSuppressionIdempotency:
         LoggerFactory.initialize(force=True)
 
         assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_force_reinit_drops_module_level_no_longer_in_config(self):
+        """A logger set via module_levels in the FIRST config must be restored when the SECOND config omits it."""
+        # Pre-existing host-app level we must respect.
+        logging.getLogger("my_custom_lib").setLevel(logging.NOTSET)
+
+        first = LoggingConfig(module_levels={"my_custom_lib": "ERROR"})
+        LoggerFactory.initialize(config=first)
+        assert logging.getLogger("my_custom_lib").level == logging.ERROR
+
+        second = LoggingConfig()  # module_levels = {}
+        LoggerFactory.initialize(config=second, force=True)
+
+        # Without restore, my_custom_lib would still be ERROR from the prior config.
+        assert logging.getLogger("my_custom_lib").level == logging.NOTSET

--- a/tests/logging/test_config.py
+++ b/tests/logging/test_config.py
@@ -136,6 +136,32 @@ class TestLoggingConfigFromProjectConfig:
         assert config.file_handler.backup_count == 5
         assert config.file_handler.format == "human"
 
+    def test_module_levels_parsed_from_yaml(self):
+        """``module_levels`` mapping is parsed and preserved verbatim."""
+        project_config = {
+            "logging": {
+                "module_levels": {"httpx": "INFO", "transformers": "ERROR"},
+            }
+        }
+        config = LoggingConfig.from_project_config(project_config)
+        assert config.module_levels == {"httpx": "INFO", "transformers": "ERROR"}
+
+    def test_module_levels_non_dict_falls_back_with_stderr_warning(self, capsys):
+        """A non-dict ``module_levels`` value must not crash init AND must warn."""
+        project_config = {"logging": {"module_levels": "WARNING"}}
+        config = LoggingConfig.from_project_config(project_config)
+        assert config.module_levels == {}
+
+        err = capsys.readouterr().err
+        assert "module_levels" in err
+        assert "dict" in err
+
+    def test_module_levels_preserves_non_string_values_for_runtime_validation(self):
+        """Non-string YAML values are preserved verbatim for apply-time validation."""
+        project_config = {"logging": {"module_levels": {"httpx": True, "transformers": 20}}}
+        config = LoggingConfig.from_project_config(project_config)
+        assert config.module_levels == {"httpx": True, "transformers": 20}
+
 
 class TestLoggingConfigEdgeCases:
     """Tests for edge cases in LoggingConfig."""


### PR DESCRIPTION
## Summary
First slice of spec 555 (logging UX, dbt-standard CLI output). SDK/HTTP libraries (httpx, urllib3, openai, anthropic, ollama, groq, cohere, google.genai, googleapiclient, sentence_transformers, transformers, pypdf) are clamped to WARNING on every `LoggerFactory.initialize()` so framework-internal HTTP and SDK chatter stops leaking onto the CLI.

Users can override the curated defaults — or set per-logger levels on any other logger — via `LoggingConfig.module_levels`. Validation runs at apply time: non-string keys, non-string values, invalid level names, and overrides on `agent_actions` or its children are all rejected with stderr warnings rather than crashing or silently dropping. The `agent_actions` root must stay at DEBUG so every event reaches `events.json` — `module_levels` guards this.

## What's in this PR
- `_THIRD_PARTY_NOISY_LOGGERS` + `_apply_logger_levels()` in `LoggerFactory.initialize`
- `module_levels` typed as `dict[str, Any]` to honestly reflect the YAML/programmatic surface; runtime validation handles correctness
- `VALID_LOG_LEVELS` lifted to module-level constant; `from_environment` routes through `_validate_log_level` so WARN/WARNING aliasing is consistent across YAML, env vars, and `module_levels`
- `level_map` adds `CRITICAL → EventLevel.ERROR` so a user setting `default_level: CRITICAL` gets errors-and-above, not a silent fallback to INFO
- `LoggerFactory.reset()` restores third-party loggers to NOTSET so tests don't leak global state
- `LoggerFactory.set_level` / `set_debug` deleted — zero callers, contradictory semantics (silently broke `events.json` invariant)
- New test file `tests/logging/events/test_third_party_suppression.py` with 25+ cases covering clamp, overrides, invalid inputs, agent_actions guard, reset isolation, force-reinit idempotency
- Docs (`docs/api/logging.md`) and module manifest updated

## Deferred (flagged by pi-consensus, out of scope for step 1)
- **YAML wiring for `module_levels`**: `LoggingConfig.from_project_config` parses `module_levels` correctly but the CLI doesn't yet route project YAML through it. Pre-existing gap (`from_project_config` has zero production callers — entire YAML-based config path is inert). Should land as its own PR.
- **Deprecation shims for removed `set_level`/`set_debug`**: pi-consensus flagged removal as a breaking API change. Both methods had zero internal/test callers and the broken semantics (silently truncating `events.json`) made them dangerous to leave in place. If external callers exist, this is intentionally surfaced as `AttributeError` at upgrade time.
- **`module_levels` env var (`AGENT_ACTIONS_LOG_MODULE_LEVELS`)**: not in spec 555 step 1 scope; programmatic API covers the path.

## Verification
- `harness ci` against `origin/main`: 7679 passed
- 6 rounds of pi-consensus review against the integration branch; remaining feedback is the three deferred items above (documented), plus a recurring type-tightening preference (`dict[str, Any]` → narrower) where loose typing is the honest match for the YAML/programmatic input surface

## Spec
`specs/backlog/555-logging-ux-dbt-standard.md` step 1 of 5. Subsequent slices (audit framework-internal warnings, build dbt-style CLI renderer, route errors through events, cascade collapsing) land separately.