### PR TITLE
fix(VIOL-0100): wire passthrough_on_error through guard config; reject on UDF guards

### DIFF
--- a/agent_actions/guards/consolidated_guard.py
+++ b/agent_actions/guards/consolidated_guard.py
@@ -20,7 +20,7 @@ class GuardBehavior(StrEnum):
 _UNSUPPORTED_GUARD_BEHAVIORS: frozenset[str] = frozenset({"write_to", "reprocess"})
 
 # Only keys whose values reach the runtime; expander synthesizes the rest.
-_ALLOWED_GUARD_KEYS: frozenset[str] = frozenset({"condition", "on_false"})
+_ALLOWED_GUARD_KEYS: frozenset[str] = frozenset({"condition", "on_false", "passthrough_on_error"})
 
 
 class GuardConfig:
@@ -30,10 +30,12 @@ class GuardConfig:
         self,
         condition: str,
         on_false: GuardBehavior | str,
+        passthrough_on_error: bool = True,
         _parsed: "GuardExpression | None" = None,
     ):
         """Initialize guard configuration."""
         self.condition = condition
+        self.passthrough_on_error = passthrough_on_error
         if isinstance(on_false, GuardBehavior):
             self.on_false = on_false
         elif isinstance(on_false, str):
@@ -105,10 +107,25 @@ class GuardConfig:
             )
         condition = config_dict["condition"]
         on_false = config_dict.get("on_false")
+        passthrough_on_error = config_dict.get("passthrough_on_error", True)
+        if not isinstance(passthrough_on_error, bool):
+            raise ConfigValidationError(
+                "passthrough_on_error",
+                f"passthrough_on_error must be a boolean, got {type(passthrough_on_error).__name__}",
+                context={
+                    "passthrough_on_error_value": repr(passthrough_on_error),
+                    "operation": "parse_guard_config",
+                },
+            )
         parsed = GuardParser.parse(condition)
         if on_false is None:
             on_false = GuardBehavior.SKIP if parsed.type == GuardType.UDF else GuardBehavior.FILTER
-        return cls(condition=condition, on_false=on_false, _parsed=parsed)
+        return cls(
+            condition=condition,
+            on_false=on_false,
+            passthrough_on_error=passthrough_on_error,
+            _parsed=parsed,
+        )
 
     @classmethod
     def from_string(cls, guard_string: str) -> "GuardConfig":

--- a/agent_actions/output/response/expander_action_types.py
+++ b/agent_actions/output/response/expander_action_types.py
@@ -41,12 +41,22 @@ def process_guard_config(agent: dict[str, Any], action: dict[str, Any]) -> None:
                         "operation": "expand_actions_to_agents",
                     },
                 )
+            if guard_config.passthrough_on_error is not True:
+                raise ConfigurationError(
+                    "passthrough_on_error is only supported for SQL-style guards; "
+                    "UDF conditions always pass records through on error.",
+                    context={
+                        "action_name": action.get("name", "unknown"),
+                        "operation": "expand_actions_to_agents",
+                    },
+                )
             agent["conditional_clause"] = guard_config.get_condition_expression()
         else:
             agent["guard"] = {
                 "clause": guard_config.get_condition_expression(),
                 "scope": "item",
                 "behavior": guard_config.on_false.value,
+                "passthrough_on_error": guard_config.passthrough_on_error,
             }
 
 

--- a/tests/core/utils/test_consolidated_guard.py
+++ b/tests/core/utils/test_consolidated_guard.py
@@ -136,16 +136,47 @@ class TestConsolidatedGuardParser:
         assert "foo" in msg
         assert "bar" in msg
 
-    def test_parse_rejects_passthrough_keys_until_wire_through_lands(self):
+    def test_passthrough_on_error_round_trips_through_parser(self):
+        cfg = parse_guard_config(
+            {"condition": "score >= 80", "on_false": "filter", "passthrough_on_error": False}
+        )
+        assert cfg.passthrough_on_error is False
+
+    def test_passthrough_on_error_defaults_true_when_omitted(self):
+        cfg = parse_guard_config({"condition": "score >= 80", "on_false": "filter"})
+        assert cfg.passthrough_on_error is True
+
+    def test_passthrough_on_error_rejects_non_bool(self):
         with pytest.raises(ConfigValidationError) as exc:
             parse_guard_config(
-                {
-                    "condition": "score >= 80",
-                    "on_false": "filter",
-                    "passthrough_on_error": False,
-                }
+                {"condition": "score >= 80", "on_false": "filter", "passthrough_on_error": "false"}
             )
         assert "passthrough_on_error" in str(exc.value)
+
+    def test_passthrough_on_empty_still_rejected_no_consumer(self):
+        """passthrough_on_empty has no runtime consumer, so it must stay rejected."""
+        with pytest.raises(ConfigValidationError) as exc:
+            parse_guard_config(
+                {"condition": "score >= 80", "on_false": "filter", "passthrough_on_empty": False}
+            )
+        assert "passthrough_on_empty" in str(exc.value)
+
+    def test_passthrough_on_error_rejected_on_udf_guard(self):
+        """UDF guards cannot honor passthrough_on_error, so setting it must fail loud."""
+        from agent_actions.errors import ConfigurationError
+        from agent_actions.output.response.expander_action_types import process_guard_config
+
+        agent: dict = {}
+        action = {
+            "name": "a",
+            "guard": {
+                "condition": "udf:validators.my_check",
+                "on_false": "skip",
+                "passthrough_on_error": False,
+            },
+        }
+        with pytest.raises(ConfigurationError):
+            process_guard_config(agent, action)
 
     def test_parse_rejects_non_string_keys_as_config_error(self):
         with pytest.raises(ConfigValidationError) as exc:

