### PR TITLE
fix(udf-discovery): import only files that declare udf_tool

### DIFF
--- a/agent_actions/input/loaders/_MANIFEST.md
+++ b/agent_actions/input/loaders/_MANIFEST.md
@@ -18,6 +18,6 @@ processing.
 | `source_data.py` | Module | `SourceDataLoader` that loads/saves source data via storage backend (`read_source`/`write_source`), requiring a `StorageBackend` at init. | `config.interfaces`, `errors`, `storage.backend` |
 | `tabular.py` | Module | `TabularLoader` for CSV/TSV content; reads via `csv.DictReader` and wraps parsing errors in `AgentActionsError`. | `errors`, `logging` |
 | `text.py` | Module | `TextLoader` for plain text/markdown/HTML content with the same fallback/validation pattern as other loaders. | `errors` |
-| `udf.py` | Module | Discovers user-defined functions (UDFs) under `user_code` by importing discovered modules and validating `impl` references. | `utils.module_loader`, `utils.udf_management`, `errors` |
+| `udf.py` | Module | Discovers user-defined functions (UDFs) under `user_code` by importing only modules that declare a tool-registering decorator (`udf_tool`/`reprompt_validation`) and validating `impl` references. | `utils.module_loader`, `utils.udf_management`, `errors` |
 | `xml.py` | Module | `XmlLoader` that parses XML text into `ElementTree` roots, exposes helper for turning elements to dicts, and surfaces parse metadata. | `errors`, `xml` |
 | `data_source.py` | Module | `DataSourceType` enum, `DataSourceConfig` model, and resolver that maps `data_source` config values to concrete directories (staging, local, API). | `config`, `errors`, `pydantic` |

--- a/agent_actions/input/loaders/udf.py
+++ b/agent_actions/input/loaders/udf.py
@@ -12,11 +12,12 @@ from agent_actions.utils.udf_management.registry import UDF_REGISTRY, get_udf
 
 logger = logging.getLogger(__name__)
 
-_UDF_DECORATOR = "udf_tool"
+# Decorators that register user tool code via import side effect.
+_TOOL_DECORATORS = frozenset({"udf_tool", "reprompt_validation"})
 
 
-def _declares_udf_tool(py_file: Path) -> bool:
-    """True if the file declares a udf_tool-decorated function, without executing it."""
+def _declares_tool_decorator(py_file: Path) -> bool:
+    """True if the file declares a tool-registering decorated function, without executing it."""
     try:
         source = py_file.read_text(encoding="utf-8")
     except (OSError, ValueError) as e:
@@ -25,9 +26,9 @@ def _declares_udf_tool(py_file: Path) -> bool:
     try:
         tree = ast.parse(source)
     except (SyntaxError, ValueError):
-        # Unparseable: can't prove intent structurally. A udf_tool mention keeps
-        # the file on the import path so its syntax error surfaces loudly.
-        return _UDF_DECORATOR in source
+        # Unparseable: can't prove intent structurally. A decorator-name mention
+        # keeps the file on the import path so its syntax error surfaces loudly.
+        return any(name in source for name in _TOOL_DECORATORS)
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             for dec in node.decorator_list:
@@ -37,7 +38,7 @@ def _declares_udf_tool(py_file: Path) -> bool:
                     if isinstance(target, ast.Attribute)
                     else getattr(target, "id", None)
                 )
-                if name == _UDF_DECORATOR:
+                if name in _TOOL_DECORATORS:
                     return True
     return False
 
