### PR TITLE
feat(inspect): warn when a kind:tool passthrough UDF meets a strict output schema

### DIFF
--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -161,7 +161,9 @@ class PreflightService:
         for name, config in self.action_configs.items():
             if config.get("kind") != "tool":
                 continue
-            impl = config.get("impl")
+            # Post-expansion, the UDF name lives in model_name (the expander maps
+            # impl -> model_name); impl is the raw pre-expansion key.
+            impl = config.get("model_name") or config.get("impl")
             if not impl:
                 continue
             schema = config.get("json_output_schema")

--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -3,15 +3,21 @@ call it without spinning up storage or execution services."""
 
 from __future__ import annotations
 
+import inspect
 import logging
 from pathlib import Path
 from typing import Any
 
-from agent_actions.errors import ConfigValidationError, PromptValidationError
+from agent_actions.errors import (
+    ConfigValidationError,
+    FunctionNotFoundError,
+    PromptValidationError,
+)
 from agent_actions.errors.preflight import PreFlightValidationError
 from agent_actions.models.action_schema import FieldSource
 from agent_actions.prompt.formatter import PromptFormatter
 from agent_actions.utils.constants import NON_PROMPT_ACTION_KINDS
+from agent_actions.utils.udf_management.registry import get_udf_metadata
 from agent_actions.validation.dep_observe_validator import find_missing_observe_deps
 from agent_actions.validation.preflight.guard_validation import validate_guard_conditions
 from agent_actions.validation.preflight.resolution_service import (
@@ -23,6 +29,7 @@ from agent_actions.validation.prompt_required_field_validator import (
 from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
     apply_guard_nullable_schema_fixes,
 )
+from agent_actions.validation.udf_passthrough_validator import find_passthrough_schema_risks
 from agent_actions.workflow.schema_service import WorkflowSchemaService
 
 logger = logging.getLogger(__name__)
@@ -109,6 +116,9 @@ class PreflightService:
         ):
             logger.warning("Pre-flight: %s", finding)
 
+        # 7. Cross-check kind:tool passthrough UDFs against strict output schemas
+        self._warn_tool_passthrough_risks()
+
     def _collect_prompts(self) -> dict[str, str]:
         """Resolved prompt text per prompt-bearing action, keyed by action name."""
         prompts: dict[str, str] = {}
@@ -141,3 +151,32 @@ class PreflightService:
             if base and base not in schemas:
                 schemas[base] = {"fields": fields}
         return schemas
+
+    def _collect_tool_passthrough_inputs(self) -> dict[str, dict[str, Any]]:
+        """UDF source + output-schema strictness per kind:tool action.
+
+        Actions whose impl is unregistered or has no readable source are skipped:
+        this is an advisory warning and must never break inspect."""
+        inputs: dict[str, dict[str, Any]] = {}
+        for name, config in self.action_configs.items():
+            if config.get("kind") != "tool":
+                continue
+            impl = config.get("impl")
+            if not impl:
+                continue
+            try:
+                source = inspect.getsource(get_udf_metadata(impl)["function"])
+            except (FunctionNotFoundError, OSError, TypeError) as exc:
+                logger.debug("Skipping passthrough check for '%s': %s", name, exc)
+                continue
+            schema = config.get("json_output_schema") or {}
+            inputs[name] = {
+                "source": source,
+                "additional_properties": bool(schema.get("additionalProperties", False)),
+            }
+        return inputs
+
+    def _warn_tool_passthrough_risks(self) -> None:
+        """Warn when a kind:tool UDF passes upstream dicts through a strict schema."""
+        for finding in find_passthrough_schema_risks(self._collect_tool_passthrough_inputs()):
+            logger.warning("Pre-flight: %s", finding)

--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -164,12 +164,16 @@ class PreflightService:
             impl = config.get("impl")
             if not impl:
                 continue
+            schema = config.get("json_output_schema")
+            if not schema:
+                # No compiled output schema → runtime does no output validation and
+                # cannot reject, so there is nothing to warn about.
+                continue
             try:
                 source = inspect.getsource(get_udf_metadata(impl)["function"])
             except (FunctionNotFoundError, OSError, TypeError) as exc:
                 logger.debug("Skipping passthrough check for '%s': %s", name, exc)
                 continue
-            schema = config.get("json_output_schema") or {}
             inputs[name] = {
                 "source": source,
                 "additional_properties": bool(schema.get("additionalProperties", False)),

--- a/agent_actions/validation/udf_passthrough_validator.py
+++ b/agent_actions/validation/udf_passthrough_validator.py
@@ -17,7 +17,7 @@ def _target_names(target: ast.AST) -> set[str]:
     return set()
 
 
-def _first_param(func: ast.AST) -> str | None:
+def _first_param(func: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
     """The UDF's first positional parameter — the bus/record the framework passes in."""
     args = func.args
     params = list(args.posonlyargs) + list(args.args)

--- a/agent_actions/validation/udf_passthrough_validator.py
+++ b/agent_actions/validation/udf_passthrough_validator.py
@@ -17,84 +17,94 @@ def _target_names(target: ast.AST) -> set[str]:
     return set()
 
 
