### PR TITLE
fix(VIOL-0040): route coordinator progress to stderr for jq-clean --json

### DIFF
--- a/agent_actions/workflow/coordinator.py
+++ b/agent_actions/workflow/coordinator.py
@@ -115,7 +115,7 @@ class AgentWorkflow:
     def __init__(self, config: WorkflowRuntimeConfig):
         """Initialize workflow with configuration and dependencies."""
         self.config = config
-        self.runtime = RuntimeContext(state=WorkflowState(), console=Console())
+        self.runtime = RuntimeContext(state=WorkflowState(), console=Console(stderr=True))
 
         # Config pipeline (fires WorkflowInitializationStartEvent internally)
         self.metadata = load_workflow_configs(config, self.console)

--- a/tests/cli/test_json_stdout_clean.py
+++ b/tests/cli/test_json_stdout_clean.py
@@ -29,11 +29,24 @@ from agent_actions.workflow.config_pipeline import _discover_udfs_from_path
 from agent_actions.workflow.coordinator import AgentWorkflow
 
 
+def _evict_udf_modules() -> None:
+    """Drop framework-imported UDF modules so the next discovery actually re-imports.
+
+    discover_udfs() skips files whose synthetic module name is already in
+    sys.modules — otherwise repeated calls with different tmp_paths would
+    silently no-op and the @udf_tool decorator never re-fires.
+    """
+    for name in [k for k in sys.modules if k.startswith("agent_actions._udfs.")]:
+        sys.modules.pop(name, None)
+
+
 @pytest.fixture(autouse=True)
 def _isolated_registry():
     clear_registry()
+    _evict_udf_modules()
     yield
     clear_registry()
+    _evict_udf_modules()
 
 
 class TestCoordinatorConsoleTargetsStderr:
@@ -51,10 +64,6 @@ class TestCoordinatorConsoleTargetsStderr:
             "AgentWorkflow.__init__ must construct its Console with stderr=True "
             "so the shared progress channel stays off stdout. A bare Console() "
             "writes to stdout and breaks `agac <cmd> --json | jq .`."
-        )
-        assert "console=Console()" not in src, (
-            "Bare `Console()` defaults to sys.stdout — would re-contaminate "
-            "--json command stdout. Use Console(stderr=True)."
         )
 
 

--- a/tests/cli/test_json_stdout_clean.py
+++ b/tests/cli/test_json_stdout_clean.py
@@ -1,24 +1,8 @@
-"""Regression tests for `--json` stdout cleanliness.
-
-Every `agac … --json` command must emit a single jq-parseable JSON document
-on stdout. The framework's coordinator owns a single rich Console used by
-every progress-emitting call site downstream. If that Console writes to
-stdout, status banners ("Discovering Tools …", "Discovered N Tools")
-appear above the JSON payload and break `jq`.
-
-Two complementary regressions live here:
-
-* A source-level property test that pins the Console-construction literal
-  at the coordinator. Cheap and fast; fails loudly if anyone reverts to a
-  stdout-bound Console.
-* A behavioral test exercising the discovery print site directly. It feeds
-  the print site a stderr-bound Console and asserts stdout stays clean
-  while stderr receives the banner.
-"""
+"""Regression tests for --json stdout cleanliness."""
 
 from __future__ import annotations
 
-import inspect as inspect_mod
+import inspect
 import sys
 
 import pytest
@@ -50,26 +34,14 @@ def _isolated_registry():
 
 
 class TestCoordinatorConsoleTargetsStderr:
-    """The coordinator's shared rich Console must write to stderr."""
-
     def test_agent_workflow_init_constructs_stderr_console(self):
-        """`AgentWorkflow.__init__` must construct its Console with stderr=True.
-
-        Bare `Console()` defaults to `sys.stdout`. Stdout is reserved for
-        the machine-readable payload of any `--json` command; routing
-        progress text there breaks downstream JSON parsers.
-        """
-        src = inspect_mod.getsource(AgentWorkflow.__init__)
+        src = inspect.getsource(AgentWorkflow.__init__)
         assert "Console(stderr=True)" in src, (
-            "AgentWorkflow.__init__ must construct its Console with stderr=True "
-            "so the shared progress channel stays off stdout. A bare Console() "
-            "writes to stdout and breaks `agac <cmd> --json | jq .`."
+            "Bare Console() writes to stdout and breaks `agac <cmd> --json | jq .`."
         )
 
 
 class TestDiscoveryProgressChannel:
-    """The discovery print site honors the Console it is handed."""
-
     @staticmethod
     def _write_noop_udf(tools_dir):
         tools_dir.mkdir()