--- a/tests/unit/output/response/test_guard_passthrough_wire_through.py
+++ b/tests/unit/output/response/test_guard_passthrough_wire_through.py
@@ -1,0 +1,50 @@
+"""passthrough_on_error must reach the runtime guard dict for SQL guards and
+change evaluator behavior on an evaluation error."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent_actions.input.preprocessing.filtering.evaluator import GuardEvaluator
+from agent_actions.output.response.expander_action_types import process_guard_config
+
+
+def test_expander_forwards_passthrough_on_error_for_sql_guard():
+    agent: dict = {}
+    action = {
+        "name": "a",
+        "guard": {"condition": "x > 0", "on_false": "filter", "passthrough_on_error": False},
+    }
+    process_guard_config(agent, action)
+    assert agent["guard"]["passthrough_on_error"] is False
+
+
+def test_expander_defaults_passthrough_on_error_true():
+    agent: dict = {}
+    action = {"name": "a", "guard": {"condition": "x > 0", "on_false": "filter"}}
+    process_guard_config(agent, action)
+    assert agent["guard"]["passthrough_on_error"] is True
+
+
+def test_evaluator_applies_behavior_when_passthrough_on_error_false():
+    evaluator = GuardEvaluator()
+    guard = {
+        "clause": "x > 0",
+        "scope": "item",
+        "behavior": "filter",
+        "passthrough_on_error": False,
+    }
+    with patch.object(evaluator, "_filter") as mock_filter:
+        mock_filter.filter_item.side_effect = TypeError("boom")
+        result = evaluator.evaluate({"x": 1}, guard)
+    assert result.should_execute is False
+    assert result.behavior == "filter"
+
+
+def test_evaluator_passes_record_when_passthrough_on_error_true():
+    evaluator = GuardEvaluator()
+    guard = {"clause": "x > 0", "scope": "item", "behavior": "filter", "passthrough_on_error": True}
+    with patch.object(evaluator, "_filter") as mock_filter:
+        mock_filter.filter_item.side_effect = TypeError("boom")
+        result = evaluator.evaluate({"x": 1}, guard)
+    assert result.should_execute is True


### PR DESCRIPTION
## Summary

The `passthrough_on_error` guard flag was documented and already consumed by the guard evaluator and skip manager, but users could not actually set it: the guard-key allowlist rejected it at config load, and even before that the expander never forwarded it into the runtime guard dict — so the evaluator always fell back to its `True` default.

This wires the key end to end for SQL-style guards, on the same rails as `condition`/`on_false`:

- **Allowlist** (`consolidated_guard.py`): admit `passthrough_on_error` (only).
- **Parser** (`GuardConfig`): store it as an optional attribute (`= True`); `from_dict` extracts it with a bool check; `from_string` uses the default.
- **Expander** (`process_guard_config`): forward `passthrough_on_error` in the SQL branch's runtime guard dict.
- **UDF guards**: the UDF path always passes records through on error and has no consumer for the flag, so a non-default value on a UDF guard now raises `ConfigurationError` (fail loud) instead of being silently dropped.

`passthrough_on_empty` is intentionally left rejected — it has no runtime consumer on any path, so admitting it would deposit a dead key that changes no behavior. A test pins that it stays rejected.

Defaults are unchanged (`passthrough_on_error=True`); the `condition`/`on_false` flow and the semantic-error-always-bypasses rule are untouched.

## Verification

- RED first: parser round-trip and expander-forward tests failed for the right reason (key rejected at the allowlist / dropped by the expander); the `passthrough_on_empty` rejection test passed as a baseline.
- GREEN after wiring: `tests/core/utils/test_consolidated_guard.py` + `tests/unit/output/response/test_guard_passthrough_wire_through.py` — 31 passed. New tests cover: parser round-trip, default-when-omitted, non-bool rejection, `passthrough_on_empty` stays rejected, UDF-guard fail-loud, expander SQL forward + default, and evaluator behavior (applies guard behavior when `False`, passes record when `True`) via the public `evaluate()` entry point.
- No regression: `tests/unit/output/response/` (137), `tests/unit/workflow/managers/` (133), `tests/preprocessing/` excluding a pre-existing circular-import collection quirk (234), plus the guard/evaluator/skip/parity suites — all pass.
- `ruff check` clean; `ruff format --check` clean.

### Out of scope (observed, not fixed)
- `tests/preprocessing/staging/test_source_data_protection.py` fails to collect on a circular import (`InitialStageContext`) — reproduces on clean `main`, unrelated to this change.
- Docs alignment for the `passthrough_on_error` example lives in a separate `docs.agent-actions/` tree not in this checkout.