### PR TITLE
fix(prompt): name the seed_path namespace in the missing-seed-data error (578)

### DIFF
--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -717,22 +717,24 @@ class PromptPreparationService:
             logger.warning("Error during seed data resolution: %s", e, exc_info=True)
             # Fall through to error raising
 
-        # Not found - raise an error that names the folder AND the seed_path namespace.
+        # Not found - name the folder and distinguish it from the seed_path
+        # context_scope directive (the common point of confusion).
         message = (
-            f"Seed data directory not found. Create '{seed_dir_name}' folder "
-            "at workflow root (same level as agent_config/, schema/, prompt_store/) "
-            "to store static reference data files. The folder name comes from "
-            f"'seed_data_path' in agent_actions.yml (currently '{seed_dir_name}'); "
-            "actions always reference seed data under the 'seed_path' context "
-            "namespace, regardless of the folder name."
+            f"Seed data directory not found. Looked for the '{seed_dir_name}' folder "
+            "at the workflow root (same level as agent_config/, schema/, prompt_store/). "
+            "The folder name defaults to 'seed_data' and can be changed with "
+            "'seed_data_path' in agent_actions.yml; it is separate from the 'seed_path' "
+            "directive in an action's context_scope, which only lists the seed files to "
+            "load. Create the folder to store static reference data files."
         )
         if seed_dir_name == "seed_path" and PromptPreparationService._default_seed_folder_exists(
             workflow_config_path
         ):
             message += (
-                " A 'seed_data' folder already exists — 'seed_path' is the context "
-                "namespace, not the folder name. Remove 'seed_data_path: seed_path' "
-                "from agent_actions.yml to use the default 'seed_data' folder."
+                " A 'seed_data' folder already exists — 'seed_path' is the context_scope "
+                "directive that lists seed files, not the folder name. Remove "
+                "'seed_data_path: seed_path' from agent_actions.yml to use the default "
+                "'seed_data' folder."
             )
         raise StaticDataLoadError(
             message,
@@ -757,7 +759,11 @@ class PromptPreparationService:
 
     @staticmethod
     def _default_seed_folder_exists(workflow_config_path: str | None) -> bool:
-        """Whether a conventional ``seed_data`` folder exists at the workflow or project root."""
+        """Whether a conventional ``seed_data`` folder exists at the workflow or project root.
+
+        Best-effort diagnostic: any probing failure yields ``False`` so the primary
+        "seed data directory not found" error is never replaced by a probe error.
+        """
         from agent_actions.config.paths import PathManager, ProjectRootNotFoundError
 
         candidates: list[Path] = []
@@ -768,6 +774,12 @@ class PromptPreparationService:
             )
         try:
             candidates.append(PathManager().get_project_root(start_path=start_path) / "seed_data")
-        except ProjectRootNotFoundError:
-            pass
-        return any(candidate.is_dir() for candidate in candidates)
+        except ProjectRootNotFoundError as exc:
+            logger.debug("No project root while probing for a default seed_data folder: %s", exc)
+        except OSError as exc:
+            logger.debug("Filesystem error resolving project root while probing: %s", exc)
+        try:
+            return any(candidate.is_dir() for candidate in candidates)
+        except OSError as exc:
+            logger.debug("Could not stat a candidate seed_data folder: %s", exc)
+            return False

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -695,23 +695,7 @@ class PromptPreparationService:
                     logger.debug("No project root found from %s", start_path)
 
             if workflow_config_path:
-                file_path_obj = Path(workflow_config_path).resolve()
-                current = file_path_obj.parent
-                workflow_root = None
-
-                search_up = current
-                while search_up != search_up.parent:
-                    if (search_up / "agent_config").exists():
-                        workflow_root = search_up
-                        break
-                    if search_up.name == "agent_config":  # In case we are inside it
-                        workflow_root = search_up.parent
-                        break
-                    search_up = search_up.parent
-
-                if not workflow_root:
-                    workflow_root = current
-
+                workflow_root = PromptPreparationService._find_workflow_root(workflow_config_path)
                 workflow_seed_dir = workflow_root / seed_dir_name
                 if workflow_seed_dir.exists() and workflow_seed_dir.is_dir():
                     logger.debug("Found workflow-level seed data: %s", workflow_seed_dir)
@@ -733,13 +717,57 @@ class PromptPreparationService:
             logger.warning("Error during seed data resolution: %s", e, exc_info=True)
             # Fall through to error raising
 
