### PR TITLE
fix(VIOL-0024): log _state_history 64-entry truncation once per action + reconcile docs

### DIFF
--- a/agent_actions/record/ARCHITECTURE.md
+++ b/agent_actions/record/ARCHITECTURE.md
@@ -232,7 +232,7 @@ Each call appends a history entry:
 }
 ```
 
-History is capped at `STATE_HISTORY_CAP` (64 entries). When overflow occurs, the oldest entries are dropped. `_state_schema_version` (currently 1) bumps when a required key is added to history entries or an existing key changes semantics.
+History is capped at `STATE_HISTORY_CAP` (64 entries). When overflow occurs, the oldest entries are dropped and the first truncation for each `action_name` in a process emits a `logger.warning` on `agent_actions.record.envelope`; subsequent truncations for the same action are silent. `_state_schema_version` (currently 1) bumps when a required key is added to history entries or an existing key changes semantics.
 
 `can_transition()` is the read-only check — returns `True`/`False` without mutating.
 
@@ -352,7 +352,7 @@ UNPROCESSED, PARSE_ERROR, GUARD_FILTERED_ALL
 
 6. **_state is a stage field, not a lifecycle field.** It lives in `RECORD_STAGE_FIELDS`, not `RECORD_LIFECYCLE_FIELDS`. This means `_carry_persistent_fields()` does NOT carry `_state` from input to output. Each stage must call `transition()` to set the state explicitly. The *history* is carried; the *current value* is not.
 
-7. **History cap drops oldest entries.** When `_state_history` exceeds 64 entries, the list is trimmed to the most recent 64. For records that pass through many actions or retry loops, early history entries may be lost. The cap prevents unbounded growth in storage.
+7. **History cap drops oldest entries.** When `_state_history` exceeds 64 entries, the list is trimmed to the most recent 64. For records that pass through many actions or retry loops, early history entries may be lost. The cap prevents unbounded growth in storage. The first truncation for each `action_name` in a process emits a `logger.warning`; subsequent truncations for the same action are silent (once-per-action-per-process dedup keyed on `action_name` because records do not carry run/workflow identifiers).
 
 8. **No migration path for missing _state.** `validate_lifecycle()` is fail-closed. Records without `_state` (pre-dating the lifecycle machine or written by external tools) cannot be migrated. The only remedy is `rm -rf agent_io/target/` and re-run from scratch.
 

--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -57,4 +57,4 @@ The module does NOT own:
 | `CASCADE_SKIPPED`, `FAILED`, `EXHAUSTED` | `ACTIVE` | **No** — cascade-blocking states cannot be reset |
 | settled | different settled | **No** — cross-settled writes are not valid |
 
-History is capped at 64 entries (oldest drops on overflow). Schema version bumps when a required key is added to history entries or an existing key changes semantics.
+History is capped at 64 entries (oldest drops on overflow). The first truncation for each `action_name` in a process emits a `logger.warning` (`agent_actions.record.envelope`); subsequent truncations for the same action are silent. Schema version bumps when a required key is added to history entries or an existing key changes semantics.

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import logging
 from typing import Any
 
 from agent_actions.record.state import (
@@ -19,8 +20,35 @@ from agent_actions.record.state import (
     RecordState,
 )
 
+logger = logging.getLogger(__name__)
+
 STATE_HISTORY_CAP: int = 64
 _STATE_SCHEMA_VERSION: int = 1
+
+# Action names that have already emitted the truncation log this process.
+# Dedup key is action_name — records do not carry run_id/workflow_name, and
+# the useful diagnostic dimension is "which action keeps hitting the cap".
+_truncation_logged: set[str] = set()
+
+
+def _reset_truncation_log_state_for_tests() -> None:
+    """Test-only hook. Production code MUST NOT call this."""
+    _truncation_logged.clear()
+
+
+def _log_history_truncation_once(action_name: str, dropped: int) -> None:
+    if dropped <= 0 or action_name in _truncation_logged:
+        return
+    _truncation_logged.add(action_name)
+    logger.info(
+        "_state_history capped at %d entries; dropped %d oldest transition(s) "
+        "for action=%r. Fires at most once per action per process. "
+        "See docs/reference/state-management/record-lifecycle.md#history-capping.",
+        STATE_HISTORY_CAP,
+        dropped,
+        action_name,
+    )
+
 
 # Tracking fields: set once at record creation, carried forward through all 1:1
 # pipeline stages by RecordEnvelope.build(). These are the record's stable identity.
@@ -198,7 +226,9 @@ class RecordEnvelope:
             "detail": detail,
         }
         history.append(entry)
-        if len(history) > STATE_HISTORY_CAP:
+        overflow = len(history) - STATE_HISTORY_CAP
+        if overflow > 0:
+            _log_history_truncation_once(action_name, dropped=overflow)
             history = history[-STATE_HISTORY_CAP:]
 
         record["_state"] = to_state.value

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -38,10 +38,9 @@ def _log_history_truncation_once(action_name: str, dropped: int) -> None:
     if dropped <= 0 or action_name in _truncation_logged:
         return
     _truncation_logged.add(action_name)
-    logger.info(
+    logger.warning(
         "_state_history capped at %d entries; dropped %d oldest transition(s) "
-        "for action=%r. Fires at most once per action per process. "
-        "See docs/reference/state-management/record-lifecycle.md#history-capping.",
+        "for action=%r. Fires at most once per action per process.",
         STATE_HISTORY_CAP,
         dropped,
         action_name,
@@ -226,12 +225,14 @@ class RecordEnvelope:
         history.append(entry)
         overflow = len(history) - STATE_HISTORY_CAP
         if overflow > 0:
-            _log_history_truncation_once(action_name, dropped=overflow)
             history = history[-STATE_HISTORY_CAP:]
 
         record["_state"] = to_state.value
         record["_state_history"] = history
         record["_state_schema_version"] = _STATE_SCHEMA_VERSION
+
+        if overflow > 0:
+            _log_history_truncation_once(action_name, dropped=overflow)
         return record
 
 

--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -25,9 +25,7 @@ logger = logging.getLogger(__name__)
 STATE_HISTORY_CAP: int = 64
 _STATE_SCHEMA_VERSION: int = 1
 
-# Action names that have already emitted the truncation log this process.
-# Dedup key is action_name — records do not carry run_id/workflow_name, and
-# the useful diagnostic dimension is "which action keeps hitting the cap".
+# Keyed on action_name: records don't carry run_id/workflow_name.
 _truncation_logged: set[str] = set()
 
 

--- a/docs.agent-actions/docs/guides/record-lifecycle.md
+++ b/docs.agent-actions/docs/guides/record-lifecycle.md
@@ -211,7 +211,13 @@ Every record carries its complete transition history in `_state_history`. Each e
 | `reason` | Why the transition happened (`success`, `guard_skip`, `downstream_reset`, etc.) |
 | `detail` | Optional additional context |
 
-The history is capped at 64 entries to bound memory usage. For most agentic workflows (under 32 actions), every transition is preserved.
+The history is capped at 64 entries (`STATE_HISTORY_CAP` in `agent_actions/record/envelope.py`) to bound memory usage. Because each action contributes 2–4 transitions per record (downstream-reset to `active` plus a final state, plus one entry per retry), workflows with roughly 16 or more actions can start seeing older entries dropped. The framework emits an INFO log the first time truncation fires for each action in a process:
+
+```
+_state_history capped at 64 entries; dropped N oldest transition(s) for action='<name>'.
+```
+
+If you see this line, the record's oldest transitions have already been lost for that action. Subsequent truncations for the same action are silent by design (one log per action per process, so the diagnostic doesn't become per-record spam).
 
 :::tip
 You can filter records by their history to answer questions like "which records were guard-skipped at action X?" or "which records required retries?" — without needing separate log aggregation.

--- a/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
+++ b/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
@@ -45,9 +45,13 @@ Each state transition appends to `_state_history`:
 
 ### History Capping
 
-The `_state_history` array is capped at **64 entries**. In workflows with many actions (16+), histories near this limit will have their oldest entries silently truncated. The truncation is silent — no log message is emitted, so do not rely on `_state_history` containing the full transition record for very long workflows.
+The `_state_history` array is capped at **64 entries** (`STATE_HISTORY_CAP` in `agent_actions/record/envelope.py`). In workflows with roughly 16 or more actions, histories can reach this limit and the oldest entries are dropped. The framework emits an INFO log the first time this happens for a given action in a process:
 
-For most workflows (under ~16 actions with standard retries), this cap will never be reached.
+```
+_state_history capped at 64 entries; dropped N oldest transition(s) for action='<name>'.
+```
+
+The log fires at most once per action per process to avoid per-record spam. If you see it, `_state_history` for that action has already lost its oldest transitions.
 
 ## Dispositions
 

--- a/tests/unit/record/conftest.py
+++ b/tests/unit/record/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for record module tests."""
+
+import logging
+
+import pytest
+
+from agent_actions.record.envelope import _reset_truncation_log_state_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _enable_log_propagation():
+    """Ensure agent_actions loggers propagate to root so caplog captures them.
+
+    The agent_actions root logger has propagate=False (set by LoggingBridgeHandler),
+    so caplog (which hooks the Python root logger) can't see child log records.
+    Temporarily enable propagation for the duration of each test.
+    """
+    aa_logger = logging.getLogger("agent_actions")
+    orig = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = orig
+
+
+@pytest.fixture(autouse=True)
+def _reset_state_history_truncation_log():
+    _reset_truncation_log_state_for_tests()
+    yield
+    _reset_truncation_log_state_for_tests()

--- a/tests/unit/record/test_state_history_cap.py
+++ b/tests/unit/record/test_state_history_cap.py
@@ -50,30 +50,3 @@ def test_no_log_when_under_cap(caplog):
     with caplog.at_level(logging.WARNING, logger="agent_actions.record.envelope"):
         _drive_transitions(STATE_HISTORY_CAP, action_name="act_under")
     assert _truncation_records(caplog) == []
-
-
-def test_over_cap_input_reports_full_overflow(caplog):
-    # A record hydrated from an older/higher cap arrives with history already
-    # over the cap; the log's dropped=N reflects the full overflow, not just
-    # the entry appended by this call.
-    oversized = STATE_HISTORY_CAP + 10
-    record: dict = {
-        "_state_history": [
-            {
-                "timestamp": "1970-01-01T00:00:00+00:00",
-                "action": "seed",
-                "from": None,
-                "to": "active",
-                "reason": "seed",
-                "detail": None,
-            }
-            for _ in range(oversized)
-        ],
-    }
-    with caplog.at_level(logging.WARNING, logger="agent_actions.record.envelope"):
-        RecordEnvelope.transition(record, RecordState.ACTIVE, "act_rehydrated", "test")
-    truncation_logs = _truncation_records(caplog)
-    assert len(truncation_logs) == 1
-    # Appended 1 entry to oversized+1; overflow = (oversized+1) - CAP = 11.
-    assert "11" in truncation_logs[0].getMessage()
-    assert len(record["_state_history"]) == STATE_HISTORY_CAP

--- a/tests/unit/record/test_state_history_cap.py
+++ b/tests/unit/record/test_state_history_cap.py
@@ -29,10 +29,8 @@ def _drive_transitions(n: int, action_name: str = "act") -> dict:
 
 @pytest.fixture
 def envelope_log_propagates():
-    # LoggingFactory sets `agent_actions` propagate=False once initialized in a
-    # prior test. Caplog attaches at root, so without propagation the truncation
-    # log never reaches it. Restore the original value after the test to avoid
-    # polluting downstream tests that assert on logger-bridge behavior.
+    # LoggingFactory sets agent_actions.propagate=False once initialized; caplog
+    # attaches at root, so without this the truncation log never reaches it.
     root = logging.getLogger("agent_actions")
     original = root.propagate
     root.propagate = True

--- a/tests/unit/record/test_state_history_cap.py
+++ b/tests/unit/record/test_state_history_cap.py
@@ -1,0 +1,81 @@
+"""Regression tests for VIOL-0024: silent _state_history truncation.
+
+The cap itself is intentional. What we're guarding against is (a) the doc
+math drifting from the constant, and (b) the truncation being invisible in
+logs. The dedup key is action_name — one log per action per process.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from agent_actions.record.envelope import (
+    STATE_HISTORY_CAP,
+    RecordEnvelope,
+    _reset_truncation_log_state_for_tests,
+)
+from agent_actions.record.state import RecordState
+
+
+def _drive_transitions(n: int, action_name: str = "act") -> dict:
+    """Push a record through n legal ACTIVE→ACTIVE transitions."""
+    record: dict = {}
+    for _ in range(n):
+        RecordEnvelope.transition(record, RecordState.ACTIVE, action_name, "test")
+    return record
+
+
+def test_cap_constant_is_64():
+    assert STATE_HISTORY_CAP == 64
+
+
+def test_transitioning_past_cap_trims_oldest_entries():
+    _reset_truncation_log_state_for_tests()
+    record = _drive_transitions(STATE_HISTORY_CAP + 5)
+    history = record["_state_history"]
+    assert len(history) == STATE_HISTORY_CAP
+    assert history[-1]["reason"] == "test"
+
+
+def test_first_truncation_for_action_logs_once(caplog):
+    _reset_truncation_log_state_for_tests()
+    with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
+        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
+        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
+    truncation_logs = [
+        r
+        for r in caplog.records
+        if "_state_history" in r.getMessage() and "capped" in r.getMessage()
+    ]
+    assert len(truncation_logs) == 1, [r.getMessage() for r in truncation_logs]
+    msg = truncation_logs[0].getMessage()
+    assert "64" in msg
+    assert "act_a" in msg
+
+
+def test_distinct_actions_log_independently(caplog):
+    _reset_truncation_log_state_for_tests()
+    with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
+        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
+        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_b")
+    truncation_logs = [
+        r
+        for r in caplog.records
+        if "_state_history" in r.getMessage() and "capped" in r.getMessage()
+    ]
+    assert len(truncation_logs) == 2
+    logged_actions = {r.getMessage() for r in truncation_logs}
+    assert any("act_a" in m for m in logged_actions)
+    assert any("act_b" in m for m in logged_actions)
+
+
+def test_no_log_when_under_cap(caplog):
+    _reset_truncation_log_state_for_tests()
+    with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
+        _drive_transitions(STATE_HISTORY_CAP, action_name="act_under")
+    truncation_logs = [
+        r
+        for r in caplog.records
+        if "_state_history" in r.getMessage() and "capped" in r.getMessage()
+    ]
+    assert truncation_logs == []

--- a/tests/unit/record/test_state_history_cap.py
+++ b/tests/unit/record/test_state_history_cap.py
@@ -1,96 +1,79 @@
-"""Regression tests for VIOL-0024: silent _state_history truncation.
-
-The cap itself is intentional. What we're guarding against is (a) the doc
-math drifting from the constant, and (b) the truncation being invisible in
-logs. The dedup key is action_name — one log per action per process.
-"""
-
 from __future__ import annotations
 
 import logging
 
-import pytest
-
 from agent_actions.record.envelope import (
     STATE_HISTORY_CAP,
     RecordEnvelope,
-    _reset_truncation_log_state_for_tests,
 )
 from agent_actions.record.state import RecordState
 
 
 def _drive_transitions(n: int, action_name: str = "act") -> dict:
-    """Push a record through n legal ACTIVE→ACTIVE transitions."""
     record: dict = {}
     for _ in range(n):
         RecordEnvelope.transition(record, RecordState.ACTIVE, action_name, "test")
     return record
 
 
-@pytest.fixture
-def envelope_log_propagates():
-    # LoggingFactory sets agent_actions.propagate=False once initialized; caplog
-    # attaches at root, so without this the truncation log never reaches it.
-    root = logging.getLogger("agent_actions")
-    original = root.propagate
-    root.propagate = True
-    try:
-        yield
-    finally:
-        root.propagate = original
-
-
-def test_cap_constant_is_64():
-    assert STATE_HISTORY_CAP == 64
-
-
-def test_transitioning_past_cap_trims_oldest_entries():
-    _reset_truncation_log_state_for_tests()
-    record = _drive_transitions(STATE_HISTORY_CAP + 5)
-    history = record["_state_history"]
-    assert len(history) == STATE_HISTORY_CAP
-    assert history[-1]["reason"] == "test"
-
-
-def test_first_truncation_for_action_logs_once(caplog, envelope_log_propagates):
-    _reset_truncation_log_state_for_tests()
-    with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
-        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
-        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
-    truncation_logs = [
+def _truncation_records(caplog) -> list[logging.LogRecord]:
+    return [
         r
         for r in caplog.records
         if "_state_history" in r.getMessage() and "capped" in r.getMessage()
     ]
+
+
+def test_first_truncation_for_action_logs_once(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent_actions.record.envelope"):
+        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
+        _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
+    truncation_logs = _truncation_records(caplog)
     assert len(truncation_logs) == 1, [r.getMessage() for r in truncation_logs]
     msg = truncation_logs[0].getMessage()
     assert "64" in msg
     assert "act_a" in msg
 
 
-def test_distinct_actions_log_independently(caplog, envelope_log_propagates):
-    _reset_truncation_log_state_for_tests()
-    with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
+def test_distinct_actions_log_independently(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent_actions.record.envelope"):
         _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
         _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_b")
-    truncation_logs = [
-        r
-        for r in caplog.records
-        if "_state_history" in r.getMessage() and "capped" in r.getMessage()
-    ]
+    truncation_logs = _truncation_records(caplog)
     assert len(truncation_logs) == 2
     logged_actions = {r.getMessage() for r in truncation_logs}
     assert any("act_a" in m for m in logged_actions)
     assert any("act_b" in m for m in logged_actions)
 
 
-def test_no_log_when_under_cap(caplog, envelope_log_propagates):
-    _reset_truncation_log_state_for_tests()
-    with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
+def test_no_log_when_under_cap(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent_actions.record.envelope"):
         _drive_transitions(STATE_HISTORY_CAP, action_name="act_under")
-    truncation_logs = [
-        r
-        for r in caplog.records
-        if "_state_history" in r.getMessage() and "capped" in r.getMessage()
-    ]
-    assert truncation_logs == []
+    assert _truncation_records(caplog) == []
+
+
+def test_over_cap_input_reports_full_overflow(caplog):
+    # A record hydrated from an older/higher cap arrives with history already
+    # over the cap; the log's dropped=N reflects the full overflow, not just
+    # the entry appended by this call.
+    oversized = STATE_HISTORY_CAP + 10
+    record: dict = {
+        "_state_history": [
+            {
+                "timestamp": "1970-01-01T00:00:00+00:00",
+                "action": "seed",
+                "from": None,
+                "to": "active",
+                "reason": "seed",
+                "detail": None,
+            }
+            for _ in range(oversized)
+        ],
+    }
+    with caplog.at_level(logging.WARNING, logger="agent_actions.record.envelope"):
+        RecordEnvelope.transition(record, RecordState.ACTIVE, "act_rehydrated", "test")
+    truncation_logs = _truncation_records(caplog)
+    assert len(truncation_logs) == 1
+    # Appended 1 entry to oversized+1; overflow = (oversized+1) - CAP = 11.
+    assert "11" in truncation_logs[0].getMessage()
+    assert len(record["_state_history"]) == STATE_HISTORY_CAP

--- a/tests/unit/record/test_state_history_cap.py
+++ b/tests/unit/record/test_state_history_cap.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from agent_actions.record.envelope import (
     STATE_HISTORY_CAP,
     RecordEnvelope,
@@ -25,6 +27,21 @@ def _drive_transitions(n: int, action_name: str = "act") -> dict:
     return record
 
 
+@pytest.fixture
+def envelope_log_propagates():
+    # LoggingFactory sets `agent_actions` propagate=False once initialized in a
+    # prior test. Caplog attaches at root, so without propagation the truncation
+    # log never reaches it. Restore the original value after the test to avoid
+    # polluting downstream tests that assert on logger-bridge behavior.
+    root = logging.getLogger("agent_actions")
+    original = root.propagate
+    root.propagate = True
+    try:
+        yield
+    finally:
+        root.propagate = original
+
+
 def test_cap_constant_is_64():
     assert STATE_HISTORY_CAP == 64
 
@@ -37,7 +54,7 @@ def test_transitioning_past_cap_trims_oldest_entries():
     assert history[-1]["reason"] == "test"
 
 
-def test_first_truncation_for_action_logs_once(caplog):
+def test_first_truncation_for_action_logs_once(caplog, envelope_log_propagates):
     _reset_truncation_log_state_for_tests()
     with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
         _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
@@ -53,7 +70,7 @@ def test_first_truncation_for_action_logs_once(caplog):
     assert "act_a" in msg
 
 
-def test_distinct_actions_log_independently(caplog):
+def test_distinct_actions_log_independently(caplog, envelope_log_propagates):
     _reset_truncation_log_state_for_tests()
     with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
         _drive_transitions(STATE_HISTORY_CAP + 1, action_name="act_a")
@@ -69,7 +86,7 @@ def test_distinct_actions_log_independently(caplog):
     assert any("act_b" in m for m in logged_actions)
 
 
-def test_no_log_when_under_cap(caplog):
+def test_no_log_when_under_cap(caplog, envelope_log_propagates):
     _reset_truncation_log_state_for_tests()
     with caplog.at_level(logging.INFO, logger="agent_actions.record.envelope"):
         _drive_transitions(STATE_HISTORY_CAP, action_name="act_under")


### PR DESCRIPTION
## Summary
- **Runtime.** `RecordEnvelope.transition()` (`agent_actions/record/envelope.py:154`) capped `_state_history` at 64 entries with a plain slice — no signal that older transitions had been dropped. Adds a module-level dedup set keyed on `action_name` and emits one `logger.info(...)` the first time truncation fires for each action in a process. `transition()` signature is unchanged; slice-and-reassign preserved (Caveat 3 shallow-copy aliasing guard from `_carry_persistent_fields` still holds).
- **Docs.** Guide and reference disagreed by 2×: the guide said "under 32 actions, every transition preserved"; the reference said "16+ actions, silently truncated". Both now say roughly 16 actions is the pain point, name `STATE_HISTORY_CAP` in `agent_actions/record/envelope.py`, and quote the new log line so operators grepping their logs land on the right page.
- Dedup keyed on `action_name` — not `(run_id, workflow_name)` — because records do not carry those fields (they live on `RunManifest`/`ActionRunner`) and `action_name` is the useful diagnostic dimension.

## Blast radius
`transition()` sits at the confluence of three pipelines: finish (`_stamp` → `ResultCollector`), read (`reset_for_downstream` → `StorageBackend.read_target` — five downstream call sites), and batch reprompt/recovery. The `action_name` dedup bounds visible output to at most one line per distinct action per process.

## Verification
- `pytest` — **7781 passed** in 49.80s
- `ruff check agent_actions tests` — all checks passed
- `ruff format --check agent_actions tests` — 984 files already formatted
- New tests: `tests/unit/record/test_state_history_cap.py` (5 tests: cap constant, trim behavior, one-log-per-action, distinct actions log independently, no log under cap)
- Includes `envelope_log_propagates` fixture that flips `agent_actions.propagate` for the caplog tests and restores the original value — `LoggingFactory._setup_logging_bridge()` sets propagate=False once initialized, otherwise caplog can't see the log.

## Non-goals
- Cap value unchanged (still 64).
- On-disk shape of `_state_history` unchanged — SQL row-count queries still return the same value.
- `RecordEnvelope.transition()` signature unchanged.