### PR TITLE
fix(VIOL-0101): forbid unknown keys in version/retry/hitl config blocks

### DIFF
--- a/agent_actions/config/schema.py
+++ b/agent_actions/config/schema.py
@@ -55,6 +55,8 @@ class VersionMode(str, Enum):
 class VersionConfig(BaseModel):
     """Configuration for version-based actions."""
 
+    model_config = ConfigDict(extra="forbid")
+
     param: str = Field(default="i", description="Parameter name for version variable")
     range: list[int] = Field(  # noqa: A003 — shadows builtin; rename breaks YAML compat
         ..., description="Range of values for version parameter"
@@ -72,6 +74,8 @@ class MergePattern(str, Enum):
 class VersionConsumptionConfig(BaseModel):
     """Configuration for consuming version outputs."""
 
+    model_config = ConfigDict(extra="forbid")
+
     source: str = Field(..., description="Base name of the version action to consume")
     pattern: MergePattern = Field(
         default=MergePattern.MERGE, description="Pattern for merging version outputs"
@@ -80,6 +84,8 @@ class VersionConsumptionConfig(BaseModel):
 
 class RetryConfig(BaseModel):
     """Configuration for retry behavior on transport-layer failures."""
+
+    model_config = ConfigDict(extra="forbid")
 
     enabled: bool = Field(default=True, description="Whether retry is enabled")
     max_attempts: int = Field(
@@ -136,6 +142,8 @@ class RepromptConfig(BaseModel):
 
 class HitlConfig(BaseModel):
     """Configuration for Human-in-the-Loop actions."""
+
+    model_config = ConfigDict(extra="forbid")
 
     port: int = Field(
         default=3001,

--- a/tests/unit/config/test_nested_config_extra_forbid.py
+++ b/tests/unit/config/test_nested_config_extra_forbid.py
@@ -1,0 +1,42 @@
+"""Nested config blocks reject unknown keys instead of silently dropping them."""
+
+import pytest
+from pydantic import ValidationError
+
+from agent_actions.config.schema import (
+    HitlConfig,
+    RetryConfig,
+    VersionConfig,
+    VersionConsumptionConfig,
+)
+
+
+def test_retry_rejects_typo():
+    with pytest.raises(ValidationError) as excinfo:
+        RetryConfig(max_retires=3)
+    assert "max_retires" in str(excinfo.value)
+
+
+def test_version_rejects_typo():
+    with pytest.raises(ValidationError) as excinfo:
+        VersionConfig(parem="i", range=[0, 1, 2])
+    assert "parem" in str(excinfo.value)
+
+
+def test_version_consumption_rejects_typo():
+    with pytest.raises(ValidationError) as excinfo:
+        VersionConsumptionConfig(source="vote_quality", sorce="vote_quality")
+    assert "sorce" in str(excinfo.value)
+
+
+def test_hitl_rejects_typo():
+    with pytest.raises(ValidationError) as excinfo:
+        HitlConfig(instructions="Review", tiemout=600)
+    assert "tiemout" in str(excinfo.value)
+
+
+def test_valid_configs_still_parse():
+    assert RetryConfig(max_attempts=3).max_attempts == 3
+    assert VersionConfig(range=[0, 1, 2]).param == "i"
+    assert VersionConsumptionConfig(source="vote_quality").pattern.value == "merge"
+    assert HitlConfig(instructions="Review", timeout=600).timeout == 600


### PR DESCRIPTION
## Summary
Four nested Pydantic config blocks on the action config lacked `model_config = ConfigDict(extra="forbid")`. Pydantic does not propagate `extra` to nested model fields, so a typo'd key inside `version:`, `version_consumption:`, `retry:`, or `hitl:` was silently dropped — the field kept its default and the user got no error until a run failed, if ever.

Added `extra="forbid"` to the four classes so a typo now raises a `ValidationError` naming the key at parse time:
- `VersionConfig`
- `VersionConsumptionConfig`
- `RetryConfig`
- `HitlConfig`

This matches the sibling reprompt block, which already opts in.

Left untouched by design:
- The reprompt block and the action config already enforce `extra="forbid"`.
- `DefaultsConfig` keeps `extra="ignore"` deliberately (it passes vendor-specific keys through).
- The top-level workflow container is out of scope (it may legitimately carry pass-through keys; forbidding there needs its own decision).

## Verification
- New regression test `tests/unit/config/test_nested_config_extra_forbid.py`: RED before the fix (all four typo cases returned `DID NOT RAISE`), GREEN after (5 passed). The version-consumption case supplies the valid required `source` alongside the typo so the only possible error is the extra key — otherwise a missing-field error would echo the input and mask the bug.
- `tests/unit/config/` + `tests/unit/test_hitl_config.py`: 302 passed.
- Full suite: 7817 passed, 0 failures — no fixture relied on the silent-drop behavior.
- `ruff check` and `ruff format --check`: clean.