### PR TITLE
fix(inspect): fail preflight when a dependency has no observe field

### DIFF
--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -12,6 +12,7 @@ from agent_actions.errors.preflight import PreFlightValidationError
 from agent_actions.models.action_schema import FieldSource
 from agent_actions.prompt.formatter import PromptFormatter
 from agent_actions.utils.constants import NON_PROMPT_ACTION_KINDS
+from agent_actions.validation.dep_observe_validator import find_missing_observe_deps
 from agent_actions.validation.preflight.guard_validation import validate_guard_conditions
 from agent_actions.validation.preflight.resolution_service import (
     WorkflowResolutionService,
@@ -81,7 +82,16 @@ class PreflightService:
                 hint="Fix the guard condition errors above before running the workflow.",
             )
 
-        # 4. Resolution checks (API keys, seed files, vendor batch)
+        # 4. Dependency/observe consistency — fatal at runtime, so fatal here
+        observe_errors = find_missing_observe_deps(self.action_configs)
+        if observe_errors:
+            raise PreFlightValidationError(
+                "\n".join(observe_errors),
+                hint="Add an observe or passthrough field for each dependency, "
+                "or drop the unused dependency.",
+            )
+
+        # 5. Resolution checks (API keys, seed files, vendor batch)
         resolution_result = WorkflowResolutionService(
             action_configs=self.action_configs,
             workflow_config_path=self.workflow_config_path,
@@ -93,7 +103,7 @@ class PreflightService:
         for warning in resolution_result.warnings:
             logger.warning("Pre-flight: %s", warning.message)
 
-        # 5. Cross-check prompt refs against each producer's required set
+        # 6. Cross-check prompt refs against each producer's required set
         for finding in find_unguarded_required_refs(
             self._collect_prompts(), self._collect_producing_schemas()
         ):

--- a/agent_actions/validation/_MANIFEST.md
+++ b/agent_actions/validation/_MANIFEST.md
@@ -25,6 +25,7 @@ decoders to schema validators and preflight checks.
 | `batch_validator.py` | Module | Validator that ensures batch CLI arguments conform to expectations. | `validation`, `llm.batch` |
 | `clean_validator.py` | Module | `CleanCommandArgs` pydantic model used by the CLI. | `validation` |
 | `config_validator.py` | Module | Central config parser/validator used across startup flows. | `configuration`, `validation` |
+| `dep_observe_validator.py` | Module | `find_missing_observe_deps`: preflight mirror of the fatal runtime check that every declared dependency has an observe/passthrough field reference. | `validation` |
 | `init_validator.py` | Module | `InitCommandArgs` pydantic model used by the CLI. | `validation` |
 | `path_validator.py` | Module | Path validation utilities conforming to BaseValidator interface. | `validation` |
 | `prompt_ast.py` | Module | Jinja2 AST parser for extracting template variables. | `prompt_generation` |

--- a/agent_actions/validation/dep_observe_validator.py
+++ b/agent_actions/validation/dep_observe_validator.py
@@ -1,0 +1,61 @@
+"""Preflight check: every declared dependency needs an observe/passthrough field."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agent_actions.prompt.context.scope_parsing import parse_field_reference
+
+logger = logging.getLogger(__name__)
+
+
+def _referenced_namespaces(context_scope: dict[str, Any], action_name: str) -> set[str]:
+    """Namespaces named by well-formed observe/passthrough refs.
+
+    Malformed refs are skipped, exactly as the runtime skips them — a
+    dotless ref like ``"producer"`` must not satisfy a dependency here
+    when it would not satisfy it at execution time.
+    """
+    refs = list(context_scope.get("observe") or []) + list(context_scope.get("passthrough") or [])
+    namespaces: set[str] = set()
+    for ref in refs:
+        try:
+            namespace, _ = parse_field_reference(ref)
+        except ValueError as exc:
+            logger.debug(
+                "Skipping unparseable context_scope ref %r on '%s': %s", ref, action_name, exc
+            )
+            continue
+        namespaces.add(namespace)
+    return namespaces
+
+
+def find_missing_observe_deps(action_configs: dict[str, dict[str, Any]]) -> list[str]:
+    """Return one finding per declared dependency with no field in context_scope.
+
+    Pure preflight mirror of the fatal runtime check in
+    ``scope_namespace._extract_allowed_fields_per_dependency``: no events,
+    no raising on the first offender — all offenders are reported.
+    """
+    findings: list[str] = []
+    for name, cfg in action_configs.items():
+        deps = cfg.get("dependencies") or []
+        if not deps:
+            continue
+        scope = cfg.get("context_scope") or {}
+        if not scope:
+            findings.append(
+                f"{name}: has dependencies {deps} but no context_scope. "
+                f"Every dependency needs at least one field declaration."
+            )
+            continue
+        referenced = _referenced_namespaces(scope, name)
+        for dep in deps:
+            if dep not in referenced:
+                findings.append(
+                    f"{name}: dependency '{dep}' declared but not referenced in "
+                    f"context_scope. Add '{dep}.*' or '{dep}.<field>' to observe "
+                    f"or passthrough, or drop '{dep}' from dependencies."
+                )
+    return findings

--- a/agent_actions/validation/dep_observe_validator.py
+++ b/agent_actions/validation/dep_observe_validator.py
@@ -17,6 +17,11 @@ def _referenced_namespaces(context_scope: dict[str, Any], action_name: str) -> s
     Malformed refs are skipped, exactly as the runtime skips them — a
     dotless ref like ``"producer"`` must not satisfy a dependency here
     when it would not satisfy it at execution time.
+
+    Deliberately not ``scope_parsing.extract_action_names_from_context_scope``:
+    that fires a ``ContextFieldSkippedEvent`` per malformed ref, and the
+    preceding ``infer_dependencies`` call already fires those for the same
+    refs — reusing it would surface duplicate skip events during inspect.
     """
     refs = list(context_scope.get("observe") or []) + list(context_scope.get("passthrough") or [])
     namespaces: set[str] = set()

--- a/agent_actions/validation/dep_observe_validator.py
+++ b/agent_actions/validation/dep_observe_validator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from agent_actions.prompt.context.scope_inference import infer_dependencies
 from agent_actions.prompt.context.scope_parsing import parse_field_reference
 
 logger = logging.getLogger(__name__)
@@ -37,10 +38,21 @@ def find_missing_observe_deps(action_configs: dict[str, dict[str, Any]]) -> list
     Pure preflight mirror of the fatal runtime check in
     ``scope_namespace._extract_allowed_fields_per_dependency``: no events,
     no raising on the first offender — all offenders are reported.
+
+    The dependency set comes from ``infer_dependencies`` exactly as the
+    runtime's scope_builder derives it. That is load-bearing: the loader
+    expands a versioned producer into ``<base>_N`` actions and rewrites the
+    consumer's observe refs to the branch names while its ``dependencies``
+    keep the base name — comparing raw config strings would reject those
+    valid workflows.
     """
     findings: list[str] = []
+    workflow_actions = list(action_configs)
     for name, cfg in action_configs.items():
-        deps = cfg.get("dependencies") or []
+        input_sources, context_sources = infer_dependencies(
+            cfg, workflow_actions, name, validate=False
+        )
+        deps = input_sources + context_sources
         if not deps:
             continue
         scope = cfg.get("context_scope") or {}

--- a/docs.agent-actions/docs/reference/cli/inspect.md
+++ b/docs.agent-actions/docs/reference/cli/inspect.md
@@ -39,9 +39,11 @@ review_analyzer  ● validated                              5 actions
 ```
 
 Preflight covers action definitions, dependency cycles, `context_scope`
-references, template variables, schema structure, and guard syntax. If
-any static check fails you get a `PreFlightValidationError` naming the
-exact YAML field instead of the list.
+references — including that every declared dependency is referenced by
+at least one `observe` or `passthrough` field — template variables,
+schema structure, and guard syntax. If any static check fails you get
+a `PreFlightValidationError` naming the exact YAML field instead of
+the list.
 
 For structure, drill down with `inspect action <name>` (deps + prompt
 + schema + who reads this action) or `inspect context <name>`

--- a/tests/cli/test_inspect_commands_integration.py
+++ b/tests/cli/test_inspect_commands_integration.py
@@ -387,6 +387,64 @@ def _build_over_declared_dep_project(root: Path) -> str:
     return wf
 
 
+def _build_versioned_merge_project(root: Path) -> str:
+    """Scaffold a real on-disk project with a fan-out producer (versions) and
+    a merge consumer whose dependency stays on the base name after the loader
+    expands the branches. Returns the workflow name."""
+    wf = "demo"
+    (root / "agent_actions.yml").write_text("version: '1.0'\n")
+    for name in ("templates", "rendered_workflows", "prompt_store"):
+        (root / name).mkdir(parents=True, exist_ok=True)
+    (root / "agent_workflow" / wf / "agent_io").mkdir(parents=True, exist_ok=True)
+    cfg_dir = root / "agent_workflow" / wf / "agent_config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / f"{wf}.yml").write_text(
+        textwrap.dedent(f"""\
+        name: {wf}
+        description: demo
+        defaults:
+          json_mode: true
+          granularity: Record
+          run_mode: online
+          model_name: gpt-4o-mini
+          model_vendor: openai
+          api_key: OPENAI_API_KEY
+        actions:
+          - name: producer
+            intent: produce a
+            kind: llm
+            prompt: "Produce a."
+            versions:
+              param: iteration
+              range: [1, 2]
+              mode: parallel
+            context_scope:
+              observe: ["source.*"]
+            schema:
+              fields:
+                - id: a
+                  type: string
+                  required: true
+          - name: consumer
+            intent: merge producer versions
+            kind: llm
+            prompt: "Merge the observed context."
+            dependencies: [producer]
+            version_consumption:
+              source: producer
+              pattern: merge
+            context_scope:
+              observe: ["producer.*"]
+            schema:
+              fields:
+                - id: out
+                  type: string
+                  required: true
+        """)
+    )
+    return wf
+
+
 class TestInspectDepObserveEndToEnd:
     """`agac inspect` on a real on-disk workflow with a dependency that has
     no observe/passthrough reference must fail preflight — the runtime
@@ -398,3 +456,12 @@ class TestInspectDepObserveEndToEnd:
         result = CliRunner().invoke(cli, ["inspect", "-a", wf])
         assert result.exit_code != 0, result.output
         assert "'other'" in result.output
+
+    def test_versioned_merge_workflow_passes_inspect(self, tmp_path, monkeypatch):
+        """The loader rewrites the merge consumer's observe refs to producer_1/
+        producer_2 while dependencies keep the base name — a valid workflow
+        that a raw-string dependency check would wrongly reject."""
+        wf = _build_versioned_merge_project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(cli, ["inspect", "-a", wf])
+        assert result.exit_code == 0, result.output

--- a/tests/cli/test_inspect_commands_integration.py
+++ b/tests/cli/test_inspect_commands_integration.py
@@ -323,3 +323,78 @@ class TestInspectPromptRequiredEndToEnd:
         result = CliRunner().invoke(cli, ["inspect", "-a", wf])
         assert result.exit_code == 0, result.output
         assert "producer.b" not in result.output
+
+
+def _build_over_declared_dep_project(root: Path) -> str:
+    """Scaffold a real on-disk project whose consumer declares dependencies
+    [producer, other] but only references producer in context_scope. Returns
+    the workflow name."""
+    wf = "demo"
+    (root / "agent_actions.yml").write_text("version: '1.0'\n")
+    for name in ("templates", "rendered_workflows", "prompt_store"):
+        (root / name).mkdir(parents=True, exist_ok=True)
+    (root / "agent_workflow" / wf / "agent_io").mkdir(parents=True, exist_ok=True)
+    cfg_dir = root / "agent_workflow" / wf / "agent_config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / f"{wf}.yml").write_text(
+        textwrap.dedent(f"""\
+        name: {wf}
+        description: demo
+        defaults:
+          json_mode: true
+          granularity: Record
+          run_mode: online
+          model_name: gpt-4o-mini
+          model_vendor: openai
+          api_key: OPENAI_API_KEY
+        actions:
+          - name: producer
+            intent: produce a
+            kind: llm
+            prompt: "Produce a."
+            context_scope:
+              observe: ["source.*"]
+            schema:
+              fields:
+                - id: a
+                  type: string
+                  required: true
+          - name: other
+            intent: produce b
+            kind: llm
+            prompt: "Produce b."
+            context_scope:
+              observe: ["source.*"]
+            schema:
+              fields:
+                - id: b
+                  type: string
+                  required: true
+          - name: consumer
+            intent: consume producer output
+            kind: llm
+            prompt: "Use the observed context."
+            dependencies: [producer, other]
+            context_scope:
+              observe: ["producer.a"]
+            schema:
+              fields:
+                - id: out
+                  type: string
+                  required: true
+        """)
+    )
+    return wf
+
+
+class TestInspectDepObserveEndToEnd:
+    """`agac inspect` on a real on-disk workflow with a dependency that has
+    no observe/passthrough reference must fail preflight — the runtime
+    treats it as fatal, so inspect reporting green wastes upstream tokens."""
+
+    def test_over_declared_dependency_fails_inspect(self, tmp_path, monkeypatch):
+        wf = _build_over_declared_dep_project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(cli, ["inspect", "-a", wf])
+        assert result.exit_code != 0, result.output
+        assert "'other'" in result.output

