### PR TITLE
fix(559): warn at preflight on unguarded prompt refs to non-required schema fields

### DIFF
--- a/agent_actions/prompt/formatter.py
+++ b/agent_actions/prompt/formatter.py
@@ -3,7 +3,7 @@
 from agent_actions.errors import ConfigValidationError, PromptValidationError
 from agent_actions.logging.filters import _redact_sensitive_data
 from agent_actions.prompt.handler import PromptLoader
-from agent_actions.utils.constants import PROMPT_KEY
+from agent_actions.utils.constants import NON_PROMPT_ACTION_KINDS, PROMPT_KEY
 
 
 class PromptFormatter:
@@ -25,7 +25,7 @@ class PromptFormatter:
             PromptValidationError: If prompt retrieval or loading fails
         """
         raw_prompt = agent_config.get(PROMPT_KEY)
-        if agent_config.get("kind") not in ("tool", "hitl", "seed", "source"):
+        if agent_config.get("kind") not in NON_PROMPT_ACTION_KINDS:
             if isinstance(raw_prompt, str) and not raw_prompt.strip():
                 raise ConfigValidationError(
                     f"prompt cannot be an empty string for action "

--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -7,10 +7,16 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from agent_actions.errors import ConfigValidationError, PromptValidationError
 from agent_actions.errors.preflight import PreFlightValidationError
+from agent_actions.models.action_schema import FieldSource
+from agent_actions.prompt.formatter import PromptFormatter
 from agent_actions.validation.preflight.guard_validation import validate_guard_conditions
 from agent_actions.validation.preflight.resolution_service import (
     WorkflowResolutionService,
+)
+from agent_actions.validation.prompt_required_field_validator import (
+    find_unguarded_required_refs,
 )
 from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
     apply_guard_nullable_schema_fixes,
@@ -18,6 +24,8 @@ from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
 from agent_actions.workflow.schema_service import WorkflowSchemaService
 
 logger = logging.getLogger(__name__)
+
+_NON_PROMPT_KINDS = ("tool", "hitl", "seed", "source")
 
 
 class PreflightService:
@@ -85,3 +93,35 @@ class PreflightService:
 
         for warning in resolution_result.warnings:
             logger.warning("Pre-flight: %s", warning.message)
+
+        # 5. Cross-check prompt refs against each producer's required set
+        for finding in find_unguarded_required_refs(
+            self._collect_prompts(), self._collect_producing_schemas()
+        ):
+            logger.warning("Pre-flight: %s", finding)
+
+    def _collect_prompts(self) -> dict[str, str]:
+        """Resolved prompt text per prompt-bearing action, keyed by action name."""
+        prompts: dict[str, str] = {}
+        for name, config in self.action_configs.items():
+            if config.get("kind") in _NON_PROMPT_KINDS:
+                continue
+            try:
+                prompts[name] = PromptFormatter.get_raw_prompt(config)
+            except (ConfigValidationError, PromptValidationError) as exc:
+                logger.debug("Skipping prompt cross-check for %s: %s", name, exc)
+        return prompts
+
+    def _collect_producing_schemas(self) -> dict[str, dict[str, Any]]:
+        """Declared schema-source fields per action with their required flags."""
+        if self.schema_service is None:
+            return {}
+        schemas: dict[str, dict[str, Any]] = {}
+        for name, action_schema in self.schema_service.get_all_schemas().items():
+            fields = [
+                {"id": f.name, "required": f.is_required}
+                for f in action_schema.output_fields
+                if f.source is FieldSource.SCHEMA
+            ]
+            schemas[name] = {"fields": fields}
+        return schemas

--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -11,6 +11,7 @@ from agent_actions.errors import ConfigValidationError, PromptValidationError
 from agent_actions.errors.preflight import PreFlightValidationError
 from agent_actions.models.action_schema import FieldSource
 from agent_actions.prompt.formatter import PromptFormatter
+from agent_actions.utils.constants import NON_PROMPT_ACTION_KINDS
 from agent_actions.validation.preflight.guard_validation import validate_guard_conditions
 from agent_actions.validation.preflight.resolution_service import (
     WorkflowResolutionService,
@@ -24,8 +25,6 @@ from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
 from agent_actions.workflow.schema_service import WorkflowSchemaService
 
 logger = logging.getLogger(__name__)
-
-_NON_PROMPT_KINDS = ("tool", "hitl", "seed", "source")
 
 
 class PreflightService:
@@ -104,7 +103,7 @@ class PreflightService:
         """Resolved prompt text per prompt-bearing action, keyed by action name."""
         prompts: dict[str, str] = {}
         for name, config in self.action_configs.items():
-            if config.get("kind") in _NON_PROMPT_KINDS:
+            if config.get("kind") in NON_PROMPT_ACTION_KINDS:
                 continue
             try:
                 prompts[name] = PromptFormatter.get_raw_prompt(config)
@@ -113,7 +112,11 @@ class PreflightService:
         return prompts
 
     def _collect_producing_schemas(self) -> dict[str, dict[str, Any]]:
-        """Declared schema-source fields per action with their required flags."""
+        """Available (non-dropped) schema-source fields per producing action.
+
+        Fan-out versions are additionally indexed under their shared base name,
+        which is how downstream prompts reference them.
+        """
         if self.schema_service is None:
             return {}
         schemas: dict[str, dict[str, Any]] = {}
@@ -121,7 +124,10 @@ class PreflightService:
             fields = [
                 {"id": f.name, "required": f.is_required}
                 for f in action_schema.output_fields
-                if f.source is FieldSource.SCHEMA
+                if f.source is FieldSource.SCHEMA and not f.is_dropped
             ]
             schemas[name] = {"fields": fields}
+            base = self.action_configs.get(name, {}).get("version_base_name")
+            if base and base not in schemas:
+                schemas[base] = {"fields": fields}
         return schemas

--- a/agent_actions/utils/constants.py
+++ b/agent_actions/utils/constants.py
@@ -10,6 +10,8 @@ MODEL_NAME_KEY = "model_name"
 JSON_MODE_KEY = "json_mode"
 API_KEY_KEY = "api_key"
 PROMPT_KEY = "prompt"
+# Action kinds that do not carry a user-authored prompt template.
+NON_PROMPT_ACTION_KINDS = ("tool", "hitl", "seed", "source")
 SCHEMA_NAME_KEY = "schema_name"
 SCHEMA_KEY = "schema"
 CHUNK_CONFIG_KEY = "chunk_config"

--- a/agent_actions/validation/prompt_required_field_validator.py
+++ b/agent_actions/validation/prompt_required_field_validator.py
@@ -3,40 +3,116 @@
 from __future__ import annotations
 
 import logging
-import re
 
-from agent_actions.validation.prompt_ast import PromptASTAnalyzer
+from jinja2 import Environment, nodes
+from jinja2.exceptions import TemplateSyntaxError
+
+from agent_actions.utils.template_escape import escape_jinja_in_inline_code
 
 logger = logging.getLogger(__name__)
 
-_JINJA_TAG = re.compile(r"{%-?.*?%}", re.DOTALL)
-_TAG_NAME = re.compile(r"{%-?\s*(\w+)")
+# Roots that are Jinja builtins / the implicit loop var — never producing actions.
+_NON_ACTION_ROOTS = frozenset(
+    {"loop", "range", "dict", "lipsum", "cycler", "joiner", "namespace", "true", "false", "none"}
+)
+
+_ENV = Environment()
 
 
-def _strip_if_blocks(template: str) -> str:
-    """Return the template with every ``{% if %}``…``{% endif %}`` region removed.
+def _chain_root_and_field(node: nodes.Node) -> tuple[str, str] | None:
+    """Return (root, first_field) for an attribute/subscript chain, else None.
 
-    A depth counter tracks nesting so inner ``{% endif %}`` tags do not close an
-    outer block early. Only text outside all if-blocks survives, so downstream
-    extraction sees unconditional references only.
+    ``producer.b`` and ``producer["b"].x`` both yield ``("producer", "b")``.
+    Non-string subscripts (int/dynamic keys) and chains not rooted in a plain
+    name yield None.
     """
