### PR TITLE
fix(VIOL-0075): ${i-1} now resolves in dependencies + versions.md cleanup (E-15)

### DIFF
--- a/agent_actions/output/response/expander.py
+++ b/agent_actions/output/response/expander.py
@@ -323,8 +323,13 @@ class ActionExpander:
                 context_scope_defaults, context_scope_action
             )
 
-        # Initialize dependencies from action if present, else empty list
-        agent["dependencies"] = action.get("dependencies", [])
+        # Initialize dependencies from action if present, else empty list.
+        # Run them through the version template_replacer so per-iteration
+        # references like "refine_${i-1}" resolve at expansion time. Strings
+        # whose substitution yields an empty stub (e.g. ${i-1} on iteration 1)
+        # produce a value that compute_execution_levels filters out because
+        # it is not in the workflow's execution_set.
+        agent["dependencies"] = template_replacer(action.get("dependencies", []))
 
         # Process chunk configuration
         process_chunk_config(agent, action, defaults)

--- a/docs.agent-actions/docs/reference/execution/versions.md
+++ b/docs.agent-actions/docs/reference/execution/versions.md
@@ -177,13 +177,18 @@ When observe uses wildcards (`score_quality.*`), fields are also expanded as qua
 
 ### Sequential Refinement
 
+Dependency strings use **dollar-brace substitution** (`${i}`, `${i-1}`, etc.) — Jinja2 templating is **not** evaluated against dependency strings. Earlier revisions of this page showed `{% if %}` / `{% else %}` forms; those were read as literal text and never resolved. Inside the prompt body Jinja2 *is* evaluated normally.
+
 ```yaml
 - name: refine_iteration
   versions:
     range: [1, 3]
     mode: sequential
   dependencies:
-    - "{% if i == 1 %}draft_content{% else %}refine_iteration_{{ i-1 }}{% endif %}"
+    # version 1 expands to "refine_iteration_" which is filtered out (no such
+    # action exists); versions 2 and 3 depend on refine_iteration_1 and
+    # refine_iteration_2 respectively.
+    - "refine_iteration_${i-1}"
 ```
 
 ### Parallel Model Comparison
@@ -227,10 +232,10 @@ context_scope:
 
 ## Debugging
 
-Inspect expanded version actions:
+Inspect expanded version actions. `agac inspect` requires a subcommand — `graph` prints the dependency graph with each version's expanded node IDs:
 
 ```bash
-agac inspect -a workflow_name
+agac inspect graph -a workflow_name
 ```
 
 Enable prompt debug to see rendered prompts per iteration:

--- a/docs.agent-actions/docs/reference/execution/versions.md
+++ b/docs.agent-actions/docs/reference/execution/versions.md
@@ -177,7 +177,7 @@ When observe uses wildcards (`score_quality.*`), fields are also expanded as qua
 
 ### Sequential Refinement
 
-Dependency strings use **dollar-brace substitution** (`${i}`, `${i-1}`, etc.) — Jinja2 templating is **not** evaluated against dependency strings. Earlier revisions of this page showed `{% if %}` / `{% else %}` forms; those were read as literal text and never resolved. Inside the prompt body Jinja2 *is* evaluated normally.
+Dependency strings support **dollar-brace substitution** (`${i}`, `${i-1}`, etc.). Inside the prompt body, Jinja2 is also evaluated as usual — but dependency strings themselves are dollar-brace only.
 
 ```yaml
 - name: refine_iteration
@@ -185,9 +185,8 @@ Dependency strings use **dollar-brace substitution** (`${i}`, `${i-1}`, etc.) �
     range: [1, 3]
     mode: sequential
   dependencies:
-    # version 1 expands to "refine_iteration_" which is filtered out (no such
-    # action exists); versions 2 and 3 depend on refine_iteration_1 and
-    # refine_iteration_2 respectively.
+    # Version 1 has no predecessor; the framework drops the empty stub.
+    # Versions 2 and 3 depend on refine_iteration_1 and refine_iteration_2.
     - "refine_iteration_${i-1}"
 ```
 
@@ -232,7 +231,7 @@ context_scope:
 
 ## Debugging
 
