### PR TITLE
fix(correlation): key versioned 1:1 correlation id on source_guid, not position

### DIFF
--- a/agent_actions/utils/correlation/version_id.py
+++ b/agent_actions/utils/correlation/version_id.py
@@ -92,10 +92,13 @@ class VersionIdGenerator:
     ) -> dict:
         """Add version correlation ID to an object.
 
-        For versioned agents (``is_versioned_agent=True``), always assigns.
-        For non-versioned agents, only assigns when *force* is ``True``
-        (used by ``VersionIdEnricher`` for 1→N expansions where each new
-        item needs a unique identity for downstream fan-in grouping).
+        For versioned agents (``is_versioned_agent=True``), keys on
+        ``source_guid`` for 1:1 records — so all N parallel versions of one
+        source record share an id — and on position for expansions
+        (``force=True``) and records without a ``source_guid``. For
+        non-versioned agents, only assigns when *force* is ``True`` (used by
+        ``VersionIdEnricher`` for 1→N expansions where each new item needs a
+        unique identity for downstream fan-in grouping).
 
         Raises:
             ValueError: If workflow_session_id is missing in version context.

--- a/agent_actions/utils/correlation/version_id.py
+++ b/agent_actions/utils/correlation/version_id.py
@@ -93,12 +93,10 @@ class VersionIdGenerator:
         """Add version correlation ID to an object.
 
         For versioned agents (``is_versioned_agent=True``), keys on
-        ``source_guid`` for 1:1 records — so all N parallel versions of one
-        source record share an id — and on position for expansions
-        (``force=True``) and records without a ``source_guid``. For
-        non-versioned agents, only assigns when *force* is ``True`` (used by
-        ``VersionIdEnricher`` for 1→N expansions where each new item needs a
-        unique identity for downstream fan-in grouping).
+        ``source_guid`` so all N parallel versions of one source record share
+        an id. Expansions (``force=True``) are keyed on position instead, so
+        each 1→N child gets a unique id for downstream fan-in grouping;
+        non-versioned agents assign only on that expansion path.
 
         Raises:
             ValueError: If workflow_session_id is missing in version context.

--- a/agent_actions/utils/correlation/version_id.py
+++ b/agent_actions/utils/correlation/version_id.py
@@ -122,22 +122,25 @@ class VersionIdGenerator:
             )
 
         obj = obj.copy()
-        if record_index is not None:
+        source_guid = obj.get("source_guid")
+        is_versioned = agent_config.get("is_versioned_agent", False)
+        if not force and is_versioned and source_guid:
+            # Versioned 1:1 — key on source_guid so all N parallel versions of
+            # the same source record share one id regardless of per-version
+            # position (guard filters shift positions independently per version).
+            obj["version_correlation_id"] = cls.get_or_create_version_correlation_id(
+                source_guid, version_base_name, workflow_session_id
+            )
+        elif record_index is not None:
             obj["version_correlation_id"] = cls.get_or_create_position_based_version_correlation_id(
-                record_index,
-                version_base_name,
-                workflow_session_id,
-                file_context=obj.get("source_guid", ""),
+                record_index, version_base_name, workflow_session_id, file_context=source_guid or ""
+            )
+        elif source_guid:
+            obj["version_correlation_id"] = cls.get_or_create_version_correlation_id(
+                source_guid, version_base_name, workflow_session_id
             )
         else:
-            source_guid = obj.get("source_guid")
-            if source_guid:
-                obj["version_correlation_id"] = cls.get_or_create_version_correlation_id(
-                    source_guid, version_base_name, workflow_session_id
-                )
-            else:
-                logger.debug(
-                    "Skipping version correlation: source_guid absent for %s",
-                    version_base_name,
-                )
+            logger.debug(
+                "Skipping version correlation: source_guid absent for %s", version_base_name
+            )
         return obj