@@ -82,8 +54,6 @@ class TestDiscoveryProgressChannel:
         )
 
     def test_stderr_console_keeps_discovery_off_stdout(self, tmp_path, capfd):
-        """Given a stderr-bound Console, discovery prints the banner to
-        stderr only — stdout stays clean."""
         tools = tmp_path / "tools"
         self._write_noop_udf(tools)
 
@@ -91,19 +61,10 @@ class TestDiscoveryProgressChannel:
         _discover_udfs_from_path(str(tools), project_root=None, console=console)
 
         captured = capfd.readouterr()
-        assert "Discovering Tools" not in captured.out, (
-            "Discovery banner leaked to stdout — would break `--json | jq`.\n"
-            f"stdout was: {captured.out!r}"
-        )
-        assert "Discovering Tools" in captured.err, (
-            "Discovery banner must remain visible on stderr — humans need it.\n"
-            f"stderr was: {captured.err!r}"
-        )
+        assert "Discovering Tools" not in captured.out, f"leaked to stdout: {captured.out!r}"
+        assert "Discovering Tools" in captured.err, f"missing from stderr: {captured.err!r}"
 
     def test_stdout_console_demonstrates_the_bug(self, tmp_path, capfd):
-        """Negative control: a stdout-bound Console DOES leak to stdout.
-        If this ever stops being true, the test above is meaningless —
-        re-derive the regression."""
         tools = tmp_path / "tools"
         self._write_noop_udf(tools)
 
@@ -112,6 +73,5 @@ class TestDiscoveryProgressChannel:
 
         captured = capfd.readouterr()
         assert "Discovering Tools" in captured.out, (
-            "Stdout-bound Console no longer leaks discovery progress — the "
-            "print site moved or was removed. Re-derive the regression."
+            "stdout-bound Console no longer leaks — print site moved"
         )

--- a/tests/cli/test_json_stdout_clean.py
+++ b/tests/cli/test_json_stdout_clean.py
@@ -1,0 +1,108 @@
+"""Regression tests for `--json` stdout cleanliness.
+
+Every `agac … --json` command must emit a single jq-parseable JSON document
+on stdout. The framework's coordinator owns a single rich Console used by
+every progress-emitting call site downstream. If that Console writes to
+stdout, status banners ("Discovering Tools …", "Discovered N Tools")
+appear above the JSON payload and break `jq`.
+
+Two complementary regressions live here:
+
+* A source-level property test that pins the Console-construction literal
+  at the coordinator. Cheap and fast; fails loudly if anyone reverts to a
+  stdout-bound Console.
+* A behavioral test exercising the discovery print site directly. It feeds
+  the print site a stderr-bound Console and asserts stdout stays clean
+  while stderr receives the banner.
+"""
+
+from __future__ import annotations
+
+import inspect as inspect_mod
+import sys
+
+import pytest
+from rich.console import Console
+
+from agent_actions.utils.udf_management.registry import clear_registry
+from agent_actions.workflow.config_pipeline import _discover_udfs_from_path
+from agent_actions.workflow.coordinator import AgentWorkflow
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+class TestCoordinatorConsoleTargetsStderr:
+    """The coordinator's shared rich Console must write to stderr."""
+
+    def test_agent_workflow_init_constructs_stderr_console(self):
+        """`AgentWorkflow.__init__` must construct its Console with stderr=True.
+
+        Bare `Console()` defaults to `sys.stdout`. Stdout is reserved for
+        the machine-readable payload of any `--json` command; routing
+        progress text there breaks downstream JSON parsers.
+        """
+        src = inspect_mod.getsource(AgentWorkflow.__init__)
+        assert "Console(stderr=True)" in src, (
+            "AgentWorkflow.__init__ must construct its Console with stderr=True "
+            "so the shared progress channel stays off stdout. A bare Console() "
+            "writes to stdout and breaks `agac <cmd> --json | jq .`."
+        )
+        assert "console=Console()" not in src, (
+            "Bare `Console()` defaults to sys.stdout — would re-contaminate "
+            "--json command stdout. Use Console(stderr=True)."
+        )
+
+
+class TestDiscoveryProgressChannel:
+    """The discovery print site honors the Console it is handed."""
+
+    @staticmethod
+    def _write_noop_udf(tools_dir):
+        tools_dir.mkdir()
+        (tools_dir / "noop.py").write_text(
+            "from agent_actions.utils.udf_management.registry import udf_tool\n"
+            "\n"
+            "@udf_tool\n"
+            "def noop(x):\n"
+            "    return x\n"
+        )
+
+    def test_stderr_console_keeps_discovery_off_stdout(self, tmp_path, capfd):
+        """Given a stderr-bound Console, discovery prints the banner to
+        stderr only — stdout stays clean."""
+        tools = tmp_path / "tools"
+        self._write_noop_udf(tools)
+
+        console = Console(file=sys.stderr, force_terminal=False, width=120)
+        _discover_udfs_from_path(str(tools), project_root=None, console=console)
+
+        captured = capfd.readouterr()
+        assert "Discovering Tools" not in captured.out, (
+            "Discovery banner leaked to stdout — would break `--json | jq`.\n"
+            f"stdout was: {captured.out!r}"
+        )
+        assert "Discovering Tools" in captured.err, (
+            "Discovery banner must remain visible on stderr — humans need it.\n"
+            f"stderr was: {captured.err!r}"
+        )
+
+    def test_stdout_console_demonstrates_the_bug(self, tmp_path, capfd):
+        """Negative control: a stdout-bound Console DOES leak to stdout.
+        If this ever stops being true, the test above is meaningless —
+        re-derive the regression."""
+        tools = tmp_path / "tools"
+        self._write_noop_udf(tools)
+
+        console = Console(file=sys.stdout, force_terminal=False, width=120)
+        _discover_udfs_from_path(str(tools), project_root=None, console=console)
+
+        captured = capfd.readouterr()
+        assert "Discovering Tools" in captured.out, (
+            "Stdout-bound Console no longer leaks discovery progress — the "
+            "print site moved or was removed. Re-derive the regression."
+        )


