### PR TITLE
feat(udf): runtime data.require() strict accessor for RECORD-mode UDFs

### DIFF
--- a/agent_actions/utils/udf_management/_MANIFEST.md
+++ b/agent_actions/utils/udf_management/_MANIFEST.md
@@ -13,4 +13,6 @@
 | `clear_registry` | Function | Clears the registry (test cleanup) in a thread-safe manner. | `logging` |
 | `tooling.py` | Module | Utilities for loading/executing user-defined functions with schema validation support. | `errors`, `logging` |
 | `load_user_defined_function` | Function | Dynamically imports a module and returns the requested callable, searching sys.path if needed. | `errors` |
-| `execute_user_defined_function` | Function | Runs a UDF (optionally validates output against compiled schemas) and surfaces validation errors. | `errors` |
+| `execute_user_defined_function` | Function | Runs a UDF (RECORD-mode dict input wrapped in a `Bus`; optionally validates output against compiled schemas) and surfaces validation errors. | `errors` |
+| `bus.py` | Module | The action-name-keyed namespace dict handed to RECORD-mode UDFs, with a strict accessor. | — |
+| `Bus` | Class | `dict` subclass: `get`/`[]`/iteration stay tolerant; `require(namespace)` raises naming the unknown key and the available namespaces. | — |

--- a/agent_actions/utils/udf_management/bus.py
+++ b/agent_actions/utils/udf_management/bus.py
@@ -6,13 +6,14 @@ from typing import Any
 
 
 class Bus(dict[str, Any]):
-    """Action-name-keyed bus. `get`/`[]` stay tolerant; `require` raises on unknown."""
+    """Strict-accessor dict for UDF input. `get`/`[]` stay tolerant; `require` raises on unknown."""
 
     def require(self, namespace: str) -> Any:
+        # Message stays generic: the same accessor wraps the action-keyed tool
+        # bus and the flat guard-clause context, so it names the key + the
+        # available keys and does not assume an action-name keying.
         if namespace not in self:
             raise KeyError(
-                f"UDF read unknown bus namespace '{namespace}'. The bus is keyed by "
-                f"action name; available: {sorted(self.keys())}. Check for an "
-                f"impl-name/action-name mismatch."
+                f"UDF read unknown key '{namespace}'. Available keys: {sorted(self.keys())}."
             )
         return self[namespace]

--- a/agent_actions/utils/udf_management/bus.py
+++ b/agent_actions/utils/udf_management/bus.py
@@ -1,0 +1,18 @@
+"""Bus: the namespace dict passed to RECORD-mode UDFs, with a strict accessor."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Bus(dict[str, Any]):
+    """Action-name-keyed bus. `get`/`[]` stay tolerant; `require` raises on unknown."""
+
+    def require(self, namespace: str) -> Any:
+        if namespace not in self:
+            raise KeyError(
+                f"UDF read unknown bus namespace '{namespace}'. The bus is keyed by "
+                f"action name; available: {sorted(self.keys())}. Check for an "
+                f"impl-name/action-name mismatch."
+            )
+        return self[namespace]

--- a/agent_actions/utils/udf_management/tooling.py
+++ b/agent_actions/utils/udf_management/tooling.py
@@ -64,9 +64,10 @@ def execute_user_defined_function(
     udf = metadata["function"]
     granularity = metadata["granularity"]
 
-    # RECORD-mode input is the action-name-keyed bus dict; hand the UDF a Bus so
-    # authors can opt into data.require(). FILE mode receives a list, so it is
-    # excluded. Bus is a transparent dict subclass — get/[]/iteration unchanged.
+    # Hand RECORD-mode dict input to the UDF as a Bus so authors can opt into
+    # data.require() (the action-keyed bus on the tool path; a flat eval context
+    # on the guard-clause path). FILE mode receives a list, so it is excluded.
+    # Bus is a transparent dict subclass — get/[]/iteration unchanged.
     if (
         granularity == Granularity.RECORD
         and isinstance(input_data, dict)

--- a/agent_actions/utils/udf_management/tooling.py
+++ b/agent_actions/utils/udf_management/tooling.py
@@ -56,11 +56,23 @@ def execute_user_defined_function(
         SchemaValidationError: If output validation fails.
         AgentActionsError: If execution fails.
     """
+    from agent_actions.config.types import Granularity
+    from agent_actions.utils.udf_management.bus import Bus
     from agent_actions.utils.udf_management.registry import get_udf_metadata
 
     metadata = get_udf_metadata(udf_name)
     udf = metadata["function"]
     granularity = metadata["granularity"]
