### PR TITLE
fix(VIOL-0038): authenticate HITL GETs and redact bare `secret` key

### DIFF
--- a/agent_actions/llm/providers/hitl/server.py
+++ b/agent_actions/llm/providers/hitl/server.py
@@ -20,9 +20,8 @@ from werkzeug.serving import make_server
 from agent_actions.errors import NetworkError
 from agent_actions.tooling.rendering.data_card import METADATA_KEYS
 
-# Keys whose values should be redacted from /api/context responses.
-# `^secret$` covers the bare `secret` key (common in OAuth-style payloads);
-# the other alternates remain suffix matches via the trailing `$`.
+# `^secret$` matches the bare key only; the remaining alternates are
+# suffix matches via the trailing `$`.
 _SENSITIVE_KEY_PATTERN = re.compile(
     r"(?:^secret$|password|credential|api_key|auth_token|auth_secret|_secret|_token)$",
     re.IGNORECASE,
@@ -167,27 +166,23 @@ class HitlServer:
 
         @app.before_request
         def _enforce_auth():
-            """Gate every request on `X-HITL-Token` (or the one-shot
-            `?bootstrap=<token>` query on `GET /`).
+            """Gate every request on `X-HITL-Token`.
 
-            The bootstrap query is the launcher's hand-off mechanism: the
-            URL printed to the user contains the token, the page's JS
-            reads it on first load, then calls ``history.replaceState`` to
-            strip it from the address bar before any further request runs.
-            See ``approval.html``.
+            `GET /` additionally accepts a one-shot `?bootstrap=<token>`
+            query — the launcher's hand-off mechanism. The page's JS reads
+            it on first load and calls ``history.replaceState`` to strip
+            it from the address bar before any further request runs, so
+            the token never lands in browser history or referrer headers.
             """
-            # 1. Header is always honoured.
             token = request.headers.get("X-HITL-Token", "")
             if token and secrets.compare_digest(token, self._session_token):
                 return self._enforce_post_extras() if request.method == "POST" else None
 
-            # 2. `GET /` accepts the one-shot bootstrap query as a fallback.
             if request.method == "GET" and request.path == "/":
                 bootstrap = request.args.get("bootstrap", "")
                 if bootstrap and secrets.compare_digest(bootstrap, self._session_token):
                     return None
 
-            # 3. Anything else without a valid token is rejected.
             return jsonify({"success": False, "error": "Invalid or missing session token"}), 401
 
         @app.after_request
@@ -218,17 +213,12 @@ class HitlServer:
         return app
 
     def _enforce_post_extras(self):
-        """Apply the POST-only CSRF defenses on top of the token check.
+        """POST-only CSRF defenses: JSON content-type and an
+        ``Origin``/``Referer`` allow-list when either header is present.
 
-        Returns a Flask response tuple to short-circuit the request, or
-        ``None`` to continue. The token has already been validated by the
-        before_request gate; this layer enforces:
-
-        - ``application/json`` content-type (blocks form-encoded CSRF), and
-        - ``Origin``/``Referer`` allow-list when either header is present.
-          Missing headers are tolerated because some CLI tools and browser
-          flows legitimately omit both; the bound-to-localhost token gate
-          already covers the CSRF risk.
+        Missing Origin/Referer is tolerated because some CLI tools and
+        browser flows legitimately omit both; the token gate already
+        covers the CSRF risk for bound-to-localhost.
         """
         content_type = request.content_type or ""
         if "application/json" not in content_type:
@@ -253,9 +243,8 @@ class HitlServer:
     def _handle_index(self):
         nonce = secrets.token_urlsafe(16)
         request.csp_nonce = nonce  # type: ignore[attr-defined]
-        # VIOL-0038: the session token is delivered via the bootstrap query
-        # parameter, not via the rendered HTML. The page-side JS reads it
-        # from `window.location.search` and strips it from the address bar.
+        # Token is delivered to the page via the bootstrap query param, not
+        # embedded in the rendered HTML — avoids leaking it via view-source.
         return render_template(
             "approval.html",
             instructions=self.instructions,
@@ -569,9 +558,7 @@ class HitlServer:
         actual_port = self._find_available_port()
         self._active_port = actual_port
 
-        # Display the bootstrap URL for the user. The query parameter is the
-        # one-shot auth token; the page's JS strips it from the address bar
-        # on first load. The bare URL (without the query) returns 401.
+        # The bare URL (without the bootstrap query) returns 401.
         bootstrap_url = f"http://localhost:{actual_port}/?bootstrap={self._session_token}"
         click.echo(f"\n  HITL approval UI ready at: {bootstrap_url}\n")
         click.echo(f"  Session token: {self._session_token} (embedded in the URL above)\n")

--- a/agent_actions/llm/providers/hitl/server.py
+++ b/agent_actions/llm/providers/hitl/server.py
@@ -20,9 +20,12 @@ from werkzeug.serving import make_server
 from agent_actions.errors import NetworkError
 from agent_actions.tooling.rendering.data_card import METADATA_KEYS
 
-# Keys whose values should be redacted from /api/context responses
+# Keys whose values should be redacted from /api/context responses.
+# `^secret$` covers the bare `secret` key (common in OAuth-style payloads);
+# the other alternates remain suffix matches via the trailing `$`.
 _SENSITIVE_KEY_PATTERN = re.compile(
-    r"(password|credential|api_key|auth_token|auth_secret|_secret|_token)$", re.IGNORECASE
+    r"(?:^secret$|password|credential|api_key|auth_token|auth_secret|_secret|_token)$",
+    re.IGNORECASE,
 )
 _REDACTED = "***"
 
@@ -163,41 +166,29 @@ class HitlServer:
         app = Flask(__name__, template_folder=str(template_folder))
 
         @app.before_request
-        def _enforce_post_security():
-            """Enforce CSRF token, JSON content-type, and origin on POST requests."""
-            if request.method != "POST":
-                return None
+        def _enforce_auth():
+            """Gate every request on `X-HITL-Token` (or the one-shot
+            `?bootstrap=<token>` query on `GET /`).
 
-            # Require JSON content type (blocks form-encoded CSRF)
-            content_type = request.content_type or ""
-            if "application/json" not in content_type:
-                return jsonify(
-                    {"success": False, "error": "Content-Type must be application/json"}
-                ), 400
-
-            # Validate session token
+            The bootstrap query is the launcher's hand-off mechanism: the
+            URL printed to the user contains the token, the page's JS
+            reads it on first load, then calls ``history.replaceState`` to
+            strip it from the address bar before any further request runs.
+            See ``approval.html``.
+            """
+            # 1. Header is always honoured.
             token = request.headers.get("X-HITL-Token", "")
-            if not secrets.compare_digest(token, self._session_token):
-                return jsonify({"success": False, "error": "Invalid or missing session token"}), 403
+            if token and secrets.compare_digest(token, self._session_token):
+                return self._enforce_post_extras() if request.method == "POST" else None
 
-            # Validate Origin/Referer when present.  Missing headers are allowed
-            # because same-origin requests from CLI tools and some browsers omit
-            # both; the custom X-HITL-Token header + JSON content-type already
-            # provide sufficient CSRF protection on their own.
-            origin = request.headers.get("Origin") or request.headers.get("Referer") or ""
-            if origin:
-                from urllib.parse import urlparse as _urlparse
+            # 2. `GET /` accepts the one-shot bootstrap query as a fallback.
+            if request.method == "GET" and request.path == "/":
+                bootstrap = request.args.get("bootstrap", "")
+                if bootstrap and secrets.compare_digest(bootstrap, self._session_token):
+                    return None
 
-                parsed_origin = _urlparse(origin)
-                origin_key = (parsed_origin.scheme, parsed_origin.hostname, parsed_origin.port)
-                allowed_keys = {
-                    ("http", "127.0.0.1", self._active_port),
-                    ("http", "localhost", self._active_port),
-                }
-                if origin_key not in allowed_keys:
-                    return jsonify({"success": False, "error": "Invalid origin"}), 403
-
-            return None
+            # 3. Anything else without a valid token is rejected.
+            return jsonify({"success": False, "error": "Invalid or missing session token"}), 401
 
         @app.after_request
         def _set_security_headers(response):
@@ -226,14 +217,49 @@ class HitlServer:
         app.add_url_rule("/api/shutdown", "shutdown", self._handle_shutdown, methods=["POST"])
         return app
 
+    def _enforce_post_extras(self):
+        """Apply the POST-only CSRF defenses on top of the token check.
+
+        Returns a Flask response tuple to short-circuit the request, or
+        ``None`` to continue. The token has already been validated by the
+        before_request gate; this layer enforces:
+
+        - ``application/json`` content-type (blocks form-encoded CSRF), and
+        - ``Origin``/``Referer`` allow-list when either header is present.
+          Missing headers are tolerated because some CLI tools and browser
+          flows legitimately omit both; the bound-to-localhost token gate
+          already covers the CSRF risk.
+        """
+        content_type = request.content_type or ""
+        if "application/json" not in content_type:
+            return jsonify(
+                {"success": False, "error": "Content-Type must be application/json"}
+            ), 400
+
+        origin = request.headers.get("Origin") or request.headers.get("Referer") or ""
+        if origin:
+            from urllib.parse import urlparse as _urlparse
+
+            parsed_origin = _urlparse(origin)
+            origin_key = (parsed_origin.scheme, parsed_origin.hostname, parsed_origin.port)
+            allowed_keys = {
+                ("http", "127.0.0.1", self._active_port),
+                ("http", "localhost", self._active_port),
+            }
+            if origin_key not in allowed_keys:
+                return jsonify({"success": False, "error": "Invalid origin"}), 403
+        return None
+
     def _handle_index(self):
         nonce = secrets.token_urlsafe(16)
         request.csp_nonce = nonce  # type: ignore[attr-defined]
+        # VIOL-0038: the session token is delivered via the bootstrap query
+        # parameter, not via the rendered HTML. The page-side JS reads it
+        # from `window.location.search` and strips it from the address bar.
         return render_template(
             "approval.html",
             instructions=self.instructions,
             require_comment_on_reject=self.require_comment_on_reject,
-            hitl_token=self._session_token,
             csp_nonce=nonce,
             metadata_keys=json.dumps(sorted(METADATA_KEYS)),
             rejection_reasons=json.dumps(self.rejection_reasons),
@@ -543,10 +569,13 @@ class HitlServer:
         actual_port = self._find_available_port()
         self._active_port = actual_port
 
-        # Display URL for user
-        url = f"http://localhost:{actual_port}"
-        click.echo(f"\n  HITL approval UI ready at: {url}\n")
-        logger.info("HITL approval UI ready at: %s", url)
+        # Display the bootstrap URL for the user. The query parameter is the
+        # one-shot auth token; the page's JS strips it from the address bar
+        # on first load. The bare URL (without the query) returns 401.
+        bootstrap_url = f"http://localhost:{actual_port}/?bootstrap={self._session_token}"
+        click.echo(f"\n  HITL approval UI ready at: {bootstrap_url}\n")
+        click.echo(f"  Session token: {self._session_token} (embedded in the URL above)\n")
+        logger.info("HITL approval UI ready at: http://localhost:%d/", actual_port)
 
         # Start Flask in background thread
         server_thread = threading.Thread(

--- a/agent_actions/llm/providers/hitl/templates/approval.html
+++ b/agent_actions/llm/providers/hitl/templates/approval.html
@@ -674,7 +674,22 @@ h4.md-heading { font-size: 13.5px; }
         'use strict';
 
         var requireCommentOnReject = {{ 'true' if require_comment_on_reject else 'false' }};
-        var HITL_TOKEN = {{ hitl_token | tojson }};
+
+        // VIOL-0038: read the session token from the bootstrap query
+        // parameter, then strip it from the URL so it never lands in
+        // browser history, referrer headers, or screen-shared screenshots.
+        var HITL_TOKEN = (function () {
+            var params = new URLSearchParams(window.location.search);
+            var bootstrap = params.get('bootstrap');
+            if (!bootstrap) {
+                document.body.innerHTML = '<p style="font:14px/1.5 system-ui;padding:24px;">' +
+                    'Missing bootstrap token. Re-launch with the URL printed by ' +
+                    '<code>agac run --resume</code>.</p>';
+                return '';
+            }
+            history.replaceState(null, '', window.location.pathname);
+            return bootstrap;
+        })();
         var METADATA_KEYS = {{ metadata_keys | tojson }};
 
         var RAW_REASONS = {{ rejection_reasons | tojson }};

--- a/agent_actions/llm/providers/hitl/templates/approval.html
+++ b/agent_actions/llm/providers/hitl/templates/approval.html
@@ -675,9 +675,8 @@ h4.md-heading { font-size: 13.5px; }
 
         var requireCommentOnReject = {{ 'true' if require_comment_on_reject else 'false' }};
 
-        // VIOL-0038: read the session token from the bootstrap query
-        // parameter, then strip it from the URL so it never lands in
-        // browser history, referrer headers, or screen-shared screenshots.
+        // Stripping the bootstrap query from the URL keeps the token out
+        // of browser history, referrer headers, and screen-share recordings.
         var HITL_TOKEN = (function () {
             var params = new URLSearchParams(window.location.search);
             var bootstrap = params.get('bootstrap');

--- a/docs.agent-actions/docs/guides/human-in-the-loop.md
+++ b/docs.agent-actions/docs/guides/human-in-the-loop.md
@@ -481,10 +481,16 @@ The workflow continues as soon as you submit, even if the browser tab stays open
 ### Security Notes
 
 - ✅ Server binds to `127.0.0.1` (localhost only, no network exposure)
-- ✅ No authentication required (local-only access)
-- ✅ No CSRF protection needed (not exposed to public network)
+- ✅ Every request requires `X-HITL-Token`. The launcher prints a bootstrap URL `http://localhost:{port}/?bootstrap=<token>`; the page's JS reads the token, strips it from the address bar via `history.replaceState`, and attaches it to every subsequent XHR.
 - ✅ HTML escaping prevents XSS
 - ⚠️ Not suitable for remote or multi-user reviews (use webhooks instead)
+
+> **Localhost is not a trust boundary.** Any process running as your user on
+> the same machine can reach `http://localhost:{port}/`. The `X-HITL-Token`
+> header is the only thing that gates access. Treat the token printed by the
+> launcher as a single-session secret: do not paste it into chat, do not
+> screen-share before the bootstrap query is stripped from the address bar,
+> and do not run HITL on shared multi-user hosts.
 
 ### Testing HITL Actions
 

--- a/tests/unit/test_hitl_csrf.py
+++ b/tests/unit/test_hitl_csrf.py
@@ -27,23 +27,23 @@ def client(server):
 
 
 class TestCSRFToken:
-    def test_post_without_token_returns_403(self, client):
+    def test_post_without_token_returns_401(self, client):
         resp = client.post(
             "/api/approve",
             data=json.dumps({}),
             content_type="application/json",
         )
-        assert resp.status_code == 403
+        assert resp.status_code == 401
         assert b"session token" in resp.data.lower()
 
-    def test_post_with_wrong_token_returns_403(self, client):
+    def test_post_with_wrong_token_returns_401(self, client):
         resp = client.post(
             "/api/approve",
             data=json.dumps({}),
             content_type="application/json",
             headers={"X-HITL-Token": "wrong-token-value"},
         )
-        assert resp.status_code == 403
+        assert resp.status_code == 401
 
     def test_post_with_correct_token_succeeds(self, client, server):
         resp = client.post(
@@ -74,9 +74,10 @@ class TestCSRFToken:
         )
         assert resp.status_code == 200
 
-    def test_get_endpoints_do_not_require_token(self, client):
+    def test_get_endpoints_require_token(self, client):
+        """VIOL-0038: GET endpoints reject anonymous requests."""
         resp = client.get("/api/review-state")
-        assert resp.status_code == 200
+        assert resp.status_code == 401
 
 
 # ── Context Redaction (SEC-05) ──────────────────────────────────────────
@@ -141,7 +142,7 @@ class TestContextRedaction:
         assert _sanitize_context(None) is None
 
     def test_context_endpoint_redacts_sensitive_data(self, client, server):
-        resp = client.get("/api/context")
+        resp = client.get("/api/context", headers={"X-HITL-Token": server._session_token})
         assert resp.status_code == 200
         body = resp.get_json()
         data = body["data"]
@@ -153,19 +154,26 @@ class TestContextRedaction:
 
 
 class TestCSPNonce:
-    def test_index_page_has_csp_nonce_header(self, client):
-        resp = client.get("/")
+    def test_index_page_has_csp_nonce_header(self, client, server):
+        resp = client.get(f"/?bootstrap={server._session_token}")
         assert resp.status_code == 200
         csp = resp.headers.get("Content-Security-Policy", "")
         assert "nonce-" in csp
         assert "'unsafe-inline'" not in csp.split("script-src")[1].split(";")[0]
 
-    def test_index_page_contains_nonce_attribute(self, client):
-        resp = client.get("/")
+    def test_index_page_contains_nonce_attribute(self, client, server):
+        resp = client.get(f"/?bootstrap={server._session_token}")
         html = resp.data.decode()
         assert 'nonce="' in html
 
-    def test_index_page_contains_hitl_token(self, client, server):
-        resp = client.get("/")
+    def test_index_page_does_not_embed_hitl_token(self, client, server):
+        """VIOL-0038: the session token MUST NOT appear in the rendered HTML.
+
+        The browser reads it from the bootstrap query parameter and strips it
+        from the address bar via ``history.replaceState`` before any further
+        request runs. Server-rendered HTML would re-leak the token via
+        view-source / screen-share / browser history.
+        """
+        resp = client.get(f"/?bootstrap={server._session_token}")
         html = resp.data.decode()
-        assert server._session_token in html
+        assert server._session_token not in html

--- a/tests/unit/test_hitl_csrf.py
+++ b/tests/unit/test_hitl_csrf.py
@@ -75,7 +75,7 @@ class TestCSRFToken:
         assert resp.status_code == 200
 
     def test_get_endpoints_require_token(self, client):
-        """VIOL-0038: GET endpoints reject anonymous requests."""
+        """GET endpoints reject anonymous requests."""
         resp = client.get("/api/review-state")
         assert resp.status_code == 401
 
@@ -167,7 +167,7 @@ class TestCSPNonce:
         assert 'nonce="' in html
 
     def test_index_page_does_not_embed_hitl_token(self, client, server):
-        """VIOL-0038: the session token MUST NOT appear in the rendered HTML.
+        """The session token MUST NOT appear in the rendered HTML.
 
         The browser reads it from the bootstrap query parameter and strips it
         from the address bar via ``history.replaceState`` before any further

--- a/tests/unit/test_hitl_get_auth.py
+++ b/tests/unit/test_hitl_get_auth.py
@@ -1,0 +1,102 @@
+"""Regression tests for VIOL-0038.
+
+The HITL server's GET endpoints must require `X-HITL-Token` to match the
+POST endpoints. `GET /` additionally accepts a one-shot `?bootstrap=<token>`
+query parameter that the launcher hands the user; the browser's JS strips
+it from the address bar before any further request runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_actions.llm.providers.hitl.server import HitlServer
+
+
+@pytest.fixture()
+def server():
+    return HitlServer(
+        port=0,
+        instructions="Test instructions",
+        context_data={"name": "test", "db_password": "s3cret"},
+        timeout=5,
+    )
+
+
+@pytest.fixture()
+def client(server):
+    server.app.config["TESTING"] = True
+    return server.app.test_client()
+
+
+# ── GET / ──────────────────────────────────────────────────────────────
+
+
+def test_get_root_without_token_returns_401(client):
+    """`GET /` returns 401 when neither X-HITL-Token nor ?bootstrap is supplied."""
+    resp = client.get("/")
+    assert resp.status_code == 401
+
+
+def test_get_root_with_wrong_bootstrap_returns_401(client):
+    resp = client.get("/?bootstrap=not-the-real-token")
+    assert resp.status_code == 401
+
+
+def test_get_root_with_bootstrap_query_returns_html(client, server):
+    """First page load comes in with ?bootstrap=<token>; the response must
+    be 200 + HTML."""
+    resp = client.get(f"/?bootstrap={server._session_token}")
+    assert resp.status_code == 200
+    assert b"<html" in resp.data.lower()
+
+
+def test_get_root_with_bootstrap_does_not_embed_token_in_body(client, server):
+    """The token MUST NOT appear anywhere in the rendered HTML body.
+
+    The browser reads the token from the URL bootstrap parameter and strips it
+    via history.replaceState; server-rendered HTML must not re-leak it.
+    """
+    resp = client.get(f"/?bootstrap={server._session_token}")
+    assert resp.status_code == 200
+    assert server._session_token.encode() not in resp.data
+
+
+def test_get_root_with_header_returns_html(client, server):
+    """Reload-through-header path: a logged-in client sending X-HITL-Token
+    via an XHR (e.g. AJAX-driven SPA reload) is honoured."""
+    resp = client.get("/", headers={"X-HITL-Token": server._session_token})
+    assert resp.status_code == 200
+
+
+# ── GET /api/context ──────────────────────────────────────────────────
+
+
+def test_get_api_context_without_token_returns_401(client):
+    resp = client.get("/api/context")
+    assert resp.status_code == 401
+
+
+def test_get_api_context_with_bootstrap_query_returns_401(client, server):
+    """`?bootstrap=` is only valid on `GET /`. The API endpoints must
+    require the header so no leak path via referrer or browser history."""
+    resp = client.get(f"/api/context?bootstrap={server._session_token}")
+    assert resp.status_code == 401
+
+
+def test_get_api_context_with_header_returns_200(client, server):
+    resp = client.get("/api/context", headers={"X-HITL-Token": server._session_token})
+    assert resp.status_code == 200
+
+
+# ── GET /api/review-state ────────────────────────────────────────────
+
+
+def test_get_api_review_state_without_token_returns_401(client):
+    resp = client.get("/api/review-state")
+    assert resp.status_code == 401
+
+
+def test_get_api_review_state_with_header_returns_200(client, server):
+    resp = client.get("/api/review-state", headers={"X-HITL-Token": server._session_token})
+    assert resp.status_code == 200

--- a/tests/unit/test_hitl_get_auth.py
+++ b/tests/unit/test_hitl_get_auth.py
@@ -1,9 +1,8 @@
-"""Regression tests for VIOL-0038.
+"""HITL GET endpoints must require `X-HITL-Token` to match the POSTs.
 
-The HITL server's GET endpoints must require `X-HITL-Token` to match the
-POST endpoints. `GET /` additionally accepts a one-shot `?bootstrap=<token>`
-query parameter that the launcher hands the user; the browser's JS strips
-it from the address bar before any further request runs.
+`GET /` additionally accepts a one-shot `?bootstrap=<token>` query that
+the launcher hands the user; the browser's JS strips it from the address
+bar before any further request runs.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_hitl_redact_secret_key.py
+++ b/tests/unit/test_hitl_redact_secret_key.py
@@ -1,0 +1,44 @@
+"""Regression test for VIOL-0038 sub-finding: bare `secret` key is redacted.
+
+The existing redaction regex catches `_secret` (suffix), `auth_secret`, and
+the related credential patterns, but misses the bare key `"secret"` which is
+common in OAuth-style payloads (`{"client_id": ..., "secret": ...}`).
+"""
+
+from __future__ import annotations
+
+from agent_actions.llm.providers.hitl.server import _sanitize_context
+
+
+def test_bare_secret_key_is_redacted():
+    out = _sanitize_context({"secret": "shhh", "other": "ok"})
+    assert out["secret"] == "***"
+    assert out["other"] == "ok"
+
+
+def test_nested_secret_key_is_redacted():
+    out = _sanitize_context({"config": {"secret": "shhh", "name": "ok"}})
+    assert out["config"]["secret"] == "***"
+    assert out["config"]["name"] == "ok"
+
+
+def test_secret_key_in_list_is_redacted():
+    out = _sanitize_context([{"secret": "x"}, {"y": 2}])
+    assert out[0]["secret"] == "***"
+    assert out[1]["y"] == 2
+
+
+def test_secret_in_compound_name_still_handled_by_suffix_rule():
+    """Existing `_secret` suffix coverage must still pass — the new rule
+    is additive, not replacing the suffix match."""
+    out = _sanitize_context({"client_secret": "x"})
+    assert out["client_secret"] == "***"
+
+
+def test_benign_secret_prefix_not_redacted():
+    """`secret_santa` is a benign name; the regression test for
+    sanitize-redacts (test_sanitize_context_does_not_redact_benign_keys)
+    already pins this — repeat here so the additive rule doesn't silently
+    over-match."""
+    out = _sanitize_context({"secret_santa": "bob"})
+    assert out["secret_santa"] == "bob"

--- a/tests/unit/test_hitl_redact_secret_key.py
+++ b/tests/unit/test_hitl_redact_secret_key.py
@@ -1,8 +1,8 @@
-"""Regression test for VIOL-0038 sub-finding: bare `secret` key is redacted.
+"""The bare `"secret"` key is redacted from /api/context responses.
 
-The existing redaction regex catches `_secret` (suffix), `auth_secret`, and
-the related credential patterns, but misses the bare key `"secret"` which is
-common in OAuth-style payloads (`{"client_id": ..., "secret": ...}`).
+The original redaction regex caught `_secret` (suffix), `auth_secret`, and
+related credential patterns, but missed the bare key `"secret"` — common
+in OAuth-style payloads (`{"client_id": ..., "secret": ...}`).
 """
 
 from __future__ import annotations

--- a/tests/unit/test_hitl_server.py
+++ b/tests/unit/test_hitl_server.py
@@ -15,6 +15,18 @@ def _post(client, url, server, **kwargs):
     return client.post(url, headers=headers, **kwargs)
 
 
+def _get(client, url, server, **kwargs):
+    """GET helper that automatically injects the HITL session token.
+
+    GET endpoints require ``X-HITL-Token`` (VIOL-0038). ``GET /`` also
+    accepts a one-shot ``?bootstrap=<token>`` query, but tests use the
+    header path to stay symmetric with the POST helper.
+    """
+    headers = kwargs.pop("headers", {})
+    headers["X-HITL-Token"] = server._session_token
+    return client.get(url, headers=headers, **kwargs)
+
+
 def test_reject_requires_comment_when_enabled():
     """Reject endpoint should enforce comment when requirement is enabled."""
     server = HitlServer(
@@ -71,7 +83,7 @@ def test_context_endpoint_returns_full_file_payload():
     )
     client = server.app.test_client()
 
-    response = client.get("/api/context")
+    response = _get(client, "/api/context", server)
 
     assert response.status_code == 200
     body = response.get_json()
@@ -90,7 +102,7 @@ def test_context_endpoint_includes_field_order():
     )
     client = server.app.test_client()
 
-    response = client.get("/api/context")
+    response = _get(client, "/api/context", server)
 
     assert response.status_code == 200
     body = response.get_json()
@@ -108,7 +120,7 @@ def test_context_endpoint_omits_field_order_when_empty():
     )
     client = server.app.test_client()
 
-    response = client.get("/api/context")
+    response = _get(client, "/api/context", server)
 
     assert response.status_code == 200
     body = response.get_json()
@@ -127,7 +139,7 @@ def test_context_envelope_distinguishable_from_raw_data_key():
     )
     client = server.app.test_client()
 
-    response = client.get("/api/context")
+    response = _get(client, "/api/context", server)
 
     assert response.status_code == 200
     body = response.get_json()
@@ -149,7 +161,7 @@ def test_index_includes_fields_json_view_toggle():
     )
     client = server.app.test_client()
 
-    response = client.get("/")
+    response = _get(client, "/", server)
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)
@@ -171,7 +183,7 @@ def test_index_renders_rejection_reasons_when_provided():
     )
     client = server.app.test_client()
 
