### PR TITLE
fix(VIOL-0081): wire .tsv through staging dispatch (E-19)

### DIFF
--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -419,8 +419,9 @@ def _prepare_batch_data(ctx: DataPreparationContext):
         )
         src_text = []
 
-    elif ctx.file_type == ".csv":
-        # CSV: let TabularLoader read the file itself (FileReader returns list[list], not str)
+    elif ctx.file_type in (".csv", ".tsv"):
+        # Tabular: let TabularLoader read the file itself (FileReader returns list[list], not str).
+        # TabularLoader handles both comma- and tab-separated by routing on extension.
         rows = tabular_loader.process(content=None, file_path=ctx.file_path)
         data_chunk = _add_batch_metadata(rows, local_batch_id, node_id)
         src_text = []
@@ -448,7 +449,18 @@ def _prepare_batch_data(ctx: DataPreparationContext):
         src_text = []
 
     else:
-        supported = [".txt", ".md", ".pdf", ".docx", ".html", ".json", ".csv", ".xlsx", ".xml"]
+        supported = [
+            ".txt",
+            ".md",
+            ".pdf",
+            ".docx",
+            ".html",
+            ".json",
+            ".csv",
+            ".tsv",
+            ".xlsx",
+            ".xml",
+        ]
         raise AgentActionsError(
             "Unsupported file type in staging loader",
             context={
@@ -522,7 +534,9 @@ def _prepare_online_data(ctx: DataPreparationContext):
             else:
                 src_text.append(item)
 
-    elif ctx.file_type == ".csv":
+    elif ctx.file_type in (".csv", ".tsv"):
+        # TabularLoader routes on extension and handles tab-separated files
+        # via csv.reader(..., delimiter="\t").
         data_chunk = tabular_loader.process(content=None, file_path=ctx.file_path)
         src_text = data_chunk
 
@@ -535,7 +549,18 @@ def _prepare_online_data(ctx: DataPreparationContext):
         src_text = data_chunk
 
     else:
-        supported = [".txt", ".md", ".pdf", ".docx", ".html", ".json", ".csv", ".xlsx", ".xml"]
+        supported = [
+            ".txt",
+            ".md",
+            ".pdf",
+            ".docx",
+            ".html",
+            ".json",
+            ".csv",
+            ".tsv",
+            ".xlsx",
+            ".xml",
+        ]
         raise AgentActionsError(
             "Unsupported file type in staging loader",
             context={

--- a/tests/unit/input/test_staging_tsv_dispatch.py
+++ b/tests/unit/input/test_staging_tsv_dispatch.py
@@ -1,0 +1,94 @@
+"""Regression tests for VIOL-0081 — `.tsv` files staging dispatch.
+
+Before this fix, the staging dispatch in
+``agent_actions/input/preprocessing/staging/initial_pipeline.py`` had no
+``.tsv`` branch in ``_prepare_batch_data`` or ``_prepare_online_data``, and
+the ``supported`` lists in the else-branches excluded ``.tsv``. ``TabularLoader``
+already accepted ``.tsv``, so doc readers placing a ``.tsv`` file in
+``agent_io/staging/`` hit ``AgentActionsError("Unsupported file type in
+staging loader")`` before the loader ever saw the file.
+
+These tests pin both code paths so a future refactor that adds a new
+file-type branch cannot silently re-introduce the trap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_actions.input.preprocessing.staging.initial_pipeline import (
+    DataPreparationContext,
+    _prepare_batch_data,
+    _prepare_online_data,
+)
+
+
+def _write_tsv(tmp_path: Path, name: str = "rows.tsv") -> Path:
+    p = tmp_path / name
+    p.write_text(
+        "id\tcontent\tcategory\n1\tFirst row\ttechnical\n2\tSecond row\tgeneral\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+@pytest.fixture
+def tsv_ctx(tmp_path: Path) -> DataPreparationContext:
+    tsv_file = _write_tsv(tmp_path)
+    return DataPreparationContext(
+        content=None,
+        file_type=".tsv",
+        agent_config={},
+        file_path=str(tsv_file),
+        agent_name="tsv_workflow",
+        idx=0,
+    )
+
+
+class TestBatchTsvDispatch:
+    """``_prepare_batch_data`` routes ``.tsv`` through the tabular loader."""
+
+    def test_tsv_routes_through_tabular_loader(self, tsv_ctx):
+        data_chunk, src_text = _prepare_batch_data(tsv_ctx)
+
+        assert data_chunk, "TSV staging produced no data chunk"
+        assert src_text == []
+
+        first = data_chunk[0]
+        assert "batch_id" in first
+        assert "batch_uuid" in first
+
+    def test_tsv_listed_in_batch_supported_types(self):
+        """When a future refactor changes the dispatch table, the ``supported``
+        list still names ``.tsv`` so the error context tells the user it is
+        accepted."""
+        import inspect
+
+        from agent_actions.input.preprocessing.staging import initial_pipeline
+
+        source = inspect.getsource(initial_pipeline._prepare_batch_data)
+        assert '".tsv"' in source, (
+            "_prepare_batch_data must reference .tsv in its supported-types list"
+        )
+
+
+class TestOnlineTsvDispatch:
+    """``_prepare_online_data`` routes ``.tsv`` through the tabular loader."""
+
+    def test_tsv_routes_through_tabular_loader(self, tsv_ctx):
+        data_chunk, src_text = _prepare_online_data(tsv_ctx)
+
+        assert data_chunk, "TSV online prep produced no data chunk"
+        assert data_chunk == src_text
+
+    def test_tsv_listed_in_online_supported_types(self):
+        import inspect
+
+        from agent_actions.input.preprocessing.staging import initial_pipeline
+
+        source = inspect.getsource(initial_pipeline._prepare_online_data)
+        assert '".tsv"' in source, (
+            "_prepare_online_data must reference .tsv in its supported-types list"
+        )


### PR DESCRIPTION
## Summary

`reference/data-io/input-formats.md` lists TSV as a supported staging format and `TabularLoader` (`agent_actions/input/loaders/tabular.py:74`) already accepts `.tsv`. The staging pipeline never routed `.tsv` to the loader though — `_prepare_batch_data` and `_prepare_online_data` only matched `.csv`, and the `supported` lists in their else-branches omitted `.tsv`. A `.tsv` file under `agent_io/staging/` was rejected with `AgentActionsError("Unsupported file type in staging loader")` before `TabularLoader` ever saw it.

Both dispatch branches now match `(".csv", ".tsv")` and route through `tabular_loader.process`; the loader's `csv.reader(..., delimiter='\t')` path handles tab-separated rows. Both `supported` lists now include `.tsv`.

## Regression coverage

`tests/unit/input/test_staging_tsv_dispatch.py` pins:
1. `_prepare_batch_data` returns a chunk for a `.tsv` file routed through `TabularLoader`.
2. `_prepare_online_data` returns the same `data_chunk` and `src_text` for a `.tsv` file.
3. Both functions' source still names `.tsv` in their supported-types list — guard against a future refactor that re-fans the dispatch and silently re-introduces the trap.

## Decision

Per locked decision on `coordination/status.md` (E-19 ★ option (a)): **wire TSV through staging** rather than remove the row from the doc, since the loader already supports it and dropping it would also require deleting `.tsv` from `tabular.py:74` for consistency.

## Verification

```
$ pytest tests/ -k "input or staging or tabular"
340 passed, 7311 deselected in 3.16s

$ ruff check / ruff format --check
clean
```

## Ownership note

Crosses Clone 6's docs-only bucket into `agent_actions/input/preprocessing/staging/initial_pipeline.py`. Matches the staff-engineer pattern user authorized for E-15 / E-22.

Source: `specs/active/uat-audit/violations/VIOL-0081-input-formats-docs.md`