+
+    # RECORD-mode input is the action-name-keyed bus dict; hand the UDF a Bus so
+    # authors can opt into data.require(). FILE mode receives a list, so it is
+    # excluded. Bus is a transparent dict subclass — get/[]/iteration unchanged.
+    if (
+        granularity == Granularity.RECORD
+        and isinstance(input_data, dict)
+        and not isinstance(input_data, Bus)
+    ):
+        input_data = Bus(input_data)
 
     try:
         result = udf(input_data, **kwargs)

--- a/tests/unit/utils/udf_management/test_bus.py
+++ b/tests/unit/utils/udf_management/test_bus.py
@@ -16,8 +16,8 @@ def test_require_raises_on_unknown():
 
 
 def test_require_error_lists_available_namespaces():
-    # Distinct names (no substring overlap) pin the available-namespaces list; a
-    # trivial `return self[ns]` — which the spec's own fixtures would pass — omits it.
+    # Distinct names (no substring overlap) pin the available-keys list; a trivial
+    # `return self[ns]` raises a bare KeyError that omits the other keys.
     with pytest.raises(KeyError) as exc:
         Bus({"ground": {}, "writer": {}}).require("typo")
     msg = str(exc.value)

--- a/tests/unit/utils/udf_management/test_bus.py
+++ b/tests/unit/utils/udf_management/test_bus.py
@@ -1,0 +1,42 @@
+"""Bus dict subclass: require() is strict, get()/[]/iteration stay tolerant."""
+
+import pytest
+
+from agent_actions.utils.udf_management.bus import Bus
+
+
+def test_require_returns_value():
+    assert Bus({"author": {"x": 1}}).require("author") == {"x": 1}
+
+
+def test_require_raises_on_unknown():
+    with pytest.raises(KeyError) as exc:
+        Bus({"author": {}}).require("fb_author")
+    assert "fb_author" in str(exc.value)
+
+
+def test_require_error_lists_available_namespaces():
+    # Distinct names (no substring overlap) pin the available-namespaces list; a
+    # trivial `return self[ns]` — which the spec's own fixtures would pass — omits it.
+    with pytest.raises(KeyError) as exc:
+        Bus({"ground": {}, "writer": {}}).require("typo")
+    msg = str(exc.value)
+    assert "typo" in msg and "ground" in msg and "writer" in msg
+
+
+def test_get_stays_tolerant():
+    assert Bus({"author": {}}).get("missing") is None
+    assert Bus({"author": {}}).get("missing", 5) == 5
+
+
+def test_is_a_dict():
+    b = Bus({"a": 1})
+    assert b["a"] == 1 and "a" in b and dict(b) == {"a": 1}
+
+
+def test_wrapping_does_not_leak_top_level_mutation():
+    # Bus(original) is a top-level copy: a UDF rebinding a top-level key does not
+    # leak back to the caller. Nested mutations still propagate (shared refs).
+    original = {"author": {}}
+    Bus(original)["injected"] = 1
+    assert "injected" not in original

--- a/tests/unit/utils/udf_management/test_bus_wiring.py
+++ b/tests/unit/utils/udf_management/test_bus_wiring.py
@@ -1,0 +1,36 @@
+"""RECORD-mode UDF input is a Bus, so data.require() fails loud at the wire point."""
+
+import pytest
+
+from agent_actions.config.schema import Granularity
+from agent_actions.errors import AgentActionsError
+from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+from agent_actions.utils.udf_management.tooling import execute_user_defined_function
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def test_record_udf_require_raises_naming_namespace():
+    @udf_tool(granularity=Granularity.RECORD)
+    def strict_reader(data):
+        return data.require("nope")
+
+    with pytest.raises(AgentActionsError) as exc:
+        execute_user_defined_function("strict_reader", {"author": {}})
+    # The unknown namespace must surface through the execute wrapper — a plain
+    # dict input raises "no attribute 'require'" instead, which omits "nope".
+    assert "nope" in str(exc.value)
+
+
+def test_record_udf_tolerant_reads_survive_wrap():
+    @udf_tool(granularity=Granularity.RECORD)
+    def mixed_reader(data):
+        return {"missing": data.get("nope"), "present": data["author"], "has": "author" in data}
+
+    result = execute_user_defined_function("mixed_reader", {"author": {"x": 1}})
+    assert result == {"missing": None, "present": {"x": 1}, "has": True}

--- a/tests/unit/utils/udf_management/test_bus_wiring.py
+++ b/tests/unit/utils/udf_management/test_bus_wiring.py
@@ -34,3 +34,18 @@ def test_record_udf_tolerant_reads_survive_wrap():
 
     result = execute_user_defined_function("mixed_reader", {"author": {"x": 1}})
     assert result == {"missing": None, "present": {"x": 1}, "has": True}