-def _root_is_data(node: ast.AST) -> bool:
-    """True if an attribute/subscript/call chain is ultimately rooted at name ``data``."""
-    current = node
-    while True:
-        if isinstance(current, ast.Call):
-            current = current.func
-        elif isinstance(current, ast.Attribute):
-            current = current.value
-        elif isinstance(current, ast.Subscript):
-            current = current.value
-        else:
-            break
-    return isinstance(current, ast.Name) and current.id == "data"
+def _first_param(func: ast.AST) -> str | None:
+    """The UDF's first positional parameter — the bus/record the framework passes in."""
+    args = func.args
+    params = list(args.posonlyargs) + list(args.args)
+    if params:
+        return params[0].arg
+    return args.vararg.arg if args.vararg else None
 
 
-def _is_bus_read(node: ast.AST) -> bool:
-    """True for ``data[...]`` or a ``data.get(...)`` chain — a read straight off the bus."""
-    if isinstance(node, ast.Subscript) and _root_is_data(node):
-        return True
-    return (
+def _reads_input(node: ast.AST, root: str, tainted: set[str]) -> bool:
+    """True for ``x.get(...)`` or ``x[...]`` where ``x`` is the input or derived from it."""
+    if isinstance(node, ast.Subscript):
+        return _is_input(node.value, root, tainted)
+    if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and node.func.attr == "get"
-        and _root_is_data(node.func.value)
-    )
-
-
-def _is_derived(node: ast.AST, tainted: set[str]) -> bool:
-    """True if *node* carries bus data through unchanged (opaque keys), not a fresh literal.
-
-    A dict/list literal and a call to any other function are construction
-    boundaries — their key set is bounded by the code, so they are not derived.
-    """
-    if _is_bus_read(node):
-        return True
-    if isinstance(node, ast.Name):
-        return node.id in tainted
-    if isinstance(node, (ast.ListComp, ast.GeneratorExp, ast.SetComp)):
-        local = set(tainted)
-        for gen in node.generators:
-            if _is_derived(gen.iter, local):
-                local |= _target_names(gen.target)
-        return _is_derived(node.elt, local)
-    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
-        return any(_is_derived(elt, tainted) for elt in node.elts)
+    ):
+        return _is_input(node.func.value, root, tainted)
     return False
 
 
-def _bus_tainted_names(func: ast.AST) -> set[str]:
+def _is_input(node: ast.AST, root: str, tainted: set[str]) -> bool:
+    """True if *node* is the input parameter itself or a value already read from it."""
+    if isinstance(node, ast.Name):
+        return node.id == root or node.id in tainted
+    return _reads_input(node, root, tainted)
+
+
+def _is_derived(node: ast.AST, root: str, tainted: set[str]) -> bool:
+    """True if *node* carries bus data through unchanged (opaque keys), not a fresh literal.
+
+    A read off a *key* of the input is derived; the bare input parameter is not —
+    returning the whole input is a filter whose keys already match its own schema.
+    Dict/list literals and calls to other functions are construction boundaries.
+    """
+    if _reads_input(node, root, tainted):
+        return True
+    if isinstance(node, ast.Name):
+        return node.id in tainted
+    if isinstance(node, ast.IfExp):
+        return _is_derived(node.body, root, tainted) or _is_derived(node.orelse, root, tainted)
+    if isinstance(node, ast.BoolOp):
+        return any(_is_derived(v, root, tainted) for v in node.values)
+    if isinstance(node, ast.BinOp):
+        return _is_derived(node.left, root, tainted) or _is_derived(node.right, root, tainted)
+    if isinstance(node, (ast.ListComp, ast.GeneratorExp, ast.SetComp)):
+        local = set(tainted)
+        for gen in node.generators:
+            if _is_derived(gen.iter, root, local):
+                local |= _target_names(gen.target)
+        return _is_derived(node.elt, root, local)
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return any(_is_derived(elt, root, tainted) for elt in node.elts)
+    return False
+
+
+def _bus_tainted_names(func: ast.AST, root: str) -> set[str]:
     """Local names holding bus-derived values, to a fixpoint over the function body."""
     tainted: set[str] = set()
     while True:
         before = len(tainted)
         for node in ast.walk(func):
-            if isinstance(node, ast.For) and _is_derived(node.iter, tainted):
+            if isinstance(node, ast.For) and _is_derived(node.iter, root, tainted):
                 tainted |= _target_names(node.target)
-            elif isinstance(node, ast.comprehension) and _is_derived(node.iter, tainted):
+            elif isinstance(node, ast.comprehension) and _is_derived(node.iter, root, tainted):
                 tainted |= _target_names(node.target)
-            elif isinstance(node, ast.Assign) and _is_derived(node.value, tainted):
+            elif isinstance(node, ast.Assign) and _is_derived(node.value, root, tainted):
                 for tgt in node.targets:
                     tainted |= _target_names(tgt)
             elif (
                 isinstance(node, (ast.AnnAssign, ast.NamedExpr))
                 and node.value is not None
-                and _is_derived(node.value, tainted)
+                and _is_derived(node.value, root, tainted)
             ):
                 tainted |= _target_names(node.target)
         if len(tainted) == before:
             return tainted
 
 
-def _returns_passthrough(func: ast.AST, tainted: set[str]) -> bool:
-    """True if a bus-derived value reaches the function's output (return/append/extend/+=)."""
+def _returns_passthrough(func: ast.AST, root: str) -> bool:
+    """True if a bus-derived value reaches output via return/append/extend/+=."""
+    tainted = _bus_tainted_names(func, root)
     for node in ast.walk(func):
         if isinstance(node, ast.Return) and node.value is not None:
-            if _is_derived(node.value, tainted):
+            if _is_derived(node.value, root, tainted):
                 return True
-        elif isinstance(node, ast.AugAssign) and _is_derived(node.value, tainted):
+        elif isinstance(node, ast.AugAssign) and _is_derived(node.value, root, tainted):
             return True
         elif (
             isinstance(node, ast.Call)
@@ -102,7 +112,7 @@ def _returns_passthrough(func: ast.AST, tainted: set[str]) -> bool:
             and node.func.attr in ("append", "extend")
             and isinstance(node.func.value, ast.Name)
             and node.args
-            and _is_derived(node.args[0], tainted)
+            and _is_derived(node.args[0], root, tainted)
         ):
             return True
     return False
@@ -115,7 +125,8 @@ def _source_is_passthrough(source: str) -> bool:
         return False
     for func in ast.walk(tree):
         if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if _returns_passthrough(func, _bus_tainted_names(func)):
+            root = _first_param(func)
+            if root and _returns_passthrough(func, root):
                 return True
     return False
 

--- a/agent_actions/validation/udf_passthrough_validator.py
+++ b/agent_actions/validation/udf_passthrough_validator.py
@@ -26,9 +26,28 @@ def _first_param(func: ast.AST) -> str | None:
     return args.vararg.arg if args.vararg else None
 
 
