### PR TITLE
docs(VIOL-0087): drop phantom -a/--artefact row from agac docs options (E-24)

### DIFF
--- a/docs.agent-actions/docs/reference/cli/utilities.md
+++ b/docs.agent-actions/docs/reference/cli/utilities.md
@@ -169,7 +169,6 @@ agac docs [options]
 |--------|-------------|
 | `-o, --output` | Output directory for generated files (default: `artefact`) |
 | `-p, --port` | Port to run server on (default: `8000`) |
-| `-a, --artefact` | Path to artefact directory (default: `./artefact`) |
 
 **Examples:**
 ```bash


### PR DESCRIPTION
## Summary

The `agac docs` options table in `cli/utilities.md` listed `-a, --artefact` with a `./artefact` default. The CLI exposes only `-o/--output` and `-p/--port` (verified via `agac docs --help`). Removed the phantom row.

## VIOL-0096 — no-op on current main

The companion violation about the same flag mention in `documentation-site.md` is already inert. That page does not list `--artefact` anywhere; the only `custom-artefact` text is `agac docs --output ./custom-artefact`, which uses the real `--output` flag with a folder named `custom-artefact`. Clone 2's T2-O work is rewriting `documentation-site.md` for the build/serve split and will overwrite any future churn there — no doc change needed in this PR.

## Verification

```
$ agac docs --help
Options:
  -o, --output TEXT   Output directory for generated files (default: artefact)
  -p, --port INTEGER  Port to run server on (default: 8000)
  --help              Show this message and exit.

$ grep -n -- '--artefact\b' docs.agent-actions/docs/reference/cli/utilities.md docs.agent-actions/docs/reference/documentation-site.md
(no matches)
```

Source: `specs/active/uat-audit/violations/VIOL-0087-utilities-docs.md`