### PR TITLE
fix(VIOL-0034): cascade-skip instead of crashing when all version branches filtered

### DIFF
--- a/agent_actions/record/reasons.py
+++ b/agent_actions/record/reasons.py
@@ -19,6 +19,7 @@ LLM_LAYER_GUARD_FILTER = "llm_layer_guard_filter"
 # -- Cascade / upstream ------------------------------------------------------
 UPSTREAM_UNPROCESSED = "upstream_unprocessed"
 OBSERVE_FIELD_MISSING = "observe_field_missing"
+ALL_VERSIONS_FILTERED = "all_versions_filtered"
 
 # -- Prep failures -----------------------------------------------------------
 PREP_FAILED = "prep_failed"

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -20,7 +20,7 @@ from agent_actions.logging.events import (
     BatchCompleteEvent,
     BatchSubmittedEvent,
 )
-from agent_actions.record.reasons import GUARD_FILTERED_ALL
+from agent_actions.record.reasons import ALL_VERSIONS_FILTERED, GUARD_FILTERED_ALL
 from agent_actions.storage.backend import (
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
@@ -32,6 +32,7 @@ from agent_actions.storage.backend import (
 )
 from agent_actions.tooling.docs.run_tracker import ActionCompleteConfig
 from agent_actions.utils.constants import DEFAULT_ACTION_KIND
+from agent_actions.workflow.managers.output import AllVersionsFilteredError
 from agent_actions.workflow.managers.state import COMPLETED_STATUSES, ActionStatus
 
 logger = logging.getLogger(__name__)
@@ -549,6 +550,59 @@ class ActionExecutor:
         return ActionExecutionResult(
             success=True,
             output_folder=output_folder,
+            status=ActionStatus.SKIPPED,
+            metrics=ExecutionMetrics(duration=duration),
+        )
+
+    def _handle_all_versions_filtered(
+        self, params: ActionRunParams, avf: AllVersionsFilteredError
+    ) -> ActionExecutionResult:
+        """Cascade-skip a version-consumption action whose every branch was filtered.
+
+        All version sources produced no output, so there is nothing to merge.
+        Resolve the action as SKIPPED with reason=all_versions_filtered and let
+        the pipeline continue instead of crashing.
+        """
+        duration = (datetime.now() - params.start_time).total_seconds()
+        self.deps.state_manager.update_status(
+            params.action_name,
+            ActionStatus.SKIPPED,
+            execution_time=duration,
+            skip_reason=ALL_VERSIONS_FILTERED,
+        )
+        storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
+        if storage_backend is not None:
+            storage_backend.set_disposition(
+                params.action_name,
+                NODE_LEVEL_RECORD_ID,
+                DISPOSITION_SKIPPED,
+                reason=ALL_VERSIONS_FILTERED,
+                detail=f"All version sources filtered: {avf.version_sources}",
+            )
+        total_actions = (
+            len(self.deps.action_runner.execution_order)
+            if hasattr(self.deps.action_runner, "execution_order")
+            else 0
+        )
+        fire_event(
+            ActionSkipEvent(
+                action_name=params.action_name,
+                action_index=params.action_idx,
+                total_actions=total_actions,
+                skip_reason=ALL_VERSIONS_FILTERED,
+                mode=params.action_config.get("run_mode", ""),
+            )
+        )
+        self._track_action_complete(
+            params.action_name, duration, ActionStatus.SKIPPED, skip_reason=ALL_VERSIONS_FILTERED
+        )
+        logger.warning(
+            "All version sources filtered for '%s' (%s) — cascade-skipping; no output produced.",
+            params.action_name,
+            avf.version_sources,
+        )
+        return ActionExecutionResult(
+            success=True,
             status=ActionStatus.SKIPPED,
             metrics=ExecutionMetrics(duration=duration),
         )
@@ -1142,7 +1196,10 @@ class ActionExecutor:
         """Execute action run (synchronous)."""
         self.deps.state_manager.update_status(params.action_name, ActionStatus.RUNNING)
         self._track_action_start(params)
-        correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
+        try:
+            correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
+        except AllVersionsFilteredError as avf:
+            return self._handle_all_versions_filtered(params, avf)
 
         # Snapshot must surface storage errors loudly (no silent 0 fallback).
         # Both pre-run and post-run snapshots are intentionally OUTSIDE the
@@ -1174,7 +1231,10 @@ class ActionExecutor:
         """Execute action run (asynchronous)."""
         self.deps.state_manager.update_status(params.action_name, ActionStatus.RUNNING)
         self._track_action_start(params)
-        correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
+        try:
+            correlated_input = self.deps.output_manager.resolve_correlated_input(params.action_idx)
+        except AllVersionsFilteredError as avf:
+            return self._handle_all_versions_filtered(params, avf)
 
         # See sync counterpart for the rationale on snapshot placement.
         pre_run_count = self._count_records_for_action(params.action_name)

--- a/agent_actions/workflow/executor.py
+++ b/agent_actions/workflow/executor.py
@@ -570,15 +570,11 @@ class ActionExecutor:
             execution_time=duration,
             skip_reason=ALL_VERSIONS_FILTERED,
         )
