### PR TITLE
feat(validate-udfs): warn on UDF reads of unknown bus namespaces

### DIFF
--- a/agent_actions/utils/constants.py
+++ b/agent_actions/utils/constants.py
@@ -100,6 +100,15 @@ SCHEMA_FILE_GLOBS = tuple(f"*{s}" for s in SCHEMA_SUFFIXES)
 # - Context scope processor
 SPECIAL_NAMESPACES = RESERVED_AGENT_NAMES - {"context_scope"}
 
+# Framework-injected keys that the runtime actually writes into a tool UDF's
+# `data` bus, alongside per-dependency action-name namespaces. Populated by
+# build_field_context_with_history (source/version/workflow) + scope_application
+# (seed). Deliberately narrower than SPECIAL_NAMESPACES: prompt/schema/action are
+# reserved config/agent-name tokens that never appear as runtime bus keys, and
+# "loop" is the Jinja loop variable, not bus data. Version-promoted keys
+# (i/idx/custom params) are dynamic and not statically enumerable here.
+RUNTIME_BUS_NAMESPACES = frozenset({"source", "version", "workflow", "seed"})
+
 HITL_FILE_GRANULARITY_ERROR = (
     "HITL actions require FILE granularity. "
     "Record granularity launches a separate approval UI per record. "

--- a/agent_actions/validation/_MANIFEST.md
+++ b/agent_actions/validation/_MANIFEST.md
@@ -23,6 +23,7 @@ decoders to schema validators and preflight checks.
 |------|------|-------------|---------|
 | `base_validator.py` | Module | `BaseValidator` base class with helper assertions for validators. | `validation` |
 | `batch_validator.py` | Module | Validator that ensures batch CLI arguments conform to expectations. | `validation`, `llm.batch` |
+| `bus_namespace_validator.py` | Module | `find_unknown_bus_namespaces`: AST scan flagging tool-UDF reads of `data.get("X")` / `data["X"]` where X is not a runtime bus namespace (action name or framework key), catching silent namespace typos at `validate-udfs`. | `validation` |
 | `clean_validator.py` | Module | `CleanCommandArgs` pydantic model used by the CLI. | `validation` |
 | `config_validator.py` | Module | Central config parser/validator used across startup flows. | `configuration`, `validation` |
 | `dep_observe_validator.py` | Module | `find_missing_observe_deps`: preflight mirror of the fatal runtime check that every declared dependency has an observe/passthrough field reference. | `validation` |

--- a/agent_actions/validation/bus_namespace_validator.py
+++ b/agent_actions/validation/bus_namespace_validator.py
@@ -1,0 +1,89 @@
+"""Flag UDF reads of `data.get("X")` / `data["X"]` where X is not a bus namespace."""
+
+from __future__ import annotations
+
+import ast
+
+
+def _bus_key(node: ast.AST) -> str | None:
+    """Return the literal key of a `data.get("X")` / `data["X"]` read, else None."""
+    # data.get("literal")
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "data"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        return node.args[0].value
+    # data["literal"]
+    if (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "data"
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, str)
+    ):
+        return node.slice.value
+    return None
+
+
+class _BusKeyCollector(ast.NodeVisitor):
+    """Collect (enclosing-function, literal bus key) pairs; innermost function wins."""
+
+    def __init__(self, fallback: str) -> None:
+        self._fallback = fallback
+        self._func_stack: list[str] = []
+        self.reads: list[tuple[str, str]] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def _record(self, node: ast.AST) -> None:
+        key = _bus_key(node)
+        if key is not None:
+            owner = self._func_stack[-1] if self._func_stack else self._fallback
+            self.reads.append((owner, key))
+
+    def visit_Call(self, node: ast.Call) -> None:
+        self._record(node)
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        self._record(node)
+        self.generic_visit(node)
+
+
+def find_unknown_bus_namespaces(sources: dict[str, str], valid_namespaces: set[str]) -> list[str]:
+    """Return one warning per literal bus key that is not a valid namespace.
+
+    Findings are attributed to the enclosing UDF, so a source file holding several
+    UDFs never cross-attributes; a `sources` key is only the fallback label for a
+    read outside any function. Non-literal keys (`data.get(var)`) are skipped.
+    """
+    findings: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for label, src in sources.items():
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:
+            continue
+        collector = _BusKeyCollector(label)
+        collector.visit(tree)
+        for owner, key in collector.reads:
+            if key in valid_namespaces or (owner, key) in seen:
+                continue
+            seen.add((owner, key))
+            findings.append(
+                f"{owner}: reads bus namespace '{key}' which is not an action name "
+                f"in the workflow. The bus is keyed by action name — check for an "
+                f"impl-name/action-name mismatch (a wrong key reads an empty dict silently)."
+            )
+    return findings