-Inspect expanded version actions. `agac inspect` requires a subcommand — `graph` prints the dependency graph with each version's expanded node IDs:
+Inspect expanded version actions. `agac inspect graph` prints the dependency graph with each version's expanded node IDs:
 
 ```bash
 agac inspect graph -a workflow_name

--- a/tests/core/parser/test_action_expander_template_vars.py
+++ b/tests/core/parser/test_action_expander_template_vars.py
@@ -164,6 +164,42 @@ class TestTemplateVariableReplacement:
         assert agents[0]["prompt"] == "Iteration 1 only"
         assert agents[1]["prompt"] == "Iteration 2 only"
 
+    def test_template_var_in_dependency_string(self):
+        """Sequential refinement: ${param-1} resolves inside the dependencies list.
+
+        Regression test for VIOL-0075 — the docs example for sequential refinement
+        used Jinja2 conditional syntax inside dependency strings, which the expander
+        does not evaluate. The fix wires deps through the same template_replacer
+        already applied to prompts and schemas. Per-iteration values like
+        ``refine_iteration_${i-1}`` must now expand:
+
+        * iteration 1: empty stub (``refine_iteration_``), filtered downstream
+          because it is not an action in the workflow.
+        * iteration 2+: the previous version's expanded name.
+        """
+        config = {
+            "name": "test_workflow",
+            "description": "Test workflow",
+            "version": "1.0.0",
+            "defaults": {"model_vendor": "openai", "model_name": "gpt-4o-mini"},
+            "actions": [
+                {
+                    "name": "refine",
+                    "intent": "Sequential refinement",
+                    "api_key": "OPENAI_API_KEY",
+                    "prompt": "Refine v${i}",
+                    "dependencies": ["refine_${i-1}"],
+                    "versions": {"param": "i", "range": [1, 3], "mode": "sequential"},
+                }
+            ],
+            "plan": ["refine"],
+        }
+        result = ActionExpander.expand_actions_to_agents(config)
+        agents = result["test_workflow"]
+        assert agents[0]["dependencies"] == ["refine_"]
+        assert agents[1]["dependencies"] == ["refine_1"]
+        assert agents[2]["dependencies"] == ["refine_2"]
+
     def test_multiple_previous_refs_in_string(self):
         """Test multiple ${param-1} occurrences in the same string."""
         config = {


### PR DESCRIPTION
## Summary

Two drifts on `docs/reference/execution/versions.md`:

1. **Sequential refinement (VIOL-0075):** The example wired the dep with Jinja2 (`{% if i == 1 %}...{% else %}refine_iteration_{{ i-1 }}{% endif %}`). The expander does not evaluate Jinja2 against dep strings — and on inspection, it also did **not** apply the `${i-1}` dollar-brace `template_replacer` that already runs against prompts and schemas. Both the documented Jinja2 form *and* the spec's proposed `${i-1}` form would have been read as literal text.

   The staff fix is to make the runtime match what the doc claims, not perpetuate a broken example. One-line wire-up in `_create_agent_from_action` passes the dep list through the same `template_replacer`. Iteration 1's `${i-1}` collapses to an empty stub which `compute_execution_levels` filters out — exactly the "no predecessor on v1" semantics users expect from sequential refinement.

2. **Debug command (VIOL-0076):** `agac inspect -a workflow_name` rejected with "No such option: -a". Corrected to `agac inspect graph -a workflow_name` (subcommand required).

## Files

- `agent_actions/output/response/expander.py` — line 327: deps run through `template_replacer`.
- `docs.agent-actions/docs/reference/execution/versions.md` — replace Jinja2 dep example with `${i-1}` form + add callout; fix debug command.
- `tests/core/parser/test_action_expander_template_vars.py` — regression test pinning `refine_${i-1}` → `["refine_"]`, `["refine_1"]`, `["refine_2"]` across iterations.

## Verification

- New test `test_template_var_in_dependency_string` passes.
- Full expander/parser/response suite: 233/233 passing.
- Broader `tests/core/` + `tests/unit/config/` + key workflow tests: 626/626 passing.
- `ruff check` / `ruff format --check` clean.

## Ownership note

This crosses Clone 6's docs-only bucket into `agent_actions/output/response/expander.py`. The user explicitly asked for a staff-engineer decision after I surfaced that the spec's proposed `${i-1}` doc fix didn't actually work either; the right call was to fix the runtime so the doc claim becomes true rather than ship a second non-working example.

Source: `specs/active/uat-audit/violations/VIOL-0075-versions-docs.md`