### PR TITLE
fix(VIOL-0098): 409 on /api/review-record when a different reviewer already staged

### DIFF
--- a/agent_actions/llm/providers/hitl/server.py
+++ b/agent_actions/llm/providers/hitl/server.py
@@ -267,7 +267,29 @@ class HitlServer:
         if reject_error:
             return jsonify({"success": False, "error": reject_error}), 400
 
+        reviewer_id = str(payload.get("reviewer_id", ""))[:200]
+        if not reviewer_id:
+            return jsonify({"success": False, "error": "reviewer_id is required."}), 400
+        normalized_review["reviewer_id"] = reviewer_id
+        normalized_review["staged_at"] = _utc_timestamp()
+
         with self._lock:
+            existing = self.record_reviews[raw_index]
+            if existing is not None and existing.get("reviewer_id") != reviewer_id:
+                # A different reviewer already staged this record. Refuse rather
+                # than silently clobber their decision. The same reviewer
+                # overwriting their own slot (change-of-mind) is allowed.
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "error": "Record already staged by a different reviewer.",
+                            "reviewer_id": existing.get("reviewer_id"),
+                            "staged_at": existing.get("staged_at"),
+                        }
+                    ),
+                    409,
+                )
             self.record_reviews[raw_index] = normalized_review
         logger.debug("Saved review for record %d: %s", raw_index, normalized_review["hitl_status"])
         self._persist_state()

--- a/agent_actions/llm/providers/hitl/templates/approval.html
+++ b/agent_actions/llm/providers/hitl/templates/approval.html
@@ -805,6 +805,23 @@ h4.md-heading { font-size: 13.5px; }
         var showQueue = true;
         var showInspector = true;
 
+        /* ── Per-browser reviewer id (persisted in localStorage) ──
+           Identifies which browser staged a decision so the server can reject
+           (409) a different reviewer's overwrite. There is no per-session
+           token, so this localStorage UUID is the reviewer discriminator. */
+        var REVIEWER_ID_KEY = 'hitl-reviewer-id';
+        function reviewerId() {
+            var id = null;
+            try { id = localStorage.getItem(REVIEWER_ID_KEY); } catch(e) {}
+            if (!id) {
+                id = (window.crypto && crypto.randomUUID)
+                    ? crypto.randomUUID()
+                    : 'r-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+                try { localStorage.setItem(REVIEWER_ID_KEY, id); } catch(e) {}
+            }
+            return id;
+        }
+
         /* ── Field visibility preferences (persisted in localStorage) ── */
         var FIELD_VIS_KEY = 'hitl-field-vis';
         var fieldVisPrefs = {};
@@ -1646,9 +1663,16 @@ h4.md-heading { font-size: 13.5px; }
                 index: index,
                 hitl_status: decision.hitl_status,
                 user_comment: decision.user_comment || '',
+                reviewer_id: reviewerId(),
             });
             if (!resp.ok) {
                 var p = await resp.json().catch(function() { return {}; });
+                if (resp.status === 409 && p.reviewer_id) {
+                    throw new Error(
+                        'Already decided by another reviewer (' + p.reviewer_id +
+                        (p.staged_at ? ' at ' + p.staged_at : '') + ').'
+                    );
+                }
                 throw new Error(p.error || 'Failed to save');
             }
         }

