### PR TITLE
fix(validation): body-scan FILE-mode UDFs so filter mode is not flagged

### DIFF
--- a/agent_actions/validation/file_udf_contract_validator.py
+++ b/agent_actions/validation/file_udf_contract_validator.py
@@ -1,7 +1,11 @@
-"""Flag FILE-granularity UDFs whose return annotation is not FileUDFResult."""
+"""Flag FILE-granularity UDFs that return freshly-built dicts without FileUDFResult."""
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
+from collections.abc import Callable, Iterator
 from typing import Any
 
 from agent_actions.config.types import Granularity
@@ -9,10 +13,8 @@ from agent_actions.utils.udf_management.registry import FileUDFResult
 
 
 def _returns_fileudfresult(annotation: Any) -> bool:
-    # Coarse check by design: class identity, or the annotation's text mentions
-    # FileUDFResult (covers string forward-refs and Optional/Union wrappers). It
-    # reads only what is already recorded — never imports or resolves the
-    # annotation, which could fail.
+    # Text-match by design: never imports or resolves the annotation (that can
+    # raise); covers the class, string forward-refs, and Optional/Union wrappers.
     if annotation is FileUDFResult:
         return True
     if isinstance(annotation, str):
@@ -20,10 +22,125 @@ def _returns_fileudfresult(annotation: Any) -> bool:
     return "FileUDFResult" in str(annotation)
 
 
+def _is_dict_construct(node: ast.AST, dict_vars: set[str]) -> bool:
+    """A freshly-built dict: a dict literal/comprehension, dict(...), or a name bound to one."""
+    if isinstance(node, (ast.Dict, ast.DictComp)):
+        return True
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "dict":
+        return True
+    return isinstance(node, ast.Name) and node.id in dict_vars
+
+
+def _is_list_of_dicts(node: ast.AST, dict_vars: set[str]) -> bool:
+    """A list literal or comprehension whose elements are freshly-built dicts."""
+    if isinstance(node, ast.List):
+        return any(_is_dict_construct(elt, dict_vars) for elt in node.elts)
+    if isinstance(node, (ast.ListComp, ast.GeneratorExp, ast.SetComp)):
+        return _is_dict_construct(node.elt, dict_vars)
+    return False
+
+
+def _scope_nodes(func: ast.FunctionDef | ast.AsyncFunctionDef) -> Iterator[ast.AST]:
+    """Yield nodes in the function's own scope, not descending into nested defs/lambdas."""
+    stack: list[ast.AST] = list(func.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        for child in ast.iter_child_nodes(node):
+            if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                stack.append(child)
+
+
+def _constructs_new_dicts(func: Callable[..., Any]) -> bool:
+    """True if the UDF returns freshly-built dicts (merge/expand), not the items it received.
+
+    Mirrors the runtime discriminator: returning a list of plain dicts crashes,
+    while returning input items or a FileUDFResult is safe. A dict literal used
+    only as a local lookup table (never returned or appended to a returned list)
+    is not construction. A UDF whose source cannot be read is left unflagged.
+    """
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):
+        return False
+    return _source_constructs_new_dicts(textwrap.dedent(source))
+
+
+def _source_constructs_new_dicts(source: str) -> bool:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    fn = next(
+        (n for n in tree.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))), None
+    )
+    if fn is None:
+        return False
+    nodes = list(_scope_nodes(fn))
+
+    # Names bound to a freshly-built dict, to a fixpoint (covers d2 = d1 chains).
+    dict_vars: set[str] = set()
+    while True:
+        before = len(dict_vars)
+        for node in nodes:
+            if isinstance(node, ast.Assign) and _is_dict_construct(node.value, dict_vars):
+                dict_vars |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+            elif (
+                isinstance(node, (ast.AnnAssign, ast.NamedExpr))
+                and node.value is not None
+                and isinstance(node.target, ast.Name)
+                and _is_dict_construct(node.value, dict_vars)
+            ):
+                dict_vars.add(node.target.id)
+        if len(dict_vars) == before:
+            break
+
+    # List accumulators that receive freshly-built dicts.
+    list_dict_vars: set[str] = set()
+    for node in nodes:
+        if isinstance(node, ast.Assign) and _is_list_of_dicts(node.value, dict_vars):
+            list_dict_vars |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and node.value is not None
+            and isinstance(node.target, ast.Name)
+            and _is_list_of_dicts(node.value, dict_vars)
+        ):
+            list_dict_vars.add(node.target.id)
+        elif (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Name)
+            and _is_list_of_dicts(node.value, dict_vars)
+        ):
+            list_dict_vars.add(node.target.id)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.args
+        ):
+            if node.func.attr == "append" and _is_dict_construct(node.args[0], dict_vars):
+                list_dict_vars.add(node.func.value.id)
+            elif node.func.attr == "extend" and _is_list_of_dicts(node.args[0], dict_vars):
+                list_dict_vars.add(node.func.value.id)
+
+    # Construction is only a problem when the freshly-built dicts are returned —
+    # a list wrapped in FileUDFResult(...) is a call, not a bare dict/list, so it
+    # is safe and correctly not matched here.
+    for node in nodes:
+        if isinstance(node, ast.Return) and node.value is not None:
+            value = node.value
+            if _is_dict_construct(value, dict_vars) or _is_list_of_dicts(value, dict_vars):
+                return True
+            if isinstance(value, ast.Name) and value.id in list_dict_vars:
+                return True
+    return False
+
+
 def find_file_udf_contract_warnings(
     registry: dict[str, dict], referenced: set[str] | None = None
 ) -> list[str]:
