### PR TITLE
fix(VIOL-0088): trace records model_name across all run modes

### DIFF
--- a/agent_actions/processing/task_preparer.py
+++ b/agent_actions/processing/task_preparer.py
@@ -126,7 +126,8 @@ class TaskPreparer:
                 record_id=prepared.target_id,
                 compiled_prompt=prepared.formatted_prompt,
                 llm_context=json.dumps(prepared.llm_context, ensure_ascii=False, default=str),
-                model_name=context.agent_config.get("model"),
+                model_name=context.agent_config.get("model_name")
+                or context.agent_config.get("model"),
                 model_vendor=context.agent_config.get("model_vendor"),
                 run_mode=context.mode.value if context.mode else None,
             )

--- a/tests/unit/processing/test_prompt_trace_model_name.py
+++ b/tests/unit/processing/test_prompt_trace_model_name.py
@@ -1,0 +1,58 @@
+"""The prompt trace must record the action's model name for every run mode."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_actions.config.types import RunMode
+from agent_actions.input.preprocessing.filtering.evaluator import GuardResult
+from agent_actions.processing.prepared_task import PreparationContext
+from agent_actions.processing.task_preparer import TaskPreparer
+
+
+def _context(mode: RunMode) -> MagicMock:
+    ctx = MagicMock(spec=PreparationContext)
+    ctx.agent_name = "score"
+    ctx.agent_config = {"model_name": "gpt-4o-mini", "model_vendor": "openai"}
+    ctx.mode = mode
+    ctx.is_first_stage = False
+    ctx.source_data = None
+    ctx.agent_indices = None
+    ctx.dependency_configs = None
+    ctx.workflow_metadata = None
+    ctx.version_context = None
+    ctx.file_path = None
+    ctx.output_directory = None
+    ctx.storage_backend = MagicMock()
+    ctx.current_item = None
+    ctx.record_index = 0
+    return ctx
+
+
+@pytest.mark.parametrize("mode", [RunMode.ONLINE, RunMode.BATCH])
+def test_prompt_trace_persists_model_name_for_both_modes(mode):
+    preparer = TaskPreparer()
+    ctx = _context(mode)
+    item = {"content": {"quality_score": 0.9}, "source_guid": "sg-1"}
+    with (
+        patch.object(preparer, "_normalize_input", return_value=(item, "sg-1", item)),
+        patch.object(preparer, "_load_full_context", return_value={"quality_score": 0.9}),
+        patch.object(preparer, "_evaluate_guard", return_value=GuardResult.warned()),
+        patch.object(
+            preparer,
+            "_render_prompt",
+            return_value=MagicMock(
+                formatted_prompt="p", llm_context={}, passthrough_fields={}, prompt_context={}
+            ),
+        ),
+    ):
+        preparer.prepare(item, ctx)
+
+    ctx.storage_backend.write_prompt_trace.assert_called_once()
+    kwargs = ctx.storage_backend.write_prompt_trace.call_args.kwargs
+    assert kwargs["model_name"] == "gpt-4o-mini", (
+        f"model_name not persisted: {kwargs['model_name']!r}"
+    )
+    assert kwargs["model_vendor"] == "openai"

--- a/tests/unit/processing/test_prompt_trace_model_name.py
+++ b/tests/unit/processing/test_prompt_trace_model_name.py
@@ -12,10 +12,12 @@ from agent_actions.processing.prepared_task import PreparationContext
 from agent_actions.processing.task_preparer import TaskPreparer
 
 
-def _context(mode: RunMode) -> MagicMock:
+def _context(mode: RunMode, agent_config: dict | None = None) -> MagicMock:
     ctx = MagicMock(spec=PreparationContext)
     ctx.agent_name = "score"
-    ctx.agent_config = {"model_name": "gpt-4o-mini", "model_vendor": "openai"}
+    if agent_config is None:
+        agent_config = {"model_name": "gpt-4o-mini", "model_vendor": "openai"}
+    ctx.agent_config = agent_config
     ctx.mode = mode
     ctx.is_first_stage = False
     ctx.source_data = None
@@ -31,11 +33,7 @@ def _context(mode: RunMode) -> MagicMock:
     return ctx
 
 
-@pytest.mark.parametrize("mode", [RunMode.ONLINE, RunMode.BATCH])
-def test_prompt_trace_persists_model_name_for_both_modes(mode):
-    preparer = TaskPreparer()
-    ctx = _context(mode)
-    item = {"content": {"quality_score": 0.9}, "source_guid": "sg-1"}
+def _prepare_and_get_trace_kwargs(preparer: TaskPreparer, ctx: MagicMock, item: dict) -> dict:
     with (
         patch.object(preparer, "_normalize_input", return_value=(item, "sg-1", item)),
         patch.object(preparer, "_load_full_context", return_value={"quality_score": 0.9}),
@@ -51,8 +49,26 @@ def test_prompt_trace_persists_model_name_for_both_modes(mode):
         preparer.prepare(item, ctx)
 
     ctx.storage_backend.write_prompt_trace.assert_called_once()
-    kwargs = ctx.storage_backend.write_prompt_trace.call_args.kwargs
+    return ctx.storage_backend.write_prompt_trace.call_args.kwargs
+
+
+@pytest.mark.parametrize("mode", [RunMode.ONLINE, RunMode.BATCH])
+def test_prompt_trace_persists_model_name_for_both_modes(mode):
+    preparer = TaskPreparer()
+    ctx = _context(mode)
+    item = {"content": {"quality_score": 0.9}, "source_guid": "sg-1"}
+    kwargs = _prepare_and_get_trace_kwargs(preparer, ctx, item)
     assert kwargs["model_name"] == "gpt-4o-mini", (
         f"model_name not persisted: {kwargs['model_name']!r}"
     )
     assert kwargs["model_vendor"] == "openai"
+
+
+def test_prompt_trace_falls_back_to_model_alias_when_model_name_absent():
+    preparer = TaskPreparer()
+    ctx = _context(RunMode.ONLINE, agent_config={"model": "gpt-4o-mini", "model_vendor": "openai"})
+    item = {"content": {"quality_score": 0.9}, "source_guid": "sg-1"}
+    kwargs = _prepare_and_get_trace_kwargs(preparer, ctx, item)
+    assert kwargs["model_name"] == "gpt-4o-mini", (
+        f"model alias not used as model_name fallback: {kwargs['model_name']!r}"
+    )


### PR DESCRIPTION
## Summary
- The prompt-trace write in `TaskPreparer.prepare()` read `context.agent_config.get("model")`, but `AgentConfig`'s field is `model_name`. The key `model` does not exist in the runtime config dict, so `model_name` was persisted NULL on every prompt-trace row.
- `write_prompt_trace` has a single caller shared by both run modes (online via the online LLM strategy, batch via the batch preparator), so the NULL affected online and batch equally — not a batch-only defect.
- Fix reads the correct key with a fallback to the legacy `model` alias: `agent_config.get("model_name") or agent_config.get("model")`, mirroring the existing model accessor used elsewhere. `model_vendor` on the adjacent line already used the correct key and is unchanged.
- Restores the ability to reconstruct per-model cost from the trace table alone.

## Verification
- Added `tests/unit/processing/test_prompt_trace_model_name.py`: drives the real `TaskPreparer.prepare()` parametrized over both run modes and asserts `write_prompt_trace` receives the action's `model_name` (and that `model_vendor` stays populated).
- RED (before fix): both modes failed with `model_name not persisted: None`.
- GREEN (after fix): both modes pass.
- Regression surface: `tests/unit/processing/` + `tests/unit/storage/` = 606 passed; `tests/unit/llm/batch/` + `tests/unit/prompt/test_renderer.py` = 234 passed.
- Lint: `ruff check agent_actions tests` clean; `ruff format --check` clean.

## Out of scope (noted, not fixed)
- `tests/unit/llm/batch/test_abandoned_records_context_map.py` fails at collection with a pre-existing circular import (`UnifiedProcessor` from `agent_actions.processing.unified`) when collected in isolation. Confirmed present on the unmodified source — unrelated to this change.