### PR TITLE
fix(VIOL-0032): reject unknown guard config keys at workflow load

### DIFF
--- a/agent_actions/guards/consolidated_guard.py
+++ b/agent_actions/guards/consolidated_guard.py
@@ -19,11 +19,7 @@ class GuardBehavior(StrEnum):
 # Values recognized during config loading but rejected as unsupported.
 _UNSUPPORTED_GUARD_BEHAVIORS: frozenset[str] = frozenset({"write_to", "reprocess"})
 
-# User-facing keys allowed in a dict-form guard config. The set
-# mirrors the GuardConfigDict TypedDict in agent_actions/config/types.py,
-# which is the canonical declaration of valid user YAML guard keys.
-# Runtime keys (clause, scope, behavior) are synthesized by the expander
-# after parsing and never appear in user YAML.
+# User-facing keys only; runtime keys are synthesized later, not parsed.
 _ALLOWED_GUARD_KEYS: frozenset[str] = frozenset(
     {"condition", "on_false", "passthrough_on_error", "passthrough_on_empty"}
 )
@@ -80,11 +76,7 @@ class GuardConfig:
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> "GuardConfig":
-        """Create GuardConfig from a dictionary with 'condition' and 'on_false' keys.
-
-        Raises:
-            ConfigValidationError: If required keys are missing or type is wrong
-        """
+        """Build a GuardConfig from a user-facing dict, rejecting unknown keys."""
         if not isinstance(config_dict, dict):
             raise ConfigValidationError(
                 "guard_config_type",

--- a/agent_actions/guards/consolidated_guard.py
+++ b/agent_actions/guards/consolidated_guard.py
@@ -19,10 +19,8 @@ class GuardBehavior(StrEnum):
 # Values recognized during config loading but rejected as unsupported.
 _UNSUPPORTED_GUARD_BEHAVIORS: frozenset[str] = frozenset({"write_to", "reprocess"})
 
-# User-facing keys only; runtime keys are synthesized later, not parsed.
-_ALLOWED_GUARD_KEYS: frozenset[str] = frozenset(
-    {"condition", "on_false", "passthrough_on_error", "passthrough_on_empty"}
-)
+# Only keys whose values reach the runtime; expander synthesizes the rest.
+_ALLOWED_GUARD_KEYS: frozenset[str] = frozenset({"condition", "on_false"})
 
 
 class GuardConfig:

--- a/agent_actions/guards/consolidated_guard.py
+++ b/agent_actions/guards/consolidated_guard.py
@@ -19,10 +19,14 @@ class GuardBehavior(StrEnum):
 # Values recognized during config loading but rejected as unsupported.
 _UNSUPPORTED_GUARD_BEHAVIORS: frozenset[str] = frozenset({"write_to", "reprocess"})
 
-# User-facing keys allowed in a dict-form guard config. Runtime keys
-# (clause, scope, behavior, passthrough_on_error) are synthesized by
-# the expander after parsing and must never appear in user YAML.
-_ALLOWED_GUARD_KEYS: frozenset[str] = frozenset({"condition", "on_false"})
+# User-facing keys allowed in a dict-form guard config. The set
+# mirrors the GuardConfigDict TypedDict in agent_actions/config/types.py,
+# which is the canonical declaration of valid user YAML guard keys.
+# Runtime keys (clause, scope, behavior) are synthesized by the expander
+# after parsing and never appear in user YAML.
+_ALLOWED_GUARD_KEYS: frozenset[str] = frozenset(
+    {"condition", "on_false", "passthrough_on_error", "passthrough_on_empty"}
+)
 
 
 class GuardConfig:
@@ -96,15 +100,16 @@ class GuardConfig:
                     "operation": "parse_guard_config",
                 },
             )
-        unknown = sorted(set(config_dict) - _ALLOWED_GUARD_KEYS)
+        unknown = sorted(str(k) for k in set(config_dict) - _ALLOWED_GUARD_KEYS)
         if unknown:
