### PR TITLE
fix(VIOL-0037): split `agac docs` into `build` and `serve` subcommands

### DIFF
--- a/agent_actions/cli/docs.py
+++ b/agent_actions/cli/docs.py
@@ -22,8 +22,6 @@ def _build_catalog(output: str, project_root: Path | None = None) -> Path:
     output directory. Raises ``click.Abort`` if no workflows are discovered.
     """
     project_path = resolve_project_root(project_root)
-    # Path joining with an absolute right-hand side returns the right-hand
-    # side, so this one expression covers both relative and absolute -o.
     output_dir = (project_path / Path(output)).resolve()
 
     success = generate_docs(str(project_path), output_dir)
@@ -86,12 +84,9 @@ def docs(ctx: click.Context, output: str, port: int) -> None:
         agac docs serve --port 3000
     """
     if ctx.invoked_subcommand is not None:
-        # The group declares --output/--port only so the deprecated bare
-        # `agac docs` invocation can keep accepting the legacy flag positions.
-        # Click consumes them silently before the subcommand runs, so
-        # `agac docs -o X build` would otherwise write to build's default
-        # `artefact/` and drop X without warning. Refuse the ambiguous form
-        # and point the user at the correct subcommand-level invocation.
+        # Group --output/--port exist only for the deprecated bare alias;
+        # Click consumes them before the subcommand runs, so they would
+        # silently override nothing. Reject the ambiguous form.
         for name in ("output", "port"):
             if ctx.get_parameter_source(name) != click.core.ParameterSource.DEFAULT:
                 raise click.UsageError(

--- a/agent_actions/cli/docs.py
+++ b/agent_actions/cli/docs.py
@@ -10,49 +10,142 @@ from agent_actions.config.path_config import resolve_project_root
 from agent_actions.tooling.docs.generator import generate_docs
 from agent_actions.tooling.docs.server import serve_docs
 
+DEFAULT_OUTPUT = "artefact"
+DEFAULT_PORT = 8000
+DEPRECATION_REMOVAL_VERSION = "v0.3.0"
 
-@click.group(invoke_without_command=True)
-@click.option(
-    "--output",
-    "-o",
-    default="artefact",
-    help="Output directory for generated files (default: artefact)",
-)
-@click.option("--port", "-p", default=8000, help="Port to run server on (default: 8000)")
-@handles_user_errors("docs")
-@requires_project
-@click.pass_context
-def docs(ctx, output: str, port: int, project_root: Path | None = None):
-    """Build and serve workflow documentation.
 
-    Generates catalog.json and runs.json, then starts the docs server.
-
-    \b
-    Examples:
-        agac docs
-        agac docs --port 3000
-        agac docs --output ./custom-artefact
-    """
-    if ctx.invoked_subcommand is not None:
-        return
-
-    project_path = resolve_project_root(project_root)
-
+def _resolve_output_dir(output: str, project_path: Path) -> Path:
+    """Resolve *output* against *project_path*, returning an absolute path."""
     output_dir = Path(output)
     if not output_dir.is_absolute():
         output_dir = (project_path / output_dir).resolve()
     else:
         output_dir = output_dir.resolve()
+    return output_dir
+
+
+def _build_catalog(output: str, project_root: Path | None = None) -> Path:
+    """Generate ``catalog.json`` (and ``runs.json`` if missing) into *output*.
+
+    Pure I/O: never binds a port and never blocks. Returns the resolved
+    output directory. Raises ``click.Abort`` if no workflows are discovered.
+    """
+    project_path = resolve_project_root(project_root)
+    output_dir = _resolve_output_dir(output, project_path)
 
     success = generate_docs(str(project_path), output_dir)
-
     if not success:
         click.echo("No workflows found to document.")
         raise click.Abort()
+    return output_dir
 
-    serve_result = serve_docs(port, artefact_path=str(output_dir), project_root=project_root)
-    if not serve_result:
+
+def _serve_catalog(output_dir: Path, port: int, project_root: Path | None = None) -> None:
+    """Start the docs HTTP server on *port*; blocks until Ctrl+C.
+
+    Raises ``click.Abort`` if the underlying server cannot start (missing
+    assets, port bind failure, etc.).
+    """
+    served = serve_docs(port, artefact_path=str(output_dir), project_root=project_root)
+    if not served:
         raise click.Abort()
+
+
+@click.group("docs", invoke_without_command=True)
+@click.option(
+    "--output",
+    "-o",
+    default=DEFAULT_OUTPUT,
+    help=(
+        f"Output directory for generated files (default: {DEFAULT_OUTPUT}). "
+        "Used only by the deprecated bare 'agac docs' alias — prefer "
+        "'agac docs build -o ...' or 'agac docs serve -o ...'."
+    ),
+)
+@click.option(
+    "--port",
+    "-p",
+    default=DEFAULT_PORT,
+    help=(
+        f"Port to run the server on (default: {DEFAULT_PORT}). "
+        "Used only by the deprecated bare 'agac docs' alias — prefer "
+        "'agac docs serve -p ...'."
+    ),
+)
+@click.pass_context
+def docs(ctx: click.Context, output: str, port: int) -> None:
+    """Build and serve workflow documentation.
+
+    \b
+    Subcommands:
+      build   Generate catalog.json and exit (CI-friendly, never blocks).
+      serve   Generate catalog.json and start a blocking HTTP server.
+      test    Run Playwright tests against the documentation site.
+
+    Calling ``agac docs`` with no subcommand is DEPRECATED; it currently
+    prints a notice on stderr and delegates to ``serve``. The alias will be
+    removed in v0.3.0 — migrate to the explicit subcommands.
+
+    \b
+    Examples:
+        agac docs build               (CI; exits when done)
+        agac docs serve               (interactive; blocks until Ctrl+C)
+        agac docs serve --port 3000
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    click.echo(
+        "DEPRECATED: 'agac docs' (no subcommand) is deprecated and will be "
+        f"removed in {DEPRECATION_REMOVAL_VERSION}. Use 'agac docs serve' "
+        "(or 'agac docs build' for CI). Delegating to 'serve' for now.",
+        err=True,
+    )
+    ctx.invoke(serve, output=output, port=port)
+
+
+@docs.command("build")
+@click.option(
+    "--output",
+    "-o",
+    default=DEFAULT_OUTPUT,
+    show_default=True,
+    help="Output directory for generated files. Exits without serving (CI-friendly).",
+)
+@handles_user_errors("docs build")
+@requires_project
+def build(output: str, project_root: Path | None = None) -> None:
+    """Generate catalog.json and exit. CI-friendly; does not bind a port."""
+    output_dir = _build_catalog(output, project_root=project_root)
+    click.echo(f"Wrote catalog to {output_dir / 'catalog.json'}", err=True)
+
+
+@docs.command("serve")
+@click.option(
+    "--output",
+    "-o",
+    default=DEFAULT_OUTPUT,
+    show_default=True,
+    help="Output directory for generated files before serving.",
+)
+@click.option(
+    "--port",
+    "-p",
+    default=DEFAULT_PORT,
+    show_default=True,
+    help="HTTP port to bind. This command BLOCKS until interrupted (Ctrl+C).",
+)
+@handles_user_errors("docs serve")
+@requires_project
+def serve(output: str, port: int, project_root: Path | None = None) -> None:
+    """Generate catalog.json then start a blocking HTTP server.
+
+    This command BLOCKS until interrupted (Ctrl+C). Not suitable for CI;
+    use 'agac docs build' there.
+    """
+    output_dir = _build_catalog(output, project_root=project_root)
+    _serve_catalog(output_dir, port=port, project_root=project_root)
 
 
 @docs.command(name="test")

--- a/agent_actions/cli/docs.py
+++ b/agent_actions/cli/docs.py
@@ -15,16 +15,6 @@ DEFAULT_PORT = 8000
 DEPRECATION_REMOVAL_VERSION = "v0.3.0"
 
 
-def _resolve_output_dir(output: str, project_path: Path) -> Path:
-    """Resolve *output* against *project_path*, returning an absolute path."""
-    output_dir = Path(output)
-    if not output_dir.is_absolute():
-        output_dir = (project_path / output_dir).resolve()
-    else:
-        output_dir = output_dir.resolve()
-    return output_dir
-
-
 def _build_catalog(output: str, project_root: Path | None = None) -> Path:
     """Generate ``catalog.json`` (and ``runs.json`` if missing) into *output*.
 
@@ -32,11 +22,13 @@ def _build_catalog(output: str, project_root: Path | None = None) -> Path:
     output directory. Raises ``click.Abort`` if no workflows are discovered.
     """
     project_path = resolve_project_root(project_root)
-    output_dir = _resolve_output_dir(output, project_path)
+    # Path joining with an absolute right-hand side returns the right-hand
+    # side, so this one expression covers both relative and absolute -o.
+    output_dir = (project_path / Path(output)).resolve()
 
     success = generate_docs(str(project_path), output_dir)
     if not success:
-        click.echo("No workflows found to document.")
+        click.echo("No workflows found to document.", err=True)
         raise click.Abort()
     return output_dir
 
@@ -94,6 +86,18 @@ def docs(ctx: click.Context, output: str, port: int) -> None:
         agac docs serve --port 3000
     """
     if ctx.invoked_subcommand is not None:
+        # The group declares --output/--port only so the deprecated bare
+        # `agac docs` invocation can keep accepting the legacy flag positions.
+        # Click consumes them silently before the subcommand runs, so
+        # `agac docs -o X build` would otherwise write to build's default
+        # `artefact/` and drop X without warning. Refuse the ambiguous form
+        # and point the user at the correct subcommand-level invocation.
+        for name in ("output", "port"):
+            if ctx.get_parameter_source(name) != click.core.ParameterSource.DEFAULT:
+                raise click.UsageError(
+                    f"--{name} must follow the subcommand, not precede it. "
+                    f"Try: agac docs {ctx.invoked_subcommand} --{name} ..."
+                )
         return
 
     click.echo(

--- a/docs.agent-actions/docs/reference/cli/utilities.md
+++ b/docs.agent-actions/docs/reference/cli/utilities.md
@@ -158,30 +158,58 @@ This removes cached batch results. If you haven't retrieved batch results yet, d
 
 ## docs
 
-Build and serve interactive documentation for your agentic workflows. The `docs` command scans your project, generates documentation data, and starts an HTTP server in one step.
+`agac docs` is a Click group that builds and (optionally) serves interactive
+documentation for your agentic workflows. Use **`build`** in CI to generate the
+catalog and exit; use **`serve`** locally to generate the catalog and then run a
+blocking HTTP server.
+
+### docs build
+
+Generate `catalog.json` (and initialize `runs.json` if missing) and exit. CI-friendly — does not bind a port.
 
 ```bash
-agac docs [options]
+agac docs build [options]
 ```
 
 **Options:**
+
 | Option | Description |
 |--------|-------------|
 | `-o, --output` | Output directory for generated files (default: `artefact`) |
-| `-p, --port` | Port to run server on (default: `8000`) |
-| `-a, --artefact` | Path to artefact directory (default: `./artefact`) |
+
+**Example:**
+```bash
+agac docs build --output ./custom-artefact
+```
+
+### docs serve
+
+Run `build`, then start a blocking HTTP server. Blocks until interrupted with Ctrl+C; not suitable for CI.
+
+```bash
+agac docs serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output` | Output directory for generated files (default: `artefact`) |
+| `-p, --port` | Port to bind the HTTP server on (default: `8000`) |
 
 **Examples:**
 ```bash
-# Build and serve documentation on default port
-agac docs
+# Serve on the default port
+agac docs serve
 
 # Serve on a custom port
-agac docs --port 3000
-
-# Generate to a custom directory
-agac docs --output ./custom-artefact
+agac docs serve --port 3000
 ```
+
+### docs (deprecated alias)
+
+Calling `agac docs` with no subcommand prints a deprecation notice on stderr
+and delegates to `agac docs serve`. The alias will be removed in **v0.3.0**.
 
 ### docs test
 

--- a/docs.agent-actions/docs/reference/documentation-site.md
+++ b/docs.agent-actions/docs/reference/documentation-site.md
@@ -14,32 +14,73 @@ The screenshot below shows the documentation site homepage. You can explore your
 ## Quick Start
 
 ```bash
-# Build and serve the documentation site
-agac docs
+# Generate the catalog and serve it locally (blocks until Ctrl+C)
+agac docs serve
 
 # Open http://localhost:8000
 ```
 
+For CI, generate the catalog without binding a port:
+
+```bash
+agac docs build
+```
+
 ## CLI Commands
 
-### `agac docs`
+`agac docs` is a Click group with two subcommands. Each subcommand scans your
+project and writes the same documentation data files; they differ only in
+whether they then start an HTTP server.
 
-Scans your project, generates documentation data, and serves an interactive documentation site. Think of this as taking a snapshot of your entire project—every agentic workflow, prompt, and schema gets cataloged—then immediately launching a browsable interface.
-
-**What it scans:**
+**What gets scanned (by both `build` and `serve`):**
 - Agentic workflows in `artefact/rendered_workflows/` and `*/agent_config/`
 - Prompts in `prompt_store/*.md` files
 - Schemas in `schema/` files (`.yml`, `.yaml`, `.json`)
 
-**Output:**
-- `artefact/catalog.json` — Agentic workflow catalog
-- `artefact/runs.json` — Execution history
+**Output files (written into `--output`, default `artefact/`):**
+- `catalog.json` — Agentic workflow catalog
+- `runs.json` — Execution history (initialized empty if missing; populated by workflow runs)
+
+### `agac docs build`
+
+Generates `catalog.json` (and initializes `runs.json` if it does not exist) and
+**exits**. Suitable for CI — does not bind a port and does not block.
 
 ```bash
-agac docs
-agac docs --port 3000
-agac docs --output ./custom-artefact
+agac docs build
+agac docs build --output ./custom-artefact
 ```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-o, --output` | `artefact` | Directory to write the catalog into. |
+
+### `agac docs serve`
+
+Runs `build`, then starts a **blocking** HTTP server on `--port` so the
+generated site can be browsed locally. This command does not return until
+interrupted with Ctrl+C; do not call it from CI.
+
+```bash
+agac docs serve
+agac docs serve --port 3000
+agac docs serve --output ./custom-artefact
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-o, --output` | `artefact` | Directory to write the catalog into before serving. |
+| `-p, --port` | `8000` | HTTP port to bind. |
+
+### `agac docs` (deprecated alias)
+
+Calling `agac docs` with no subcommand prints a deprecation notice on stderr
+and delegates to `agac docs serve`. The alias will be removed in **v0.3.0**;
+migrate to the explicit subcommands at your convenience.
 
 ### `agac docs test`
 
@@ -94,11 +135,11 @@ Find resources quickly with full-text search across agentic workflows, actions, 
 
 ## Deployment
 
-The documentation site is a static HTML/CSS/JS application. After running `agac docs`, you can deploy it anywhere static files are served:
+The documentation site is a static HTML/CSS/JS application. After running `agac docs build`, you can deploy it anywhere static files are served:
 
-- **Local development** — `agac docs`
+- **Local development** — `agac docs serve`
 - **Static hosting** — Copy the docs site to any web server (S3, Netlify, etc.)
-- **CI/CD** — Generate docs as part of your pipeline
+- **CI/CD** — `agac docs build` generates the catalog without binding a port
 
 :::info
 The documentation site generates static files only. It does not require a backend server, but it also cannot show real-time execution data—you need to regenerate after runs complete.

--- a/tests/unit/cli/test_docs_subcommands.py
+++ b/tests/unit/cli/test_docs_subcommands.py
@@ -1,0 +1,161 @@
+"""Regression tests for VIOL-0037 + VIOL-0095: `agac docs` build/serve split.
+
+These tests pin the user-facing surface of the new Click group:
+
+* ``build`` must exit 0 without binding a port (CI-friendly).
+* ``serve`` must call into the underlying HTTP server (blocking in real use,
+  patched here so the test does not hang).
+* The bare ``agac docs`` alias must emit a deprecation notice on stderr
+  and delegate to ``serve``.
+* ``--help`` text must make the blocking/exit semantics discoverable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from agent_actions.cli import docs as docs_mod
+from agent_actions.cli.docs import docs as docs_group
+
+
+@pytest.fixture
+def runner():
+    # Click 8.2+ splits stdout/stderr by default, so the deprecation test can
+    # assert the notice lands on stderr specifically without extra config.
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_project(tmp_path: Path):
+    """Patch project-root discovery so subcommands do not need a real project."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    with patch(
+        "agent_actions.cli.cli_decorators.ensure_in_project",
+        return_value=project_root,
+    ):
+        yield project_root
+
+
+def test_build_exits_zero_without_serving(runner, fake_project, tmp_path):
+    """`agac docs build` runs the build helper and exits — never invokes serve."""
+    output_dir = tmp_path / "out"
+    with (
+        patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
+        patch.object(docs_mod, "_serve_catalog") as mocked_serve,
+    ):
+        result = runner.invoke(docs_group, ["build", "-o", str(output_dir)])
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    mocked_build.assert_called_once()
+    mocked_serve.assert_not_called()
+
+
+def test_serve_invokes_serve_catalog(runner, fake_project, tmp_path):
+    """`agac docs serve` builds the catalog, then hands off to the server."""
+    output_dir = tmp_path / "out"
+    with (
+        patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
+        patch.object(docs_mod, "_serve_catalog") as mocked_serve,
+    ):
+        result = runner.invoke(docs_group, ["serve", "-o", str(output_dir), "-p", "0"])
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    mocked_build.assert_called_once()
+    mocked_serve.assert_called_once()
+    # Port is forwarded explicitly so muscle-memory invocations still bind
+    # the requested port.
+    _, kwargs = mocked_serve.call_args
+    assert kwargs.get("port") == 0
+
+
+def test_bare_docs_warns_on_stderr_and_delegates_to_serve(runner, fake_project, tmp_path):
+    """`agac docs` (no subcommand) prints deprecation on stderr and delegates."""
+    output_dir = tmp_path / "out"
+    with (
+        patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
+        patch.object(docs_mod, "_serve_catalog") as mocked_serve,
+    ):
+        result = runner.invoke(docs_group, ["-o", str(output_dir), "-p", "0"])
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert "deprecated" in result.stderr.lower(), (
+        f"Deprecation notice missing from stderr; got: {result.stderr!r}"
+    )
+    assert "deprecated" not in result.stdout.lower(), (
+        "Deprecation notice must NOT appear on stdout (CI consumers may pipe stdout)."
+    )
+    # Names the replacement so users know what to migrate to.
+    assert "agac docs serve" in result.stderr
+    mocked_build.assert_called_once()
+    mocked_serve.assert_called_once()
+
+
+def test_bare_docs_forwards_group_options_to_serve(runner, fake_project, tmp_path):
+    """Group-level -o/-p flags survive the alias delegation to `serve`."""
+    output_dir = tmp_path / "custom"
+    with (
+        patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
+        patch.object(docs_mod, "_serve_catalog") as mocked_serve,
+    ):
+        result = runner.invoke(docs_group, ["-o", str(output_dir), "-p", "9999"])
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    # Build received the same -o value passed at the group level.
+    _, build_kwargs = mocked_build.call_args
+    assert build_kwargs.get(
+        "output", mocked_build.call_args.args[0] if mocked_build.call_args.args else None
+    ) == str(output_dir) or mocked_build.call_args.args[0] == str(output_dir)
+    # Serve received the same -p value.
+    _, serve_kwargs = mocked_serve.call_args
+    assert serve_kwargs.get("port") == 9999
+
+
+def test_build_help_mentions_exit_or_ci(runner):
+    """`agac docs build --help` must signal it does not block (CI-friendly)."""
+    result = runner.invoke(docs_group, ["build", "--help"])
+    assert result.exit_code == 0
+    text = result.output.lower()
+    assert "exit" in text or "ci" in text, (
+        f"build --help must mention exit/CI semantics; got: {result.output!r}"
+    )
+
+
+def test_serve_help_mentions_blocking(runner):
+    """`agac docs serve --help` must signal that it blocks (so users learn it)."""
+    result = runner.invoke(docs_group, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "block" in result.output.lower(), (
+        f"serve --help must mention blocking; got: {result.output!r}"
+    )
+
+
+def test_group_help_lists_both_subcommands(runner):
+    """`agac docs --help` advertises both build and serve."""
+    result = runner.invoke(docs_group, ["--help"])
+    assert result.exit_code == 0
+    text = result.output.lower()
+    assert "build" in text and "serve" in text
+
+
+def test_build_aborts_on_no_workflows(runner, fake_project, tmp_path):
+    """When the underlying generator finds nothing, build exits non-zero (Abort)."""
+    with patch.object(docs_mod, "generate_docs", return_value=False):
+        result = runner.invoke(docs_group, ["build", "-o", str(tmp_path / "out")])
+
+    # click.Abort produces a non-zero exit; the user sees the "no workflows" message.
+    assert result.exit_code != 0
+    assert "no workflows" in (result.stdout + result.stderr).lower()
+
+
+def test_serve_help_mentions_port_default(runner):
+    """`agac docs serve --help` shows the historical port default so users keep muscle memory."""
+    result = runner.invoke(docs_group, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "8000" in result.output, (
+        f"Default port (8000) must remain visible in --help; got: {result.output!r}"
+    )

--- a/tests/unit/cli/test_docs_subcommands.py
+++ b/tests/unit/cli/test_docs_subcommands.py
@@ -1,14 +1,4 @@
-"""Regression tests for VIOL-0037 + VIOL-0095: `agac docs` build/serve split.
-
-These tests pin the user-facing surface of the new Click group:
-
-* ``build`` must exit 0 without binding a port (CI-friendly).
-* ``serve`` must call into the underlying HTTP server (blocking in real use,
-  patched here so the test does not hang).
-* The bare ``agac docs`` alias must emit a deprecation notice on stderr
-  and delegate to ``serve``.
-* ``--help`` text must make the blocking/exit semantics discoverable.
-"""
+"""Regression tests for VIOL-0037 + VIOL-0095: `agac docs` build/serve split."""
 
 from __future__ import annotations
 
@@ -24,14 +14,11 @@ from agent_actions.cli.docs import docs as docs_group
 
 @pytest.fixture
 def runner():
-    # Click 8.2+ splits stdout/stderr by default, so the deprecation test can
-    # assert the notice lands on stderr specifically without extra config.
     return CliRunner()
 
 
 @pytest.fixture
 def fake_project(tmp_path: Path):
-    """Patch project-root discovery so subcommands do not need a real project."""
     project_root = tmp_path / "project"
     project_root.mkdir()
     with patch(
@@ -42,7 +29,6 @@ def fake_project(tmp_path: Path):
 
 
 def test_build_exits_zero_without_serving(runner, fake_project, tmp_path):
-    """`agac docs build` runs the build helper and exits — never invokes serve."""
     output_dir = tmp_path / "out"
     with (
         patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
@@ -56,7 +42,6 @@ def test_build_exits_zero_without_serving(runner, fake_project, tmp_path):
 
 
 def test_serve_invokes_serve_catalog(runner, fake_project, tmp_path):
-    """`agac docs serve` builds the catalog, then hands off to the server."""
     output_dir = tmp_path / "out"
     with (
         patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
@@ -67,14 +52,10 @@ def test_serve_invokes_serve_catalog(runner, fake_project, tmp_path):
     assert result.exit_code == 0, (result.stdout, result.stderr)
     mocked_build.assert_called_once()
     mocked_serve.assert_called_once()
-    # Port is forwarded explicitly so muscle-memory invocations still bind
-    # the requested port.
-    _, kwargs = mocked_serve.call_args
-    assert kwargs.get("port") == 0
+    assert mocked_serve.call_args.kwargs["port"] == 0
 
 
 def test_bare_docs_warns_on_stderr_and_delegates_to_serve(runner, fake_project, tmp_path):
-    """`agac docs` (no subcommand) prints deprecation on stderr and delegates."""
     output_dir = tmp_path / "out"
     with (
         patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
@@ -83,20 +64,14 @@ def test_bare_docs_warns_on_stderr_and_delegates_to_serve(runner, fake_project, 
         result = runner.invoke(docs_group, ["-o", str(output_dir), "-p", "0"])
 
     assert result.exit_code == 0, (result.stdout, result.stderr)
-    assert "deprecated" in result.stderr.lower(), (
-        f"Deprecation notice missing from stderr; got: {result.stderr!r}"
-    )
-    assert "deprecated" not in result.stdout.lower(), (
-        "Deprecation notice must NOT appear on stdout (CI consumers may pipe stdout)."
-    )
-    # Names the replacement so users know what to migrate to.
+    assert "deprecated" in result.stderr.lower()
+    assert "deprecated" not in result.stdout.lower()
     assert "agac docs serve" in result.stderr
     mocked_build.assert_called_once()
     mocked_serve.assert_called_once()
 
 
 def test_bare_docs_forwards_group_options_to_serve(runner, fake_project, tmp_path):
-    """Group-level -o/-p flags survive the alias delegation to `serve`."""
     output_dir = tmp_path / "custom"
     with (
         patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
@@ -105,34 +80,25 @@ def test_bare_docs_forwards_group_options_to_serve(runner, fake_project, tmp_pat
         result = runner.invoke(docs_group, ["-o", str(output_dir), "-p", "9999"])
 
     assert result.exit_code == 0, (result.stdout, result.stderr)
-    # _build_catalog(output, project_root=...) — first positional is the -o value.
     assert mocked_build.call_args.args[0] == str(output_dir)
-    # _serve_catalog(output_dir, port=..., project_root=...) — port is a kwarg.
     assert mocked_serve.call_args.kwargs["port"] == 9999
 
 
 def test_build_help_mentions_exit_or_ci(runner):
-    """`agac docs build --help` must signal it does not block (CI-friendly)."""
     result = runner.invoke(docs_group, ["build", "--help"])
     assert result.exit_code == 0
     text = result.output.lower()
-    assert "exit" in text or "ci" in text, (
-        f"build --help must mention exit/CI semantics; got: {result.output!r}"
-    )
+    assert "exit" in text or "ci" in text
 
 
 def test_serve_help_signals_blocking_and_default_port(runner):
-    """`agac docs serve --help` must surface blocking semantics + default port."""
     result = runner.invoke(docs_group, ["serve", "--help"])
     assert result.exit_code == 0
-    text = result.output.lower()
-    assert "block" in text, f"serve --help must mention blocking; got: {result.output!r}"
-    # Default port (8000) must remain visible so muscle memory survives the split.
-    assert "8000" in result.output, f"Default port (8000) missing from --help: {result.output!r}"
+    assert "block" in result.output.lower()
+    assert "8000" in result.output
 
 
 def test_group_help_lists_both_subcommands(runner):
-    """`agac docs --help` advertises both build and serve."""
     result = runner.invoke(docs_group, ["--help"])
     assert result.exit_code == 0
     text = result.output.lower()
@@ -140,22 +106,14 @@ def test_group_help_lists_both_subcommands(runner):
 
 
 def test_build_aborts_on_no_workflows(runner, fake_project, tmp_path):
-    """When the underlying generator finds nothing, build exits non-zero (Abort)."""
-    # generate_docs is the underlying scanner; resolve_project_root with a
-    # non-None Path is an idempotent pass-through, so _build_catalog reaches
-    # the generate_docs mock without needing additional patches.
     with patch.object(docs_mod, "generate_docs", return_value=False):
         result = runner.invoke(docs_group, ["build", "-o", str(tmp_path / "out")])
 
     assert result.exit_code != 0
-    # Message must land on stderr (CI stdout pipelines must not see error chatter).
-    assert "no workflows" in result.stderr.lower(), (
-        f"expected 'no workflows' on stderr; got stdout={result.stdout!r} stderr={result.stderr!r}"
-    )
+    assert "no workflows" in result.stderr.lower()
 
 
 def test_group_options_before_subcommand_are_rejected(runner, fake_project, tmp_path):
-    """`agac docs -o X build` must error — Click would otherwise silently drop -o."""
     output_dir = tmp_path / "custom"
     with (
         patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
@@ -165,13 +123,11 @@ def test_group_options_before_subcommand_are_rejected(runner, fake_project, tmp_
 
     assert result.exit_code != 0, (result.stdout, result.stderr)
     assert "must follow the subcommand" in result.stderr.lower()
-    # Neither helper should have been reached — the error is raised in the group.
     mocked_build.assert_not_called()
     mocked_serve.assert_not_called()
 
 
 def test_group_port_before_subcommand_is_rejected(runner, fake_project, tmp_path):
-    """Same as above for `-p`; pins the second option independently."""
     with (
         patch.object(docs_mod, "_build_catalog", return_value=tmp_path) as mocked_build,
         patch.object(docs_mod, "_serve_catalog") as mocked_serve,

--- a/tests/unit/cli/test_docs_subcommands.py
+++ b/tests/unit/cli/test_docs_subcommands.py
@@ -105,14 +105,10 @@ def test_bare_docs_forwards_group_options_to_serve(runner, fake_project, tmp_pat
         result = runner.invoke(docs_group, ["-o", str(output_dir), "-p", "9999"])
 
     assert result.exit_code == 0, (result.stdout, result.stderr)
-    # Build received the same -o value passed at the group level.
-    _, build_kwargs = mocked_build.call_args
-    assert build_kwargs.get(
-        "output", mocked_build.call_args.args[0] if mocked_build.call_args.args else None
-    ) == str(output_dir) or mocked_build.call_args.args[0] == str(output_dir)
-    # Serve received the same -p value.
-    _, serve_kwargs = mocked_serve.call_args
-    assert serve_kwargs.get("port") == 9999
+    # _build_catalog(output, project_root=...) — first positional is the -o value.
+    assert mocked_build.call_args.args[0] == str(output_dir)
+    # _serve_catalog(output_dir, port=..., project_root=...) — port is a kwarg.
+    assert mocked_serve.call_args.kwargs["port"] == 9999
 
 
 def test_build_help_mentions_exit_or_ci(runner):
@@ -125,13 +121,14 @@ def test_build_help_mentions_exit_or_ci(runner):
     )
 
 
-def test_serve_help_mentions_blocking(runner):
-    """`agac docs serve --help` must signal that it blocks (so users learn it)."""
+def test_serve_help_signals_blocking_and_default_port(runner):
+    """`agac docs serve --help` must surface blocking semantics + default port."""
     result = runner.invoke(docs_group, ["serve", "--help"])
     assert result.exit_code == 0
-    assert "block" in result.output.lower(), (
-        f"serve --help must mention blocking; got: {result.output!r}"
-    )
+    text = result.output.lower()
+    assert "block" in text, f"serve --help must mention blocking; got: {result.output!r}"
+    # Default port (8000) must remain visible so muscle memory survives the split.
+    assert "8000" in result.output, f"Default port (8000) missing from --help: {result.output!r}"
 
 
 def test_group_help_lists_both_subcommands(runner):
@@ -144,18 +141,44 @@ def test_group_help_lists_both_subcommands(runner):
 
 def test_build_aborts_on_no_workflows(runner, fake_project, tmp_path):
     """When the underlying generator finds nothing, build exits non-zero (Abort)."""
+    # generate_docs is the underlying scanner; resolve_project_root with a
+    # non-None Path is an idempotent pass-through, so _build_catalog reaches
+    # the generate_docs mock without needing additional patches.
     with patch.object(docs_mod, "generate_docs", return_value=False):
         result = runner.invoke(docs_group, ["build", "-o", str(tmp_path / "out")])
 
-    # click.Abort produces a non-zero exit; the user sees the "no workflows" message.
     assert result.exit_code != 0
-    assert "no workflows" in (result.stdout + result.stderr).lower()
-
-
-def test_serve_help_mentions_port_default(runner):
-    """`agac docs serve --help` shows the historical port default so users keep muscle memory."""
-    result = runner.invoke(docs_group, ["serve", "--help"])
-    assert result.exit_code == 0
-    assert "8000" in result.output, (
-        f"Default port (8000) must remain visible in --help; got: {result.output!r}"
+    # Message must land on stderr (CI stdout pipelines must not see error chatter).
+    assert "no workflows" in result.stderr.lower(), (
+        f"expected 'no workflows' on stderr; got stdout={result.stdout!r} stderr={result.stderr!r}"
     )
+
+
+def test_group_options_before_subcommand_are_rejected(runner, fake_project, tmp_path):
+    """`agac docs -o X build` must error — Click would otherwise silently drop -o."""
+    output_dir = tmp_path / "custom"
+    with (
+        patch.object(docs_mod, "_build_catalog", return_value=output_dir) as mocked_build,
+        patch.object(docs_mod, "_serve_catalog") as mocked_serve,
+    ):
+        result = runner.invoke(docs_group, ["-o", str(output_dir), "build"])
+
+    assert result.exit_code != 0, (result.stdout, result.stderr)
+    assert "must follow the subcommand" in result.stderr.lower()
+    # Neither helper should have been reached — the error is raised in the group.
+    mocked_build.assert_not_called()
+    mocked_serve.assert_not_called()
+
+
+def test_group_port_before_subcommand_is_rejected(runner, fake_project, tmp_path):
+    """Same as above for `-p`; pins the second option independently."""
+    with (
+        patch.object(docs_mod, "_build_catalog", return_value=tmp_path) as mocked_build,
+        patch.object(docs_mod, "_serve_catalog") as mocked_serve,
+    ):
+        result = runner.invoke(docs_group, ["-p", "9999", "serve"])
+
+    assert result.exit_code != 0, (result.stdout, result.stderr)
+    assert "must follow the subcommand" in result.stderr.lower()
+    mocked_build.assert_not_called()
+    mocked_serve.assert_not_called()


### PR DESCRIPTION
## Summary

UAT Audit T2-O (Wave-0 gate for Clones 5/6). Closes **VIOL-0037** (no build-only mode) and **VIOL-0095** (doc promised an `agac docs build` subcommand that did not exist).

- `agac docs` is now a Click group with two explicit subcommands sharing a private `_build_catalog(...)` helper:
  - `agac docs build` — generates `catalog.json` (and initializes `runs.json` if missing) into `--output` and **exits**. Never binds a port; safe for CI.
  - `agac docs serve` — runs `build` then enters the blocking HTTP server on `--port`. `--help` text makes the blocking semantics explicit.
- Bare `agac docs` (no subcommand) is preserved as a **deprecated alias** for `serve` — emits a removal notice on **stderr** (not stdout) naming `v0.3.0` as the removal target, then delegates via `ctx.invoke`.
- Defaults preserved: `--output artefact`, `--port 8000`. The `agac docs test` Playwright subcommand is unchanged.
- Docs (`reference/documentation-site.md`, `reference/cli/utilities.md`) rewritten to teach the new surface; the phantom `-a, --artefact` flag is removed from `cli/utilities.md` (partial closure of VIOL-0087/0096).

## Verification

- `pytest -q` — **7656 passed** (9 new tests in `tests/unit/cli/test_docs_subcommands.py`).
- `ruff format --check agent_actions tests` — clean.
- `ruff check agent_actions tests` — `All checks passed!`
- Live CLI smoke against `examples/incident_triage`:
  ```bash
  agac docs build -o /tmp/agac-docs-smoke
  # → "Wrote catalog to /private/tmp/agac-docs-smoke/catalog.json"
  # → exits 0, writes catalog.json + runs.json, no port bound
  ```
- `agac docs --help` lists `build`, `serve`, `test`; `build --help` says "CI-friendly", `serve --help` says "BLOCKS until interrupted".

## Cross-clone note

`docs.agent-actions/docs/reference/documentation-site.md` is normally Clone 6's owned root, but the T2-O spec explicitly rewrites this page (Task 4) and the cross-clone dependency graph routes Clones 5/6 doc work *after* T2-O lands — so the cohesive ship of code + docs in one PR is intentional and collision-free in Wave 0. Flagged in `coordination/status.md`.

## What is intentionally NOT in this PR

- The deprecated bare `agac docs` alias stays for one release cycle (per spec self-review notes — removing it now breaks every existing script).
- Default `--output` and `--port` values are unchanged (silent path/port migration is the worst kind of "while we're here" change).