### PR TITLE
fix(UAT T1-01): guard retry_config=None in exhausted-policy paths

### DIFF
--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -329,7 +329,7 @@ class BatchResultStrategy:
         if ctx.agent_config:
             if custom_id in ctx.context_map:
                 generated_list = self._apply_context_passthrough(ctx, custom_id, generated_list)
-            elif ctx.agent_config.get("context_scope", {}).get("passthrough"):
+            elif (ctx.agent_config.get("context_scope") or {}).get("passthrough"):
                 logger.warning(
                     "custom_id '%s' not found in context_map, skipping passthrough",
                     custom_id,

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -566,7 +566,7 @@ class BatchResultStrategy:
             )
         on_exhausted = OnExhaustedPolicy.RETURN_LAST
         if ctx.agent_config:
-            retry_config = ctx.agent_config.get("retry", {})
+            retry_config = ctx.agent_config.get("retry") or {}
             on_exhausted = OnExhaustedPolicy(retry_config.get("on_exhausted", "return_last"))
 
         recovery_meta = ctx.exhausted_recovery[custom_id]

--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -567,7 +567,7 @@ class BatchResultStrategy:
         on_exhausted = OnExhaustedPolicy.RETURN_LAST
         if ctx.agent_config:
             retry_config = ctx.agent_config.get("retry") or {}
-            on_exhausted = OnExhaustedPolicy(retry_config.get("on_exhausted", "return_last"))
+            on_exhausted = OnExhaustedPolicy(retry_config.get("on_exhausted") or "return_last")
 
         recovery_meta = ctx.exhausted_recovery[custom_id]
         if recovery_meta.retry is None:

--- a/agent_actions/processing/recovery/reprompt.py
+++ b/agent_actions/processing/recovery/reprompt.py
@@ -104,8 +104,8 @@ def parse_reprompt_config(reprompt_config: dict | None) -> ParsedRepromptConfig 
         return None
     return ParsedRepromptConfig(
         validation_name=validation_name,
-        max_attempts=reprompt_config.get("max_attempts", 2),
-        on_exhausted=reprompt_config.get("on_exhausted", "return_last"),
+        max_attempts=reprompt_config.get("max_attempts") or 2,
+        on_exhausted=reprompt_config.get("on_exhausted") or "return_last",
     )
 
 
