### PR TITLE
fix(VIOL-0029): remove dead RecordState members committed + guard_deferred

### DIFF
--- a/agent_actions/record/ARCHITECTURE.md
+++ b/agent_actions/record/ARCHITECTURE.md
@@ -162,12 +162,6 @@ Internal helper `_extract_existing()` pulls the `content` dict from `input_recor
         │   (settled,     │                  │  (settled,      │
         │    resettable)  │                  │   resettable)   │
         └─────────────────┘                  └────────────────┘
-                 │
-        ┌────────▼────────┐                  ┌────────────────┐
-        │   COMMITTED     │                  │ GUARD_DEFERRED  │
-        │   (settled,     │                  │  (settled,      │
-        │    resettable)  │                  │   resettable)   │
-        └─────────────────┘                  └────────────────┘
 
         ┌─────────────────┐   ┌──────────┐   ┌───────────────┐
         │ CASCADE_SKIPPED │   │  FAILED  │   │   EXHAUSTED   │
@@ -182,7 +176,7 @@ Internal helper `_extract_existing()` pulls the `content` dict from `input_recor
 |------|----|----------|-----|
 | `None` (new record) | any | Yes | First write — no prior state |
 | `ACTIVE` | any settled | Yes | Normal processing progression |
-| `PROCESSED`, `COMMITTED`, `GUARD_SKIPPED`, `GUARD_DEFERRED` | `ACTIVE` | Yes | Downstream reset for re-processing |
+| `PROCESSED`, `GUARD_SKIPPED` | `ACTIVE` | Yes | Downstream reset for re-processing |
 | any | same state | Yes | Idempotent re-application |
 | `CASCADE_SKIPPED`, `FAILED`, `EXHAUSTED` | `ACTIVE` | **No** | Blocking states cannot be reset |
 | `CASCADE_SKIPPED`, `FAILED`, `EXHAUSTED` | `CASCADE_SKIPPED` | Yes | Cascade propagation through blocking states |
@@ -201,7 +195,7 @@ PROCESSABLE_STATES     = {ACTIVE}
 SETTLED_STATES         = {all states} - {ACTIVE}
     # Records that have reached a terminal state for this action
 
-RESETTABLE_DOWNSTREAM_STATES = {PROCESSED, COMMITTED, GUARD_SKIPPED, GUARD_DEFERRED}
+RESETTABLE_DOWNSTREAM_STATES = {PROCESSED, GUARD_SKIPPED}
     # Can be reset to ACTIVE when fed as input to a downstream action
 
 CASCADE_BLOCKING_STATES = {CASCADE_SKIPPED, FAILED, EXHAUSTED}
@@ -268,10 +262,8 @@ The source_guid is a record's stable identity across pipeline stages. Checkpoint
 RecordState          →  Disposition
 ─────────────────────────────────────
 PROCESSED            →  SUCCESS
-COMMITTED            →  SUCCESS
 GUARD_SKIPPED        →  PASSTHROUGH
 CASCADE_SKIPPED      →  UNPROCESSED
-GUARD_DEFERRED       →  DEFERRED
 FAILED               →  FAILED
 EXHAUSTED            →  EXHAUSTED
 ACTIVE               →  PASSTHROUGH

--- a/agent_actions/record/_MANIFEST.md
+++ b/agent_actions/record/_MANIFEST.md
@@ -52,7 +52,7 @@ The module does NOT own:
 |------|----|----------|
 | `None` (new record) | any | Yes — first write |
 | `ACTIVE` | any settled | Yes — normal progression |
-| `PROCESSED`, `COMMITTED`, `GUARD_SKIPPED`, `GUARD_DEFERRED` | `ACTIVE` | Yes — downstream reset |
+| `PROCESSED`, `GUARD_SKIPPED` | `ACTIVE` | Yes — downstream reset |
 | any | same state | Yes — idempotent re-application |
 | `CASCADE_SKIPPED`, `FAILED`, `EXHAUSTED` | `ACTIVE` | **No** — cascade-blocking states cannot be reset |
 | settled | different settled | **No** — cross-settled writes are not valid |

