### PR TITLE
fix(VIOL-0064): raise on ambiguous agent-name folder match

### DIFF
--- a/agent_actions/errors/__init__.py
+++ b/agent_actions/errors/__init__.py
@@ -75,6 +75,7 @@ from agent_actions.errors.resources import (
 
 # Validation errors
 from agent_actions.errors.validation import (
+    AmbiguousAgentName,
     DataValidationError,
     PromptValidationError,
     SchemaValidationError,
@@ -102,6 +103,7 @@ __all__ = [
     "PromptValidationError",
     "DataValidationError",
     "SchemaValidationError",
+    "AmbiguousAgentName",
     # Processing
     "ProcessingError",
     "TransformationError",

--- a/agent_actions/errors/validation.py
+++ b/agent_actions/errors/validation.py
@@ -1,5 +1,6 @@
 """Validation-related errors."""
 
+from pathlib import Path
 from typing import Any
 
 from agent_actions.errors.base import AgentActionsError
@@ -10,6 +11,20 @@ class ValidationError(AgentActionsError):
     """Base exception for validation failures."""
 
     pass
+
+
+class AmbiguousAgentName(ValidationError):
+    """Multiple directories share the agent base name; the resolver refuses to guess."""
+
+    def __init__(self, agent_name: str, candidates: list[str]) -> None:
+        self.agent_name = agent_name
+        self.candidates = candidates
+        bullets = "\n  ".join(f"{c}  (workflow: {Path(c).parent.parent.name})" for c in candidates)
+        super().__init__(
+            f"Multiple workflows named '{agent_name}' found:\n  {bullets}\n"
+            "Disambiguate by reorganizing so the base name is unique.",
+            context={"agent_name": agent_name, "candidates": candidates},
+        )
 
 
 class PromptValidationError(ValidationError):

--- a/agent_actions/utils/file_handler.py
+++ b/agent_actions/utils/file_handler.py
@@ -33,12 +33,28 @@ class FileHandler:
         return None
 
     @staticmethod
+    def find_all_specific_folders(current_dir, parent_folder_name, folder_name):
+        """Return every matching folder path under a named parent folder (empty if none)."""
+        matches = []
+        for root, dirs, _ in os.walk(current_dir):
+            if parent_folder_name in dirs:
+                target_folder_path = Path(root) / parent_folder_name / folder_name
+                if target_folder_path.is_dir():
+                    matches.append(str(target_folder_path))
+        return matches
+
+    @staticmethod
     def get_agent_paths(agent_name, project_root: Path | None = None):
-        """Return (agent_config_dir, io_dir) for the given agent name."""
+        """Return (agent_config_dir, io_dir), raising when the agent name is ambiguous."""
+        from agent_actions.errors.validation import AmbiguousAgentName
+
         search_dir = resolve_project_root(project_root)
-        agent_config_dir = FileHandler.find_specific_folder(
+        config_matches = FileHandler.find_all_specific_folders(
             str(search_dir), agent_name, "agent_config"
         )
+        if len(config_matches) >= 2:
+            raise AmbiguousAgentName(agent_name, config_matches)
+        agent_config_dir = config_matches[0] if config_matches else None
         io_dir = FileHandler.find_specific_folder(str(search_dir), agent_name, "agent_io")
         return agent_config_dir, io_dir
 

--- a/tests/unit/utils/test_get_agent_paths_disambiguation.py
+++ b/tests/unit/utils/test_get_agent_paths_disambiguation.py
@@ -1,0 +1,61 @@
+"""Duplicate agent base names must raise instead of silently resolving the first."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_actions.config.project_paths import ProjectPathsFactory
+from agent_actions.errors.validation import AmbiguousAgentName, ValidationError
+from agent_actions.utils.file_handler import FileHandler
+
+
+def _make_agent(base: Path, workflow: str, agent: str) -> None:
+    (base / workflow / agent / "agent_config").mkdir(parents=True)
+    (base / workflow / agent / "agent_io").mkdir(parents=True)
+
+
+def test_ambiguous_name_raises_naming_every_candidate(tmp_path):
+    proj = tmp_path / "proj"
+    _make_agent(proj, "team_a", "resume_review")
+    _make_agent(proj, "team_b", "resume_review")
+    with pytest.raises(AmbiguousAgentName) as excinfo:
+        FileHandler.get_agent_paths("resume_review", project_root=proj)
+    msg = str(excinfo.value)
+    assert "team_a" in msg and "team_b" in msg
+    assert set(excinfo.value.candidates) == {
+        str(proj / "team_a" / "resume_review" / "agent_config"),
+        str(proj / "team_b" / "resume_review" / "agent_config"),
+    }
+
+
+def test_factory_surfaces_candidate_list_without_generic_rewrap(tmp_path):
+    proj = tmp_path / "proj"
+    _make_agent(proj, "team_a", "resume_review")
+    _make_agent(proj, "team_b", "resume_review")
+    with pytest.raises(AmbiguousAgentName) as excinfo:
+        ProjectPathsFactory.get_agent_paths("resume_review", project_root=proj)
+    msg = str(excinfo.value)
+    assert "team_a" in msg and "team_b" in msg
+    assert "Failed to get agent paths" not in msg
+
+
+def test_ambiguous_name_is_a_validation_error():
+    exc = AmbiguousAgentName("resume_review", ["/a/resume_review/agent_config"])
+    assert isinstance(exc, ValidationError)
+
+
+def test_single_match_returns_the_only_candidate(tmp_path):
+    proj = tmp_path / "proj"
+    _make_agent(proj, "team_a", "resume_review")
+    cfg, io = FileHandler.get_agent_paths("resume_review", project_root=proj)
+    assert cfg is not None and cfg.endswith(str(Path("team_a") / "resume_review" / "agent_config"))
+    assert io is not None and io.endswith(str(Path("team_a") / "resume_review" / "agent_io"))
+
+
+def test_zero_match_returns_none(tmp_path):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    cfg, io = FileHandler.get_agent_paths("nope", project_root=proj)
+    assert cfg is None and io is None


### PR DESCRIPTION
## Summary
The agent-name resolver (`FileHandler.get_agent_paths`) walked the project tree and returned the **first** `<name>/agent_config` directory it happened to reach, silently. In a project where two directories share the same base name (multi-tenant / multi-workflow layouts), an operator running any CLI command with `-a <name>` could target the **wrong** workflow — reading and writing the wrong `agent_io` — with no warning or error.

**Root cause:** a first-match `return` inside `os.walk`.

**Fix:**
- Add `FileHandler.find_all_specific_folders` — collects every matching folder instead of returning the first.
- `get_agent_paths` now raises `AmbiguousAgentName` listing every candidate (full path + parent workflow directory) when two or more `agent_config` directories share the base name.
- **0-match and 1-match behavior is byte-identical** (`(None, None)` and the single path, respectively).
- `find_specific_folder` (first-match) is left intact for the `agent_io` lookup and action-folder resolution — the `agent_config` raise fires first and covers the common case.

**Why `AmbiguousAgentName` subclasses `ValidationError`:** the sole caller (`ProjectPathsFactory.get_agent_paths`) re-raises `ValidationError` unchanged but wraps any *other* exception into a generic `"Failed to get agent paths"` message that would destroy the candidate list. Subclassing `ValidationError` lets the precise error — with its full candidate listing — propagate cleanly to every CLI command via `create_project_paths`, with **no caller edit**. This also aligns the ≥2-match case with the existing 0-match case, which already surfaces as a `ValidationError`.

## Verification
- **RED:** the two ambiguous-fixture tests failed with `DID NOT RAISE` (proving the silent first-match bug), while single/zero/subclass baselines passed.
- **GREEN:** all five tests in `tests/unit/utils/test_get_agent_paths_disambiguation.py` pass after the fix, at both the util layer and the CLI-facing factory layer (candidate list survives, not re-wrapped).
- No regression: `tests/unit/test_errors.py`, `tests/unit/utils/`, `tests/cli/test_cli_hardening.py` (incl. the single-match `test_project_root_reaches_file_handler`), `tests/workflow/test_runner.py`, `tests/unit/llm_invocation/test_agent_manager.py`, `tests/config/` — all pass.
- `ruff check` clean; `ruff format --check` clean.

## Out of scope (follow-up)
`agent_io` ambiguity is not guarded — the `agent_config` raise fires first. Guard it the same way if a case arises. The separate `AgentManager` realtime resolver is a different code path and is untouched.