-        storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
-        if storage_backend is not None:
-            storage_backend.set_disposition(
-                params.action_name,
-                NODE_LEVEL_RECORD_ID,
-                DISPOSITION_SKIPPED,
-                reason=ALL_VERSIONS_FILTERED,
-                detail=f"All version sources filtered: {avf.version_sources}",
-            )
+        self._write_skipped_disposition(
+            params.action_name,
+            ALL_VERSIONS_FILTERED,
+            detail=f"All version sources filtered: {avf.version_sources}",
+        )
         total_actions = (
             len(self.deps.action_runner.execution_order)
             if hasattr(self.deps.action_runner, "execution_order")
@@ -683,7 +679,9 @@ class ActionExecutor:
                     disp_err,
                 )
 
-    def _write_skipped_disposition(self, action_name: str, reason: str) -> None:
+    def _write_skipped_disposition(
+        self, action_name: str, reason: str, *, detail: str | None = None
+    ) -> None:
         """Write DISPOSITION_SKIPPED to storage so downstream and future runs detect the skip."""
         storage_backend = getattr(self.deps.action_runner, "storage_backend", None)
         if storage_backend is not None:
@@ -693,6 +691,7 @@ class ActionExecutor:
                     record_id=NODE_LEVEL_RECORD_ID,
                     disposition=DISPOSITION_SKIPPED,
                     reason=reason[:500],
+                    detail=detail[:500] if detail is not None else None,
                 )
             except Exception as disp_err:
                 logger.warning(

--- a/agent_actions/workflow/managers/output.py
+++ b/agent_actions/workflow/managers/output.py
@@ -23,6 +23,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class AllVersionsFilteredError(RuntimeError):
+    """Every version source of a version-consumption action produced no output.
+
+    Raised by ``resolve_correlated_input`` when all version branches were
+    filtered out (nothing to correlate), so the caller can cascade-skip the
+    action instead of raising a hard ``ConfigurationError``.
+    """
+
+    def __init__(self, action_name: str, version_sources: list[str]) -> None:
+        self.action_name = action_name
+        self.version_sources = version_sources
+        super().__init__(
+            f"All version sources filtered for '{action_name}': {version_sources}. "
+            "Nothing to correlate; cascade-skip with reason=all_versions_filtered."
+        )
+
+
 @dataclass
 class OutputManagerConfig:
     """Configuration for ActionOutputManager."""

--- a/agent_actions/workflow/managers/output.py
+++ b/agent_actions/workflow/managers/output.py
@@ -214,7 +214,14 @@ class ActionOutputManager:
             )
             return [str(correlated_dir)]
 
-        from agent_actions.errors import ConfigurationError
+        # No correlated dir. Distinguish all-sources-empty (every version branch
+        # produced no output — e.g. all guard-filtered) from a genuine correlation
+        # failure (some source had output but correlation still failed).
+        all_sources_empty = all(
+            not self.storage_backend.list_target_files(src) for src in version_sources
+        )
+        if all_sources_empty:
+            raise AllVersionsFilteredError(current_agent, version_sources)
 
         raise ConfigurationError(
             f"Version correlation failed for '{current_agent}'. "

--- a/tests/core/graph/test_version_correlator.py
+++ b/tests/core/graph/test_version_correlator.py
@@ -680,8 +680,10 @@ class TestVersionCorrelationFailureError:
             )
             output_manager = AgentOutputManager(config)
 
-            # Resolve correlated input for consumer (idx=2) — no version
-            # outputs exist so this should raise ConfigurationError
+            # Resolve correlated input for consumer (idx=2). The mock storage
+            # backend reports version-source outputs (truthy list_target_files),
+            # so this is the genuine correlation-failure path → ConfigurationError.
+            # (The all-sources-empty path raises AllVersionsFilteredError instead.)
             with pytest.raises(ConfigurationError) as exc_info:
                 output_manager.resolve_correlated_input(idx=2)
 

