### PR TITLE
fix(VIOL-0036): LSP ignores identifiers inside quoted string literals

### DIFF
--- a/agent_actions/tooling/lsp/indexer.py
+++ b/agent_actions/tooling/lsp/indexer.py
@@ -431,9 +431,8 @@ def _add_reference(
     )
 
 
-# Single- or double-quoted string literal, allowing escaped quotes
-# (`"can\"t"`). Match length is preserved by the substitution below so
-# downstream offset-based mappings stay valid. See VIOL-0036.
+# Match length is preserved by the substitution below so any downstream
+# offset-based mapping over the sanitised string stays valid.
 _QUOTED_LITERAL_RE = re.compile(
     r'"(?:\\.|[^"\\])*"'
     r"|'(?:\\.|[^'\\])*'"
@@ -441,11 +440,6 @@ _QUOTED_LITERAL_RE = re.compile(
 
 
 def _blank_out_quoted_literals(condition: str) -> str:
-    """Replace each quoted-string span with spaces of equal length.
-
-    VIOL-0036: identifiers inside quoted string literals are values, not
-    variable references; the LSP must not flag them.
-    """
     return _QUOTED_LITERAL_RE.sub(lambda m: " " * (m.end() - m.start()), condition)
 
 
@@ -453,7 +447,7 @@ def _extract_condition_variables(condition: str) -> list[str]:
     """Extract variable-like tokens from a guard/validation condition.
 
     Identifiers inside single- or double-quoted string literals are
-    ignored (VIOL-0036).
+    ignored — they are values, not variable references.
     """
     sanitised = _blank_out_quoted_literals(condition)
     tokens = re.findall(r"\b[a-zA-Z_][\w\.]*\b", sanitised)

--- a/agent_actions/tooling/lsp/indexer.py
+++ b/agent_actions/tooling/lsp/indexer.py
@@ -431,9 +431,32 @@ def _add_reference(
     )
 
 
+# Single- or double-quoted string literal, allowing escaped quotes
+# (`"can\"t"`). Match length is preserved by the substitution below so
+# downstream offset-based mappings stay valid. See VIOL-0036.
+_QUOTED_LITERAL_RE = re.compile(
+    r'"(?:\\.|[^"\\])*"'
+    r"|'(?:\\.|[^'\\])*'"
+)
+
+
+def _blank_out_quoted_literals(condition: str) -> str:
+    """Replace each quoted-string span with spaces of equal length.
+
+    VIOL-0036: identifiers inside quoted string literals are values, not
+    variable references; the LSP must not flag them.
+    """
+    return _QUOTED_LITERAL_RE.sub(lambda m: " " * (m.end() - m.start()), condition)
+
+
 def _extract_condition_variables(condition: str) -> list[str]:
-    """Extract variable-like tokens from a guard/validation condition."""
-    tokens = re.findall(r"\b[a-zA-Z_][\w\.]*\b", condition)
+    """Extract variable-like tokens from a guard/validation condition.
+
+    Identifiers inside single- or double-quoted string literals are
+    ignored (VIOL-0036).
+    """
+    sanitised = _blank_out_quoted_literals(condition)
+    tokens = re.findall(r"\b[a-zA-Z_][\w\.]*\b", sanitised)
     keywords = {"and", "or", "not", "in", "is", "true", "false", "null", "none"}
     return [token for token in tokens if token.lower() not in keywords]
 

--- a/tests/tooling/lsp/test_extract_condition_variables.py
+++ b/tests/tooling/lsp/test_extract_condition_variables.py
@@ -1,0 +1,58 @@
+"""Regression tests for VIOL-0036.
+
+The LSP variable extractor must ignore identifiers that appear inside
+single- or double-quoted string literals — they are guard literals, not
+variable references, and `agac validate-udfs` already treats them as
+such. The LSP must agree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_actions.tooling.lsp.indexer import _extract_condition_variables
+
+
+@pytest.mark.parametrize(
+    "condition,expected_vars",
+    [
+        # The original VIOL-0036 case — `approved` is a string literal.
+        ('x.hitl_status == "approved"', {"x.hitl_status"}),
+        # Single quotes — same rule.
+        ("x.hitl_status == 'approved'", {"x.hitl_status"}),
+        # Multi-comparison with a quoted literal mid-expression.
+        (
+            'source.status == "ready" and source.count > 0',
+            {"source.status", "source.count"},
+        ),
+        # Two quoted literals — neither should appear.
+        ('"foo" == source.label or source.label == "bar"', {"source.label"}),
+        # No quotes — baseline that prior behavior holds.
+        ("source.a > source.b", {"source.a", "source.b"}),
+        # Escaped quotes inside a string must not break out of the literal.
+        (r'source.label == "can\"t"', {"source.label"}),
+    ],
+)
+def test_extract_ignores_quoted_string_literals(condition: str, expected_vars: set[str]) -> None:
+    result = _extract_condition_variables(condition)
+    dotted = {token for token in result if "." in token}
+    assert dotted == expected_vars, (
+        f"For condition {condition!r}, extractor returned {result!r}; "
+        f"expected dotted variable set {expected_vars!r}."
+    )
+
+
+def test_extract_bare_identifier_outside_quotes_still_returned() -> None:
+    """Bare identifiers (no dot) outside quotes remain extracted; only
+    keywords are filtered. This guards the path that the strip pass
+    doesn't accidentally swallow non-quoted tokens."""
+    result = _extract_condition_variables("flag and source.x")
+    assert "flag" in result
+    assert "source.x" in result
+
+
+def test_extract_bare_identifier_inside_quotes_is_ignored() -> None:
+    """Quoted bare identifiers must not be extracted either."""
+    result = _extract_condition_variables('source.x == "flag"')
+    assert "flag" not in result
+    assert "source.x" in result

--- a/tests/tooling/lsp/test_extract_condition_variables.py
+++ b/tests/tooling/lsp/test_extract_condition_variables.py
@@ -1,6 +1,4 @@
-"""Regression tests for VIOL-0036.
-
-The LSP variable extractor must ignore identifiers that appear inside
+"""The LSP variable extractor must ignore identifiers that appear inside
 single- or double-quoted string literals — they are guard literals, not
 variable references, and `agac validate-udfs` already treats them as
 such. The LSP must agree.
@@ -16,7 +14,7 @@ from agent_actions.tooling.lsp.indexer import _extract_condition_variables
 @pytest.mark.parametrize(
     "condition,expected_vars",
     [
-        # The original VIOL-0036 case — `approved` is a string literal.
+        # `approved` is a string literal, not a variable.
         ('x.hitl_status == "approved"', {"x.hitl_status"}),
         # Single quotes — same rule.
         ("x.hitl_status == 'approved'", {"x.hitl_status"}),

--- a/tests/tooling/lsp/test_guard_completions.py
+++ b/tests/tooling/lsp/test_guard_completions.py
@@ -289,11 +289,10 @@ class TestGuardDiagnostics:
         assert "Did you mean" not in diag.message
 
     def test_guard_with_quoted_string_literal_no_diagnostic(self, tmp_path: Path):
-        """VIOL-0036: identifiers inside quoted literals must not produce a
-        guard diagnostic. The integration test mirrors how the indexer feeds
-        diagnostics — `guard_variables` is the extractor's output, so an
-        empty-modulo-observe list here proves the extractor + diagnostics
-        path agrees with `agac validate-udfs`.
+        """Identifiers inside quoted literals must not produce a guard
+        diagnostic — the integration test mirrors how the indexer feeds
+        diagnostics, so an empty-modulo-observe list here proves the
+        extractor + diagnostics path agrees with `agac validate-udfs`.
         """
         from agent_actions.tooling.lsp.indexer import _extract_condition_variables
 

--- a/tests/tooling/lsp/test_guard_completions.py
+++ b/tests/tooling/lsp/test_guard_completions.py
@@ -288,6 +288,29 @@ class TestGuardDiagnostics:
         assert "`wrong_action.field`" in diag.message
         assert "Did you mean" not in diag.message
 
+    def test_guard_with_quoted_string_literal_no_diagnostic(self, tmp_path: Path):
+        """VIOL-0036: identifiers inside quoted literals must not produce a
+        guard diagnostic. The integration test mirrors how the indexer feeds
+        diagnostics — `guard_variables` is the extractor's output, so an
+        empty-modulo-observe list here proves the extractor + diagnostics
+        path agrees with `agac validate-udfs`.
+        """
+        from agent_actions.tooling.lsp.indexer import _extract_condition_variables
+
+        condition = 'x.hitl_status == "approved"'
+        action = ActionMetadata(
+            name="gated",
+            location=Location(file_path=tmp_path / "w.yml", line=0),
+            context_observe=["x.hitl_status"],
+            guard_condition=condition,
+            guard_line=5,
+            guard_variables=_extract_condition_variables(condition),
+        )
+        idx, wf = _make_index(tmp_path, {"gated": action})
+        diagnostics = collect_diagnostics(wf, idx)
+
+        assert diagnostics == []
+
     def test_guard_scoped_to_own_action(self, tmp_path: Path):
         """Action A's guard cannot reference action B's observe entries."""
         action_a = ActionMetadata(


### PR DESCRIPTION
## Summary

`_extract_condition_variables` in the agac LSP server was flagging identifiers that appeared inside single- or double-quoted string literals as undefined variable references. A guard like

```yaml
guard:
  condition: 'x.hitl_status == "approved"'
```

triggered a *"Warning: undefined variable `approved`"* in editors using the LSP, even though `agac validate-udfs` (the canonical checker) reports the workflow clean.

Fix: add a quote-stripping pre-pass that replaces every quoted-string span with spaces of equal length before running the variable extraction regex. Handles both quote styles plus escaped quotes (`"can\\"t"`). Character offsets are preserved so any downstream range-mapping in the LSP stays valid.

LSP and `validate-udfs` now agree on the quoted-literal case.

## Verification

- `pytest tests/tooling/lsp/ tests/unit/tooling/` — 268 passed
- Full `pytest` — 7656 passed
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean

New tests:
- `tests/tooling/lsp/test_extract_condition_variables.py` — unit-level regression with both quote styles, escaped quotes, mixed expressions, and a no-quote baseline.
- `tests/tooling/lsp/test_guard_completions.py::test_guard_with_quoted_string_literal_no_diagnostic` — integration test driving the diagnostics layer; asserts zero warnings for the canonical VIOL-0036 case.

## Scope notes

- Self-review checked sibling regex extractors in `agent_actions/tooling/lsp/`; no other extractor operates over condition strings. `reprompt_validation` is captured but never tokenised.
- No new dependencies; stdlib `re` only.