### PR TITLE
docs(VIOL-0086): correct dispatch UDF signature in dispatch.md (E-23)

### DIFF
--- a/docs.agent-actions/docs/reference/prompts/dispatch.md
+++ b/docs.agent-actions/docs/reference/prompts/dispatch.md
@@ -28,12 +28,16 @@ dispatch_task('handle_quiz_type')
 ## Creating a Dispatch Tool
 
 ```python
+import json
+
 from agent_actions import udf_tool
 
+
 @udf_tool
-def handle_quiz_type(input_data: dict) -> dict:
+def handle_quiz_type(input_data: str) -> dict:
     """Return appropriate authoring prompt based on quiz type."""
-    quiz_type = input_data["source"]["quiz_type"].upper()
+    context = json.loads(input_data)
+    quiz_type = context["source"]["quiz_type"].upper()
 
     prompts = {
         "UNDERSTANDING": "Generate a conceptual question...",
@@ -42,11 +46,11 @@ def handle_quiz_type(input_data: dict) -> dict:
 
     return {
         "authoring_prompt": prompts.get(quiz_type, prompts["APPLICATION"]),
-        "quiz_type_used": quiz_type
+        "quiz_type_used": quiz_type,
     }
 ```
 
-The tool receives context (source fields, seed data, upstream outputs) and the return value replaces the `dispatch_task()` call.
+The tool receives a JSON-encoded context string (source fields, seed data, upstream outputs); decode it with `json.loads()` and read fields from the resulting dict. The return value replaces the `dispatch_task()` call.
 
 ## Capturing Dispatch Results
 


### PR DESCRIPTION
## Summary

The dispatch UDF example in `dispatch.md` showed `input_data: dict` and indexed the parameter directly. The runtime passes a JSON-encoded context string — see `_prepare_context_data_str` in `agent_actions/output/response/context_data.py` and `string_transformer.py:call_user_function` line 63 (`function(context_data_str, *function_args)`). Copy-paste of the previous example produced a `TypeError` as soon as the function tried to subscript a string.

Updated to use `input_data: str` and demonstrate `json.loads()`. Adjusted the surrounding sentence to describe the encoded-string contract.

## Verification

```
$ grep -nE 'def \w+\(input_data: ?str|json\.loads\(input_data\)' docs.agent-actions/docs/reference/prompts/dispatch.md
37:def handle_quiz_type(input_data: str) -> dict:
39:    context = json.loads(input_data)
```

Source: `specs/active/uat-audit/violations/VIOL-0086-dispatch-docs.md`