### PR TITLE
docs(VIOL-0072): align field-references reserved-name list with runtime (E-14)

### DIFF
--- a/docs.agent-actions/docs/reference/context/field-references.md
+++ b/docs.agent-actions/docs/reference/context/field-references.md
@@ -46,11 +46,11 @@ Action names cannot use reserved namespaces. The following names are disallowed:
 
 - `action`
 - `context_scope`
-- `versions`
 - `prompt`
 - `schema`
 - `seed`
 - `source`
+- `version`
 - `workflow`
 
 ### Nested Field Access


### PR DESCRIPTION
## Summary

`docs/reference/context/field-references.md` listed the reserved action name as `versions` (plural). The runtime constant `RESERVED_AGENT_NAMES` in `agent_actions/utils/constants.py` reserves `version` (singular). Aligned the doc with the runtime so the documented reserved-name list is what validation actually enforces.

Also re-sorted the bullet list alphabetically while editing.

## Out of scope

The spec (VIOL-0072) recommends also widening `RESERVED_AGENT_NAMES` to include both `version` and `versions` so an action literally named `versions` fails validation. Clone 6's UAT-audit ownership is docs-only (`agent_actions/` is explicitly excluded), so the runtime widening is logged as a cross-clone follow-up in `coordination/status.md`.

## Verification

- Doc grep — only `version` (singular) now appears in the reserved-name list:
  ```
  $ grep -nE '\`version\`|\`versions\`' docs.agent-actions/docs/reference/context/field-references.md
  53:- \`version\`
  ```
- Runtime cross-check — `agent_actions/utils/constants.py:19-21` reserves `{"source", "version", "workflow", "seed", "prompt", "schema", "context_scope", "action"}`; all eight names are now present in the doc.
- `ruff check` / `ruff format --check` clean.

Source: `specs/active/uat-audit/violations/VIOL-0072-field-references-docs.md`