### PR TITLE
fix(source_guid): single authority for the exclusion set

### DIFF
--- a/agent_actions/record/envelope.py
+++ b/agent_actions/record/envelope.py
@@ -94,6 +94,21 @@ _PERSISTENT_FIELDS: frozenset[str] = RECORD_TRACKING_FIELDS | RECORD_LIFECYCLE_F
 # pipeline_file_mode (tool input stripping), and scope_namespace (metadata exclusion).
 RECORD_FRAMEWORK_FIELDS: frozenset[str] = _PERSISTENT_FIELDS | RECORD_STAGE_FIELDS
 
+# Volatile identity fields excluded from the source_guid content hash (generator.py
+# imports this): positional envelope ids + the staging batch ids. NOT RECORD_FRAMEWORK_FIELDS
+# — that set also holds content/metadata, which ARE the payload here (excluding = collapse).
+SOURCE_GUID_EXCLUDED_FIELDS: frozenset[str] = frozenset(
+    {
+        "source_guid",
+        "target_id",
+        "node_id",
+        "parent_target_id",
+        "root_target_id",
+        "batch_id",
+        "batch_uuid",
+    }
+)
+
 
 class RecordEnvelopeError(Exception):
     """Raised when a record envelope contract is violated."""

--- a/agent_actions/utils/id_generation/generator.py
+++ b/agent_actions/utils/id_generation/generator.py
@@ -31,11 +31,12 @@ class IDGenerator:
 
         The same input content always yields the same guid (across runs and stamp
         sites), so the disposition/checkpoint gate matches records on re-run and the
-        ingestion and processing stamps agree. Framework envelope fields are excluded.
+        ingestion and processing stamps agree. The volatile envelope/identity fields in
+        ``SOURCE_GUID_EXCLUDED_FIELDS`` are excluded from the hash.
 
-        Note: the envelope exclusion is name-based — a user content field named exactly
-        like a framework field (e.g. `node_id`) is treated as envelope. Those names are
-        reserved.
+        Note: the exclusion is name-based — a user content field named exactly like an
+        excluded field (e.g. `node_id`, `batch_id`) is dropped from the hash. Those
+        names are reserved.
         """
         if isinstance(record, dict):
             content: Any = {k: v for k, v in record.items() if k not in SOURCE_GUID_EXCLUDED_FIELDS}

--- a/agent_actions/utils/id_generation/generator.py
+++ b/agent_actions/utils/id_generation/generator.py
@@ -4,20 +4,7 @@ import json
 import uuid
 from typing import Any
 
-# Framework envelope fields excluded from the source_guid content projection: they
-# are per-run/positional (target_id, batch_uuid, …) so hashing them would defeat the
-# deterministic identity. Everything else is the record's content.
-_ENVELOPE_FIELDS = frozenset(
-    {
-        "source_guid",
-        "target_id",
-        "batch_id",
-        "batch_uuid",
-        "node_id",
-        "parent_target_id",
-        "root_target_id",
-    }
-)
+from agent_actions.record.envelope import SOURCE_GUID_EXCLUDED_FIELDS
 
 
 class IDGenerator:
@@ -51,7 +38,7 @@ class IDGenerator:
         reserved.
         """
         if isinstance(record, dict):
-            content: Any = {k: v for k, v in record.items() if k not in _ENVELOPE_FIELDS}
+            content: Any = {k: v for k, v in record.items() if k not in SOURCE_GUID_EXCLUDED_FIELDS}
         elif isinstance(record, str):
             # A first-stage text chunk is stamped from a {"content": text} wrapper at
             # some sites and from the raw string at others; normalize so they agree.

