### PR TITLE
fix(VIOL-0066): validate-udfs surfaces agent name/filename mismatch

### DIFF
--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from agent_actions.config.manager import ConfigManager
 from agent_actions.config.project_paths import ProjectPathsFactory
 from agent_actions.errors import (
+    ConfigurationError,
     DuplicateFunctionError,
     FunctionNotFoundError,
     UDFLoadError,
@@ -68,6 +69,16 @@ class ValidateUDFsCommand:
             }
         config_manager = ConfigManager(str(config_path), str(paths.default_config_path))
         config_manager.load_configs()
+        try:
+            config_manager.validate_agent_name()
+        except ConfigurationError as e:
+            if "agent_name" not in e.context or "config_filename" not in e.context:
+                raise
+            return {
+                "valid": False,
+                "error": e,
+                "error_type": "name_mismatch",
+            }
         config = config_manager.user_config
         if config is None:
             config = {}
@@ -100,6 +111,8 @@ class ValidateUDFsCommand:
                     self._handle_load_error(error)
                 elif error_type == "not_found":
                     self._handle_not_found_error(error)
+                elif error_type == "name_mismatch":
+                    self._handle_name_mismatch_error(error)
                 raise click.exceptions.Exit(1)
             registry = result["registry"]
             impl_refs = result["impl_refs"]
@@ -165,6 +178,16 @@ class ValidateUDFsCommand:
         self.console.print(f"  File: [cyan]{error.context['new_file']}[/cyan]\n")
         self.console.print("[yellow]Fix:[/yellow]")
         self.console.print("  Function names must be unique. Rename one of these functions.\n")
+
+    def _handle_name_mismatch_error(self, error: ConfigurationError) -> None:
+        """Report a workflow whose name field does not equal its filename stem."""
+        actual = error.context["agent_name"]
+        expected = error.context["config_filename"]
+        self.console.print(
+            f"[red]❌ Error: workflow name '{actual}' does not match filename "
+            f"'{expected}.yml'[/red]\n"
+            f"  Rename the file to '{actual}.yml', or set 'name: {expected}' in the config."
+        )
 
     def _handle_load_error(self, error: UDFLoadError) -> None:
         """Render via the shared translator chain so UX stays in sync with the CLI."""

--- a/tests/unit/validation/test_validate_udfs_name_check.py
+++ b/tests/unit/validation/test_validate_udfs_name_check.py
@@ -1,0 +1,48 @@
+"""Cover validate-udfs enforcing the workflow name matches its filename stem."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agent_actions.validation.validate_udfs import validate_udfs_cmd
+
+
+def _project(root: Path, agent_stem: str, name_value: str) -> Path:
+    (root / "agent_actions.yml").write_text("name: proj\n")
+    cfg = root / agent_stem / "agent_config"
+    cfg.mkdir(parents=True)
+    (root / agent_stem / "agent_io").mkdir(parents=True)
+    (cfg / f"{agent_stem}.yml").write_text(
+        f"name: {name_value}\nactions:\n  - name: step_one\n    prompt: hi\n"
+    )
+    udf = root / "user_code"
+    udf.mkdir()
+    return udf
+
+
+def test_validate_udfs_rejects_name_filename_mismatch(tmp_path, monkeypatch):
+    udf = _project(tmp_path, "wrong", "real_name")
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(validate_udfs_cmd, ["-a", "wrong", "-u", str(udf)])
+    assert result.exit_code == 1, result.output
+    assert "real_name" in result.output, result.output
+    assert "wrong" in result.output, result.output
+
+
+def test_validate_udfs_accepts_matching_name(tmp_path, monkeypatch):
+    udf = _project(tmp_path, "good", "good")
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(validate_udfs_cmd, ["-a", "good", "-u", str(udf)])
+    assert "does not match" not in result.output, result.output
+    assert result.exit_code == 0, result.output
+
+
+def test_validate_udfs_unnamed_config_is_not_reported_as_mismatch(tmp_path, monkeypatch):
+    udf = _project(tmp_path, "blank", "blank")
+    (tmp_path / "blank" / "agent_config" / "blank.yml").write_text("{}\n")
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(validate_udfs_cmd, ["-a", "blank", "-u", str(udf)])
+    assert result.exit_code == 1, result.output
+    assert "does not match" not in result.output, result.output


### PR DESCRIPTION
## Summary

`validate-udfs` loaded workflow configs through `ConfigManager.load_configs()` alone, skipping the agent-name identity stage the canonical loader runs immediately after it (`load_configs` then `validate_agent_name`). A workflow whose `name:` field did not equal its filename stem — e.g. `name: real_name` saved as `wrong.yml` — passed `validate-udfs` with a clean exit 0, while `run` and `inspect` rejected it. The one command whose job is to catch problems gave a false all-clear.

## Fix

- `ValidateUDFsCommand.validate()` now calls `ConfigManager.validate_agent_name()` right after `load_configs()`, mirroring the canonical loader's stage order (fail fast on identity before UDF-reference validation).
- A mismatch is returned as a structured `name_mismatch` result and rendered by `_handle_name_mismatch_error`, consistent with the command's existing structured error types. The message names both the actual `name:` value and the expected filename stem, and the command exits 1.
- A `ConfigurationError` that is not a filename mismatch (a config with no identifiable name, whose context lacks the mismatch keys) is re-raised so it surfaces through the command's existing generic error path instead of being mislabeled as a name mismatch.

Reuses the shared check — no new YAML key, config, or dependency. `run`/`inspect` and the matched-name case are unchanged.

## Verification

RED then GREEN, TDD:
- Added `tests/unit/validation/test_validate_udfs_name_check.py` driving the real CLI via `CliRunner`.
  - Mismatch test failed first because the command printed "All UDF references valid" and exited 0 (the bug), then passed after the fix (exit 1, output names both `real_name` and `wrong`).
  - Matched-name baseline exits 0 with no mismatch message (no false positive).
  - Edge test: a config with no identifiable name is not reported as a name mismatch and still fails (exit 1).
- Broader surface: `tests/validation/ tests/cli/ tests/unit/validation/ tests/unit/config/ tests/unit/workflow/test_config_pipeline_stage.py` — 1316 passed.
- `ruff check agent_actions tests` clean; `ruff format --check` clean.

## Follow-up (not this scope)

If a future command loads a workflow YAML without going through the canonical loader, it must call `validate_agent_name()` too — the canonical loader is the place that guarantees it for `run`/`inspect`.