--- a/tests/unit/test_hitl_review_record_conflict.py
+++ b/tests/unit/test_hitl_review_record_conflict.py
@@ -1,0 +1,98 @@
+"""Regression tests for VIOL-0098.
+
+A second reviewer's POST /api/review-record for an already-staged record must
+return 409 (before the fix it silently overwrote the prior reviewer's decision).
+The same reviewer may still overwrite their own slot (change-of-mind).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_actions.llm.providers.hitl.server import HitlServer
+
+
+@pytest.fixture
+def hitl_client():
+    """A HITL server with two records under review, plus its test client."""
+    server = HitlServer(
+        port=3001,
+        instructions="Review output",
+        context_data=[{"id": 1}, {"id": 2}],
+        timeout=30,
+        require_comment_on_reject=False,
+    )
+    return server, server.app.test_client()
+
+
+def _stage(client, *, index, status, reviewer_id):
+    return client.post(
+        "/api/review-record",
+        json={"index": index, "hitl_status": status, "reviewer_id": reviewer_id},
+    )
+
+
+def test_second_reviewer_gets_409(hitl_client):
+    server, client = hitl_client
+
+    r1 = _stage(client, index=0, status="approved", reviewer_id="reviewer-A")
+    assert r1.status_code == 200
+
+    r2 = _stage(client, index=0, status="rejected", reviewer_id="reviewer-B")
+    assert r2.status_code == 409
+    body = r2.get_json()
+    assert body["success"] is False
+    assert body["reviewer_id"] == "reviewer-A"  # prior reviewer named
+    assert body["staged_at"]  # non-empty timestamp of the prior decision
+
+
+def test_conflict_does_not_overwrite_prior_decision(hitl_client):
+    """The core security property: a rejected 409 leaves the prior decision intact."""
+    server, client = hitl_client
+
+    _stage(client, index=0, status="approved", reviewer_id="reviewer-A")
+    _stage(client, index=0, status="rejected", reviewer_id="reviewer-B")
+
+    assert server.record_reviews[0]["hitl_status"] == "approved"
+    assert server.record_reviews[0]["reviewer_id"] == "reviewer-A"
+
+
+def test_same_reviewer_can_overwrite(hitl_client):
+    server, client = hitl_client
+
+    _stage(client, index=0, status="approved", reviewer_id="reviewer-A")
+    r = _stage(client, index=0, status="rejected", reviewer_id="reviewer-A")
+
+    assert r.status_code == 200
+    assert server.record_reviews[0]["hitl_status"] == "rejected"
+
+
+def test_different_records_by_different_reviewers_do_not_conflict(hitl_client):
+    """Conflict is per record index — two reviewers may each own a different record."""
+    server, client = hitl_client
+
+    assert _stage(client, index=0, status="approved", reviewer_id="reviewer-A").status_code == 200
+    assert _stage(client, index=1, status="rejected", reviewer_id="reviewer-B").status_code == 200
+
+
+def test_review_record_requires_reviewer_id(hitl_client):
+    """reviewer_id is the overwrite discriminator — a missing one fails closed (400)."""
+    server, client = hitl_client
+
+    resp = client.post(
+        "/api/review-record",
+        json={"index": 0, "hitl_status": "approved"},
+    )
+    assert resp.status_code == 400
+    assert "reviewer_id" in resp.get_json()["error"].lower()
+    assert server.record_reviews[0] is None
+
+
+def test_staged_entry_records_reviewer_and_timestamp(hitl_client):
+    server, client = hitl_client
+
+    _stage(client, index=0, status="approved", reviewer_id="reviewer-A")
+
+    entry = server.record_reviews[0]
+    assert entry["reviewer_id"] == "reviewer-A"
+    assert entry["staged_at"].endswith("Z")

--- a/tests/unit/test_hitl_server.py
+++ b/tests/unit/test_hitl_server.py
@@ -223,7 +223,7 @@ def test_review_record_persists_state_for_refresh():
         client,
         "/api/review-record",
         server,
-        json={"index": 0, "hitl_status": "approved", "user_comment": "ok"},
+        json={"index": 0, "hitl_status": "approved", "user_comment": "ok", "reviewer_id": "rev-1"},
     )
     assert response.status_code == 200
 
@@ -251,7 +251,7 @@ def test_submit_uses_persisted_review_state_when_payload_missing():
         client,
         "/api/review-record",
         server,
-        json={"index": 0, "hitl_status": "approved", "user_comment": "ok"},
+        json={"index": 0, "hitl_status": "approved", "user_comment": "ok", "reviewer_id": "rev-1"},
     )
     response = _post(client, "/api/submit", server, json={"hitl_status": "approved"})
     assert response.status_code == 400
@@ -262,7 +262,12 @@ def test_submit_uses_persisted_review_state_when_payload_missing():
         client,
         "/api/review-record",
         server,
-        json={"index": 1, "hitl_status": "rejected", "user_comment": "needs fix"},
+        json={
+            "index": 1,
+            "hitl_status": "rejected",
+            "user_comment": "needs fix",
+            "reviewer_id": "rev-1",
+        },
     )
     response = _post(client, "/api/submit", server, json={"hitl_status": "rejected"})
     assert response.status_code == 200

--- a/tests/unit/test_hitl_state_persistence.py
+++ b/tests/unit/test_hitl_state_persistence.py
@@ -41,14 +41,23 @@ class TestStateFileCreation:
             client,
             "/api/review-record",
             server,
-            json={"index": 0, "hitl_status": "approved", "user_comment": ""},
+            json={
+                "index": 0,
+                "hitl_status": "approved",
+                "user_comment": "",
+                "reviewer_id": "rev-1",
+            },
         )
         assert resp.status_code == 200
 
         assert state_file.exists()
         state = json.loads(state_file.read_text())
         assert state["total_records"] == 4
-        assert state["record_reviews"][0] == {"hitl_status": "approved", "user_comment": ""}
+        entry = state["record_reviews"][0]
+        assert entry["hitl_status"] == "approved"
+        assert entry["user_comment"] == ""
+        assert entry["reviewer_id"] == "rev-1"
+        assert entry["staged_at"].endswith("Z")
         assert state["record_reviews"][1] is None
         assert "last_updated" in state
 
@@ -60,19 +69,31 @@ class TestStateFileCreation:
             client,
             "/api/review-record",
             server,
-            json={"index": 0, "hitl_status": "approved", "user_comment": ""},
+            json={
+                "index": 0,
+                "hitl_status": "approved",
+                "user_comment": "",
+                "reviewer_id": "rev-1",
+            },
         )
         _post(
             client,
             "/api/review-record",
             server,
-            json={"index": 2, "hitl_status": "rejected", "user_comment": "bad"},
+            json={
+                "index": 2,
+                "hitl_status": "rejected",
+                "user_comment": "bad",
+                "reviewer_id": "rev-1",
+            },
         )
 
         state = json.loads(state_file.read_text())
-        assert state["record_reviews"][0] == {"hitl_status": "approved", "user_comment": ""}
+        assert state["record_reviews"][0]["hitl_status"] == "approved"
+        assert state["record_reviews"][0]["user_comment"] == ""
         assert state["record_reviews"][1] is None
-        assert state["record_reviews"][2] == {"hitl_status": "rejected", "user_comment": "bad"}
+        assert state["record_reviews"][2]["hitl_status"] == "rejected"
+        assert state["record_reviews"][2]["user_comment"] == "bad"
         assert state["record_reviews"][3] is None
 
 
@@ -212,7 +233,12 @@ class TestStateDeletion:
                 client,
                 "/api/review-record",
                 server,
-                json={"index": i, "hitl_status": "approved", "user_comment": ""},
+                json={
+                    "index": i,
+                    "hitl_status": "approved",
+                    "user_comment": "",
+                    "reviewer_id": "rev-1",
+                },
             )
         assert state_file.exists()
 
@@ -238,7 +264,12 @@ class TestStateDeletion:
             client,
             "/api/review-record",
             server,
-            json={"index": 0, "hitl_status": "approved", "user_comment": ""},
+            json={
+                "index": 0,
+                "hitl_status": "approved",
+                "user_comment": "",
+                "reviewer_id": "rev-1",
+            },
         )
         assert state_file.exists()
 
@@ -264,7 +295,12 @@ class TestStateDeletion:
             client,
             "/api/review-record",
             server,
-            json={"index": 0, "hitl_status": "rejected", "user_comment": "no"},
+            json={
+                "index": 0,
+                "hitl_status": "rejected",
+                "user_comment": "no",
+                "reviewer_id": "rev-1",
+            },
         )
         assert state_file.exists()
 
@@ -287,7 +323,12 @@ class TestReviewRecordAfterSubmit:
                 client,
                 "/api/review-record",
                 server,
-                json={"index": i, "hitl_status": "approved", "user_comment": ""},
+                json={
+                    "index": i,
+                    "hitl_status": "approved",
+                    "user_comment": "",
+                    "reviewer_id": "rev-1",
+                },
             )
         _post(client, "/api/submit", server, json={})
         assert not state_file.exists()
@@ -297,7 +338,12 @@ class TestReviewRecordAfterSubmit:
             client,
             "/api/review-record",
             server,
-            json={"index": 0, "hitl_status": "rejected", "user_comment": "late"},
+            json={
+                "index": 0,
+                "hitl_status": "rejected",
+                "user_comment": "late",
+                "reviewer_id": "rev-1",
+            },
         )
         assert resp.status_code == 409
         assert not state_file.exists()
@@ -315,13 +361,23 @@ class TestStateTimeout:
             client,
             "/api/review-record",
             server,
-            json={"index": 0, "hitl_status": "approved", "user_comment": ""},
+            json={
+                "index": 0,
+                "hitl_status": "approved",
+                "user_comment": "",
+                "reviewer_id": "rev-1",
+            },
         )
         _post(
             client,
             "/api/review-record",
             server,
-            json={"index": 1, "hitl_status": "rejected", "user_comment": "fix"},
+            json={
+                "index": 1,
+                "hitl_status": "rejected",
+                "user_comment": "fix",
+                "reviewer_id": "rev-1",
+            },
         )
         assert state_file.exists()
 
@@ -353,7 +409,12 @@ class TestNoStateFile:
             client,
             "/api/review-record",
             server,
-            json={"index": 0, "hitl_status": "approved", "user_comment": ""},
+            json={
+                "index": 0,
+                "hitl_status": "approved",
+                "user_comment": "",
+                "reviewer_id": "rev-1",
+            },
         )
         assert resp.status_code == 200
         # No crash, no state file created


### PR DESCRIPTION
# VIOL-0098 — 409 on `/api/review-record` to stop silent reviewer overwrite

**Root cause:** `_handle_review_record` wrote `record_reviews[raw_index] = normalized_review`
unconditionally, with no reviewer identity on staged entries — so a second reviewer sharing the
HITL URL silently clobbered the first reviewer's decision.

**Fix:** Stamp each staged decision with a `reviewer_id` (per-browser localStorage UUID) + `staged_at`,
and return **409** (naming the prior `reviewer_id`/`staged_at`) when a *different* reviewer POSTs for
an already-staged record. Same reviewer may still overwrite (change-of-mind). `reviewer_id` is required
(400 if missing — fail-closed). Reused the existing `_utc_timestamp()` helper; `_persist_state` carries
the new fields automatically (JSON snapshot, no schema migration).

**Files changed:**
- `agent_actions/llm/providers/hitl/server.py` — reviewer_id required + stamp + 409 conflict check
- `agent_actions/llm/providers/hitl/templates/approval.html` — generate/send per-browser UUID; surface 409 message *(not in ownership row — see below)*
- `tests/unit/test_hitl_review_record_conflict.py` — new regression suite
- `tests/unit/test_hitl_server.py`, `tests/unit/test_hitl_state_persistence.py` — reconciled 10 will-go-red tests (send `reviewer_id`)

**Tests added (6, in the new file):**
- `test_second_reviewer_gets_409` — different reviewer → 409 naming prior reviewer + staged_at
- `test_conflict_does_not_overwrite_prior_decision` — the core security property (prior decision survives)
- `test_same_reviewer_can_overwrite` — change-of-mind preserved (200)
- `test_different_records_by_different_reviewers_do_not_conflict` — conflict is per record index
- `test_review_record_requires_reviewer_id` — missing discriminator fails closed (400)
- `test_staged_entry_records_reviewer_and_timestamp` — reviewer_id/staged_at round-trip

**Verify:** `pytest` full suite **7793 passed**; HITL suites **98 passed**. `ruff check` / `ruff format --check`
clean on all changed files. (Pre-existing `examples/` lint debt untouched — not my files.)

**Cross-clone issue filed:** `approval.html` is required by the spec (Task 2) but absent from my
`ownership.md` row; it is unowned by any other worktree and inside my own HITL package. Without the JS
change the now-required `reviewer_id` would 400 every real POST and break the live UI, so the edit is
mandatory, not cosmetic. Logged in `../../coordination/status.md` Cross-Clone Issues.

**No blockers.** RED→GREEN confirmed; sibling write sites (approve/reject/submit/load) checked — they are
terminal single-decision paths, not concurrent staging, so they do not share the bug.