-    """Return one warning per FILE-mode UDF whose return annotation is not FileUDFResult.
+    """Return one warning per FILE-mode UDF that returns freshly-built dicts, not FileUDFResult.
 
     When *referenced* is given, only UDFs named in it are checked — the warning
     predicts a runtime crash, which can only happen for UDFs the workflow calls.
@@ -37,6 +154,8 @@ def find_file_udf_contract_warnings(
             continue
         annotation = meta["signature"].return_annotation
         if _returns_fileudfresult(annotation):
+            continue
+        if not _constructs_new_dicts(meta["function"]):
             continue
         warnings.append(
             f"FILE-mode UDF '{meta['name']}' returns {annotation!r}, not FileUDFResult. "

--- a/agent_actions/validation/file_udf_contract_validator.py
+++ b/agent_actions/validation/file_udf_contract_validator.py
@@ -40,6 +40,13 @@ def _is_list_of_dicts(node: ast.AST, dict_vars: set[str]) -> bool:
     return False
 
 
+def _feeds_dicts(node: ast.AST, dict_vars: set[str], list_dict_vars: set[str]) -> bool:
+    """A value that is, or aliases, a list of freshly-built dicts."""
+    if _is_list_of_dicts(node, dict_vars):
+        return True
+    return isinstance(node, ast.Name) and node.id in list_dict_vars
+
+
 def _scope_nodes(func: ast.FunctionDef | ast.AsyncFunctionDef) -> Iterator[ast.AST]:
     """Yield nodes in the function's own scope, not descending into nested defs/lambdas."""
     stack: list[ast.AST] = list(func.body)
@@ -95,34 +102,39 @@ def _source_constructs_new_dicts(source: str) -> bool:
         if len(dict_vars) == before:
             break
 
-    # List accumulators that receive freshly-built dicts.
+    # List accumulators that receive freshly-built dicts, to a fixpoint so an
+    # accumulator aliased to another name (out = results) is tracked too.
     list_dict_vars: set[str] = set()
-    for node in nodes:
-        if isinstance(node, ast.Assign) and _is_list_of_dicts(node.value, dict_vars):
-            list_dict_vars |= {t.id for t in node.targets if isinstance(t, ast.Name)}
-        elif (
-            isinstance(node, ast.AnnAssign)
-            and node.value is not None
-            and isinstance(node.target, ast.Name)
-            and _is_list_of_dicts(node.value, dict_vars)
-        ):
-            list_dict_vars.add(node.target.id)
-        elif (
-            isinstance(node, ast.AugAssign)
-            and isinstance(node.target, ast.Name)
-            and _is_list_of_dicts(node.value, dict_vars)
-        ):
-            list_dict_vars.add(node.target.id)
-        elif (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and isinstance(node.func.value, ast.Name)
-            and node.args
-        ):
-            if node.func.attr == "append" and _is_dict_construct(node.args[0], dict_vars):
-                list_dict_vars.add(node.func.value.id)
-            elif node.func.attr == "extend" and _is_list_of_dicts(node.args[0], dict_vars):
-                list_dict_vars.add(node.func.value.id)
+    while True:
+        before = len(list_dict_vars)
+        for node in nodes:
+            if isinstance(node, ast.Assign) and _feeds_dicts(node.value, dict_vars, list_dict_vars):
+                list_dict_vars |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and node.value is not None
+                and isinstance(node.target, ast.Name)
+                and _feeds_dicts(node.value, dict_vars, list_dict_vars)
+            ):
+                list_dict_vars.add(node.target.id)
+            elif (
+                isinstance(node, ast.AugAssign)
+                and isinstance(node.target, ast.Name)
+                and _is_list_of_dicts(node.value, dict_vars)
+            ):
+                list_dict_vars.add(node.target.id)
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.args
+            ):
+                if node.func.attr == "append" and _is_dict_construct(node.args[0], dict_vars):
+                    list_dict_vars.add(node.func.value.id)
+                elif node.func.attr == "extend" and _is_list_of_dicts(node.args[0], dict_vars):
+                    list_dict_vars.add(node.func.value.id)
+        if len(list_dict_vars) == before:
+            break
 
     # Construction is only a problem when the freshly-built dicts are returned —
     # a list wrapped in FileUDFResult(...) is a call, not a bare dict/list, so it
