### PR TITLE
test(VIOL-0016): cover current_item GUID guard and source_mapping fallback

### DIFF
--- a/agent_actions/processing/batch_context_adapter.py
+++ b/agent_actions/processing/batch_context_adapter.py
@@ -21,12 +21,13 @@ class BatchContextAdapter:
         output_directory: str | None = None,
         parent_records: list[dict[str, Any]] | None = None,
     ) -> ProcessingContext:
-        """Build a ProcessingContext from batch-side state."""
+        """Build a ProcessingContext from batch-side state.
+
+        ``current_item=original_row`` already serves as the parent for batch
+        lookups, so ``parent_records`` defaults to ``[]`` here.
+        """
         if parent_records is None:
-            if isinstance(original_row, dict) and original_row.get("lineage"):
-                parent_records = [original_row]
-            else:
-                parent_records = []
+            parent_records = []
         return ProcessingContext(
             agent_config=cast(ActionConfigDict, agent_config),
             agent_name=agent_config.get("agent_type", "unknown_action"),

--- a/agent_actions/processing/batch_context_adapter.py
+++ b/agent_actions/processing/batch_context_adapter.py
@@ -23,7 +23,12 @@ class BatchContextAdapter:
     ) -> ProcessingContext:
         """Build a ProcessingContext from batch-side state."""
         if parent_records is None:
-            parent_records = [original_row] if original_row else []
+            if isinstance(original_row, dict) and (
+                original_row.get("lineage") or original_row.get("node_id")
+            ):
+                parent_records = [original_row]
+            else:
+                parent_records = []
         return ProcessingContext(
             agent_config=cast(ActionConfigDict, agent_config),
             agent_name=agent_config.get("agent_type", "unknown_action"),

--- a/agent_actions/processing/batch_context_adapter.py
+++ b/agent_actions/processing/batch_context_adapter.py
@@ -19,14 +19,18 @@ class BatchContextAdapter:
         original_row: dict[str, Any],
         record_index: int,
         output_directory: str | None = None,
+        parent_records: list[dict[str, Any]] | None = None,
     ) -> ProcessingContext:
         """Build a ProcessingContext from batch-side state."""
+        if parent_records is None:
+            parent_records = [original_row] if original_row else []
         return ProcessingContext(
             agent_config=cast(ActionConfigDict, agent_config),
             agent_name=agent_config.get("agent_type", "unknown_action"),
             mode=RunMode.BATCH,
             is_first_stage=not agent_config.get("dependencies"),
             current_item=original_row,
+            parent_records=parent_records,
             record_index=record_index,
             output_directory=output_directory,
         )

--- a/agent_actions/processing/batch_context_adapter.py
+++ b/agent_actions/processing/batch_context_adapter.py
@@ -23,9 +23,7 @@ class BatchContextAdapter:
     ) -> ProcessingContext:
         """Build a ProcessingContext from batch-side state."""
         if parent_records is None:
-            if isinstance(original_row, dict) and (
-                original_row.get("lineage") or original_row.get("node_id")
-            ):
+            if isinstance(original_row, dict) and original_row.get("lineage"):
                 parent_records = [original_row]
             else:
                 parent_records = []

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -153,8 +153,6 @@ class LineageEnricher(Enricher):
     @staticmethod
     def _with_parent_fallback(item: dict, parent_index: dict[str, dict] | None) -> dict:
         """If *item* lacks lineage, look up a richer match in parent_index by source_guid."""
-        if not isinstance(item, dict):
-            return item
         if item.get("lineage") or item.get("node_id"):
             return item
         if parent_index is None:

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -140,12 +140,24 @@ class LineageEnricher(Enricher):
         context: ProcessingContext,
         source_index: dict[str, dict] | None = None,
     ) -> dict | None:
-        """Look up parent item for lineage chaining; returns None for first-stage."""
+        """Look up parent item for lineage chaining; returns None for first-stage.
+
+        Prefers ``context.parent_records`` (previous-stage output, carries
+        lineage) over ``context.source_data`` (raw seed records, no lineage).
+        VIOL-0016: source_data lookup returned raw seed records, causing
+        ``add_unified_lineage`` to fall through to ``[node_id]`` because
+        ``"lineage" not in parent_item``.
+        """
         if context.is_first_stage or not source_guid:
             return None
 
         if context.current_item:
             return context.current_item
+
+        if context.parent_records:
+            for parent in context.parent_records:
+                if parent.get("source_guid") == source_guid:
+                    return parent
 
         if not context.source_data:
             return None

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -96,6 +96,9 @@ class LineageEnricher(Enricher):
                     source_items = [
                         context.source_data[idx] for idx in source_idx if idx < source_data_len
                     ]