+def _is_sequence_index(sl: ast.AST) -> bool:
+    """True for a slice or a (possibly negative) integer index — sequence access, not a mapping key."""
+    if isinstance(sl, ast.Slice):
+        return True
+    if isinstance(sl, ast.Constant) and isinstance(sl.value, int):
+        return True
+    return (
+        isinstance(sl, ast.UnaryOp)
+        and isinstance(sl.operand, ast.Constant)
+        and isinstance(sl.operand.value, int)
+    )
+
+
 def _reads_input(node: ast.AST, root: str, tainted: set[str]) -> bool:
-    """True for ``x.get(...)`` or ``x[...]`` where ``x`` is the input or derived from it."""
+    """True for a mapping read ``x.get(...)`` / ``x['key']`` where ``x`` is the input or derived.
+
+    Numeric/slice subscripts are sequence access (string/list indexing) and are
+    not mapping reads, so a string-first-param helper doing ``s[0]`` is not flagged.
+    """
     if isinstance(node, ast.Subscript):
+        if _is_sequence_index(node.slice):
+            return False
         return _is_input(node.value, root, tainted)
     if (
         isinstance(node, ast.Call)

--- a/agent_actions/validation/udf_passthrough_validator.py
+++ b/agent_actions/validation/udf_passthrough_validator.py
@@ -1,0 +1,139 @@
+"""Flag kind:tool UDFs that return bus-derived pass-through dicts under a strict schema."""
+
+from __future__ import annotations
+
+import ast
+
+
+def _target_names(target: ast.AST) -> set[str]:
+    """Names bound by an assignment or ``for`` target."""
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: set[str] = set()
+        for elt in target.elts:
+            names |= _target_names(elt)
+        return names
+    return set()
+
+
+def _root_is_data(node: ast.AST) -> bool:
+    """True if an attribute/subscript/call chain is ultimately rooted at name ``data``."""
+    current = node
+    while True:
+        if isinstance(current, ast.Call):
+            current = current.func
+        elif isinstance(current, ast.Attribute):
+            current = current.value
+        elif isinstance(current, ast.Subscript):
+            current = current.value
+        else:
+            break
+    return isinstance(current, ast.Name) and current.id == "data"
+
+
+def _is_bus_read(node: ast.AST) -> bool:
+    """True for ``data[...]`` or a ``data.get(...)`` chain — a read straight off the bus."""
+    if isinstance(node, ast.Subscript) and _root_is_data(node):
+        return True
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and _root_is_data(node.func.value)
+    )
+
+
+def _is_derived(node: ast.AST, tainted: set[str]) -> bool:
+    """True if *node* carries bus data through unchanged (opaque keys), not a fresh literal.
+
+    A dict/list literal and a call to any other function are construction
+    boundaries — their key set is bounded by the code, so they are not derived.
+    """
+    if _is_bus_read(node):
+        return True
+    if isinstance(node, ast.Name):
+        return node.id in tainted
+    if isinstance(node, (ast.ListComp, ast.GeneratorExp, ast.SetComp)):
+        local = set(tainted)
+        for gen in node.generators:
+            if _is_derived(gen.iter, local):
+                local |= _target_names(gen.target)
+        return _is_derived(node.elt, local)
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return any(_is_derived(elt, tainted) for elt in node.elts)
+    return False
+
+
+def _bus_tainted_names(func: ast.AST) -> set[str]:
+    """Local names holding bus-derived values, to a fixpoint over the function body."""
+    tainted: set[str] = set()
+    while True:
+        before = len(tainted)
+        for node in ast.walk(func):
+            if isinstance(node, ast.For) and _is_derived(node.iter, tainted):
+                tainted |= _target_names(node.target)
+            elif isinstance(node, ast.comprehension) and _is_derived(node.iter, tainted):
+                tainted |= _target_names(node.target)
+            elif isinstance(node, ast.Assign) and _is_derived(node.value, tainted):
+                for tgt in node.targets:
+                    tainted |= _target_names(tgt)
+            elif (
+                isinstance(node, (ast.AnnAssign, ast.NamedExpr))
+                and node.value is not None
+                and _is_derived(node.value, tainted)
+            ):
+                tainted |= _target_names(node.target)
+        if len(tainted) == before:
+            return tainted
+
+
+def _returns_passthrough(func: ast.AST, tainted: set[str]) -> bool:
+    """True if a bus-derived value reaches the function's output (return/append/extend/+=)."""
+    for node in ast.walk(func):
+        if isinstance(node, ast.Return) and node.value is not None:
+            if _is_derived(node.value, tainted):
+                return True
+        elif isinstance(node, ast.AugAssign) and _is_derived(node.value, tainted):
+            return True
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("append", "extend")
+            and isinstance(node.func.value, ast.Name)
+            and node.args
+            and _is_derived(node.args[0], tainted)
+        ):
+            return True
+    return False
+
+
+def _source_is_passthrough(source: str) -> bool:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    for func in ast.walk(tree):
+        if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _returns_passthrough(func, _bus_tainted_names(func)):
+                return True
+    return False
+
+
+def find_passthrough_schema_risks(actions: dict[str, dict]) -> list[str]:
+    """Return one warning per kind:tool action whose UDF passes bus dicts through a strict schema.
+
+    Each action entry provides ``source`` (UDF text) and ``additional_properties`` (bool);
+    actions that opt out with ``additional_properties: True`` are never flagged.
+    """
+    findings: list[str] = []
+    for name, info in actions.items():
+        if info.get("additional_properties"):
+            continue
+        if _source_is_passthrough(info.get("source", "")):
+            findings.append(
+                f"{name}: UDF passes upstream dicts through unchanged, but its schema is strict "
+                f"(additionalProperties not true). Extra upstream keys will be rejected at runtime "
+                f"— add them to the schema fields or set additionalProperties: true."
+            )
+    return findings

