### PR TITLE
docs(VIOL-0077): make retry.enabled=true default explicit (E-16)

### DIFF
--- a/docs.agent-actions/docs/reference/execution/retry.md
+++ b/docs.agent-actions/docs/reference/execution/retry.md
@@ -7,12 +7,14 @@ sidebar_position: 6
 
 Retry handles transient errors (rate limits, network issues, server errors) automatically with exponential backoff.
 
+Retry is **enabled by default** (`enabled: true`). The `retry:` block is optional — omitting it leaves retry on with the framework's default attempt count (`3`) and `return_last` exhaustion behavior. To opt out, set `enabled: false` explicitly.
+
 ## Configuration
 
 ```yaml
 defaults:
   retry:
-    enabled: true
+    enabled: true        # default — shown for clarity, can be omitted
     max_attempts: 3
     on_exhausted: return_last
 
@@ -21,13 +23,17 @@ actions:
     retry:
       max_attempts: 5
       on_exhausted: raise
+
+  - name: noisy_endpoint
+    retry:
+      enabled: false     # explicit opt-out; default is true
 ```
 
 ### Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `enabled` | bool | `true` | Enable/disable retry |
+| `enabled` | bool | `true` | Retry is on by default. Set `enabled: false` to opt out. Other fields below take effect only when `enabled` is `true`. |
 | `max_attempts` | int | `3` | Maximum attempts (1-10) |
 | `on_exhausted` | string | `return_last` | Behavior when retries exhausted |
 


### PR DESCRIPTION
## Summary

`retry.md`'s prose and example implied users had to set `enabled: true` to turn retry on. The Pydantic schema in `agent_actions/config/schema.py:84` declares `enabled: bool = Field(default=True)`, so retry is on for every action by default — omitting the `retry:` block is not the same as opting out. The previous wording distorted cost and observability assumptions for users who thought their workflows had no retry behavior when in fact they did.

## Changes

- Added a callout above the configuration example: "Retry is **enabled by default** ... The `retry:` block is optional ... To opt out, set `enabled: false` explicitly."
- Added a second example showing `enabled: false` as the opt-out path.
- Strengthened the Options-table cell for `enabled` to say "Retry is on by default. Set `enabled: false` to opt out. Other fields below take effect only when `enabled` is true."

## Verification

- Runtime probe matches the doc:
  ```
  $ python -c "from agent_actions.config.schema import RetryConfig; print(RetryConfig().enabled)"
  True
  ```
- Opt-in wording grep clean:
  ```
  $ grep -nE 'opt.?in|to enable retry\b|off by default' docs.agent-actions/docs/reference/execution/retry.md
  (no matches)
  ```

Source: `specs/active/uat-audit/violations/VIOL-0077-retry-docs.md`