### PR TITLE
fix(VIOL-0111): fire empty-output event from file-mode tool

### DIFF
--- a/agent_actions/processing/strategies/file_tool.py
+++ b/agent_actions/processing/strategies/file_tool.py
@@ -8,6 +8,8 @@ from typing import Any, cast
 
 from agent_actions.errors import AgentActionsError
 from agent_actions.errors.processing import EmptyOutputError
+from agent_actions.logging.core.manager import fire_event
+from agent_actions.logging.events.data_pipeline_events import RecordEmptyOutputEvent
 from agent_actions.processing.helpers import run_dynamic_agent
 from agent_actions.processing.record_helpers import build_tombstone
 from agent_actions.processing.types import (
@@ -76,6 +78,17 @@ class FileToolStrategy:
 
             if is_empty_response(raw_response) and records:
                 on_empty = context.agent_config.get("on_empty", "warn")
+
+                fire_event(
+                    RecordEmptyOutputEvent(
+                        action_name=context.agent_name,
+                        record_index=-1,
+                        source_guid="",
+                        input_field_count=len(records),
+                        output=raw_response,
+                        on_empty=on_empty,
+                    )
+                )
 
                 if on_empty == "error":
                     raise EmptyOutputError(

--- a/tests/unit/workflow/test_file_tool_empty_output_event.py
+++ b/tests/unit/workflow/test_file_tool_empty_output_event.py
@@ -1,0 +1,90 @@
+"""FILE-mode empty output fires RecordEmptyOutputEvent, matching the online strategy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_actions.logging.core.events import BaseEvent
+from agent_actions.logging.core.manager import EventManager
+from agent_actions.logging.events.data_pipeline_events import RecordEmptyOutputEvent
+from agent_actions.processing.strategies.file_tool import FileToolStrategy
+from agent_actions.record.tracking import TrackedItem
+from tests.unit.workflow.test_file_tool_on_empty_parity import _make_context
+
+
+class _Spy:
+    def __init__(self) -> None:
+        self.events: list[BaseEvent] = []
+
+    def accepts(self, event: BaseEvent) -> bool:
+        return True
+
+    def handle(self, event: BaseEvent) -> None:
+        self.events.append(event)
+
+    def flush(self) -> None:
+        pass
+
+
+def _empties(spy: _Spy) -> list[RecordEmptyOutputEvent]:
+    return [e for e in spy.events if isinstance(e, RecordEmptyOutputEvent)]
+
+
+def _invoke_empty(on_empty: str, monkeypatch: Any) -> _Spy:
+    records = [{"content": {"a": 1}}, {"content": {"a": 2}}]
+    context = _make_context(on_empty)
+    context.source_data = records
+
+    monkeypatch.setattr(
+        "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+        lambda **kwargs: ([], True),
+    )
+
+    spy = _Spy()
+    manager = EventManager.get()
+    manager.register(spy)
+    try:
+        FileToolStrategy().invoke(records, context)
+    finally:
+        manager.unregister(spy)
+    return spy
+
+
+def test_file_mode_empty_output_fires_record_empty_output_event(monkeypatch):
+    spy = _invoke_empty("skip", monkeypatch)
+
+    empties = _empties(spy)
+    assert len(empties) == 1
+    assert empties[0].on_empty == "skip"
+    assert empties[0].input_field_count == 2
+    assert empties[0].record_index == -1
+    assert empties[0].action_name == "my_file_tool"
+
+
+def test_file_mode_empty_output_event_carries_on_empty_warn(monkeypatch):
+    spy = _invoke_empty("warn", monkeypatch)
+
+    empties = _empties(spy)
+    assert len(empties) == 1
+    assert empties[0].on_empty == "warn"
+
+
+def test_file_mode_non_empty_output_fires_no_empty_event(monkeypatch):
+    records = [{"source_guid": "sg-1", "content": {"a": 1}}]
+    context = _make_context("warn")
+    context.source_data = records
+
+    monkeypatch.setattr(
+        "agent_actions.processing.strategies.file_tool.run_dynamic_agent",
+        lambda **kwargs: ([TrackedItem({"a": 1}, source_index=0)], True),
+    )
+
+    spy = _Spy()
+    manager = EventManager.get()
+    manager.register(spy)
+    try:
+        FileToolStrategy().invoke(records, context)
+    finally:
+        manager.unregister(spy)
+
+    assert _empties(spy) == []


### PR DESCRIPTION
## Summary

The file-mode tool strategy handled the empty-output case (warn/skip/error dispatch) but never fired `RecordEmptyOutputEvent`. That event is the sole signal feeding `RunResultsHandler._handle_empty_output`, the only place `empty_output_records` is incremented. As a result, `run_results.json`'s `empty_output_records` stayed 0 for every FILE-mode action — warn, skip, and error empty outputs were all invisible to the diagnostic, while the online strategy counted them correctly.

Fix: fire `RecordEmptyOutputEvent` once, at the top of the empty branch, before the `on_empty` dispatch, so all three cases count. FILE-mode is batch-scoped (one event per empty file), so `record_index=-1` and `source_guid=""`; `input_field_count=len(records)` and `output=raw_response`. This mirrors the online strategy's existing fire. The event type and the handler are unchanged.

## Verification

- Added `tests/unit/workflow/test_file_tool_empty_output_event.py`: registers a spy handler on the real `EventManager` bus, drives `FileToolStrategy().invoke(...)` on an empty tool result, and asserts exactly one `RecordEmptyOutputEvent` fires with the expected fields.
- RED (before fix): `assert 0 == 1` — zero events fired (the bug), not a collection error.
- GREEN (after fix): 3 passed, including a guard test asserting the non-empty path fires no empty event (no double/spurious fire).
- Regression: `tests/unit/workflow/ tests/logging/events/test_handlers/ tests/processing/ tests/unit/processing/` — 1284 passed. The existing `on_empty` parity tests still pass (the fire is additive, before the unchanged dispatch).
- `ruff check` and `ruff format --check` clean.