--- a/agent_actions/validation/udf_passthrough_validator.py
+++ b/agent_actions/validation/udf_passthrough_validator.py
@@ -116,16 +116,11 @@ def _bus_tainted_names(func: ast.AST, root: str) -> set[str]:
             return tainted
 
 
-def _returns_passthrough(func: ast.AST, root: str) -> bool:
-    """True if a bus-derived value reaches output via return/append/extend/+=."""
-    tainted = _bus_tainted_names(func, root)
+def _bus_accumulators(func: ast.AST, root: str, tainted: set[str]) -> set[str]:
+    """Names fed bus-derived items via append/extend/+= — candidate output lists."""
+    accs: set[str] = set()
     for node in ast.walk(func):
-        if isinstance(node, ast.Return) and node.value is not None:
-            if _is_derived(node.value, root, tainted):
-                return True
-        elif isinstance(node, ast.AugAssign) and _is_derived(node.value, root, tainted):
-            return True
-        elif (
+        if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr in ("append", "extend")
@@ -133,7 +128,27 @@ def _returns_passthrough(func: ast.AST, root: str) -> bool:
             and node.args
             and _is_derived(node.args[0], root, tainted)
         ):
-            return True
+            accs.add(node.func.value.id)
+        elif (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Name)
+            and _is_derived(node.value, root, tainted)
+        ):
+            accs.add(node.target.id)
+    return accs
+
+
+def _returns_passthrough(func: ast.AST, root: str) -> bool:
+    """True if a bus-derived value is returned — directly, or as an accumulator of bus items.
+
+    An accumulator fed bus data but only nested inside a constructed dict/other
+    literal is never returned as an output item, so it is not flagged."""
+    tainted = _bus_tainted_names(func, root)
+    reachable = tainted | _bus_accumulators(func, root, tainted)
+    for node in ast.walk(func):
+        if isinstance(node, ast.Return) and node.value is not None:
+            if _is_derived(node.value, root, reachable):
+                return True
     return False
 
 

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -736,6 +736,161 @@ class TestDependencyObserveCheck:
         self._validate(cfgs)  # completes without raising
 
 
+# Real module-level UDFs so inspect.getsource returns their true bodies.
+def _passthrough_tool(data):
+    out = []
+    for candidate in data.get("upstream", []):
+        out.append(candidate)
+    return out
+
+
+def _constructed_tool(data):
+    return [{"key": item["key"]} for item in data.get("upstream", [])]
+
+
+class TestToolPassthroughCrossCheck:
+    """Preflight must warn when a kind:tool UDF passes upstream dicts through a
+    strict output schema — the static signal for a runtime output-schema reject."""
+
+    def _svc(self, action_configs: dict) -> PreflightService:
+        return PreflightService(
+            agent_name="wf",
+            action_configs=action_configs,
+            project_root=None,
+            workflow_config_path="wf.yml",
+            verify_keys=False,
+        )
+
+    def _tool(self, impl: str, additional_properties: bool = False) -> dict:
+        return {
+            "kind": "tool",
+            "impl": impl,
+            "json_output_schema": {"type": "object", "additionalProperties": additional_properties},
+        }
+
+    def test_passthrough_tool_source_and_schema_collected(self):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            collected = self._svc(
+                {"flatten": self._tool("_passthrough_tool")}
+            )._collect_tool_passthrough_inputs()
+            assert "flatten" in collected
+            assert collected["flatten"]["additional_properties"] is False
+            assert "out.append(candidate)" in collected["flatten"]["source"]
+        finally:
+            clear_registry()
+
+    def test_passthrough_tool_under_strict_schema_is_flagged(self):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+        from agent_actions.validation.udf_passthrough_validator import find_passthrough_schema_risks
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            collected = self._svc(
+                {"flatten": self._tool("_passthrough_tool")}
+            )._collect_tool_passthrough_inputs()
+            assert find_passthrough_schema_risks(collected)
+        finally:
+            clear_registry()
+
+    def test_additionalproperties_true_tool_not_flagged(self):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+        from agent_actions.validation.udf_passthrough_validator import find_passthrough_schema_risks
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            collected = self._svc(
+                {"flatten": self._tool("_passthrough_tool", additional_properties=True)}
+            )._collect_tool_passthrough_inputs()
+            assert collected["flatten"]["additional_properties"] is True
+            assert find_passthrough_schema_risks(collected) == []
+        finally:
+            clear_registry()
+
+    def test_constructed_tool_not_flagged(self):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+        from agent_actions.validation.udf_passthrough_validator import find_passthrough_schema_risks
+
+        clear_registry()
+        udf_tool(_constructed_tool)
+        try:
+            collected = self._svc(
+                {"build": self._tool("_constructed_tool")}
+            )._collect_tool_passthrough_inputs()
+            assert find_passthrough_schema_risks(collected) == []
+        finally:
+            clear_registry()
+
+    def test_non_tool_action_not_collected(self):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            cfgs = {"scorer": {"kind": "llm", "model_name": "gpt-4o-mini"}}
+            assert self._svc(cfgs)._collect_tool_passthrough_inputs() == {}
+        finally:
+            clear_registry()
+
+    def test_unregistered_impl_skipped_without_error(self):
+        from agent_actions.utils.udf_management.registry import clear_registry
+
+        clear_registry()
+        collected = self._svc(
+            {"ghost": self._tool("not_registered")}
+        )._collect_tool_passthrough_inputs()
+        assert collected == {}
+
+    def test_missing_json_output_schema_defaults_to_strict(self):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            cfgs = {"flatten": {"kind": "tool", "impl": "_passthrough_tool"}}
+            collected = self._svc(cfgs)._collect_tool_passthrough_inputs()
+            assert collected["flatten"]["additional_properties"] is False
+        finally:
+            clear_registry()
+
+    def test_passthrough_tool_emits_preflight_warning(self, caplog):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            logger_name = "agent_actions.services.preflight_service"
+            with caplog.at_level(logging.WARNING, logger=logger_name):
+                self._svc(
+                    {"flatten": self._tool("_passthrough_tool")}
+                )._warn_tool_passthrough_risks()
+            msgs = [r.getMessage() for r in caplog.records if r.name == logger_name]
+            assert any("flatten" in m and "additionalProperties" in m for m in msgs), msgs
+        finally:
+            clear_registry()
+
+    def test_additionalproperties_true_tool_emits_nothing(self, caplog):
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            logger_name = "agent_actions.services.preflight_service"
+            with caplog.at_level(logging.WARNING, logger=logger_name):
+                self._svc(
+                    {"flatten": self._tool("_passthrough_tool", additional_properties=True)}
+                )._warn_tool_passthrough_risks()
+            msgs = [r.getMessage() for r in caplog.records if r.name == logger_name]
+            assert not any("flatten" in m for m in msgs), msgs
+        finally:
+            clear_registry()
+
+
 class TestProducingSchemaCollection:
     """`_collect_producing_schemas` feeds the cross-check the right field set."""
 

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -784,6 +784,28 @@ class TestToolPassthroughCrossCheck:
         finally:
             aa_logger.propagate = original
 
