### PR TITLE
fix(schema): honour additionalProperties: true at schema compilation

### DIFF
--- a/agent_actions/output/response/vendor_compilation.py
+++ b/agent_actions/output/response/vendor_compilation.py
@@ -76,7 +76,7 @@ def compile_unified_schema(
                 "type": "object",
                 "properties": properties,
                 "required": required,
-                "additionalProperties": False,
+                "additionalProperties": unified.get("additionalProperties", False),
             },
         }
     elif target == "anthropic":
@@ -88,7 +88,7 @@ def compile_unified_schema(
                     "type": "object",
                     "properties": properties,
                     "required": required,
-                    "additionalProperties": False,
+                    "additionalProperties": unified.get("additionalProperties", False),
                 },
             }
         ]
@@ -107,7 +107,7 @@ def compile_unified_schema(
             "type": "object",
             "properties": properties,
             "required": required,
-            "additionalProperties": False,
+            "additionalProperties": unified.get("additionalProperties", False),
         }
     elif target == "cohere":
         # Cohere native format

--- a/tests/unit/output/response/test_additional_properties_honoured.py
+++ b/tests/unit/output/response/test_additional_properties_honoured.py
@@ -1,0 +1,77 @@
+"""Schema compilation must honour a declared additionalProperties, defaulting to strict."""
+
+import jsonschema
+import pytest
+
+from agent_actions.output.response.expander_schema import compile_output_schema
+from agent_actions.output.response.vendor_compilation import compile_unified_schema
+
+_UNIFIED = {"name": "s", "fields": [{"id": "a", "type": "string"}]}
+
+
+def test_openai_honours_true():
+    compiled = compile_unified_schema({**_UNIFIED, "additionalProperties": True}, "openai")
+    assert compiled["schema"]["additionalProperties"] is True
+
+
+def test_openai_defaults_false_when_absent():
+    compiled = compile_unified_schema(_UNIFIED, "openai")
+    assert compiled["schema"]["additionalProperties"] is False
+
+
+def test_groq_honours_true():
+    compiled = compile_unified_schema({**_UNIFIED, "additionalProperties": True}, "groq")
+    assert compiled["schema"]["additionalProperties"] is True
+
+
+def test_agac_provider_honours_true():
+    compiled = compile_unified_schema({**_UNIFIED, "additionalProperties": True}, "agac-provider")
+    assert compiled["schema"]["additionalProperties"] is True
+
+
+def test_anthropic_honours_true():
+    compiled = compile_unified_schema({**_UNIFIED, "additionalProperties": True}, "anthropic")
+    assert compiled[0]["input_schema"]["additionalProperties"] is True
+
+
+def test_anthropic_defaults_false_when_absent():
+    compiled = compile_unified_schema(_UNIFIED, "anthropic")
+    assert compiled[0]["input_schema"]["additionalProperties"] is False
+
+
+def test_ollama_honours_true():
+    compiled = compile_unified_schema({**_UNIFIED, "additionalProperties": True}, "ollama_local")
+    assert compiled["additionalProperties"] is True
+
+
+def test_ollama_defaults_false_when_absent():
+    compiled = compile_unified_schema(_UNIFIED, "ollama_local")
+    assert compiled["additionalProperties"] is False
+
+
+def test_extra_key_validates_when_true():
+    compiled = compile_unified_schema({**_UNIFIED, "additionalProperties": True}, "openai")
+    jsonschema.validate({"a": "x", "steps": ["1"]}, compiled["schema"])
+
+
+def test_extra_key_rejected_when_default():
+    compiled = compile_unified_schema(_UNIFIED, "openai")
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"a": "x", "steps": ["1"]}, compiled["schema"])
+
+
+def _compile_array_item(item_additional_properties):
+    item = {"type": "object", "properties": {"a": {"type": "string"}}}
+    if item_additional_properties is not None:
+        item["additionalProperties"] = item_additional_properties
+    agent = {"agent_type": "act", "schema": {"type": "array", "items": item}}
+    compile_output_schema(agent, {})
+    return agent["json_output_schema"]["additionalProperties"]
+
+
+def test_array_item_honours_true():
+    assert _compile_array_item(True) is True
+
+
+def test_array_item_defaults_false_when_absent():
+    assert _compile_array_item(None) is False