-        # Not found - raise error
-        raise StaticDataLoadError(
+        # Not found - raise an error that names the folder AND the seed_path namespace.
+        message = (
             f"Seed data directory not found. Create '{seed_dir_name}' folder "
             "at workflow root (same level as agent_config/, schema/, prompt_store/) "
-            "to store static reference data files.",
+            "to store static reference data files. The folder name comes from "
+            f"'seed_data_path' in agent_actions.yml (currently '{seed_dir_name}'); "
+            "actions always reference seed data under the 'seed_path' context "
+            "namespace, regardless of the folder name."
+        )
+        if seed_dir_name == "seed_path" and PromptPreparationService._default_seed_folder_exists(
+            workflow_config_path
+        ):
+            message += (
+                " A 'seed_data' folder already exists — 'seed_path' is the context "
+                "namespace, not the folder name. Remove 'seed_data_path: seed_path' "
+                "from agent_actions.yml to use the default 'seed_data' folder."
+            )
+        raise StaticDataLoadError(
+            message,
             context={
                 "workflow_config_path": str(workflow_config_path),
                 "error_type": "missing_seed_data_directory",
             },
         )
+
+    @staticmethod
+    def _find_workflow_root(workflow_config_path: str) -> Path:
+        """Walk up from a workflow config file to the directory that holds ``agent_config/``."""
+        current = Path(workflow_config_path).resolve().parent
+        search_up = current
+        while search_up != search_up.parent:
+            if (search_up / "agent_config").exists():
+                return search_up
+            if search_up.name == "agent_config":  # In case we are inside it
+                return search_up.parent
+            search_up = search_up.parent
+        return current
+
+    @staticmethod
+    def _default_seed_folder_exists(workflow_config_path: str | None) -> bool:
+        """Whether a conventional ``seed_data`` folder exists at the workflow or project root."""
+        from agent_actions.config.paths import PathManager, ProjectRootNotFoundError
+
+        candidates: list[Path] = []
+        start_path = Path(workflow_config_path).parent if workflow_config_path else None
+        if workflow_config_path:
+            candidates.append(
+                PromptPreparationService._find_workflow_root(workflow_config_path) / "seed_data"
+            )
+        try:
+            candidates.append(PathManager().get_project_root(start_path=start_path) / "seed_data")
+        except ProjectRootNotFoundError:
+            pass
+        return any(candidate.is_dir() for candidate in candidates)

--- a/tests/unit/prompt/test_seed_data_missing_message.py
+++ b/tests/unit/prompt/test_seed_data_missing_message.py
@@ -18,8 +18,8 @@ def _make_workflow(tmp_path, *, seed_data_path=None, folders=()):
 
 
 class TestMissingSeedDirMessage:
-    def test_message_names_folder_and_seed_path_namespace(self, tmp_path):
-        """Missing folder: message names the resolved folder AND the seed_path namespace knob."""
+    def test_message_names_folder_and_seed_path_directive(self, tmp_path):
+        """Missing folder: message names the resolved folder, the seed_data_path knob, and the seed_path directive."""
         config_path = _make_workflow(tmp_path, seed_data_path="reference_data")
 
         with pytest.raises(StaticDataLoadError) as excinfo:
@@ -27,11 +27,24 @@ class TestMissingSeedDirMessage:
 
         msg = str(excinfo.value)
         assert "reference_data" in msg  # the resolved folder it looked for
-        assert "seed_path" in msg  # the context namespace is always seed_path
-        assert "seed_data_path" in msg  # the folder-name knob, separate from the namespace
+        assert "seed_path" in msg  # the context_scope directive, separate from the folder
+        assert "seed_data_path" in msg  # the folder-name knob
+        assert "context_scope" in msg  # frames seed_path as the directive, not a folder/namespace
+
+    def test_message_does_not_imply_unset_seed_data_path(self, tmp_path):
+        """Default folder (seed_data_path unset): message frames seed_data_path as an override, not a set key."""
+        config_path = _make_workflow(tmp_path)  # no agent_actions.yml, no seed_data_path
+
+        with pytest.raises(StaticDataLoadError) as excinfo:
+            PromptPreparationService._determine_static_data_dir(config_path)
+
+        msg = str(excinfo.value)
+        assert "seed_data_path" in msg  # the override knob is named
+        assert "defaults to 'seed_data'" in msg  # framed as the default, not "currently set to"
+        assert "currently" not in msg  # must not claim the user set a key they didn't
 
     def test_seed_path_folder_footgun_points_at_default_seed_data(self, tmp_path):
-        """seed_data_path=seed_path while seed_data/ exists: hint that they confused namespace with folder."""
+        """seed_data_path=seed_path while seed_data/ exists: hint they confused the directive with the folder."""
         config_path = _make_workflow(tmp_path, seed_data_path="seed_path", folders=("seed_data",))
 
         with pytest.raises(StaticDataLoadError) as excinfo:
@@ -39,26 +52,27 @@ class TestMissingSeedDirMessage:
 
         msg = str(excinfo.value)
         assert "already exists" in msg  # points them at the seed_data/ that holds the files
-        assert "namespace" in msg.lower()
+        assert "seed_data_path: seed_path" in msg  # the exact misconfig to remove
+        assert "directive" in msg  # frames seed_path as a context_scope directive, not the folder
 
     def test_footgun_hint_absent_when_no_default_seed_data(self, tmp_path):
-        """seed_data_path=seed_path but no seed_data/: base namespace note only, no false footgun hint."""
+        """seed_data_path=seed_path but no seed_data/: base clarification only, no false footgun hint."""
         config_path = _make_workflow(tmp_path, seed_data_path="seed_path")
 
         with pytest.raises(StaticDataLoadError) as excinfo:
             PromptPreparationService._determine_static_data_dir(config_path)
 
         msg = str(excinfo.value)
-        assert "context namespace" in msg  # base clarification still present
+        assert "context_scope" in msg  # base clarification still present
         assert "already exists" not in msg  # footgun hint gated on the folder existing
 
 
 class TestSeedDataHappyPath:
-    def test_default_seed_data_folder_resolves(self, tmp_path):
-        """Default config + seed_data/ present + seed_path namespace resolves without error."""
+    def test_default_seed_data_folder_resolves_to_workflow_level_dir(self, tmp_path):
+        """Default config + seed_data/ present resolves to the workflow-level seed_data folder."""
         config_path = _make_workflow(tmp_path, folders=("seed_data",))
 
         resolved = PromptPreparationService._determine_static_data_dir(config_path)
 
-        assert resolved.name == "seed_data"
+        assert resolved == (tmp_path / "workflow" / "seed_data").resolve()
         assert resolved.is_dir()

--- a/tests/unit/prompt/test_seed_data_missing_message.py
+++ b/tests/unit/prompt/test_seed_data_missing_message.py
@@ -1,0 +1,64 @@
+"""Seed-data resolution: happy path and the missing-folder error message."""
+
+import pytest
+
+from agent_actions.prompt.context.static_loader import StaticDataLoadError
+from agent_actions.prompt.service import PromptPreparationService
+
+
+def _make_workflow(tmp_path, *, seed_data_path=None, folders=()):
+    """Build a workflow tree; return the config path passed to resolution."""
+    workflow = tmp_path / "workflow"
+    (workflow / "agent_config").mkdir(parents=True)
+    if seed_data_path is not None:
+        (workflow / "agent_actions.yml").write_text(f"seed_data_path: {seed_data_path}\n")
+    for folder in folders:
+        (workflow / folder).mkdir()
+    return str(workflow / "agent_config" / "wf.yml")
+
+
+class TestMissingSeedDirMessage:
+    def test_message_names_folder_and_seed_path_namespace(self, tmp_path):
+        """Missing folder: message names the resolved folder AND the seed_path namespace knob."""
+        config_path = _make_workflow(tmp_path, seed_data_path="reference_data")
+
+        with pytest.raises(StaticDataLoadError) as excinfo:
+            PromptPreparationService._determine_static_data_dir(config_path)
+
+        msg = str(excinfo.value)
+        assert "reference_data" in msg  # the resolved folder it looked for
+        assert "seed_path" in msg  # the context namespace is always seed_path
+        assert "seed_data_path" in msg  # the folder-name knob, separate from the namespace
+
+    def test_seed_path_folder_footgun_points_at_default_seed_data(self, tmp_path):
+        """seed_data_path=seed_path while seed_data/ exists: hint that they confused namespace with folder."""
+        config_path = _make_workflow(tmp_path, seed_data_path="seed_path", folders=("seed_data",))
+
+        with pytest.raises(StaticDataLoadError) as excinfo:
+            PromptPreparationService._determine_static_data_dir(config_path)
+
+        msg = str(excinfo.value)
+        assert "already exists" in msg  # points them at the seed_data/ that holds the files
+        assert "namespace" in msg.lower()
+
+    def test_footgun_hint_absent_when_no_default_seed_data(self, tmp_path):
+        """seed_data_path=seed_path but no seed_data/: base namespace note only, no false footgun hint."""
+        config_path = _make_workflow(tmp_path, seed_data_path="seed_path")
+
+        with pytest.raises(StaticDataLoadError) as excinfo:
+            PromptPreparationService._determine_static_data_dir(config_path)
+
+        msg = str(excinfo.value)
+        assert "context namespace" in msg  # base clarification still present
+        assert "already exists" not in msg  # footgun hint gated on the folder existing
+
+
+class TestSeedDataHappyPath:
+    def test_default_seed_data_folder_resolves(self, tmp_path):
+        """Default config + seed_data/ present + seed_path namespace resolves without error."""
+        config_path = _make_workflow(tmp_path, folders=("seed_data",))
+
+        resolved = PromptPreparationService._determine_static_data_dir(config_path)
+
+        assert resolved.name == "seed_data"
+        assert resolved.is_dir()


### PR DESCRIPTION
## Summary

The framework has two similarly-named seed-data knobs that collide in the error path:

- The **folder** that holds seed files is configurable via `seed_data_path` in `agent_actions.yml` (default `seed_data`).
- The **context namespace** actions read seed data through is hardcoded to `seed_path`.

Because `seed_data` (folder default) and `seed_path` (namespace) look alike, a user conflated them and set `seed_data_path: seed_path`, expecting that to line the two up. Their files were still in `seed_data/`, so every run died at the first action with an opaque `Seed data directory not found. Create 'seed_path' folder …` — no indication that `seed_path` is a separate namespace concept, and no hint that a `seed_data/` folder already existed. That cost a full debugging session.

### Change (Task 1 decision: Option B)

Kept the `seed_path` namespace unchanged and fixed the guidance:

- The missing-seed-data error now names the resolved folder, states the folder name comes from `seed_data_path`, and clarifies that actions always reference seed data under the `seed_path` context namespace — a separate knob.
- When `seed_data_path` is set to `seed_path` **and** a conventional `seed_data/` folder exists (the exact reported footgun), the error appends a targeted hint to remove the misconfiguration.
- Extracted `_find_workflow_root` so the folder walk-up is shared between resolution and the footgun check (no duplicated search loop).

**Why B, not A:** Option A (make the namespace track `seed_data_path`) is a behavior change for every project already using the `seed_path` namespace and would need a compat window supporting both namespace names at once — a dual-code-path/backward-compat shim, which is merge-blocking here. B satisfies the full success metric with a message + targeted-hint change and no change to the happy path.

### Deviation from the spec

- The spec floated an *optional* "warn at load" for the `seed_data_path == seed_path` footgun. Implemented as an **error-time** hint on the single on-path raise site instead of a separate config-load warning — it lands exactly where the user hits the wall and avoids expanding into the config-validation layer. Same detection condition the spec named (`seed_data_path == "seed_path"` while a `seed_data/` folder exists).

## Verification

- **RED → GREEN:** new `tests/unit/prompt/test_seed_data_missing_message.py`
  - message names the folder + `seed_path` namespace + `seed_data_path` knob;
  - footgun hint fires only when `seed_data_path=seed_path` and `seed_data/` exists;
  - negative test asserts the hint is absent otherwise;
  - happy-path test asserts the default `seed_data/` folder resolves with no error.
- Full suite: **8039 passed**; `ruff format --check`, `ruff check`, `mypy` clean.
- The three pre-existing `_determine_static_data_dir` regression tests still pass after the `_find_workflow_root` extraction (walk-up semantics preserved: fallback to the config file's parent when no `agent_config/` is found).
- Blast radius: the only `Seed data directory not found` site in production is the one changed; `_determine_static_data_dir` has a single caller (`_load_seed_data`); no sibling instances.
- Blind review (LOW tier): **VERDICT YES**.
- **Smoke:** `scan-project.sh` registry/side-effect canary **passes** (registries match the manifest). The online smoke (`agac run` on qanalabs) was **skipped**: the run reached a live external LLM HTTPS call and hung 8+ min with zero output — it executed all code this diff touches (config load, prompt prep, seed resolution) and stalled on the external provider, i.e. environmental/host-specific, not a branch fault. `baseline.sh` has no timeout of its own, so it would reproduce the identical unbounded hang and risk leaving the repo on `main` — not an informative confirmation. The diff's only behavioral surface (missing-seed error message + a regression-test-verified refactor) is fully covered by the unit suite above.