--- a/tests/validation/test_dep_observe_validator.py
+++ b/tests/validation/test_dep_observe_validator.py
@@ -1,0 +1,122 @@
+"""Unit tests for the dependency/observe preflight checker."""
+
+from agent_actions.validation.dep_observe_validator import find_missing_observe_deps
+
+
+def test_dep_without_observe_is_flagged():
+    actions = {
+        "consumer": {
+            "dependencies": ["ground", "author"],
+            "context_scope": {"observe": ["author.stem"]},
+        }
+    }
+    findings = find_missing_observe_deps(actions)
+    assert any("consumer" in f and "'ground'" in f for f in findings)
+    assert all("'author'" not in f for f in findings)
+
+
+def test_all_deps_observed_passes():
+    actions = {
+        "consumer": {
+            "dependencies": ["author"],
+            "context_scope": {"observe": ["author.stem"]},
+        }
+    }
+    assert find_missing_observe_deps(actions) == []
+
+
+def test_wildcard_observe_satisfies_dep():
+    actions = {
+        "consumer": {
+            "dependencies": ["ground"],
+            "context_scope": {"observe": ["ground.*"]},
+        }
+    }
+    assert find_missing_observe_deps(actions) == []
+
+
+def test_passthrough_also_satisfies_dep():
+    actions = {
+        "consumer": {
+            "dependencies": ["ground"],
+            "context_scope": {"passthrough": ["ground.x"]},
+        }
+    }
+    assert find_missing_observe_deps(actions) == []
+
+
+def test_nested_field_path_satisfies_dep():
+    actions = {
+        "consumer": {
+            "dependencies": ["ground"],
+            "context_scope": {"observe": ["ground.a.b"]},
+        }
+    }
+    assert find_missing_observe_deps(actions) == []
+
+
+def test_deps_but_no_context_scope_is_flagged():
+    actions = {"consumer": {"dependencies": ["ground"]}}
+    assert any("consumer" in f for f in find_missing_observe_deps(actions))
+
+
+def test_deps_but_empty_context_scope_is_flagged():
+    actions = {"consumer": {"dependencies": ["ground"], "context_scope": {}}}
+    assert any("consumer" in f for f in find_missing_observe_deps(actions))
+
+
+def test_no_deps_is_fine():
+    assert find_missing_observe_deps({"a": {"context_scope": {"observe": []}}}) == []
+
+
+def test_malformed_ref_does_not_satisfy_dep():
+    # A dotless ref is skipped by the runtime's reference parser, so the
+    # dependency is unreferenced at execution time — preflight must agree.
+    actions = {
+        "consumer": {
+            "dependencies": ["ground"],
+            "context_scope": {"observe": ["ground"]},
+        }
+    }
+    findings = find_missing_observe_deps(actions)
+    assert any("'ground'" in f and "not referenced" in f for f in findings)
+
+
+def test_substring_dep_name_not_falsely_satisfied():
+    actions = {
+        "consumer": {
+            "dependencies": ["author"],
+            "context_scope": {"observe": ["coauthor.stem"]},
+        }
+    }
+    findings = find_missing_observe_deps(actions)
+    assert any("'author'" in f and "not referenced" in f for f in findings)
+
+
+def test_drop_refs_do_not_satisfy_dep():
+    # Only observe/passthrough load fields at runtime; drop does not.
+    actions = {
+        "consumer": {
+            "dependencies": ["ground"],
+            "context_scope": {"drop": ["ground.x"]},
+        }
+    }
+    findings = find_missing_observe_deps(actions)
+    assert any("'ground'" in f and "not referenced" in f for f in findings)
+
+
+def test_all_offenders_reported():
+    actions = {
+        "first": {
+            "dependencies": ["ground", "author"],
+            "context_scope": {"observe": ["author.stem"]},
+        },
+        "second": {
+            "dependencies": ["ground"],
+            "context_scope": {"observe": ["source.field"]},
+        },
+    }
+    findings = find_missing_observe_deps(actions)
+    assert any("first" in f and "'ground'" in f for f in findings)
+    assert any("second" in f and "'ground'" in f for f in findings)
+    assert len(findings) == 2

