### PR TITLE
fix(udf-discovery): frame auto-discovered import failures with file and next step

### DIFF
--- a/agent_actions/logging/errors/formatters/udf_load.py
+++ b/agent_actions/logging/errors/formatters/udf_load.py
@@ -108,9 +108,10 @@ class UDFLoadErrorFormatter(ErrorFormatter):
             )
 
         fix += (
-            "\n\nUDF discovery imports every Python file under the user-code "
-            "directory; a single broken file blocks all commands that load "
-            "the workflow."
+            "\n\nThis file was found by the recursive scan of the -u tree. Fix its "
+            "module-load code, or — if it is not a UDF — move it outside the -u "
+            "directory so discovery skips it. A single broken file blocks every "
+            "command that loads the workflow."
         )
 
         ctx: dict[str, Any] = {}
@@ -121,9 +122,17 @@ class UDFLoadErrorFormatter(ErrorFormatter):
         if requested_path:
             ctx["requested_path"] = requested_path
 
+        # Name the file, not the dotted module: discovery imported it from the
+        # -u tree, so "Failed to load UDF module 'X'" read as if the user chose
+        # it. Fall back to the module when no file path is available.
+        if file:
+            title = f"Auto-discovered UDF file failed to import: {file}"
+        else:
+            title = f"Auto-discovered UDF module failed to import: '{module}'"
+
         return UserError(
             category="Configuration Error",
-            title=f"Failed to load UDF module '{module}'",
+            title=title,
             details=details,
             fix=fix,
             context=ctx or None,

--- a/agent_actions/logging/errors/formatters/udf_load.py
+++ b/agent_actions/logging/errors/formatters/udf_load.py
@@ -108,10 +108,11 @@ class UDFLoadErrorFormatter(ErrorFormatter):
             )
 
         fix += (
-            "\n\nThis file was found by the recursive scan of the -u tree. Fix its "
-            "module-load code, or — if it is not a UDF — move it outside the -u "
-            "directory so discovery skips it. A single broken file blocks every "
-            "command that loads the workflow."
+            "\n\nThis file was found by the recursive scan of the user-code "
+            "directory (set via `-u <path>` or `tool_path` in your workflow "
+            "config). Fix its module-load code, or — if it is not a UDF — move "
+            "it outside that directory so discovery skips it. A single broken "
+            "file blocks every command that loads the workflow."
         )
 
         ctx: dict[str, Any] = {}
@@ -122,13 +123,11 @@ class UDFLoadErrorFormatter(ErrorFormatter):
         if requested_path:
             ctx["requested_path"] = requested_path
 