--- a/agent_actions/workflow/managers/loop.py
+++ b/agent_actions/workflow/managers/loop.py
@@ -194,7 +194,10 @@ class VersionOutputCorrelator:
                 if not correlation_key:
                     source_guid = record_copy.get("source_guid", "unknown")
                     raise DataValidationError(
-                        "Missing required field: version_correlation_id",
+                        f"Could not align versions for source record '{source_guid}': "
+                        f"version '{version_agent}' produced a record with no "
+                        f"version_correlation_id. All N parallel versions of a source "
+                        f"record must share one id before a merge consumer can group them.",
                         {
                             "source_guid": source_guid,
                             "version_agent": version_agent,

--- a/tests/core/graph/test_version_correlator.py
+++ b/tests/core/graph/test_version_correlator.py
@@ -685,6 +685,19 @@ class TestVersionCorrelationFailureError:
             result = output_manager.resolve_correlated_input(idx=0)
             assert result is None
 
+    def test_merge_abort_names_source_and_version(self):
+        """The abort message names the misaligned source record and the version agent."""
+        from agent_actions.errors import DataValidationError
+
+        correlator = VersionOutputCorrelator(Path("/tmp"))
+        with pytest.raises(DataValidationError) as exc:
+            correlator._build_correlation_groups(
+                {"extract_v1": [{"source_guid": "g1", "content": {}}]}
+            )
+        msg = str(exc.value)
+        assert "g1" in msg  # names the misaligned source record
+        assert "extract_v1" in msg  # names the version agent
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/utils/correlation/test_version_id_keying.py
+++ b/tests/unit/utils/correlation/test_version_id_keying.py
@@ -55,3 +55,12 @@ def test_versioned_no_source_guid_falls_back_to_position():
     a = VersionIdGenerator.add_version_correlation_id({}, _CFG, record_index=0)
     b = VersionIdGenerator.add_version_correlation_id({}, _CFG, record_index=1)
     assert a.get("version_correlation_id") != b.get("version_correlation_id")
+
+
+def test_versioned_shared_id_uses_guid_helper():
+    """The shared id is exactly the GUID helper's output (kills inline-hash and clamp-to-0 cheats)."""
+    VersionIdGenerator.clear()
+    v = VersionIdGenerator.add_version_correlation_id({"source_guid": "g1"}, _CFG, record_index=3)
+    assert v["version_correlation_id"] == VersionIdGenerator.get_or_create_version_correlation_id(
+        "g1", "extract", "s1"
+    )

--- a/tests/unit/utils/correlation/test_version_id_keying.py
+++ b/tests/unit/utils/correlation/test_version_id_keying.py
@@ -1,0 +1,57 @@
+"""Keying tests for VersionIdGenerator.add_version_correlation_id.
+
+Parallel versions of one source record must share a correlation id so a
+merge consumer can group them, while 1->N expansions keep unique per-item
+ids. These pin both invariants.
+"""
+
+from agent_actions.utils.correlation.version_id import VersionIdGenerator
+
+_CFG = {"is_versioned_agent": True, "version_base_name": "extract", "workflow_session_id": "s1"}
+
+
+def test_versioned_same_source_guid_shares_id_across_positions():
+    VersionIdGenerator.clear()
+    v1 = VersionIdGenerator.add_version_correlation_id({"source_guid": "g1"}, _CFG, record_index=0)
+    v2 = VersionIdGenerator.add_version_correlation_id({"source_guid": "g1"}, _CFG, record_index=2)
+    assert v1["version_correlation_id"] == v2["version_correlation_id"]
+
+
+def test_versioned_different_source_guids_get_different_ids():
+    VersionIdGenerator.clear()
+    a = VersionIdGenerator.add_version_correlation_id({"source_guid": "g1"}, _CFG, record_index=0)
+    b = VersionIdGenerator.add_version_correlation_id({"source_guid": "g2"}, _CFG, record_index=0)
+    assert a["version_correlation_id"] != b["version_correlation_id"]
+
+
+def test_expansion_items_keep_unique_ids():
+    VersionIdGenerator.clear()
+    cfg = {"is_versioned_agent": False, "action_name": "expand", "workflow_session_id": "s1"}
+    a = VersionIdGenerator.add_version_correlation_id(
+        {"source_guid": "g1"}, cfg, record_index=0, force=True
+    )
+    b = VersionIdGenerator.add_version_correlation_id(
+        {"source_guid": "g1"}, cfg, record_index=1, force=True
+    )
+    assert a["version_correlation_id"] != b["version_correlation_id"]
+
+
+def test_versioned_expansion_items_keep_unique_ids():
+    """A versioned agent that ALSO expands keeps unique per-item ids (kills the drop-`not force` cheat)."""
+    VersionIdGenerator.clear()
+    cfg = {"is_versioned_agent": True, "version_base_name": "extract", "workflow_session_id": "s1"}
+    a = VersionIdGenerator.add_version_correlation_id(
+        {"source_guid": "g1"}, cfg, record_index=0, force=True
+    )
+    b = VersionIdGenerator.add_version_correlation_id(
+        {"source_guid": "g1"}, cfg, record_index=1, force=True
+    )
+    assert a["version_correlation_id"] != b["version_correlation_id"]
+
+
+def test_versioned_no_source_guid_falls_back_to_position():
+    """Versioned records lacking source_guid keep per-position ids (kills the fallback-collapse cheat)."""
+    VersionIdGenerator.clear()
+    a = VersionIdGenerator.add_version_correlation_id({}, _CFG, record_index=0)
+    b = VersionIdGenerator.add_version_correlation_id({}, _CFG, record_index=1)
+    assert a.get("version_correlation_id") != b.get("version_correlation_id")


### PR DESCRIPTION
## Summary
Parallel versions of the same source record intermittently received **different** `version_correlation_id`s, so a `version_consumption: merge` consumer would abort with `Missing required field: version_correlation_id` on fresh runs.

Root cause: `VersionIdEnricher.enrich` always passes `record_index`, so `add_version_correlation_id` always took the **position-based** keying branch. Under `versions: {mode: parallel}`, each version filters/orders records independently, so the same source record lands at a different `record_index` per version -> different registry key -> different id.

Fix (keying decision lives in `version_id.py`, where the discriminators are available):
- **Versioned 1:1** (`is_versioned_agent` and not `force` and `source_guid` present) -> key on `source_guid`, so all N parallel versions share one id regardless of per-version position.
- **Expansions** (`force=True`) and **no-`source_guid`** records keep position keying (unique per item / per position) — expansion uniqueness is preserved.
- The merge abort now names the misaligned source record and version agent instead of a bare field-name message.

No behavior change for expansions; the enricher and the correlator grouping logic are untouched (only the abort's message string).

## Verification
- New `tests/unit/utils/correlation/test_version_id_keying.py` (6 tests): shared-id-across-positions (the RED repro), distinct-guid, expansion-uniqueness, versioned-expansion-uniqueness, no-guid position fallback, and a pin that the shared id equals the GUID helper's output (kills inline-hash / clamp-to-0 shortcuts).
- Extended `tests/core/graph/test_version_correlator.py`: asserts the abort **message** (not just context dict) names the source_guid and version agent.
- RED->GREEN confirmed at each step (T1 failed pre-fix with position ids; message test failed pre-fix with the bare string).
- Full suite: **7855 passed**; `ruff check` + `ruff format --check` clean across `agent_actions` and `tests`.