### PR TITLE
fix(VIOL-0084,0085): restore action events to default console + align logging.md paths (E-22)

### DIFF
--- a/agent_actions/logging/factory.py
+++ b/agent_actions/logging/factory.py
@@ -129,7 +129,7 @@ class LoggerFactory:
         if verbose:
             categories = None
         else:
-            categories = {"workflow", "agent", "batch"}
+            categories = {"workflow", "action", "batch"}
 
         console_handler = ConsoleEventHandler(
             min_level=console_level,

--- a/docs.agent-actions/docs/reference/architecture/logging.md
+++ b/docs.agent-actions/docs/reference/architecture/logging.md
@@ -149,7 +149,7 @@ Writes events to a JSON file in NDJSON format (one JSON object per line).
 - NDJSON format for easy streaming and parsing
 - Full event payload with metadata
 
-**Output Location:** `{workflow}/agent_io/target/events.json`
+**Output Location:** `{workflow}/agent_io/logs/events.json`
 
 **Example Entry:**
 ```json
@@ -183,7 +183,7 @@ Collects workflow execution data and outputs a `run_results.json` artifact.
 - Records output folders for each action
 - Captures error messages and skip reasons
 
-**Output Location:** `{workflow}/agent_io/target/run_results.json`
+**Output Location:** `{workflow}/agent_io/logs/run_results.json`
 
 **Output Schema:**
 ```json
@@ -392,7 +392,7 @@ def test_console_handler():
 Console verbosity can be controlled:
 
 ```bash
-# Default: INFO level, workflow/agent/batch categories
+# Default: INFO level, workflow/action/batch categories
 agac run
 
 # Verbose: DEBUG level, all categories
@@ -405,7 +405,7 @@ agac run --quiet
 ### File Handler
 
 File handler writes to:
-- `{workflow}/agent_io/target/events.json` (when output_dir is set)
+- `{workflow}/agent_io/logs/events.json` (when output_dir is set)
 - `logs/agent_actions.log` (fallback, if configured)
 
 Configure via environment or `LoggingConfig`:

--- a/tests/logging/test_console_handler.py
+++ b/tests/logging/test_console_handler.py
@@ -16,7 +16,7 @@ def handler_with_categories() -> ConsoleEventHandler:
     """Handler with default non-verbose category filter."""
     return ConsoleEventHandler(
         min_level=EventLevel.INFO,
-        categories={"workflow", "agent", "batch"},
+        categories={"workflow", "action", "batch"},
     )
 
 
@@ -38,7 +38,7 @@ class TestCategoryBypass:
     def test_debug_filtered_by_category(self, handler_with_categories):
         handler = ConsoleEventHandler(
             min_level=EventLevel.DEBUG,
-            categories={"workflow", "agent", "batch"},
+            categories={"workflow", "action", "batch"},
         )
         event = _make_event(EventLevel.DEBUG, category="llm")
         assert handler.accepts(event) is False
@@ -59,3 +59,49 @@ class TestCategoryBypass:
         )
         event = _make_event(EventLevel.WARN, category="workflow")
         assert handler.accepts(event) is False
+
+
+class TestDefaultFactoryFilterAcceptsActionEvents:
+    """Regression test for VIOL-0085 — default console categories must include `action`.
+
+    Action events use category ``"action"`` (see
+    ``agent_actions.logging.events.types.EventCategories.ACTION`` and
+    ``ActionStartEvent.__post_init__`` in workflow_events.py). The default
+    non-verbose console filter set in ``agent_actions.logging.factory`` must
+    therefore admit ``"action"`` so per-action INFO events reach stdout
+    without ``--verbose``.
+    """
+
+    def test_default_filter_admits_action_category(self):
+        from agent_actions.logging.events.workflow_events import ActionStartEvent
+
+        handler = ConsoleEventHandler(
+            min_level=EventLevel.INFO,
+            categories={"workflow", "action", "batch"},
+        )
+        event = ActionStartEvent(
+            action_name="extract_facts",
+            action_index=0,
+            total_actions=3,
+            action_type="llm",
+            input_path="agent_io/staging",
+            mode="online",
+        )
+        assert event.category == "action"
+        assert handler.accepts(event) is True
+
+    def test_factory_default_categories_match_action_category(self):
+        """The factory must produce a category set that contains the runtime
+        ``ACTION`` category. This pins the wire-up so a future rename of either
+        side fails loudly rather than silently dropping events."""
+        import inspect
+
+        from agent_actions.logging import factory
+        from agent_actions.logging.events.types import EventCategories
+        from agent_actions.logging.factory import LoggerFactory  # noqa: F401
+
+        source = inspect.getsource(factory)
+        assert f'"{EventCategories.ACTION}"' in source, (
+            "factory.py must literally reference the ACTION category in its "
+            "default non-verbose filter set"
+        )


### PR DESCRIPTION
## Summary

Two related fixes against `docs.agent-actions/docs/reference/architecture/logging.md` and the underlying logging code.

### VIOL-0085 (load-bearing)

The default non-verbose console category filter in `agent_actions/logging/factory.py:132` was `{"workflow", "agent", "batch"}`. Every `Action*Event` stamps `category = EventCategories.ACTION` (`"action"`) in `__post_init__` — the filter therefore dropped every per-action INFO line. Workflow start/end made it to stdout, but every `1/5 START extract_facts` and `1/5 OK extract_facts (15.23s, 1.2K tokens)` was silently suppressed unless the user passed `--verbose`. The string `"agent"` in the old filter never matched any real event category. Swap to `"action"`.

### VIOL-0084 (doc paths)

`logging.md` documented `JSONFileHandler` and `RunResultsCollector` writing under `agent_io/target/`. Both write under `agent_io/logs/` (`factory.py:144,152`, `run_results.py:125,137`). Fixed three path occurrences plus the default-categories line in the Logging Levels section (`workflow/agent/batch` → `workflow/action/batch`).

## Regression coverage

`TestDefaultFactoryFilterAcceptsActionEvents` asserts:
1. An `ActionStartEvent` passes a filter containing `"action"`.
2. The factory's source literally references `EventCategories.ACTION` — pins the wire-up so a future rename of either side fails loudly rather than silently dropping events again.

## Verification

```
$ pytest tests/logging/ -q
140 passed in 0.24s
$ ruff check / ruff format --check
clean
```

## Ownership note

Crosses Clone 6's docs-only bucket into `agent_actions/logging/factory.py`. Same shape as E-15 — user-authorized staff decisions for this UAT round; doc-only fix would have left the silent-suppression bug live.

Source: `specs/active/uat-audit/violations/VIOL-0084-logging-docs.md`