### PR TITLE
docs(VIOL-0080): replace non-existent agac schema --validate (E-18)

### DIFF
--- a/docs.agent-actions/docs/reference/validation/output-validation.md
+++ b/docs.agent-actions/docs/reference/validation/output-validation.md
@@ -587,7 +587,7 @@ Record filtered by guard on action 'generate_output'
 
 ### Validate Schema Syntax
 
-Schemas are validated as part of workflow compilation — there is no standalone `agac schema --validate` flag. Compile the workflow that uses the schema; any malformed schema surfaces with a path-attributed error before any LLM call is made:
+Compile the workflow that uses the schema. Malformed schemas surface with a path-attributed error before any LLM call is made:
 
 ```bash
 agac compile -a workflow_name

--- a/docs.agent-actions/docs/reference/validation/output-validation.md
+++ b/docs.agent-actions/docs/reference/validation/output-validation.md
@@ -587,8 +587,10 @@ Record filtered by guard on action 'generate_output'
 
 ### Validate Schema Syntax
 
+Schemas are validated as part of workflow compilation — there is no standalone `agac schema --validate` flag. Compile the workflow that uses the schema; any malformed schema surfaces with a path-attributed error before any LLM call is made:
+
 ```bash
-agac schema --validate schema/my_schema.yml
+agac compile -a workflow_name
 ```
 
 ### Analyze Schema Structure


### PR DESCRIPTION
## Summary

`output-validation.md` showed `agac schema --validate schema/my_schema.yml` in the "Validate Schema Syntax" section. The `schema` command exposes only `-a/-u/--json/-v` — there is no `--validate` flag, so the documented command failed with "no such option" on copy-paste.

Schemas are validated as part of `agac compile -a <workflow>` (also available as `agac render -a <workflow>`); malformed schemas surface with a path-attributed error before any LLM call. Replaced the broken example with the correct command and a one-line note that there is no standalone schema-validation flag.

## Verification

```
$ agac schema --help    # confirms only -a/-u/--json/-v/--verbose; no --validate
$ agac compile --help   # confirms compile -a <workflow> compiles schemas
$ grep -nE '\-\-validate\b' docs.agent-actions/docs/reference/validation/output-validation.md
590:  ... 'agac schema --validate' flag. Compile ...   # only the note that explains the removal
```

Source: `specs/active/uat-audit/violations/VIOL-0080-output-validation-docs.md`