### PR TITLE
fix(VIOL-0104): FILE-mode on_empty=error carries source_guids in context

### DIFF
--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -84,6 +84,9 @@ class FileToolStrategy:
                         context={
                             "agent_name": context.agent_name,
                             "record_count": len(records),
+                            "source_guids": [
+                                r.get("source_guid") for r in records if r.get("source_guid")
+                            ],
                         },
                     )
 

--- a/tests/unit/workflow/test_file_tool_on_empty_parity.py
+++ b/tests/unit/workflow/test_file_tool_on_empty_parity.py
@@ -47,6 +47,7 @@ def test_on_empty_error_raises_empty_output_error():
 
     assert "my_file_tool" in str(exc_info.value)
     assert "on_empty=error" in str(exc_info.value)
+    assert exc_info.value.context["source_guids"] == ["sg-1", "sg-2"]
 
 
 def test_on_empty_skip_produces_empty_output_tombstones():


### PR DESCRIPTION
# VIOL-0104 — Summary

**Root cause:** The VIOL-0009 FILE-mode `on_empty=error` path raises a single `EmptyOutputError` whose context held only `record_count`, dropping the per-record `source_guid` attribution the old warn path emitted — an operator could see *how many* records triggered the abort but not *which*.

**Files changed:**
- `agent_actions/processing/strategies/file_tool.py` — added `"source_guids": [r.get("source_guid") for r in records if r.get("source_guid")]` to the `EmptyOutputError` context dict (kept `agent_name` and `record_count`).
- `tests/unit/workflow/test_file_tool_on_empty_parity.py` — tightened `test_on_empty_error_raises_empty_output_error` with `assert exc_info.value.context["source_guids"] == ["sg-1", "sg-2"]`.

**Tests added:**
- New assertion on `source_guids` in the existing error-path parity test (RED → GREEN confirmed: failed with `KeyError: 'source_guids'`, now passes).

**Verify output:**
- `pytest` — 7787 passed, 0 failed.
- `ruff check .` / `ruff format --check .` — clean on both changed files; the only failures are pre-existing issues in `examples/` (unmodified, out of scope, not in my ownership).

**Sibling sweep:** Only two `EmptyOutputError` raise sites exist. `online_llm.py:529` is record-scoped (one record at a time) and already carries its single `source_guid` — the correct analogue, not a lost-attribution sibling. No further instances to fix.

**Blockers / cross-clone issues:** None. `errors/base.py` (also owned) needed no change — `AgentActionsError.__init__` already accepts arbitrary context dicts.