@@ -130,9 +142,9 @@ def _source_constructs_new_dicts(source: str) -> bool:
     for node in nodes:
         if isinstance(node, ast.Return) and node.value is not None:
             value = node.value
-            if _is_dict_construct(value, dict_vars) or _is_list_of_dicts(value, dict_vars):
-                return True
-            if isinstance(value, ast.Name) and value.id in list_dict_vars:
+            if _is_dict_construct(value, dict_vars) or _feeds_dicts(
+                value, dict_vars, list_dict_vars
+            ):
                 return True
     return False
 

--- a/tests/validation/test_file_udf_contract_validator.py
+++ b/tests/validation/test_file_udf_contract_validator.py
@@ -1,4 +1,4 @@
-"""FILE-mode UDF return-contract warnings: FILE + non-FileUDFResult annotation flagged."""
+"""FILE-mode UDF return-contract warnings: only dict-constructing UDFs are flagged."""
 
 from typing import Optional
 
@@ -21,14 +21,7 @@ def _clean():
     clear_registry()
 
 
-def test_file_udf_returning_list_is_warned():
-    @udf_tool(granularity=Granularity.FILE)
-    def dedup_list(data) -> list[dict]:
-        return data
-
-    warnings = find_file_udf_contract_warnings(UDF_REGISTRY)
-    assert any("dedup_list" in w for w in warnings)
-    assert any("FileUDFResult" in w for w in warnings)
+# --- FileUDFResult annotation is the declared-safe signal (never flagged) -----
 
 
 def test_file_udf_returning_fileudfresult_is_ok():
@@ -73,10 +66,133 @@ def test_record_udf_is_ignored():
     assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
 
 
