### PR TITLE
fix(schema): flat schema fields required by default (optional opt-out)

### DIFF
--- a/agent_actions/output/response/vendor_compilation.py
+++ b/agent_actions/output/response/vendor_compilation.py
@@ -64,7 +64,9 @@ def compile_unified_schema(
     for field in unified.get("fields", []):
         key, schema_prop = compile_field(field, target_system)
         properties[key] = schema_prop
-        if field.get("required", False):
+        # Flat fields are required by default; opt out with `optional: true`
+        # or an explicit `required: false`. Explicit `required` wins over `optional`.
+        if field.get("required", not field.get("optional", False)):
             required.append(key)
     target = target_system.lower()
     compiled: dict[str, Any] | list[dict[str, Any]]

--- a/agent_actions/tooling/docs/parser.py
+++ b/agent_actions/tooling/docs/parser.py
@@ -45,7 +45,7 @@ def extract_fields_for_docs(raw_schema: dict[str, Any]) -> list[dict[str, Any]]:
                         "name": field_def["id"],
                         "type": field_def.get("type", "unknown"),
                         "description": field_def.get("description", ""),
-                        "required": field_def.get("required", False),
+                        "required": field_def.get("required", not field_def.get("optional", False)),
                     }
                 )
 

--- a/agent_actions/validation/prompt_required_field_validator.py
+++ b/agent_actions/validation/prompt_required_field_validator.py
@@ -116,8 +116,12 @@ def _unguarded_refs(template: str) -> set[tuple[str, str]]:
 
 
 def _optional_field_names(schema: dict) -> set[str]:
-    """Names the producer declares but does not mark required."""
-    return {f["id"] for f in schema.get("fields", []) if "id" in f and not f.get("required", False)}
+    """Names the producer declares but does not guarantee (opted out of required-by-default)."""
+    return {
+        f["id"]
+        for f in schema.get("fields", [])
+        if "id" in f and not f.get("required", not f.get("optional", False))
+    }
 
 
 def find_unguarded_required_refs(prompts: dict[str, str], schemas: dict[str, dict]) -> list[str]:

