### PR TITLE
fix(VIOL-0029): remove dead RecordState members committed + guard_deferred

### DIFF
--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -7,13 +7,14 @@ import logging
 from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
+from agent_actions.errors.processing import EmptyOutputError
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.types import (
     ProcessingContext,
     ProcessingResult,
 )
-from agent_actions.record.reasons import TOOL_MISSING_RECORD
+from agent_actions.record.reasons import EMPTY_OUTPUT, TOOL_MISSING_RECORD
 from agent_actions.record.tracking import TrackedItem
 from agent_actions.utils.content import is_version_merge
 from agent_actions.utils.tools_resolver import resolve_tools_path
@@ -74,6 +75,35 @@ class FileToolStrategy:
             )
 
             if is_empty_response(raw_response) and records:
+                on_empty = context.agent_config.get("on_empty", "warn")
+
+                if on_empty == "error":
+                    raise EmptyOutputError(
+                        f"Tool '{context.agent_name}' returned empty result from "
+                        f"{len(records)} input record(s) (on_empty=error)",
+                        context={
+                            "agent_name": context.agent_name,
+                            "record_count": len(records),
+                        },
+                    )
+
+                if on_empty == "skip":
+                    return [
+                        ProcessingResult.skipped(
+                            passthrough_data=build_tombstone(
+                                context.agent_name,
+                                record,
+                                EMPTY_OUTPUT,
+                                source_guid=record.get("source_guid"),
+                            ),
+                            reason=EMPTY_OUTPUT,
+                            source_guid=record.get("source_guid"),
+                            source_snapshot=copy.deepcopy(record),
+                            input_record=record,
+                        )
+                        for record in records
+                    ]
+
                 error_msg = (
                     f"Tool '{context.agent_name}' returned empty result "
                     f"from {len(records)} input record(s)"

--- a/tests/unit/workflow/test_file_tool_on_empty_parity.py
+++ b/tests/unit/workflow/test_file_tool_on_empty_parity.py
@@ -66,7 +66,9 @@ def test_on_empty_skip_produces_empty_output_tombstones():
         assert result.skip_reason == EMPTY_OUTPUT
         assert result.source_guid == input_data[i]["source_guid"]
         assert len(result.data) == 1
-        assert result.data[0].get("_state") is not None  # tombstone was built
+        tombstone = result.data[0]
+        assert tombstone["_tombstone"] is True
+        assert tombstone["_tombstone_reason"] == EMPTY_OUTPUT
 
 
 def test_on_empty_warn_matches_prior_behavior():

--- a/tests/unit/workflow/test_file_tool_on_empty_parity.py
+++ b/tests/unit/workflow/test_file_tool_on_empty_parity.py
@@ -1,0 +1,106 @@
+"""Parity: FILE-mode empty-output must honor on_empty=warn|error|skip.
+
+The workflow config schema declares ``on_empty: Literal["warn", "error",
+"skip"]`` on every action (agent_actions/config/schema.py). The online-LLM
+strategy honors all three (agent_actions/processing/strategies/online_llm.py).
+The FILE-mode strategy today ignores the field and hard-codes the ``warn``
+semantic — ``on_empty=error`` does not abort, ``on_empty=skip`` does not
+produce an ``empty_output`` tombstone. These tests pin the intended parity.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.errors.processing import EmptyOutputError
+from agent_actions.processing.strategies.file_tool import FileToolStrategy
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.reasons import EMPTY_OUTPUT
+
+
+def _make_context(on_empty: str, agent_name: str = "my_file_tool") -> ProcessingContext:
+    return ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file", "on_empty": on_empty},
+        agent_name=agent_name,
+    )
+
+
+def _empty_response_patch():
+    return patch(
+        "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+        return_value=([], True),
+    )
+
+
+def test_on_empty_error_raises_empty_output_error():
+    context = _make_context("error")
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+    ]
+    context.source_data = input_data
+
+    with _empty_response_patch(), pytest.raises(EmptyOutputError) as exc_info:
+        FileToolStrategy().invoke(input_data, context)
+
+    assert "my_file_tool" in str(exc_info.value)
+    assert "on_empty=error" in str(exc_info.value)
+
+
+def test_on_empty_skip_produces_empty_output_tombstones():
+    context = _make_context("skip")
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+    ]
+    context.source_data = input_data
+
+    with _empty_response_patch():
+        results = FileToolStrategy().invoke(input_data, context)
+
+    assert len(results) == 2
+    for i, result in enumerate(results):
+        assert result.status == ProcessingStatus.SKIPPED
+        assert result.skip_reason == EMPTY_OUTPUT
+        assert result.source_guid == input_data[i]["source_guid"]
+        assert len(result.data) == 1
+        assert result.data[0].get("_state") is not None  # tombstone was built
+
+
+def test_on_empty_warn_matches_prior_behavior():
+    """The default 'warn' branch must be byte-identical to today's behavior."""
+    context = _make_context("warn")
+    input_data = [
+        {"source_guid": "sg-1", "content": {"prev": {"id": 1}}},
+        {"source_guid": "sg-2", "content": {"prev": {"id": 2}}},
+    ]
+    context.source_data = input_data
+
+    with _empty_response_patch():
+        results = FileToolStrategy().invoke(input_data, context)
+
+    assert len(results) == 2
+    for i, result in enumerate(results):
+        assert result.status == ProcessingStatus.FAILED
+        assert "returned empty result" in result.error
+        assert "2 input record(s)" in result.error
+        assert result.source_guid == input_data[i]["source_guid"]
+
+
+def test_on_empty_default_is_warn_when_unset():
+    """Omitting on_empty (agent_config lacks the key) must equal on_empty=warn."""
+    context = ProcessingContext(
+        agent_config={"kind": "tool", "granularity": "file"},
+        agent_name="my_file_tool",
+    )
+    input_data = [{"source_guid": "sg-1", "content": {"prev": {"id": 1}}}]
+    context.source_data = input_data
+
+    with _empty_response_patch():
+        results = FileToolStrategy().invoke(input_data, context)
+
+    assert len(results) == 1
+    assert results[0].status == ProcessingStatus.FAILED
+    assert "returned empty result" in results[0].error


### PR DESCRIPTION
# VIOL-0029 (+VIOL-0030) — Remove dead RecordState members

**Root cause:** `RecordState.COMMITTED` and `RecordState.GUARD_DEFERRED` were listed in the enum, the resettable set, the disposition map, and the docs, but no code path ever stamped them — the state machine advertised states a real run never produces.

**Fix (decision was LOCKED: remove both).** Deleted the two members at the source and swept every reference that kept them alive; a record carrying either value now fails loudly via `RecordEnvelopeError` (was silently mapped to SUCCESS/DEFERRED). `Disposition.DEFERRED` left intact — the batch path still uses it.

**Files changed (14):**
- `agent_actions/record/state.py` — enum + `RESETTABLE_DOWNSTREAM_STATES` (`SETTLED_STATES` auto-shrinks; it is derived)
- `agent_actions/record/disposition.py` — `_STATE_TO_DISPOSITION` map (2 entries)
- `agent_actions/record/lifecycle_read.py` — docstring wording
- `agent_actions/record/ARCHITECTURE.md`, `agent_actions/record/_MANIFEST.md` — state diagram, transition/reset tables, disposition map
- `docs.agent-actions/docs/guides/record-lifecycle.md` (mermaid + "8→6 states") and `.../reference/state-management/record-lifecycle.md` (dead-states note)
- `tests/unit/record/{test_derive_disposition,test_executor_reset,test_lifecycle_read,test_record_state,test_transition}.py` + `tests/unit/cli/test_preview_namespace.py`

**Tests added:**
- `tests/unit/record/test_no_dead_record_states.py` — pins removal: values not constructible, absent from enum/resettable-set/disposition-map, `derive_disposition` raises, and no `agent_actions/` source references the qualified members. (RED→GREEN: 11 failed before the fix, 11 passed after.)
- Preserved lost coverage: replaced `test_committed_cannot_go_to_guard_skipped` with `test_processed_cannot_go_to_guard_skipped` so the resettable→settled illegal-edge rule is still exercised by a surviving state.

**Verify output:**
- `pytest` — **7783 passed**, 0 failed (full suite, 65s)
- `ruff check` (changed .py) — **All checks passed**; `ruff format --check` (17 .py) — all formatted
- Invariant greps over `agent_actions/ tests/` (excluding the regression test that asserts absence) — **empty** for both `RecordState.COMMITTED|GUARD_DEFERRED` and quoted `"committed"|"guard_deferred"`
- Pre-existing `examples/` ruff errors confirmed present on baseline HEAD (untouched by this change, outside ownership)

**Scope expansion / cross-clone note:** Fixed 4 files rendered stale by the removal that were outside my declared SCOPE row but unowned by any Batch-1 worktree: `record/ARCHITECTURE.md`, `record/_MANIFEST.md`, `docs.agent-actions/docs/guides/record-lifecycle.md`, `tests/unit/cli/test_preview_namespace.py`. Claimed them under my row in `coordination/ownership.md` and logged in `status.md`. Leaving them would recreate the exact bug VIOL-0029 kills (docs describing a state that no longer exists in code). The spec's Task-2 file list also missed `tests/unit/record/test_record_state.py` (`len==8`→`6`), caught by the blast-radius sweep.

**Blockers:** none.