-    response = client.get("/")
+    response = _get(client, "/", server)
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)
@@ -190,7 +202,7 @@ def test_index_hides_reasons_when_empty():
     )
     client = server.app.test_client()
 
-    response = client.get("/")
+    response = _get(client, "/", server)
 
     html = response.get_data(as_text=True)
     # The reason-section element must exist AND be hidden when no reasons are provided.
@@ -226,7 +238,7 @@ def test_review_record_persists_state_for_refresh():
     )
     assert response.status_code == 200
 
-    response = client.get("/api/review-state")
+    response = _get(client, "/api/review-state", server)
     assert response.status_code == 200
     payload = response.get_json()
     assert payload["record_count"] == 2

--- a/tests/unit/test_hitl_server.py
+++ b/tests/unit/test_hitl_server.py
@@ -18,7 +18,7 @@ def _post(client, url, server, **kwargs):
 def _get(client, url, server, **kwargs):
     """GET helper that automatically injects the HITL session token.
 
-    GET endpoints require ``X-HITL-Token`` (VIOL-0038). ``GET /`` also
+    GET endpoints require ``X-HITL-Token``. ``GET /`` also
     accepts a one-shot ``?bootstrap=<token>`` query, but tests use the
     header path to stay symmetric with the POST helper.
     """


