### PR TITLE
fix(validate-udfs): warn when a workflow's FILE-mode UDF doesn't return FileUDFResult

### DIFF
--- a/agent_actions/validation/file_udf_contract_validator.py
+++ b/agent_actions/validation/file_udf_contract_validator.py
@@ -9,15 +9,15 @@ from agent_actions.utils.udf_management.registry import FileUDFResult
 
 
 def _returns_fileudfresult(annotation: Any) -> bool:
-    # Coarse name check by design: class identity, or the name text mentions
-    # FileUDFResult (covers string forward-refs). It reads only what is already
-    # recorded — never imports or resolves the annotation, which could fail.
+    # Coarse check by design: class identity, or the annotation's text mentions
+    # FileUDFResult (covers string forward-refs and Optional/Union wrappers). It
+    # reads only what is already recorded — never imports or resolves the
+    # annotation, which could fail.
     if annotation is FileUDFResult:
         return True
-    name = getattr(annotation, "__name__", None) or (
-        annotation if isinstance(annotation, str) else ""
-    )
-    return "FileUDFResult" in str(name)
+    if isinstance(annotation, str):
+        return "FileUDFResult" in annotation
+    return "FileUDFResult" in str(annotation)
 
 
 def find_file_udf_contract_warnings(

--- a/agent_actions/validation/file_udf_contract_validator.py
+++ b/agent_actions/validation/file_udf_contract_validator.py
@@ -20,11 +20,20 @@ def _returns_fileudfresult(annotation: Any) -> bool:
     return "FileUDFResult" in str(name)
 
 
-def find_file_udf_contract_warnings(registry: dict[str, dict]) -> list[str]:
-    """Return one warning per FILE-mode UDF whose return annotation is not FileUDFResult."""
+def find_file_udf_contract_warnings(
+    registry: dict[str, dict], referenced: set[str] | None = None
+) -> list[str]:
+    """Return one warning per FILE-mode UDF whose return annotation is not FileUDFResult.
+
+    When *referenced* is given, only UDFs named in it are checked — the warning
+    predicts a runtime crash, which can only happen for UDFs the workflow calls.
+    """
+    refs_lower = {r.lower() for r in referenced} if referenced is not None else None
     warnings: list[str] = []
     for meta in registry.values():
         if meta.get("granularity") is not Granularity.FILE:
+            continue
+        if refs_lower is not None and meta["name"].lower() not in refs_lower:
             continue
         annotation = meta["signature"].return_annotation
         if _returns_fileudfresult(annotation):

--- a/agent_actions/validation/file_udf_contract_validator.py
+++ b/agent_actions/validation/file_udf_contract_validator.py
@@ -9,6 +9,9 @@ from agent_actions.utils.udf_management.registry import FileUDFResult
 
 
 def _returns_fileudfresult(annotation: Any) -> bool:
+    # Coarse name check by design: class identity, or the name text mentions
+    # FileUDFResult (covers string forward-refs). It reads only what is already
+    # recorded — never imports or resolves the annotation, which could fail.
     if annotation is FileUDFResult:
         return True
     name = getattr(annotation, "__name__", None) or (

--- a/agent_actions/validation/file_udf_contract_validator.py
+++ b/agent_actions/validation/file_udf_contract_validator.py
@@ -1,0 +1,34 @@
+"""Flag FILE-granularity UDFs whose return annotation is not FileUDFResult."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_actions.config.types import Granularity
+from agent_actions.utils.udf_management.registry import FileUDFResult
+
+
+def _returns_fileudfresult(annotation: Any) -> bool:
+    if annotation is FileUDFResult:
+        return True
+    name = getattr(annotation, "__name__", None) or (
+        annotation if isinstance(annotation, str) else ""
+    )
+    return "FileUDFResult" in str(name)
+
+
+def find_file_udf_contract_warnings(registry: dict[str, dict]) -> list[str]:
+    """Return one warning per FILE-mode UDF whose return annotation is not FileUDFResult."""
+    warnings: list[str] = []
+    for meta in registry.values():
+        if meta.get("granularity") is not Granularity.FILE:
+            continue
+        annotation = meta["signature"].return_annotation
+        if _returns_fileudfresult(annotation):
+            continue
+        warnings.append(
+            f"FILE-mode UDF '{meta['name']}' returns {annotation!r}, not FileUDFResult. "
+            f"If it constructs new dicts, wrap them in FileUDFResult(outputs=[{{source_index, data}}]); "
+            f"if it round-trips input items unchanged (filter mode), this is safe to ignore."
+        )
+    return warnings

--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -117,7 +117,7 @@ class ValidateUDFsCommand:
                 raise click.exceptions.Exit(1)
             registry = result["registry"]
             impl_refs = result["impl_refs"]
-            contract_warnings = find_file_udf_contract_warnings(registry)
+            contract_warnings = find_file_udf_contract_warnings(registry, referenced=impl_refs)
             fire_event(
                 ValidationCompleteEvent(
                     target="UDFs",

--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -26,6 +26,7 @@ from agent_actions.utils.udf_management.registry import (
     clear_registry,
     get_udf_metadata,
 )
+from agent_actions.validation.file_udf_contract_validator import find_file_udf_contract_warnings
 
 
 class ValidateUDFsCommand:
@@ -116,9 +117,13 @@ class ValidateUDFsCommand:
                 raise click.exceptions.Exit(1)
             registry = result["registry"]
             impl_refs = result["impl_refs"]
+            contract_warnings = find_file_udf_contract_warnings(registry)
             fire_event(
                 ValidationCompleteEvent(
-                    target="UDFs", validator="validate-udfs", error_count=0, warning_count=0
+                    target="UDFs",
+                    validator="validate-udfs",
+                    error_count=0,
+                    warning_count=len(contract_warnings),
                 )
             )
             self.console.print("[green]✅ All UDF references valid[/green]")
@@ -127,6 +132,8 @@ class ValidateUDFsCommand:
             self.console.print(f"  - {len(impl_refs)} Tools referenced in config")
             self.console.print(f"  - {len(registry)} Tools discovered and registered")
             self.console.print("  - All functions found\n")
+            for warning in contract_warnings:
+                self.console.print(f"[yellow]⚠ {warning}[/yellow]")
             if impl_refs:
                 self.console.print("[bold]Referenced UDFs:[/bold]")
                 for ref in sorted(impl_refs):

--- a/tests/validation/test_file_udf_contract_validator.py
+++ b/tests/validation/test_file_udf_contract_validator.py
@@ -71,6 +71,32 @@ def test_warning_names_the_fix_path():
     assert "filter mode" in warning
 
 
+def test_referenced_filter_scopes_to_named_udfs():
+    @udf_tool(granularity=Granularity.FILE)
+    def used_udf(data) -> list[dict]:
+        return data
+
+    @udf_tool(granularity=Granularity.FILE)
+    def unused_udf(data) -> list[dict]:
+        return data
+
+    warnings = find_file_udf_contract_warnings(UDF_REGISTRY, referenced={"used_udf"})
+    assert any("used_udf" in w for w in warnings)
+    assert not any("unused_udf" in w for w in warnings)
+
+
+def test_referenced_none_warns_all():
+    @udf_tool(granularity=Granularity.FILE)
+    def a_udf(data) -> list[dict]:
+        return data
+
+    @udf_tool(granularity=Granularity.FILE)
+    def b_udf(data) -> list[dict]:
+        return data
+
+    assert len(find_file_udf_contract_warnings(UDF_REGISTRY)) == 2
+
+
 def test_unresolvable_forward_ref_does_not_crash():
     # A string annotation naming a type that does not exist must be handled
     # without importing/resolving it — it is simply not FileUDFResult, so warn.

--- a/tests/validation/test_file_udf_contract_validator.py
+++ b/tests/validation/test_file_udf_contract_validator.py
@@ -1,0 +1,71 @@
+"""FILE-mode UDF return-contract warnings: FILE + non-FileUDFResult annotation flagged."""
+
+import pytest
+
+from agent_actions.config.types import Granularity
+from agent_actions.utils.udf_management.registry import (
+    UDF_REGISTRY,
+    FileUDFResult,
+    clear_registry,
+    udf_tool,
+)
+from agent_actions.validation.file_udf_contract_validator import find_file_udf_contract_warnings
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def test_file_udf_returning_list_is_warned():
+    @udf_tool(granularity=Granularity.FILE)
+    def dedup_list(data) -> list[dict]:
+        return data
+
+    warnings = find_file_udf_contract_warnings(UDF_REGISTRY)
+    assert any("dedup_list" in w for w in warnings)
+    assert any("FileUDFResult" in w for w in warnings)
+
+
+def test_file_udf_returning_fileudfresult_is_ok():
+    @udf_tool(granularity=Granularity.FILE)
+    def merge_ok(data) -> FileUDFResult:
+        return FileUDFResult(outputs=[])
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_file_udf_string_annotation_fileudfresult_is_ok():
+    @udf_tool(granularity=Granularity.FILE)
+    def merge_str(data) -> "FileUDFResult":
+        return FileUDFResult(outputs=[])
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_record_udf_is_ignored():
+    @udf_tool(granularity=Granularity.RECORD)
+    def rec_tool(data) -> dict:
+        return data
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_file_udf_missing_return_annotation_is_warned():
+    @udf_tool(granularity=Granularity.FILE)
+    def no_annotation(data):
+        return data
+
+    assert any("no_annotation" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_warning_names_the_fix_path():
+    @udf_tool(granularity=Granularity.FILE)
+    def constructs_dicts(data) -> list[dict]:
+        return data
+
+    (warning,) = find_file_udf_contract_warnings(UDF_REGISTRY)
+    assert "source_index" in warning
+    assert "filter mode" in warning

--- a/tests/validation/test_file_udf_contract_validator.py
+++ b/tests/validation/test_file_udf_contract_validator.py
@@ -69,3 +69,13 @@ def test_warning_names_the_fix_path():
     (warning,) = find_file_udf_contract_warnings(UDF_REGISTRY)
     assert "source_index" in warning
     assert "filter mode" in warning
+
+
+def test_unresolvable_forward_ref_does_not_crash():
+    # A string annotation naming a type that does not exist must be handled
+    # without importing/resolving it — it is simply not FileUDFResult, so warn.
+    @udf_tool(granularity=Granularity.FILE)
+    def bad_ref(data) -> "TypeThatDoesNotExist":  # noqa: F821
+        return data
+
+    assert any("bad_ref" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))

--- a/tests/validation/test_file_udf_contract_validator.py
+++ b/tests/validation/test_file_udf_contract_validator.py
@@ -1,5 +1,7 @@
 """FILE-mode UDF return-contract warnings: FILE + non-FileUDFResult annotation flagged."""
 
+from typing import Optional
+
 import pytest
 
 from agent_actions.config.types import Granularity
@@ -40,6 +42,24 @@ def test_file_udf_returning_fileudfresult_is_ok():
 def test_file_udf_string_annotation_fileudfresult_is_ok():
     @udf_tool(granularity=Granularity.FILE)
     def merge_str(data) -> "FileUDFResult":
+        return FileUDFResult(outputs=[])
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_union_fileudfresult_or_none_is_ok():
+    @udf_tool(granularity=Granularity.FILE)
+    def maybe_merge(data) -> FileUDFResult | None:
+        return FileUDFResult(outputs=[])
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_typing_optional_fileudfresult_is_ok():
+    # typing.Optional (distinct from `X | None`: it has __name__ == "Optional")
+    # must also be recognised, so pin this exact spelling.
+    @udf_tool(granularity=Granularity.FILE)
+    def maybe_merge_opt(data) -> Optional[FileUDFResult]:  # noqa: UP045
         return FileUDFResult(outputs=[])
 
     assert find_file_udf_contract_warnings(UDF_REGISTRY) == []

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -368,3 +368,62 @@ class TestExecute:
         calls = [str(c) for c in cmd.console.print.call_args_list]
         # Should show "... and 5 more"
         assert any("and 5 more" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# FILE-mode UDF return-contract warnings
+# ---------------------------------------------------------------------------
+
+
+class TestFileUdfContractWarnings:
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):
+        from agent_actions.utils.udf_management.registry import clear_registry
+
+        clear_registry()
+        yield
+        clear_registry()
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_file_udf_returning_list_prints_warning_and_succeeds(self, mock_fire, tmp_path):
+        from agent_actions.config.types import Granularity
+        from agent_actions.utils.udf_management.registry import UDF_REGISTRY, udf_tool
+
+        @udf_tool(granularity=Granularity.FILE)
+        def dedup_scores(data) -> list[dict]:
+            return data
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={"valid": True, "registry": dict(UDF_REGISTRY), "impl_refs": set()}
+        )
+
+        cmd.execute()  # warning, not error: must not raise
+
+        calls = [str(c) for c in cmd.console.print.call_args_list]
+        assert any("dedup_scores" in c and "FileUDFResult" in c for c in calls)
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_file_udf_returning_fileudfresult_prints_no_warning(self, mock_fire, tmp_path):
+        from agent_actions.config.types import Granularity
+        from agent_actions.utils.udf_management.registry import (
+            UDF_REGISTRY,
+            FileUDFResult,
+            udf_tool,
+        )
+
+        @udf_tool(granularity=Granularity.FILE)
+        def merge_scores(data) -> FileUDFResult:
+            return FileUDFResult(outputs=[])
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={"valid": True, "registry": dict(UDF_REGISTRY), "impl_refs": set()}
+        )
+
+        cmd.execute()
+
+        calls = [str(c) for c in cmd.console.print.call_args_list]
+        assert not any("merge_scores" in c and "FileUDFResult" in c for c in calls)

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -449,8 +449,14 @@ class TestFileUdfContractWarnings:
 
         cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
         cmd.console = MagicMock()
+        # Reference merge_scores so the annotation is actually inspected — with an
+        # empty impl_refs the scope filter would skip it before the matcher runs.
         cmd.validate = MagicMock(
-            return_value={"valid": True, "registry": dict(UDF_REGISTRY), "impl_refs": set()}
+            return_value={
+                "valid": True,
+                "registry": dict(UDF_REGISTRY),
+                "impl_refs": {"merge_scores"},
+            }
         )
 
         cmd.execute()

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -396,13 +396,43 @@ class TestFileUdfContractWarnings:
         cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
         cmd.console = MagicMock()
         cmd.validate = MagicMock(
-            return_value={"valid": True, "registry": dict(UDF_REGISTRY), "impl_refs": set()}
+            return_value={
+                "valid": True,
+                "registry": dict(UDF_REGISTRY),
+                "impl_refs": {"dedup_scores"},
+            }
         )
 
         cmd.execute()  # warning, not error: must not raise
 
         calls = [str(c) for c in cmd.console.print.call_args_list]
         assert any("dedup_scores" in c and "FileUDFResult" in c for c in calls)
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_file_udf_not_referenced_by_workflow_is_not_warned(self, mock_fire, tmp_path):
+        # A mis-annotated FILE UDF this workflow never calls cannot crash its run,
+        # so validate-udfs -a <workflow> must not warn about it.
+        from agent_actions.config.types import Granularity
+        from agent_actions.utils.udf_management.registry import UDF_REGISTRY, udf_tool
+
+        @udf_tool(granularity=Granularity.FILE)
+        def other_workflows_udf(data) -> list[dict]:
+            return data
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": dict(UDF_REGISTRY),
+                "impl_refs": {"unrelated"},
+            }
+        )
+
+        cmd.execute()
+
+        calls = [str(c) for c in cmd.console.print.call_args_list]
+        assert not any("other_workflows_udf" in c for c in calls)
 
     @patch("agent_actions.validation.validate_udfs.fire_event")
     def test_file_udf_returning_fileudfresult_prints_no_warning(self, mock_fire, tmp_path):


### PR DESCRIPTION
## Summary

A `granularity=FILE` UDF has two legal return contracts: **filter** (return input `TrackedItem`s unchanged) or **merge/expand** (`FileUDFResult(outputs=[{source_index, data}])`). A FILE-mode UDF that constructs new plain dicts but is annotated `-> list[dict]` passed `agac validate-udfs` cleanly, then crashed at the **first record** at runtime in `reconcile_outputs` (`pipeline_file_mode.py:238`, `"returned plain dict at output[i]"`) — after preflight said green.

The static signal `(granularity, return_annotation)` is already stored in the UDF registry but no preflight read it. This adds a **warning** at `validate-udfs` time when a FILE-mode UDF the workflow references has a return annotation that is not `FileUDFResult`.

- **Scoped to the workflow's referenced UDFs.** The warning predicts the runtime crash, which can only occur for UDFs the workflow actually calls; `validate-udfs -a <workflow>` is already `-a`-scoped for its reference-existence check. So the warning is filtered to `impl_refs`, not the whole discovered registry — a shared `tools/` dir does not surface warnings for FILE UDFs belonging to other workflows.
- **Warning, not error** — filter-mode FILE UDFs legitimately return `list[dict]`; the coarse static signal can't distinguish them, so hard-failing would break valid UDFs. The message names the fix path.
- **No import-forcing resolution** — the matcher reads only stored metadata (class identity OR name text), so `from __future__ import annotations` string forward-refs are handled and unresolvable refs never crash the check.
- Runtime check in `pipeline_file_mode.py` left untouched as the last line of defence.

New module `agent_actions/validation/file_udf_contract_validator.py`; wired into `ValidateUDFsCommand.execute()` after the summary, with `warning_count` plumbed into `ValidationCompleteEvent`.

### Scope: `validate-udfs` only (not `inspect`)

`agac inspect` runs with `use_tools=False` (`workflow_inspector.py:80`), so it never discovers UDFs and has no registry to check. Wiring this into `inspect` would require enabling UDF discovery there — heavier, and able to fail on a broken tool file (the exact fragility that keeps `inspect` tool-free) — so it is deliberately out of scope. A user gating on `inspect` alone still relies on `validate-udfs` (or the runtime check) for this class. Follow-up would weigh that tradeoff.

## Verification

- RED→GREEN across the change: annotation detection (`list[dict]`→warn, `FileUDFResult` class + string forward-ref→ok, RECORD ignored, missing annotation→warn, unresolvable ref no-crash) and workflow scoping (referenced→warn, non-referenced→silent, `referenced=None`→warn-all).
- **Real-project check**: `agac validate-udfs -a qanalabs_quiz_gen -u tools` warns on the referenced mis-annotated FILE UDF (`convert_html_json_to_thinkific`) and **exits 0**; non-referenced FILE UDFs in the shared `tools/` dir are silent.
- Full suite: `pytest -q` → **7916 passed**. `ruff check` + `ruff format --check` clean.

## Review

Independent review returned **YES** on the base logic with two findings, both addressed here:
1. **Scope to referenced UDFs** (was: whole discovered registry) — implemented; the warning now matches the `-a` command scope and the crash it predicts.
2. **"inspect" over-claim** — corrected; the check is `validate-udfs`-only (see Scope note above).

Coarse-matcher false-negatives on contrived string annotations (`"list[FileUDFResult]"`, `"NotAFileUDFResult"`) err toward under-warning (safe for a non-blocking advisory) and are marked intentional; a precise AST body-scan is a deliberate follow-up.

**Review round 2:** matcher false-positived on `Optional[FileUDFResult]` / `FileUDFResult | None` (a union/optional return type had no `__name__` and isn't a `str`, so it fell through to `""` and warned a *valid* merge-mode UDF). Fixed: match against the annotation's string form (identity → string forward-ref → `str(annotation)`), so both union spellings are recognised. `typing.Optional` is pinned separately from `X | None` (distinct runtime object). Remaining coarse false-negatives (`list[FileUDFResult]`) stay in the safe under-warn direction. Suite **7918 pass**.

**Review round 3:** the FileUDFResult "no warning" *command* test was vacuous after the impl_refs scoping — with an empty impl_refs the scope filter skipped the UDF before the matcher ran, so the assertion held even against a broken matcher. Now references the UDF so recognition is actually exercised (proven via mutation: a broken matcher fails the fixed test). Recognition was already covered non-vacuously by the sibling unit test; this closes the integration-layer false-confidence gap. Test-only; suite **7918 pass**.