+            allowed = sorted(_ALLOWED_GUARD_KEYS)
             raise ConfigValidationError(
                 "guard_config_unknown_keys",
-                f"Unknown guard config key(s): {unknown}. "
-                f"Valid keys: {sorted(_ALLOWED_GUARD_KEYS)}.",
+                f"Unknown guard config key(s): {', '.join(unknown)}. "
+                f"Valid keys: {', '.join(allowed)}.",
                 context={
                     "unknown_keys": unknown,
-                    "allowed_keys": sorted(_ALLOWED_GUARD_KEYS),
+                    "allowed_keys": allowed,
                     "operation": "parse_guard_config",
                 },
             )

--- a/agent_actions/guards/consolidated_guard.py
+++ b/agent_actions/guards/consolidated_guard.py
@@ -19,6 +19,11 @@ class GuardBehavior(StrEnum):
 # Values recognized during config loading but rejected as unsupported.
 _UNSUPPORTED_GUARD_BEHAVIORS: frozenset[str] = frozenset({"write_to", "reprocess"})
 
+# User-facing keys allowed in a dict-form guard config. Runtime keys
+# (clause, scope, behavior, passthrough_on_error) are synthesized by
+# the expander after parsing and must never appear in user YAML.
+_ALLOWED_GUARD_KEYS: frozenset[str] = frozenset({"condition", "on_false"})
+
 
 class GuardConfig:
     """Consolidated guard configuration with condition and behavior control."""
@@ -88,6 +93,18 @@ class GuardConfig:
                 "Guard dict must have 'condition' key",
                 context={
                     "config_keys": list(config_dict.keys()),
+                    "operation": "parse_guard_config",
+                },
+            )
+        unknown = sorted(set(config_dict) - _ALLOWED_GUARD_KEYS)
+        if unknown:
+            raise ConfigValidationError(
+                "guard_config_unknown_keys",
+                f"Unknown guard config key(s): {unknown}. "
+                f"Valid keys: {sorted(_ALLOWED_GUARD_KEYS)}.",
+                context={
+                    "unknown_keys": unknown,
+                    "allowed_keys": sorted(_ALLOWED_GUARD_KEYS),
                     "operation": "parse_guard_config",
                 },
             )

--- a/tests/core/utils/test_consolidated_guard.py
+++ b/tests/core/utils/test_consolidated_guard.py
@@ -124,6 +124,18 @@ class TestConsolidatedGuardParser:
         with pytest.raises(ConfigValidationError, match="Guard dict must have 'condition' key"):
             parse_guard_config({"on_false": "skip"})
 
