### PR TITLE
fix(VIOL-0039): validate-udfs exits non-zero on validation failure

### DIFF
--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -100,7 +100,7 @@ class ValidateUDFsCommand:
                     self._handle_load_error(error)
                 elif error_type == "not_found":
                     self._handle_not_found_error(error)
-                return
+                raise click.exceptions.Exit(1)
             registry = result["registry"]
             impl_refs = result["impl_refs"]
             fire_event(
@@ -122,6 +122,8 @@ class ValidateUDFsCommand:
                         self.console.print(f"  • {ref} ([cyan]{udf_meta['file']}[/cyan])")
                     except FunctionNotFoundError:
                         self.console.print(f"  • {ref}")
+        except click.exceptions.Exit:
+            raise
         except Exception as e:
             error_message = format_user_error(
                 e,

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -259,7 +259,8 @@ class TestExecute:
             return_value={"valid": False, "error": dup_err, "error_type": "duplicate"}
         )
 
-        cmd.execute()
+        with pytest.raises(click.exceptions.Exit):
+            cmd.execute()
 
         calls = [str(c) for c in cmd.console.print.call_args_list]
         assert any("Duplicate function name" in c for c in calls)
@@ -275,7 +276,8 @@ class TestExecute:
             return_value={"valid": False, "error": load_err, "error_type": "load_error"}
         )
 
-        cmd.execute()
+        with pytest.raises(click.exceptions.Exit):
+            cmd.execute()
 
         joined = "\n".join(str(c) for c in cmd.console.print.call_args_list)
         # Marker line + canonical formatter output.
@@ -300,7 +302,8 @@ class TestExecute:
             return_value={"valid": False, "error": load_err, "error_type": "load_error"}
         )
 
-        cmd.execute()
+        with pytest.raises(click.exceptions.Exit):
+            cmd.execute()
 
         calls = [str(c) for c in cmd.console.print.call_args_list]
         joined = "\n".join(calls)
@@ -323,7 +326,10 @@ class TestExecute:
             return_value={"valid": False, "error": nf_err, "error_type": "not_found"}
         )
 
-        with patch("agent_actions.validation.validate_udfs.get_udf_metadata") as mock_meta:
+        with (
+            patch("agent_actions.validation.validate_udfs.get_udf_metadata") as mock_meta,
+            pytest.raises(click.exceptions.Exit),
+        ):
             mock_meta.return_value = {"file": "tools.py"}
             cmd.execute()
 
@@ -352,10 +358,13 @@ class TestExecute:
             return_value={"valid": False, "error": nf_err, "error_type": "not_found"}
         )
 
-        with patch("agent_actions.validation.validate_udfs.get_udf_metadata") as mock_meta:
+        with (
+            patch("agent_actions.validation.validate_udfs.get_udf_metadata") as mock_meta,
+            pytest.raises(click.exceptions.Exit),
+        ):
             mock_meta.return_value = {"file": "tools.py"}
             cmd.execute()
 
         calls = [str(c) for c in cmd.console.print.call_args_list]
-        # Should show "... and N more"
+        # Should show "... and 5 more"
         assert any("and 5 more" in c for c in calls)