-    kept: list[str] = []
-    depth = 0
-    keep_from = 0
-    for match in _JINJA_TAG.finditer(template):
-        name_match = _TAG_NAME.match(match.group(0))
-        name = name_match.group(1) if name_match else ""
-        if name == "if":
-            if depth == 0:
-                kept.append(template[keep_from : match.start()])
-            depth += 1
-        elif name == "endif" and depth > 0:
-            depth -= 1
-            if depth == 0:
-                keep_from = match.end()
-    if depth == 0:
-        kept.append(template[keep_from:])
-    return "".join(kept)
+    attrs: list[str | None] = []
+    current: nodes.Node = node
+    while isinstance(current, nodes.Getattr | nodes.Getitem):
+        if isinstance(current, nodes.Getattr):
+            attrs.append(current.attr)
+        elif isinstance(current.arg, nodes.Const) and isinstance(current.arg.value, str):
+            attrs.append(current.arg.value)
+        else:
+            attrs.append(None)
+        current = current.node
+    if not isinstance(current, nodes.Name) or not attrs:
+        return None
+    attrs.reverse()
+    if attrs[0] is None:
+        return None
+    return current.name, attrs[0]
+
+
+def _target_names(target: nodes.Node) -> set[str]:
+    """Loop-target names introduced by a ``{% for %}`` (locals, not refs)."""
+    if isinstance(target, nodes.Name):
+        return {target.name}
+    if isinstance(target, nodes.Tuple):
+        return {item.name for item in target.items if isinstance(item, nodes.Name)}
+    return set()
+
+
+def _guard_keys(test: nodes.Node) -> set[str]:
+    """``root.field`` keys named by an ``{% if %}`` test — the fields it guards."""
+    keys: set[str] = set()
+    for sub in test.find_all((nodes.Getattr, nodes.Getitem)):
+        ref = _chain_root_and_field(sub)
+        if ref:
+            keys.add(f"{ref[0]}.{ref[1]}")
+    return keys
+
+
+def _collect(
+    node: nodes.Node, guarded: frozenset[str], locals_: frozenset[str], found: set
+) -> None:
+    """Record an outermost chain ref as unguarded unless its field is guarded."""
+    ref = _chain_root_and_field(node)
+    if ref and ref[0] not in locals_ and ref[0] not in _NON_ACTION_ROOTS:
+        if f"{ref[0]}.{ref[1]}" not in guarded:
+            found.add(ref)
+
+
+def _walk(node: nodes.Node, guarded: frozenset[str], locals_: frozenset[str], found: set) -> None:
+    """Walk the AST, flagging unconditional refs; ``{% if %}`` bodies gain the
+    guarantees named by their own test (elif/else branches do not)."""
+    if isinstance(node, nodes.If):
+        body_guarded = guarded | _guard_keys(node.test)
+        for child in node.body:
+            _walk(child, body_guarded, locals_, found)
+        for elif_node in node.elif_:
+            _walk(elif_node, guarded, locals_, found)
+        for child in node.else_:
+            _walk(child, guarded, locals_, found)
+        return
+    if isinstance(node, nodes.For):
+        _collect(node.iter, guarded, locals_, found)
+        inner = locals_ | _target_names(node.target)
+        for child in list(node.body) + list(node.else_):
+            _walk(child, guarded, inner, found)
+        return
+    if isinstance(node, nodes.Macro):
+        inner = locals_ | {a.name for a in node.args if isinstance(a, nodes.Name)}
+        for child in node.body:
+            _walk(child, guarded, inner, found)
+        return
+    if isinstance(node, nodes.Getattr | nodes.Getitem):
+        _collect(node, guarded, locals_, found)
+        return
+    for child in node.iter_child_nodes():
+        _walk(child, guarded, locals_, found)
+
+
+def _unguarded_refs(template: str) -> set[tuple[str, str]]:
+    """Return the ``(root, field)`` refs used outside any guarding ``{% if %}``."""
+    try:
+        ast = _ENV.parse(escape_jinja_in_inline_code(template))
+    except TemplateSyntaxError as exc:
+        logger.debug("Skipping prompt scan (syntax error): %s", exc)
+        return set()
+    found: set[tuple[str, str]] = set()
+    _walk(ast, frozenset(), frozenset(), found)
+    return found
 
 
 def _optional_field_names(schema: dict) -> set[str]:
