### PR TITLE
fix(VIOL-0107): document HITL failure contract; on_empty out of scope by design

### DIFF
--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -33,6 +33,15 @@ class HITLStrategy:
     Conforms to the ``ProcessingStrategy`` protocol so it can be used
     with ``UnifiedProcessor.process()``.  Enrichment is handled by the
     processor, not by this strategy.
+
+    Failure contract: HITL signals problems by raising, never by emitting
+    "empty output".  A timed-out review raises ``AgentActionsError`` (partial
+    reviews persist on disk for resume); a missing or malformed decision
+    payload raises ``ValueError``.  The ``on_empty`` config (warn|error|skip)
+    is deliberately not honored here — it governs generative actions whose
+    model may return no content (see ``FileToolStrategy`` and
+    ``OnlineLLMStrategy``), whereas a completed human review always yields a
+    decision payload.
     """
 
     def invoke(


### PR DESCRIPTION
# VIOL-0107 — HITL Strategy Empty-Output Story

**Type:** Decision-first ticket (Task 1 blocking). Resolved **(a) Out of scope by design.**

## Decision (one sentence)
`HITLStrategy` will NOT honor `on_empty` — HITL signals problems by raising
(`AgentActionsError` on timeout, `ValueError` on missing/malformed payload), not by
emitting "empty output", so wiring `on_empty` would be net-new behavior with no
coherent "empty human decision" semantics, not a VIOL-0009 parity fix.

## Root cause / why decision (a)
Verified against the checkout: HITL has no crash or silent-data-loss gap around empty
output (unlike VIOL-0009's cascade). `is_empty_response` only fires on `[]`/empty
`FileUDFResult`, and an empty HITL payload is already intercepted as `ValueError`
(hitl.py:106-110) before any `on_empty` check could run. `on_empty` models a
*generative* action producing no content; a completed human review always yields a
decision payload.

## Files changed
- `agent_actions/processing/strategies/hitl.py` — added a "Failure contract" paragraph
  to the `HITLStrategy` class docstring documenting the timeout/payload failure modes
  and the deliberate `on_empty` exclusion. Zero behavioral change.
- `specs/active/uat-audit/violations/VIOL-0107-*.md` (orchestration file, outside
  worktree git) — filled the Decision section with rationale + noted follow-ups.

## Tests added
- None. Decision (a) is a no-behavior-change design boundary; there is no RED→GREEN.
  The timeout failure mode is already regression-covered by
  `tests/unit/workflow/test_pipeline_hitl_file_mode.py::test_file_mode_hitl_timeout_raises_with_record_count`.
  (Adding malformed-payload `ValueError` coverage would touch an unowned test file — noted as follow-up.)

## Verify output
- `pytest` — 7787 passed (0 failed).
- `ruff check .` — owned file clean; 4 pre-existing errors remain in `examples/` (outside my diff).
- `ruff format --check .` — owned file clean; 2 pre-existing reformat candidates in `examples/` (outside my diff).

## Blockers / cross-clone issues
- None blocking. Two optional follow-ups noted in the spec Decision section (config-validation
  to reject `on_empty` on `kind=hitl`, and malformed-payload test coverage) — both touch files
  outside this worktree's ownership, so deferred rather than shoehorned in.
- Informs VIOL-0109: HITL is deliberately excluded from the future shared `_dispatch_on_empty`
  helper (helper scope = `FileToolStrategy` + `OnlineLLMStrategy` only).
