### PR TITLE
docs(VIOL-0097): document runs.json + align artifacts.md paths with runtime (E-28)

### DIFF
--- a/docs.agent-actions/docs/reference/execution/artifacts.md
+++ b/docs.agent-actions/docs/reference/execution/artifacts.md
@@ -13,6 +13,7 @@ Agent Actions generates artifacts for debugging, auditing, and resuming interrup
 project/
 ├── artefact/
 │   ├── catalog.json                    # Project catalog (agac docs)
+│   ├── runs.json                       # Workflow execution history (agac run + agac docs)
 │   └── rendered_workflows/             # Compiled workflow configs (agac render)
 ├── logs/
 │   └── agent_actions.log              # Application logs
@@ -22,12 +23,14 @@ project/
             ├── .agent_status.json      # Per-action execution state
             ├── staging/                # Input data
             ├── source/                 # Source metadata tracking
+            ├── store/
+            │   └── {workflow_name}.db  # SQLite storage backend
+            ├── logs/
+            │   ├── .manifest.json      # Workflow execution manifest
+            │   ├── run_results.json    # Summary metrics and timing
+            │   ├── events.json         # Full event telemetry (JSON Lines)
+            │   └── errors.json         # Error-level events only (JSON Lines)
             └── target/
-                ├── .manifest.json      # Workflow execution manifest
-                ├── run_results.json    # Summary metrics and timing
-                ├── events.json         # Full event telemetry (JSON Lines)
-                ├── errors.json         # Error-level events only (JSON Lines)
-                ├── outputs.db          # SQLite storage backend
                 └── {action_name}/      # Per-action output directories
 ```
 
@@ -35,7 +38,7 @@ project/
 
 ### Workflow Manifest (`.manifest.json`)
 
-**Path:** `agent_io/target/.manifest.json`
+**Path:** `agent_io/logs/.manifest.json`
 
 The manifest tracks the execution plan and status for the entire workflow run. Created when the workflow starts, updated as actions complete.
 
@@ -91,7 +94,7 @@ Re-running a workflow skips completed actions and resumes from the failure point
 
 ### Run Results (`run_results.json`)
 
-**Path:** `agent_io/target/run_results.json`
+**Path:** `agent_io/logs/run_results.json`
 
 Summary of the workflow execution with per-action metrics:
 
@@ -118,9 +121,50 @@ Summary of the workflow execution with per-action metrics:
 }
 ```
 
+### Run History (`runs.json`)
+
+**Path:** `artefact/runs.json`
+
+`runs.json` is the cumulative catalog of past workflow executions surfaced by the documentation site. Every `agac run` writes to it twice via `RunTracker`:
+
+- At start — a new execution entry is appended with `status: "running"`, `started_at`, and the action plan.
+- At end — the entry is updated with the final `status` (`success` / `failed` / `paused`), `ended_at`, `duration_seconds`, and any `error_message`. Aggregate workflow metrics (`success_rate`, `avg_duration_seconds`) are recomputed in the same write.
+
+`agac docs` reads `runs.json` to render the Run History view in the documentation site; if the file is missing when `agac docs` runs, an empty catalog is initialized so the page renders even before the first run completes.
+
+```json
+{
+  "metadata": {"generated_at": "2026-03-24T10:00:00Z", "total_runs": 12},
+  "executions": [
+    {
+      "id": "run_product_pipeline_a1b2c3d4",
+      "workflow_id": "product_pipeline",
+      "workflow_name": "product_pipeline",
+      "status": "success",
+      "started_at": "2026-03-24T10:00:00Z",
+      "ended_at": "2026-03-24T10:02:30Z",
+      "duration_seconds": 150.0,
+      "actions_completed": 5,
+      "actions_total": 5
+    }
+  ],
+  "workflow_metrics": {
+    "product_pipeline": {
+      "total_runs": 8,
+      "successful_runs": 7,
+      "failed_runs": 1,
+      "success_rate": 0.875,
+      "avg_duration_seconds": 142.3
+    }
+  }
+}
+```
+
+The most recent 100 executions are kept; older entries roll off as new runs land. The authoritative per-run summary is still `agent_io/logs/run_results.json` — that file captures the full per-action breakdown for the single run that produced it.
+
 ### Events Log (`events.json`)
 