--- a/agent_actions/validation/bus_namespace_validator.py
+++ b/agent_actions/validation/bus_namespace_validator.py
@@ -69,7 +69,6 @@ def find_unknown_bus_namespaces(sources: dict[str, str], valid_namespaces: set[s
     read outside any function. Non-literal keys (`data.get(var)`) are skipped.
     """
     findings: list[str] = []
-    seen: set[tuple[str, str]] = set()
     for label, src in sources.items():
         try:
             tree = ast.parse(src)
@@ -77,6 +76,10 @@ def find_unknown_bus_namespaces(sources: dict[str, str], valid_namespaces: set[s
             continue
         collector = _BusKeyCollector(label)
         collector.visit(tree)
+        # Dedup per source only: the same (owner, key) in two different sources are
+        # genuinely distinct findings (e.g. an identically-named nested helper in two
+        # UDFs), and must not collapse into one.
+        seen: set[tuple[str, str]] = set()
         for owner, key in collector.reads:
             if key in valid_namespaces or (owner, key) in seen:
                 continue

--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -22,10 +22,12 @@ from agent_actions.input.loaders.udf import (
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.errors import format_user_error
 from agent_actions.logging.events import ValidationCompleteEvent, ValidationStartEvent
+from agent_actions.utils.constants import SPECIAL_NAMESPACES
 from agent_actions.utils.udf_management.registry import (
     clear_registry,
     get_udf_metadata,
 )
+from agent_actions.validation.bus_namespace_validator import find_unknown_bus_namespaces
 
 
 class ValidateUDFsCommand:
@@ -89,6 +91,7 @@ class ValidateUDFsCommand:
                 "valid": True,
                 "registry": registry,
                 "impl_refs": impl_refs,
+                "action_names": self._extract_action_names(config),
             }
         except FunctionNotFoundError as e:
             return {
@@ -116,9 +119,13 @@ class ValidateUDFsCommand:
                 raise click.exceptions.Exit(1)
             registry = result["registry"]
             impl_refs = result["impl_refs"]
+            namespace_warnings = self._find_bus_namespace_warnings(registry, result["action_names"])
             fire_event(
                 ValidationCompleteEvent(
-                    target="UDFs", validator="validate-udfs", error_count=0, warning_count=0
+                    target="UDFs",
+                    validator="validate-udfs",
+                    error_count=0,
+                    warning_count=len(namespace_warnings),
                 )
             )
             self.console.print("[green]✅ All UDF references valid[/green]")
@@ -127,6 +134,8 @@ class ValidateUDFsCommand:
             self.console.print(f"  - {len(impl_refs)} Tools referenced in config")
             self.console.print(f"  - {len(registry)} Tools discovered and registered")
             self.console.print("  - All functions found\n")
+            for warning in namespace_warnings:
+                self.console.print(f"[yellow]⚠ {warning}[/yellow]")
             if impl_refs:
                 self.console.print("[bold]Referenced UDFs:[/bold]")
                 for ref in sorted(impl_refs):
@@ -165,6 +174,25 @@ class ValidateUDFsCommand:
 
         extract_impl_refs(config)
         return impl_refs
+
+    def _extract_action_names(self, config: dict) -> set[str]:
+        """Return workflow action names from the raw config (list-of-dicts form)."""
+        actions = config.get("actions", [])
+        if not isinstance(actions, list):
+            return set()
+        return {
+            a["name"] for a in actions if isinstance(a, dict) and isinstance(a.get("name"), str)
+        }
+
+    def _find_bus_namespace_warnings(self, registry: dict, action_names: set[str]) -> list[str]:
+        """Scan each registered UDF's source for reads of an unknown bus namespace."""
+        sources = {
+            meta["file"]: Path(meta["file"]).read_text(encoding="utf-8")
+            for meta in registry.values()
+            if meta.get("file") and Path(meta["file"]).exists()
+        }
+        valid_namespaces = action_names | SPECIAL_NAMESPACES
+        return find_unknown_bus_namespaces(sources, valid_namespaces)
 
     def _handle_duplicate_error(self, error: DuplicateFunctionError) -> None:
         """Handle duplicate function error with formatted output."""

--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -1,5 +1,7 @@
 """Validate-udfs CLI command for checking UDF references without running workflows."""
 
+import inspect
+import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -119,7 +121,9 @@ class ValidateUDFsCommand:
                 raise click.exceptions.Exit(1)
             registry = result["registry"]
             impl_refs = result["impl_refs"]
-            namespace_warnings = self._find_bus_namespace_warnings(registry, result["action_names"])
+            namespace_warnings = self._find_bus_namespace_warnings(
+                registry, impl_refs, result["action_names"]
+            )
             fire_event(
                 ValidationCompleteEvent(
                     target="UDFs",
@@ -184,15 +188,27 @@ class ValidateUDFsCommand:
             a["name"] for a in actions if isinstance(a, dict) and isinstance(a.get("name"), str)
         }
 
-    def _find_bus_namespace_warnings(self, registry: dict, action_names: set[str]) -> list[str]:
-        """Scan each registered UDF's source for reads of an unknown bus namespace."""
-        sources = {
-            meta["file"]: Path(meta["file"]).read_text(encoding="utf-8")
-            for meta in registry.values()
-            if meta.get("file") and Path(meta["file"]).exists()
-        }
-        valid_namespaces = action_names | SPECIAL_NAMESPACES
-        return find_unknown_bus_namespaces(sources, valid_namespaces)
+    def _find_bus_namespace_warnings(
+        self, registry: dict, impl_refs: set[str], action_names: set[str]
+    ) -> list[str]:
+        """Scan each REFERENCED UDF's own source for reads of an unknown bus namespace.
+
+        Scoped to impl_refs, and to each UDF's own function body (not its whole file):
+        a shared tools/ dir holds UDFs for many workflows — each reading its own
+        workflow's action names — and a UDF file often defines record-level helpers
+        that receive a plain record, not the action-keyed bus. Scanning either would
+        flag legitimate reads against the wrong namespace set.
+        """
+        sources: dict[str, str] = {}
+        for ref in impl_refs:
+            meta = registry.get(ref) or registry.get(ref.lower())
+            if meta is None:
+                continue
+            try:
+                sources[ref] = textwrap.dedent(inspect.getsource(meta["function"]))
+            except (OSError, TypeError, KeyError):
+                continue
+        return find_unknown_bus_namespaces(sources, action_names | SPECIAL_NAMESPACES)
 
     def _handle_duplicate_error(self, error: DuplicateFunctionError) -> None:
         """Handle duplicate function error with formatted output."""

--- a/agent_actions/validation/validate_udfs.py
+++ b/agent_actions/validation/validate_udfs.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import click
 from rich.console import Console
+from rich.markup import escape
 
 from agent_actions.config.manager import ConfigManager
 from agent_actions.config.project_paths import ProjectPathsFactory
@@ -24,7 +25,7 @@ from agent_actions.input.loaders.udf import (
 from agent_actions.logging.core.manager import fire_event
 from agent_actions.logging.errors import format_user_error
 from agent_actions.logging.events import ValidationCompleteEvent, ValidationStartEvent
-from agent_actions.utils.constants import SPECIAL_NAMESPACES
+from agent_actions.utils.constants import RUNTIME_BUS_NAMESPACES
 from agent_actions.utils.udf_management.registry import (
     clear_registry,
     get_udf_metadata,
@@ -139,7 +140,10 @@ class ValidateUDFsCommand:
             self.console.print(f"  - {len(registry)} Tools discovered and registered")
             self.console.print("  - All functions found\n")
             for warning in namespace_warnings:
-                self.console.print(f"[yellow]⚠ {warning}[/yellow]")
+                # escape: the warning embeds a UDF-controlled bus-key literal that
+                # may contain Rich markup (e.g. "[/x]"), which would otherwise crash
+                # the console or silently drop the offending key.
+                self.console.print(f"[yellow]⚠ {escape(warning)}[/yellow]")
             if impl_refs:
                 self.console.print("[bold]Referenced UDFs:[/bold]")
                 for ref in sorted(impl_refs):
@@ -208,7 +212,7 @@ class ValidateUDFsCommand:
                 sources[ref] = textwrap.dedent(inspect.getsource(meta["function"]))
             except (OSError, TypeError, KeyError):
                 continue
-        return find_unknown_bus_namespaces(sources, action_names | SPECIAL_NAMESPACES)
+        return find_unknown_bus_namespaces(sources, action_names | RUNTIME_BUS_NAMESPACES)
 
     def _handle_duplicate_error(self, error: DuplicateFunctionError) -> None:
         """Handle duplicate function error with formatted output."""

--- a/tests/validation/test_bus_namespace_validator.py
+++ b/tests/validation/test_bus_namespace_validator.py
@@ -80,3 +80,19 @@ def test_multiple_unknown_keys_all_reported():
     findings = find_unknown_bus_namespaces({"f": src}, {"author"})
     assert any("one" in f for f in findings)
     assert any("two" in f for f in findings)
+
+
+def test_identical_nested_helper_across_sources_not_deduped():
+    # Two distinct UDFs each define a nested helper of the same name reading the same
+    # unknown key. These are two independent bugs and must both be reported — dedup is
+    # per-source, so the second must not be swallowed.
+    src_a = "def udf_a(data):\n    def _inner(data):\n        return data.get('bad')\n    return _inner(data)\n"
+    src_b = "def udf_b(data):\n    def _inner(data):\n        return data.get('bad')\n    return _inner(data)\n"
+    findings = find_unknown_bus_namespaces({"a": src_a, "b": src_b}, {"author"})
+    assert len(findings) == 2
+
+
+def test_same_key_repeated_within_one_function_still_deduped():
+    # Per-source dedup must still collapse a repeat within the same function.
+    src = "def f(data):\n    return data.get('bad'), data['bad'], data.get('bad')\n"
+    assert len(find_unknown_bus_namespaces({"f": src}, {"author"})) == 1

--- a/tests/validation/test_bus_namespace_validator.py
+++ b/tests/validation/test_bus_namespace_validator.py
@@ -1,0 +1,82 @@
+"""find_unknown_bus_namespaces: flag literal UDF reads of an unknown bus namespace."""
+
+from agent_actions.validation.bus_namespace_validator import find_unknown_bus_namespaces
+
+_SRC = (
+    "def agg(data):\n"
+    "    a = data.get('compile_verify_input')\n"
+    "    b = data['author']\n"
+    "    c = data.get('fb_compile_verify_input')\n"
+    "    return {}\n"
+)
+
+_VALID = {"compile_verify_input", "author", "seed"}
+
+
+def test_unknown_literal_is_flagged():
+    findings = find_unknown_bus_namespaces({"agg": _SRC}, _VALID)
+    assert any("fb_compile_verify_input" in f and "agg" in f for f in findings)
+
+
+def test_known_literals_not_flagged():
+    src = "def agg(data):\n    a = data.get('compile_verify_input')\n    b = data['author']\n    return {}\n"
+    assert find_unknown_bus_namespaces({"agg": src}, _VALID) == []
+
+
+def test_dynamic_key_is_ignored():
+    src = "def f(data):\n    k = 'x'\n    return data.get(k)\n"
+    assert find_unknown_bus_namespaces({"f": src}, {"author"}) == []
+
+
+def test_subscript_literal_flagged():
+    src = "def f(data):\n    return data['nope']\n"
+    assert any("nope" in f for f in find_unknown_bus_namespaces({"f": src}, {"author"}))
+
+
+def test_default_arg_get_is_still_flagged():
+    # data.get("X", default) is a warning, not an error — the optional read stays
+    # unbroken but the typo is still surfaced (FAILURE MODE #3).
+    src = "def f(data):\n    return data.get('maybe', {})\n"
+    assert any("maybe" in f for f in find_unknown_bus_namespaces({"f": src}, {"author"}))
+
+
+def test_non_data_variable_not_flagged():
+    # Only reads off the `data` bus count — a regex over source text would over-match.
+    src = "def f(data):\n    other = {}\n    return other.get('typo_name')\n"
+    assert find_unknown_bus_namespaces({"f": src}, {"author"}) == []
+
+
+def test_literal_in_comment_or_string_not_flagged():
+    # AST anchors on real reads — literals in comments/strings must be invisible.
+    src = "def f(data):\n    # data.get('ghost')\n    s = \"data['phantom']\"\n    return data.get('author')\n"
+    assert find_unknown_bus_namespaces({"f": src}, {"author"}) == []
+
+
+def test_finding_attributed_to_enclosing_function_not_siblings():
+    # Two UDFs in one source: only the offender is named, never its sibling.
+    src = (
+        "def reader_a(data):\n"
+        "    return data.get('bad_key')\n"
+        "def reader_b(data):\n"
+        "    return data.get('author')\n"
+    )
+    findings = find_unknown_bus_namespaces({"tools.py": src}, {"author"})
+    assert any(f.startswith("reader_a:") and "bad_key" in f for f in findings)
+    assert not any(f.startswith("reader_b:") for f in findings)
+
+
+def test_same_key_read_twice_in_one_udf_is_deduped():
+    src = "def f(data):\n    x = data.get('bad')\n    y = data['bad']\n    return x or y\n"
+    assert len(find_unknown_bus_namespaces({"f": src}, {"author"})) == 1
+
+
+def test_syntax_error_source_is_skipped():
+    src = "def f(data)\n    return data.get('bad')\n"  # missing colon
+    assert find_unknown_bus_namespaces({"f": src}, {"author"}) == []
+
+
+def test_multiple_unknown_keys_all_reported():
+    src = "def f(data):\n    return data.get('one'), data['two']\n"
+    findings = find_unknown_bus_namespaces({"f": src}, {"author"})
+    assert any("one" in f for f in findings)
+    assert any("two" in f for f in findings)

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -368,3 +368,78 @@ class TestExecute:
         calls = [str(c) for c in cmd.console.print.call_args_list]
         # Should show "... and 5 more"
         assert any("and 5 more" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# Unknown bus-namespace warnings (UDF reads data.get("X") for an unknown X)
+# ---------------------------------------------------------------------------
+
+
+class TestBusNamespaceWarnings:
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):
+        from agent_actions.utils.udf_management.registry import clear_registry
+
+        clear_registry()
+        yield
+        clear_registry()
+
+    def _discover(self, tool_dir: Path, body: str):
+        """Write an isolated tool file and register it via real discovery."""
+        from agent_actions.input.loaders.udf import discover_udfs
+
+        tool_dir.mkdir()
+        (tool_dir / "agg.py").write_text(
+            "from agent_actions import udf_tool\n\n@udf_tool\ndef aggregate(data):\n" + body
+        )
+        return discover_udfs(tool_dir)
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_unknown_bus_namespace_warns_and_exits_zero(self, mock_fire, tmp_path):
+        registry = self._discover(tmp_path / "tools", "    return data.get('typo_action_name')\n")
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": registry,
+                "impl_refs": set(),
+                "action_names": {"real_action"},
+            }
+        )
+
+        cmd.execute()  # warning, not error: must not raise
+
+        calls = [str(c) for c in cmd.console.print.call_args_list]
+        assert any("typo_action_name" in c and "aggregate" in c for c in calls)
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_action_and_framework_namespaces_are_not_flagged(self, mock_fire, tmp_path):
+        # One file mixing a known action name, a framework namespace, and a typo:
+        # only the typo must be flagged (proves the scan runs AND discriminates).
+        registry = self._discover(
+            tmp_path / "tools",
+            "    a = data.get('real_action')\n"
+            "    b = data['seed']\n"
+            "    c = data.get('typo_name')\n"
+            "    return {}\n",
+        )
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": registry,
+                "impl_refs": set(),
+                "action_names": {"real_action"},
+            }
+        )
+
+        cmd.execute()
+
+        joined = " ".join(str(c) for c in cmd.console.print.call_args_list)
+        assert "typo_name" in joined
+        assert "real_action" not in joined
+        assert "'seed'" not in joined

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -438,7 +438,7 @@ class TestBusNamespaceWarnings:
             return_value={
                 "valid": True,
                 "registry": registry,
-                "impl_refs": set(),
+                "impl_refs": {"aggregate"},
                 "action_names": {"real_action"},
             }
         )
