### PR TITLE
docs(VIOL-0050): purge file-based-arch references from data-io docs

### DIFF
--- a/docs.agent-actions/docs/guides/troubleshooting.md
+++ b/docs.agent-actions/docs/guides/troubleshooting.md
@@ -5,6 +5,8 @@ sidebar_position: 10
 
 # Troubleshooting
 
+> **Storage backend:** SQLite as of v0.2.6. File paths under `agent_io/target/.../data.json` in older snippets are stale; this page uses the current SQLite layout (`agent_io/store/<workflow>.db`, table `target_data`).
+
 What happens when something goes wrong in your agentic workflow? This guide helps you debug and fix common errors. Let's explore the error types, their causes, and how to resolve them.
 
 ## Error Types
@@ -347,23 +349,37 @@ Extract key information from the error message. Agent Actions provides structure
 
 ### Step 2: Find the Source Record
 
-Use `source_guid` to trace the record:
+Use `source_guid` to trace the record. Each action's output is a JSON array stored in the `data` column of the `target_data` table, keyed by `action_name`. Use `json_each(data)` to scan records and `json_extract` to filter by `source_guid`:
 
 ```bash
-# Find record in node outputs
-grep -r "37812c37-80a2-596b-8747-8f93e7a34e7f" agent_io/target/
+# Find every action that produced a record with this source_guid
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT DISTINCT t.action_name
+  FROM target_data t, json_each(t.data) r
+  WHERE json_extract(r.value, '\$.source_guid') = '37812c37-80a2-596b-8747-8f93e7a34e7f'
+"
 ```
 
 ### Step 3: Check Node Outputs
 
-Compare data at each stage:
+Compare data at each stage. Filter the JSON blob in the `data` column by `source_guid` to inspect the same record at each step:
 
 ```bash
-# Input to failing node
-cat agent_io/target/node_6_*/data.json | head -100
+# Input to failing action — fetch the matching record
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT json_extract(r.value, '\$')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name = '<failing_action>'
+    AND json_extract(r.value, '\$.source_guid') = '37812c37-80a2-596b-8747-8f93e7a34e7f'
+"
 
-# Previous node output
-cat agent_io/target/node_5_*/data.json | head -100
+# Previous action's output for the same record
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT json_extract(r.value, '\$')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name = '<previous_action>'
+    AND json_extract(r.value, '\$.source_guid') = '37812c37-80a2-596b-8747-8f93e7a34e7f'
+"
 ```
 
 ### Step 4: Enable Debug Mode
@@ -422,18 +438,26 @@ node_1_361c54c6-..._0        # Flattened, index 0
 node_1_361c54c6-..._1        # Flattened, index 1
 ```
 
-### Node Output Structure
+### Action Output Storage
+
+Action outputs are stored as JSON arrays in the `target_data` table of `agent_io/store/<workflow>.db`, keyed by `(action_name, relative_path)`. List what each action produced:
+
+```bash
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT action_name, relative_path, record_count
+  FROM target_data
+  ORDER BY action_name, relative_path
+"
+```
+
+Typical layout for a multi-action workflow:
 
 ```
-agent_io/target/
-├── node_0_extract_raw_qa/
-│   └── data.json
-├── node_1_flatten_questions/
-│   └── data.json
-├── node_2_classify_type/
-│   └── data.json
-└── final_workflow_output/
-    └── data.json
+target_data
+├── action_name='node_0_extract_raw_qa'      relative_path='input.json'  record_count=42
+├── action_name='node_1_flatten_questions'   relative_path='input.json'  record_count=128
+├── action_name='node_2_classify_type'       relative_path='input.json'  record_count=128
+└── action_name='final_workflow_output'      relative_path='input.json'  record_count=128
 ```
 
 ## TypedDict Best Practices

--- a/docs.agent-actions/docs/reference/data-io/data-lineage.md
+++ b/docs.agent-actions/docs/reference/data-io/data-lineage.md
@@ -5,6 +5,8 @@ sidebar_position: 4
 
 # Data Lineage
 
+> **Storage backend:** SQLite as of v0.2.6. File paths under `agent_io/target/.../data.json` in older snippets are stale; this page uses the current SQLite layout (`agent_io/store/<workflow>.db`, table `target_data`, where each row's `data` column is a JSON array of records).
+
 How does Agent Actions track data as it flows through parallel branches, merges, and splits? The **Ancestry Chain** provides complete lineage tracking that enables complex workflow patterns like Diamond, Map-Reduce, and Ensemble voting.
 
 ## Overview
@@ -223,8 +225,16 @@ When loading historical data, Agent Actions uses this priority:
 ### Inspect Record Ancestry
 
 ```bash
