### PR TITLE
fix(VIOL-0015): tool actions get tool-aware on_empty=warn reason

### DIFF
--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -75,6 +75,11 @@ def _is_empty_output(response: Any) -> bool:
     return False
 
 
+def _empty_warn_reason(action_config: dict[str, Any], agent_name: str, source_guid: str) -> str:
+    """Reason text for the on_empty=warn branch."""
+    return f"Empty LLM response for record '{source_guid}'"
+
+
 def _create_item_context(
     base_context: ProcessingContext, index: int, item: Any
 ) -> ProcessingContext:
@@ -538,7 +543,9 @@ class OnlineLLMStrategy:
 
             if on_empty == "warn":
                 return ProcessingResult.failed(
-                    error=f"Empty LLM response for record '{source_guid}'",
+                    error=_empty_warn_reason(
+                        context.agent_config, context.agent_name, source_guid
+                    ),
                     source_guid=source_guid,
                     source_snapshot=source_snapshot,
                     input_record=input_record,

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -76,7 +76,14 @@ def _is_empty_output(response: Any) -> bool:
 
 
 def _empty_warn_reason(action_config: dict[str, Any], agent_name: str, source_guid: str) -> str:
-    """Reason text for the on_empty=warn branch."""
+    """Reason text for the on_empty=warn branch; tool-aware for tool actions.
+
+    A tool action is identified by either `kind` or `model_vendor` being
+    ``"tool"`` (the same signal that routed and executed it as a tool), so the
+    reason names the empty tool output rather than blaming the LLM.
+    """
+    if action_config.get("kind") == "tool" or action_config.get("model_vendor") == "tool":
+        return f"Tool '{agent_name}' returned an empty list of records for input {source_guid}"
     return f"Empty LLM response for record '{source_guid}'"
 
 
@@ -543,9 +550,7 @@ class OnlineLLMStrategy:
 
             if on_empty == "warn":
                 return ProcessingResult.failed(
-                    error=_empty_warn_reason(
-                        context.agent_config, context.agent_name, source_guid
-                    ),
+                    error=_empty_warn_reason(context.agent_config, context.agent_name, source_guid),
                     source_guid=source_guid,
                     source_snapshot=source_snapshot,
                     input_record=input_record,

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -11,7 +11,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any, cast
 
-from agent_actions.config.types import RunMode
+from agent_actions.config.types import ActionConfigDict, RunMode
 from agent_actions.errors import ConfigurationError, RecordContextError, SchemaValidationError
 from agent_actions.errors.operations import TemplateVariableError
 from agent_actions.errors.processing import EmptyOutputError
@@ -75,7 +75,9 @@ def _is_empty_output(response: Any) -> bool:
     return False
 
 
-def _empty_warn_reason(action_config: dict[str, Any], agent_name: str, source_guid: str) -> str:
+def _empty_warn_reason(
+    action_config: ActionConfigDict, agent_name: str, source_guid: str | None
+) -> str:
     """Reason text for the on_empty=warn branch; tool-aware for tool actions.
 
     A tool action is identified by either `kind` or `model_vendor` being

--- a/tests/unit/processing/test_online_empty_warn_reason.py
+++ b/tests/unit/processing/test_online_empty_warn_reason.py
@@ -5,11 +5,9 @@ from agent_actions.processing.strategies.online_llm import _empty_warn_reason
 
 
 def test_tool_action_by_kind_gets_tool_aware_reason():
-    reason = _empty_warn_reason(
-        {"kind": "tool", "name": "flatten_code", "on_empty": "warn"},
-        agent_name="flatten_code",
-        source_guid="rec-abc-123",
-    )
+    cfg = {"kind": "tool", "name": "flatten_code", "on_empty": "warn"}
+    assert "model_vendor" not in cfg  # isolate the kind path — no vendor marker present
+    reason = _empty_warn_reason(cfg, agent_name="flatten_code", source_guid="rec-abc-123")
     assert "Tool" in reason
     assert "empty list" in reason
     assert "rec-abc-123" in reason
@@ -19,11 +17,9 @@ def test_tool_action_by_kind_gets_tool_aware_reason():
 def test_tool_action_by_model_vendor_gets_tool_aware_reason():
     # A tool declared via model_vendor (kind left at its LLM default) is routed
     # and executed as a tool, so its empty-output reason must be tool-aware too.
-    reason = _empty_warn_reason(
-        {"model_vendor": "tool", "name": "flatten_code", "on_empty": "warn"},
-        agent_name="flatten_code",
-        source_guid="rec-v-9",
-    )
+    cfg = {"model_vendor": "tool", "name": "flatten_code", "on_empty": "warn"}
+    assert cfg.get("kind") != "tool"  # isolate the model_vendor path — kind is not the trigger
+    reason = _empty_warn_reason(cfg, agent_name="flatten_code", source_guid="rec-v-9")
     assert "Tool" in reason
     assert "empty list" in reason
     assert "rec-v-9" in reason

--- a/tests/unit/processing/test_online_empty_warn_reason.py
+++ b/tests/unit/processing/test_online_empty_warn_reason.py
@@ -1,0 +1,49 @@
+"""The on_empty=warn reason must be tool-aware for tool actions (declared by
+either `kind` or `model_vendor`) and keep the LLM wording for everything else."""
+
+from agent_actions.processing.strategies.online_llm import _empty_warn_reason
+
+
+def test_tool_action_by_kind_gets_tool_aware_reason():
+    reason = _empty_warn_reason(
+        {"kind": "tool", "name": "flatten_code", "on_empty": "warn"},
+        agent_name="flatten_code",
+        source_guid="rec-abc-123",
+    )
+    assert "Tool" in reason
+    assert "empty list" in reason
+    assert "rec-abc-123" in reason
+    assert "LLM response" not in reason
+
+
+def test_tool_action_by_model_vendor_gets_tool_aware_reason():
+    # A tool declared via model_vendor (kind left at its LLM default) is routed
+    # and executed as a tool, so its empty-output reason must be tool-aware too.
+    reason = _empty_warn_reason(
+        {"model_vendor": "tool", "name": "flatten_code", "on_empty": "warn"},
+        agent_name="flatten_code",
+        source_guid="rec-v-9",
+    )
+    assert "Tool" in reason
+    assert "empty list" in reason
+    assert "rec-v-9" in reason
+    assert "LLM response" not in reason
+
+
+def test_llm_action_keeps_existing_message():
+    reason = _empty_warn_reason(
+        {"kind": "llm", "name": "summarize", "on_empty": "warn"},
+        agent_name="summarize",
+        source_guid="rec-llm-1",
+    )
+    assert "Empty LLM response" in reason
+    assert "rec-llm-1" in reason
+
+
+def test_missing_kind_and_vendor_defaults_to_llm_wording():
+    reason = _empty_warn_reason(
+        {"name": "mystery", "on_empty": "warn"},
+        agent_name="mystery",
+        source_guid="rec-2",
+    )
+    assert "Empty LLM response" in reason


### PR DESCRIPTION
## Summary
- Record/online-mode **tool** actions that returned empty output were stamped `"Empty LLM response for record '<guid>'"` in `record_disposition.reason` — blaming the LLM for a tool's empty result. Root cause: the `on_empty == "warn"` branch in `OnlineLLMStrategy` (`online_llm.py`) hardcoded LLM vocabulary for *all* action kinds (no action-type check). Reachable because strategy selection is by **granularity**, not run mode: record-granularity tool actions (the default) route through `OnlineLLMStrategy`, not the already-correct FILE-mode `file_tool.py`.
- Extracted `_empty_warn_reason(action_config, agent_name, source_guid)` and dispatch on action type:
  - tool → `Tool '<name>' returned an empty list of records for input <guid>`
  - LLM / other → unchanged `Empty LLM response for record '<guid>'`
- Tool detection uses `kind == "tool"` **OR** `model_vendor == "tool"` — the same signal that routed/executed the action as a tool (`kind:tool` is normalized to `model_vendor:tool` at config load, and `model_vendor:tool` can also be set directly). A `kind`-only check would miss the latter.
- Scope: the `warn` branch only. The `error` branch (already action-agnostic) and `skip` branch (uses the `EMPTY_OUTPUT` slug) are untouched; `file_tool.py` is untouched (its FILE-mode message is already tool-aware).

## Verification
- New `tests/unit/processing/test_online_empty_warn_reason.py`, written RED→GREEN: tool-by-`kind` and tool-by-`model_vendor` get the tool message and must not say "LLM response"; LLM and kind/vendor-less actions keep the historical wording.
- Full `tests/unit/processing/` suite: **408 passed**, no regression. The two pre-existing `"Empty LLM response"` assertions are non-tool actions and stay green.
- `ruff check` and `ruff format --check` clean on both changed files.