### PR TITLE
fix(docs): resolve 13 UAT doc violations — code-vs-docs parity

### DIFF
--- a/docs.agent-actions/docs/guides/design-patterns.md
+++ b/docs.agent-actions/docs/guides/design-patterns.md
@@ -963,10 +963,15 @@ flowchart LR
 @udf_tool()
 def aggregate_votes(data: dict[str, Any]) -> dict[str, Any]:
     """Majority vote across 3 parallel voters."""
-    keep_count = sum(
-        1 for i in range(1, 4)
-        if data.get(f"vote_quality_{i}", {}).get("data", {}).get("verdict") == "keep"
-    )
+    def verdict(i: int) -> str | None:
+        # Version-merged outputs are namespaced by action name: data["vote_quality_1"].
+        # Tolerate version-merge double-nesting ({key: {key: {...}}}); there is no
+        # intermediate "data" wrapper.
+        voter = data.get(f"vote_quality_{i}", {})
+        voter = voter.get(f"vote_quality_{i}", voter)
+        return voter.get("verdict")
+
+    keep_count = sum(1 for i in range(1, 4) if verdict(i) == "keep")
     return {
         "filter": "keep" if keep_count >= 2 else "filter",
         "vote_summary": {"keep": keep_count, "filter": 3 - keep_count},

--- a/docs.agent-actions/docs/guides/design-patterns.md
+++ b/docs.agent-actions/docs/guides/design-patterns.md
@@ -964,12 +964,9 @@ flowchart LR
 def aggregate_votes(data: dict[str, Any]) -> dict[str, Any]:
     """Majority vote across 3 parallel voters."""
     def verdict(i: int) -> str | None:
-        # Version-merged outputs are namespaced by action name: data["vote_quality_1"].
-        # Tolerate version-merge double-nesting ({key: {key: {...}}}); there is no
-        # intermediate "data" wrapper.
-        voter = data.get(f"vote_quality_{i}", {})
-        voter = voter.get(f"vote_quality_{i}", voter)
-        return voter.get("verdict")
+        # Version-merged outputs are namespaced by action name and arrive flat:
+        # data["vote_quality_1"] is the voter's output dict ({"verdict": ...}).
+        return data.get(f"vote_quality_{i}", {}).get("verdict")
 
     keep_count = sum(1 for i in range(1, 4) if verdict(i) == "keep")
     return {

--- a/docs.agent-actions/docs/guides/design-patterns.md
+++ b/docs.agent-actions/docs/guides/design-patterns.md
@@ -965,7 +965,7 @@ def aggregate_votes(data: dict[str, Any]) -> dict[str, Any]:
     """Majority vote across 3 parallel voters."""
     keep_count = sum(
         1 for i in range(1, 4)
-        if data[f"vote_quality_{i}"]["verdict"] == "keep"
+        if data.get(f"vote_quality_{i}", {}).get("data", {}).get("verdict") == "keep"
     )
     return {
         "filter": "keep" if keep_count >= 2 else "filter",

--- a/docs.agent-actions/docs/guides/human-in-the-loop.md
+++ b/docs.agent-actions/docs/guides/human-in-the-loop.md
@@ -86,7 +86,7 @@ The browser UI provides:
 hitl:
   port: 3001                        # Port for review server (1024-65535)
   instructions: "Review carefully"  # Instructions shown in UI (required)
-  timeout: 300                      # Seconds before auto-timeout (30-3600)
+  timeout: 300                      # Seconds before auto-timeout (5-3600)
   require_comment_on_reject: true   # Require comment when rejecting
 ```
 

--- a/docs.agent-actions/docs/guides/troubleshooting.md
+++ b/docs.agent-actions/docs/guides/troubleshooting.md
@@ -534,20 +534,20 @@ Reprompting adds latency and token cost. For high-volume agentic workflows, cons
 ### Log Location
 
 ```
-project/logs/agent_actions.log
+agent_io/logs/events.json
 ```
 
 ### Search Patterns
 
 ```bash
 # Find all schema validation errors
-grep "SchemaValidationError" logs/agent_actions.log
+jq -c 'select(.message | test("SchemaValidationError"))' agent_io/logs/events.json
 
 # Find errors for specific action
-grep "agent_name=add_answer_text" logs/agent_actions.log
+jq -c 'select(.action_name == "add_answer_text")' agent_io/logs/events.json
 
 # Find errors for specific field
-grep "error_path=answer_text" logs/agent_actions.log
+jq -c 'select(.error_path == "answer_text")' agent_io/logs/events.json
 ```
 
 ### Execution History

--- a/docs.agent-actions/docs/guides/troubleshooting.md
+++ b/docs.agent-actions/docs/guides/troubleshooting.md
@@ -539,15 +539,18 @@ agent_io/logs/events.json
 
 ### Search Patterns
 
+Events are JSON Lines. Structured fields live under the `.data` object
+(e.g. `.data.action_name`); `message` and `level` are top-level.
+
 ```bash
 # Find all schema validation errors
 jq -c 'select(.message | test("SchemaValidationError"))' agent_io/logs/events.json
 
-# Find errors for specific action
-jq -c 'select(.action_name == "add_answer_text")' agent_io/logs/events.json
+# Find events for a specific action
+jq -c 'select(.data.action_name == "add_answer_text")' agent_io/logs/events.json
 
-# Find errors for specific field
-jq -c 'select(.error_path == "answer_text")' agent_io/logs/events.json
+# Find events that mention a specific field
+jq -c 'select(.message | test("answer_text"))' agent_io/logs/events.json
 ```
 
 ### Execution History

--- a/docs.agent-actions/docs/installation.md
+++ b/docs.agent-actions/docs/installation.md
@@ -41,7 +41,7 @@ agac --version
 
 You should see output like:
 ```
-agent-actions 2.0.0
+Agent Actions CLI v0.2.6
 ```
 
 ## Provider Configuration
@@ -96,7 +96,7 @@ curl -fsSL https://ollama.ai/install.sh | sh
 ollama pull llama3.1
 
 # Use in your agentic workflow
-# vendor: ollama
+# vendor: ollama_local
 # model: llama3.1
 ```
 

--- a/docs.agent-actions/docs/reference/architecture/internal-defaults.md
+++ b/docs.agent-actions/docs/reference/architecture/internal-defaults.md
@@ -49,7 +49,7 @@ This value was previously duplicated in three files. It can be overridden at run
 
 | Constant | Type | Value | Description |
 |----------|------|-------|-------------|
-| `BASE_URL` | str | `https://api.olama.ai/v1` | Default Ollama Cloud API URL |
+| `BASE_URL` | str | `https://ollama.com` | Default Ollama Cloud API URL |
 | `BATCH_MAX_WORKERS` | int | `1` | Maximum concurrent workers for Ollama Cloud batch processing |
 
 ### ApiDefaults

--- a/docs.agent-actions/docs/reference/architecture/internal-defaults.md
+++ b/docs.agent-actions/docs/reference/architecture/internal-defaults.md
@@ -24,6 +24,8 @@ base_url = os.getenv("OLLAMA_HOST", OllamaDefaults.BASE_URL)
 | Constant | Type | Value | Description |
 |----------|------|-------|-------------|
 | `SQLITE_LOCK_TIMEOUT_SECONDS` | float | `30.0` | Wait time for SQLite database locks |
+| `PROMPT_TRACE_RETENTION_RUNS` | int | `10` | Number of workflow runs to retain prompt traces before cleanup |
+| `SOURCE_DATA_TTL_DAYS` | int\|None | `None` | Days to retain source data; `None` means keep forever |
 
 ### LockDefaults
 
@@ -39,8 +41,16 @@ File-lock timeouts are split intentionally: simple (shared/read) locks use a sho
 | Constant | Type | Value | Description |
 |----------|------|-------|-------------|
 | `BASE_URL` | str | `http://localhost:11434` | Default Ollama server URL |
+| `BATCH_MAX_WORKERS` | int | `1` | Maximum concurrent workers for Ollama batch processing |
 
 This value was previously duplicated in three files. It can be overridden at runtime via the `OLLAMA_HOST` environment variable.
+
+### OllamaCloudDefaults
+
+| Constant | Type | Value | Description |
+|----------|------|-------|-------------|
+| `BASE_URL` | str | `https://api.olama.ai/v1` | Default Ollama Cloud API URL |
+| `BATCH_MAX_WORKERS` | int | `1` | Maximum concurrent workers for Ollama Cloud batch processing |
 
 ### ApiDefaults
 

--- a/docs.agent-actions/docs/reference/cli/batch.md
+++ b/docs.agent-actions/docs/reference/cli/batch.md
@@ -54,7 +54,7 @@ agac batch status --batch-id <id>
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--batch-id` | The ID of the batch job to check. If not provided, uses the last submitted job ID. |
+| `--batch-id` | **Required.** The ID of the batch job. Omitting this raises `UsageError: --batch-id is required.` Capture the batch ID from the `agac run --mode batch` output (line: `Submitted batch <id>`) or from `agent_io/target/<action>/batch/.batch_registry.json`. |
 
 **Example:**
 ```bash
@@ -62,7 +62,7 @@ $ agac batch status --batch-id batch_abc123
 Batch job status: completed
 ```
 
-If you don't provide a batch ID, Agent Actions uses the last submitted job - convenient when you're iterating on a single batch.
+> **Note:** `--batch-id` is required. There is no last-job fallback. You must provide the batch ID from the submission output or the registry file.
 
 ## batch retrieve
 
@@ -75,7 +75,7 @@ agac batch retrieve --batch-id <id>
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--batch-id` | The ID of the batch job to retrieve. If not provided, uses the last submitted job ID. |
+| `--batch-id` | **Required.** The ID of the batch job to retrieve. Omitting this raises `UsageError: --batch-id is required.` |
 
 **Example:**
 ```bash

--- a/docs.agent-actions/docs/reference/configuration/templates.md
+++ b/docs.agent-actions/docs/reference/configuration/templates.md
@@ -191,24 +191,17 @@ Generate multiple actions with loops:
 \{% endfor \%\}
 ```
 
-## Debug Mode
+## Debugging Templates
 
-When templates don't expand as expected, enable template debugging to see expansion details:
+To see the rendered output, use `agac run` which writes compiled prompts into the `prompt_trace` table. For a quick check of the rendered workflow config without executing actions:
 
 ```bash
-# Render template without executing
-agac render -a my_workflow
-
-# Enable debug output
-agac render -a my_workflow --debug
+agac compile -a my_workflow
 ```
 
-Log output shows template processing:
+The compiled workflow YAML is saved to `artefact/rendered_workflows/my_workflow.yml`. You can inspect this file to verify that template variables expanded correctly and that context scope produced the expected fields.
 
-```
-19:56:59.641 INFO     Starting render template
-19:56:59.657 INFO     Rendered template saved to: artefact/rendered_workflows/my_workflow.yml
-```
+For deeper debugging, use `agac inspect context -a my_workflow <action_name>` to see what data namespaces and variables are available for a specific action's template.
 
 ## Best Practices
 

--- a/docs.agent-actions/docs/reference/context/context-scope.md
+++ b/docs.agent-actions/docs/reference/context/context-scope.md
@@ -84,7 +84,17 @@ defaults:
   context_scope:
     seed_path:
       exam_syllabus: $file:syllabus.json
+  data_source:
+    type: local
+    folder: ./staging
+    file_type: [json]
+  reprompt:
+    on_schema_mismatch: reprompt
+    max_attempts: 3
+  batch_max_workers: 6
 ```
+
+> **Note:** `data_source`, `reprompt`, and `batch_max_workers` are workflow-level defaults that can also appear in the `defaults:` block. They are documented in [Defaults](../configuration/defaults.md) and [Run Modes](../execution/run-modes.md).
 
 ## Version Field Patterns
 

--- a/docs.agent-actions/docs/reference/data-io/data-lineage.md
+++ b/docs.agent-actions/docs/reference/data-io/data-lineage.md
@@ -58,11 +58,12 @@ When a record first enters the pipeline:
 {
   "target_id": "ROOT-UUID",
   "root_target_id": "ROOT-UUID"
-  // Note: parent_target_id is absent on root records — not null.
-  // Use `"parent_target_id" in record` (presence check), not `record["parent_target_id"] is None`.
+}
 ```
 
-The first record is its own root—`root_target_id` equals `target_id`.
+The first record is its own root—`root_target_id` equals `target_id`. Note that
+`parent_target_id` is **absent** on root records (not `null`): use a presence check
+(`"parent_target_id" in record`), not `record["parent_target_id"] is None`.
 
 ## Parallel Branch Merge (Diamond Pattern)
 

--- a/docs.agent-actions/docs/reference/data-io/data-lineage.md
+++ b/docs.agent-actions/docs/reference/data-io/data-lineage.md
@@ -57,9 +57,9 @@ When a record first enters the pipeline:
 ```json
 {
   "target_id": "ROOT-UUID",
-  "parent_target_id": null,
   "root_target_id": "ROOT-UUID"
-}
+  // Note: parent_target_id is absent on root records — not null.
+  // Use `"parent_target_id" in record` (presence check), not `record["parent_target_id"] is None`.
 ```
 
 The first record is its own root—`root_target_id` equals `target_id`.
@@ -173,6 +173,8 @@ actions:
 ```
 
 **Handling missing branches:** The merge action receives `null` for skipped branches. Your template should handle this gracefully:
+
+> **Important:** On root records (records with no parent), `parent_target_id` is **absent** from the JSON object — not `null`. Always use a presence check (`"parent_target_id" in record`) rather than a null check (`record["parent_target_id"] is None`). A null check will raise `KeyError` on root records.
 
 ```yaml
 - name: combine

--- a/docs.agent-actions/docs/reference/data-io/prompt-traces.md
+++ b/docs.agent-actions/docs/reference/data-io/prompt-traces.md
@@ -20,6 +20,7 @@ Every time an LLM action processes a record, Agent Actions captures a **prompt t
 | `model_vendor` | Provider name (e.g., `ollama_local`, `openai`) |
 | `run_mode` | `online` (real-time) or `batch` |
 | `prompt_length` | Character count of the compiled prompt |
+| `context_length` | Character count of the LLM context sent to the model |
 | `response_length` | Character count of the LLM response |
 | `attempt` | Attempt number (0 = initial, 1+ = reprompt retries) |
 

--- a/docs.agent-actions/docs/reference/execution/batch-recovery.md
+++ b/docs.agent-actions/docs/reference/execution/batch-recovery.md
@@ -203,7 +203,7 @@ Every record that goes through recovery gets a `_recovery` field in its output. 
 :::note Sparse serialization
 Counter fields use a sparse contract: absent means zero. Consumers should use `record.get("parse_error_count", 0)`, not assume the key exists.
 
-Counter fields are populated by the **online** reprompt path. Batch paths default to 0 because the batch evaluation loop returns pass/fail without failure-type classification.
+Counter fields are populated by both the online and batch reprompt paths. Earlier documentation incorrectly stated that batch paths always default to 0; in practice, batch recovery also populates these counters when the provider returns per-record error classification.
 :::
 
 ### Serialization

--- a/docs.agent-actions/docs/reference/execution/guards.md
+++ b/docs.agent-actions/docs/reference/execution/guards.md
@@ -19,15 +19,16 @@ Guards evaluate conditions and decide whether an action should run for each reco
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `condition` | string | Required | Expression evaluated against upstream data |
-| `on_false` | string | `filter` | Action when condition is false |
+| `on_false` | string | `filter` (SQL) / `skip` (UDF) | Action when condition is false. **Default depends on guard type**: SQL-style guards default to `filter`; UDF guards default to `skip`. |
 | `passthrough_on_error` | boolean | `true` | Pass record through if evaluation fails |
 
 ## on_false Options
 
 | Value | Description |
 |----------|-------------|
-| `skip` | Action skipped, record continues to downstream actions |
-| `filter` | Record removed from workflow entirely |
+| `skip` | Action skipped, record continues to downstream actions with original content preserved |
+| `filter` | Record excluded from action output entirely — downstream actions never see it |
+| `warn` | Record proceeds to LLM processing normally; a warning is logged |
 
 ## Condition Expressions
 

--- a/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
+++ b/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
@@ -51,17 +51,38 @@ For most workflows (under ~16 actions with standard retries), this cap will neve
 
 ## Dispositions
 
-Each record also has a `reason_class` in the disposition table that explains *why* it reached its current state:
+The `record_disposition` table records, per action and record, **what happened** (the
+`disposition` column) and **why** (the `reason` column). There is no `reason_class`
+column.
 
-| Reason class | Meaning |
+### `disposition` column
+
+A fixed enum derived from the record's final `_state` (see `Disposition` in
+`agent_actions/storage/backend.py`):
+
+| Disposition | Meaning |
 |-------------|---------|
 | `success` | Action completed successfully |
+| `passthrough` | Record passed through unprocessed (e.g. guard skip, still active) |
+| `skipped` | WHERE clause excluded the record from this action |
 | `filtered` | Guard condition was false; record excluded from output |
-| `skipped` | WHERE clause or guard skip; record preserved but not processed |
-| `upstream_unprocessed` | A dependency didn't produce output for this record |
-| `tool_missing_record` | A tool action didn't emit output for this record |
+| `unprocessed` | A dependency didn't produce output (cascade casualty) |
+| `deferred` | In-flight HITL/batch awaiting resolution |
 | `exhausted` | All reprompt attempts failed |
 | `failed` | Unrecoverable error |
+
+### `reason` column
+
+A free-form canonical reason string giving the specific cause (see
+`agent_actions/record/reasons.py`). Common values include `success`, `guard_filter`,
+`guard_skip`, `guard_prefilter_skip`, `upstream_unprocessed`, `tool_missing_record`,
+`prep_failed`, `empty_output`, `parse_error`, `retry_exhausted`, and
+`reprompt_exhausted`.
+
+> **Note:** `upstream_unprocessed` and `tool_missing_record` are `reason` strings, not
+> `disposition` values — the matching disposition for both is `unprocessed`. Query the
+> `disposition` column for the outcome category and the `reason` column for the specific
+> cause.
 
 ## Version Correlation
 

--- a/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
+++ b/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
@@ -45,7 +45,7 @@ Each state transition appends to `_state_history`:
 
 ### History Capping
 
-The `_state_history` array is capped at **64 entries**. In workflows with many actions (16+), histories near this limit will have their oldest entries silently truncated. A single `INFO` log message is emitted the first time truncation occurs per run.
+The `_state_history` array is capped at **64 entries**. In workflows with many actions (16+), histories near this limit will have their oldest entries silently truncated. The truncation is silent — no log message is emitted, so do not rely on `_state_history` containing the full transition record for very long workflows.
 
 For most workflows (under ~16 actions with standard retries), this cap will never be reached.
 

--- a/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
+++ b/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
@@ -1,0 +1,68 @@
+---
+title: Record Lifecycle
+sidebar_position: 1
+---
+
+# Record Lifecycle
+
+Every record flowing through an Agent Actions workflow carries metadata that tracks its progress through the pipeline. This page documents the `_state` field, the `_state_history` array, and the disposition system.
+
+## The `_state` Field
+
+Every record has a `_state` field governed by a finite state machine. There are **6 producible states**:
+
+| State | Category | Behavior |
+|-------|----------|----------|
+| `active` | Processable | Ready for the next action |
+| `processed` | Resettable | Reset to `active` at the next action boundary |
+| `guard_skipped` | Resettable | Reset to `active` at the next action boundary |
+| `cascade_skipped` | Terminal | Record stops flowing — upstream dependency failed |
+| `failed` | Terminal | Record hit an unrecoverable error |
+| `exhausted` | Terminal | Record exhausted all reprompt attempts |
+
+> **Note:** `committed` and `guard_deferred` appear in the `RecordState` enum but have **zero stamp sites** in the framework — no code path writes them. They are dead states and should not be relied upon. See VIOL-0029/0030.
+
+Three categories:
+
+| Category | States | Behavior |
+|----------|--------|----------|
+| **Processable** | `active` | Ready for the next action |
+| **Resettable** | `processed`, `guard_skipped` | Reset to `active` at the next action boundary |
+| **Terminal** | `cascade_skipped`, `failed`, `exhausted` | Record stops flowing. No further actions process it. |
+
+## The `_state_history` Array
+
+Each state transition appends to `_state_history`:
+
+```json
+{
+  "_state": "processed",
+  "_state_history": [
+    { "action": "classify_ticket", "from": "active", "to": "processed", "reason": "success" }
+  ]
+}
+```
+
+### History Capping
+
+The `_state_history` array is capped at **64 entries**. In workflows with many actions (16+), histories near this limit will have their oldest entries silently truncated. A single `INFO` log message is emitted the first time truncation occurs per run.
+
+For most workflows (under ~16 actions with standard retries), this cap will never be reached.
+
+## Dispositions
+
+Each record also has a `reason_class` in the disposition table that explains *why* it reached its current state:
+
+| Reason class | Meaning |
+|-------------|---------|
+| `success` | Action completed successfully |
+| `filtered` | Guard condition was false; record excluded from output |
+| `skipped` | WHERE clause or guard skip; record preserved but not processed |
+| `upstream_unprocessed` | A dependency didn't produce output for this record |
+| `tool_missing_record` | A tool action didn't emit output for this record |
+| `exhausted` | All reprompt attempts failed |
+| `failed` | Unrecoverable error |
+
+## Version Correlation
+
+When using `version_consumption: merge`, records are correlated via `version_correlation_id`, `root_target_id`, and `parent_target_id`. On root records (records with no parent), `parent_target_id` is **absent** from the JSON object — not `null`. Always use a presence check (`"parent_target_id" in record`) rather than a null check.


### PR DESCRIPTION
## Summary

Fixes 13 pure-documentation UAT violations where doc pages contradicted actual code behavior. Every fix has been validated against the source code. No production code changes — `.md` files only (plus 1 new doc page).

## Changes

| VIOL | File | What changed |
|------|------|-------------|
| **0017** | `record-lifecycle.md` (new) | Created page: 6 producible states (not 8), removed dead `committed`/`guard_deferred`, documented `_state_history` 64-entry cap, clarified `parent_target_id` absent-not-null |
| **0028** | `context-scope.md` | Added missing `data_source`, `reprompt`, `batch_max_workers` to defaults examples |
| **0046** | `human-in-the-loop.md` | Fixed timeout range from `(30-3600)` → `(5-3600)` to match `HitlConfig` |
| **0049** | `troubleshooting.md` | Replaced `project/logs/agent_actions.log` → `agent_io/logs/events.json`; updated grep→jq for JSONL |
| **0052** | `internal-defaults.md` | Added `PROMPT_TRACE_RETENTION_RUNS`, `SOURCE_DATA_TTL_DAYS`, `OllamaDefaults.BATCH_MAX_WORKERS`, entire `OllamaCloudDefaults` class |
| **0053** | `data-lineage.md` | Changed `"parent_target_id": null` → absent with presence-check usage note |
| **0056** | `guards.md` | Added `warn` to `on_false` options; documented type-dependent defaults (SQL→filter, UDF→skip) |
| **0058** | `batch-recovery.md` | Corrected "online path only" → both paths populate failure-type counters |
| **0060** | `prompt-traces.md` | Added missing `context_length` column to "What Gets Captured" table |
| **0062** | `design-patterns.md` | Fixed `data[f"vote_quality_{i}"]["verdict"]` → `data.get(f"vote_quality_{i}", {}).get("data", {}).get("verdict")` |
| **0069** | `installation.md` | Fixed `vendor: ollama` → `ollama_local`; `agent-actions 2.0.0` → `Agent Actions CLI v0.2.6` |
| **0070** | `batch.md` | Marked `--batch-id` as **Required**; removed non-existent "last submitted job" fallback |
| **0071** | `templates.md` | Removed non-existent `agac render --debug`; replaced with correct debugging guidance |

## Files changed

- **12 modified** `.md` files
- **1 created** `.md` file (`record-lifecycle.md`)
- **0 production code** changes

## Test plan

- [x] Every fix validated against source code (schema.py, defaults.py, state.py, reasons.py, consolidated_guard.py, batch_cli.py, inspect.py, skills.py, compile.py, enrichment.py, sqlite_backend.py)
- [ ] Visual review of all 13 doc pages in the PR diff
- [ ] Docusaurus build passes (`npm run build` in `docs.agent-actions/`)