--- a/tests/validation/test_dep_observe_validator.py
+++ b/tests/validation/test_dep_observe_validator.py
@@ -105,6 +105,36 @@ def test_drop_refs_do_not_satisfy_dep():
     assert any("'ground'" in f and "not referenced" in f for f in findings)
 
 
+def test_version_base_dependency_satisfied_by_expanded_branches():
+    # The loader expands a versioned producer into <base>_N actions and
+    # rewrites the consumer's observe refs to the branch names, but leaves
+    # dependencies on the base name. The runtime resolves this through
+    # infer_dependencies — a raw string comparison false-positives here.
+    actions = {
+        "extract_raw_qa_1": {"context_scope": {"observe": ["source.*"]}},
+        "extract_raw_qa_2": {"context_scope": {"observe": ["source.*"]}},
+        "consumer": {
+            "dependencies": ["extract_raw_qa"],
+            "context_scope": {"observe": ["extract_raw_qa_1.*", "extract_raw_qa_2.*"]},
+        },
+    }
+    assert find_missing_observe_deps(actions) == []
+
+
+def test_version_base_dependency_with_unreferenced_branches_is_flagged():
+    actions = {
+        "extract_raw_qa_1": {"context_scope": {"observe": ["source.*"]}},
+        "extract_raw_qa_2": {"context_scope": {"observe": ["source.*"]}},
+        "consumer": {
+            "dependencies": ["extract_raw_qa"],
+            "context_scope": {"observe": ["source.*"]},
+        },
+    }
+    findings = find_missing_observe_deps(actions)
+    assert findings, "unreferenced version branches must still be flagged"
+    assert all("extract_raw_qa" in f for f in findings)
+
+
 def test_all_offenders_reported():
     actions = {
         "first": {

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -9,6 +9,7 @@ import logging
 import pytest
 
 from agent_actions.config.schema import ActionConfig, WorkflowConfig
+from agent_actions.errors.preflight import PreFlightValidationError
 from agent_actions.services.preflight_service import PreflightService
 from agent_actions.validation.orchestration.action_entry_validation_orchestrator import (
     ActionEntryValidationOrchestrator,
@@ -624,6 +625,96 @@ class TestPromptRequiredCrossCheck:
         }
         matches = [w for w in _preflight_warnings(cfgs, caplog) if "producer.b" in w]
         assert len(matches) == 1, matches
+
+
+class TestDependencyObserveCheck:
+    """Preflight must hard-fail when a declared dependency has no
+    observe/passthrough reference in context_scope — the runtime treats
+    that as fatal (scope_namespace), so inspect must not report green."""
+
+    @staticmethod
+    def _llm_action(**overrides) -> dict:
+        base = {
+            "agent_type": "llm",
+            "kind": "llm",
+            "model_name": "gpt-4o-mini",
+            "prompt": "Do the thing.",
+            "context_scope": {"observe": ["source.*"]},
+            "schema": {"fields": [{"id": "out", "type": "string", "required": True}]},
+        }
+        base.update(overrides)
+        return base
+
+    def _validate(self, action_configs: dict) -> None:
+        PreflightService(
+            agent_name="wf",
+            action_configs=action_configs,
+            project_root=None,
+            workflow_config_path="wf.yml",
+            verify_keys=False,
+        ).validate()
+
+    def _producers(self) -> dict:
+        return {
+            "producer": self._llm_action(
+                schema={"fields": [{"id": "a", "type": "string", "required": True}]}
+            ),
+            "other": self._llm_action(
+                schema={"fields": [{"id": "b", "type": "string", "required": True}]}
+            ),
+        }
+
+    def test_over_declared_dependency_raises(self):
+        cfgs = {
+            **self._producers(),
+            "consumer": self._llm_action(
+                dependencies=["producer", "other"],
+                context_scope={"observe": ["producer.a"]},
+            ),
+        }
+        with pytest.raises(PreFlightValidationError, match="'other'.*not referenced"):
+            self._validate(cfgs)
+
+    def test_all_offenders_reported_in_one_error(self):
+        cfgs = {
+            **self._producers(),
+            "first_consumer": self._llm_action(
+                dependencies=["producer", "other"],
+                context_scope={"observe": ["producer.a"]},
+            ),
+            "second_consumer": self._llm_action(
+                dependencies=["producer"],
+                context_scope={"observe": ["source.*"]},
+            ),
+        }
+        with pytest.raises(PreFlightValidationError) as excinfo:
+            self._validate(cfgs)
+        message = str(excinfo.value)
+        assert "first_consumer" in message and "'other'" in message
+        assert "second_consumer" in message and "'producer'" in message
+
+    def test_dotless_ref_does_not_satisfy_dep(self):
+        # observe: ["producer"] (no dot) is skipped by the runtime's
+        # reference parser, so the dependency is unreferenced at runtime.
+        cfgs = {
+            **self._producers(),
+            "consumer": self._llm_action(
+                dependencies=["producer"],
+                context_scope={"observe": ["producer"]},
+            ),
+        }
+        with pytest.raises(PreFlightValidationError, match="'producer'.*not referenced"):
+            self._validate(cfgs)
+
+    def test_satisfied_deps_pass(self):
+        cfgs = {
+            **self._producers(),
+            "consumer": self._llm_action(
+                dependencies=["producer", "other"],
+                context_scope={"observe": ["producer.a"], "passthrough": ["other.b"]},
+            ),
+        }
+        self._validate(cfgs)  # completes without raising
 
 
 class TestProducingSchemaCollection:

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -716,6 +716,25 @@ class TestDependencyObserveCheck:
         }
         self._validate(cfgs)  # completes without raising
 
+    def test_version_base_dependency_passes(self):
+        # Post-loader shape of version_consumption: the producer is expanded
+        # into <base>_N actions, the consumer's observe refs are rewritten to
+        # the branch names, but its dependencies keep the base name.
+        branch = {
+            "is_versioned_agent": True,
+            "version_base_name": "producer",
+            "schema": {"fields": [{"id": "a", "type": "string", "required": True}]},
+        }
+        cfgs = {
+            "producer_1": self._llm_action(**branch),
+            "producer_2": self._llm_action(**branch),
+            "consumer": self._llm_action(
+                dependencies=["producer"],
+                context_scope={"observe": ["producer_1.*", "producer_2.*"]},
+            ),
+        }
+        self._validate(cfgs)  # completes without raising
+
 
 class TestProducingSchemaCollection:
     """`_collect_producing_schemas` feeds the cross-check the right field set."""


### PR DESCRIPTION
## Summary
- `agac inspect` (and `agac run` preflight) now hard-fails when a declared dependency has no `observe`/`passthrough` field reference in `context_scope` — previously inspect reported green and the run crashed on the first record inside `scope_namespace._extract_allowed_fields_per_dependency`, after upstream LLM tokens were already spent (spec 565 / ISSUE-007).
- New pure checker `agent_actions/validation/dep_observe_validator.py` (`find_missing_observe_deps`): mirrors the fatal runtime check but fires no events and reports **all** offenders instead of raising on the first. Wired into `PreflightService.validate()` after guard-syntax validation, so both the inspect path (`workflow_inspector.py`) and the run path (`coordinator.py`) are covered. The runtime check stays as the last line of defence.
- Namespace parity is deliberate: refs are parsed with the runtime's own `parse_field_reference`, skipping refs that raise — a dotless ref like `observe: ["producer"]` does not satisfy a dependency here because it does not satisfy it at execution time. A naive `split('.')` (the spec's original draft) diverges exactly there and was rejected during spec verification.
- Docs: `reference/cli/inspect.md` preflight coverage sentence extended; validation `_MANIFEST.md` row added.

## Verification
- Red→green: behavioral tests committed failing first (65852092) — `PreflightService.validate()` DID NOT RAISE on an over-declared dep, and end-to-end `agac inspect` on a real scaffolded project exited 0. Both flip with the wiring commit.
- Live probes on a scaffolded project (pre-fix: inspect exit 0 "validated" for both shapes; runtime `ConfigurationError` confirmed for both): post-fix inspect exits 1 naming the exact dependency, message parity with the runtime error.
- Unit tests include discriminators that each kill a specific wrong implementation: dotless ref (naive split), substring dep name (`dep in ref`), drop-only scope, empty-scope dict, all-offenders count (raise-on-first).
- Full suite: **7921 passed**; `ruff check` + `ruff format --check` clean; no `ISSUE-`/`VIOL-` identifiers in source or tests.
- Known residual (not a blocker, cannot false-positive): versioned/fan-in dep expansion is not mirrored — the check reads the loader-validated `dependencies: list[str]` directly, so it can only under-flag those shapes; the runtime check still catches them.