--- a/tests/unit/workflow/managers/test_resolve_correlated_input_all_filtered.py
+++ b/tests/unit/workflow/managers/test_resolve_correlated_input_all_filtered.py
@@ -6,6 +6,7 @@ When every version source of a version-consumption action produced no output,
 pipeline continues instead of exiting non-zero.
 """
 
+import asyncio
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -13,6 +14,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent_actions.errors import ConfigurationError
+from agent_actions.record.reasons import ALL_VERSIONS_FILTERED
+from agent_actions.storage.backend import DISPOSITION_SKIPPED, NODE_LEVEL_RECORD_ID
 from agent_actions.workflow.managers.output import (
     ActionOutputManager,
     AllVersionsFilteredError,
@@ -58,7 +61,7 @@ def test_some_source_has_output_raises_configuration_error():
         mgr.resolve_correlated_input(2)
 
 
-def test_executor_cascade_skips_instead_of_crashing():
+def _make_executor(version_sources: list[str]):
     from agent_actions.workflow.executor import (
         ActionExecutor,
         ActionRunParams,
@@ -73,19 +76,52 @@ def test_executor_cascade_skips_instead_of_crashing():
         output_manager=MagicMock(),
     )
     deps.output_manager.resolve_correlated_input.side_effect = AllVersionsFilteredError(
-        "consumer", ["v1", "v2"]
+        "consumer", version_sources
     )
-    deps.action_runner.execution_order = ["v1", "v2", "consumer"]
+    deps.action_runner.execution_order = [*version_sources, "consumer"]
     executor = ActionExecutor(deps, console=MagicMock())
     params = ActionRunParams(
         action_name="consumer",
-        action_idx=2,
+        action_idx=len(version_sources),
         action_config={},
         is_last_action=True,
         start_time=datetime.now(),
     )
+    return executor, params, deps
 
+
+def test_executor_cascade_skips_instead_of_crashing():
+    executor, params, _ = _make_executor(["v1", "v2"])
     result = executor._execute_action_run(params)  # must NOT raise
+    assert result.status == ActionStatus.SKIPPED
+    assert result.success is True
 
+
+def test_executor_writes_node_level_skip_disposition():
+    executor, params, deps = _make_executor(["v1", "v2"])
+    executor._execute_action_run(params)
+    set_disposition = deps.action_runner.storage_backend.set_disposition
+    set_disposition.assert_called_once()
+    kwargs = set_disposition.call_args.kwargs
+    assert kwargs["record_id"] == NODE_LEVEL_RECORD_ID
+    assert kwargs["disposition"] == DISPOSITION_SKIPPED
+    assert kwargs["reason"] == ALL_VERSIONS_FILTERED
+    assert "v1" in kwargs["detail"]
+    assert "v2" in kwargs["detail"]
+
+
+def test_executor_cascade_skip_survives_disposition_write_error():
+    """A storage error while recording the skip must not re-crash the cascade-skip path."""
+    executor, params, deps = _make_executor(["v1", "v2"])
+    deps.action_runner.storage_backend.set_disposition.side_effect = RuntimeError("db locked")
+    result = executor._execute_action_run(params)  # must NOT raise
+    assert result.status == ActionStatus.SKIPPED
+    assert result.success is True
+
+
+def test_executor_async_cascade_skip_survives_disposition_write_error():
+    executor, params, deps = _make_executor(["v1", "v2"])
+    deps.action_runner.storage_backend.set_disposition.side_effect = RuntimeError("db locked")
+    result = asyncio.run(executor._execute_action_run_async(params))  # must NOT raise
     assert result.status == ActionStatus.SKIPPED
     assert result.success is True

--- a/tests/unit/workflow/managers/test_resolve_correlated_input_all_filtered.py
+++ b/tests/unit/workflow/managers/test_resolve_correlated_input_all_filtered.py
@@ -1,0 +1,91 @@
+"""All version branches filtered must cascade-skip, not crash.
+
+When every version source of a version-consumption action produced no output,
+``resolve_correlated_input`` raises ``AllVersionsFilteredError`` (not
+``ConfigurationError``) and the executor resolves the action as SKIPPED so the
+pipeline continues instead of exiting non-zero.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.workflow.managers.output import (
+    ActionOutputManager,
+    AllVersionsFilteredError,
+    OutputManagerConfig,
+)
+from agent_actions.workflow.managers.state import ActionStatus
+
+
+def _make_manager(version_sources: list[str], storage_backend: MagicMock) -> ActionOutputManager:
+    correlator = MagicMock()
+    correlator.detect_explicit_version_consumption.return_value = {
+        "consumer": {"version_agents": version_sources, "pattern": "merge"}
+    }
+    correlator.prepare_correlated_input.return_value = None  # nothing correlated
+    config = OutputManagerConfig(
+        agent_folder=Path("."),
+        execution_order=[*version_sources, "consumer"],
+        action_configs={},
+        action_status={},
+        version_correlator=correlator,
+        console=MagicMock(),
+        storage_backend=storage_backend,
+    )
+    return ActionOutputManager(config)
+
+
+def test_all_sources_empty_raises_all_versions_filtered_error():
+    backend = MagicMock()
+    backend.list_target_files.return_value = []  # every version source empty
+    mgr = _make_manager(["v1", "v2"], backend)
+    with pytest.raises(AllVersionsFilteredError) as exc:
+        mgr.resolve_correlated_input(2)  # idx of "consumer"
+    assert "consumer" in str(exc.value)
+    assert exc.value.version_sources == ["v1", "v2"]
+
+
+def test_some_source_has_output_raises_configuration_error():
+    """A source produced output but correlation still failed → keep the loud error."""
+    backend = MagicMock()
+    backend.list_target_files.side_effect = lambda a: ["out.json"] if a == "v1" else []
+    mgr = _make_manager(["v1", "v2"], backend)
+    with pytest.raises(ConfigurationError):
+        mgr.resolve_correlated_input(2)
+
+
+def test_executor_cascade_skips_instead_of_crashing():
+    from agent_actions.workflow.executor import (
+        ActionExecutor,
+        ActionRunParams,
+        ExecutorDependencies,
+    )
+
+    deps = ExecutorDependencies(
+        action_runner=MagicMock(),
+        state_manager=MagicMock(),
+        skip_evaluator=MagicMock(),
+        batch_manager=MagicMock(),
+        output_manager=MagicMock(),
+    )
+    deps.output_manager.resolve_correlated_input.side_effect = AllVersionsFilteredError(
+        "consumer", ["v1", "v2"]
+    )
+    deps.action_runner.execution_order = ["v1", "v2", "consumer"]
+    executor = ActionExecutor(deps, console=MagicMock())
+    params = ActionRunParams(
+        action_name="consumer",
+        action_idx=2,
+        action_config={},
+        is_last_action=True,
+        start_time=datetime.now(),
+    )
+
+    result = executor._execute_action_run(params)  # must NOT raise
+
+    assert result.status == ActionStatus.SKIPPED
+    assert result.success is True