@@ -467,7 +467,7 @@ class TestBusNamespaceWarnings:
             return_value={
                 "valid": True,
                 "registry": registry,
-                "impl_refs": set(),
+                "impl_refs": {"aggregate"},
                 "action_names": {"real_action"},
             }
         )
@@ -478,3 +478,74 @@ class TestBusNamespaceWarnings:
         assert "typo_name" in joined
         assert "real_action" not in joined
         assert "'seed'" not in joined
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_unreferenced_udf_in_shared_dir_is_not_scanned(self, mock_fire, tmp_path):
+        # A shared tools/ dir holds UDFs for several workflows. A UDF this workflow
+        # does NOT reference reads its own workflow's namespace — it must not be
+        # flagged against this workflow's action names (the real-project failure).
+        from agent_actions.input.loaders.udf import discover_udfs
+
+        tool_dir = tmp_path / "tools"
+        tool_dir.mkdir()
+        (tool_dir / "used.py").write_text(
+            "from agent_actions import udf_tool\n\n@udf_tool\ndef used_tool(data):\n"
+            "    return data.get('real_action')\n"
+        )
+        (tool_dir / "other.py").write_text(
+            "from agent_actions import udf_tool\n\n@udf_tool\ndef other_tool(data):\n"
+            "    return data.get('some_other_workflow_ns')\n"
+        )
+        registry = discover_udfs(tool_dir)
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": registry,
+                "impl_refs": {"used_tool"},
+                "action_names": {"real_action"},
+            }
+        )
+
+        cmd.execute()
+
+        joined = " ".join(str(c) for c in cmd.console.print.call_args_list)
+        assert "some_other_workflow_ns" not in joined
+        assert "other_tool" not in joined
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_record_helper_in_referenced_file_is_not_scanned(self, mock_fire, tmp_path):
+        # A referenced UDF's file also defines a plain helper that receives a record
+        # (not the action bus) and reads record fields. Only the registered UDF's own
+        # body is scoped, so the helper's field reads must not warn.
+        from agent_actions.input.loaders.udf import discover_udfs
+
+        tool_dir = tmp_path / "tools"
+        tool_dir.mkdir()
+        # The helper's `data` is a record passed by used_tool, not the action bus;
+        # a whole-file scan would wrongly flag `question` against the bus namespaces.
+        (tool_dir / "used.py").write_text(
+            "from agent_actions import udf_tool\n\n"
+            "def _process_record(data):\n    return data.get('question')\n\n"
+            "@udf_tool\ndef used_tool(data):\n    return data.get('real_action')\n"
+        )
+        registry = discover_udfs(tool_dir)
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": registry,
+                "impl_refs": {"used_tool"},
+                "action_names": {"real_action"},
+            }
+        )
+
+        cmd.execute()
+
+        joined = " ".join(str(c) for c in cmd.console.print.call_args_list)
+        assert "question" not in joined
+        assert "_process_record" not in joined

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from rich.console import Console
 
 from agent_actions.errors import (
     DuplicateFunctionError,
@@ -403,21 +404,27 @@ class TestExecute:
 class TestBusNamespaceWarnings:
     @pytest.fixture(autouse=True)
     def _clean_registry(self):
+        import sys
+
         from agent_actions.utils.module_loader import clear_module_cache
         from agent_actions.utils.udf_management.registry import clear_registry
 
-        clear_registry()
-        clear_module_cache()
+        def _reset():
+            clear_registry()
+            clear_module_cache()
+            # clear_registry/clear_module_cache do NOT evict the sys.modules entries
+            # discover_udfs creates under the "agent_actions._udfs." prefix; without
+            # this, a second discover of the same file stem returns a stale (empty)
+            # module and the test silently scans nothing.
+            for name in [k for k in sys.modules if k.startswith("agent_actions._udfs.")]:
+                sys.modules.pop(name, None)
+
+        _reset()
         yield
-        clear_registry()
-        clear_module_cache()
+        _reset()
 
     def _discover(self, tool_dir: Path, mod: str, body: str):
-        """Write an isolated, uniquely-named tool file and register it via real discovery.
-
-        `mod` must be unique per test — the module loader caches by module name, so a
-        shared stem would return a stale module and skip re-registration.
-        """
+        """Write an isolated tool file and register it via real discovery."""
         from agent_actions.input.loaders.udf import discover_udfs
 
         tool_dir.mkdir()
@@ -490,7 +497,7 @@ class TestBusNamespaceWarnings:
         tool_dir.mkdir()
         (tool_dir / "used.py").write_text(
             "from agent_actions import udf_tool\n\n@udf_tool\ndef used_tool(data):\n"
-            "    return data.get('real_action')\n"
+            "    return data.get('used_typo')\n"
         )
         (tool_dir / "other.py").write_text(
             "from agent_actions import udf_tool\n\n@udf_tool\ndef other_tool(data):\n"
@@ -512,6 +519,9 @@ class TestBusNamespaceWarnings:
         cmd.execute()
 
         joined = " ".join(str(c) for c in cmd.console.print.call_args_list)
+        # Positive (non-vacuous): the referenced UDF's own typo IS flagged...
+        assert "used_typo" in joined
+        # ...while the unreferenced tool's read is not scanned at all.
         assert "some_other_workflow_ns" not in joined
         assert "other_tool" not in joined
 
@@ -529,7 +539,7 @@ class TestBusNamespaceWarnings:
         (tool_dir / "used.py").write_text(
             "from agent_actions import udf_tool\n\n"
             "def _process_record(data):\n    return data.get('question')\n\n"
-            "@udf_tool\ndef used_tool(data):\n    return data.get('real_action')\n"
+            "@udf_tool\ndef used_tool(data):\n    return data.get('used_typo')\n"
         )
         registry = discover_udfs(tool_dir)
 
@@ -547,5 +557,82 @@ class TestBusNamespaceWarnings:
         cmd.execute()
 
         joined = " ".join(str(c) for c in cmd.console.print.call_args_list)
+        # Positive (non-vacuous): the registered UDF's own typo IS flagged...
+        assert "used_typo" in joined
+        # ...while the same-file helper's record-field read is not scanned.
         assert "question" not in joined
         assert "_process_record" not in joined
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_reserved_config_token_is_flagged(self, mock_fire, tmp_path):
+        # prompt/schema/action are reserved config tokens, NOT runtime bus keys, so a
+        # UDF reading data.get("schema") silently gets {} — it must be flagged (they
+        # are deliberately excluded from the valid runtime-bus set).
+        registry = self._discover(
+            tmp_path / "tools", "tool_reserved", "    return data.get('schema')\n"
+        )
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": registry,
+                "impl_refs": {"aggregate"},
+                "action_names": {"real_action"},
+            }
+        )
+
+        cmd.execute()
+
+        joined = " ".join(str(c) for c in cmd.console.print.call_args_list)
+        assert "bus namespace 'schema'" in joined
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_framework_namespaces_are_not_flagged(self, mock_fire, tmp_path):
+        # The four real framework bus keys must never be flagged.
+        registry = self._discover(
+            tmp_path / "tools",
+            "tool_framework",
+            "    return (data.get('source'), data['version'], data.get('workflow'), data['seed'])\n",
+        )
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = MagicMock()
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": registry,
+                "impl_refs": {"aggregate"},
+                "action_names": {"real_action"},
+            }
+        )
+
+        cmd.execute()
+
+        joined = " ".join(str(c) for c in cmd.console.print.call_args_list)
+        assert "bus namespace" not in joined
+
+    @patch("agent_actions.validation.validate_udfs.fire_event")
+    def test_bracketed_bus_key_does_not_crash(self, mock_fire, tmp_path):
+        # A bus-key literal containing Rich markup must not crash the console or drop
+        # the offending key — the warning text is escaped before printing.
+        registry = self._discover(
+            tmp_path / "tools", "tool_markup", "    return data.get('[/x]y')\n"
+        )
+
+        cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
+        cmd.console = Console()  # real console, markup enabled — would MarkupError unescaped
+        cmd.validate = MagicMock(
+            return_value={
+                "valid": True,
+                "registry": registry,
+                "impl_refs": {"aggregate"},
+                "action_names": {"real_action"},
+            }
+        )
+
+        with cmd.console.capture() as cap:
+            cmd.execute()  # must not raise
+
+        assert "[/x]y" in cap.get()

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -68,6 +68,30 @@ class TestCountImplReferences:
         assert cmd._count_impl_references(config) == {"a", "c"}
 
 