--- a/tests/validation/test_validate_udfs_exit_code.py
+++ b/tests/validation/test_validate_udfs_exit_code.py
@@ -1,0 +1,75 @@
+"""Regression test: validate-udfs must exit non-zero on any validation
+failure (FunctionNotFoundError, UDFLoadError, DuplicateFunctionError)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from click.testing import CliRunner
+
+from agent_actions.errors import (
+    DuplicateFunctionError,
+    FunctionNotFoundError,
+    UDFLoadError,
+)
+from agent_actions.validation.validate_udfs import (
+    ValidateUDFsCommand,
+    validate_udfs_cmd,
+)
+
+
+def _run_cli(monkeypatch, tmp_path: Path, validate_return: dict) -> click.testing.Result:
+    """Invoke the Click command with validate() stubbed on the real class.
+
+    Stubs only validate() so execute()'s formatter dispatch and exit-code
+    behavior are exercised end-to-end. CliRunner translates
+    click.exceptions.Exit into result.exit_code.
+    """
+    monkeypatch.setattr(ValidateUDFsCommand, "validate", lambda self: validate_return)
+    return CliRunner().invoke(validate_udfs_cmd, ["-a", "wf", "-u", str(tmp_path)])
+
+
+def test_missing_impl_function_exits_non_zero(monkeypatch, tmp_path):
+    nf = FunctionNotFoundError(
+        "Function 'nonexistent_fn' not found",
+        context={"function_name": "nonexistent_fn", "available_functions": []},
+    )
+    result = _run_cli(
+        monkeypatch, tmp_path, {"valid": False, "error": nf, "error_type": "not_found"}
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_udf_load_error_exits_non_zero(monkeypatch, tmp_path):
+    load_err = UDFLoadError(module="bad_module", file="bad.py", error="SyntaxError")
+    result = _run_cli(
+        monkeypatch,
+        tmp_path,
+        {"valid": False, "error": load_err, "error_type": "load_error"},
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_duplicate_function_error_exits_non_zero(monkeypatch, tmp_path):
+    dup = DuplicateFunctionError(
+        function_name="dup_func",
+        existing_location="a",
+        existing_file="a.py",
+        new_location="b",
+        new_file="b.py",
+    )
+    result = _run_cli(
+        monkeypatch, tmp_path, {"valid": False, "error": dup, "error_type": "duplicate"}
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_valid_result_exits_zero(monkeypatch, tmp_path):
+    """Baseline — success must still exit 0 (guards against an unconditional exit-1 fix)."""
+    result = _run_cli(
+        monkeypatch,
+        tmp_path,
+        {"valid": True, "registry": {"fn": {}}, "impl_refs": {"fn"}},
+    )
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

`agac validate-udfs` was exiting `0` after printing a formatted validation error, so CI hooks gating on the exit code could not block bad commits (INV-7-01 violation).

Root cause: `ValidateUDFsCommand.execute()`'s failure branch `return`s after the formatter prints. Click's default exit is `0`. The three handled failure types (`FunctionNotFoundError`, `UDFLoadError`, `DuplicateFunctionError`) never reach the outer `except Exception → raise click.ClickException` handler because `validate()` catches them and returns a result dict.

Fix:
- Replace `return` with `raise click.exceptions.Exit(1)` after the formatter dispatch.
- Add `except click.exceptions.Exit: raise` before the broad `except Exception` so the exit propagates cleanly. Without it, the outer handler catches `Exit` (it inherits from `Exception`), wraps it as `ClickException`, and the user sees a doubled/misleading `Problem: Exit: 1` block after the real error message.

Follows the recipe:

1. **RED** — new `tests/validation/test_validate_udfs_exit_code.py` stubs only `validate()` on the real class (so real `execute()` runs) and asserts `result.exit_code != 0` via `CliRunner` for all three failure types + `== 0` for the success baseline. Committed separately; on the pre-fix codebase the 3 failure tests fail with the formatter output present and `exit_code == 0` — proving the tests exercise the bug.
2. **GREEN** — the fix above, plus the 5 existing `TestExecute` failure-path tests wrapped in `pytest.raises(click.exceptions.Exit)`.

The success path and the outer-handler contract for unexpected exceptions (`test_valid_result_prints_success`, `test_unexpected_exception_raises_click_exception`) are unchanged.

## Verification

- `pytest tests/validation/test_validate_udfs_exit_code.py tests/validation/test_validate_udfs.py` — 24 passed
- `pytest tests/validation tests/cli` — 421 passed
- `ruff format --check agent_actions tests` — clean
- `ruff check agent_actions tests` — clean
- Manual CLI check: real invocation with a bogus `impl: nonexistent_fn` prints only the formatter's `❌ Function 'nonexistent_fn' not found` block and exits `1` (no `Problem: Exit: 1` noise).

Scope-limited to Option A of VIOL-0039. Option B (align with `@handles_user_errors`) is left as a follow-up so the outer handler's contract for unexpected exceptions stays pinned by its existing test.