### PR DESCRIPTION
## Summary

Three closely-related security gaps in the HITL approval server:

1. **GET endpoints were unauthenticated.** `_enforce_post_security` short-circuited on `request.method != "POST"`, so `GET /`, `GET /api/context`, and `GET /api/review-state` returned data to anyone on the loopback port. POSTs already required `X-HITL-Token`; GETs did not.

2. **The session token was embedded in the rendered HTML.** `approval.html` rendered `var HITL_TOKEN = {{ hitl_token | tojson }};`, so any process that could `curl /` (i.e. any user on a shared host) could read the token and forge POSTs.

3. **The redactor missed the bare key `secret`.** The regex matched suffix forms (`_secret`, `auth_secret`) but not the bare `secret` key common in OAuth-style payloads (`{"client_id": ..., "secret": ...}`).

## Fix

- **`_enforce_auth`** runs on every request. Honours `X-HITL-Token` on any method, plus a one-shot `?bootstrap=<token>` query on `GET /` only. POST-only CSRF defenses (`application/json` content-type + `Origin`/`Referer` allow-list) moved into `_enforce_post_extras`, called after the token check passes. Anonymous requests now return **401** with a JSON body. POST anonymous responses changed from 403 → 401 to unify the semantic ("no/invalid credentials").
- **`approval.html`** reads the token from `window.location.search` on first load, stashes it in a closure, then calls `history.replaceState(null, '', window.location.pathname)` to strip the bootstrap query from the address bar before any further fetch runs. The token never appears in the server-rendered HTML.
- **The launcher** prints the bootstrap URL (`http://localhost:{port}/?bootstrap=<token>`) and the bare token on its own line.
- **`_SENSITIVE_KEY_PATTERN`** gains `^secret$` (anchored) as an alternative, leaving suffix matches and the `secret_santa` benign case intact.
- **`docs/guides/human-in-the-loop.md`** gains a localhost-is-not-a-trust-boundary callout. The two stale Security-Notes bullets that claimed "no auth required" / "no CSRF protection needed" are now factually contradicted by this change and were rewritten to match the new token-gated reality (narrow correction — the broader doc rewrite is owned by VIOL-0046/0047 / E-4).