@@ -48,29 +124,27 @@ def find_unguarded_required_refs(prompts: dict[str, str], schemas: dict[str, dic
     """Return findings for unguarded prompt refs to non-required producer fields.
 
     A ref ``ns.field`` is flagged when ``ns`` has a producing schema, ``field``
-    is declared by that schema but not marked required, and the ref is not
-    inside an ``{% if %}`` block. Refs whose ``ns`` has no producing schema, or
-    whose ``field`` the schema does not declare, belong to other checks and are
-    left alone here.
+    is declared by that schema but not marked required, and the ref is not inside
+    the body of an ``{% if %}`` that guards ``ns.field``. Refs to an unknown
+    namespace, to a field the schema does not declare, or to the action's own
+    output namespace belong to other checks and are left alone here.
     """
-    analyzer = PromptASTAnalyzer()
+    if not prompts or not schemas:
+        return []
+    optional_by_ns = {ns: _optional_field_names(schema) for ns, schema in schemas.items()}
     findings: list[str] = []
+    seen: set[tuple[str, str, str]] = set()
     for action_name, template in prompts.items():
-        unconditional = _strip_if_blocks(template)
-        try:
-            tokens = analyzer.extract_variables(unconditional)
-        except ValueError as exc:
-            logger.debug("Skipping prompt scan for %s: %s", action_name, exc)
-            continue
-        for token in sorted(tokens):
-            ns, _, remainder = token.partition(".")
-            if not remainder or ns not in schemas:
+        for ns, field in sorted(_unguarded_refs(template)):
+            if ns == action_name or field not in optional_by_ns.get(ns, frozenset()):
                 continue
-            field = remainder.split(".", 1)[0].split("[", 1)[0]
-            if field in _optional_field_names(schemas[ns]):
-                findings.append(
-                    f"{action_name}: prompt references '{token}' but producer '{ns}' "
-                    f"does not guarantee '{field}' (not marked required, and no "
-                    f"if-guard protects the ref)"
-                )
+            key = (action_name, ns, field)
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                f"{action_name}: prompt references '{ns}.{field}' but producer '{ns}' "
+                f"does not guarantee '{field}' (declared without required: true, and "
+                f"no if-guard protects the ref)"
+            )
     return findings

--- a/agent_actions/validation/prompt_required_field_validator.py
+++ b/agent_actions/validation/prompt_required_field_validator.py
@@ -1,0 +1,76 @@
+"""Flag prompt refs to schema fields the producing action does not mark required."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from agent_actions.validation.prompt_ast import PromptASTAnalyzer
+
+logger = logging.getLogger(__name__)
+
+_JINJA_TAG = re.compile(r"{%-?.*?%}", re.DOTALL)
+_TAG_NAME = re.compile(r"{%-?\s*(\w+)")
+
+
+def _strip_if_blocks(template: str) -> str:
+    """Return the template with every ``{% if %}``…``{% endif %}`` region removed.
+
+    A depth counter tracks nesting so inner ``{% endif %}`` tags do not close an
+    outer block early. Only text outside all if-blocks survives, so downstream
+    extraction sees unconditional references only.
+    """
+    kept: list[str] = []
+    depth = 0
+    keep_from = 0
+    for match in _JINJA_TAG.finditer(template):
+        name_match = _TAG_NAME.match(match.group(0))
+        name = name_match.group(1) if name_match else ""
+        if name == "if":
+            if depth == 0:
+                kept.append(template[keep_from : match.start()])
+            depth += 1
+        elif name == "endif" and depth > 0:
+            depth -= 1
+            if depth == 0:
+                keep_from = match.end()
+    if depth == 0:
+        kept.append(template[keep_from:])
+    return "".join(kept)
+
+
+def _optional_field_names(schema: dict) -> set[str]:
+    """Names the producer declares but does not mark required."""
+    return {f["id"] for f in schema.get("fields", []) if "id" in f and not f.get("required", False)}
+
+
+def find_unguarded_required_refs(prompts: dict[str, str], schemas: dict[str, dict]) -> list[str]:
+    """Return findings for unguarded prompt refs to non-required producer fields.
+
+    A ref ``ns.field`` is flagged when ``ns`` has a producing schema, ``field``
+    is declared by that schema but not marked required, and the ref is not
+    inside an ``{% if %}`` block. Refs whose ``ns`` has no producing schema, or
+    whose ``field`` the schema does not declare, belong to other checks and are
+    left alone here.
+    """
+    analyzer = PromptASTAnalyzer()
+    findings: list[str] = []
+    for action_name, template in prompts.items():
+        unconditional = _strip_if_blocks(template)
+        try:
+            tokens = analyzer.extract_variables(unconditional)
+        except ValueError as exc:
+            logger.debug("Skipping prompt scan for %s: %s", action_name, exc)
+            continue
+        for token in sorted(tokens):
+            ns, _, remainder = token.partition(".")
+            if not remainder or ns not in schemas:
+                continue
+            field = remainder.split(".", 1)[0].split("[", 1)[0]
+            if field in _optional_field_names(schemas[ns]):
+                findings.append(
+                    f"{action_name}: prompt references '{token}' but producer '{ns}' "
+                    f"does not guarantee '{field}' (not marked required, and no "
+                    f"if-guard protects the ref)"
+                )
+    return findings

--- a/tests/cli/test_inspect_commands_integration.py
+++ b/tests/cli/test_inspect_commands_integration.py
@@ -1,16 +1,20 @@
 """Integration tests for inspect command _output_rich() and _output_json() methods."""
 
 import json
+import textwrap
 from io import StringIO
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from click.testing import CliRunner
 from rich.console import Console
 
 from agent_actions.cli.inspect import (
     ActionCommand,
     ContextCommand,
 )
+from agent_actions.cli.main import cli
 from agent_actions.models.action_schema import (
     ActionKind,
     ActionSchema,
@@ -240,3 +244,82 @@ class TestWorkflowMockSpecEnforcement:
     def test_spec_mock_allows_new_attribute(self):
         wf = _make_workflow_mock()
         assert wf.action_configs is not None
+
+
+# ── End-to-end: prompt-required cross-check through real `agac inspect` ───────
+
+
+def _build_prompt_ref_project(root: Path, *, required_b: bool) -> str:
+    """Scaffold a real on-disk project whose consumer prompt is a prompt_store
+    `$`-ref reading a producer field. Returns the workflow name."""
+    wf = "demo"
+    (root / "agent_actions.yml").write_text("version: '1.0'\n")
+    for name in ("templates", "rendered_workflows", "prompt_store"):
+        (root / name).mkdir(parents=True, exist_ok=True)
+    (root / "agent_workflow" / wf / "agent_io").mkdir(parents=True, exist_ok=True)
+    (root / "prompt_store" / f"{wf}.md").write_text(
+        "{prompt consumer}\nUse {{ producer.b }} here.\n{end_prompt}\n"
+    )
+    cfg_dir = root / "agent_workflow" / wf / "agent_config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / f"{wf}.yml").write_text(
+        textwrap.dedent(f"""\
+        name: {wf}
+        description: demo
+        defaults:
+          json_mode: true
+          granularity: Record
+          run_mode: online
+          model_name: gpt-4o-mini
+          model_vendor: openai
+          api_key: OPENAI_API_KEY
+        actions:
+          - name: producer
+            intent: produce a and b
+            kind: llm
+            context_scope:
+              observe: ["source.*"]
+            schema:
+              fields:
+                - id: a
+                  type: string
+                  required: true
+                - id: b
+                  type: string
+                  required: {str(required_b).lower()}
+          - name: consumer
+            intent: consume producer output
+            kind: llm
+            dependencies: [producer]
+            prompt: ${wf}.consumer
+            context_scope:
+              observe: ["producer.a", "producer.b"]
+            schema:
+              fields:
+                - id: out
+                  type: string
+                  required: true
+        """)
+    )
+    return wf
+
+
+class TestInspectPromptRequiredEndToEnd:
+    """`agac inspect` on a real on-disk workflow whose consumer prompt (a
+    prompt_store `$`-ref) reads a non-required producer field warns and still
+    exits 0."""
+
+    def test_unguarded_optional_ref_warns_but_inspect_succeeds(self, tmp_path, monkeypatch):
+        wf = _build_prompt_ref_project(tmp_path, required_b=False)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(cli, ["inspect", "-a", wf])
+        assert result.exit_code == 0, result.output
+        assert "producer.b" in result.output
+        assert "consumer" in result.output
+
+    def test_required_ref_produces_no_warning(self, tmp_path, monkeypatch):
+        wf = _build_prompt_ref_project(tmp_path, required_b=True)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(cli, ["inspect", "-a", wf])
+        assert result.exit_code == 0, result.output
+        assert "producer.b" not in result.output

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -606,10 +606,82 @@ class TestPromptRequiredCrossCheck:
         warnings = _preflight_warnings(cfgs, caplog)
         assert not any("producer.b" in w for w in warnings), warnings
 
-    def test_unguarded_ref_warns_but_does_not_raise(self, caplog):
+    def test_guard_on_other_field_still_warns(self, caplog):
+        # Guard tests producer.a; body reads the unguarded producer.b.
         cfgs = {
             "producer": _producer(required_b=False),
-            "consumer": _consumer("Use {{ producer.b }} here."),
+            "consumer": _consumer("{% if producer.a is defined %}{{ producer.b }}{% endif %}"),
         }
-        # Must complete (warn, never raise) — the fix is a warning, not an error.
-        _preflight_warnings(cfgs, caplog)
+        warnings = _preflight_warnings(cfgs, caplog)
+        assert any("producer.b" in w for w in warnings), warnings
+
+    def test_optional_ref_warns_exactly_once_and_does_not_raise(self, caplog):
+        # Same field referenced twice — one warning, and validate() completes
+        # (warn, never raise).
+        cfgs = {
+            "producer": _producer(required_b=False),
+            "consumer": _consumer("Use {{ producer.b }} and again {{ producer.b }}."),
+        }
+        matches = [w for w in _preflight_warnings(cfgs, caplog) if "producer.b" in w]
+        assert len(matches) == 1, matches
+
+
+class TestProducingSchemaCollection:
+    """`_collect_producing_schemas` feeds the cross-check the right field set."""
+
+    def _service(self, action_configs: dict, schemas: dict) -> PreflightService:
+        from unittest.mock import MagicMock
+
+        svc = PreflightService(
+            agent_name="wf",
+            action_configs=action_configs,
+            project_root=None,
+            workflow_config_path="wf.yml",
+            verify_keys=False,
+        )
+        svc.schema_service = MagicMock()
+        svc.schema_service.get_all_schemas.return_value = schemas
+        return svc
+
+    def test_dropped_field_is_excluded(self):
+        from agent_actions.models.action_schema import (
+            ActionKind,
+            ActionSchema,
+            FieldInfo,
+            FieldSource,
+        )
+
+        schema = ActionSchema(
+            name="producer",
+            kind=ActionKind.LLM,
+            output_fields=[
+                FieldInfo(name="kept", source=FieldSource.SCHEMA, is_required=False),
+                FieldInfo(
+                    name="gone", source=FieldSource.SCHEMA, is_required=False, is_dropped=True
+                ),
+            ],
+        )
+        svc = self._service({"producer": {"kind": "llm"}}, {"producer": schema})
+        ids = {f["id"] for f in svc._collect_producing_schemas()["producer"]["fields"]}
+        assert ids == {"kept"}
+
+    def test_versioned_producer_indexed_under_base_name(self):
+        from agent_actions.models.action_schema import (
+            ActionKind,
+            ActionSchema,
+            FieldInfo,
+            FieldSource,
+        )
+
+        schema = ActionSchema(
+            name="classify_1",
+            kind=ActionKind.LLM,
+            output_fields=[FieldInfo(name="label", source=FieldSource.SCHEMA, is_required=False)],
+        )
+        svc = self._service(
+            {"classify_1": {"kind": "llm", "version_base_name": "classify"}},
+            {"classify_1": schema},
+        )
+        collected = svc._collect_producing_schemas()
+        assert "classify" in collected
+        assert {f["id"] for f in collected["classify"]["fields"]} == {"label"}

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -560,19 +560,22 @@ def _consumer(prompt: str) -> dict:
 
 def _preflight_warnings(action_configs: dict, caplog) -> list[str]:
     """Run PreflightService.validate() and return preflight warning messages."""
-    caplog.set_level(logging.WARNING, logger="agent_actions.services.preflight_service")
-    PreflightService(
-        agent_name="wf",
-        action_configs=action_configs,
-        project_root=None,
-        workflow_config_path="wf.yml",
-        verify_keys=False,
-    ).validate()
-    return [
-        r.getMessage()
-        for r in caplog.records
-        if r.name == "agent_actions.services.preflight_service"
-    ]
+    logger_name = "agent_actions.services.preflight_service"
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger_name):
+            PreflightService(
+                agent_name="wf",
+                action_configs=action_configs,
+                project_root=None,
+                workflow_config_path="wf.yml",
+                verify_keys=False,
+            ).validate()
+        return [r.getMessage() for r in caplog.records if r.name == logger_name]
+    finally:
+        aa_logger.propagate = original
 
 
 class TestPromptRequiredCrossCheck:

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -4,9 +4,12 @@ Ensures every detectable misconfiguration is caught before execution.
 Organized by category of misconfiguration.
 """
 
+import logging
+
 import pytest
 
 from agent_actions.config.schema import ActionConfig, WorkflowConfig
+from agent_actions.services.preflight_service import PreflightService
 from agent_actions.validation.orchestration.action_entry_validation_orchestrator import (
     ActionEntryValidationOrchestrator,
 )
@@ -520,3 +523,90 @@ class TestActionableErrors:
         assert len(reprompt_errors) > 0
         # Should suggest defining a schema
         assert any("schema" in e.lower() or "define" in e.lower() for e in reprompt_errors)
+
+
+# ── TestPromptRequiredCrossCheck ─────────────────────────────────────
+
+
+def _producer(required_b: bool) -> dict:
+    """LLM producer with flat fields a (required) and b (required_b)."""
+    return {
+        "agent_type": "llm",
+        "kind": "llm",
+        "model_name": "gpt-4o-mini",
+        "prompt": "Produce values a and b.",
+        "context_scope": {"observe": ["source.*"]},
+        "schema": {
+            "fields": [
+                {"id": "a", "type": "string", "required": True},
+                {"id": "b", "type": "string", "required": required_b},
+            ]
+        },
+    }
+
+
+def _consumer(prompt: str) -> dict:
+    """LLM consumer that observes both producer fields and renders `prompt`."""
+    return {
+        "agent_type": "llm",
+        "kind": "llm",
+        "model_name": "gpt-4o-mini",
+        "depends_on": ["producer"],
+        "prompt": prompt,
+        "context_scope": {"observe": ["producer.a", "producer.b"]},
+        "schema": {"fields": [{"id": "out", "type": "string", "required": True}]},
+    }
+
+
+def _preflight_warnings(action_configs: dict, caplog) -> list[str]:
+    """Run PreflightService.validate() and return preflight warning messages."""
+    caplog.set_level(logging.WARNING, logger="agent_actions.services.preflight_service")
+    PreflightService(
+        agent_name="wf",
+        action_configs=action_configs,
+        project_root=None,
+        workflow_config_path="wf.yml",
+        verify_keys=False,
+    ).validate()
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "agent_actions.services.preflight_service"
+    ]
+
+
+class TestPromptRequiredCrossCheck:
+    """Preflight must warn when a prompt references a producer field the
+    producer does not mark required and no `{% if %}` guards it."""
+
+    def test_unguarded_ref_to_non_required_field_warns(self, caplog):
+        cfgs = {
+            "producer": _producer(required_b=False),
+            "consumer": _consumer("Use {{ producer.b }} here."),
+        }
+        warnings = _preflight_warnings(cfgs, caplog)
+        assert any("producer.b" in w and "consumer" in w for w in warnings), warnings
+
+    def test_ref_to_required_field_does_not_warn(self, caplog):
+        cfgs = {
+            "producer": _producer(required_b=True),
+            "consumer": _consumer("Use {{ producer.b }} here."),
+        }
+        warnings = _preflight_warnings(cfgs, caplog)
+        assert not any("producer.b" in w for w in warnings), warnings
+
+    def test_guarded_ref_does_not_warn(self, caplog):
+        cfgs = {
+            "producer": _producer(required_b=False),
+            "consumer": _consumer("{% if producer.b is defined %}{{ producer.b }}{% endif %}"),
+        }
+        warnings = _preflight_warnings(cfgs, caplog)
+        assert not any("producer.b" in w for w in warnings), warnings
+
+    def test_unguarded_ref_warns_but_does_not_raise(self, caplog):
+        cfgs = {
+            "producer": _producer(required_b=False),
+            "consumer": _consumer("Use {{ producer.b }} here."),
+        }
+        # Must complete (warn, never raise) — the fix is a warning, not an error.
+        _preflight_warnings(cfgs, caplog)