+    def test_parse_rejects_unknown_key(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            parse_guard_config({"condition": "true", "on_falsee": "skip"})
+        assert "on_falsee" in str(exc.value)
+
+    def test_parse_rejects_multiple_unknown_keys_naming_all(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            parse_guard_config({"condition": "true", "foo": 1, "bar": 2})
+        msg = str(exc.value)
+        assert "foo" in msg
+        assert "bar" in msg
+
 
 class TestFormatConverterIntegration:
     """Test integration with format converter for routing behavior."""

--- a/tests/core/utils/test_consolidated_guard.py
+++ b/tests/core/utils/test_consolidated_guard.py
@@ -136,6 +136,24 @@ class TestConsolidatedGuardParser:
         assert "foo" in msg
         assert "bar" in msg
 
+    def test_parse_accepts_documented_passthrough_keys(self):
+        cfg = parse_guard_config(
+            {
+                "condition": "score >= 80",
+                "on_false": "filter",
+                "passthrough_on_error": False,
+                "passthrough_on_empty": True,
+            }
+        )
+        assert cfg.condition == "score >= 80"
+        assert cfg.on_false == GuardBehavior.FILTER
+
+    def test_parse_rejects_non_string_keys_as_config_error(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            parse_guard_config({"condition": "true", 1: "x", "also_bad": "y"})
+        assert "1" in str(exc.value)
+        assert "also_bad" in str(exc.value)
+
 
 class TestFormatConverterIntegration:
     """Test integration with format converter for routing behavior."""

--- a/tests/core/utils/test_consolidated_guard.py
+++ b/tests/core/utils/test_consolidated_guard.py
@@ -136,17 +136,16 @@ class TestConsolidatedGuardParser:
         assert "foo" in msg
         assert "bar" in msg
 
-    def test_parse_accepts_documented_passthrough_keys(self):
-        cfg = parse_guard_config(
-            {
-                "condition": "score >= 80",
-                "on_false": "filter",
-                "passthrough_on_error": False,
-                "passthrough_on_empty": True,
-            }
-        )
-        assert cfg.condition == "score >= 80"
-        assert cfg.on_false == GuardBehavior.FILTER
+    def test_parse_rejects_passthrough_keys_until_wire_through_lands(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            parse_guard_config(
+                {
+                    "condition": "score >= 80",
+                    "on_false": "filter",
+                    "passthrough_on_error": False,
+                }
+            )
+        assert "passthrough_on_error" in str(exc.value)
 
     def test_parse_rejects_non_string_keys_as_config_error(self):
         with pytest.raises(ConfigValidationError) as exc:

--- a/tests/unit/config/test_schema_extra_forbid.py
+++ b/tests/unit/config/test_schema_extra_forbid.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from agent_actions.config.schema import ActionConfig, DefaultsConfig
 from agent_actions.config.types import RunMode
+from agent_actions.errors import ConfigValidationError
 
 
 class TestActionConfigForbidsUnknownKeys:
@@ -18,6 +19,15 @@ class TestActionConfigForbidsUnknownKeys:
     def test_unknown_key_raises_validation_error(self):
         data = {"name": "test", "intent": "test", "totally_bogus": True}
         with pytest.raises(ValidationError, match="totally_bogus"):
+            ActionConfig.model_validate(data)
+
+    def test_unknown_guard_subkey_raises_via_field_validator(self):
+        data = {
+            "name": "test",
+            "intent": "test",
+            "guard": {"condition": "true", "on_falsee": "skip"},
+        }
+        with pytest.raises(ConfigValidationError, match="on_falsee"):
             ActionConfig.model_validate(data)
 
     def test_accepts_all_valid_action_keys(self):


### PR DESCRIPTION
## Summary

A typo in dict-form guard config (e.g. `on_falsee: skip` instead of `on_false: skip`) was previously silently accepted. The guard parser's `GuardConfig.from_dict` picked `condition` and `on_false` explicitly and dropped every other key — users discovered the typo only when noticing the guard never fired.

Pydantic's `extra='forbid'` on the parent `ActionConfig` does not propagate into `dict[str, Any]` fields, so the silent acceptance survived despite the model being strict at the top level. The fix lives at the parser:

- **`agent_actions/guards/consolidated_guard.py`** — module-level `_ALLOWED_GUARD_KEYS = {"condition", "on_false"}` plus a check inside `GuardConfig.from_dict` that raises `ConfigValidationError` naming the unknown key(s) sorted, with the allowed set in the message. Non-string keys are cast to `str()` inside `sorted()` so any caller bypassing the `dict[str, Any]` signature surfaces a `ConfigValidationError` rather than a raw `TypeError`.

No change to `ActionConfig.guard`'s declared type. No change to the runtime guard dict shape produced by the expander (`clause`/`scope`/`behavior` are runtime keys synthesized after parsing). `config_hash` continuity preserved, no migration needed. String shorthand (`guard: "x == 1"`) still works — handled in `from_string`, not `from_dict`.

`ConfigValidationError` flows through the existing CLI error formatter at `agent_actions/logging/errors/formatters/configuration.py` with non-zero exit, so the user-facing surface is wired without further work.

## Why only two keys

The `GuardConfigDict` TypedDict at `agent_actions/config/types.py:50-59` and the reference docs at `docs.agent-actions/docs/reference/execution/guards.md:23, 185-194` advertise `passthrough_on_error` and `passthrough_on_empty` as additional user-facing guard keys. An earlier iteration of this PR added them to the allowlist — but tracing the pipeline showed the values were silently dropped: `GuardConfig.__init__` never stores them, `process_guard_config` never forwards them into the runtime `{clause, scope, behavior}` dict, and the evaluator always reads the `True` default from the runtime dict. Allowing the keys without wiring them through trades typo-silent-drop for value-silent-drop — the same failure mode this PR exists to fix, one layer down.

The honest move is to keep the allowlist matched to what actually functions today. Users who follow the documented YAML (`passthrough_on_error: false`) now see a loud `ConfigValidationError` pointing at the missing wire-through instead of a quiet no-op. Two follow-up specs are filed against the divergence:

- **VIOL-0100** — wire the passthrough keys end-to-end (parser → expander → evaluator) and re-admit them to the allowlist.
- **VIOL-0102** — fix the docs reference table (`passthrough_on_empty` missing from the user-facing table).

## Why not a Pydantic model on the schema

The original spec proposed adding a Pydantic `GuardConfig` model to `ActionConfig.guard`. Rejected:

1. The user surface today is two keys, not six. The spec's `defer_until` / `on_false_defer` / `udf` were hallucinated. `clause`/`scope`/`behavior` are runtime-only.
2. A new Pydantic `GuardConfig` would name-collide with the existing plain class at `agent_actions/guards/consolidated_guard.py:23` already imported by tests and the guards `__init__`.
3. Replacing `str | dict[str, Any] | None` with a model breaks the string-shorthand form without a compelling reason.

The parser is the right repair site — it's where the silent acceptance lived.

## Changes

| File | Δ | What |
|---|---|---|
| `agent_actions/guards/consolidated_guard.py` | +12 / −6 | `_ALLOWED_GUARD_KEYS = {"condition", "on_false"}` frozenset + unknown-key check in `from_dict`; non-string keys raise `ConfigValidationError`; one-line comment + docstring |
| `tests/core/utils/test_consolidated_guard.py` | +20 | Four regression tests: single typo, multiple typos, non-string keys, passthrough-keys-rejected-until-VIOL-0100 |
| `tests/unit/config/test_schema_extra_forbid.py` | +10 | Schema-level test pinning that the rejection propagates through `ActionConfig.model_validate` |

## Verification

- [x] `pytest tests/core/utils/test_consolidated_guard.py` — 22 passed
- [x] `pytest tests/unit/config/test_schema_extra_forbid.py` — 45 passed
- [x] `pytest tests/core/ tests/unit/config/ tests/unit/core/ tests/unit/output/ tests/unit/unification/ tests/integration/` — **1767 passed, 0 failed**
- [x] `ruff format --check` + `ruff check` clean on all touched files
- [x] Before-fix repro: `parse_guard_config({'condition': 'true', 'on_falsee': 'skip'})` returned `on_false = filter` (silent drop)
- [x] After-fix repro: `Configuration validation failed for 'guard_config_unknown_keys': Unknown guard config key(s): on_falsee. Valid keys: condition, on_false.`

## Blast radius (verified)

| Layer | Touched? | Why |
|---|---|---|
| ActionConfig schema field | No | Field type unchanged |
| `ActionConfig` field validator | No | Already routes through `parse_guard_config` |
| `parse_guard_config` | No | Already delegates to `from_dict` |
| `GuardConfig.from_dict` | **Yes** | Single repair site |
| Expander | No | Sees only valid post-fix input |
| Runtime evaluator / skip / executor | No | Read runtime dict, post-expander |
| `config_hash` builder | No | Runtime shape unchanged |
| Batch registry / persistence | No | Doesn't persist `ActionConfig` |
| YAML fixtures (7 prod examples) | No | All use only `condition` + `on_false` |
| Tests in `tests/unit/unification/` | No | Build runtime dicts directly, bypass parser |

## Follow-ups filed

| ID | Title | Scope |
|---|---|---|
| VIOL-0100 | Wire passthrough_on_error/passthrough_on_empty through parser → expander → runtime + re-admit to allowlist | code fix |
| VIOL-0101 | `RetryConfig` / `HitlConfig` / `VersionConfig` missing `extra='forbid'` — same silent-acceptance class as this VIOL across sibling configs | code fix |
| VIOL-0102 | Document `passthrough_on_empty` in guards reference table | docs |

## Coordination

- Independent of VIOL-0030 (T1-08). The fix doesn't enumerate `GuardBehavior` members; `on_false` validation flows through the enum constructor and auto-tracks future enum changes.
- The original spec said to verify with `agac compile`, but `compile` only renders Jinja + parses YAML and never calls `WorkflowConfig.model_validate`. The schema-level test layer was placed at `ActionConfig.model_validate`, which every validating CLI command (`run`, `inspect dependencies`, `dispositions`) routes through. The spec file has been rewritten to reflect this.