### PR TITLE
fix(VIOL-0035): register LSP trigger characters via @server.feature options

### DIFF
--- a/agent_actions/tooling/lsp/server.py
+++ b/agent_actions/tooling/lsp/server.py
@@ -107,6 +107,10 @@ def initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
                 server.project_indexes[fallback_root] = server.index
                 logger.info("Indexed project at %s", fallback_root)
 
+    # pygls discards the return value of user-supplied initialize handlers and
+    # rebuilds capabilities from `fm.feature_options`. Trigger characters live on
+    # the `@server.feature(...)` decorators below — completion + signature help.
+    # The remaining fields here are advisory and dropped on the wire.
     return lsp.InitializeResult(
         capabilities=lsp.ServerCapabilities(
             text_document_sync=lsp.TextDocumentSyncOptions(
@@ -116,13 +120,6 @@ def initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
             ),
             definition_provider=True,
             hover_provider=True,
-            completion_provider=lsp.CompletionOptions(
-                trigger_characters=["$", ":", ".", "-"],
-                resolve_provider=False,
-            ),
-            signature_help_provider=lsp.SignatureHelpOptions(
-                trigger_characters=[":"],
-            ),
             document_symbol_provider=True,
             document_highlight_provider=True,
             code_lens_provider=lsp.CodeLensOptions(resolve_provider=False),
@@ -216,7 +213,13 @@ def hover(params: lsp.HoverParams) -> lsp.Hover | None:
     )
 
 
-@server.feature(lsp.TEXT_DOCUMENT_COMPLETION)
+@server.feature(
+    lsp.TEXT_DOCUMENT_COMPLETION,
+    lsp.CompletionOptions(
+        trigger_characters=["$", ":", ".", "-"],
+        resolve_provider=False,
+    ),
+)
 def completions(params: lsp.CompletionParams) -> lsp.CompletionList:
     """Handle completion request."""
     current_file = uri_to_path(params.text_document.uri)
@@ -528,7 +531,10 @@ def code_lens(params: lsp.CodeLensParams) -> list[lsp.CodeLens]:
     return lenses
 
 
-@server.feature(lsp.TEXT_DOCUMENT_SIGNATURE_HELP)
+@server.feature(
+    lsp.TEXT_DOCUMENT_SIGNATURE_HELP,
+    lsp.SignatureHelpOptions(trigger_characters=[":"]),
+)
 def signature_help(params: lsp.SignatureHelpParams) -> lsp.SignatureHelp | None:
     """Provide signature help for guard/reprompt conditions."""
     current_file = uri_to_path(params.text_document.uri)

--- a/agent_actions/tooling/lsp/server.py
+++ b/agent_actions/tooling/lsp/server.py
@@ -107,10 +107,9 @@ def initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
                 server.project_indexes[fallback_root] = server.index
                 logger.info("Indexed project at %s", fallback_root)
 
-    # pygls discards the return value of user-supplied initialize handlers and
-    # rebuilds capabilities from `fm.feature_options`. Trigger characters live on
-    # the `@server.feature(...)` decorators below — completion + signature help.
-    # The remaining fields here are advisory and dropped on the wire.
+    # pygls discards this return value and rebuilds capabilities from
+    # `fm.feature_options`; the trigger-bearing options live on the
+    # `@server.feature(...)` decorators below.
     return lsp.InitializeResult(
         capabilities=lsp.ServerCapabilities(
             text_document_sync=lsp.TextDocumentSyncOptions(

--- a/tests/tooling/lsp/test_feature_options.py
+++ b/tests/tooling/lsp/test_feature_options.py
@@ -1,13 +1,5 @@
-"""Regression tests for VIOL-0035.
-
-The LSP must advertise non-empty ``trigger_characters`` on both
-``completionProvider`` and ``signatureHelpProvider`` in the
-``InitializeResult.capabilities`` returned to the client. Today the
-``@server.feature(...)`` decorators are called without ``options=``, so
-pygls registers default ``CompletionOptions()`` / ``SignatureHelpOptions()``
-with empty trigger lists and the ``InitializeResult.capabilities`` that
-reaches the IDE has no triggers — auto-completion never fires on member
-access in guard conditions.
+"""The LSP must advertise non-empty ``trigger_characters`` on both
+``completionProvider`` and ``signatureHelpProvider``.
 
 pygls discards the return value of any user-supplied ``initialize``
 handler and rebuilds capabilities from ``fm.feature_options`` (see

--- a/tests/tooling/lsp/test_feature_options.py
+++ b/tests/tooling/lsp/test_feature_options.py
@@ -1,0 +1,61 @@
+"""Regression tests for VIOL-0035.
+
+The LSP must advertise non-empty ``trigger_characters`` on both
+``completionProvider`` and ``signatureHelpProvider`` in the
+``InitializeResult.capabilities`` returned to the client. Today the
+``@server.feature(...)`` decorators are called without ``options=``, so
+pygls registers default ``CompletionOptions()`` / ``SignatureHelpOptions()``
+with empty trigger lists and the ``InitializeResult.capabilities`` that
+reaches the IDE has no triggers — auto-completion never fires on member
+access in guard conditions.
+
+pygls discards the return value of any user-supplied ``initialize``
+handler and rebuilds capabilities from ``fm.feature_options`` (see
+``pygls/protocol/language_server.py::lsp_initialize`` and
+``pygls/capabilities.py::ServerCapabilitiesBuilder``). Asserting on
+``fm.feature_options`` is therefore equivalent to asserting on the wire
+payload.
+"""
+
+from __future__ import annotations
+
+from lsprotocol import types as lsp
+
+from agent_actions.tooling.lsp.server import server
+
+
+def _options_for(method: str):
+    return server.protocol.fm.feature_options.get(method)
+
+
+def test_completion_provider_advertises_trigger_characters() -> None:
+    opts = _options_for(lsp.TEXT_DOCUMENT_COMPLETION)
+    assert opts is not None, (
+        "No options registered for textDocument/completion — pygls will "
+        "build InitializeResult with default empty trigger_characters."
+    )
+    assert isinstance(opts, lsp.CompletionOptions)
+    assert opts.trigger_characters, (
+        "completionProvider.trigger_characters is empty; IDE auto-trigger "
+        "will never fire on member access."
+    )
+    assert "." in opts.trigger_characters
+    # Preserve the wider set the manual InitializeResult was advertising.
+    for ch in ("$", ":", "-"):
+        assert ch in opts.trigger_characters, (
+            f"completion trigger char {ch!r} dropped from advertised set."
+        )
+
+
+def test_signature_help_provider_advertises_trigger_characters() -> None:
+    opts = _options_for(lsp.TEXT_DOCUMENT_SIGNATURE_HELP)
+    assert opts is not None, (
+        "No options registered for textDocument/signatureHelp — pygls will "
+        "build InitializeResult with default empty trigger_characters."
+    )
+    assert isinstance(opts, lsp.SignatureHelpOptions)
+    assert opts.trigger_characters, (
+        "signatureHelpProvider.trigger_characters is empty; signature help "
+        "will never pop up automatically."
+    )
+    assert ":" in opts.trigger_characters


### PR DESCRIPTION
## Summary

The agac LSP advertised `completionProvider.triggerCharacters` and `signatureHelpProvider.triggerCharacters` only on the manually-built `InitializeResult` returned from the custom `initialize` handler. pygls's `lsp_initialize` discards the user handler's return value and rebuilds capabilities from `fm.feature_options`:

- `pygls/protocol/language_server.py::lsp_initialize` — yields to the user handler for side effects, then builds its own `InitializeResult` from `ServerCapabilitiesBuilder`.
- `pygls/capabilities.py::ServerCapabilitiesBuilder._with_completion` / `_with_signature_help` — fall back to default empty-trigger options when no `options=` is registered.

Result: the client received `triggerCharacters: []` for both providers, and IDE auto-trigger never fired on `.` (completion) or `:` (signature help).

Fix: pass `CompletionOptions(...)` and `SignatureHelpOptions(...)` to the matching `@server.feature(...)` decorators with the exact trigger sets the manual `InitializeResult` was trying to advertise (`["$", ":", ".", "-"]` for completion, `[":"]` for signature help). Drop the now-redundant `completion_provider=` and `signature_help_provider=` from the manual `InitializeResult` so there is a single source of truth.

A short comment on the `initialize` handler flags the rest of the manual `InitializeResult` as advisory — pygls rebuilds it. Fixing those wider fields is out of scope for this ticket.

## Verification

- `pytest tests/tooling/lsp/test_feature_options.py -v` — 2 passed (failed before the fix)
- `pytest tests/tooling/lsp/ tests/unit/tooling/` — 159 passed
- Full `pytest` — 7649 passed
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- Live inspection: `server.protocol.fm.feature_options['textDocument/completion'].trigger_characters == ['$', ':', '.', '-']` and `[':'`] for signature help.

New test:
- `tests/tooling/lsp/test_feature_options.py` — asserts on `fm.feature_options`, which is the exact object pygls's `ServerCapabilitiesBuilder` consumes to populate the wire payload.

## Scope notes

- The wider InitializeResult dead-code (text_document_sync save options, semantic_tokens legend, code_lens resolve_provider) is also discarded by pygls but is out of scope for VIOL-0035. Logged for a separate ticket.
- No protocol change. No new dependencies. pygls pinned in `pyproject.toml`.