### PR TITLE
docs(VIOL-0079): add use_llm_critique + critique_after_attempt to reprompting options (E-17)

### DIFF
--- a/docs.agent-actions/docs/reference/validation/reprompting.md
+++ b/docs.agent-actions/docs/reference/validation/reprompting.md
@@ -49,6 +49,8 @@ defaults:
 | `max_attempts` | integer | 2 | Maximum retry attempts |
 | `on_exhausted` | string | `return_last` | Behavior when attempts exhausted |
 | `use_self_reflection` | boolean | `false` | Include self-reflection instruction in retry prompts |
+| `use_llm_critique` | boolean | `false` | Enable LLM critique for stubborn validation failures. When `true`, after a failed attempt the previous response is fed to a critique LLM, whose feedback is injected into the next reprompt. |
+| `critique_after_attempt` | integer | 2 | Attempt at which critique starts firing (1-10). Default `2` means critique runs after the second failed attempt onward. Has no effect unless `use_llm_critique: true`. |
 
 ### Custom Validation Functions
 


### PR DESCRIPTION
## Summary

Both `use_llm_critique` and `critique_after_attempt` exist on `RepromptConfig` (`agent_actions/config/schema.py:125,129`) but were absent from the Configuration Options table on `reference/validation/reprompting.md`. Users either never discovered the LLM-critique feature or tripped on key-not-allowed errors when guessing the key names. Added the two missing rows with pinned defaults and a note that `critique_after_attempt` only takes effect when `use_llm_critique` is `true`.

## Verification

```
$ python -c "from agent_actions.config.schema import RepromptConfig; rc=RepromptConfig(); print(rc.use_llm_critique, rc.critique_after_attempt)"
False 2
```

Matches the doc rows.

Source: `specs/active/uat-audit/violations/VIOL-0079-reprompting-docs.md`

## Follow-up not in this PR

`validation` and `on_schema_mismatch` (also on `RepromptConfig`) are not in the options table either — `validation` is covered by the "Custom Validation Functions" section below the table, but `on_schema_mismatch` is entirely undocumented. Out of scope per the narrow spec; flagging for a future doc audit.