### PR TITLE
fix(VIOL-0009): FILE-mode empty output honors on_empty config

### DIFF
--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -7,13 +7,14 @@ import logging
 from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
+from agent_actions.errors.processing import EmptyOutputError
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
 )
-from agent_actions.record.reasons import TOOL_MISSING_RECORD
+from agent_actions.record.reasons import EMPTY_OUTPUT, TOOL_MISSING_RECORD
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -74,6 +75,35 @@ class FileToolStrategy:
             )
 
             if is_empty_response(raw_response) and records:
+                on_empty = context.agent_config.get("on_empty", "warn")
+
+                if on_empty == "error":
+                    raise EmptyOutputError(
+                        f"Tool '{context.agent_name}' returned empty result from "
+                        f"{len(records)} input record(s) (on_empty=error)",
+                        context={
+                            "agent_name": context.agent_name,
+                            "record_count": len(records),
+                        },
+                    )
+
+                if on_empty == "skip":
+                    return [
+                        ProcessingResult.skipped(
+                            passthrough_data=build_tombstone(
+                                context.agent_name,
+                                record,
+                                EMPTY_OUTPUT,
+                                source_guid=record.get("source_guid"),
+                            ),
+                            reason=EMPTY_OUTPUT,
+                            source_guid=record.get("source_guid"),
+                            source_snapshot=copy.deepcopy(record),
+                            input_record=record,
+                        )
+                        for record in records
+                    ]
+
                 error_msg = (
                     f"Tool '{context.agent_name}' returned empty result "
                     f"from {len(records)} input record(s)"

--- a/tests/unit/workflow/test_file_tool_on_empty_parity.py
+++ b/tests/unit/workflow/test_file_tool_on_empty_parity.py
@@ -66,7 +66,9 @@ def test_on_empty_skip_produces_empty_output_tombstones():
         assert result.skip_reason == EMPTY_OUTPUT
         assert result.source_guid == input_data[i]["source_guid"]
         assert len(result.data) == 1
-        assert result.data[0].get("_state") is not None  # tombstone was built
+        tombstone = result.data[0]
+        assert tombstone["_tombstone"] is True
+        assert tombstone["_tombstone_reason"] == EMPTY_OUTPUT
 
 
 def test_on_empty_warn_matches_prior_behavior():

--- a/tests/unit/workflow/test_file_tool_on_empty_parity.py
+++ b/tests/unit/workflow/test_file_tool_on_empty_parity.py
@@ -1,0 +1,106 @@
+"""Parity: FILE-mode empty-output must honor on_empty=warn|error|skip.
+
+The workflow config schema declares ``on_empty: Literal["warn", "error",
+"skip"]`` on every action (agent_actions/config/schema.py). The online-LLM
+strategy honors all three (agent_actions/processing/strategies/online_llm.py).
+The FILE-mode strategy today ignores the field and hard-codes the ``warn``
+semantic — ``on_empty=error`` does not abort, ``on_empty=skip`` does not
+produce an ``empty_output`` tombstone. These tests pin the intended parity.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.errors.processing import EmptyOutputError
+from agent_actions.processing.strategies.file_tool import FileToolStrategy
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.reasons import EMPTY_OUTPUT
+
+
+def _make_context(on_empty: str, agent_name: str = "my_file_tool") -> ProcessingContext:
+    return ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file", "on_empty": on_empty},
+        agent_name=agent_name,
+    )
+
+
+def _empty_response_patch():
+    return patch(
+        "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+        return_value=([], True),
+    )
+
+
+def test_on_empty_error_raises_empty_output_error():
+    context = _make_context("error")
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+    ]
+    context.source_data = input_data
+
+    with _empty_response_patch(), pytest.raises(EmptyOutputError) as exc_info:
+        FileToolStrategy().invoke(input_data, context)
+
+    assert "my_file_tool" in str(exc_info.value)
+    assert "on_empty=error" in str(exc_info.value)
+
+
+def test_on_empty_skip_produces_empty_output_tombstones():
+    context = _make_context("skip")
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+    ]
+    context.source_data = input_data
+
+    with _empty_response_patch():
+        results = FileToolStrategy().invoke(input_data, context)
+
+    assert len(results) == 2
+    for i, result in enumerate(results):
+        assert result.status == ProcessingStatus.SKIPPED
+        assert result.skip_reason == EMPTY_OUTPUT
+        assert result.source_guid == input_data[i]["source_guid"]
+        assert len(result.data) == 1
+        assert result.data[0].get("_state") is not None  # tombstone was built
+
+
+def test_on_empty_warn_matches_prior_behavior():
+    """The default 'warn' branch must be byte-identical to today's behavior."""
+    context = _make_context("warn")
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+    ]
+    context.source_data = input_data
+
+    with _empty_response_patch():
+        results = FileToolStrategy().invoke(input_data, context)
+
+    assert len(results) == 2
+    for i, result in enumerate(results):
+        assert result.status == ProcessingStatus.FAILED
+        assert "returned empty result" in result.error
+        assert "2 input record(s)" in result.error
+        assert result.source_guid == input_data[i]["source_guid"]
+
+
+def test_on_empty_default_is_warn_when_unset():
+    """Omitting on_empty (agent_config lacks the key) must equal on_empty=warn."""
+    context = ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file"},
+        agent_name="my_file_tool",
+    )
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+    context.source_data = input_data
+
+    with _empty_response_patch():
+        results = FileToolStrategy().invoke(input_data, context)
+
+    assert len(results) == 1
+    assert results[0].status == ProcessingStatus.FAILED
+    assert "returned empty result" in results[0].error