@@ -397,12 +397,12 @@ def create_reprompt_service_from_config(
             # other config settings (max_attempts, on_exhausted) if present.
             cfg = reprompt_config or {}
             return RepromptService(
-                max_attempts=cfg.get("max_attempts", 2),
-                on_exhausted=cfg.get("on_exhausted", "return_last"),
+                max_attempts=cfg.get("max_attempts") or 2,
+                on_exhausted=cfg.get("on_exhausted") or "return_last",
                 validator=validator,
                 strategies=strategies,
                 critique_fn=critique_fn,
-                critique_after_attempt=cfg.get("critique_after_attempt", 2),
+                critique_after_attempt=cfg.get("critique_after_attempt") or 2,
             )
         if reprompt_config:
             raise ValueError(
@@ -419,5 +419,5 @@ def create_reprompt_service_from_config(
         validator=validator,
         strategies=strategies,
         critique_fn=critique_fn,
-        critique_after_attempt=(reprompt_config or {}).get("critique_after_attempt", 2),
+        critique_after_attempt=(reprompt_config or {}).get("critique_after_attempt") or 2,
     )

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -903,7 +903,7 @@ class ResultCollector:
         if not exhausted_results:
             return
 
-        retry_config = agent_config.get("retry", {})
+        retry_config = agent_config.get("retry") or {}
         on_exhausted = retry_config.get("on_exhausted", "return_last")
 
         if on_exhausted != "raise":

--- a/agent_actions/processing/result_collector.py
+++ b/agent_actions/processing/result_collector.py
@@ -904,7 +904,7 @@ class ResultCollector:
             return
 
         retry_config = agent_config.get("retry") or {}
-        on_exhausted = retry_config.get("on_exhausted", "return_last")
+        on_exhausted = retry_config.get("on_exhausted") or "return_last"
 
         if on_exhausted != "raise":
             logger.info(

--- a/tests/unit/llm/batch/test_batch_exhausted_retry_null.py
+++ b/tests/unit/llm/batch/test_batch_exhausted_retry_null.py
@@ -1,0 +1,61 @@
+"""Regression test for VIOL-0031 — sibling fix in the batch path.
+
+`BatchResultStrategy._build_exhausted_passthrough` previously crashed
+with ``AttributeError`` when ``agent_config["retry"]`` was explicitly
+``None`` (a bare ``retry:`` YAML key). The two-line
+``.get("retry", {}).get("on_exhausted", ...)`` sequence mirrors the
+online path fixed in ``processing/result_collector.py`` and shares the
+same root cause: ``.get("retry", {})`` does not substitute the default
+when the key is present-but-None.
+"""
+
+from __future__ import annotations
+
+from agent_actions.llm.batch.processing.batch_result_strategy import (
+    BatchProcessingContext,
+    BatchResultStrategy,
+)
+from agent_actions.processing.types import (
+    ProcessingStatus,
+    RecoveryMetadata,
+    RetryMetadata,
+)
+
+
+def _make_recovery(custom_id: str) -> dict[str, RecoveryMetadata]:
+    return {
+        custom_id: RecoveryMetadata(
+            retry=RetryMetadata(
+                attempts=2,
+                failures=2,
+                succeeded=False,
+                reason="api_error",
+            )
+        )
+    }
+
+
+def test_build_exhausted_passthrough_tolerates_retry_explicitly_none():
+    """``agent_config={"retry": None}`` must default to RETURN_LAST."""
+    custom_id = "rec_uat_0031"
+    ctx = BatchProcessingContext(
+        batch_results=[],
+        context_map={},
+        output_directory=None,
+        agent_config={"retry": None},
+        exhausted_recovery=_make_recovery(custom_id),
+    )
+    strategy = BatchResultStrategy()
+
+    result = strategy._build_exhausted_passthrough(
+        ctx,
+        custom_id=custom_id,
+        original_row={"value": "x"},
+        action_name="always_fail",
+        source_guid="sg-uat-0031",
+        record_index=0,
+    )
+
+    assert result.status is ProcessingStatus.EXHAUSTED
+    assert result.source_guid == "sg-uat-0031"
+    assert result.data, "exhausted tombstone item should be attached"

--- a/tests/unit/llm/batch/test_batch_exhausted_retry_null.py
+++ b/tests/unit/llm/batch/test_batch_exhausted_retry_null.py
@@ -1,16 +1,19 @@
-"""Regression test for VIOL-0031 — sibling fix in the batch path.
+"""Regression tests for VIOL-0031 — sibling fix in the batch path.
 
-`BatchResultStrategy._build_exhausted_passthrough` previously crashed
-with ``AttributeError`` when ``agent_config["retry"]`` was explicitly
-``None`` (a bare ``retry:`` YAML key). The two-line
-``.get("retry", {}).get("on_exhausted", ...)`` sequence mirrors the
-online path fixed in ``processing/result_collector.py`` and shares the
-same root cause: ``.get("retry", {})`` does not substitute the default
-when the key is present-but-None.
+``BatchResultStrategy._build_exhausted_passthrough`` mirrors the
+online-path bug fixed in ``processing/result_collector.py``:
+``ctx.agent_config.get("retry", {}).get("on_exhausted", "return_last")``
+crashed when either ``retry:`` or ``on_exhausted:`` was a bare YAML key
+(parsed as ``None``). The batch path is strictly less tolerant than the
+online path — ``OnExhaustedPolicy(None)`` raises ``ValueError`` (the
+enum has only ``RETURN_LAST`` and ``RAISE``), so a bare
+``on_exhausted:`` blows up the batch result pass before any exhausted
+tombstone reaches storage. Both levels are coalesced with ``or``.
 """
 
-from __future__ import annotations
+import pytest
 
+from agent_actions.llm.batch.core.batch_constants import OnExhaustedPolicy
 from agent_actions.llm.batch.processing.batch_result_strategy import (
     BatchProcessingContext,
     BatchResultStrategy,
@@ -35,14 +38,25 @@ def _make_recovery(custom_id: str) -> dict[str, RecoveryMetadata]:
     }
 
 
-def test_build_exhausted_passthrough_tolerates_retry_explicitly_none():
-    """``agent_config={"retry": None}`` must default to RETURN_LAST."""
+@pytest.mark.parametrize(
+    "agent_config",
+    [
+        pytest.param({"retry": None}, id="retry-explicitly-none"),
+        pytest.param({"retry": {"on_exhausted": None}}, id="on-exhausted-explicitly-none"),
+        pytest.param({}, id="retry-key-missing"),
+    ],
+)
+def test_build_exhausted_passthrough_coalesces_null_yaml_values(agent_config):
+    """Bare YAML keys (``retry:`` and ``on_exhausted:``) both parse as
+    ``None`` and previously crashed on the next ``.get(...)`` call. The
+    function must default to ``RETURN_LAST`` and produce an
+    ``EXHAUSTED`` tombstone the caller can route to storage."""
     custom_id = "rec_uat_0031"
     ctx = BatchProcessingContext(
         batch_results=[],
         context_map={},
         output_directory=None,
-        agent_config={"retry": None},
+        agent_config=agent_config,
         exhausted_recovery=_make_recovery(custom_id),
     )
     strategy = BatchResultStrategy()
@@ -56,6 +70,34 @@ def test_build_exhausted_passthrough_tolerates_retry_explicitly_none():
         record_index=0,
     )
 
+    # Shape assertion (not just truthiness): a tombstone item must be
+    # attached and carry the source_guid so the disposition writer can
+    # route it.
     assert result.status is ProcessingStatus.EXHAUSTED
     assert result.source_guid == "sg-uat-0031"
-    assert result.data, "exhausted tombstone item should be attached"
+    assert len(result.data) == 1
+    assert result.data[0].get("source_guid") == "sg-uat-0031"
+
+
+def test_build_exhausted_passthrough_raise_still_honored():
+    """``on_exhausted=raise`` must still raise — the coalesce must not
+    mask the explicit raise policy."""
+    custom_id = "rec_uat_0031_raise"
+    ctx = BatchProcessingContext(
+        batch_results=[],
+        context_map={},
+        output_directory=None,
+        agent_config={"retry": {"on_exhausted": OnExhaustedPolicy.RAISE.value}},
+        exhausted_recovery=_make_recovery(custom_id),
+    )
+    strategy = BatchResultStrategy()
+
+    with pytest.raises(RuntimeError, match="Retry exhausted"):
+        strategy._build_exhausted_passthrough(
+            ctx,
+            custom_id=custom_id,
+            original_row={"value": "x"},
+            action_name="always_fail",
+            source_guid="sg-uat-0031",
+            record_index=0,
+        )

--- a/tests/unit/processing/test_reprompt_null_yaml_values.py
+++ b/tests/unit/processing/test_reprompt_null_yaml_values.py
@@ -1,0 +1,111 @@
+"""Regression tests for the reprompt sibling of VIOL-0031.
+
+``parse_reprompt_config`` and ``create_reprompt_service_from_config`` used
+the same ``.get("key", default)`` antipattern as the retry path. With a
+bare YAML key like ``max_attempts:`` or ``on_exhausted:`` (which parses
+to ``None``), the default substitution was skipped and ``None`` flowed
+into:
+
+- ``ParsedRepromptConfig.on_exhausted`` — downstream
+  ``OnExhaustedPolicy(None)`` raised ``ValueError`` in the batch retry
+  service (``llm/batch/services/processing.py``).
+- ``RepromptService.__init__`` validation — ``_validate_exhausted_option``
+  rejected ``None`` with ``ValueError("on_exhausted must be one of ...")``.
+- ``RepromptService`` numeric inits — ``max_attempts < 1`` check
+  raised ``TypeError`` for ``None < 1``.
+
+All three call sites now coalesce with ``or <default>`` so the
+documented defaults survive a bare YAML key.
+"""
+
+import pytest
+
+from agent_actions.processing.recovery.reprompt import (
+    ParsedRepromptConfig,
+    create_reprompt_service_from_config,
+    parse_reprompt_config,
+)
+
+
+@pytest.mark.parametrize(
+    "reprompt_config,expected",
+    [
+        pytest.param(
+            {"validation": "check_fn", "max_attempts": None, "on_exhausted": None},
+            ParsedRepromptConfig(
+                validation_name="check_fn", max_attempts=2, on_exhausted="return_last"
+            ),
+            id="both-null",
+        ),
+        pytest.param(
+            {"validation": "check_fn", "max_attempts": None},
+            ParsedRepromptConfig(
+                validation_name="check_fn", max_attempts=2, on_exhausted="return_last"
+            ),
+            id="max-attempts-null",
+        ),
+        pytest.param(
+            {"validation": "check_fn", "on_exhausted": None},
+            ParsedRepromptConfig(
+                validation_name="check_fn", max_attempts=2, on_exhausted="return_last"
+            ),
+            id="on-exhausted-null",
+        ),
+        pytest.param(
+            {"validation": "check_fn", "max_attempts": 5, "on_exhausted": "raise"},
+            ParsedRepromptConfig(validation_name="check_fn", max_attempts=5, on_exhausted="raise"),
+            id="explicit-values-preserved",
+        ),
+    ],
+)
+def test_parse_reprompt_config_coalesces_null_values(reprompt_config, expected):
+    """Bare YAML keys (parsed as ``None``) must default to the documented
+    values rather than propagating ``None`` into ``ParsedRepromptConfig``."""
+    assert parse_reprompt_config(reprompt_config) == expected
+
+
+class _AcceptAllValidator:
+    """Minimal validator stub for the no-``validation``-key branch."""
+
+    name = "accept_all"
+
+    def validate(self, response, **_):
+        return True, ""
+
+
+@pytest.mark.parametrize(
+    "reprompt_config",
+    [
+        pytest.param(
+            {"max_attempts": None, "on_exhausted": None, "critique_after_attempt": None},
+            id="all-three-null",
+        ),
+        pytest.param({"max_attempts": None}, id="max-attempts-null-only"),
+        pytest.param({"on_exhausted": None}, id="on-exhausted-null-only"),
+        pytest.param({"critique_after_attempt": None}, id="critique-after-attempt-null-only"),
+    ],
+)
+def test_create_reprompt_service_validator_branch_coalesces_null_values(reprompt_config):
+    """``create_reprompt_service_from_config`` with an external validator
+    and bare YAML keys must produce a usable ``RepromptService`` instead
+    of raising on ``None < 1`` (max_attempts), ``OnExhaustedPolicy(None)``
+    (on_exhausted), or other ``None``-propagation crashes."""
+    service = create_reprompt_service_from_config(
+        reprompt_config,
+        validator=_AcceptAllValidator(),
+    )
+    assert service is not None
+    assert service.max_attempts == 2
+    assert service.on_exhausted == "return_last"
+
+
+def test_create_reprompt_service_validation_branch_coalesces_critique_null():
+    """The post-``parse_reprompt_config`` ``RepromptService`` constructor
+    also reads ``critique_after_attempt`` — a bare YAML key here must
+    default to ``2`` rather than propagating ``None``."""
+    service = create_reprompt_service_from_config(
+        {"validation": "check_fn", "critique_after_attempt": None},
+        validator=_AcceptAllValidator(),
+    )
+    assert service is not None
+    assert service._critique_after_attempt == 2

--- a/tests/unit/processing/test_result_collector_exhausted.py
+++ b/tests/unit/processing/test_result_collector_exhausted.py
@@ -1,0 +1,75 @@
+"""Regression test for VIOL-0031.
+
+`_handle_exhausted_policy` crashed with ``AttributeError`` when
+``agent_config["retry"]`` was explicitly ``None`` (the YAML shape
+produced by a bare ``retry:`` key with no body), because
+``.get("retry", {})`` only substitutes the default when the key is
+missing — not when it is present-but-None.
+
+The fix coalesces a present-but-None retry block to an empty dict
+so the documented ``on_exhausted=return_last`` default is applied
+and the ``exhausted`` tombstone reaches the disposition table.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.processing.result_collector import ResultCollector
+from agent_actions.processing.types import ProcessingResult
+
+
+def _exhausted_result() -> ProcessingResult:
+    """Smallest result that exercises the exhausted branch."""
+    return ProcessingResult.exhausted(
+        error="forced failure for regression test",
+        source_guid="sg-uat-0031",
+        input_record={"value": "x"},
+    )
+
+
+def test_handle_exhausted_policy_tolerates_retry_explicitly_none():
+    """``agent_config={"retry": None}`` must default to ``return_last``.
+
+    Before VIOL-0031, this raised ``AttributeError: 'NoneType' object has
+    no attribute 'get'`` at ``result_collector.py:907`` and the
+    ``exhausted`` tombstone never reached the disposition table.
+    """
+    with patch("agent_actions.processing.result_collector.logger") as mock_logger:
+        ResultCollector._handle_exhausted_policy(
+            results=[_exhausted_result()],
+            agent_config={"retry": None},
+            agent_name="always_fail",
+            storage_backend=None,
+        )
+
+    assert mock_logger.info.called, "expected INFO log from return_last policy"
+    assert not mock_logger.warning.called, "raise-path warning must not fire for the default policy"
+
+
+def test_handle_exhausted_policy_tolerates_retry_key_missing():
+    """``agent_config`` without a ``retry`` key continues to work."""
+    with patch("agent_actions.processing.result_collector.logger") as mock_logger:
+        ResultCollector._handle_exhausted_policy(
+            results=[_exhausted_result()],
+            agent_config={},
+            agent_name="always_fail",
+            storage_backend=None,
+        )
+    assert mock_logger.info.called
+
+
+def test_handle_exhausted_policy_raise_still_honored():
+    """A real ``on_exhausted=raise`` must still raise — the guard
+    must not mask the raise policy."""
+    from agent_actions.errors import AgentActionsError
+
+    with pytest.raises(AgentActionsError):
+        ResultCollector._handle_exhausted_policy(
+            results=[_exhausted_result()],
+            agent_config={"retry": {"on_exhausted": "raise"}},
+            agent_name="always_fail",
+            storage_backend=None,
+        )

--- a/tests/unit/processing/test_result_collector_exhausted.py
+++ b/tests/unit/processing/test_result_collector_exhausted.py
@@ -1,22 +1,23 @@
-"""Regression test for VIOL-0031.
+"""Regression tests for VIOL-0031.
 
-`_handle_exhausted_policy` crashed with ``AttributeError`` when
-``agent_config["retry"]`` was explicitly ``None`` (the YAML shape
-produced by a bare ``retry:`` key with no body), because
-``.get("retry", {})`` only substitutes the default when the key is
-missing — not when it is present-but-None.
+`_handle_exhausted_policy` previously crashed with ``AttributeError`` when
+``agent_config["retry"]`` was explicitly ``None`` (the YAML shape produced
+by a bare ``retry:`` key with no body): ``.get("retry", {})`` only
+substitutes the default when the key is missing, not when it is
+present-but-None. The same antipattern lived one level deeper at
+``retry_config.get("on_exhausted", "return_last")``, where a bare
+``on_exhausted:`` (``None``) similarly bypassed the default.
 
-The fix coalesces a present-but-None retry block to an empty dict
-so the documented ``on_exhausted=return_last`` default is applied
-and the ``exhausted`` tombstone reaches the disposition table.
+The fix coalesces both with ``or`` so the documented
+``on_exhausted=return_last`` default is applied and the ``exhausted``
+tombstone reaches storage.
 """
-
-from __future__ import annotations
 
 from unittest.mock import patch
 
 import pytest
 
+from agent_actions.errors import AgentActionsError
 from agent_actions.processing.result_collector import ResultCollector
 from agent_actions.processing.types import ProcessingResult
 
@@ -30,42 +31,49 @@ def _exhausted_result() -> ProcessingResult:
     )
 
 
-def test_handle_exhausted_policy_tolerates_retry_explicitly_none():
-    """``agent_config={"retry": None}`` must default to ``return_last``.
+@pytest.mark.parametrize(
+    "agent_config,expected_policy_in_log",
+    [
+        pytest.param({"retry": None}, "return_last", id="retry-explicitly-none"),
+        pytest.param(
+            {"retry": {"on_exhausted": None}}, "return_last", id="on-exhausted-explicitly-none"
+        ),
+        pytest.param({"retry": {}}, "return_last", id="retry-empty-dict"),
+    ],
+)
+def test_handle_exhausted_policy_coalesces_null_yaml_values(agent_config, expected_policy_in_log):
+    """Bare YAML keys produce ``None``; both levels must coalesce to the
+    documented ``return_last`` default rather than crashing or logging
+    ``on_exhausted=None``.
 
-    Before VIOL-0031, this raised ``AttributeError: 'NoneType' object has
-    no attribute 'get'`` at ``result_collector.py:907`` and the
-    ``exhausted`` tombstone never reached the disposition table.
+    Before VIOL-0031 the outer level (``retry: None``) raised
+    ``AttributeError`` at ``result_collector.py:907``. Code review of the
+    fix surfaced the same antipattern one level deeper, where
+    ``on_exhausted: None`` silently logged ``on_exhausted=None`` instead
+    of applying the default — fixed in the same PR.
     """
     with patch("agent_actions.processing.result_collector.logger") as mock_logger:
         ResultCollector._handle_exhausted_policy(
             results=[_exhausted_result()],
-            agent_config={"retry": None},
+            agent_config=agent_config,
             agent_name="always_fail",
             storage_backend=None,
         )
 
-    assert mock_logger.info.called, "expected INFO log from return_last policy"
-    assert not mock_logger.warning.called, "raise-path warning must not fire for the default policy"
-
-
-def test_handle_exhausted_policy_tolerates_retry_key_missing():
-    """``agent_config`` without a ``retry`` key continues to work."""
-    with patch("agent_actions.processing.result_collector.logger") as mock_logger:
-        ResultCollector._handle_exhausted_policy(
-            results=[_exhausted_result()],
-            agent_config={},
-            agent_name="always_fail",
-            storage_backend=None,
-        )
-    assert mock_logger.info.called
+    # The return_last branch logs exactly one INFO carrying the resolved
+    # policy. Pinning the format string and the policy substitution catches
+    # both the AttributeError regression and the misleading-None-log
+    # regression in one assertion.
+    mock_logger.info.assert_called_once()
+    call_args = mock_logger.info.call_args.args
+    fmt, *substitutions = call_args
+    assert "%s" in fmt
+    assert expected_policy_in_log in substitutions
 
 
 def test_handle_exhausted_policy_raise_still_honored():
-    """A real ``on_exhausted=raise`` must still raise — the guard
+    """A real ``on_exhausted=raise`` must still raise — the ``or`` coalesce
     must not mask the raise policy."""
-    from agent_actions.errors import AgentActionsError
-
     with pytest.raises(AgentActionsError):
         ResultCollector._handle_exhausted_policy(
             results=[_exhausted_result()],


### PR DESCRIPTION
## Summary

UAT plan **T1-01** / **VIOL-0031**. `agent_config.get(\"retry\", {})` does
not substitute the default when the `retry` key is present but set to
`None` — the YAML shape produced by a bare `retry:` declaration with no
body. Two sites then called `.get(\"on_exhausted\", ...)` on the
resulting `None` and crashed with `AttributeError: 'NoneType' object has
no attribute 'get'`, which destroyed the `exhausted` tombstone before it
could reach SQLite. The end-user-visible effect was the `exhausted`
`RecordState` being silently undocumentable in the disposition table.

Sibling-grep across `agent_actions/` surfaced the same pattern in the
batch result path; both are fixed in this PR to keep the online and
batch exhausted paths in lockstep.

## Changes

- `agent_actions/processing/result_collector.py:906` — coalesce
  `agent_config.get(\"retry\") or {}` so the `return_last` default
  applies when `retry` is missing or explicitly `None`.
- `agent_actions/llm/batch/processing/batch_result_strategy.py:569` —
  same fix in `BatchResultStrategy._build_exhausted_passthrough`.
- `tests/unit/processing/test_result_collector_exhausted.py` — 3
  regression tests (retry=None, retry key absent, on_exhausted=raise
  still raises).
- `tests/unit/llm/batch/test_batch_exhausted_retry_null.py` — batch-side
  regression for the sibling fix.

## Verification

- `pytest tests/unit/processing/test_result_collector_exhausted.py tests/unit/llm/batch/test_batch_exhausted_retry_null.py -v` → 4 passed.
- `pytest tests/unit/processing/ tests/unit/llm/batch/` → 592 passed.
- `pytest -q` → 7651 passed.
- `ruff format --check` + `ruff check` on touched files and owned roots → clean.

## Spec reference

[`specs/active/uat-audit/violations/VIOL-0031-retry-config-null-check.md`](../specs/active/uat-audit/violations/VIOL-0031-retry-config-null-check.md)