@@ -61,9 +62,10 @@ def discover_tool_files(tool_dir: Path) -> list[Path]:
 def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
     """Discover and register all UDFs in the user code directory.
 
-    Only files that declare a ``udf_tool``-decorated function are imported;
-    other ``.py`` files under the tree (helper scripts, notes) are skipped so
-    a broken non-UDF file cannot block discovery.
+    Only files that declare a tool-registering decorator (``udf_tool`` or
+    ``reprompt_validation``) are imported; other ``.py`` files under the tree
+    (helper scripts, notes) are skipped so a broken non-UDF file cannot block
+    discovery.
 
     Raises:
         UDFLoadError: If the user-code directory is missing or invalid
@@ -109,8 +111,8 @@ def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
                 cause=e,
             ) from e
 
-        if not _declares_udf_tool(py_file):
-            logger.debug("Skipping %s: no udf_tool declaration", py_file)
+        if not _declares_tool_decorator(py_file):
+            logger.debug("Skipping %s: no tool-registering decorator declared", py_file)
             continue
 
         if f"agent_actions._udfs.{module_name}" in sys.modules:

--- a/agent_actions/input/loaders/udf.py
+++ b/agent_actions/input/loaders/udf.py
@@ -1,12 +1,45 @@
 """UDF discovery and validation."""
 
+import ast
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 from typing import Any
 
 from agent_actions.errors import DuplicateFunctionError, UDFLoadError
 from agent_actions.utils.udf_management.registry import UDF_REGISTRY, get_udf
+
+logger = logging.getLogger(__name__)
+
+_UDF_DECORATOR = "udf_tool"
+
+
+def _declares_udf_tool(py_file: Path) -> bool:
+    """True if the file declares a udf_tool-decorated function, without executing it."""
+    try:
+        source = py_file.read_text(encoding="utf-8")
+    except (OSError, ValueError) as e:
+        logger.debug("Skipping unreadable file %s: %s", py_file, e)
+        return False
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        # Unparseable: can't prove intent structurally. A udf_tool mention keeps
+        # the file on the import path so its syntax error surfaces loudly.
+        return _UDF_DECORATOR in source
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for dec in node.decorator_list:
+                target = dec.func if isinstance(dec, ast.Call) else dec
+                name = (
+                    target.attr
+                    if isinstance(target, ast.Attribute)
+                    else getattr(target, "id", None)
+                )
+                if name == _UDF_DECORATOR:
+                    return True
+    return False
 
 
 def discover_tool_files(tool_dir: Path) -> list[Path]:
@@ -28,12 +61,16 @@ def discover_tool_files(tool_dir: Path) -> list[Path]:
 def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
     """Discover and register all UDFs in the user code directory.
 