-        # Name the file, not the dotted module: discovery imported it from the
-        # -u tree, so "Failed to load UDF module 'X'" read as if the user chose
-        # it. Fall back to the module when no file path is available.
-        if file:
-            title = f"Auto-discovered UDF file failed to import: {file}"
-        else:
-            title = f"Auto-discovered UDF module failed to import: '{module}'"
+        # Name the file, not the dotted module — discovery found it by scanning
+        # the user-code directory, so the old module-named title read as if the
+        # user had chosen it. Fall back to the module identifier when no file
+        # path is available.
+        title = f"Auto-discovered UDF file failed to import: {file or module}"
 
         return UserError(
             category="Configuration Error",

--- a/tests/unit/error_formatters/test_udf_load.py
+++ b/tests/unit/error_formatters/test_udf_load.py
@@ -60,9 +60,9 @@ class TestCanHandle:
 
 class TestImportFailureFormatting:
     def test_title_reframes_to_name_auto_discovered_file(self, formatter, udf_import_error):
-        # Spec 570: "Failed to load UDF module 'X'" read as if the user named
-        # the module. The file was auto-discovered by the recursive -u walk, so
-        # the title now names the file and says it was auto-discovered.
+        # The old title "Failed to load UDF module 'X'" read as if the user
+        # named the module; the file was auto-discovered by the recursive scan,
+        # so the title now names the file and says it was auto-discovered.
         result = formatter.format(
             udf_import_error,
             udf_import_error,
@@ -76,7 +76,7 @@ class TestImportFailureFormatting:
         assert "auto-discovered" in result.title.lower()
         # Cause stays visible through the reframe (FAILURE MODE: don't bury it).
         assert "No module named 'markdown2'" in result.details
-        # Actionable next step: the -u tree + the move-it-out option.
+        # Actionable next step names the user-code dir (-u / tool_path) + move-out.
         assert "-u" in result.fix
         assert "move it outside" in result.fix.lower()
 

--- a/tests/unit/error_formatters/test_udf_load.py
+++ b/tests/unit/error_formatters/test_udf_load.py
@@ -59,14 +59,34 @@ class TestCanHandle:
 
 
 class TestImportFailureFormatting:
-    def test_names_module_in_title(self, formatter, udf_import_error):
+    def test_title_reframes_to_name_auto_discovered_file(self, formatter, udf_import_error):
+        # Spec 570: "Failed to load UDF module 'X'" read as if the user named
+        # the module. The file was auto-discovered by the recursive -u walk, so
+        # the title now names the file and says it was auto-discovered.
         result = formatter.format(
             udf_import_error,
             udf_import_error,
             str(udf_import_error),
             _context_for(udf_import_error),
         )
-        assert result.title == "Failed to load UDF module 'run_thinkific_gen.apply_html_text'"
+        assert result.title == (
+            "Auto-discovered UDF file failed to import: "
+            "/proj/tools/run_thinkific_gen/apply_html_text.py"
+        )
+        assert "auto-discovered" in result.title.lower()
+        # Cause stays visible through the reframe (FAILURE MODE: don't bury it).
+        assert "No module named 'markdown2'" in result.details
+        # Actionable next step: the -u tree + the move-it-out option.
+        assert "-u" in result.fix
+        assert "move it outside" in result.fix.lower()
+
+    def test_title_falls_back_to_module_when_file_unknown(self, formatter):
+        # No file path on the error — the title still frames it as an
+        # auto-discovered import, naming the module instead.
+        exc = UDFLoadError(module="proj.bad", error="boom")
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert "auto-discovered" in result.title.lower()
+        assert "proj.bad" in result.title
 
     def test_details_include_underlying_import_error(self, formatter, udf_import_error):
         result = formatter.format(
@@ -224,7 +244,10 @@ class TestImportFailureFormatting:
             _context_for(udf_import_error),
         )
         rendered = result.format_for_cli()
-        assert "Configuration Error: Failed to load UDF module" in rendered
+        assert (
+            "Configuration Error: Auto-discovered UDF file failed to import: "
+            "/proj/tools/run_thinkific_gen/apply_html_text.py" in rendered
+        )
         assert "Problem: Python could not import the UDF module" in rendered
         assert "File: /proj/tools/run_thinkific_gen/apply_html_text.py" in rendered
         assert "Fix: Python could not find the module 'markdown2'" in rendered
@@ -275,6 +298,19 @@ class TestDiscoveryFailureFormatting:
         result = formatter.format(exc, exc, str(exc), _context_for(exc))
         assert result.context["file_path"] == "/no/such/dir"
 
+    def test_sentinel_title_not_reframed_as_auto_discovered(self, formatter):
+        # A directory-level discovery failure is not the import of a discovered
+        # file; the "auto-discovered file" reframe must not touch it. Guards
+        # against a blanket "add auto-discovered to every UDFLoadError" fix.
+        exc = UDFLoadError(
+            module=UDFLoadError.DISCOVERY_SENTINEL,
+            file="/no/such/dir",
+            error="User code directory not found",
+        )
+        result = formatter.format(exc, exc, str(exc), _context_for(exc))
+        assert result.title == "UDF discovery failed"
+        assert "auto-discovered" not in result.title.lower()
+
 
 class TestFirstNonNone:
     """Direct coverage for the explicit-None coalescing helper.
@@ -307,7 +343,10 @@ class TestRegistrationInTranslatorChain:
     def test_translator_uses_udf_load_formatter(self, udf_import_error):
         translator = ErrorTranslator()
         result = translator.translate(udf_import_error)
-        assert result.title == "Failed to load UDF module 'run_thinkific_gen.apply_html_text'"
+        assert result.title == (
+            "Auto-discovered UDF file failed to import: "
+            "/proj/tools/run_thinkific_gen/apply_html_text.py"
+        )
         # Sanity: the install-hint surfaced (i.e. function/config formatters did not steal it).
         assert "Python could not find the module 'markdown2'" in result.fix
 
@@ -340,7 +379,7 @@ class TestRegistrationInTranslatorChain:
         )
         translator = ErrorTranslator()
         result = translator.translate(exc)
-        assert result.title == "Failed to load UDF module 'proj.tools.uses_yaml'"
+        assert result.title == "Auto-discovered UDF file failed to import: /proj/tools/uses_yaml.py"
         assert "Python could not find the module 'PyYAML'" in result.fix
 
     def test_translator_routes_udf_with_yaml_cause_through_udf_formatter(self):
@@ -365,7 +404,7 @@ class TestRegistrationInTranslatorChain:
         )
         translator = ErrorTranslator()
         result = translator.translate(exc)
-        assert result.title == "Failed to load UDF module 'proj.uses_yaml'"
+        assert result.title == "Auto-discovered UDF file failed to import: /proj/tools/uses_yaml.py"
         assert result.category == "Configuration Error"
         assert "YAML syntax error" not in result.title
 

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -308,7 +308,7 @@ class TestExecute:
         joined = "\n".join(str(c) for c in cmd.console.print.call_args_list)
         # Marker line + canonical formatter output.
         assert "UDF load failed" in joined
-        assert "Failed to load UDF module 'bad'" in joined
+        assert "Auto-discovered UDF file failed to import: bad.py" in joined
         assert "Python could not import the UDF module: SyntaxError" in joined
         assert "File: bad.py" in joined
 


### PR DESCRIPTION
## Summary
When a `.py` file under the `-u` user-code tree is auto-discovered by the recursive UDF scan and fails to import, the CLI error title read `Failed to load UDF module 'scripts.fix_prompts'` — as if the user had named that module. They didn't; the recursive walk found it. The title now names the offending **file**, states it was **auto-discovered**, keeps the underlying import error visible, and gives an actionable next step. Spec: `specs/active/570-udf-discovery-error-framing.md` (ISSUE-006 rec #3; follow-up to 564).

Before → after (rendered via `format_user_error`):
```
- Configuration Error: Failed to load UDF module 'scripts.fix_prompts'
+ Configuration Error: Auto-discovered UDF file failed to import: tools/scripts/fix_prompts.py

  Problem: Python could not import the UDF module: [Errno 2] No such file or directory
  File: tools/scripts/fix_prompts.py
  Fix: ... This file was found by the recursive scan of the -u tree. Fix its
       module-load code, or — if it is not a UDF — move it outside the -u
       directory so discovery skips it. ...
```

Scope: `_format_import_failure` (non-sentinel branch) only — `title` reframe + the `-u`-tree next step. `details` (the cause), the ModuleNotFoundError install guidance, and the directory-level discovery-sentinel branch (`UDF discovery failed`) are all unchanged. The fix wording also drops a now-stale claim — post-564, discovery no longer "imports every Python file," so "found by the recursive scan of the -u tree" is the accurate framing.

## Deviations from the spec
- **Spec's test file/path were wrong.** The spec pointed at `tests/logging/errors/formatters/test_udf_load_formatter.py` (does not exist) and `UDFLoadErrorFormatter().format(err)` (wrong signature — `format` takes `(exc, root, message, context)` and returns a `UserError`, not a string). Real test file: `tests/unit/error_formatters/test_udf_load.py`. Followed the spec's appended adversarial review, which had already corrected these.
- **Blast radius was larger than documented.** The adversarial review named four old-title assertions (lines 69, 310, 343, 368). Verify-first found **two more**: `test_udf_load.py:227` (`format_for_cli` prefix) and `tests/validation/test_validate_udfs.py:311` (the `validate-udfs` command renders the same formatter). Six title assertions updated in total, across two files.
- **`configuration.py:114` `str(exc)` left as-is (deliberate).** `UDFLoadError.__init__` builds a separate `Failed to load UDF module 'X'` string for `str(exc)`. It is log-only and never user-facing — the blind reviewer confirmed `config_pipeline.py:165`'s warning uses `e.context.get("error", e)`, so the old string doesn't even surface there. The formatter is the sole user-facing rendering path; changing the log string is out of the spec's message/formatter scope.

## Verification
- RED (`4ca45909`, test-only): 7 genuine assertion failures on the reframe; the discovery-sentinel guard stayed green (kills a "blanket add auto-discovered everywhere" cheat).
- GREEN (`fdfc0ae5`, source-only): full suite **7977 passed**, `ruff check`/`ruff format --check`/`mypy` clean.
- New/updated tests pin: file-in-title reframe, module fallback when no file path, cause preserved, `-u` + move-it-out next step in `fix`, and the sentinel title unchanged.
- Manual: rendered the spec's exact scenario through `format_user_error` — output matches the spec mockup; sentinel branch confirmed unchanged.
- Reward-hack note: the 6 old-title assertion swaps are a legitimate behavior change (title intentionally reframed) — net assertions increased (added auto-discovered/`-u`/move-out/cause checks + 2 new tests).
- Smoke skipped: formatter-only change, no chokepoint/registry surface (`risk.sh` smoke_required=no).
- Review: LOW risk → one blind fresh-context reviewer, VERDICT YES.