### PR TITLE
docs(VIOL-0083): align chunking.md defaults with runtime + pin (E-21)

### DIFF
--- a/docs.agent-actions/docs/reference/data-io/chunking.md
+++ b/docs.agent-actions/docs/reference/data-io/chunking.md
@@ -23,9 +23,11 @@ default_agent_config:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `chunk_size` | 1000 | Maximum size per chunk (tokens or characters) |
-| `overlap` | 200 | Overlap between consecutive chunks |
+| `chunk_size` | 300 | Maximum size per chunk (tokens or characters) |
+| `overlap` | 10 | Overlap between consecutive chunks |
 | `split_method` | `tiktoken` | Chunking strategy: `tiktoken`, `chars`, or `spacy` |
+
+The defaults are tuned for the framework's own short-document benchmarks. The examples below show larger values (4000 / 8000) tuned for OpenAI-class context windows — start there for production workloads on long documents.
 
 ### Per-Action Override
 

--- a/tests/unit/config/test_chunking_defaults.py
+++ b/tests/unit/config/test_chunking_defaults.py
@@ -1,0 +1,33 @@
+"""Regression tests for VIOL-0083 — chunking defaults pinning.
+
+``docs/reference/data-io/chunking.md`` documents the framework's default
+``chunk_size`` and ``overlap``. The values must match the canonical defaults
+in ``agent_actions/output/response/config_fields.py``. If a future refactor
+moves the defaults without updating the doc table, these tests fail loudly.
+
+These constants are also surfaced via ``get_default(...)`` and consumed by
+``agent_actions/input/preprocessing/staging/initial_pipeline.py`` and the
+project-init template at ``agent_actions/config/init.py``.
+"""
+
+from __future__ import annotations
+
+from agent_actions.output.response.config_fields import SIMPLE_CONFIG_FIELDS, get_default
+
+
+def test_chunk_size_default_pinned_at_300() -> None:
+    """``chunk_size=300`` is the documented default in chunking.md."""
+    assert SIMPLE_CONFIG_FIELDS["chunk_size"] == 300
+    assert get_default("chunk_size") == 300
+
+
+def test_chunk_overlap_default_pinned_at_10() -> None:
+    """``overlap=10`` is the documented default in chunking.md.
+
+    Note the field rename at the boundary: user YAML uses ``overlap`` (inside
+    ``chunk_config``), but the framework's internal config field is
+    ``chunk_overlap`` — both names route to the same value via the loader
+    in ``initial_pipeline.py:336``.
+    """
+    assert SIMPLE_CONFIG_FIELDS["chunk_overlap"] == 10
+    assert get_default("chunk_overlap") == 10


### PR DESCRIPTION
## Summary

`chunking.md` showed `chunk_size=1000 / overlap=200` as defaults. The canonical defaults in `agent_actions/output/response/config_fields.py:51-52` are `chunk_size=300 / chunk_overlap=10` — what every existing workflow runs with. The project-init template at `agent_actions/config/init.py:100` already uses the runtime values, so the doc was the outlier.

Per the locked decision in `coordination/status.md` (E-21 option (a) — doc-wins), updated the Defaults table to `300 / 10`. Option (b) would have silently changed chunking behaviour for every existing project on upgrade.

Added a one-line note above the table that the examples below intentionally use `4000` / `8000` — those are tuned for OpenAI-class context windows. Without that, readers might read the larger example numbers as "the framework default lies".

## Regression coverage

`tests/unit/config/test_chunking_defaults.py` pins both defaults via `SIMPLE_CONFIG_FIELDS` and `get_default()`. A future constant rename or value change fails loudly with a doc-update reminder.

## Field-name footnote

User YAML uses `overlap` (inside `chunk_config`); the framework's internal config field is `chunk_overlap`. Both route to the same value via the loader in `initial_pipeline.py:336`. The doc table shows `overlap` (user-facing name) matching the loader contract.

## Verification

```
$ pytest tests/unit/config/test_chunking_defaults.py -v
2 passed in 0.26s

$ ruff check / ruff format --check
clean
```

Source: `specs/active/uat-audit/violations/VIOL-0083-chunking-docs.md`