-def test_file_udf_missing_return_annotation_is_warned():
+# --- Filter mode: returns the received items unchanged (never flagged) --------
+
+
+def test_filter_mode_udf_not_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def filter_only(data) -> list[dict]:
+        out = []
+        for item in data:
+            out.append(item)  # returns input items → filter mode
+        return out
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_return_data_directly_not_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def passthrough(data) -> list[dict]:
+        return data
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_filter_comprehension_over_items_not_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def keep_scored(data) -> list[dict]:
+        return [item for item in data if item.get("score")]
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_local_lookup_dict_not_flagged():
+    # A dict literal used as a local lookup table is never returned/appended,
+    # so it must not be mistaken for output construction.
+    @udf_tool(granularity=Granularity.FILE)
+    def with_lookup(data) -> list[dict]:
+        lookup = {"a": 1, "b": 2}
+        out = []
+        for item in data:
+            item["rank"] = lookup.get(item.get("grade"))
+            out.append(item)
+        return out
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+def test_returns_fileudfresult_in_body_not_flagged():
+    # No return annotation, but the body appends dict literals to a list that is
+    # wrapped in FileUDFResult and returned — the correct N→M idiom. The runtime
+    # never crashes here, so it must not be flagged.
+    @udf_tool(granularity=Granularity.FILE)
+    def build_result(data):
+        outputs = []
+        for idx, record in enumerate(data):
+            outputs.append({"source_index": idx, "data": record})
+        return FileUDFResult(outputs=outputs)
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
+# --- Construct mode: returns freshly-built dicts (must be flagged) -------------
+
+
+def test_construct_mode_udf_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def construct(data) -> list[dict]:
+        out = []
+        for item in data:
+            out.append({"key": item.get("key")})  # new dict → needs FileUDFResult
+        return out
+
+    assert any("construct" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_return_list_of_dict_literals_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def make(data) -> list[dict]:
+        return [{"key": "v"}]
+
+    assert any("make" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_return_dict_comprehension_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def expand(data) -> list[dict]:
+        return [{"key": d.get("key")} for d in data]
+
+    assert any("expand" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_dict_constructor_call_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def via_dict_call(data) -> list[dict]:
+        out = []
+        for d in data:
+            out.append(dict(key=d.get("key")))  # dict(...) builds a new dict
+        return out
+
+    assert any("via_dict_call" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_build_dict_in_var_then_append_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def build_var(data) -> list[dict]:
+        out = []
+        for d in data:
+            row = {"key": d.get("key")}
+            out.append(row)
+        return out
+
+    assert any("build_var" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_return_bare_dict_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def bare(data) -> list[dict]:
+        return {"only": "one"}
+
+    assert any("bare" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_missing_annotation_construct_is_warned():
     @udf_tool(granularity=Granularity.FILE)
     def no_annotation(data):
-        return data
+        out = []
+        for d in data:
+            out.append({"id": d.get("id")})
+        return out
 
     assert any("no_annotation" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
 
@@ -84,21 +200,24 @@ def test_file_udf_missing_return_annotation_is_warned():
 def test_warning_names_the_fix_path():
     @udf_tool(granularity=Granularity.FILE)
     def constructs_dicts(data) -> list[dict]:
-        return data
+        return [{"id": d.get("id")} for d in data]
 
     (warning,) = find_file_udf_contract_warnings(UDF_REGISTRY)
     assert "source_index" in warning
-    assert "filter mode" in warning
+    assert "FileUDFResult" in warning
+
+
+# --- referenced-scoping (unchanged contract; UDFs must construct to be warned) -
 
 
 def test_referenced_filter_scopes_to_named_udfs():
     @udf_tool(granularity=Granularity.FILE)
     def used_udf(data) -> list[dict]:
-        return data
+        return [{"id": d.get("id")} for d in data]
 
     @udf_tool(granularity=Granularity.FILE)
     def unused_udf(data) -> list[dict]:
-        return data
+        return [{"id": d.get("id")} for d in data]
 
     warnings = find_file_udf_contract_warnings(UDF_REGISTRY, referenced={"used_udf"})
     assert any("used_udf" in w for w in warnings)
@@ -108,20 +227,20 @@ def test_referenced_filter_scopes_to_named_udfs():
 def test_referenced_none_warns_all():
     @udf_tool(granularity=Granularity.FILE)
     def a_udf(data) -> list[dict]:
-        return data
+        return [{"id": d.get("id")} for d in data]
 
     @udf_tool(granularity=Granularity.FILE)
     def b_udf(data) -> list[dict]:
-        return data
+        return [{"id": d.get("id")} for d in data]
 
     assert len(find_file_udf_contract_warnings(UDF_REGISTRY)) == 2
 
 
 def test_unresolvable_forward_ref_does_not_crash():
     # A string annotation naming a type that does not exist must be handled
-    # without importing/resolving it — it is simply not FileUDFResult, so warn.
+    # without importing/resolving it; the body constructs dicts, so it warns.
     @udf_tool(granularity=Granularity.FILE)
     def bad_ref(data) -> "TypeThatDoesNotExist":  # noqa: F821
-        return data
+        return [{"id": d.get("id")} for d in data]
 
     assert any("bad_ref" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))

--- a/tests/validation/test_file_udf_contract_validator.py
+++ b/tests/validation/test_file_udf_contract_validator.py
@@ -125,6 +125,19 @@ def test_returns_fileudfresult_in_body_not_flagged():
     assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
 
 
+def test_filter_accumulator_alias_not_flagged():
+    # An accumulator of input items, returned via an alias, is still filter mode.
+    @udf_tool(granularity=Granularity.FILE)
+    def passthrough_alias(data) -> list[dict]:
+        results = []
+        for item in data:
+            results.append(item)
+        out = results
+        return out
+
+    assert find_file_udf_contract_warnings(UDF_REGISTRY) == []
+
+
 # --- Construct mode: returns freshly-built dicts (must be flagged) -------------
 
 
@@ -176,6 +189,18 @@ def test_build_dict_in_var_then_append_flagged():
         return out
 
     assert any("build_var" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
+
+
+def test_list_accumulator_alias_flagged():
+    @udf_tool(granularity=Granularity.FILE)
+    def expand(data) -> list[dict]:
+        results = []
+        for d in data:
+            results.append({"key": d.get("key")})
+        out = results  # returned via an alias — still a list of new dicts
+        return out
+
+    assert any("expand" in w for w in find_file_udf_contract_warnings(UDF_REGISTRY))
 
 
 def test_return_bare_dict_flagged():

--- a/tests/validation/test_validate_udfs.py
+++ b/tests/validation/test_validate_udfs.py
@@ -659,7 +659,7 @@ class TestFileUdfContractWarnings:
 
         @udf_tool(granularity=Granularity.FILE)
         def dedup_scores(data) -> list[dict]:
-            return data
+            return [{"id": d.get("id")} for d in data]
 
         cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
         cmd.console = MagicMock()
@@ -686,7 +686,7 @@ class TestFileUdfContractWarnings:
 
         @udf_tool(granularity=Granularity.FILE)
         def other_workflows_udf(data) -> list[dict]:
-            return data
+            return [{"id": d.get("id")} for d in data]
 
         cmd = ValidateUDFsCommand("agent.yml", str(tmp_path))
         cmd.console = MagicMock()


### PR DESCRIPTION
## Summary

`agac validate-udfs` warned about every FILE-granularity UDF whose return annotation was not `FileUDFResult` — including legitimate **filter-mode** UDFs that return their input items unchanged as `list[dict]`, which the runtime accepts. That is noise: the runtime (`pipeline_file_mode.py`) only raises when a FILE-mode UDF returns a `list` containing freshly-built plain `dict` objects rather than the tracked input items.

This gates the warning on an AST **body-scan** that mirrors the runtime discriminator: warn only when the UDF **returns freshly-built dicts** — directly, as a list literal/comprehension of dict literals or `dict()` calls, or via a list accumulator (append/extend/assignment, including aliases) that those were fed into. Filter-mode UDFs, local lookup-table dict literals, and lists wrapped in `FileUDFResult(...)` are all silent.

### Why key on the return value, not on `append({...})` sites
The spec draft flagged any `X.append({...})`. But the idiomatic N→M UDF builds `outputs.append({"source_index": ..., "data": ...})` and then `return FileUDFResult(outputs=outputs)` — which is **safe**. Keying on append sites false-positives on it; keying on what is actually **returned** matches the runtime exactly (`FileUDFResult(...)` is a call, never a bare dict/list).

## Deviations from the spec (566 had already landed)
- The spec said "add tests," but spec 566 shipped with tests that asserted filter-mode UDFs (`return data`) **are** warned — the exact behavior 571 removes. Those 6 existing tests plus 2 in `test_validate_udfs.py` were **updated** to construct dicts where a warning is intended (they now assert corrected behavior — not weakened to pass). The green gate's reward-hack check flagged 5 removed assert/def lines; this is that legitimate update.
- The draft `_constructs_new_dicts` is replaced by a return-based scan that also closes its documented false negatives: `dict()` calls, build-in-a-var-then-append, and dict comprehensions are now detected.
- A blind review found one further false negative — a list accumulator aliased before return (`out = results; return out`) — now closed via fixpoint alias propagation, pinned by a flagged-alias test and a filter-alias guard test.

## Known limitation
Static heuristic: merge/expand via un-modelled shapes (e.g. `collections.OrderedDict(...)`, a dict returned from a helper call) is not flagged. The runtime check remains the backstop; UDFs whose source can't be read are left unflagged.

## Verification
- `pytest tests/validation/test_file_udf_contract_validator.py tests/validation/test_validate_udfs.py` — pass.
- Full suite: **8024 passed**; `ruff check` / `ruff format --check` clean; `mypy agent_actions` clean.
- **Real project** (`qanalabs-quiz-maker`): ran the detection logic against all 9 real FILE-mode UDFs — **0 false positives**, including `convert_html_json_to_thinkific` (unannotated, appends dict literals to `outputs`, returns `FileUDFResult(outputs=outputs)`) which the draft would have wrongly flagged.
- Smoke ring skipped: validation-only static AST check, no chokepoint/runtime/project-I/O surface touched.