--- a/agent_actions/validation/schema_output_validator.py
+++ b/agent_actions/validation/schema_output_validator.py
@@ -265,6 +265,9 @@ def _extract_schema_fields(schema: dict[str, Any]) -> tuple[set[str], set[str], 
                 elif field_id in top_level_required:
                     # Fall back to top-level required array
                     required_fields.add(field_id)
+                elif not field_def.get("optional", False):
+                    # Required by default; opt out with `optional: true`.
+                    required_fields.add(field_id)
                 if "type" in field_def:
                     field_types[field_id] = field_def["type"]
 

--- a/agent_actions/workflow/schema_service.py
+++ b/agent_actions/workflow/schema_service.py
@@ -206,7 +206,7 @@ class WorkflowSchemaService:
                     return (
                         field_def.get("type", "unknown"),
                         field_def.get("description", ""),
-                        field_def.get("required", False),
+                        field_def.get("required", not field_def.get("optional", False)),
                     )
                 # Array field with items.properties
                 if (

--- a/tests/services/test_workflow_schema_service.py
+++ b/tests/services/test_workflow_schema_service.py
@@ -239,7 +239,7 @@ class TestExtractFieldMetadata:
         assert desc == "Full name"
         assert req is True
 
-    def test_format1_defaults_required_false(self):
+    def test_format1_defaults_required_true(self):
         schema = {
             "fields": [
                 {"id": "age", "type": "integer", "description": "Age in years"},
@@ -248,7 +248,17 @@ class TestExtractFieldMetadata:
         ft, desc, req = self._extract(schema, "age")
         assert ft == "integer"
         assert desc == "Age in years"
-        assert req is False
+        assert req is True
+
+    def test_format1_optional_opts_out_of_required(self):
+        schema = {
+            "fields": [
+                {"id": "a", "type": "string", "optional": True},
+                {"id": "b", "type": "string", "required": False},
+            ]
+        }
+        assert self._extract(schema, "a")[2] is False
+        assert self._extract(schema, "b")[2] is False
 
     def test_format1_field_not_found(self):
         schema = {"fields": [{"id": "name", "type": "string"}]}
@@ -267,7 +277,7 @@ class TestExtractFieldMetadata:
         ft, desc, req = self._extract(schema, "title")
         assert ft == "string"
         assert desc == "Title field"
-        assert req is False
+        assert req is True  # unmarked → required by default
 
     def test_format1_non_dict_items_skipped(self):
         """Non-dict items in the fields array should be skipped, not raise."""
@@ -281,7 +291,7 @@ class TestExtractFieldMetadata:
         ft, desc, req = self._extract(schema, "valid")
         assert ft == "boolean"
         assert desc == "A flag"
-        assert req is False
+        assert req is True  # unmarked → required by default
 
     def test_format1_id_takes_precedence_over_name(self):
         """When both 'id' and 'name' are present, 'id' is used (via or short-circuit)."""

--- a/tests/unit/output/response/test_flat_fields_required_default.py
+++ b/tests/unit/output/response/test_flat_fields_required_default.py
@@ -1,0 +1,79 @@
+"""Flat schema fields are required by default; opt out with `optional: true`.
+
+Covers both enforcement paths: the vendor compiler (drives the compiled JSON
+Schema used by agac/UDF) and the LLM-output validator (drives the
+`on_schema_mismatch: reprompt` / reject decision).
+"""
+
+from agent_actions.output.response.vendor_compilation import compile_unified_schema
+from agent_actions.validation.schema_output_validator import validate_output_against_schema
+
+
+def _compiled_required(fields):
+    return compile_unified_schema({"name": "s", "fields": fields}, "openai")["schema"]["required"]
+
+
+# --- Compiler path -----------------------------------------------------------
+
+
+def test_flat_field_required_by_default():
+    assert _compiled_required([{"id": "a", "type": "string"}]) == ["a"]
+
+
+def test_optional_true_opts_out():
+    required = _compiled_required(
+        [{"id": "a", "type": "string"}, {"id": "b", "type": "string", "optional": True}]
+    )
+    assert required == ["a"]
+
+
+def test_explicit_required_false_opts_out():
+    assert _compiled_required([{"id": "a", "type": "string", "required": False}]) == []
+
+
+def test_explicit_required_true_still_required():
+    assert _compiled_required([{"id": "a", "type": "string", "required": True}]) == ["a"]
+
+
+def test_explicit_required_true_beats_optional_true():
+    """A field marked both required: true and optional: true stays required."""
+    assert _compiled_required(
+        [{"id": "a", "type": "string", "required": True, "optional": True}]
+    ) == ["a"]
+
+
+# --- Validator path (reprompt / reject decision) -----------------------------
+
+
+def test_omitted_flat_field_is_rejected():
+    """Omitting an unmarked flat field is non-compliant, so reprompt fires."""
+    schema = {"name": "s", "fields": [{"id": "a"}, {"id": "b"}]}
+    report = validate_output_against_schema({"a": "x"}, schema, "act")
+    assert not report.is_compliant
+    assert "b" in report.missing_required
+
+
+def test_optional_true_field_omission_accepted():
+    schema = {"name": "s", "fields": [{"id": "a"}, {"id": "b", "optional": True}]}
+    report = validate_output_against_schema({"a": "x"}, schema, "act")
+    assert report.is_compliant
+    assert "b" in report.missing_optional
+
+
+def test_required_false_field_omission_accepted():
+    schema = {"name": "s", "fields": [{"id": "a"}, {"id": "b", "required": False}]}
+    report = validate_output_against_schema({"a": "x"}, schema, "act")
+    assert report.is_compliant
+    assert "b" in report.missing_optional
+
+
+def test_top_level_required_array_still_honored():
+    """The existing top-level `required` array behaviour is preserved."""
+    schema = {
+        "name": "s",
+        "required": ["a"],
+        "fields": [{"id": "a", "optional": True}, {"id": "b", "required": False}],
+    }
+    report = validate_output_against_schema({}, schema, "act")
+    assert "a" in report.missing_required
+    assert "b" not in report.missing_required

--- a/tests/validation/test_prompt_required_field_validator.py
+++ b/tests/validation/test_prompt_required_field_validator.py
@@ -160,3 +160,20 @@ def test_empty_prompts_or_schemas_short_circuit():
     schemas = {"producer": _schema(required=set(), optional={"b"})}
     assert find_unguarded_required_refs({}, schemas) == []
     assert find_unguarded_required_refs({"consumer": "{{ producer.b }}"}, {}) == []
+
+
+def test_unmarked_field_ref_is_not_flagged_required_by_default():
+    # An unmarked producer field is required by default (guaranteed), so an
+    # unguarded ref to it is safe and must not be flagged.
+    prompts = {"consumer": "Use {{ producer.b }} here."}
+    schemas = {"producer": {"fields": [{"id": "a"}, {"id": "b"}]}}
+    assert find_unguarded_required_refs(prompts, schemas) == []
+
+
+def test_optional_true_field_ref_is_flagged():
+    # optional: true opts a field out of required-by-default, so an unguarded
+    # ref to it is a risk and must be flagged.
+    prompts = {"consumer": "Use {{ producer.b }} here."}
+    schemas = {"producer": {"fields": [{"id": "a"}, {"id": "b", "optional": True}]}}
+    findings = find_unguarded_required_refs(prompts, schemas)
+    assert any("producer.b" in f for f in findings)


### PR DESCRIPTION
## Summary

A field listed in a flat output schema's `fields:` was only treated as required when explicitly marked `required: true` — unmarked flat fields defaulted to **optional**. So an LLM omitting an unmarked flat field passed validation and `on_schema_mismatch: reprompt` never fired, inconsistent with array-item `required:` (already enforced). This spec (568, ISSUE-001 option B) flips the default: **a flat field is required by default**, with opt-out via `optional: true` or `required: false`. `required: true` still means required; explicit `required` wins over `optional`.

Truth table (applied consistently everywhere): unmarked → required · `optional: true` → optional · `required: false` → optional · `required: true` → required.

## What changed

| Path | File | Why it had to move |
|---|---|---|
| Vendor schema compiler | `output/response/vendor_compilation.py` | Builds the compiled JSON Schema `required` list (agac/UDF enforcement). The one-line flip the spec scoped. |
| **LLM-output validator** | `validation/schema_output_validator.py` (`_extract_schema_fields`) | **Drives the `on_schema_mismatch` reprompt/reject decision.** It reads the *raw* schema, so the compiler fix alone does NOT reach it — an omitted flat field would still be silently accepted on the reprompt path. Verified pre-fix: `validate_output_against_schema({"a":"x"}, {"fields":[{"id":"a"},{"id":"b"}]}, ...)` → `is_compliant=True`. |
| Schema service | `workflow/schema_service.py` (`_extract_field_metadata`) | Source of the required flag shown by `agac inspect`/`schema` **and** the flag `preflight` normalizes into the unguarded-prompt-ref warning. Effective root of that warning: without this, an unmarked (now-required) field is still reported optional → false-positive warning + `inspect` misreports. |
| Prompt required-field validator | `validation/prompt_required_field_validator.py` (`_optional_field_names`) | Aligned to the same truth table so it is correct for raw schemas too. |
| Docs parser | `tooling/docs/parser.py` | Generated docs now reflect required-by-default. |

The top-level `required` array handling and empty-object guard in `_extract_schema_fields`, the `required: false` opt-out, and the "field not found → False" default in `schema_service` are all preserved unchanged.

## Deviations from the spec (verify-first)

1. **Scope expanded from compiler-only to full-path + siblings.** The spec's formal SCOPE lists only `vendor_compilation.py`, but its stated GOAL ("omission triggers reprompt"), its VERIFICATION, and its own two embedded review sections require also fixing the LLM-output validator — otherwise the fix does not reach the reprompt path. Verified against real code and ratified with the requester. A blind review then surfaced additional consumers of the same default; the effective root for the preflight warning turned out to be `schema_service` (not `_optional_field_names`, whose default is bypassed because preflight pre-normalizes `required`). All four required-ness consumers now move together.
2. **Task 3 Step 2 (field model) skipped — dead work.** There is no Pydantic field model gating flat-field dicts (`extra="forbid"` models are `GuardCondition`/`SkipConditionConfig`). `optional: true` flows through as a raw dict; confirmed a `fields:` schema with `optional: true` loads and compiles without error.
3. **Task 4 (example schemas) — reviewed, intentionally left required.** The audit found 43/44 flat example schemas are optional-reliant, and **no test asserts flat-schema optionality**, so the suite is green with the flip (7975 pass) — there is no CI signal to "triage". These are teaching examples where declared fields should be produced; required-by-default is the intended behavior. Not speculatively marking fields `optional: true` (that would be a wrong-direction silent change). Documented per the requester's decision.
4. **Existing schema-service tests updated, not weakened.** Three `_extract_field_metadata` tests asserted the old unmarked→optional default (incl. one named `test_format1_defaults_required_false`); updated to the new contract and **added** opt-out coverage + two prompt-validator regression tests. Net assertions increased.

Out of scope (confirmed by review): `static_analyzer/schema_extractor.py:65` operates on internal UDF-derived schemas (and already defaults `True`); `schema_conversion.py:72` tests whether an array *itself* is required in its parent, not flat-field required-ness. Spec 563 (additionalProperties, merged #774) touched only `vendor_compilation.py` — **no clash** with the validator change here.

## Verification

- **RED → GREEN**: new `tests/unit/output/response/test_flat_fields_required_default.py` (9 tests) covers both the compiler and the validator/reprompt path; genuine behavioral RED (3 fail pre-fix: compiler default, compiler `optional` opt-out, validator omission) → all pass post-fix.
- **Full suite**: `pytest` **7975 passed**; `ruff check` + `ruff format --check` clean.
- **Blast radius / siblings**: swept every `get("required", …)` flat-field site; all four consumers fixed; two others verified out of scope.
- **Review**: LOW risk → one blind fresh-context reviewer, **VERDICT: YES** (independently rebuilt the truth table across all four sites, confirmed the preflight-normalization path, no missed siblings).
- **Real-project smoke**: `scan-project.sh` registry canary **PASSED** at HEAD. `smoke-test.sh online` could not exercise the change — the smoke project's first LLM action needs ollama model `gpt-oss:120b`, absent here (`ollama: model not found`); it fails before any schema output is produced. `baseline.sh` confirms `main` fails **identically** → pre-existing/environmental, not this branch.