-jq '.[0] | {source_guid, target_id, parent_target_id, root_target_id, lineage}' \
-  agent_io/target/merge/data.json
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT json_extract(r.value, '\$.source_guid'),
+         json_extract(r.value, '\$.target_id'),
+         json_extract(r.value, '\$.parent_target_id'),
+         json_extract(r.value, '\$.root_target_id'),
+         json_extract(r.value, '\$.lineage')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name = 'merge'
+  LIMIT 1
+"
 ```
 
 ### Verify Sibling Relationships
@@ -232,10 +242,12 @@ jq '.[0] | {source_guid, target_id, parent_target_id, root_target_id, lineage}' 
 Check that parallel branches share the same parent:
 
 ```bash
-# All three should have the same parent_target_id
-jq '.[].parent_target_id' agent_io/target/branch_a/*.json
-jq '.[].parent_target_id' agent_io/target/branch_b/*.json
-jq '.[].parent_target_id' agent_io/target/branch_c/*.json
+# All three should return the same parent_target_id
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT t.action_name, json_extract(r.value, '\$.parent_target_id')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name IN ('branch_a', 'branch_b', 'branch_c')
+"
 ```
 
 ### Trace Root Ancestry
@@ -243,7 +255,11 @@ jq '.[].parent_target_id' agent_io/target/branch_c/*.json
 For Map-Reduce, verify all chunks trace back to the same root:
 
 ```bash
-jq '.[].root_target_id' agent_io/target/process_chunk/*.json | sort -u
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT DISTINCT json_extract(r.value, '\$.root_target_id')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name = 'process_chunk'
+"
 # Should output exactly one UUID
 ```
 

--- a/docs.agent-actions/docs/reference/data-io/index.md
+++ b/docs.agent-actions/docs/reference/data-io/index.md
@@ -5,9 +5,11 @@ sidebar_position: 1
 
 # Data I/O
 
-Every agentic workflow needs data to flow in, through, and out. Agent Actions uses a standardized directory structure that makes this flow predictable and traceable.
+> **Storage backend:** SQLite as of v0.2.6. All source and target records live in a single SQLite database per workflow at `agent_io/store/<workflow>.db`. Older snippets that reference `agent_io/source/` and `agent_io/target/` directories are stale — only `agent_io/staging/` remains as on-disk JSON.
 
-Think of it like a factory floor: raw materials enter through one door (`staging/`), get registered for tracking (`source/`), move through workstations (actions), and finished products exit through another (`target/`). The directory structure enforces this separation, making it easy to inspect what went in and what came out.
+Every agentic workflow needs data to flow in, through, and out. Agent Actions uses a standardized layout that makes this flow predictable and traceable.
+
+Raw materials enter through one door (`staging/`), the framework registers them in `source_data`, they move through workstations (actions) that write to `target_data`, and you query the result out of the SQLite database. The layout enforces this separation, making it easy to inspect what went in and what came out.
 
 ## Directory Structure
 
@@ -15,22 +17,16 @@ Think of it like a factory floor: raw materials enter through one door (`staging
 agent_workflow/
 └── my_workflow/
     ├── agent_config/
-    │   └── my_workflow.yml    # Workflow definition
+    │   └── my_workflow.yml         # Workflow definition
     ├── agent_io/
-    │   ├── staging/           # Input data (starting point)
-    │   ├── source/            # Metadata tracking staging files (JSON mode)
-    │   ├── target/            # Output data (JSON mode)
-    │   └── outputs.db          # SQLite database (database mode)
-    └── seed_data/             # Static reference data
+    │   ├── staging/                # Input data (on-disk JSON / CSV / etc.)
+    │   └── store/
+    │       └── my_workflow.db      # SQLite database — source, target, dispositions, traces
+    └── seed_data/                  # Static reference data
 ```
 
 :::tip Storage Backend
-Agent Actions supports two storage modes for source and target data:
-
-- **SQLite mode** (default): All data in a single `outputs.db` database file, configured via `output_storage` in `agent_actions.yml`
-- **JSON mode**: Individual JSON files in `source/` and `target/` directories
-
-SQLite mode offers better query performance, built-in deduplication, and atomic writes. Staging data always remains as JSON files regardless of mode.
+SQLite is the only supported storage backend. Source records, target records, dispositions, prompt traces, and checkpoint outputs all live in `agent_io/store/<workflow>.db`. Only `staging/` remains as on-disk JSON because that is what users place by hand.
 :::
 
 ### staging/
@@ -55,29 +51,31 @@ actions:
       file_type: [json, csv]
 ```
 
-### source/
+### source_data (table)
 
 Metadata layer that tracks what's in staging:
 
-- References to staging files for lineage tracking
-- Enables tracing outputs back to original inputs
-- Auto-generated when you run the agentic workflow
+- One row per `(relative_path, source_guid)` from the staging files
+- Auto-populated on `agac run`
+- Provides the join key (`source_guid`) that ties target records back to their origin
 
-### target/
+### target_data (table)
 
-Outputs organized by action. In JSON mode:
+Outputs are stored per action in the `target_data` table:
 
+```sql
+CREATE TABLE target_data (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    action_name   TEXT NOT NULL,
+    relative_path TEXT NOT NULL,
+    data          TEXT NOT NULL,         -- JSON array of records
+    record_count  INTEGER,
+    created_at    TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(action_name, relative_path)
+)
 ```
-agent_io/target/
-├── node_0_extract_facts/
-│   └── document_1.json
-├── node_1_validate_facts/
-│   └── document_1.json
-└── node_2_summarize/
-    └── document_1.json
-```
 
-In SQLite mode, the same data is stored in the `target_data` table with `action_name` and `relative_path` columns.
+Each row stores every record an action produced for a given input file (`relative_path`) as a single JSON array in `data`. Fan it out with `json_each(data)` and pull fields with `json_extract`.
 
 ## Data Flow
 
@@ -85,42 +83,47 @@ Let's trace how a document moves through an agentic workflow:
 
 ```mermaid
 flowchart LR
-    ST[staging/] --> SR[source/]
+    ST[staging/] --> SR[source_data]
     SR --> A1[Action 1]
-    A1 --> T1[target/node_0/]
+    A1 --> T1[target_data: action_name='node_0']
     T1 --> A2[Action 2]
-    A2 --> T2[target/node_1/]
+    A2 --> T2[target_data: action_name='node_1']
 ```
 
 Here is what happens at each stage:
 
 1. Input data placed in `staging/`
-2. Agent Actions creates tracking references in `source/`
-3. Each action writes to `target/node_{n}_{name}/`
-4. Downstream actions read from upstream `target/` folders
-5. Filenames preserved through the agentic workflow
+2. Agent Actions registers each input record in `source_data` with a stable `source_guid`
+3. Each action writes its output as a `target_data` row keyed by `(action_name, relative_path)`
+4. Downstream actions read from `target_data` rows of their upstream actions
+5. `relative_path` is preserved across actions, so the same input file is traceable through every step
 
-Notice that filenames stay consistent across all stages. The `source/` layer provides lineage tracking—you can trace any output back to its original staging file, which is essential for debugging and auditing.
+The `source_guid` field provides lineage tracking — you can trace any output record back to its original staging file, which is essential for debugging and auditing.
 
 ## Storage Backend
 
-Agent Actions uses a pluggable storage backend system for source and target data. The default SQLite backend stores all workflow data in a single database file.
+All workflow data lives in `agent_io/store/<workflow>.db`. The framework manages this file — it is created on first `agac run`, migrated in place when columns are added, and truncated (not deleted) by `--fresh`.
 
 ### SQLite Database Schema
 
-The database contains two main tables:
+The database carries five framework-owned tables:
 
-| Table | Purpose |
-|-------|---------|
-| `source_data` | Stores source records with deduplication by `source_guid` |
-| `target_data` | Stores action outputs organized by `action_name` |
+| Table                | Purpose                                                                            |
+|----------------------|------------------------------------------------------------------------------------|
+| `source_data`        | Source records, deduplicated by `(relative_path, source_guid)`                     |
+| `target_data`        | Per-action output records, one row per `(action_name, relative_path)`              |
+| `record_disposition` | Per-record dispositions (success/failed/exhausted/skipped) emitted by each action  |
+| `prompt_trace`       | Compiled prompt + LLM response per record per attempt (online and batch)           |
+| `checkpoint_output`  | Mid-action checkpoint records (resumable batch retrieval and reprompt recovery)    |
+
+Plus a `workflow_metadata` bookkeeping table for run-level key/value state.
 
 ### Querying the Database
 
 You can inspect workflow data directly using SQLite:
 
 ```bash
-sqlite3 my_workflow/agent_io/outputs.db
+sqlite3 agent_io/store/<workflow>.db
 
 -- List all actions with output
 SELECT DISTINCT action_name FROM target_data;
@@ -128,15 +131,18 @@ SELECT DISTINCT action_name FROM target_data;
 -- Count records per action
 SELECT action_name, SUM(record_count) FROM target_data GROUP BY action_name;
 
--- Preview data from an action
-SELECT data FROM target_data WHERE action_name = 'extract_facts' LIMIT 1;
+-- Preview the first record produced by an action
+SELECT json_extract(r.value, '$')
+FROM target_data t, json_each(t.data) r
+WHERE t.action_name = 'extract_facts'
+LIMIT 1;
 ```
 
 ### Benefits
 
 - **Performance**: Indexed queries for fast data access
 - **Integrity**: ACID transactions prevent partial writes
-- **Deduplication**: Automatic source_guid-based deduplication
+- **Deduplication**: Automatic `source_guid`-based deduplication
 - **Concurrency**: WAL mode enables concurrent reads
 
 ## Learn More

--- a/docs.agent-actions/docs/reference/data-io/output-format.md
+++ b/docs.agent-actions/docs/reference/data-io/output-format.md
@@ -5,63 +5,89 @@ sidebar_position: 3
 
 # Output Format
 
-Where does your data end up after an agentic workflow runs? Action outputs are written to `agent_io/target/` as JSON files, organized by action. This structure makes it easy to inspect what each action produced and trace results back to their sources.
+> **Storage backend:** SQLite as of v0.2.6. File paths under `agent_io/target/.../data.json` in older snippets are stale; this page describes the current SQLite layout.
 
-## Directory Structure
+Where does your data end up after an agentic workflow runs? Action outputs are written to a single SQLite database per workflow at `agent_io/store/<workflow>.db`. Every action's output rows live in the `target_data` table, keyed by `action_name`. This layout makes outputs easy to query, durable across reruns, and trivially deduplicable.
+
+## Storage Layout
 
 ```
-agent_io/target/
-├── extract_facts/
-│   └── source_file.json
-├── validate_facts/
-│   └── source_file.json
-└── generate_summary/
-    └── source_file.json
+<project_dir>/
+└── agent_io/
+    ├── staging/             # Raw input files (unchanged)
+    └── store/
+        └── <workflow>.db    # SQLite database — all source, target, disposition, and trace data
 ```
 
-- Each action creates a subdirectory named after the action
-- Source filenames are preserved through the pipeline
-- All outputs are JSON arrays
+There is exactly one `.db` file per workflow. The framework creates and migrates it automatically on `agac run`.
 
-## Output Structure
+## Tables
 
-Each output file contains an array of records:
+The SQLite database carries five framework-owned tables:
+
+| Table                 | Purpose                                                                                  |
+|-----------------------|------------------------------------------------------------------------------------------|
+| `source_data`         | Staged input records, deduplicated by `(relative_path, source_guid)`                     |
+| `target_data`         | Per-action output records — one row per `(action_name, relative_path)`                   |
+| `record_disposition`  | Per-record dispositions (success/failed/exhausted/skipped) emitted by each action        |
+| `prompt_trace`        | Compiled prompt + LLM response per record per attempt (online and batch)                 |
+| `checkpoint_output`   | Mid-action checkpoint records (used for resumable batch retrieval and reprompt recovery) |
+
+Plus one bookkeeping table `workflow_metadata` for run-level key/value state.
+
+## `target_data` Schema
+
+```sql
+CREATE TABLE target_data (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    action_name   TEXT NOT NULL,
+    relative_path TEXT NOT NULL,
+    data          TEXT NOT NULL,          -- JSON array of records
+    record_count  INTEGER,
+    created_at    TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(action_name, relative_path)
+)
+```
+
+Each row stores **all records produced by `action_name` for a given input file** (`relative_path`) as a single JSON array in the `data` column. Use `json_each(data)` to fan rows out into individual records, and `json_extract` to pull fields.
+
+## Record Structure
+
+Each element of the JSON array in `data` is a record with this shape:
 
 ```json
-[
-  {
-    "source_guid": "cbbd09ca-2503-591c-b712-4c378c101b9d",
-    "node_id": "extract_facts_354c6e1e-4925-403b-9748-52f9386bc154",
-    "target_id": "6059b048-9adc-4497-be79-fe6dd04544eb",
-    "parent_target_id": "64058522-1cc5-4fea-9372-ade1ecc64fc1",
-    "root_target_id": "e1bec28c-c709-4646-845a-2be2bbc8eab1",
-    "content": {
-      "facts": [...],
-      "count": 5
-    },
-    "lineage": [
-      "extract_facts_354c6e1e-4925-403b-9748-52f9386bc154"
-    ],
-    "metadata": {
-      "model": "gpt-4o-mini",
-      "provider": "openai"
-    }
+{
+  "source_guid": "cbbd09ca-2503-591c-b712-4c378c101b9d",
+  "node_id": "extract_facts_354c6e1e-4925-403b-9748-52f9386bc154",
+  "target_id": "6059b048-9adc-4497-be79-fe6dd04544eb",
+  "parent_target_id": "64058522-1cc5-4fea-9372-ade1ecc64fc1",
+  "root_target_id": "e1bec28c-c709-4646-845a-2be2bbc8eab1",
+  "content": {
+    "facts": [...],
+    "count": 5
+  },
+  "lineage": [
+    "extract_facts_354c6e1e-4925-403b-9748-52f9386bc154"
+  ],
+  "metadata": {
+    "model": "gpt-4o-mini",
+    "provider": "openai"
   }
-]
+}
 ```
 
 ### Fields
 
-| Field | Description |
-|-------|-------------|
-| `source_guid` | Links back to original source file |
-| `node_id` | Action that produced this output (includes run UUID) |
-| `target_id` | Unique identifier for this output record |
-| `parent_target_id` | ID of the upstream record that produced this output |
-| `root_target_id` | ID of the original source record |
-| `content` | LLM/tool output (schema-validated) |
-| `lineage` | Array tracking the processing chain |
-| `metadata` | Execution metadata (model, provider) |
+| Field                | Description                                                       |
+|----------------------|-------------------------------------------------------------------|
+| `source_guid`        | Links back to the original source row in `source_data`            |
+| `node_id`            | Action that produced this output (includes run UUID)              |
+| `target_id`          | Unique identifier for this output record                          |
+| `parent_target_id`   | ID of the upstream record that produced this output               |
+| `root_target_id`     | ID of the original source record                                  |
+| `content`            | LLM/tool output (schema-validated)                                |
+| `lineage`            | Array tracking the processing chain                               |
+| `metadata`           | Execution metadata (model, provider)                              |
 
 ### Metadata Fields
 
@@ -119,7 +145,7 @@ For tool actions, `content` contains the tool return value.
 
 ## Passthrough Fields
 
-Fields from `context_scope.passthrough` are preserved at the root level of the output:
+Fields from `context_scope.passthrough` are preserved at the root level of each record:
 
 ```yaml
 # Workflow config
@@ -140,22 +166,44 @@ context_scope:
 
 ## Reading Outputs
 
-### Single File
+### What actions ran, and how many records did each produce
 
 ```bash
-cat agent_io/target/extract_facts/document_1.json | jq .
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT action_name, relative_path, record_count
+  FROM target_data
+  ORDER BY action_name, relative_path
+"
 ```
 
-### All Outputs from Action
+### Dump every record for one action
 
 ```bash
-cat agent_io/target/extract_facts/*.json | jq -s 'add'
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT json_extract(r.value, '\$')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name = 'extract_facts'
+"
 ```
 
-### Extract Content Only
+### Extract one field across all records for an action
 
 ```bash
-jq '.[].content' agent_io/target/extract_facts/document_1.json
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT json_extract(r.value, '\$.content.headline')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name = 'extract_facts'
+"
+```
+
+### Locate the row for one source record
+
+```bash
+sqlite3 agent_io/store/<workflow>.db "
+  SELECT t.action_name, json_extract(r.value, '\$.target_id')
+  FROM target_data t, json_each(t.data) r
+  WHERE json_extract(r.value, '\$.source_guid') = '<source_guid>'
+"
 ```
 
 ## Clean Outputs
@@ -163,10 +211,10 @@ jq '.[].content' agent_io/target/extract_facts/document_1.json
 Remove previous outputs before a fresh run:
 
 ```bash
-agac clean -a my_workflow
+agac run -a my_workflow --fresh
 ```
 
-This removes `source/` and `target/` directories. Use `--all` to also remove `staging/`.
+`--fresh` truncates the relevant tables (`source_data`, `target_data`, `record_disposition`, `prompt_trace`, `checkpoint_output`) without deleting the database file. Use `agac clean --all` to drop the database file entirely.
 
 ## See Also
 
@@ -174,3 +222,4 @@ This removes `source/` and `target/` directories. Use `--all` to also remove `st
 - [Data Lineage](./data-lineage.md) — Ancestry tracking for parallel branches and merges
 - [Artifacts](../execution/artifacts.md) — Run tracking and detailed output structure
 - [Context Scope](../context/context-scope.md) — Passthrough configuration
+- [Prompt Traces](./prompt-traces.md) — Compiled prompts and LLM responses per record

--- a/docs.agent-actions/docs/reference/data-io/prompt-traces.md
+++ b/docs.agent-actions/docs/reference/data-io/prompt-traces.md
@@ -5,6 +5,8 @@ sidebar_position: 6
 
 # Prompt Traces
 
+> **Storage backend:** SQLite as of v0.2.6. Traces are stored in `agent_io/store/<workflow>.db`, table `prompt_trace`.
+
 Every time an LLM action processes a record, Agent Actions captures a **prompt trace** — the compiled prompt sent to the model and the raw response received. Traces are stored in the `prompt_trace` table of your workflow's SQLite database and surfaced automatically in the Data Explorer.
 
 ## What Gets Captured
@@ -21,7 +23,12 @@ Every time an LLM action processes a record, Agent Actions captures a **prompt t
 | `response_length` | Character count of the LLM response |
 | `attempt` | Attempt number (0 = initial, 1+ = reprompt retries) |
 
-Traces are linked to records by `action_name` and `record_id` (matching `source_guid`).
+Traces are linked to records by `action_name` and `record_id`. The value used for `record_id` depends on the run path:
+
+- **Online actions** write `record_id = target_id` (the per-record identifier assigned during processing).
+- **Batch actions** write `record_id = source_guid` (the stable identifier of the originating source row).
+
+Join `prompt_trace.record_id` against `target_id` for online actions and against `source_guid` for batch actions.
 
 ## Viewing Traces in the Data Explorer
 
@@ -70,7 +77,7 @@ Traces are excluded from Table view by design — prompt text is unreadable in t
 You can query the `prompt_trace` table using SQLite:
 
 ```bash
-sqlite3 my_workflow/agent_io/outputs.db
+sqlite3 agent_io/store/<workflow>.db
 ```
 
 ```sql
@@ -80,11 +87,19 @@ SELECT DISTINCT action_name FROM prompt_trace;
 -- Count traces per action
 SELECT action_name, COUNT(*) FROM prompt_trace GROUP BY action_name;
 
--- View a specific record's trace
+-- View a specific record's trace (online action — record_id is target_id)
 SELECT compiled_prompt, response_text, model_name
 FROM prompt_trace
 WHERE action_name = 'classify_issue'
-  AND record_id = '2362b687-87c7-5534-83a1...'
+  AND record_id = '<target_id>'
+ORDER BY attempt DESC
+LIMIT 1;
+
+-- View a specific record's trace (batch action — record_id is source_guid)
+SELECT compiled_prompt, response_text, model_name
+FROM prompt_trace
+WHERE action_name = 'classify_issue'
+  AND record_id = '<source_guid>'
 ORDER BY attempt DESC
 LIMIT 1;
 

--- a/docs.agent-actions/docs/tutorials/index.md
+++ b/docs.agent-actions/docs/tutorials/index.md
@@ -57,10 +57,12 @@ For this tutorial, you'll create a workflow under `agent_workflow/`:
 agent_workflow/
 └── product_pipeline/
     ├── agent_config/
-    │   └── product_pipeline.yml    # Workflow definition
+    │   └── product_pipeline.yml       # Workflow definition
     └── agent_io/
-        └── staging/
-            └── products.json       # Input data
+        ├── staging/
+        │   └── products.json          # Input data (the only on-disk data you write)
+        └── store/
+            └── product_pipeline.db    # SQLite database — created on first run
 ```
 
 ## 2. Define Your Schemas
@@ -177,11 +179,9 @@ default_agent_config:
 schema_path: schema
 tool_path: ["tools"]
 seed_data_path: seed_data
-
-output_storage:
-  backend: sqlite
-  db_path: ./agent_io/outputs.db
 ```
+
+Agent Actions stores all workflow outputs in `agent_io/store/<workflow>.db` automatically — no storage config is required.
 
 Use whichever provider you have an API key for. For example, with Anthropic:
 
@@ -205,10 +205,18 @@ Running workflow: product_pipeline
 ├── extract_data ✓
 └── generate_content ✓
 
-Results written to: agent_io/target/
+Results written to: agent_io/store/product_pipeline.db
 ```
 
-Check `agent_io/target/` for your results:
+Check the `target_data` table for your results:
+
+```bash
+sqlite3 agent_io/store/product_pipeline.db "
+  SELECT json_extract(r.value, '\$.content')
+  FROM target_data t, json_each(t.data) r
+  WHERE t.action_name = 'generate_content'
+"
+```
 
 ```json
 {
@@ -227,7 +235,7 @@ Let's walk through what Agent Actions did behind the scenes:
 
 1. **extract_data** read from `staging/`, called the LLM, and validated the output against the `product_data` schema
 2. **generate_content** received extract_data's output via `{{ extract_data.field }}` references, generated marketing content, and validated against the `marketing_content` schema
-3. Results were written to `target/`
+3. Both actions wrote their records as rows in the `target_data` table of `agent_io/store/product_pipeline.db`
 
 **What if the LLM returns invalid JSON?** If you configure reprompting on an action, Agent Actions automatically retries until the output conforms to your schema. See [Reprompting](../reference/validation/reprompting.md) to enable this.
 


### PR DESCRIPTION
## Summary

Wave-0 gate for Clone 5 (UAT-audit T1-04). SQLite replaced file-based storage in v0.2.6, but six doc pages still reasoned about `agent_io/target/<action>/data.json`. This PR sweeps that pattern out of the data-I/O surface and replaces every snippet with a runnable `sqlite3` query against the real schema.

Covers VIOL-0050, VIOL-0055, VIOL-0059, VIOL-0082 (full rewrite), plus the related `outputs.db` / "JSON mode" misstatements in `data-io/index.md` and `tutorials/index.md`.

## What changed

- **`docs/guides/troubleshooting.md`** — replaced `grep -r ... agent_io/target/` and `cat agent_io/target/.../data.json` snippets with `json_each(data)` + `json_extract` queries; rewrote "Node Output Structure" around `target_data` rows.
- **`docs/reference/data-io/data-lineage.md`** — replaced `jq` ancestry queries with their SQLite equivalents using the actual lineage fields (`parent_target_id`, `root_target_id`).
- **`docs/reference/data-io/output-format.md`** — full rewrite: SQLite layout, five framework tables, real `target_data` schema, minimal-viable read queries, system-fields table, passthrough, `--fresh` semantics. Title, H1, and anchor unchanged.
- **`docs/reference/data-io/prompt-traces.md`** — fixed wrong DB path (`my_workflow/agent_io/outputs.db` → `agent_io/store/<workflow>.db`); split the trace join-key explanation so it documents the online (`target_id`) vs batch (`source_guid`) divergence per VIOL-0060.
- **`docs/reference/data-io/index.md`** — removed the misleading "SQLite mode vs JSON mode" dichotomy (there is only SQLite), replaced the file-based `target/` directory tree with the actual `target_data` schema and a corrected Mermaid flow.
- **`docs/tutorials/index.md`** — dropped the dead `output_storage:` config block (the framework ignores it — `db_path` is hardcoded to `agent_io/store/<workflow>.db`); rewrote the "Check your results" step to query `target_data` instead of `cat`-ing.

Each modified page gets a one-line `> **Storage backend:** SQLite as of v0.2.6 …` blockquote immediately after the H1.

## Verification

### Headline grep (spec Task 4 Step 1)

```bash
grep -rn 'agent_io/target/[^/]*/data\.json' docs.agent-actions/docs/ | grep -v '> \*\*Storage'
# (no matches)
```

### Related shell-snippet grep (spec Task 4 Step 2)

```bash
grep -rnE 'cat agent_io/target|jq.*agent_io/target|ls agent_io/target' docs.agent-actions/docs/
# remaining hits are 3 lines in docs/reference/execution/artifacts.md (run_results.json,
# errors.json, events.json) — explicitly out of scope per spec ("Do not touch the events.json
# location bug — VIOL-0084 is a separate plan"). Logged in coordination/status.md as a
# cross-clone follow-up for Clone 6 / future logging-docs bucket.
```

### Storage-backend note presence

```
OK  docs.agent-actions/docs/guides/troubleshooting.md
OK  docs.agent-actions/docs/reference/data-io/data-lineage.md
OK  docs.agent-actions/docs/reference/data-io/output-format.md
OK  docs.agent-actions/docs/reference/data-io/prompt-traces.md
OK  docs.agent-actions/docs/reference/data-io/index.md
```

(`api/logging.md` and `guides/design-patterns.md` were on the spec's nominal list but carry zero `agent_io/target/.../data.json` references in the current tree — `api/logging.md`'s only `target/` paths are the out-of-scope `events.json`/`run_results.json` ones owned by VIOL-0084, and `design-patterns.md` was already clean. Not modified to avoid scope creep.)

### SQL snippets execute end-to-end

Built an in-memory SQLite DB mirroring the real schema in `agent_actions/storage/backends/sqlite_backend.py` (5 framework tables, real column names) and ran every new `sqlite3 …` snippet from every modified page. Every snippet exits 0 and returns the expected rows — no "no such column" or "no such table" errors. Verified column names against the actual `_REQUIRED_COLUMNS` map: `target_data.{action_name, relative_path, data, record_count}`, `prompt_trace.{action_name, record_id, attempt, …}`.

### Internal links

All `[…](../…)` links in modified pages resolve to existing files (`execution/batch-recovery.md`, `data-io/input-formats.md`, `data-io/data-lineage.md`, `execution/artifacts.md`, `context/context-scope.md`, `data-io/prompt-traces.md`, `data-io/chunking.md`).

## Out-of-scope siblings (logged in coordination/status.md)

- `docs/reference/execution/artifacts.md` and `docs/reference/architecture/logging.md` still point `events.json` / `run_results.json` / `errors.json` at `agent_io/target/` — actual location is `agent_io/logs/` per `agent_actions/logging/factory.py:144/152/207`. This is the VIOL-0084 family the spec explicitly defers.
- `docs/guides/editor-setup.md` still calls `.manifest.json` an `agent_io/target/` file — actual location is `agent_io/logs/.manifest.json` per `agent_actions/workflow/managers/manifest.py:36-37`. Sibling cleanup; no current UAT owner.