-**Path:** `agent_io/target/events.json`
+**Path:** `agent_io/logs/events.json`
 
 Complete telemetry of all system events in JSON Lines format (one event per line):
 
@@ -161,7 +205,7 @@ Both `events.json` and `errors.json` accumulate across runs by default. When `--
 
 ### Errors Log (`errors.json`)
 
-**Path:** `agent_io/target/errors.json`
+**Path:** `agent_io/logs/errors.json`
 
 ERROR-level events only — a filtered subset of `events.json` for quick error diagnosis:
 
@@ -180,7 +224,7 @@ When debugging, check `errors.json` first for a quick overview, then dive into `
 
 ## Storage Backend (SQLite)
 
-**Path:** Configured via `output_storage.db_path` in `agent_actions.yml` (default: `./agent_io/outputs.db`)
+**Path:** `agent_io/store/{workflow_name}.db` (one database per workflow)
 
 The SQLite database stores structured workflow data:
 
@@ -206,7 +250,7 @@ The `failed` and `exhausted` dispositions also store an `input_snapshot` column 
 ### Querying the Database
 
 ```bash
-sqlite3 agent_io/outputs.db
+sqlite3 agent_io/store/my_workflow.db
 
 -- List all actions with output
 SELECT DISTINCT action_name FROM target_data;
@@ -283,13 +327,13 @@ Log file location: `{project_root}/logs/agent_actions.log`
 
 ```bash
 # Inspect run results
-cat agent_io/target/run_results.json | python3 -m json.tool
+cat agent_io/logs/run_results.json | python3 -m json.tool
 
 # Check for errors
-cat agent_io/target/errors.json
+cat agent_io/logs/errors.json
 
 # Count events by type
-cat agent_io/target/events.json | python3 -c "
+cat agent_io/logs/events.json | python3 -c "
 import sys, json, collections
 counts = collections.Counter()
 for line in sys.stdin:


### PR DESCRIPTION
## Summary

VIOL-0097 was framed around adding an auto-regen hook to `agac run` so the doc claim that "runs.json auto-updates after agac run" becomes true. On current main, `agac run` **already** updates `runs.json` automatically via `RunTracker` — both at workflow start (`start_workflow_run` inserts the execution record) and at finalize (`finalize_workflow_run` sets the final status, ended_at, duration_seconds, and recomputes workflow_metrics, all via portalocker'd atomic writes to `artefact/runs.json`). The spec's premise was stale.

What the doc actually needed was: a Run History section describing what `RunTracker` writes, plus the path drift the page shared with VIOL-0084.

## Run History section (the E-28 charter)

Added a `Run History (runs.json)` section under Runtime Artifacts. Describes:

- Path: `artefact/runs.json`
- Write pattern: `agac run` writes via `RunTracker` at start + finalize
- `agac docs` reads `runs.json` to render the Run History view; initializes empty if missing
- Example JSON shape (executions, workflow_metrics)
- 100-entry retention; pointer to `agent_io/logs/run_results.json` for the per-run summary

## Path drift (sibling fix from VIOL-0084 / PR #738)

The same `agent_io/target/` → `agent_io/logs/` drift that PR #738 patched in `logging.md` was also present here. Fixed all instances:

- Directory tree: `.manifest.json`, `run_results.json`, `events.json`, `errors.json` moved from `target/` to `logs/` (per `factory.py:144,152`, `run_results.py:125,137`, `workflow/managers/manifest.py:37`).
- Storage Backend section: SQLite path corrected from `./agent_io/outputs.db` to `agent_io/store/{workflow_name}.db` (per `storage/__init__.py:32` and `service_init.py:60`). One DB per workflow, not a shared outputs.db.
- Useful-commands `cat ...` and `sqlite3 ...` examples updated to real paths.

## Decision

User locked option (b) (code+doc) on the assumption that an auto-regen hook was needed. Discovery showed the hook is already there (see `agent_actions/cli/run.py:82-87,170-181`), so this PR is doc-only — but matches the spirit of (b) by making the doc claim true rather than papering over the staleness.

## Verification

```
$ grep -nE 'agent_io/target/(events|errors|run_results|\.manifest)\.json|agent_io/outputs\.db' \
    docs.agent-actions/docs/reference/execution/artifacts.md
(no matches)

$ pytest tests/ -k "run_tracker"
73 passed
```

Source: `specs/active/uat-audit/violations/VIOL-0097-artifacts-docs.md`