+class TestExtractActionNames:
+    def _make_cmd(self) -> ValidateUDFsCommand:
+        return ValidateUDFsCommand.__new__(ValidateUDFsCommand)
+
+    def test_list_of_action_dicts(self):
+        cmd = self._make_cmd()
+        config = {"name": "wf", "actions": [{"name": "split"}, {"name": "score"}]}
+        assert cmd._extract_action_names(config) == {"split", "score"}
+
+    def test_no_actions_key(self):
+        cmd = self._make_cmd()
+        assert cmd._extract_action_names({}) == set()
+
+    def test_non_list_actions_is_safe(self):
+        # Legacy/malformed shapes must degrade to empty, never raise.
+        cmd = self._make_cmd()
+        assert cmd._extract_action_names({"actions": {"s": {"impl": "f"}}}) == set()
+
+    def test_action_without_name_is_skipped(self):
+        cmd = self._make_cmd()
+        config = {"actions": [{"name": "ok"}, {"impl": "no_name"}, "bare_string"]}
+        assert cmd._extract_action_names(config) == {"ok"}
+
+
 # ---------------------------------------------------------------------------
 # validate() — mock external dependencies
 # ---------------------------------------------------------------------------
@@ -233,6 +257,7 @@ class TestExecute:
                 "valid": True,
                 "registry": {"fn": {}},
                 "impl_refs": {"fn"},