--- a/tests/unit/utils/id_generation/test_source_guid_single_authority.py
+++ b/tests/unit/utils/id_generation/test_source_guid_single_authority.py
@@ -1,0 +1,127 @@
+"""Single authority for the source_guid exclusion set (spec 576).
+
+derive_source_guid must exclude exactly the fields record.envelope declares
+authoritative — as the same object — so the exclusion list cannot drift from the
+field definitions. The set is the *volatile positional/identity* subset only: it
+must NOT contain content-carrying framework fields (content, metadata), which are
+the hash payload at the first-stage stamp sites.
+"""
+
+import pytest
+
+from agent_actions.utils.id_generation import IDGenerator
+
+
+def test_generator_shares_envelope_authority_object():
+    """Single authority: generator excludes the SAME object record.envelope owns."""
+    from agent_actions.record import envelope
+    from agent_actions.utils.id_generation import generator
+
+    assert hasattr(envelope, "SOURCE_GUID_EXCLUDED_FIELDS"), (
+        "record.envelope must own the authoritative source_guid exclusion set "
+        "(SOURCE_GUID_EXCLUDED_FIELDS)"
+    )
+    assert (
+        getattr(generator, "SOURCE_GUID_EXCLUDED_FIELDS", None)
+        is envelope.SOURCE_GUID_EXCLUDED_FIELDS
+    ), "generator must import that same object, not maintain its own list"
+
+
+def test_derive_excludes_whatever_the_authority_declares(monkeypatch):
+    """Data-driven: extending the authoritative set changes what derive strips."""
+    from agent_actions.utils.id_generation import generator
+
+    if not hasattr(generator, "SOURCE_GUID_EXCLUDED_FIELDS"):
+        pytest.fail("generator must consult record.envelope.SOURCE_GUID_EXCLUDED_FIELDS")
+
+    probe = "_drift_probe_field"
+    monkeypatch.setattr(
+        generator,
+        "SOURCE_GUID_EXCLUDED_FIELDS",
+        generator.SOURCE_GUID_EXCLUDED_FIELDS | {probe},
+    )
+    a = {"content": "same", probe: "one"}
+    b = {"content": "same", probe: "two"}
+    assert generator.IDGenerator.derive_source_guid(a) == generator.IDGenerator.derive_source_guid(
+        b
+    )
+
+
+def test_excluded_set_equals_the_historical_envelope_fields():
+    """Pin the exact set: a no-op refactor must keep excluding precisely these."""
+    from agent_actions.record import envelope
+
+    if not hasattr(envelope, "SOURCE_GUID_EXCLUDED_FIELDS"):
+        pytest.fail("record.envelope must own SOURCE_GUID_EXCLUDED_FIELDS")
+    assert set(envelope.SOURCE_GUID_EXCLUDED_FIELDS) == {
+        "source_guid",
+        "target_id",
+        "node_id",
+        "parent_target_id",
+        "root_target_id",
+        "batch_id",
+        "batch_uuid",
+    }
+
+
+def test_excluded_set_is_volatile_identity_subset_not_content():
+    """Excluded fields are all framework fields, but content/metadata are payload."""
+    from agent_actions.record import envelope
+
+    if not hasattr(envelope, "SOURCE_GUID_EXCLUDED_FIELDS"):
+        pytest.fail("record.envelope must own SOURCE_GUID_EXCLUDED_FIELDS")
+    excl = envelope.SOURCE_GUID_EXCLUDED_FIELDS
+    framework_plus_batch = envelope.RECORD_FRAMEWORK_FIELDS | {"batch_id", "batch_uuid"}
+    assert excl <= framework_plus_batch, "every excluded field must be a framework field"
+    assert "content" not in excl and "metadata" not in excl, (
+        "content/metadata are the hash payload at the stamp sites, not envelope"
+    )
+
+
+def test_content_and_metadata_are_hash_payload_not_excluded():
+    """content/metadata must enter the hash — excluding them collapses identity."""
+    G = IDGenerator.derive_source_guid
+    assert G({"content": "chunk A", "target_id": "t"}) != G(
+        {"content": "chunk B", "target_id": "t"}
+    )
+    assert G({"q": "x", "metadata": {"a": 1}}) != G({"q": "x", "metadata": {"a": 2}})
+
+
+def test_golden_projections_unchanged():
+    """Failure-mode #2 guard: no persisted source_guid may change.
+
+    Frozen values for representative stamp-site records under the current
+    projection. If the exclusion ever strips a content-carrying field, these
+    change and the test fails.
+    """
+    G = IDGenerator.derive_source_guid
+    tid = "11111111-1111-1111-1111-111111111111"
+    text_chunk = {
+        "content": "The mitochondria is the powerhouse of the cell.",
+        "batch_id": "batch_abc",
+        "batch_uuid": "batch_abc_3",
+        "target_id": tid,
+        "parent_target_id": None,
+        "root_target_id": tid,
+        "node_id": "node_0_xyz",
+    }
+    json_row = {
+        "question": "What is 2+2?",
+        "answer": "4",
+        "metadata": {"src": "quiz.json", "row": 7},
+        "batch_id": "batch_abc",
+        "batch_uuid": "batch_abc_7",
+        "target_id": tid,
+        "parent_target_id": None,
+        "root_target_id": tid,
+        "node_id": "node_0_xyz",
+    }
+    online_text = {"content": "A short online paragraph."}
+    online_json = {"id": 42, "title": "Widget", "tags": ["a", "b"]}
+
+    assert G(text_chunk) == "865e85c1-c292-5537-a9dc-aed6618263eb"
+    assert G(json_row) == "cac9d8de-ed99-5b95-948e-ebd0439e27e2"
+    assert G(online_text) == "6aaf98d9-eb44-552f-adc8-2267290fda73"
+    assert G(online_json) == "bd78edf7-5e94-567f-b848-dd4c1de6142e"
+    # bare-string normalization (575) still agrees with the {"content": …} wrapper
+    assert G("A short online paragraph.") == G(online_text)