--- a/tests/unit/workflow/test_circuit_breaker.py
+++ b/tests/unit/workflow/test_circuit_breaker.py
@@ -403,6 +403,7 @@ class TestWriteSkippedDisposition:
             record_id=NODE_LEVEL_RECORD_ID,
             disposition=DISPOSITION_SKIPPED,
             reason="Upstream failed",
+            detail=None,
         )
 
     def test_logs_warning_on_storage_error(self, executor, mock_deps, caplog):


### PR DESCRIPTION
## Summary
- A `version_consumption: merge` action whose every version branch was guard-filtered **crashed the pipeline** with `ConfigurationError: Version correlation failed` (exit 1). All-branches-filtered is a legitimate low-density input shape, not a misconfiguration. Root cause: `resolve_correlated_input` (`workflow/managers/output.py`) raised unconditionally whenever correlation returned nothing, and the executor called it **uncaught** (`_execute_action_run`, `executor.py:1145`, outside the try/except).
- `resolve_correlated_input` now distinguishes **all-sources-empty** (every version source has no target files) → raises the typed `AllVersionsFilteredError` — from a **genuine correlation failure** (some source had output) → still raises `ConfigurationError`.
- The executor catches `AllVersionsFilteredError` at both action-run sites (sync + async) and resolves the action as **SKIPPED** (`reason=all_versions_filtered`, node-level disposition), mirroring the existing `_handle_all_guard_filtered` "produced nothing → SKIPPED" pattern — so the pipeline exits 0. Downstream consumers then cascade-skip via the normal mechanism.

## Verification
- New `tests/unit/workflow/managers/test_resolve_correlated_input_all_filtered.py`, RED→GREEN:
  - all sources empty → `AllVersionsFilteredError`
  - some source has output → `ConfigurationError` (genuine failure preserved)
  - executor `_execute_action_run` cascade-skips (SKIPPED, no raise) instead of propagating — pins the actual crash path, not just the isolated raise
- Existing `test_version_correlation_failure_raises_error` comment corrected: its mock storage reports outputs, so it exercises the genuine-error `ConfigurationError` path; still green.
- Blast radius: `tests/unit/workflow/` + `tests/core/graph/` → **826 passed**. `ruff check`/`format` clean; `uv run mypy agent_actions` → no issues (447 files).