+    def test_expanded_config_model_name_is_used_as_impl(self):
+        # Post-expansion tool configs carry the UDF name in model_name (the
+        # expander maps impl -> model_name); impl does not survive. The check
+        # must read model_name or it never fires on a real workflow.
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            cfgs = {
+                "flatten": {
+                    "kind": "tool",
+                    "model_name": "_passthrough_tool",
+                    "json_output_schema": {"type": "object", "additionalProperties": False},
+                }
+            }
+            collected = self._svc(cfgs)._collect_tool_passthrough_inputs()
+            assert "flatten" in collected
+            assert "out.append(candidate)" in collected["flatten"]["source"]
+        finally:
+            clear_registry()
+
     def test_passthrough_tool_source_and_schema_collected(self):
         from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
 

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -848,7 +848,10 @@ class TestToolPassthroughCrossCheck:
         clear_registry()
         udf_tool(_passthrough_tool)
         try:
-            cfgs = {"scorer": {"kind": "llm", "model_name": "gpt-4o-mini"}}
+            # llm action carries an impl too — only the kind filter should exclude it.
+            cfgs = {
+                "scorer": {"kind": "llm", "impl": "_passthrough_tool", "model_name": "gpt-4o-mini"}
+            }
             assert self._svc(cfgs)._collect_tool_passthrough_inputs() == {}
         finally:
             clear_registry()
@@ -862,15 +865,16 @@ class TestToolPassthroughCrossCheck:
         )._collect_tool_passthrough_inputs()
         assert collected == {}
 
-    def test_missing_json_output_schema_defaults_to_strict(self):
+    def test_missing_json_output_schema_is_skipped(self):
+        # No compiled output schema means the runtime does no output validation
+        # and cannot reject — so preflight must not warn. Parity with runtime.
         from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
 
         clear_registry()
         udf_tool(_passthrough_tool)
         try:
             cfgs = {"flatten": {"kind": "tool", "impl": "_passthrough_tool"}}
-            collected = self._svc(cfgs)._collect_tool_passthrough_inputs()
-            assert collected["flatten"]["additional_properties"] is False
+            assert self._svc(cfgs)._collect_tool_passthrough_inputs() == {}
         finally:
             clear_registry()
 
@@ -893,6 +897,40 @@ class TestToolPassthroughCrossCheck:
         try:
             cfgs = {"flatten": self._tool("_passthrough_tool", additional_properties=True)}
             assert not any("flatten" in m for m in self._emit_warnings(cfgs, caplog)), cfgs
+        finally:
+            clear_registry()
+
+    def test_validate_emits_passthrough_warning_end_to_end(self, caplog):
+        # Full validate() must reach the passthrough check and stay non-fatal.
+        from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+        clear_registry()
+        udf_tool(_passthrough_tool)
+        try:
+            cfgs = {
+                "flatten": {
+                    "kind": "tool",
+                    "impl": "_passthrough_tool",
+                    "context_scope": {"observe": ["source.*"]},
+                    "schema": {"type": "object", "properties": {"k": {"type": "string"}}},
+                    "json_output_schema": {
+                        "type": "object",
+                        "properties": {"k": {"type": "string"}},
+                        "additionalProperties": False,
+                    },
+                }
+            }
+            logger_name = "agent_actions.services.preflight_service"
+            aa_logger = logging.getLogger("agent_actions")
+            original = aa_logger.propagate
+            aa_logger.propagate = True
+            try:
+                with caplog.at_level(logging.WARNING, logger=logger_name):
+                    self._svc(cfgs).validate()  # completes without raising
+                msgs = [r.getMessage() for r in caplog.records if r.name == logger_name]
+            finally:
+                aa_logger.propagate = original
+            assert any("flatten" in m and "upstream dicts" in m for m in msgs), msgs
         finally:
             clear_registry()
 

--- a/tests/validation/test_preflight_consolidation.py
+++ b/tests/validation/test_preflight_consolidation.py
@@ -768,6 +768,22 @@ class TestToolPassthroughCrossCheck:
             "json_output_schema": {"type": "object", "additionalProperties": additional_properties},
         }
 
+    def _emit_warnings(self, cfgs: dict, caplog) -> list[str]:
+        """Run the passthrough warning step and return its preflight messages.
+
+        The ``agent_actions`` logger does not propagate by default, so caplog
+        (which listens on root) needs propagation toggled on for the call."""
+        logger_name = "agent_actions.services.preflight_service"
+        aa_logger = logging.getLogger("agent_actions")
+        original = aa_logger.propagate
+        aa_logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger=logger_name):
+                self._svc(cfgs)._warn_tool_passthrough_risks()
+            return [r.getMessage() for r in caplog.records if r.name == logger_name]
+        finally:
+            aa_logger.propagate = original
+
     def test_passthrough_tool_source_and_schema_collected(self):
         from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
 