--- a/tests/validation/test_prompt_required_field_validator.py
+++ b/tests/validation/test_prompt_required_field_validator.py
@@ -88,3 +88,75 @@ def test_second_workflow_shape_is_flagged():
     schemas = {"analyzer": _schema(required={"score"}, optional={"summary"})}
     findings = find_unguarded_required_refs(prompts, schemas)
     assert any("analyzer.summary" in f and "writer" in f for f in findings)
+
+
+# ── Guard analysis must be field-aware, not block-aware ──────────────
+
+
+def test_guard_on_a_different_field_does_not_cover_the_ref():
+    # The `{% if %}` tests producer.a, but the body reads producer.b — b is
+    # still unguarded and must be flagged.
+    prompts = {"consumer": "{% if producer.a is defined %}{{ producer.b }}{% endif %}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.b" in f for f in findings)
+
+
+def test_else_branch_ref_is_flagged():
+    # The else branch runs precisely when b is absent — the highest-risk case.
+    prompts = {"consumer": "{% if producer.b is defined %}ok{% else %}{{ producer.b }}{% endif %}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.b" in f for f in findings)
+
+
+def test_elif_body_guarded_by_its_own_test_is_not_flagged():
+    prompts = {
+        "consumer": (
+            "{% if producer.a is defined %}a"
+            "{% elif producer.b is defined %}{{ producer.b }}{% endif %}"
+        )
+    }
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_subscript_ref_is_flagged():
+    prompts = {"consumer": '{{ producer["b"] }}'}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.b" in f for f in findings)
+
+
+def test_whitespace_control_guard_is_honoured():
+    prompts = {"consumer": "{%+ if producer.b is defined %}{{ producer.b }}{%+ endif %}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_self_namespace_ref_is_not_flagged():
+    # An action referencing its own output is a different error class.
+    prompts = {"producer": "Emit {{ producer.b }}."}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_one_field_referenced_many_ways_warns_once():
+    prompts = {"consumer": '{{ producer.b }} {{ producer.b["x"] }} {{ producer.b.detail }}'}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert len(findings) == 1
+
+
+def test_comment_hidden_if_tag_does_not_suppress():
+    # A commented-out `{% if %}` is not a real guard; the ref stays unguarded.
+    prompts = {"consumer": "{# {% if producer.b is defined %} #}{{ producer.b }}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.b" in f for f in findings)
+
+
+def test_empty_prompts_or_schemas_short_circuit():
+    schemas = {"producer": _schema(required=set(), optional={"b"})}
+    assert find_unguarded_required_refs({}, schemas) == []
+    assert find_unguarded_required_refs({"consumer": "{{ producer.b }}"}, {}) == []

--- a/tests/validation/test_prompt_required_field_validator.py
+++ b/tests/validation/test_prompt_required_field_validator.py
@@ -1,0 +1,90 @@
+from agent_actions.validation.prompt_required_field_validator import (
+    find_unguarded_required_refs,
+)
+
+
+def _schema(*, required: set[str], optional: set[str]) -> dict:
+    fields = [{"id": name, "type": "string", "required": True} for name in sorted(required)]
+    fields += [{"id": name, "type": "string", "required": False} for name in sorted(optional)]
+    return {"fields": fields}
+
+
+def test_unguarded_ref_to_non_required_field_is_flagged():
+    prompts = {"consumer": "Use {{ producer.b }} here."}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.b" in f and "consumer" in f for f in findings)
+
+
+def test_required_field_ref_is_not_flagged():
+    prompts = {"consumer": "Use {{ producer.a }} here."}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_guarded_ref_is_not_flagged():
+    prompts = {"consumer": "{% if producer.b is defined %}{{ producer.b }}{% endif %}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_ref_to_unknown_namespace_is_ignored():
+    prompts = {"consumer": "{{ mystery.b }}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_ref_to_field_absent_from_schema_is_ignored():
+    # `producer.z` is not declared at all — a dependency/observe concern,
+    # not a required-ness one. Not flagged here.
+    prompts = {"consumer": "{{ producer.z }}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_nested_if_guard_does_not_crash_and_suppresses():
+    prompts = {
+        "consumer": (
+            "{% if producer.a is defined %}"
+            "{% if producer.b is defined %}{{ producer.b }}{% endif %}"
+            "{% endif %}"
+        )
+    }
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_loop_iterable_over_optional_field_is_flagged():
+    # A `{{ }}`-only regex would extract `c.key` and miss the loop iterable;
+    # AST extraction surfaces `producer.items`, the real crash point.
+    prompts = {"consumer": "{% for c in producer.items %}{{ c.key }}{% endfor %}"}
+    schemas = {"producer": _schema(required=set(), optional={"items"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.items" in f for f in findings)
+
+
+def test_partially_guarded_ref_is_flagged_on_unconditional_use():
+    # `b` appears once guarded and once unconditionally — the unconditional
+    # use is the risk and must be flagged.
+    prompts = {
+        "consumer": "{% if producer.b is defined %}{{ producer.b }}{% endif %} {{ producer.b }}"
+    }
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.b" in f for f in findings)
+
+
+def test_nested_attr_ref_checks_top_level_field_only():
+    # `producer.a.detail` — `a` is required, so the ref is not flagged even
+    # though the `.detail` sub-attribute is unverifiable (documented coarseness).
+    prompts = {"consumer": "{{ producer.a.detail }}"}
+    schemas = {"producer": _schema(required={"a"}, optional={"b"})}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_second_workflow_shape_is_flagged():
+    # A second, differently-named shape raises the cost of input-matching.
+    prompts = {"writer": "Draft using {{ analyzer.summary }}."}
+    schemas = {"analyzer": _schema(required={"score"}, optional={"summary"})}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("analyzer.summary" in f and "writer" in f for f in findings)


### PR DESCRIPTION
## Summary

`agac inspect` reported `● validated`, then `agac run` crashed mid-pipeline at prompt render:

```
Error rendering prompt template: 'dict object' has no attribute 'candidate_2_common_wrong_answer'
```

An upstream LLM with a flat schema (top-level `fields:`, no `required:`) is allowed to omit a field; a downstream prompt referenced it unconditionally under StrictUndefined and the run died — after the upstream LLM call was already paid for. Inspect already loaded both halves (the prompt's `{{ ns.field }}` tokens and the producer's required set) but never compared them.

This adds that comparison as a **preflight warning** (never an error — conditional refs are legitimate). Scope is ISSUE-001 option A; required-by-default (option B) is a separate, breaking follow-up (spec 568).

### What changed
- **New** `agent_actions/validation/prompt_required_field_validator.py` — `find_unguarded_required_refs(prompts, schemas)`, a pure function reusing `PromptASTAnalyzer` to flag each `{{ ns.field }}` where `ns` produces `field` as a **declared-but-optional** schema field and no `{% if %}` guards the ref.
- **Wired** into `PreflightService.validate()` — resolves prompt text via `PromptFormatter.get_raw_prompt` (so `$`-refs load from `prompt_store`) and derives each producer's required set from `schema_service.get_all_schemas()` (SCHEMA-source fields), logging every finding through the existing preflight warning path.

### Two deliberate improvements over the drafted approach
- **Nesting-aware `{% if %}` stripper** instead of a single non-greedy regex, which crashes on nested ifs (`ValueError: unknown tag 'endif'`) — verified against the exact case.
- **Required set sourced from the schema service**, matching the field namespace the static analyzer already checks refs against — sidesteps raw-`id` vs compiled-`key` divergence. Only fields the schema *declares* are flagged; absent fields and unknown namespaces are left to the dependency/observe checks, avoiding false positives.

## Verification
- RED→GREEN across 4 commits: a real-path preflight test (with negatives locking out blanket-warn / always-warn / raise-instead-of-warn) was RED (`warnings=[]`), went green only once the validator was written *and* wired.
- New tests: validator units (10 — nested-if no-crash, loop-iterable, absent-field ignored, 2 shapes), preflight real-path (4), CLI end-to-end through real `agac inspect` on a tmp project with a prompt-file `$`-ref (2 — asserts exit 0 + warning present, and no warning when the field is required).
- Full suite: **7864 passed, 0 failed** (the check runs on every inspect/run — no regressions).
- `ruff check` and `ruff format --check` on `agent_actions tests` → clean.
- Manual: `agac inspect` on a workflow with a known unguarded optional-field ref prints the named warning and exits 0.