### PR TITLE
fix(VIOL-0045): advisory lock on `agac run` to prevent concurrent double-execute

### DIFF
--- a/agent_actions/cli/run.py
+++ b/agent_actions/cli/run.py
@@ -15,6 +15,7 @@ from agent_actions.cli.cli_decorators import handles_user_errors, requires_proje
 from agent_actions.cli.workflow_loader import load_workflow
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.logging.factory import LoggerFactory
+from agent_actions.storage.lock import WorkflowLockHeld, workflow_lock
 from agent_actions.tooling.docs.run_tracker import RunTracker
 from agent_actions.validation.prompt_validator import PromptValidator
 from agent_actions.validation.run_validator import RunCommandArgs
@@ -235,6 +236,15 @@ class RunCommand:
     default=False,
     help="Verify API keys are valid by probing vendor endpoints before execution",
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bypass the advisory concurrency lock. Use only if you understand that "
+        "two parallel runs double-execute every action and double the LLM cost."
+    ),
+)
 @handles_user_errors("run")
 @requires_project
 def run(
@@ -245,6 +255,7 @@ def run(
     concurrency_limit: int = 5,
     fresh: bool = False,
     verify_keys: bool = False,
+    force: bool = False,
     project_root: Path | None = None,
 ) -> None:
     """
@@ -269,4 +280,19 @@ def run(
         verify_keys=verify_keys,
     )
     command = RunCommand(args)
-    command.execute(project_root=project_root)
+
+    if force:
+        command.execute(project_root=project_root)
+        return
+
+    # Advisory lock (VIOL-0045): one `agac run` writer per workflow per machine.
+    # Wraps the whole run — releasing mid-run would reopen the double-execute
+    # window. The lock keys on the config name (`-a`), so repeat invocations of
+    # the same workflow contend; the OS releases it if the process is killed.
+    store_dir = project_root / "agent_io" / "store"
+    try:
+        with workflow_lock(store_dir, command.agent_name):
+            command.execute(project_root=project_root)
+    except WorkflowLockHeld as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(1) from exc

--- a/agent_actions/storage/lock.py
+++ b/agent_actions/storage/lock.py
@@ -1,0 +1,113 @@
+"""Advisory file lock for ``agac run`` to prevent concurrent double-execute.
+
+See VIOL-0045 (UAT Round 5B). SQLite's WAL mode keeps two parallel writers from
+corrupting the database, but nothing above it stops both runs from doing all the
+(paid) LLM work and having the later writer win. This module adds the missing
+concurrency control: a cooperative advisory lock on a sidecar file next to the
+workflow's SQLite database.
+
+The lock is *advisory* — only ``agac run`` acquires it. Read-only commands
+(``inspect``, ``status``, ``list``) do not, so they are never blocked. It is
+*non-blocking*: a second run fails fast with :class:`WorkflowLockHeld` rather
+than hanging. The OS releases the lock automatically when the holding process
+dies, so a killed run cannot leave it stuck.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+IS_WINDOWS = sys.platform == "win32"
+
+if IS_WINDOWS:
+    import msvcrt
+else:
+    import fcntl
+
+
+class WorkflowLockHeld(RuntimeError):
+    """Raised when another ``agac run`` already holds the workflow lock."""
+
+    def __init__(self, pid: int | None, lock_path: Path):
+        self.pid = pid
+        self.lock_path = lock_path
+        pid_str = str(pid) if pid is not None else "unknown"
+        super().__init__(
+            f"Another `agac run` is already executing this workflow "
+            f"(pid {pid_str}). Pass `--force` to override (not recommended)."
+        )
+
+
+def _read_pid(lock_path: Path) -> int | None:
+    try:
+        text = lock_path.read_text(encoding="utf-8").strip()
+        return int(text) if text else None
+    except (OSError, ValueError):
+        return None
+
+
+def _try_lock_posix(fd: int) -> bool:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _release_lock_posix(fd: int) -> None:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+def _try_lock_windows(fd: int) -> bool:
+    try:
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        return True
+    except OSError:
+        return False
+
+
+def _release_lock_windows(fd: int) -> None:
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    except OSError:
+        pass
+
+
+@contextlib.contextmanager
+def workflow_lock(store_dir: Path, workflow_name: str) -> Iterator[Path]:
+    """Hold an exclusive non-blocking advisory lock for ``workflow_name``.
+
+    The lock file is ``{store_dir}/{workflow_name}.db.lock`` — alongside the
+    SQLite database, so it shares the database's mount and cannot collide across
+    projects. Raises :class:`WorkflowLockHeld` on contention (the body carries
+    the prior holder's pid for the diagnostic message).
+    """
+    store_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = store_dir / f"{workflow_name}.db.lock"
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    acquired = _try_lock_windows(fd) if IS_WINDOWS else _try_lock_posix(fd)
+    if not acquired:
+        prior_pid = _read_pid(lock_path)
+        os.close(fd)
+        raise WorkflowLockHeld(prior_pid, lock_path)
+    try:
+        # Stamp our pid into the body so a contending run can name us.
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.ftruncate(fd, 0)
+        os.write(fd, str(os.getpid()).encode("utf-8"))
+        os.fsync(fd)
+        yield lock_path
+    finally:
+        if IS_WINDOWS:
+            _release_lock_windows(fd)
+        else:
+            _release_lock_posix(fd)
+        os.close(fd)

--- a/tests/unit/cli/test_run_concurrent_lock.py
+++ b/tests/unit/cli/test_run_concurrent_lock.py
@@ -1,0 +1,101 @@
+"""Regression tests for VIOL-0045: `agac run` acquires an advisory file lock so
+a second concurrent run against the same workflow store cannot silently
+double-execute. `--force` bypasses the lock.
+
+These drive the `run` Click command in-process (CliRunner) with the actual
+workflow execution mocked out, so they exercise the real lock-acquisition
+wiring without needing an LLM or a full project workflow. The contended lock is
+held via a raw `fcntl.flock` on a *separate* open file description — POSIX
+treats that as a distinct holder even within the same process, so the command's
+own acquire attempt is denied exactly as a second `agac run` process would be.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from agent_actions.cli.run import run
+
+
+def _make_project(root: Path) -> Path:
+    (root / "agent_actions.yml").write_text("name: test_project\n", encoding="utf-8")
+    store_dir = root / "agent_io" / "store"
+    store_dir.mkdir(parents=True, exist_ok=True)
+    return store_dir
+
+
+def _lock_path(store_dir: Path, workflow_name: str) -> Path:
+    return store_dir / f"{workflow_name}.db.lock"
+
+
+def _hold_lock(lock_path: Path) -> int:
+    """Hold an exclusive non-blocking flock on the lock file, stamping our pid
+    into the body the way a live run would. Returns the fd; caller closes it."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    os.write(fd, str(os.getpid()).encode("utf-8"))
+    os.fsync(fd)
+    return fd
+
+
+@pytest.fixture()
+def project(tmp_path, monkeypatch):
+    store_dir = _make_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path, store_dir
+
+
+def test_second_concurrent_run_exits_with_lock_message(project):
+    _, store_dir = project
+    fd = _hold_lock(_lock_path(store_dir, "lock_smoke"))
+    try:
+        with patch("agent_actions.cli.run.RunCommand.execute") as mock_exec:
+            result = CliRunner().invoke(run, ["-a", "lock_smoke"])
+    finally:
+        os.close(fd)
+
+    assert mock_exec.call_count == 0, "workflow must not execute while lock is held"
+    assert result.exit_code == 1, result.output
+    combined = result.output.lower()
+    assert "another" in combined
+    assert "agac run" in combined
+    assert "pid" in combined
+    assert "--force" in combined
+
+
+def test_force_bypasses_the_lock(project):
+    _, store_dir = project
+    fd = _hold_lock(_lock_path(store_dir, "lock_smoke"))
+    try:
+        with patch("agent_actions.cli.run.RunCommand.execute") as mock_exec:
+            result = CliRunner().invoke(run, ["-a", "lock_smoke", "--force"])
+    finally:
+        os.close(fd)
+
+    assert result.exit_code == 0, result.output
+    assert mock_exec.call_count == 1, "--force must run the workflow despite the held lock"
+
+
+def test_normal_run_acquires_and_releases_lock(project):
+    _, store_dir = project
+    with patch("agent_actions.cli.run.RunCommand.execute") as mock_exec:
+        result = CliRunner().invoke(run, ["-a", "lock_smoke"])
+
+    assert result.exit_code == 0, result.output
+    assert mock_exec.call_count == 1
+
+    # The run released the lock: a fresh non-blocking acquire must succeed.
+    lock_path = _lock_path(store_dir, "lock_smoke")
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)