@@ -864,12 +880,7 @@ class TestToolPassthroughCrossCheck:
         clear_registry()
         udf_tool(_passthrough_tool)
         try:
-            logger_name = "agent_actions.services.preflight_service"
-            with caplog.at_level(logging.WARNING, logger=logger_name):
-                self._svc(
-                    {"flatten": self._tool("_passthrough_tool")}
-                )._warn_tool_passthrough_risks()
-            msgs = [r.getMessage() for r in caplog.records if r.name == logger_name]
+            msgs = self._emit_warnings({"flatten": self._tool("_passthrough_tool")}, caplog)
             assert any("flatten" in m and "additionalProperties" in m for m in msgs), msgs
         finally:
             clear_registry()
@@ -880,13 +891,8 @@ class TestToolPassthroughCrossCheck:
         clear_registry()
         udf_tool(_passthrough_tool)
         try:
-            logger_name = "agent_actions.services.preflight_service"
-            with caplog.at_level(logging.WARNING, logger=logger_name):
-                self._svc(
-                    {"flatten": self._tool("_passthrough_tool", additional_properties=True)}
-                )._warn_tool_passthrough_risks()
-            msgs = [r.getMessage() for r in caplog.records if r.name == logger_name]
-            assert not any("flatten" in m for m in msgs), msgs
+            cfgs = {"flatten": self._tool("_passthrough_tool", additional_properties=True)}
+            assert not any("flatten" in m for m in self._emit_warnings(cfgs, caplog)), cfgs
         finally:
             clear_registry()
 

--- a/tests/validation/test_udf_passthrough_validator.py
+++ b/tests/validation/test_udf_passthrough_validator.py
@@ -64,6 +64,13 @@ _MUTATE_RETURN_INPUT = "def mark(record):\n    record['status'] = 'KEEP'\n    re
 _SUBKEY_CONSTRUCT = (
     "def build(data):\n    cfg = data.get('config', {})\n    return {'ok': cfg.get('threshold')}\n"
 )
+# String first param with sequence indexing — a prompt/parse helper, not a dict
+# passthrough. Numeric index / slice must not be mistaken for a mapping read.
+_STR_INDEX = "def make_prompt(context_str):\n    return context_str[0]\n"
+_STR_SLICE = "def make_prompt(context_str):\n    return context_str[0:100]\n"
+_NEG_INDEX = "def last(seq):\n    return seq[-1]\n"
+# Variable string key is still a mapping read — real tools index by a key var.
+_VAR_KEY = "def f(data):\n    k = 'ns'\n    return data[k]\n"
 
 
 def _risks(source, additional_properties=False):
@@ -150,6 +157,22 @@ def test_mutate_and_return_input_not_flagged():
 
 def test_subkey_read_into_dict_literal_not_flagged():
     assert _risks(_SUBKEY_CONSTRUCT) == []
+
+
+def test_string_index_not_flagged():
+    assert _risks(_STR_INDEX) == []
+
+
+def test_string_slice_not_flagged():
+    assert _risks(_STR_SLICE) == []
+
+
+def test_negative_index_not_flagged():
+    assert _risks(_NEG_INDEX) == []
+
+
+def test_variable_key_subscript_is_flagged():
+    assert _risks(_VAR_KEY) != []
 
 
 def test_missing_source_is_ignored():

--- a/tests/validation/test_udf_passthrough_validator.py
+++ b/tests/validation/test_udf_passthrough_validator.py
@@ -64,6 +64,26 @@ _MUTATE_RETURN_INPUT = "def mark(record):\n    record['status'] = 'KEEP'\n    re
 _SUBKEY_CONSTRUCT = (
     "def build(data):\n    cfg = data.get('config', {})\n    return {'ok': cfg.get('threshold')}\n"
 )
+# Accumulator fed from bus data, then nested as a VALUE in a constructed output
+# dict whose keys are bounded — safe. The output item is the dict, not the list.
+_ACC_INTO_DICT = (
+    "def build(data):\n"
+    "    opts = data.get('src', {}).get('options', [])\n"
+    "    texts = []\n"
+    "    for i in range(len(opts)):\n"
+    "        texts.append(opts[i])\n"
+    "    return {'answer_text': texts, 'options': opts}\n"
+)
+# Aggregate-into-summary-dict: extend an accumulator from bus reads, return it
+# under a declared key of a constructed dict — safe.
+_AGG_SUMMARY = (
+    "def agg(data):\n"
+    "    issues = []\n"
+    "    for i in range(3):\n"
+    "        r = data.get('rev', {})\n"
+    "        issues.extend(r.get('items', []))\n"
+    "    return {'count': len(issues), 'remaining': issues}\n"
+)
 # String first param with sequence indexing — a prompt/parse helper, not a dict
 # passthrough. Numeric index / slice must not be mistaken for a mapping read.
 _STR_INDEX = "def make_prompt(context_str):\n    return context_str[0]\n"
@@ -157,6 +177,14 @@ def test_mutate_and_return_input_not_flagged():
 
 def test_subkey_read_into_dict_literal_not_flagged():
     assert _risks(_SUBKEY_CONSTRUCT) == []
+
+
+def test_accumulator_nested_in_constructed_dict_not_flagged():
+    assert _risks(_ACC_INTO_DICT) == []
+
+
+def test_aggregate_into_summary_dict_not_flagged():
+    assert _risks(_AGG_SUMMARY) == []
 
 
 def test_string_index_not_flagged():