--- a/tests/unit/output/response/test_additional_properties_honoured.py
+++ b/tests/unit/output/response/test_additional_properties_honoured.py
@@ -3,8 +3,10 @@
 import jsonschema
 import pytest
 
+from agent_actions.errors import SchemaValidationError
 from agent_actions.output.response.expander_schema import compile_output_schema
 from agent_actions.output.response.vendor_compilation import compile_unified_schema
+from agent_actions.utils.udf_management.tooling import _validate_against_schema
 
 _UNIFIED = {"name": "s", "fields": [{"id": "a", "type": "string"}]}
 
@@ -75,3 +77,14 @@ def test_array_item_honours_true():
 
 def test_array_item_defaults_false_when_absent():
     assert _compile_array_item(None) is False
+
+
+def test_udf_output_extra_key_accepted_when_true():
+    schema = compile_unified_schema({**_UNIFIED, "additionalProperties": True}, "openai")["schema"]
+    _validate_against_schema({"a": "x", "extra": 1}, schema, "udf", validation_type="output")
+
+
+def test_udf_output_extra_key_rejected_when_default():
+    schema = compile_unified_schema(_UNIFIED, "openai")["schema"]
+    with pytest.raises(SchemaValidationError):
+        _validate_against_schema({"a": "x", "extra": 1}, schema, "udf", validation_type="output")


### PR DESCRIPTION
## Summary

`compile_unified_schema` (`agent_actions/output/response/vendor_compilation.py`) hardcoded `"additionalProperties": False` for the OpenAI-compatible, Anthropic, and Ollama targets, ignoring a schema file's declared `additionalProperties: true`. A UDF (`kind: tool`) or LLM output carrying an extra key then passed preflight but crashed mid-run with `Additional properties are not allowed` — after upstream LLM tokens were already spent, with downstream cascade-skips.

The fix reads the declared value at each of the three compile sites:

```python
"additionalProperties": unified.get("additionalProperties", False),
```

- **One fix, both validators.** The compiled schema feeds both UDF-output validation (`_validate_against_schema`) and LLM-output validation, so fixing the compiler fixes both paths.
- **Default stays strict.** When the schema file omits the key, the compiled schema still emits `False` — no behaviour change for existing schemas (7897 existing tests unchanged).
- **Nested-items sibling verified, not edited.** `expander_schema.py:83` uses `setdefault("additionalProperties", False)` on the source item dict, which already preserves a declared `true`. Left unchanged; pinned with a regression test so a future refactor can't silently regress it.
- **Provider caveat (documented, not blocked):** OpenAI structured-outputs strict mode requires `additionalProperties: false`. A user who declares `true` and targets strict OpenAI opts into the provider's behaviour — that is the author's explicit choice; the framework honours the file.

Scope: only the three hardcoded `False` sites changed. The gemini/cohere branches (already omit the key) and the jsonschema validator (correctly enforces whatever it's handed) are untouched.

## Verification

- RED→GREEN: `tests/unit/output/response/test_additional_properties_honoured.py` (new). The five vendor honour-true cases + extra-key-validates were RED against the hardcode; GREEN after the fix. Default-strict guards and the nested-items pinning guards are green throughout.
- End-to-end: `test_udf_output_extra_key_accepted_when_true` compiles a `additionalProperties: true` schema and runs an extra-key payload through the real `_validate_against_schema` UDF path — no crash; the default schema still raises `SchemaValidationError`.
- `pytest tests/unit/output tests/validation tests/core/test_udf_schema_validation.py -q` → 542 passed.
- Full suite: `pytest -q` → 7897 passed.
- `ruff check agent_actions tests` and `ruff format --check agent_actions tests` → clean.