### PR DESCRIPTION
## Summary

`FileToolStrategy` ignored the workflow config's `on_empty` field. The schema at `agent_actions/config/schema.py:231` declares `on_empty: Literal[\"warn\", \"error\", \"skip\"]` on every action, and `online_llm.py:512-560` honors all three — but `file_tool.py:76-88` unconditionally returned per-record `ProcessingResult.failed(...)`, silently collapsing `error` and `skip` to the `warn` semantic. A workflow declaring `on_empty: error` on a FILE-mode tool did **not** abort; declaring `on_empty: skip` did **not** produce `empty_output` tombstones.

This PR brings FILE-mode to parity by adding the same three-way dispatch, reusing the existing `EmptyOutputError` and `EMPTY_OUTPUT` reason string. The `warn` branch is byte-identical to the prior behavior, so no existing workflow regresses.

## Root cause

`context.agent_config` was available (used at line 66 for cast) but never queried for `on_empty` on the empty-response branch. The fix reads it and branches like `online_llm.py` does.

## Verification

- RED commit `eee85faf` adds `tests/unit/workflow/test_file_tool_on_empty_parity.py` with 4 tests; the two parity tests (`test_on_empty_error_raises`, `test_on_empty_skip_produces_empty_output_tombstones`) fail on that commit for the right reason (\"DID NOT RAISE\"; status FAILED instead of SKIPPED). Baseline `warn` and default-unset tests pass.
- GREEN commit `d04fd25e` applies the fix — all 4 parity tests pass.
- Full FILE-mode + processing suites: **486 passed** (`pytest tests/unit/processing/ tests/unit/workflow/test_pipeline_file_mode_tool.py tests/unit/workflow/test_file_tool_on_empty_parity.py`).
- `ruff format --check` and `ruff check` clean on changed files.
- 28 pre-existing failures elsewhere (`test_parallel_exception_handling.py`, `test_stale_completion_verification.py`) are on `main` too — unrelated.

## Why not add a new `fail_fast_on_empty_file_mode_output` setting?

An earlier spec draft proposed a parallel setting and a new exception class. Both would duplicate existing mechanisms (`on_empty=\"error\"` and `EmptyOutputError`). The real defect is that FILE-mode wasn't wired to the existing field — not a missing field.