--- a/tests/validation/test_udf_passthrough_validator.py
+++ b/tests/validation/test_udf_passthrough_validator.py
@@ -1,0 +1,104 @@
+from agent_actions.validation.udf_passthrough_validator import find_passthrough_schema_risks
+
+# Appends an item taken straight off the bus — opaque upstream keys reach output.
+_PASSTHROUGH = (
+    "def flatten(data):\n"
+    "    out = []\n"
+    "    for c in data.get('canonicalize', {}).get('items', []):\n"
+    "        out.append(c)\n"
+    "    return out\n"
+)
+# Returns a list of dict literals whose keys are visible and bounded — safe.
+_CONSTRUCTED = (
+    "def build(data):\n"
+    "    src = data.get('upstream', {})\n"
+    "    return [{'key': src.get('key'), 'summary': src.get('summary')}]\n"
+)
+# Builds a dict literal in a loop variable, then appends it — the idiomatic
+# safe constructing tool. Must NOT be flagged.
+_CONSTRUCTED_VAR = (
+    "def build(data):\n"
+    "    out = []\n"
+    "    for i in data.get('ns', []):\n"
+    "        item = {'key': i['key'], 'summary': i['summary']}\n"
+    "        out.append(item)\n"
+    "    return out\n"
+)
+# Delegates construction to a helper — the call is a construction boundary, safe.
+_WRAPPER_CALL = "def build(data):\n    return build_items(data.get('ns'))\n"
+# Appends a dict literal directly — keys visible, safe.
+_APPEND_DICT_LITERAL = (
+    "def build(data):\n"
+    "    out = []\n"
+    "    for i in data.get('ns', []):\n"
+    "        out.append({'key': i['key']})\n"
+    "    return out\n"
+)
+# extend / += / comprehension are all pass-through idioms the draft missed.
+_EXTEND = "def flatten(data):\n    out = []\n    out.extend(data.get('ns'))\n    return out\n"
+_AUGASSIGN = "def flatten(data):\n    out = []\n    out += data.get('ns')\n    return out\n"
+_COMPREHENSION = "def flatten(data):\n    return [c for c in data.get('ns')]\n"
+_RETURN_DIRECT = "def flatten(data):\n    return data.get('ns')\n"
+
+
+def _risks(source, additional_properties=False):
+    return find_passthrough_schema_risks({"f": {"source": source, "additional_properties": additional_properties}})
+
+
+def test_passthrough_with_strict_schema_is_flagged():
+    assert any("f" in finding for finding in _risks(_PASSTHROUGH))
+
+
+def test_passthrough_with_additionalproperties_true_is_ok():
+    assert _risks(_PASSTHROUGH, additional_properties=True) == []
+
+
+def test_constructed_dicts_not_flagged():
+    assert _risks(_CONSTRUCTED) == []
+
+
+def test_constructed_var_appended_not_flagged():
+    assert _risks(_CONSTRUCTED_VAR) == []
+
+
+def test_wrapper_call_not_flagged():
+    assert _risks(_WRAPPER_CALL) == []
+
+
+def test_append_dict_literal_not_flagged():
+    assert _risks(_APPEND_DICT_LITERAL) == []
+
+
+def test_extend_bus_read_is_flagged():
+    assert _risks(_EXTEND) != []
+
+
+def test_augassign_bus_read_is_flagged():
+    assert _risks(_AUGASSIGN) != []
+
+
+def test_comprehension_passthrough_is_flagged():
+    assert _risks(_COMPREHENSION) != []
+
+
+def test_return_direct_bus_read_is_flagged():
+    assert _risks(_RETURN_DIRECT) != []
+
+
+def test_multiple_actions_each_reported_once():
+    actions = {
+        "flatten": {"source": _PASSTHROUGH, "additional_properties": False},
+        "build": {"source": _CONSTRUCTED, "additional_properties": False},
+        "extend": {"source": _EXTEND, "additional_properties": False},
+    }
+    findings = find_passthrough_schema_risks(actions)
+    flagged = {name for name in ("flatten", "build", "extend") if any(name in f for f in findings)}
+    assert flagged == {"flatten", "extend"}
+
+
+def test_missing_source_is_ignored():
+    assert find_passthrough_schema_risks({"f": {"additional_properties": False}}) == []
+
+
+def test_syntactically_invalid_source_is_ignored():
+    assert _risks("def f(data):\n    this is not python\n") == []

--- a/tests/validation/test_udf_passthrough_validator.py
+++ b/tests/validation/test_udf_passthrough_validator.py
@@ -39,6 +39,31 @@ _EXTEND = "def flatten(data):\n    out = []\n    out.extend(data.get('ns'))\n   
 _AUGASSIGN = "def flatten(data):\n    out = []\n    out += data.get('ns')\n    return out\n"
 _COMPREHENSION = "def flatten(data):\n    return [c for c in data.get('ns')]\n"
 _RETURN_DIRECT = "def flatten(data):\n    return data.get('ns')\n"
+# Two-level namespace flatten with a ternary and `or []` guard — the canonical
+# real-world flatten shape. Taint must survive the sub-read off a derived value.
+_TWO_LEVEL = (
+    "def flatten(data):\n"
+    "    cq = data.get('canonicalize', {})\n"
+    "    items = cq.get('items') if isinstance(cq, dict) else None\n"
+    "    out = []\n"
+    "    for q in items or []:\n"
+    "        out.append(q)\n"
+    "    return out\n"
+)
+# Reads via subscript, not .get.
+_SUBSCRIPT = "def flatten(data):\n    return data['ns']\n"
+# Bus param named something other than `data` — the runtime passes it positionally.
+_NONDATA_PARAM = "def flatten(bus):\n    out = []\n    for c in bus.get('ns'):\n        out.append(c)\n    return out\n"
+# out = out + bus_read (plain Assign with BinOp, the sibling of +=).
+_BINOP_ASSIGN = "def flatten(data):\n    out = []\n    out = out + data.get('ns')\n    return out\n"
+# Returns the whole input unchanged (pure filter) — input already conforms, safe.
+_RETURN_INPUT = "def keep(record):\n    return record if record['ok'] else {}\n"
+# Mutates the input record and returns it — out of scope (not a namespace read); safe.
+_MUTATE_RETURN_INPUT = "def mark(record):\n    record['status'] = 'KEEP'\n    return record\n"
+# Reads a sub-key but builds a fresh dict literal — safe.
+_SUBKEY_CONSTRUCT = (
+    "def build(data):\n    cfg = data.get('config', {})\n    return {'ok': cfg.get('threshold')}\n"
+)
 
 
 def _risks(source, additional_properties=False):