+    Only files that declare a ``udf_tool``-decorated function are imported;
+    other ``.py`` files under the tree (helper scripts, notes) are skipped so
+    a broken non-UDF file cannot block discovery.
+
     Raises:
         UDFLoadError: If the user-code directory is missing or invalid
             (``module == UDFLoadError.DISCOVERY_SENTINEL``), if path-to-module
             derivation fails for a discovered file (also routed through the
-            sentinel), or if a Python file fails to import (module set to the
-            failing dotted import name).
+            sentinel), or if a UDF-declaring file fails to import (module set
+            to the failing dotted import name).
         DuplicateFunctionError: If duplicate function names are detected.
     """
     user_code_path = Path(user_code_path)
@@ -71,6 +108,10 @@ def discover_udfs(user_code_path: Path) -> dict[str, dict[str, Any]]:
                 context={"error_type": type(e).__name__},
                 cause=e,
             ) from e
+
+        if not _declares_udf_tool(py_file):
+            logger.debug("Skipping %s: no udf_tool declaration", py_file)
+            continue
 
         if f"agent_actions._udfs.{module_name}" in sys.modules:
             continue

--- a/docs.agent-actions/docs/reference/tools/index.md
+++ b/docs.agent-actions/docs/reference/tools/index.md
@@ -186,9 +186,10 @@ Reference tools by function name:
 ### Discovery Process
 
 1. Scans directories in `tool_path` recursively
-2. Loads all Python files (`*.py`), skipping files starting with `_` or `test_`
-3. Executes modules to trigger `@udf_tool` decorator registration
-4. Validates `impl` references in agentic workflow config
+2. Lists Python files (`*.py`), skipping files starting with `_` or `test_`
+3. Imports only files that declare a tool-registering decorator (`@udf_tool` or `@reprompt_validation`), detected by parsing the source without executing it — helper scripts without a decorator are skipped, so a broken helper cannot block discovery
+4. Executes matching modules to trigger decorator registration
+5. Validates `impl` references in agentic workflow config
 
 :::info Thread Safety
 Tool discovery is thread-safe and cached. Concurrent discovery calls are properly synchronized, and modules are loaded only once.

--- a/tests/unit/input/loaders/test_discover_udfs_isolation.py
+++ b/tests/unit/input/loaders/test_discover_udfs_isolation.py
@@ -1,0 +1,111 @@
+"""UDF discovery imports only udf_tool-declaring files; broken helpers must not block it."""
+
+import sys
+
+import pytest
+
+from agent_actions.errors import UDFLoadError
+from agent_actions.input.loaders.udf import discover_udfs
+from agent_actions.utils.udf_management.registry import UDF_REGISTRY, clear_registry
+
+_GOOD_UDF = (
+    "from agent_actions import udf_tool\n"
+    "\n"
+    "@udf_tool()\n"
+    "def normalize_text(data):\n"
+    "    return data\n"
+)
+
+# Not a UDF; raises FileNotFoundError at import time.
+_BROKEN_HELPER = 'with open(__file__ + ".missing.md") as fh:\n    TEMPLATE = fh.read()\n'
+
+# Parseable, mentions the decorator name only in a comment, raises at import.
+_MENTIONS_ONLY = (
+    "# Formats release notes; unrelated to @udf_tool registration.\n"
+    'raise RuntimeError("boom at import")\n'
+)
+
+# A real UDF whose import fails at runtime.
+_BROKEN_UDF = (
+    "from agent_actions import udf_tool\n"
+    "import missing_dependency_zzz\n"
+    "\n"
+    "@udf_tool()\n"
+    "def compute_metrics(data):\n"
+    "    return data\n"
+)
+
+# A real UDF with a syntax error (missing colon) — unparseable but clearly UDF-intent.
+_SYNTAX_UDF = (
+    "from agent_actions import udf_tool\n"
+    "\n"
+    "@udf_tool()\n"
+    "def tag_records(data)\n"
+    "    return data\n"
+)
+
+# Unparseable scratch file with no udf_tool mention at all.
+_SYNTAX_HELPER = "def scratch(:\n    pass\n"
+
+_ATTR_FORM_UDF = (
+    "from agent_actions.utils.udf_management import registry\n"
+    "\n"
+    "@registry.udf_tool()\n"
+    "def rewrite_labels(data):\n"
+    "    return data\n"
+)
+
+
+def _evict_udf_modules():
+    for name in [k for k in sys.modules if k.startswith("agent_actions._udfs.")]:
+        sys.modules.pop(name, None)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    clear_registry()
+    _evict_udf_modules()
+    yield
+    clear_registry()
+    _evict_udf_modules()
+
+
+def test_broken_non_udf_helper_does_not_block_discovery(tmp_path):
+    (tmp_path / "good.py").write_text(_GOOD_UDF)
+    (tmp_path / "formatting_tools.py").write_text(_BROKEN_HELPER)
+    discover_udfs(tmp_path)
+    assert "normalize_text" in UDF_REGISTRY
+
+
+def test_decorator_mention_in_comment_does_not_make_a_helper_a_udf(tmp_path):
+    (tmp_path / "good.py").write_text(_GOOD_UDF)
+    (tmp_path / "release_notes.py").write_text(_MENTIONS_ONLY)
+    discover_udfs(tmp_path)
+    assert "normalize_text" in UDF_REGISTRY
+
+
+def test_unparseable_helper_without_udf_mention_is_skipped(tmp_path):
+    (tmp_path / "good.py").write_text(_GOOD_UDF)
+    (tmp_path / "scratch_notes.py").write_text(_SYNTAX_HELPER)
+    discover_udfs(tmp_path)
+    assert "normalize_text" in UDF_REGISTRY
+
+
+def test_broken_udf_file_still_raises(tmp_path):
+    (tmp_path / "metrics_udf.py").write_text(_BROKEN_UDF)
+    with pytest.raises(UDFLoadError) as exc_info:
+        discover_udfs(tmp_path)
+    assert "metrics_udf.py" in exc_info.value.context["file"]
+
+
+def test_syntax_error_udf_file_still_raises(tmp_path):
+    (tmp_path / "tags_udf.py").write_text(_SYNTAX_UDF)
+    with pytest.raises(UDFLoadError) as exc_info:
+        discover_udfs(tmp_path)
+    assert "tags_udf.py" in exc_info.value.context["file"]
+
+
+def test_attribute_form_decorator_is_discovered(tmp_path):
+    (tmp_path / "labels_udf.py").write_text(_ATTR_FORM_UDF)
+    discover_udfs(tmp_path)
+    assert "rewrite_labels" in UDF_REGISTRY

--- a/tests/unit/input/loaders/test_discover_udfs_isolation.py
+++ b/tests/unit/input/loaders/test_discover_udfs_isolation.py
@@ -37,11 +37,7 @@ _BROKEN_UDF = (
 
 # A real UDF with a syntax error (missing colon) — unparseable but clearly UDF-intent.
 _SYNTAX_UDF = (
-    "from agent_actions import udf_tool\n"
-    "\n"
-    "@udf_tool()\n"
-    "def tag_records(data)\n"
-    "    return data\n"
+    "from agent_actions import udf_tool\n\n@udf_tool()\ndef tag_records(data)\n    return data\n"
 )
 
 # Unparseable scratch file with no udf_tool mention at all.

--- a/tests/unit/input/loaders/test_discover_udfs_isolation.py
+++ b/tests/unit/input/loaders/test_discover_udfs_isolation.py
@@ -6,6 +6,7 @@ import pytest
 
 from agent_actions.errors import UDFLoadError
 from agent_actions.input.loaders.udf import discover_udfs
+from agent_actions.processing.recovery.validation import _VALIDATION_REGISTRY
 from agent_actions.utils.udf_management.registry import UDF_REGISTRY, clear_registry
 
 _GOOD_UDF = (
@@ -51,6 +52,15 @@ _ATTR_FORM_UDF = (
     "    return data\n"
 )
 
+# Registers a reprompt validator via import side effect; declares no udf_tool.
+_VALIDATION_ONLY = (
+    "from agent_actions import reprompt_validation\n"
+    "\n"
+    '@reprompt_validation("answer must cite a source")\n'
+    "def check_citation(data):\n"
+    "    return True\n"
+)
+
 
 def _evict_udf_modules():
     for name in [k for k in sys.modules if k.startswith("agent_actions._udfs.")]:
@@ -60,9 +70,11 @@ def _evict_udf_modules():
 @pytest.fixture(autouse=True)
 def _isolated_registry():
     clear_registry()
+    _VALIDATION_REGISTRY.clear()
     _evict_udf_modules()
     yield
     clear_registry()
+    _VALIDATION_REGISTRY.clear()
     _evict_udf_modules()
 
 
@@ -105,3 +117,9 @@ def test_attribute_form_decorator_is_discovered(tmp_path):
     (tmp_path / "labels_udf.py").write_text(_ATTR_FORM_UDF)
     discover_udfs(tmp_path)
     assert "rewrite_labels" in UDF_REGISTRY
+
+
+def test_reprompt_validation_only_file_is_imported(tmp_path):
+    (tmp_path / "citation_checks.py").write_text(_VALIDATION_ONLY)
+    discover_udfs(tmp_path)
+    assert "check_citation" in _VALIDATION_REGISTRY


### PR DESCRIPTION
## Summary

`discover_udfs` imported every `.py` file under the `-u` tree. Any file that raised at import time — even an unrelated helper script — aborted `inspect`/`validate-udfs`/`run` for every workflow with a misleading `Failed to load UDF module ...` error, before any workflow YAML was parsed.

Discovery is now opt-in by decorator: an `ast.parse` pre-scan (`_declares_udf_tool`) detects a `udf_tool`-decorated function without executing the file, and `discover_udfs` skips files that don't declare one (logged at debug). A broken file that *does* declare `@udf_tool` still raises `UDFLoadError` — real UDF failures stay loud. The detector matches `@udf_tool`, `@udf_tool(...)`, and attribute forms (`@registry.udf_tool()`).

**Unparseable files:** a file that can't be AST-parsed can't prove it isn't a UDF. Blanket-skipping would downgrade a genuine UDF's precise SyntaxError into a later, confusing "function not found" — new misleading behavior in a fix about misleading errors (and it breaks the existing pinned test `test_discover_udfs_handles_import_errors`). Instead, an unparseable file that mentions `udf_tool` in its source stays on the import path, so its syntax error surfaces loudly with the real location; one with no mention is skipped. A genuine UDF file necessarily contains that text (import + decorator), so no loud diagnostic is lost.

**Filter placement — in `discover_udfs`' import loop, not `discover_tool_files`:**
- Every affected surface (`config_pipeline` → `inspect`/`run`, `validate-udfs`, `list-udfs`) flows through `discover_udfs`; filtering there covers them all.
- `discover_tool_files` keeps its pure file-listing contract: its existing tests pin plain-`.py` fixtures, and the LSP indexer (`tooling/lsp/indexer.py`) consumes it with its own decorator check — no behavior change there.
- The filter runs after module-name derivation, preserving the pinned `DISCOVERY_SENTINEL` behavior for `relative_to` failures.

Note: the LSP indexer has its own inline (narrower) `@udf_tool` AST check; a follow-up could have it reuse `_declares_udf_tool` to prevent drift.

## Verification

- RED→GREEN: `tests/unit/input/loaders/test_discover_udfs_isolation.py` (new, 6 tests). RED against the old code: broken helper, comment-mention-only helper, and unparseable helper each blocked discovery with the ticket's exact `UDFLoadError`. GREEN after: all skipped, the good UDF registers. Loud-failure guards (runtime-broken UDF, syntax-broken UDF, attribute-form decorator) green throughout.
- The comment-mention fixture separates the AST scan from a substring-only cheat; the syntax-broken-UDF fixture pins the loud fallback.
- Hermetic fixture clears the registry and evicts `agent_actions._udfs.*` from `sys.modules` (same pattern as `test_json_stdout_clean.py`), so the tests are order-independent under the full suite.
- End-to-end through `_discover_udfs_from_path` (the `agac inspect`/`run` surface): a broken helper shaped like the original report (`open('prompt_store/ql_build_list.md')`) no longer blocks discovery; a broken real UDF still fails loud with the enriched error.
- Blast-radius suite (udf loader, discovery methods, list-udfs, validate-udfs, json-stdout, module loader, config pipeline, error formatters): 122 passed.
- Full suite: `pytest -q` → 7903 passed. `ruff check` + `ruff format --check` clean.

## Post-review hardening (consensus gate + smoke test)

Five independent consensus reviewers (4/5 YES; the NO flagged stale docs) plus a real-project smoke inspection surfaced two follow-ups, both fixed in the third commit:

- **Regression caught & fixed: `reprompt_validation`-only files.** Reprompt validators register via import side effect during discovery, exactly like UDFs — a user tool file decorated only with `@reprompt_validation` (no `@udf_tool`) was imported before this PR but skipped by the original pre-scan, leaving `_VALIDATION_REGISTRY` empty and breaking `reprompt: {validation: ...}` resolution. The detector now accepts any tool-registering decorator (`udf_tool`, `reprompt_validation`); RED test `test_reprompt_validation_only_file_is_imported` proved the regression before the fix.
- **Stale docs updated (Gate 7):** `docs.agent-actions/docs/reference/tools/index.md` discovery-process steps and the `input/loaders/_MANIFEST.md` row for `udf.py` now describe opt-in-by-decorator discovery.

Real-project equivalence check (qanalabs-quiz-maker, editable install): main and this branch both discover **67 UDFs and the identical 7 reprompt validators**. The smoke run's `summarize_page_content` seed-data failure reproduces identically on main — pre-existing environmental issue, unrelated to this change.

Full suite after hardening: 7904 passed; ruff clean.