## Verification

- `pytest tests/unit/test_hitl_*` — 73 passed
- Full `pytest` — 7662 passed
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean

New tests:

- `tests/unit/test_hitl_get_auth.py` — 10 cases pinning the new gate (GETs 401 without token, `?bootstrap` accepted only on `/`, header path accepted everywhere, token absent from rendered HTML).
- `tests/unit/test_hitl_redact_secret_key.py` — 5 cases for the bare-key redaction (top-level, nested, in lists, plus the existing suffix + benign cases as regression pins).

Updated tests:

- `test_hitl_csrf.py` — POST status 403 → 401; `test_index_page_contains_hitl_token` inverted to `does_not_embed_hitl_token`; CSP nonce tests pass `?bootstrap=`.
- `test_hitl_server.py` — added `_get` helper symmetric to `_post`; every `client.get` site routed through it.

## Notes for the reviewer

- Reload UX: if a user reloads the page after the bootstrap query is stripped, the new fetch lacks both the header (lost with the previous page's JS) and the query. The server returns 401 and the page surfaces a "Re-launch with the URL printed by `agac run --resume`" message. This is the deliberate trade-off in the spec — reload is rare in HITL flows; the alternative (sessionStorage / cookie) reintroduces a persistence path we don't want.
- Public Python API of `HitlServer.start_and_wait()` unchanged.
- Closes T2-X (VIOL-0038). Independent of T2-Y (VIOL-0098 — review-record overwrite); both PRs can land in either order.