--- a/tests/unit/utils/id_generation/test_source_guid_single_authority.py
+++ b/tests/unit/utils/id_generation/test_source_guid_single_authority.py
@@ -21,6 +21,8 @@ def test_generator_shares_envelope_authority_object():
         "record.envelope must own the authoritative source_guid exclusion set "
         "(SOURCE_GUID_EXCLUDED_FIELDS)"
     )
+    # Identity (`is`), not `==`: a value-equal *copy* in generator would pass equality
+    # yet silently drift if envelope's set later changed. Same object IS the invariant.
     assert (
         getattr(generator, "SOURCE_GUID_EXCLUDED_FIELDS", None)
         is envelope.SOURCE_GUID_EXCLUDED_FIELDS


### PR DESCRIPTION
## Summary
`IDGenerator.derive_source_guid` — which mints the deterministic content-identity `source_guid` (the disposition/checkpoint gate's cross-run match key) — hand-listed the volatile envelope fields to strip in a **private `_ENVELOPE_FIELDS` frozenset** inside `generator.py`, duplicating concepts that live in `record/envelope.py`. A new positional-identity field added to the envelope definitions but missed in `generator.py` would silently change every first-stage `source_guid` and break batch checkpoint-resume + dedup.

This moves the exclusion set to `record/envelope.py` as **`SOURCE_GUID_EXCLUDED_FIELDS`**, co-located with the other record field partitions, and imports it into `generator.py` (same object — single authority). The set is **byte-for-byte the fields excluded before**, so no persisted `source_guid` changes.

## ⚠️ Spec deviation (major — reported per harness rule)
Spec 576 as drafted said to *"exclude exactly `RECORD_FRAMEWORK_FIELDS`."* **Verify-first proved that mechanism ships an identity collapse** and was not implemented. `RECORD_FRAMEWORK_FIELDS` also contains the content-carrying fields (`content`, `metadata`, `lineage`, …), and `content` is the actual payload key at the text-chunk stamp sites (`initial_pipeline.py:359`, `:517`). Excluding it makes the projection `{}` — **every text chunk hashes to the same guid**:

```
chunk1 (RECORD_FRAMEWORK_FIELDS mechanism): 56bd00e8-…
chunk2 (different text):                    56bd00e8-…   ← identical
```

The spec's own failure-mode #2 ("projection must not change") contradicts its success metric. The implemented fix instead defines a **distinct volatile-identity-only set** equal to today's exact exclusion (`{source_guid, target_id, node_id, parent_target_id, root_target_id, batch_id, batch_uuid}`) — a strict no-op that still achieves single-authorship. Approach confirmed with the maintainer before implementation.

## Changes
- `agent_actions/record/envelope.py` — add `SOURCE_GUID_EXCLUDED_FIELDS` (append-only; does not restructure the existing field partitions or the state machine).
- `agent_actions/utils/id_generation/generator.py` — import that set, delete the private `_ENVELOPE_FIELDS`, use it in `derive_source_guid`.
- `tests/unit/utils/id_generation/test_source_guid_single_authority.py` — new: single-object authority, data-driven exclusion (monkeypatch proves runtime consultation), exact-set pin, content/metadata-are-payload guard, and frozen golden guids for 4 representative stamp-site records.

## Verification
- **RED → GREEN**: RED pinned the missing authority as a genuine assertion failure; GREEN full suite **8060 passed**, `ruff format`/`ruff check`/`mypy` clean. No circular import (`record.envelope → record.state → enum`, a leaf; verified both import orders).
- **No-op proof**: old `_ENVELOPE_FIELDS` and new `SOURCE_GUID_EXCLUDED_FIELDS` are set-equal; golden guids for batch text-chunk, batch json-row-with-metadata, online text, and online json are unchanged. `metadata` stays in the hash (`cac9d8de-…`), confirming payload is not stripped.
- **Risk HIGH** (touches `record/`) → **3 diverse-lens blind reviewers**: correctness **YES**, anti-gaming **YES**, blast-radius **NO** on a single non-blocking comment-precision point (`batch_id`/`batch_uuid` are excluded but aren't framework fields) — **fixed**: the comment now names both categories (positional envelope ids + staging batch ids). Recorded **YES_WITH_ISSUES**.
- **Smoke skipped** — no smoke surface touched (a field-set constant + its import; strict no-op on the projection).

## Coordination
`record/envelope.py` is unowned by any Batch-1 worktree but sits in `wt-viol-0029`'s active `record/` package; the edit is a frozenset constant + docstring (no state-machine/partition changes) and is flagged in `coordination/status.md`. Tests live in the unowned `tests/unit/utils/id_generation/`.