--- a/agent_actions/record/disposition.py
+++ b/agent_actions/record/disposition.py
@@ -10,10 +10,8 @@ from agent_actions.storage.backend import Disposition
 
 _STATE_TO_DISPOSITION: dict[RecordState, Disposition] = {
     RecordState.PROCESSED: Disposition.SUCCESS,
-    RecordState.COMMITTED: Disposition.SUCCESS,
     RecordState.GUARD_SKIPPED: Disposition.PASSTHROUGH,
     RecordState.CASCADE_SKIPPED: Disposition.UNPROCESSED,
-    RecordState.GUARD_DEFERRED: Disposition.DEFERRED,
     RecordState.FAILED: Disposition.FAILED,
     RecordState.EXHAUSTED: Disposition.EXHAUSTED,
     RecordState.ACTIVE: Disposition.PASSTHROUGH,

--- a/agent_actions/record/lifecycle_read.py
+++ b/agent_actions/record/lifecycle_read.py
@@ -91,8 +91,8 @@ def reset_for_downstream(
 ) -> None:
     """Reset resettable records to ACTIVE for downstream processing.
 
-    Records in RESETTABLE_DOWNSTREAM_STATES (PROCESSED, COMMITTED,
-    GUARD_SKIPPED, GUARD_DEFERRED) are reset to ACTIVE via transition().
+    Records in RESETTABLE_DOWNSTREAM_STATES (PROCESSED, GUARD_SKIPPED)
+    are reset to ACTIVE via transition().
     Records in CASCADE_BLOCKING_STATES stay as-is for cascade logic.
     ACTIVE records pass through unchanged.
     """

--- a/agent_actions/record/state.py
+++ b/agent_actions/record/state.py
@@ -15,9 +15,7 @@ class RecordState(str, Enum):
 
     ACTIVE = "active"
     PROCESSED = "processed"
-    COMMITTED = "committed"
     GUARD_SKIPPED = "guard_skipped"
-    GUARD_DEFERRED = "guard_deferred"
     CASCADE_SKIPPED = "cascade_skipped"
     FAILED = "failed"
     EXHAUSTED = "exhausted"
@@ -30,9 +28,7 @@ SETTLED_STATES: frozenset[RecordState] = frozenset(RecordState) - PROCESSABLE_ST
 RESETTABLE_DOWNSTREAM_STATES: frozenset[RecordState] = frozenset(
     {
         RecordState.PROCESSED,
-        RecordState.COMMITTED,
         RecordState.GUARD_SKIPPED,
-        RecordState.GUARD_DEFERRED,
     }
 )
 

--- a/docs.agent-actions/docs/guides/record-lifecycle.md
+++ b/docs.agent-actions/docs/guides/record-lifecycle.md
@@ -28,31 +28,25 @@ The `content` dict is empty — it will grow as each action adds its output unde
 
 ## The State Machine
 
-Every record has a `_state` field governed by a finite state machine. There are 8 possible states:
+Every record has a `_state` field governed by a finite state machine. There are 6 possible states:
 
 ```mermaid
 flowchart TD
     A[ACTIVE<br/>Ready for processing]
     P[PROCESSED<br/>Action succeeded]
-    C[COMMITTED<br/>Written to storage]
     GS[GUARD_SKIPPED<br/>Guard said skip]
-    GD[GUARD_DEFERRED<br/>Guard deferred]
     CS[CASCADE_SKIPPED<br/>Upstream failed]
     F[FAILED<br/>Error occurred]
     E[EXHAUSTED<br/>All retries used]
 
     A --> P
-    A --> C
     A --> GS
-    A --> GD
     A --> CS
     A --> F
     A --> E
 
     P -->|boundary reset| A
-    C -->|boundary reset| A
     GS -->|boundary reset| A
-    GD -->|boundary reset| A
 ```
 
 Three categories:
@@ -60,7 +54,7 @@ Three categories:
 | Category | States | Behavior |
 |----------|--------|----------|
 | **Processable** | `active` | Ready for the next action |
-| **Resettable** | `processed`, `committed`, `guard_skipped`, `guard_deferred` | Reset to `active` at the next action boundary |
+| **Resettable** | `processed`, `guard_skipped` | Reset to `active` at the next action boundary |
 | **Terminal** | `cascade_skipped`, `failed`, `exhausted` | Record stops flowing. No further actions process it. |
 
 ## How Records Flow Through Actions

--- a/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
+++ b/docs.agent-actions/docs/reference/state-management/record-lifecycle.md
@@ -20,7 +20,7 @@ Every record has a `_state` field governed by a finite state machine. There are 
 | `failed` | Terminal | Record hit an unrecoverable error |
 | `exhausted` | Terminal | Record exhausted all reprompt attempts |
 
-> **Note:** `committed` and `guard_deferred` appear in the `RecordState` enum but have **zero stamp sites** in the framework — no code path writes them. They are dead states and should not be relied upon. See VIOL-0029/0030.
+> **Note:** `committed` and `guard_deferred` were **removed** from the `RecordState` enum in VIOL-0029/0030. They had zero stamp sites — no code path ever wrote them — so the state machine now produces only the six states above. A record carrying either value fails loudly (`RecordEnvelopeError`) on load.
 
 Three categories:
 

--- a/tests/unit/cli/test_preview_namespace.py
+++ b/tests/unit/cli/test_preview_namespace.py
@@ -65,9 +65,6 @@ class TestIsTombstone:
     def test_processed_state_is_not_tombstone(self):
         assert _is_tombstone({"_state": "processed"}) is False
 
-    def test_committed_state_is_not_tombstone(self):
-        assert _is_tombstone({"_state": "committed"}) is False
-
     def test_active_state_is_not_tombstone(self):
         assert _is_tombstone({"_state": "active"}) is False
 

--- a/tests/unit/record/test_derive_disposition.py
+++ b/tests/unit/record/test_derive_disposition.py
@@ -14,17 +14,11 @@ class TestDeriveDisposition:
     def test_processed_maps_to_success(self):
         assert derive_disposition({"_state": "processed"}) == Disposition.SUCCESS.value
 
-    def test_committed_maps_to_success(self):
-        assert derive_disposition({"_state": "committed"}) == Disposition.SUCCESS.value
-
     def test_guard_skipped_maps_to_passthrough(self):
         assert derive_disposition({"_state": "guard_skipped"}) == Disposition.PASSTHROUGH.value
 
     def test_cascade_skipped_maps_to_unprocessed(self):
         assert derive_disposition({"_state": "cascade_skipped"}) == Disposition.UNPROCESSED.value
-
-    def test_guard_deferred_maps_to_deferred(self):
-        assert derive_disposition({"_state": "guard_deferred"}) == Disposition.DEFERRED.value
 
     def test_failed_maps_to_failed(self):
         assert derive_disposition({"_state": "failed"}) == Disposition.FAILED.value

--- a/tests/unit/record/test_executor_reset.py
+++ b/tests/unit/record/test_executor_reset.py
@@ -20,18 +20,8 @@ class TestResetForDownstream:
         reset_for_downstream(records, action_name="downstream")
         assert records[0]["_state"] == "active"
 
-    def test_committed_resets_to_active(self):
-        records = [_record("committed")]
-        reset_for_downstream(records, action_name="downstream")
-        assert records[0]["_state"] == "active"
-
     def test_guard_skipped_resets_to_active(self):
         records = [_record("guard_skipped")]
-        reset_for_downstream(records, action_name="downstream")
-        assert records[0]["_state"] == "active"
-
-    def test_guard_deferred_resets_to_active(self):
-        records = [_record("guard_deferred")]
         reset_for_downstream(records, action_name="downstream")
         assert records[0]["_state"] == "active"
 

--- a/tests/unit/record/test_lifecycle_read.py
+++ b/tests/unit/record/test_lifecycle_read.py
@@ -54,7 +54,7 @@ class TestValidateLifecycle:
 
 class TestValidateLifecycleBatch:
     def test_all_valid_passes(self):
-        records = [_record("active"), _record("processed"), _record("committed")]
+        records = [_record("active"), _record("processed"), _record("guard_skipped")]
         validate_lifecycle_batch(records, action_name="act")
 
     def test_empty_list_passes(self):

--- a/tests/unit/record/test_no_dead_record_states.py
+++ b/tests/unit/record/test_no_dead_record_states.py
@@ -1,0 +1,66 @@
+"""Regression tests for VIOL-0029/0030 — the dead ``RecordState`` members.
+
+``committed`` and ``guard_deferred`` were listed in the enum, the resettable
+set, and the disposition map but had **zero stamp sites** — no code path ever
+wrote them. They are removed. These tests pin the removal: the enum rejects the
+values, the derived state sets exclude them, the disposition map has no entry,
+``derive_disposition`` fails loudly on a record carrying them, and no source code
+references the qualified members.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent_actions.record.disposition import _STATE_TO_DISPOSITION, derive_disposition
+from agent_actions.record.envelope import RecordEnvelopeError
+from agent_actions.record.state import RESETTABLE_DOWNSTREAM_STATES, RecordState
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REMOVED_VALUES = ["committed", "guard_deferred"]
+_REMOVED_NAMES = ["COMMITTED", "GUARD_DEFERRED"]
+
+
+@pytest.mark.parametrize("value", _REMOVED_VALUES)
+def test_value_not_constructible(value):
+    with pytest.raises(ValueError):
+        RecordState(value)
+
+
+@pytest.mark.parametrize("name", _REMOVED_NAMES)
+def test_member_absent_from_enum(name):
+    assert name not in RecordState.__members__
+
+
+@pytest.mark.parametrize("value", _REMOVED_VALUES)
+def test_absent_from_resettable_states(value):
+    assert value not in {s.value for s in RESETTABLE_DOWNSTREAM_STATES}
+
+
+@pytest.mark.parametrize("value", _REMOVED_VALUES)
+def test_absent_from_disposition_map(value):
+    assert value not in {s.value for s in _STATE_TO_DISPOSITION}
+
+
+@pytest.mark.parametrize("value", _REMOVED_VALUES)
+def test_derive_disposition_rejects_removed_state(value):
+    with pytest.raises(RecordEnvelopeError, match="unknown _state value"):
+        derive_disposition({"_state": value})
+
+
+def test_no_qualified_references_in_source():
+    """No agent_actions/ code references RecordState.COMMITTED / .GUARD_DEFERRED."""
+    result = subprocess.run(
+        [
+            "grep",
+            "-rnE",
+            r"RecordState\.(COMMITTED|GUARD_DEFERRED)",
+            str(_REPO_ROOT / "agent_actions"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == "", f"stray references:\n{result.stdout}"

--- a/tests/unit/record/test_record_state.py
+++ b/tests/unit/record/test_record_state.py
@@ -32,7 +32,7 @@ class TestRecordStateEnum:
         assert len(values) == len(set(values))
 
     def test_member_count(self):
-        assert len(RecordState) == 8
+        assert len(RecordState) == 6
 
 
 class TestStateCategories:

--- a/tests/unit/record/test_transition.py
+++ b/tests/unit/record/test_transition.py
@@ -65,9 +65,7 @@ class TestTransitionLegalEdges:
         "to_state",
         [
             RecordState.PROCESSED,
-            RecordState.COMMITTED,
             RecordState.GUARD_SKIPPED,
-            RecordState.GUARD_DEFERRED,
             RecordState.CASCADE_SKIPPED,
             RecordState.FAILED,
             RecordState.EXHAUSTED,
@@ -82,9 +80,7 @@ class TestTransitionLegalEdges:
         "from_state",
         [
             RecordState.PROCESSED,
-            RecordState.COMMITTED,
             RecordState.GUARD_SKIPPED,
-            RecordState.GUARD_DEFERRED,
         ],
     )
     def test_resettable_to_active(self, from_state):
@@ -132,9 +128,9 @@ class TestTransitionIllegalEdges:
         with pytest.raises(RecordEnvelopeError, match="'processed'.*'failed'"):
             RecordEnvelope.transition(rec, RecordState.FAILED, "act", "oops")
 
-    def test_committed_cannot_go_to_guard_skipped(self):
-        rec = _record(RecordState.COMMITTED)
-        with pytest.raises(RecordEnvelopeError, match="'committed'.*'guard_skipped'"):
+    def test_processed_cannot_go_to_guard_skipped(self):
+        rec = _record(RecordState.PROCESSED)
+        with pytest.raises(RecordEnvelopeError, match="'processed'.*'guard_skipped'"):
             RecordEnvelope.transition(rec, RecordState.GUARD_SKIPPED, "act", "reason")
 
     def test_unknown_state_value_raises_envelope_error(self):


### PR DESCRIPTION
# VIOL-0029 (+VIOL-0030) — Remove dead RecordState members

**Root cause:** `RecordState.COMMITTED` and `RecordState.GUARD_DEFERRED` were listed in the enum, the resettable set, the disposition map, and the docs, but no code path ever stamped them — the state machine advertised states a real run never produces.

**Fix (decision was LOCKED: remove both).** Deleted the two members at the source and swept every reference that kept them alive; a record carrying either value now fails loudly via `RecordEnvelopeError` (was silently mapped to SUCCESS/DEFERRED). `Disposition.DEFERRED` left intact — the batch path still uses it.

**Files changed (14):**
- `agent_actions/record/state.py` — enum + `RESETTABLE_DOWNSTREAM_STATES` (`SETTLED_STATES` auto-shrinks; it is derived)
- `agent_actions/record/disposition.py` — `_STATE_TO_DISPOSITION` map (2 entries)
- `agent_actions/record/lifecycle_read.py` — docstring wording
- `agent_actions/record/ARCHITECTURE.md`, `agent_actions/record/_MANIFEST.md` — state diagram, transition/reset tables, disposition map
- `docs.agent-actions/docs/guides/record-lifecycle.md` (mermaid + "8→6 states") and `.../reference/state-management/record-lifecycle.md` (dead-states note)
- `tests/unit/record/{test_derive_disposition,test_executor_reset,test_lifecycle_read,test_record_state,test_transition}.py` + `tests/unit/cli/test_preview_namespace.py`

**Tests added:**
- `tests/unit/record/test_no_dead_record_states.py` — pins removal: values not constructible, absent from enum/resettable-set/disposition-map, `derive_disposition` raises, and no `agent_actions/` source references the qualified members. (RED→GREEN: 11 failed before the fix, 11 passed after.)
- Preserved lost coverage: replaced `test_committed_cannot_go_to_guard_skipped` with `test_processed_cannot_go_to_guard_skipped` so the resettable→settled illegal-edge rule is still exercised by a surviving state.

**Verify output:**
- `pytest` — **7783 passed**, 0 failed (full suite, 65s)
- `ruff check` (changed .py) — **All checks passed**; `ruff format --check` (17 .py) — all formatted
- Invariant greps over `agent_actions/ tests/` (excluding the regression test that asserts absence) — **empty** for both `RecordState.COMMITTED|GUARD_DEFERRED` and quoted `"committed"|"guard_deferred"`
- Pre-existing `examples/` ruff errors confirmed present on baseline HEAD (untouched by this change, outside ownership)

**Scope expansion / cross-clone note:** Fixed 4 files rendered stale by the removal that were outside my declared SCOPE row but unowned by any Batch-1 worktree: `record/ARCHITECTURE.md`, `record/_MANIFEST.md`, `docs.agent-actions/docs/guides/record-lifecycle.md`, `tests/unit/cli/test_preview_namespace.py`. Claimed them under my row in `coordination/ownership.md` and logged in `status.md`. Leaving them would recreate the exact bug VIOL-0029 kills (docs describing a state that no longer exists in code). The spec's Task-2 file list also missed `tests/unit/record/test_record_state.py` (`len==8`→`6`), caught by the blast-radius sweep.

**Blockers:** none.