+
+
+def test_file_mode_input_is_not_wrapped():
+    # FILE mode receives a list, not the bus dict — the dict guard must exclude
+    # it. Wrapping a list in Bus would raise ValueError before the UDF ran.
+    seen = {}
+
+    @udf_tool(granularity=Granularity.FILE)
+    def file_reader(data):
+        seen["is_list"] = isinstance(data, list)
+        return [{"ok": True}]
+
+    result = execute_user_defined_function("file_reader", [{"a": 1}, {"b": 2}])
+    assert seen["is_list"] is True
+    assert result == [{"ok": True}]


### PR DESCRIPTION
## Summary
- Adds `Bus(dict[str, Any])` (`agent_actions/utils/udf_management/bus.py`): a transparent `dict` subclass. `get`/`[]`/iteration/membership stay tolerant; `require(namespace)` raises a `KeyError` naming the unknown namespace **and** the available ones — so RECORD-mode UDF authors can opt into fail-loud reads on a namespace typo. Runtime companion to spec 567's static bus-namespace scan.
- Wires it at the sole invocation point (`execute_user_defined_function`, `tooling.py`): RECORD-mode dict input is wrapped in a `Bus` before the UDF runs. FILE-mode (a `list`) is excluded via `isinstance(input_data, dict)`; already-wrapped inputs are a no-op. Imported lazily inside the function, matching the file's existing `registry` import convention.

## Deviations from the spec
- **Test layout split (harness-driven).** The spec's RED is an `ImportError` on the missing `Bus` in a single `test_bus.py`. The harness RED gate rejects collection errors (ImportError) as fake-RED and forbids the RED file changing between RED and GREEN. So the RED anchor is a genuine **assertion** failure at the wire point — a RECORD UDF calling `data.require("nope")` on a plain dict raises `AttributeError` whose wrapped message omits `"nope"` — in `test_bus_wiring.py` (no `Bus` import). The `Bus` unit tests live in `test_bus.py`, created at GREEN. Added `tests/unit/utils/udf_management/__init__.py` (package-style test tree).
- **Behavior change (documented, low risk):** `Bus(input_data)` is a shallow copy, so a UDF that rebinds a **top-level** bus key in place no longer leaks that mutation to the caller (nested mutations still propagate). Blast-radius review found zero real consumers that mutate UDF input in place; both callers (`llm/providers/tools/client.py:102`, `input/preprocessing/filtering/evaluator.py:202`) use only the return value/truthiness, and the guard path already treats its input as copy-safe.

## Review — HIGH tier (touches the `udf_management/` chokepoint), 3 diverse-lens blind reviewers
- **Correctness → YES**: `granularity` is the `Granularity` enum at the wrap; `Bus` preserves every relied-on dict behavior; FILE-mode excluded; double-wrap guard idempotent; grep found zero `type(x) is dict` strict-identity breaks.
- **Blast-radius → NO → fixed**: one LOW — `bus.py`/`Bus` missing from `_MANIFEST.md`; added. No bypass path (the only other `get_udf_metadata` users are static `inspect.getsource` analysis).
- **Anti-gaming → NO → fixed**: one MEDIUM — the FILE-mode exclusion guard was untested (a regression → `Bus([...])` `ValueError` crash); added `test_file_mode_input_is_not_wrapped`. Confirmed the suite is non-gameable: a trivial `def require(self, ns): return self[ns]` FAILS `test_require_error_lists_available_namespaces` (distinct names `ground`/`writer`/`typo`, no substring overlap), and the wiring assertion distinguishes "require ran and named the namespace" from "any exception."
- Both actionable issues fixed in `b784917f` (reviewed source logic unchanged); recorded `YES_WITH_ISSUES`.

## Verification
- **Harness gates:** RED = genuine assertion failure at the wire point; GREEN re-ran the RED target (hash-verified) + ruff + mypy + full suite **8022 passed**; risk.sh=HIGH → 3 blind reviewers; smoke **skipped** — `udf_management/` is not a smoke surface (surfaces: input/loaders, output/response, config, cli, llm, storage, prompt); the UDF-invocation path is exercised by the passing suite.
- **Real-project probe (`qanalabs-quiz-maker`):** the real RECORD-mode tool `aggregate_code_verification` (reads `data.get('compile_verify_input')`) ran unchanged through the wrap; the UDF now receives a `Bus` (`has_require=True`); `data.require('verify_code_answr_1')` — a real typo of `verify_code_answer_1` — failed loud through `execute`, naming the bad key and the available namespaces (`compile_verify_input`, `verify_code_answer_1`, ...). Project left git-clean (read-only import).
- 9 new tests (`test_bus.py` 6 unit incl. anti-gaming + mutation-copy; `test_bus_wiring.py` 3 invocation incl. FILE-mode no-wrap). `get`/`[]`/iteration unchanged.

Out of scope: the static preflight scan is spec 567; `data.get(...)` stays the tolerant path for genuinely optional reads.