### PR DESCRIPTION
## Summary

`agac <cmd> --json | jq .` failed with `parse error: Invalid numeric literal` for `schema`, `inspect graph`, `inspect context`, and `inspect dependencies`. Two rich-formatted banners (`🔍 Discovering Tools in …` and `✅ Discovered N Tools`) landed on stdout before the JSON payload, breaking every downstream parser.

The workflow coordinator owns a single rich `Console` plumbed through `load_workflow_configs → discover_workflow_udfs → _discover_udfs_from_path` and used directly for step-progress prints. It was constructed bare — `rich.Console()` defaults `self.file` to `sys.stdout`, so every coordinator-driven `console.print(…)` landed on stdout. Every CLI command that called `load_workflow()` inherited it.

Fix at the construction site: `Console()` → `Console(stderr=True)`. Stdout is now reserved for machine-readable payloads (the `click.echo(json.dumps(...))` body in each `--json` command); humans still see the banners on stderr (terminals render both streams identically).

`list-udfs --json` was already clean — it doesn't construct an `AgentWorkflow` and its own per-command banners are gated by `if not self.json_output:`. Confirmed on this branch; VIOL-0093 closed as not-reproducing.

## Behavior change

Any script that piped `agac run` stdout to scrape status text (`Found N actions to run`, step markers, `--fresh: cleared …`) must now read stderr. Interactive terminal users see no visual difference. The fix moves all coordinator-driven progress — discovery banners during init and step markers during `agac run` — to stderr together; this is the desired end-state (stdout = machine payload, stderr = human progress).

## Test plan

- [x] `pytest tests/cli/test_json_stdout_clean.py` — 3 regression tests pass
- [x] Full suite: `pytest` — 7775 passed
- [x] Lint: `ruff check`, `ruff format --check` — clean
- [x] Manual smoke against `qanalabs/qanalabs-quiz-maker`:
  - `agac schema -a qana_quiz --json | jq .` → exit 0
  - `agac list-udfs -u tools --json | jq .` → exit 0
  - `agac inspect graph -a qana_quiz --json | jq .` → exit 0
  - `agac inspect context -a qana_quiz summarize_page_content --json | jq .` → exit 0
  - `agac inspect dependencies -a qana_quiz --json | jq .` → exit 0
  - `agac inspect action -a qana_quiz summarize_page_content --json | jq .` → exit 0
- [x] Verified discovery banner still appears on stderr (not silenced)
- [x] Verified `agac inspect graph` (non-JSON) still produces the rich tree on stdout via the command's own console

## Test coverage

Three regression tests in `tests/cli/test_json_stdout_clean.py`:
1. Source-pin property test on `AgentWorkflow.__init__` — guards the one-line fix from accidental revert.
2. Behavioral test: stderr-bound Console → banner on stderr, stdout clean (captured via `capfd`).
3. Negative control: stdout-bound Console DOES leak — proves the regression mechanism is still real.

Test fixture also evicts `agent_actions._udfs.*` from `sys.modules` between tests so repeated `_discover_udfs_from_path` calls actually re-import; the framework's import-dedup check would otherwise silently no-op the second test's discovery.