+                "action_names": set(),
             }
         )
 
@@ -378,25 +403,34 @@ class TestExecute:
 class TestBusNamespaceWarnings:
     @pytest.fixture(autouse=True)
     def _clean_registry(self):
+        from agent_actions.utils.module_loader import clear_module_cache
         from agent_actions.utils.udf_management.registry import clear_registry
 
         clear_registry()
+        clear_module_cache()
         yield
         clear_registry()
+        clear_module_cache()
 
-    def _discover(self, tool_dir: Path, body: str):
-        """Write an isolated tool file and register it via real discovery."""
+    def _discover(self, tool_dir: Path, mod: str, body: str):
+        """Write an isolated, uniquely-named tool file and register it via real discovery.
+
+        `mod` must be unique per test — the module loader caches by module name, so a
+        shared stem would return a stale module and skip re-registration.
+        """
         from agent_actions.input.loaders.udf import discover_udfs
 
         tool_dir.mkdir()
-        (tool_dir / "agg.py").write_text(
+        (tool_dir / f"{mod}.py").write_text(
             "from agent_actions import udf_tool\n\n@udf_tool\ndef aggregate(data):\n" + body
         )
         return discover_udfs(tool_dir)
 
     @patch("agent_actions.validation.validate_udfs.fire_event")
     def test_unknown_bus_namespace_warns_and_exits_zero(self, mock_fire, tmp_path):
-        registry = self._discover(tmp_path / "tools", "    return data.get('typo_action_name')\n")
+        registry = self._discover(
+            tmp_path / "tools", "tool_unknown", "    return data.get('typo_action_name')\n"
+        )
 
         cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
         cmd.console = MagicMock()
@@ -420,6 +454,7 @@ class TestBusNamespaceWarnings:
         # only the typo must be flagged (proves the scan runs AND discriminates).
         registry = self._discover(
             tmp_path / "tools",
+            "tool_mixed",
             "    a = data.get('real_action')\n"
             "    b = data['seed']\n"
             "    c = data.get('typo_name')\n"

--- a/tests/validation/test_validate_udfs_exit_code.py
+++ b/tests/validation/test_validate_udfs_exit_code.py
@@ -70,6 +70,6 @@ def test_valid_result_exits_zero(monkeypatch, tmp_path):
     result = _run_cli(
         monkeypatch,
         tmp_path,
-        {"valid": True, "registry": {"fn": {}}, "impl_refs": {"fn"}},
+        {"valid": True, "registry": {"fn": {}}, "impl_refs": {"fn"}, "action_names": set()},
     )
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

The UDF `data` bus is keyed by **action name**. `data.get("wrong_name")` returns `{}` silently — a namespace typo (e.g. reading the *impl* name instead of the *action* name) yields an empty dict with no error, so downstream gates reject every record while the run reports success (`36/36 ✓`). Diagnosis today means poking the SQLite store by hand.

This adds a static preflight to `agac validate-udfs` / `inspect`:

- **`agent_actions/validation/bus_namespace_validator.py`** — `find_unknown_bus_namespaces()` AST-scans each UDF source for literal `data.get("X")` / `data["X"]` reads and warns when `X` is outside the valid namespace set. Dynamic keys (`data.get(var)`), non-`data` variables, and literals inside comments/strings are ignored. Each finding is attributed to its **enclosing UDF** via a function-name stack, so one file holding several UDFs never cross-attributes.
- **`agent_actions/validation/validate_udfs.py`** — `validate()` now returns the workflow's `action_names`; `execute()` unions them with `SPECIAL_NAMESPACES` and prints one `⚠` per unknown read. It stays a **warning, not an error** (exit 0) so intentional optional reads (`data.get("optional", default)`) stay unbroken.

## Deviations from the spec (called out)

1. **Valid framework set = `SPECIAL_NAMESPACES`, not `{"seed","source"}`.** The spec hardcoded 2 framework namespaces; the authoritative reserved set (`agent_actions/utils/constants.py`) has 7 (`action, prompt, schema, seed, source, version, workflow`). Using the full set removes false positives on legitimate reads like `data.get("workflow")`; reserved names can't be action names, so there is no false-negative risk. The bus keying (by action name) was confirmed against `schema_output_validator.py`.
2. **Attribution to the enclosing function + `sources` keyed by file path.** The registry records one `file` per function, so the spec's `{name: read_text(file)}` map would scan a shared file twice and blame both functions for one typo. Keying `sources` by file (dedup) plus enclosing-function attribution fixes this.
3. **Commit structure.** A behavioral (command-level) RED lands first — the harness RED gate rejects `ImportError` collection errors as fake-RED — then GREEN adds the module, the wiring, and the pure-function unit tests together.

## Verification

- `pytest tests/validation/test_bus_namespace_validator.py tests/validation/test_validate_udfs.py` — pure-function unit tests (unknown flagged, known/dynamic/non-`data`/comment-string ignored, enclosing-function attribution, dedup, syntax-error skip, default-arg still flagged) + command-level tests (typo warns + exit 0; action name & framework namespace not flagged).
- Full suite: **7942 passed**; `ruff check` and `ruff format --check` clean.
- Blast radius: extended `validate()`'s return contract with `action_names`; updated the only other consumer mocks (`test_validate_udfs_exit_code.py`, `TestExecute`). No other callers of the return.
- **Live end-to-end** (`agac validate-udfs -a contract_reviewer -u tools` on `examples/contract_reviewer`): a UDF reading `data.get("split_into_clause")` (typo for action `split_into_clauses`) produced `⚠ probe_typo: reads bus namespace 'split_into_clause' ...`, while `data.get("analyze_clause")` (real action) and `data["seed"]` (framework namespace) were **not** flagged; exit code **0**.
- Blind fresh-context review: **YES** (correct AST scan, valid-namespace set, exit-0, dedup/attribution; no missed siblings).

**Smoke:** skipped — `risk.sh` reported `smoke_required=no` (validation-only, no chokepoint surface). The live `contract_reviewer` run above already exercised the real CLI path.