@@ -87,15 +112,44 @@ def test_return_direct_bus_read_is_flagged():
     assert _risks(_RETURN_DIRECT) != []
 
 
-def test_multiple_actions_each_reported_once():
+def test_two_flagged_actions_yield_exactly_two_findings():
     actions = {
         "flatten": {"source": _PASSTHROUGH, "additional_properties": False},
         "build": {"source": _CONSTRUCTED, "additional_properties": False},
         "extend": {"source": _EXTEND, "additional_properties": False},
     }
     findings = find_passthrough_schema_risks(actions)
+    assert len(findings) == 2
     flagged = {name for name in ("flatten", "build", "extend") if any(name in f for f in findings)}
     assert flagged == {"flatten", "extend"}
+
+
+def test_two_level_namespace_flatten_is_flagged():
+    assert _risks(_TWO_LEVEL) != []
+
+
+def test_subscript_bus_read_is_flagged():
+    assert _risks(_SUBSCRIPT) != []
+
+
+def test_non_data_param_name_is_flagged():
+    assert _risks(_NONDATA_PARAM) != []
+
+
+def test_binop_assign_bus_read_is_flagged():
+    assert _risks(_BINOP_ASSIGN) != []
+
+
+def test_return_whole_input_not_flagged():
+    assert _risks(_RETURN_INPUT) == []
+
+
+def test_mutate_and_return_input_not_flagged():
+    assert _risks(_MUTATE_RETURN_INPUT) == []
+
+
+def test_subkey_read_into_dict_literal_not_flagged():
+    assert _risks(_SUBKEY_CONSTRUCT) == []
 
 
 def test_missing_source_is_ignored():

--- a/tests/validation/test_udf_passthrough_validator.py
+++ b/tests/validation/test_udf_passthrough_validator.py
@@ -42,7 +42,9 @@ _RETURN_DIRECT = "def flatten(data):\n    return data.get('ns')\n"
 
 
 def _risks(source, additional_properties=False):
-    return find_passthrough_schema_risks({"f": {"source": source, "additional_properties": additional_properties}})
+    return find_passthrough_schema_risks(
+        {"f": {"source": source, "additional_properties": additional_properties}}
+    )
 
 
 def test_passthrough_with_strict_schema_is_flagged():


### PR DESCRIPTION
## Summary

`agac inspect` now warns when a `kind: tool` action's UDF passes upstream bus dicts through unchanged while its declared output schema is strict (`additionalProperties` not true) — the static signal for the runtime output-schema reject. It respects the `additionalProperties: true` opt-out and never breaks inspect.

- New detector `agent_actions/validation/udf_passthrough_validator.py` — `find_passthrough_schema_risks(actions)`.
- Wired into `PreflightService.validate()` (the `agac inspect` path, alongside the sibling prompt-ref check).

## Deviation from the spec draft

The draft said to wire this into `validate-udfs`. I wired it into **`preflight_service.py`** instead, because that is where per-action compiled schemas already live. The spec's own title names `agac inspect`.

## Heuristic (bounded intra-function AST taint)

A value is *bus-derived* if it is a mapping read (`p.get(k)` / `p['k']`) off the UDF's **first positional parameter**, a name assigned from one, a `for` item over one, or a comprehension element over one — propagated through two-level sub-reads, ternary, `or`, `+`. A warning fires when a bus-derived value is **returned** as output — directly, or as an accumulator (`append`/`extend`/`+=` of bus data) that is itself returned.

Deliberately **not** flagged (low false positive is paramount):
- dict/list literals and calls to other functions (construction boundaries);
- the bare input parameter returned unchanged (a pure filter);
- numeric/slice subscripts (`s[0]`) — sequence access by a string/parse helper;
- an accumulator fed bus data but only nested inside a constructed output dict (bounded keys) — the aggregate-into-summary pattern.

Skips a tool with **no** compiled output schema (runtime does no validation without one → parity).

## Two bugs the real project caught (not synthetic tests)

Validating against a real multi-workflow project (`qanalabs-quiz-maker`) exposed two defects invisible to unit/e2e tests and four prior reviewers, all of which used hand-built configs:

1. **The check was inert on real workflows.** It read `config["impl"]`, but the expander maps `impl → model_name` (and the runtime dispatches on `model_name`), so the expanded config has no `impl` key — every tool was skipped. Fixed to read `model_name`.
2. **False positives on constructing tools.** Two real tools build a list from bus data and return it nested in a constructed dict (bounded keys, safe) — flagged at the mutation site. Fixed: flag an accumulator only when it is actually returned as the output item.

## Known limitations (advisory, non-blocking — false negatives only)

- passthrough via `.copy()`, `dict(item)`, `{**item}`, `list(bus)` (construction boundaries);
- an accumulator aliased through a plain assignment before return (`a.append(bus); b=a; return b`) — verified absent from all 74 real tool files;
- positional `for r in <bare input>` iteration.

## Verification

- `pytest`: **7976 passed**; `ruff check`, `ruff format --check`, and **mypy agent_actions** clean. CI green (Lint & Type Check, Build, Tests).
- ~40 tests: detector matrix (single/two-level namespace reads, subscript, non-`data` param, extend/`+=`/comprehension/binop, string index/slice, plus low-FP guards incl. accumulator-into-dict) and preflight wiring (`model_name` expanded shape, schema-less skip, unregistered-impl skip, emission, and a full `validate()` end-to-end that guards the wiring call).
- Real `agac inspect` on both workflows → exit 0, **zero passthrough warnings**. The check is confirmed live (not inert): the real `flatten_canonical_questions` two-level flatten is detected as passthrough and correctly suppressed by its `additionalProperties: true`; the six strict-schema tools are true negatives.
- Review: HIGH tier → three diverse-lens blind reviewers on the initial structure + a confirmation reviewer + a final blind reviewer at HEAD after the two real-project fixes (VERDICT: YES, real-project-verified).