+                    source_items = [
+                        self._with_parent_fallback(s, parent_index) for s in source_items
+                    ]
                     skipped = len(source_idx) - len(source_items)
                     if skipped:
                         logger.warning(
@@ -119,7 +122,9 @@ class LineageEnricher(Enricher):
                 else:
                     # One-to-one: single input record
                     if source_idx < source_data_len:
-                        parent_item = context.source_data[source_idx]
+                        parent_item = self._with_parent_fallback(
+                            context.source_data[source_idx], parent_index
+                        )
                     else:
                         logger.warning(
                             "source_mapping[%d] -> %d is out of bounds "
@@ -145,6 +150,21 @@ class LineageEnricher(Enricher):
         result.node_id = base_node_id
         return result
 
+    @staticmethod
+    def _with_parent_fallback(item: dict, parent_index: dict[str, dict] | None) -> dict:
+        """If *item* lacks lineage, look up a richer match in parent_index by source_guid."""
+        if not isinstance(item, dict):
+            return item
+        if item.get("lineage") or item.get("node_id"):
+            return item
+        if parent_index is None:
+            return item
+        sg = item.get("source_guid")
+        if sg is None:
+            return item
+        richer = parent_index.get(sg)
+        return richer if richer is not None else item
+
     def _get_parent_item(
         self,
         source_guid: str | None,
@@ -165,7 +185,9 @@ class LineageEnricher(Enricher):
             return None
 
         if context.current_item:
-            return context.current_item
+            current_guid = context.current_item.get("source_guid")
+            if current_guid is None or current_guid == source_guid:
+                return context.current_item
 
         if parent_index is not None:
             hit = parent_index.get(source_guid)

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -41,21 +41,8 @@ class LineageEnricher(Enricher):
 
         use_per_item_parent_lookup = result.source_guid is None and not context.is_first_stage
 
-        source_index: dict[str, dict] | None = None
-        if context.source_data:
-            source_index = {
-                sg: item
-                for item in context.source_data
-                if (sg := item.get("source_guid")) is not None
-            }
-
-        parent_index: dict[str, dict] | None = None
-        if context.parent_records:
-            parent_index = {
-                sg: item
-                for item in context.parent_records
-                if (sg := item.get("source_guid")) is not None
-            }
+        source_index = self._index_by_source_guid(context.source_data)
+        parent_index = self._index_by_source_guid(context.parent_records)
 
         parent_item = None
         if not use_per_item_parent_lookup:
@@ -151,9 +138,20 @@ class LineageEnricher(Enricher):
         return result
 
     @staticmethod
+    def _index_by_source_guid(
+        records: list[dict[str, Any]] | None,
+    ) -> dict[str, dict] | None:
+        """Build a {source_guid: record} dict, or None when *records* is empty."""
+        if not records:
+            return None
+        return {sg: r for r in records if (sg := r.get("source_guid")) is not None}
+
+    @staticmethod
     def _with_parent_fallback(item: dict, parent_index: dict[str, dict] | None) -> dict:
         """If *item* lacks lineage, look up a richer match in parent_index by source_guid."""
-        if item.get("lineage"):
+        from agent_actions.utils.lineage import LineageBuilder
+
+        if LineageBuilder.is_lineage_bearing(item):
             return item
         if parent_index is None:
             return item
@@ -187,26 +185,19 @@ class LineageEnricher(Enricher):
             if current_guid is None or current_guid == source_guid:
                 return context.current_item
 
+        if parent_index is None:
+            parent_index = self._index_by_source_guid(context.parent_records)
         if parent_index is not None:
             hit = parent_index.get(source_guid)
             if hit is not None:
                 return hit
-        elif context.parent_records:
-            for parent in context.parent_records:
-                if parent.get("source_guid") == source_guid:
-                    return parent
 
         if not context.source_data:
             return None
 
-        if source_index is not None:
-            return source_index.get(source_guid)
-
-        for source_item in context.source_data:
-            if source_item.get("source_guid") == source_guid:
-                return source_item
-
-        return None
+        if source_index is None:
+            source_index = self._index_by_source_guid(context.source_data)
+        return source_index.get(source_guid) if source_index else None
 
 
 class MetadataEnricher(Enricher):

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -153,7 +153,7 @@ class LineageEnricher(Enricher):
     @staticmethod
     def _with_parent_fallback(item: dict, parent_index: dict[str, dict] | None) -> dict:
         """If *item* lacks lineage, look up a richer match in parent_index by source_guid."""
-        if item.get("lineage") or item.get("node_id"):
+        if item.get("lineage"):
             return item
         if parent_index is None:
             return item

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -49,9 +49,19 @@ class LineageEnricher(Enricher):
                 if (sg := item.get("source_guid")) is not None
             }
 
+        parent_index: dict[str, dict] | None = None
+        if context.parent_records:
+            parent_index = {
+                sg: item
+                for item in context.parent_records
+                if (sg := item.get("source_guid")) is not None
+            }
+
         parent_item = None
         if not use_per_item_parent_lookup:
-            parent_item = self._get_parent_item(result.source_guid, context, source_index)
+            parent_item = self._get_parent_item(
+                result.source_guid, context, source_index, parent_index
+            )
 
         source_data_len = len(context.source_data) if context.source_data else 0
 
@@ -80,7 +90,6 @@ class LineageEnricher(Enricher):
                 and context.source_data is not None
                 and i in result.source_mapping
             ):
-                # Index-based lookup — resolve parent by source_mapping
                 source_idx = result.source_mapping[i]
                 if isinstance(source_idx, list):
                     # Many-to-one: multiple input records merged into one output
@@ -123,7 +132,9 @@ class LineageEnricher(Enricher):
                         parent_item = None
             elif use_per_item_parent_lookup:
                 item_source_guid = item.get("source_guid")
-                parent_item = self._get_parent_item(item_source_guid, context, source_index)
+                parent_item = self._get_parent_item(
+                    item_source_guid, context, source_index, parent_index
+                )
 
             result.data[i] = LineageBuilder.add_unified_lineage(
                 obj=item,
@@ -139,14 +150,16 @@ class LineageEnricher(Enricher):
         source_guid: str | None,
         context: ProcessingContext,
         source_index: dict[str, dict] | None = None,
+        parent_index: dict[str, dict] | None = None,
     ) -> dict | None:
         """Look up parent item for lineage chaining; returns None for first-stage.
 
-        Prefers ``context.parent_records`` (previous-stage output, carries
-        lineage) over ``context.source_data`` (raw seed records, no lineage).
-        VIOL-0016: source_data lookup returned raw seed records, causing
-        ``add_unified_lineage`` to fall through to ``[node_id]`` because
-        ``"lineage" not in parent_item``.
+        Precedence (highest first):
+        1. ``context.current_item`` — explicit parent set by the strategy.
+        2. ``context.parent_records`` (or ``parent_index`` for O(1) lookup) —
+           previous-stage output that carries lineage.
+        3. ``context.source_data`` (or ``source_index`` for O(1) lookup) —
+           fallback when source_data is itself lineage-bearing.
         """
         if context.is_first_stage or not source_guid:
             return None
@@ -154,7 +167,11 @@ class LineageEnricher(Enricher):
         if context.current_item:
             return context.current_item
 
-        if context.parent_records:
+        if parent_index is not None:
+            hit = parent_index.get(source_guid)
+            if hit is not None:
+                return hit
+        elif context.parent_records:
             for parent in context.parent_records:
                 if parent.get("source_guid") == source_guid:
                     return parent

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -345,12 +345,8 @@ class ProcessingContext:
     dependency_configs: dict[str, Any] | None = None
     current_item: dict[str, Any] | None = None
     storage_backend: Optional["StorageBackend"] = None
-    # Previous-stage output records (carry lineage/node_id). Distinct from
-    # source_data, which holds raw seed records loaded from storage for
-    # prompt context and context-scope inference. The LineageEnricher reads
-    # parent_records to find the ancestry-bearing parent for each item; the
-    # raw seed records do not carry lineage and would force a self-only
-    # fallback (VIOL-0016).
+    # Previous-stage output records (carry lineage). Distinct from source_data,
+    # which holds records used for prompt context and scope inference.
     parent_records: list[dict[str, Any]] = field(default_factory=list)
 
     @property

--- a/agent_actions/processing/types.py
+++ b/agent_actions/processing/types.py
@@ -345,6 +345,13 @@ class ProcessingContext:
     dependency_configs: dict[str, Any] | None = None
     current_item: dict[str, Any] | None = None
     storage_backend: Optional["StorageBackend"] = None
+    # Previous-stage output records (carry lineage/node_id). Distinct from
+    # source_data, which holds raw seed records loaded from storage for
+    # prompt context and context-scope inference. The LineageEnricher reads
+    # parent_records to find the ancestry-bearing parent for each item; the
+    # raw seed records do not carry lineage and would force a self-only
+    # fallback (VIOL-0016).
+    parent_records: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def action_name(self) -> str:

--- a/agent_actions/prompt/data_generator.py
+++ b/agent_actions/prompt/data_generator.py
@@ -67,12 +67,14 @@ class DataGenerator(IGenerator):
             GenerationError: If agent creation or data generation fails.
         """
         try:
+            source_content_list = source_content if isinstance(source_content, list) else []
             context = ProcessingContext(
                 agent_config=cast(ActionConfigDict, self.agent_config),
                 agent_name=self.agent_name,
                 mode=RunMode.ONLINE,
                 is_first_stage=False,  # This is subsequent-stage processing
-                source_data=source_content if isinstance(source_content, list) else [],
+                source_data=source_content_list,
+                parent_records=source_content_list,
                 file_path=file_path,
                 version_context=version_context,
                 workflow_metadata=workflow_metadata,

--- a/agent_actions/prompt/data_generator.py
+++ b/agent_actions/prompt/data_generator.py
@@ -68,13 +68,18 @@ class DataGenerator(IGenerator):
         """
         try:
             source_content_list = source_content if isinstance(source_content, list) else []
+            parent_records = [
+                r
+                for r in source_content_list
+                if isinstance(r, dict) and (r.get("lineage") or r.get("node_id"))
+            ]
             context = ProcessingContext(
                 agent_config=cast(ActionConfigDict, self.agent_config),
                 agent_name=self.agent_name,
                 mode=RunMode.ONLINE,
                 is_first_stage=False,
                 source_data=source_content_list,
-                parent_records=list(source_content_list),
+                parent_records=parent_records,
                 file_path=file_path,
                 version_context=version_context,
                 workflow_metadata=workflow_metadata,

--- a/agent_actions/prompt/data_generator.py
+++ b/agent_actions/prompt/data_generator.py
@@ -72,9 +72,9 @@ class DataGenerator(IGenerator):
                 agent_config=cast(ActionConfigDict, self.agent_config),
                 agent_name=self.agent_name,
                 mode=RunMode.ONLINE,
-                is_first_stage=False,  # This is subsequent-stage processing
+                is_first_stage=False,
                 source_data=source_content_list,
-                parent_records=source_content_list,
+                parent_records=list(source_content_list),
                 file_path=file_path,
                 version_context=version_context,
                 workflow_metadata=workflow_metadata,

--- a/agent_actions/prompt/data_generator.py
+++ b/agent_actions/prompt/data_generator.py
@@ -69,9 +69,7 @@ class DataGenerator(IGenerator):
         try:
             source_content_list = source_content if isinstance(source_content, list) else []
             parent_records = [
-                r
-                for r in source_content_list
-                if isinstance(r, dict) and (r.get("lineage") or r.get("node_id"))
+                r for r in source_content_list if isinstance(r, dict) and r.get("lineage")
             ]
             context = ProcessingContext(
                 agent_config=cast(ActionConfigDict, self.agent_config),

--- a/agent_actions/prompt/data_generator.py
+++ b/agent_actions/prompt/data_generator.py
@@ -67,9 +67,11 @@ class DataGenerator(IGenerator):
             GenerationError: If agent creation or data generation fails.
         """
         try:
+            from agent_actions.utils.lineage import LineageBuilder
+
             source_content_list = source_content if isinstance(source_content, list) else []
             parent_records = [
-                r for r in source_content_list if isinstance(r, dict) and r.get("lineage")
+                r for r in source_content_list if LineageBuilder.is_lineage_bearing(r)
             ]
             context = ProcessingContext(
                 agent_config=cast(ActionConfigDict, self.agent_config),

--- a/agent_actions/utils/lineage/builder.py
+++ b/agent_actions/utils/lineage/builder.py
@@ -19,6 +19,17 @@ class LineageBuilder:
     """Builds and tracks lineage chains for data processing."""
 
     @staticmethod
+    def is_lineage_bearing(record: Any) -> bool:
+        """True when *record* carries a lineage chain that can extend a child's ancestry.
+
+        Matches the contract that ``add_unified_lineage`` and ``build_lineage``
+        enforce: a parent must have a ``lineage`` key to be useful. A record
+        with only ``node_id`` will fall through to self-only lineage in the
+        builder and so must not be treated as a parent_records candidate.
+        """
+        return isinstance(record, dict) and bool(record.get("lineage"))
+
+    @staticmethod
     def _propagate_ancestry_chain(obj: dict, parent_item: dict) -> None:
         """Propagate parent_target_id, root_target_id, and source_guid from parent to *obj* in place."""
         if "target_id" in parent_item:

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -478,7 +478,7 @@ class ProcessingPipeline:
         source_data = data
 
         parent_records = (
-            [r for r in data if isinstance(r, dict) and (r.get("lineage") or r.get("node_id"))]
+            [r for r in data if isinstance(r, dict) and r.get("lineage")]
             if isinstance(data, list)
             else []
         )

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -477,6 +477,11 @@ class ProcessingPipeline:
         # data IS the source — there's no staging data in this workflow for them.
         source_data = data
 
+        # parent_records carries the previous-stage output (with lineage/node_id)
+        # so the LineageEnricher can extend the ancestry chain even after
+        # source_data is overwritten with raw seed records below. VIOL-0016.
+        parent_records = list(data) if isinstance(data, list) else []
+
         if self.config.source_relative_path and self.config.storage_backend is not None:
             try:
                 from agent_actions.input.loaders.source_data import SourceDataLoader
@@ -549,6 +554,7 @@ class ProcessingPipeline:
             mode=RunMode.ONLINE,
             is_first_stage=False,
             source_data=source_data,  # Pass the loaded source data
+            parent_records=parent_records,  # Previous-stage output (lineage source)
             file_path=file_path,
             output_directory=output_directory,
             agent_indices=agent_indices,

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -477,9 +477,11 @@ class ProcessingPipeline:
         # data IS the source — there's no staging data in this workflow for them.
         source_data = data
 
-        # Preserve previous-stage records before source_data is overwritten below
-        # so the LineageEnricher can extend the ancestry chain.
-        parent_records = list(data) if isinstance(data, list) else []
+        parent_records = (
+            [r for r in data if isinstance(r, dict) and (r.get("lineage") or r.get("node_id"))]
+            if isinstance(data, list)
+            else []
+        )
 
         if self.config.source_relative_path and self.config.storage_backend is not None:
             try:

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -477,8 +477,10 @@ class ProcessingPipeline:
         # data IS the source — there's no staging data in this workflow for them.
         source_data = data
 
+        from agent_actions.utils.lineage import LineageBuilder
+
         parent_records = (
-            [r for r in data if isinstance(r, dict) and r.get("lineage")]
+            [r for r in data if LineageBuilder.is_lineage_bearing(r)]
             if isinstance(data, list)
             else []
         )

--- a/agent_actions/workflow/pipeline.py
+++ b/agent_actions/workflow/pipeline.py
@@ -477,9 +477,8 @@ class ProcessingPipeline:
         # data IS the source — there's no staging data in this workflow for them.
         source_data = data
 
-        # parent_records carries the previous-stage output (with lineage/node_id)
-        # so the LineageEnricher can extend the ancestry chain even after
-        # source_data is overwritten with raw seed records below. VIOL-0016.
+        # Preserve previous-stage records before source_data is overwritten below
+        # so the LineageEnricher can extend the ancestry chain.
         parent_records = list(data) if isinstance(data, list) else []
 
         if self.config.source_relative_path and self.config.storage_backend is not None:

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -1,14 +1,4 @@
-"""Regression test for VIOL-0016: downstream lineage must extend the chain.
-
-The bug: `pipeline.py` overwrote `context.source_data` with raw seed records
-from storage (no `lineage`/`node_id`), then `LineageEnricher` used those as
-parent_item. `LineageBuilder.add_unified_lineage` fell through to
-``obj["lineage"] = [node_id]`` because ``"lineage" not in parent_item``.
-
-The fix: ``ProcessingContext.parent_records`` carries the previous-stage
-output (with lineage). ``LineageEnricher._get_parent_item`` prefers it over
-``source_data``.
-"""
+"""LineageEnricher must extend downstream chains via parent_records."""
 
 from __future__ import annotations
 
@@ -106,25 +96,24 @@ class TestParentRecordsLineagePropagation:
         assert enriched_item["lineage"][0] == parent_node_id
 
     def test_falls_back_to_source_data_when_parent_records_empty(self):
-        """No parent_records → fall back to source_data behavior (legacy path)."""
-        # Source data with full lineage (simulating FILE-mode unified.py:113 path).
-        legacy_parent_node_id = "stage_one_legacy"
+        """No parent_records → look up parent in source_data (FILE-mode path)."""
+        parent_node_id = "stage_one_file_mode"
         source_data_with_lineage = [
             {
-                "source_guid": "guid_legacy",
-                "node_id": legacy_parent_node_id,
-                "lineage": [legacy_parent_node_id],
+                "source_guid": "guid_fm",
+                "node_id": parent_node_id,
+                "lineage": [parent_node_id],
             }
         ]
-        item = {"source_guid": "guid_legacy", "content": {"stage_two": {"y": 2}}}
-        result = ProcessingResult.success(data=[item], source_guid="guid_legacy")
+        item = {"source_guid": "guid_fm", "content": {"stage_two": {"y": 2}}}
+        result = ProcessingResult.success(data=[item], source_guid="guid_fm")
 
         context = _make_context(parent_records=[], source_data=source_data_with_lineage)
         enriched = LineageEnricher().enrich(result, context)
 
         enriched_item = enriched.data[0]
         assert len(enriched_item["lineage"]) == 2
-        assert enriched_item["lineage"][0] == legacy_parent_node_id
+        assert enriched_item["lineage"][0] == parent_node_id
 
     def test_raw_seed_only_produces_self_lineage(self):
         """Sanity: with neither parent_records nor lineage-bearing source_data, lineage is self-only.
@@ -163,3 +152,87 @@ class TestParentRecordsLineagePropagation:
 
         enriched_item = enriched.data[0]
         assert enriched_item["lineage"] == [enriched_item["node_id"]]
+
+    def test_parent_index_o1_lookup(self):
+        """Per-item lookup uses an O(1) parent_index, not a linear scan.
+
+        With 1000 parents, repeated lookups must complete in well under
+        a second. A linear scan would be O(N*M) and become observable.
+        """
+        import time
+
+        N = 1000
+        parents = [
+            {
+                "source_guid": f"guid_{i}",
+                "node_id": f"stage_one_{i}",
+                "lineage": [f"stage_one_{i}"],
+            }
+            for i in range(N)
+        ]
+        # 100 outputs, each mapped to a different parent via per-item source_guid
+        items = [{"source_guid": f"guid_{i}", "content": {"stage_two": {}}} for i in range(100)]
+        result = ProcessingResult.success(
+            data=items,
+            source_guid=None,  # forces per-item parent lookup
+        )
+
+        context = _make_context(parent_records=parents)
+        start = time.perf_counter()
+        enriched = LineageEnricher().enrich(result, context)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.5, f"Parent lookup took {elapsed:.3f}s — index may not be in use"
+        for i, item in enumerate(enriched.data):
+            assert item["lineage"][0] == f"stage_one_{i}", (
+                f"Item {i} lineage didn't extend correct parent: {item['lineage']}"
+            )
+
+
+class TestBatchContextAdapterParentRecords:
+    """Batch path populates parent_records symmetrically with the online path."""
+
+    def test_batch_adapter_defaults_parent_records_to_original_row(self):
+        """When no parent_records passed, adapter defaults to [original_row]."""
+        from agent_actions.processing.batch_context_adapter import BatchContextAdapter
+
+        original_row = {
+            "source_guid": "guid_b",
+            "node_id": "stage_one_b",
+            "lineage": ["stage_one_b"],
+        }
+        ctx = BatchContextAdapter.to_processing_context(
+            agent_config={"agent_type": "stage_two", "dependencies": ["stage_one"]},
+            original_row=original_row,
+            record_index=0,
+        )
+        assert ctx.parent_records == [original_row]
+        assert ctx.current_item is original_row
+
+    def test_batch_adapter_accepts_explicit_parent_records(self):
+        """Caller can pass an explicit list (overrides default)."""
+        from agent_actions.processing.batch_context_adapter import BatchContextAdapter
+
+        original_row = {"source_guid": "guid_b1"}
+        explicit_parents = [
+            {"source_guid": "guid_b1", "node_id": "p1", "lineage": ["p1"]},
+            {"source_guid": "guid_b2", "node_id": "p2", "lineage": ["p2"]},
+        ]
+        ctx = BatchContextAdapter.to_processing_context(
+            agent_config={"agent_type": "stage_two", "dependencies": ["stage_one"]},
+            original_row=original_row,
+            record_index=0,
+            parent_records=explicit_parents,
+        )
+        assert ctx.parent_records == explicit_parents
+
+    def test_batch_adapter_empty_when_no_original_row(self):
+        """No original_row → empty parent_records, not [None]."""
+        from agent_actions.processing.batch_context_adapter import BatchContextAdapter
+
+        ctx = BatchContextAdapter.to_processing_context(
+            agent_config={"agent_type": "stage_one"},
+            original_row={},  # falsy
+            record_index=0,
+        )
+        assert ctx.parent_records == []

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -150,40 +150,23 @@ class TestParentRecordsLineagePropagation:
         enriched_item = enriched.data[0]
         assert enriched_item["lineage"] == [enriched_item["node_id"]]
 
-    def test_parent_index_o1_lookup(self):
-        """Per-item lookup uses an O(1) parent_index, not a linear scan.
-
-        With 1000 parents, repeated lookups must complete in well under
-        a second. A linear scan would be O(N*M) and become observable.
-        """
-        import time
-
-        N = 1000
+    def test_per_item_parent_lookup_resolves_correct_parent_for_each_item(self):
+        """Per-item lookups (source_guid is None at result level) must pick the right parent for each output."""
         parents = [
-            {
-                "source_guid": f"guid_{i}",
-                "node_id": f"stage_one_{i}",
-                "lineage": [f"stage_one_{i}"],
-            }
-            for i in range(N)
+            {"source_guid": f"guid_{i}", "node_id": f"n_{i}", "lineage": [f"n_{i}"]}
+            for i in range(5)
         ]
-        # 100 outputs, each mapped to a different parent via per-item source_guid
-        items = [{"source_guid": f"guid_{i}", "content": {"stage_two": {}}} for i in range(100)]
-        result = ProcessingResult.success(
-            data=items,
-            source_guid=None,  # forces per-item parent lookup
-        )
+        items = [{"source_guid": f"guid_{i}", "content": {"x": {}}} for i in range(5)]
+        result = ProcessingResult.success(data=items, source_guid=None)
 
         context = _make_context(parent_records=parents)
-        start = time.perf_counter()
         enriched = LineageEnricher().enrich(result, context)
-        elapsed = time.perf_counter() - start
 
-        assert elapsed < 0.5, f"Parent lookup took {elapsed:.3f}s — index may not be in use"
         for i, item in enumerate(enriched.data):
-            assert item["lineage"][0] == f"stage_one_{i}", (
-                f"Item {i} lineage didn't extend correct parent: {item['lineage']}"
+            assert item["lineage"][0] == f"n_{i}", (
+                f"Item {i} resolved to wrong parent: {item['lineage']}"
             )
+            assert item["lineage"][-1] == item["node_id"]
 
 
 class TestBatchContextAdapterParentRecords:

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -233,3 +233,72 @@ class TestBatchContextAdapterParentRecords:
             record_index=0,
         )
         assert ctx.parent_records == []
+
+
+class TestGetParentItemDirect:
+    """Direct unit tests for LineageEnricher._get_parent_item lookup precedence."""
+
+    def _ctx(
+        self,
+        is_first_stage: bool = False,
+        current_item: dict | None = None,
+        parent_records: list[dict] | None = None,
+        source_data: list[dict] | None = None,
+    ) -> ProcessingContext:
+        return ProcessingContext(
+            agent_config={"agent_type": "x"},
+            agent_name="x",
+            mode=RunMode.ONLINE,
+            is_first_stage=is_first_stage,
+            current_item=current_item,
+            parent_records=parent_records or [],
+            source_data=source_data or [],
+        )
+
+    def test_returns_none_when_first_stage(self):
+        ctx = self._ctx(
+            is_first_stage=True,
+            parent_records=[{"source_guid": "g", "node_id": "n"}],
+        )
+        assert LineageEnricher()._get_parent_item("g", ctx) is None
+
+    def test_returns_none_when_source_guid_missing(self):
+        ctx = self._ctx(parent_records=[{"source_guid": "g", "node_id": "n"}])
+        assert LineageEnricher()._get_parent_item(None, ctx) is None
+
+    def test_current_item_wins_over_parent_records(self):
+        current = {"source_guid": "g", "node_id": "from_current"}
+        parents = [{"source_guid": "g", "node_id": "from_parents"}]
+        ctx = self._ctx(current_item=current, parent_records=parents)
+        assert LineageEnricher()._get_parent_item("g", ctx)["node_id"] == "from_current"
+
+    def test_parent_index_hit_returned(self):
+        target = {"source_guid": "g", "node_id": "n"}
+        parents = [target, {"source_guid": "other", "node_id": "o"}]
+        index = {p["source_guid"]: p for p in parents}
+        ctx = self._ctx(parent_records=parents)
+        assert LineageEnricher()._get_parent_item("g", ctx, parent_index=index) is target
+
+    def test_parent_index_miss_falls_through_to_source_data(self):
+        """Miss in parent_records falls through to source_data so FILE-mode lookups still resolve."""
+        parents = [{"source_guid": "other", "node_id": "o"}]
+        index = {p["source_guid"]: p for p in parents}
+        source_match = {"source_guid": "g", "node_id": "from_source"}
+        ctx = self._ctx(parent_records=parents, source_data=[source_match])
+        source_index = {source_match["source_guid"]: source_match}
+        result = LineageEnricher()._get_parent_item(
+            "g", ctx, source_index=source_index, parent_index=index
+        )
+        assert result is source_match
+
+    def test_linear_scan_when_parent_index_omitted(self):
+        target = {"source_guid": "g", "node_id": "n"}
+        ctx = self._ctx(parent_records=[target])
+        assert LineageEnricher()._get_parent_item("g", ctx) is target
+
+    def test_falls_through_to_source_index_when_parents_empty(self):
+        seed = [{"source_guid": "g", "node_id": "from_seed"}]
+        source_index = {p["source_guid"]: p for p in seed}
+        ctx = self._ctx(parent_records=[], source_data=seed)
+        result = LineageEnricher()._get_parent_item("g", ctx, source_index=source_index)
+        assert result is seed[0]

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -1,0 +1,165 @@
+"""Regression test for VIOL-0016: downstream lineage must extend the chain.
+
+The bug: `pipeline.py` overwrote `context.source_data` with raw seed records
+from storage (no `lineage`/`node_id`), then `LineageEnricher` used those as
+parent_item. `LineageBuilder.add_unified_lineage` fell through to
+``obj["lineage"] = [node_id]`` because ``"lineage" not in parent_item``.
+
+The fix: ``ProcessingContext.parent_records`` carries the previous-stage
+output (with lineage). ``LineageEnricher._get_parent_item`` prefers it over
+``source_data``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_actions.config.types import RunMode
+from agent_actions.processing.enrichment import LineageEnricher
+from agent_actions.processing.types import ProcessingContext, ProcessingResult
+from agent_actions.utils.correlation import VersionIdGenerator
+
+
+@pytest.fixture(autouse=True)
+def clear_correlation_registry():
+    VersionIdGenerator.clear_version_correlation_registry()
+    yield
+    VersionIdGenerator.clear_version_correlation_registry()
+
+
+def _make_context(
+    parent_records: list[dict] | None = None,
+    source_data: list[dict] | None = None,
+) -> ProcessingContext:
+    return ProcessingContext(
+        agent_config={"agent_type": "stage_two"},
+        agent_name="stage_two",
+        mode=RunMode.ONLINE,
+        is_first_stage=False,
+        parent_records=parent_records or [],
+        source_data=source_data or [],
+    )
+
+
+class TestParentRecordsLineagePropagation:
+    """parent_records is preferred over source_data for parent lookup."""
+
+    def test_downstream_lineage_extends_parent_chain(self):
+        """The bug repro: a downstream record's lineage must include the parent's node_id."""
+        # Stage-one output: has lineage (would be in parent_records).
+        stage_one_node_id = "stage_one_abc123"
+        parent = {
+            "source_guid": "guid_1",
+            "node_id": stage_one_node_id,
+            "lineage": [stage_one_node_id],
+            "content": {"stage_one": {"data": "value"}},
+        }
+
+        # Stage-two output before enrichment.
+        stage_two_item = {
+            "source_guid": "guid_1",
+            "content": {"stage_two": {"derived": "from stage_one"}},
+        }
+        result = ProcessingResult.success(
+            data=[stage_two_item],
+            source_guid="guid_1",
+        )
+
+        # Raw seed records (no lineage) — what source_data would carry.
+        raw_seed = [{"source_guid": "guid_1", "page_content": "raw text"}]
+
+        context = _make_context(parent_records=[parent], source_data=raw_seed)
+        enriched = LineageEnricher().enrich(result, context)
+
+        enriched_item = enriched.data[0]
+        assert "lineage" in enriched_item
+        assert len(enriched_item["lineage"]) == 2, (
+            f"Expected lineage to extend parent chain (2 entries), got {enriched_item['lineage']}"
+        )
+        assert enriched_item["lineage"][0] == stage_one_node_id, (
+            "Parent node_id must be first in the chain"
+        )
+        assert enriched_item["lineage"][1] == enriched_item["node_id"], (
+            "Self node_id must be the tail of the chain"
+        )
+
+    def test_parent_records_preferred_over_source_data(self):
+        """When both are present, parent_records wins — even if source_data has the same source_guid."""
+        parent_node_id = "stage_one_xyz789"
+        parent = {
+            "source_guid": "guid_shared",
+            "node_id": parent_node_id,
+            "lineage": [parent_node_id],
+        }
+        # source_data has the same source_guid but no lineage (raw seed shape).
+        raw_seed = [{"source_guid": "guid_shared", "page_content": "raw"}]
+
+        item = {"source_guid": "guid_shared", "content": {"stage_two": {"x": 1}}}
+        result = ProcessingResult.success(data=[item], source_guid="guid_shared")
+
+        context = _make_context(parent_records=[parent], source_data=raw_seed)
+        enriched = LineageEnricher().enrich(result, context)
+
+        enriched_item = enriched.data[0]
+        # If source_data had won, lineage would be [self] (raw_seed has no lineage).
+        assert len(enriched_item["lineage"]) == 2
+        assert enriched_item["lineage"][0] == parent_node_id
+
+    def test_falls_back_to_source_data_when_parent_records_empty(self):
+        """No parent_records → fall back to source_data behavior (legacy path)."""
+        # Source data with full lineage (simulating FILE-mode unified.py:113 path).
+        legacy_parent_node_id = "stage_one_legacy"
+        source_data_with_lineage = [
+            {
+                "source_guid": "guid_legacy",
+                "node_id": legacy_parent_node_id,
+                "lineage": [legacy_parent_node_id],
+            }
+        ]
+        item = {"source_guid": "guid_legacy", "content": {"stage_two": {"y": 2}}}
+        result = ProcessingResult.success(data=[item], source_guid="guid_legacy")
+
+        context = _make_context(parent_records=[], source_data=source_data_with_lineage)
+        enriched = LineageEnricher().enrich(result, context)
+
+        enriched_item = enriched.data[0]
+        assert len(enriched_item["lineage"]) == 2
+        assert enriched_item["lineage"][0] == legacy_parent_node_id
+
+    def test_raw_seed_only_produces_self_lineage(self):
+        """Sanity: with neither parent_records nor lineage-bearing source_data, lineage is self-only.
+
+        This pins the pre-fix behavior so it's clear when the new code is doing the work.
+        """
+        raw_seed = [{"source_guid": "guid_solo", "page_content": "raw"}]
+        item = {"source_guid": "guid_solo", "content": {"stage_two": {"z": 3}}}
+        result = ProcessingResult.success(data=[item], source_guid="guid_solo")
+
+        context = _make_context(parent_records=[], source_data=raw_seed)
+        enriched = LineageEnricher().enrich(result, context)
+
+        enriched_item = enriched.data[0]
+        # parent_item is the raw seed (no lineage) → fallback to [node_id]
+        assert enriched_item["lineage"] == [enriched_item["node_id"]]
+
+    def test_first_stage_unchanged(self):
+        """is_first_stage=True still returns no parent (source records get self-only lineage)."""
+        parent = {
+            "source_guid": "guid_first",
+            "node_id": "irrelevant",
+            "lineage": ["irrelevant"],
+        }
+        item = {"source_guid": "guid_first", "content": {"stage_one": {"a": 1}}}
+        result = ProcessingResult.success(data=[item], source_guid="guid_first")
+
+        context = ProcessingContext(
+            agent_config={"agent_type": "stage_one"},
+            agent_name="stage_one",
+            mode=RunMode.ONLINE,
+            is_first_stage=True,
+            parent_records=[parent],
+        )
+        enriched = LineageEnricher().enrich(result, context)
+
+        enriched_item = enriched.data[0]
+        assert enriched_item["lineage"] == [enriched_item["node_id"]]

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -269,6 +269,20 @@ class TestGetParentItemDirect:
         ctx = self._ctx(current_item=current, parent_records=parents)
         assert LineageEnricher()._get_parent_item("g", ctx)["node_id"] == "from_current"
 
+    def test_current_item_skipped_when_source_guid_mismatches(self):
+        """Misconfigured strategy: current_item.source_guid != requested → fall through."""
+        current = {"source_guid": "wrong_guid", "node_id": "stale"}
+        parents = [{"source_guid": "g", "node_id": "correct_parent", "lineage": ["correct_parent"]}]
+        ctx = self._ctx(current_item=current, parent_records=parents)
+        assert LineageEnricher()._get_parent_item("g", ctx)["node_id"] == "correct_parent"
+
+    def test_current_item_used_when_source_guid_is_none(self):
+        """A current_item without source_guid is treated as the explicit parent for any lookup."""
+        current = {"node_id": "from_current"}  # no source_guid
+        parents = [{"source_guid": "g", "node_id": "from_parents"}]
+        ctx = self._ctx(current_item=current, parent_records=parents)
+        assert LineageEnricher()._get_parent_item("g", ctx)["node_id"] == "from_current"
+
     def test_parent_index_hit_returned(self):
         target = {"source_guid": "g", "node_id": "n"}
         parents = [target, {"source_guid": "other", "node_id": "o"}]
@@ -299,3 +313,59 @@ class TestGetParentItemDirect:
         ctx = self._ctx(parent_records=[], source_data=seed)
         result = LineageEnricher()._get_parent_item("g", ctx, source_index=source_index)
         assert result is seed[0]
+
+
+class TestSourceMappingParentFallback:
+    """When source_mapping pins a lineage-less record, parent_index recovers the real parent."""
+
+    def test_one_to_one_source_mapping_recovers_lineage_from_parent_records(self):
+        # source_data has the raw seed (no lineage) at index 0
+        seed = {"source_guid": "g", "page_content": "raw"}
+        # parent_records has the lineage-bearing record for the same guid
+        lineage_parent = {
+            "source_guid": "g",
+            "node_id": "stage_one",
+            "lineage": ["stage_one"],
+        }
+
+        item = {"source_guid": "g", "content": {"x": {}}}
+        result = ProcessingResult.success(data=[item], source_guid=None)
+        result.source_mapping = {0: 0}
+
+        context = ProcessingContext(
+            agent_config={"agent_type": "stage_two"},
+            agent_name="stage_two",
+            mode=RunMode.ONLINE,
+            is_first_stage=False,
+            source_data=[seed],
+            parent_records=[lineage_parent],
+        )
+        enriched = LineageEnricher().enrich(result, context)
+        enriched_item = enriched.data[0]
+
+        assert enriched_item["lineage"][0] == "stage_one"
+        assert enriched_item["lineage"][-1] == enriched_item["node_id"]
+
+    def test_many_to_one_source_mapping_recovers_lineage_for_each_source(self):
+        seed_a = {"source_guid": "g_a", "page_content": "raw a"}
+        seed_b = {"source_guid": "g_b", "page_content": "raw b"}
+        parent_a = {"source_guid": "g_a", "node_id": "p_a", "lineage": ["p_a"]}
+        parent_b = {"source_guid": "g_b", "node_id": "p_b", "lineage": ["p_b"]}
+
+        item = {"source_guid": "g_a", "content": {"x": {}}}
+        result = ProcessingResult.success(data=[item], source_guid=None)
+        result.source_mapping = {0: [0, 1]}
+
+        context = ProcessingContext(
+            agent_config={"agent_type": "stage_two"},
+            agent_name="stage_two",
+            mode=RunMode.ONLINE,
+            is_first_stage=False,
+            source_data=[seed_a, seed_b],
+            parent_records=[parent_a, parent_b],
+        )
+        enriched = LineageEnricher().enrich(result, context)
+        enriched_item = enriched.data[0]
+
+        assert "p_a" in enriched_item["lineage"]
+        assert enriched_item["lineage"][-1] == enriched_item["node_id"]

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -116,10 +116,7 @@ class TestParentRecordsLineagePropagation:
         assert enriched_item["lineage"][0] == parent_node_id
 
     def test_raw_seed_only_produces_self_lineage(self):
-        """Sanity: with neither parent_records nor lineage-bearing source_data, lineage is self-only.
-
-        This pins the pre-fix behavior so it's clear when the new code is doing the work.
-        """
+        """With neither parent_records nor lineage-bearing source_data, lineage is self-only."""
         raw_seed = [{"source_guid": "guid_solo", "page_content": "raw"}]
         item = {"source_guid": "guid_solo", "content": {"stage_two": {"z": 3}}}
         result = ProcessingResult.success(data=[item], source_guid="guid_solo")

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -217,6 +217,20 @@ class TestBatchContextAdapterParentRecords:
         )
         assert ctx.parent_records == []
 
+    def test_batch_adapter_rejects_seed_record_without_lineage(self):
+        """First-stage batch: original_row is raw seed (no lineage) → parent_records empty."""
+        from agent_actions.processing.batch_context_adapter import BatchContextAdapter
+
+        seed = {"source_guid": "seed_1", "page_content": "raw text"}  # no lineage / node_id
+        ctx = BatchContextAdapter.to_processing_context(
+            agent_config={"agent_type": "stage_one"},
+            original_row=seed,
+            record_index=0,
+        )
+        assert ctx.parent_records == []
+        # current_item is still set so the enricher can use it if appropriate
+        assert ctx.current_item is seed
+
 
 class TestGetParentItemDirect:
     """Direct unit tests for LineageEnricher._get_parent_item lookup precedence."""

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -172,8 +172,8 @@ class TestParentRecordsLineagePropagation:
 class TestBatchContextAdapterParentRecords:
     """Batch path populates parent_records symmetrically with the online path."""
 
-    def test_batch_adapter_defaults_parent_records_to_original_row(self):
-        """When no parent_records passed, adapter defaults to [original_row]."""
+    def test_batch_adapter_defaults_parent_records_to_empty(self):
+        """No explicit parent_records → empty; batch relies on current_item for parent lookup."""
         from agent_actions.processing.batch_context_adapter import BatchContextAdapter
 
         original_row = {
@@ -186,7 +186,7 @@ class TestBatchContextAdapterParentRecords:
             original_row=original_row,
             record_index=0,
         )
-        assert ctx.parent_records == [original_row]
+        assert ctx.parent_records == []
         assert ctx.current_item is original_row
 
     def test_batch_adapter_accepts_explicit_parent_records(self):
@@ -217,30 +217,17 @@ class TestBatchContextAdapterParentRecords:
         )
         assert ctx.parent_records == []
 
-    def test_batch_adapter_rejects_record_with_node_id_but_no_lineage(self):
-        """A node_id without lineage cannot extend the chain — must not become parent_records."""
+    def test_batch_adapter_seed_record_keeps_current_item_but_no_parents(self):
+        """Raw seed input still flows through as current_item; parent_records stays empty."""
         from agent_actions.processing.batch_context_adapter import BatchContextAdapter
 
-        record = {"source_guid": "g", "node_id": "n_only"}  # node_id present, lineage missing
-        ctx = BatchContextAdapter.to_processing_context(
-            agent_config={"agent_type": "stage_two", "dependencies": ["stage_one"]},
-            original_row=record,
-            record_index=0,
-        )
-        assert ctx.parent_records == []
-
-    def test_batch_adapter_rejects_seed_record_without_lineage(self):
-        """First-stage batch: original_row is raw seed (no lineage) → parent_records empty."""
-        from agent_actions.processing.batch_context_adapter import BatchContextAdapter
-
-        seed = {"source_guid": "seed_1", "page_content": "raw text"}  # no lineage / node_id
+        seed = {"source_guid": "seed_1", "page_content": "raw text"}
         ctx = BatchContextAdapter.to_processing_context(
             agent_config={"agent_type": "stage_one"},
             original_row=seed,
             record_index=0,
         )
         assert ctx.parent_records == []
-        # current_item is still set so the enricher can use it if appropriate
         assert ctx.current_item is seed
 
 

--- a/tests/unit/core/test_lineage_parent_records.py
+++ b/tests/unit/core/test_lineage_parent_records.py
@@ -217,6 +217,18 @@ class TestBatchContextAdapterParentRecords:
         )
         assert ctx.parent_records == []
 
+    def test_batch_adapter_rejects_record_with_node_id_but_no_lineage(self):
+        """A node_id without lineage cannot extend the chain — must not become parent_records."""
+        from agent_actions.processing.batch_context_adapter import BatchContextAdapter
+
+        record = {"source_guid": "g", "node_id": "n_only"}  # node_id present, lineage missing
+        ctx = BatchContextAdapter.to_processing_context(
+            agent_config={"agent_type": "stage_two", "dependencies": ["stage_one"]},
+            original_row=record,
+            record_index=0,
+        )
+        assert ctx.parent_records == []
+
     def test_batch_adapter_rejects_seed_record_without_lineage(self):
         """First-stage batch: original_row is raw seed (no lineage) → parent_records empty."""
         from agent_actions.processing.batch_context_adapter import BatchContextAdapter

--- a/tests/unit/processing/test_enrichment_expansion_guid.py
+++ b/tests/unit/processing/test_enrichment_expansion_guid.py
@@ -13,6 +13,7 @@ def _make_context(action_name: str = "test_action") -> ProcessingContext:
     ctx.agent_name = action_name
     ctx.is_first_stage = True
     ctx.source_data = None
+    ctx.parent_records = []
     ctx.record_index = 0
     ctx.agent_config = {}
     return ctx

--- a/tests/unit/processing/test_enrichment_non_dict_guard.py
+++ b/tests/unit/processing/test_enrichment_non_dict_guard.py
@@ -11,6 +11,7 @@ def _make_context(**kwargs: object) -> ProcessingContext:
     ctx.action_name = kwargs.get("action_name", "test_action")
     ctx.action_config = kwargs.get("action_config", MagicMock())
     ctx.source_data = kwargs.get("source_data", [])
+    ctx.parent_records = kwargs.get("parent_records", [])
     return ctx
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-actions"
-version = "0.1.16"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -90,12 +90,12 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.0.0,<26" },
     { name = "anthropic", specifier = ">=0.30.0,<2" },
     { name = "beautifulsoup4", specifier = ">=4.12.3,<5" },
-    { name = "cohere", specifier = ">=5.0.0,<7" },
+    { name = "cohere", specifier = ">=5.0.0,<8" },
     { name = "defusedxml", specifier = ">=0.7.1,<1" },
     { name = "flask", specifier = ">=3.0.3,<4" },
     { name = "flask-cors", specifier = ">=4.0.1,<7" },
     { name = "google-api-python-client", specifier = ">=2.130.0,<3" },
-    { name = "google-genai", specifier = ">=1.0.0,<2" },
+    { name = "google-genai", specifier = ">=1.0.0,<3" },
     { name = "groq", specifier = ">=0.1.0,<2" },
     { name = "ipdb", marker = "extra == 'dev'", specifier = ">=0.13.0,<1" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.0.0,<10" },
@@ -103,7 +103,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.30.0,<1" },
     { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "lsprotocol", specifier = ">=2024.0.0,<2026" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0,<3" },
     { name = "networkx", specifier = ">=3.3,<4" },
     { name = "numpy", specifier = ">=1.26.4,<3" },
     { name = "ollama", specifier = ">=0.1.0,<1" },
@@ -138,10 +138,9 @@ dev = [
     { name = "hypothesis", specifier = ">=6.139.2,<7" },
     { name = "ipdb", specifier = ">=0.13.0,<1" },
     { name = "ipython", specifier = ">=8.0.0,<10" },
-    { name = "mypy", specifier = ">=1.8.0,<2" },
+    { name = "mypy", specifier = ">=1.8.0,<3" },
     { name = "pandas-stubs", specifier = ">=2.0.3,<4" },
     { name = "pre-commit", specifier = ">=3.6.0,<4" },
-    { name = "pytest", specifier = ">=7.4.0,<9" },
     { name = "pytest", specifier = ">=7.4.0,<10" },
     { name = "pytest-asyncio", specifier = ">=1.2.0,<2" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-actions"
-version = "0.2.6"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -90,12 +90,12 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.0.0,<26" },
     { name = "anthropic", specifier = ">=0.30.0,<2" },
     { name = "beautifulsoup4", specifier = ">=4.12.3,<5" },
-    { name = "cohere", specifier = ">=5.0.0,<8" },
+    { name = "cohere", specifier = ">=5.0.0,<7" },
     { name = "defusedxml", specifier = ">=0.7.1,<1" },
     { name = "flask", specifier = ">=3.0.3,<4" },
     { name = "flask-cors", specifier = ">=4.0.1,<7" },
     { name = "google-api-python-client", specifier = ">=2.130.0,<3" },
-    { name = "google-genai", specifier = ">=1.0.0,<3" },
+    { name = "google-genai", specifier = ">=1.0.0,<2" },
     { name = "groq", specifier = ">=0.1.0,<2" },
     { name = "ipdb", marker = "extra == 'dev'", specifier = ">=0.13.0,<1" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.0.0,<10" },
@@ -103,7 +103,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.30.0,<1" },
     { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "lsprotocol", specifier = ">=2024.0.0,<2026" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0,<3" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
     { name = "networkx", specifier = ">=3.3,<4" },
     { name = "numpy", specifier = ">=1.26.4,<3" },
     { name = "ollama", specifier = ">=0.1.0,<1" },
@@ -138,9 +138,10 @@ dev = [
     { name = "hypothesis", specifier = ">=6.139.2,<7" },
     { name = "ipdb", specifier = ">=0.13.0,<1" },
     { name = "ipython", specifier = ">=8.0.0,<10" },
-    { name = "mypy", specifier = ">=1.8.0,<3" },
+    { name = "mypy", specifier = ">=1.8.0,<2" },
     { name = "pandas-stubs", specifier = ">=2.0.3,<4" },
     { name = "pre-commit", specifier = ">=3.6.0,<4" },
+    { name = "pytest", specifier = ">=7.4.0,<9" },
     { name = "pytest", specifier = ">=7.4.0,<10" },
     { name = "pytest-asyncio", specifier = ">=1.2.0,<2" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6" },


### PR DESCRIPTION
## Summary
- fix(VIOL-0016): preserve previous-stage lineage in LineageEnricher
- fix(VIOL-0016): broaden lineage fix coverage, O(1) lookup, batch + DataGenerator symmetry
- fix(VIOL-0016): address review followups
- fix(VIOL-0016): add direct _get_parent_item unit tests
- fix(VIOL-0016): guard parent_records against lineage-less records
- fix(VIOL-0016): guard current_item GUID match and add source_mapping fallback
- test(VIOL-0016): cover batch seed-record path
- test(VIOL-0016): cover current_item GUID guard and source_mapping fallback

## Verification
- ruff + pytest pass (.harness/ci.ok)
- pi-consensus pass (.harness/review.ok)
- smoke pass (.harness/smoke.ok)