--- a/tests/unit/storage/test_lock.py
+++ b/tests/unit/storage/test_lock.py
@@ -1,0 +1,61 @@
+"""Unit tests for the VIOL-0045 advisory workflow lock helper."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agent_actions.storage.lock import WorkflowLockHeld, workflow_lock
+
+
+def test_acquires_creates_file_and_stamps_pid(tmp_path):
+    with workflow_lock(tmp_path, "wf") as lock_path:
+        assert lock_path == tmp_path / "wf.db.lock"
+        assert lock_path.exists()
+        assert lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_second_acquire_while_held_raises_with_pid(tmp_path):
+    with workflow_lock(tmp_path, "wf"):
+        with pytest.raises(WorkflowLockHeld) as ei:
+            with workflow_lock(tmp_path, "wf"):
+                pass
+    assert ei.value.pid == os.getpid()
+    assert ei.value.lock_path == tmp_path / "wf.db.lock"
+    message = str(ei.value).lower()
+    assert "another" in message
+    assert "pid" in message
+    assert "--force" in message
+
+
+def test_lock_is_reacquirable_after_release(tmp_path):
+    with workflow_lock(tmp_path, "wf"):
+        pass
+    # Released — a fresh acquire must succeed rather than raise.
+    with workflow_lock(tmp_path, "wf") as lock_path:
+        assert lock_path.exists()
+
+
+def test_different_workflows_do_not_collide(tmp_path):
+    with workflow_lock(tmp_path, "a"):
+        with workflow_lock(tmp_path, "b") as b_path:
+            assert b_path == tmp_path / "b.db.lock"
+
+
+def test_store_dir_created_on_demand(tmp_path):
+    store_dir = tmp_path / "agent_io" / "store"
+    assert not store_dir.exists()
+    with workflow_lock(store_dir, "wf") as lock_path:
+        assert store_dir.is_dir()
+        assert lock_path.parent == store_dir
+
+
+def test_stale_pid_body_does_not_block_reacquire(tmp_path):
+    """A leftover lock file body (e.g. from a SIGKILLed run) must not itself
+    block a new acquire — the OS lock, not the pid text, is the mutex."""
+    lock_path = tmp_path / "wf.db.lock"
+    lock_path.write_text("999999", encoding="utf-8")
+    with workflow_lock(tmp_path, "wf") as held:
+        assert held == lock_path
+        assert held.read_text(encoding="utf-8").strip() == str(os.getpid())


### PR DESCRIPTION
# VIOL-0045 — Advisory file lock on `agac run`

**Root cause:** Nothing above SQLite's WAL layer stopped two `agac run -a X`
processes from both doing all the (paid) LLM work against the same store — there
was no "someone is already running this" check.

**Fix:** New advisory `fcntl.flock` (POSIX) / `msvcrt.locking` (Windows) on a
sidecar file `agent_io/store/{workflow}.db.lock`, acquired at `agac run` start
via a context manager and released on every exit path. On contention the second
run exits 1 with `Another \`agac run\` is already executing this workflow (pid N).
Pass \`--force\` to override`. New `--force` flag bypasses the lock entirely.

**Files changed:**
- `agent_actions/storage/lock.py` (new) — `workflow_lock()` context manager + `WorkflowLockHeld`.
- `agent_actions/cli/run.py` — `--force` flag; wrap `command.execute` in `workflow_lock`.

**Tests added:**
- `tests/unit/storage/test_lock.py` (6) — acquire/stamp-pid, contention raises, re-acquire after release, per-workflow isolation, store-dir created on demand, stale-pid body doesn't block.
- `tests/unit/cli/test_run_concurrent_lock.py` (3) — second run exits 1 with message; `--force` bypasses; normal run acquires+releases.

**Verify:** `pytest` → 7796 passed, 0 failed. `ruff check`/`ruff format --check`
on the 4 changed files → clean. (Repo-wide `ruff check .`/`format --check .`
report pre-existing issues only in `examples/` — outside VIOL-0045 ownership,
present on base commit; not touched.)

**Deviations from spec (verify-first):** spec's Task 1 test used `agac run -w`
(real flag is `-a`) and a subprocess + `tests/fixtures/{workflows/lock_smoke,udfs.py}`
harness outside my ownership. Reimplemented as in-process CliRunner tests with
`RunCommand.execute` mocked — deterministic and within owned files. `--force`
lives on `run()` only (not `RunCommandArgs`); `execute` never consumes it, so
adding it there would be dead data. Task 4 doc (`docs/reference/cli/run.md`) is
absent and out of ownership — deferred.

**Cross-clone / deferred:** `agent_actions/cli/retry.py:250` also runs a workflow
(`workflow.run()`) without a lock — same double-execute risk, reusable via
`workflow_lock`. Out of my ownership and out of VIOL-0045 scope; logged as a
cross-clone note.
