### PR TITLE
fix(context): rename the seed_path directive to seed; retire static_data

### DIFF
--- a/agent_actions/cli/inspect_action.py
+++ b/agent_actions/cli/inspect_action.py
@@ -464,11 +464,10 @@ class ContextCommand(BaseInspectCommand):
         context_scope = action_config.get("context_scope") or {}
 
         # `seed.*` is populated by the `seed` directive.
-        seed_entries = context_scope.get("seed")
-        seed_keys: list[str] = list(seed_entries.keys()) if isinstance(seed_entries, dict) else []
+        seed_keys = self._seed_namespace_keys(context_scope)
         # Don't shadow a user action literally named `seed`.
         if seed_keys and "seed" not in namespaces:
-            namespaces["seed"] = list(dict.fromkeys(seed_keys))
+            namespaces["seed"] = seed_keys
 
         return {
             "action_name": self.target_action_name,
@@ -481,6 +480,14 @@ class ContextCommand(BaseInspectCommand):
             },
             "total_template_variables": sum(len(fs) for fs in namespaces.values()),
         }
+
+    @staticmethod
+    def _seed_namespace_keys(context_scope: dict[str, Any]) -> list[str]:
+        """Keys exposed under the ``seed.*`` namespace, from the ``seed`` directive."""
+        seed_entries = context_scope.get("seed")
+        if not isinstance(seed_entries, dict):
+            return []
+        return list(dict.fromkeys(seed_entries.keys()))
 
     @staticmethod
     def _group_refs_by_namespace(refs: list[Any]) -> dict[str, list[str]]:

--- a/agent_actions/cli/inspect_action.py
+++ b/agent_actions/cli/inspect_action.py
@@ -463,13 +463,9 @@ class ContextCommand(BaseInspectCommand):
 
         context_scope = action_config.get("context_scope") or {}
 
-        # `seed.*` is populated by the `seed_path` and `static_data` directives.
-        # (`seed_data` in SEED_CONFIG_KEYS is an anti-typo flag, not a real key.)
-        seed_keys: list[str] = []
-        for src_key in ("seed_path", "static_data"):
-            entries = context_scope.get(src_key)
-            if isinstance(entries, dict):
-                seed_keys.extend(entries.keys())
+        # `seed.*` is populated by the `seed` directive.
+        seed_entries = context_scope.get("seed")
+        seed_keys: list[str] = list(seed_entries.keys()) if isinstance(seed_entries, dict) else []
         # Don't shadow a user action literally named `seed`.
         if seed_keys and "seed" not in namespaces:
             namespaces["seed"] = list(dict.fromkeys(seed_keys))

--- a/agent_actions/config/types.py
+++ b/agent_actions/config/types.py
@@ -43,8 +43,7 @@ class ContextScopeDict(TypedDict, total=False):
     passthrough: list[str]
     drop: list[str]
     keep: list[str]
-    seed_path: dict[str, Any]
-    static_data: dict[str, Any]
+    seed: dict[str, Any]
 
 
 class GuardConfigDict(TypedDict, total=False):

--- a/agent_actions/input/context/normalizer.py
+++ b/agent_actions/input/context/normalizer.py
@@ -15,11 +15,14 @@ DIRECTIVE_REGISTRY = {
     "drop": {"type": "list", "expand_versions": True},
     "drops": {"type": "list", "expand_versions": True},
     # Dict directives - preserve as-is (never expand)
-    "seed_path": {"type": "dict", "expand_versions": False},
+    "seed": {"type": "dict", "expand_versions": False},
 }
 
-# Config keys that users confuse with the runtime 'seed' namespace in references.
-SEED_CONFIG_KEYS = frozenset({"seed_data", "seed_path"})
+# Directive keys that were removed, mapped to their replacement (for a loud error).
+REMOVED_DIRECTIVES = {"seed_path": "seed", "static_data": "seed"}
+
+# Namespaces users write in prompt references when they mean the 'seed' namespace.
+SEED_CONFIG_KEYS = frozenset({"seed_data", "seed_path", "static_data"})
 
 # Directive names that belong UNDER context_scope, not as sibling keys.
 _CONTEXT_SCOPE_DIRECTIVES = ("observe", "passthrough", "drop")
@@ -50,6 +53,14 @@ def normalize_context_scope(
     expanded_scope = {}
 
     for directive_name, directive_value in context_scope.items():
+        if directive_name in REMOVED_DIRECTIVES:
+            replacement = REMOVED_DIRECTIVES[directive_name]
+            raise ConfigurationError(
+                f"context_scope.{directive_name} is no longer a valid directive; "
+                f"it was renamed to '{replacement}'. Rename '{directive_name}:' to "
+                f"'{replacement}:' under context_scope.",
+                context={"directive": directive_name, "replacement": replacement},
+            )
         directive_info = DIRECTIVE_REGISTRY.get(
             directive_name, {"type": "unknown", "expand_versions": False}
         )

--- a/agent_actions/llm/ARCHITECTURE.md
+++ b/agent_actions/llm/ARCHITECTURE.md
@@ -823,7 +823,7 @@ context_scope controls what the LLM sees:
   │    department: Engineering  (observe fields)  │
   │                                               │
   │  Available in Jinja2 templates:               │
-  │    {{ seed.rules }}  (static_data)            │
+  │    {{ seed.rules }}  (seed directive)         │
   └──────────────────────────────────────────────┘
 
   ┌──────────────────────────────────────────────┐

--- a/agent_actions/llm/ARCHITECTURE.md
+++ b/agent_actions/llm/ARCHITECTURE.md
@@ -811,7 +811,7 @@ context_scope controls what the LLM sees:
              drop: [ssn, salary]
              observe: [department]
              passthrough: [name]
-             static_data: seed_data/rules.json
+             seed: seed_data/rules.json
                          │
                          ▼
   ┌──────────────────────────────────────────────┐

--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -46,7 +46,7 @@ def create_dynamic_agent(
     """
     # IMPORTANT: formatted_prompt MUST be prepared using PromptPreparationService
     # before calling create_dynamic_agent(). This ensures:
-    # - Static data loading (context_scope.static_data)
+    # - Static data loading (context_scope.seed)
     # - Field reference replacement ({action.field}, {static.field})
     # - Context scope transformations (observe/drop/passthrough)
     # - Few-shot sample injection

--- a/agent_actions/llm/realtime/builder.py
+++ b/agent_actions/llm/realtime/builder.py
@@ -47,7 +47,7 @@ def create_dynamic_agent(
     # IMPORTANT: formatted_prompt MUST be prepared using PromptPreparationService
     # before calling create_dynamic_agent(). This ensures:
     # - Static data loading (context_scope.seed)
-    # - Field reference replacement ({action.field}, {static.field})
+    # - Field reference replacement ({action.field})
     # - Context scope transformations (observe/drop/passthrough)
     # - Few-shot sample injection
     # - Consistent behavior across batch and online modes

--- a/agent_actions/output/ARCHITECTURE.md
+++ b/agent_actions/output/ARCHITECTURE.md
@@ -334,7 +334,7 @@ Mutable values (list, dict) are deep-copied to prevent
 cross-agent state leakage.
 ```
 
-`context_scope` is a special case -- it uses `deep_merge_context_scope()` which merges action-level directives **into** defaults (dicts merged, lists deduplicated) rather than replacing them. This lets an action add drop fields while inheriting seed_path from defaults.
+`context_scope` is a special case -- it uses `deep_merge_context_scope()` which merges action-level directives **into** defaults (dicts merged, lists deduplicated) rather than replacing them. This lets an action add drop fields while inheriting seed from defaults.
 
 ---
 
@@ -430,4 +430,4 @@ ResponseBuilder (static methods):
 
 12. **Array-type schemas produce separate output_schema and json_output_schema.** When the schema is `type: array`, the full unified schema goes to `output_schema` (for LLM providers) while `json_output_schema` gets just the `items` definition (for validation). This is because validation operates on individual items, not the outer array wrapper.
 
-13. **context_scope merges, not replaces.** Unlike all other config fields that follow "action overrides defaults", `context_scope` uses `deep_merge_context_scope()` which merges action-level directives into defaults. Dicts are shallow-merged; lists are concatenated and deduplicated. This lets an action add `drop` fields while inheriting `seed_path` from defaults.
+13. **context_scope merges, not replaces.** Unlike all other config fields that follow "action overrides defaults", `context_scope` uses `deep_merge_context_scope()` which merges action-level directives into defaults. Dicts are shallow-merged; lists are concatenated and deduplicated. This lets an action add `drop` fields while inheriting `seed` from defaults.

--- a/agent_actions/output/response/config_schema.py
+++ b/agent_actions/output/response/config_schema.py
@@ -230,7 +230,7 @@ class AgentConfig(BaseModel):
     context_scope: dict[str, Any] | None = Field(
         default=None,
         description="Context scope configuration for data visibility and flow control "
-        "(seed_path, observe, drop directives). Normalized in-place by config pipeline "
+        "(seed, observe, drop directives). Normalized in-place by config pipeline "
         "(version references expanded to field prefix patterns).",
     )
 

--- a/agent_actions/output/response/expander_merge.py
+++ b/agent_actions/output/response/expander_merge.py
@@ -21,7 +21,7 @@ def deep_merge_context_scope(
     Deep merge context_scope directives from defaults and action levels.
 
     Action-level directives are merged with (not replace) defaults directives.
-    This allows actions to define drop/observe while inheriting seed_path from defaults.
+    This allows actions to define drop/observe while inheriting seed from defaults.
     """
     if not defaults_scope:
         return action_scope or {}

--- a/agent_actions/prompt/ARCHITECTURE.md
+++ b/agent_actions/prompt/ARCHITECTURE.md
@@ -85,7 +85,7 @@ context_scope:
   observe:      ["extract.title", "extract.body"]
   passthrough:  ["source.customer_id"]
   drop:         ["source.ssn", "source.salary"]
-  seed_path:
+  seed:
     rules: "grading_rubric.json"
 ```
 
@@ -232,7 +232,7 @@ Step 2: BUILD FIELD CONTEXT
   --> Pops _dependency_metadata for diagnostic use later
   
 Step 3: LOAD SEED DATA
-  StaticDataLoader.load_static_data(seed_path_config)
+  StaticDataLoader.load_static_data(seed_config)
   --> Loads JSON/YAML/CSV/text files from seed_data/ directory
   --> Returns dict keyed by field_name from config
   
@@ -327,7 +327,7 @@ MessageBuilder.build(provider, prompt, context, schema, json_mode, ...)
 
 ```
 context_scope:
-  seed_path:
+  seed:
     rubric: "grading_rubric.json"
     examples: "few_shot_examples.yml"
 

--- a/agent_actions/prompt/_MANIFEST.md
+++ b/agent_actions/prompt/_MANIFEST.md
@@ -34,7 +34,7 @@ and service wiring used by CLI commands and runtime agents.
 | `PromptLoader.discover_prompt_files()` | `prompt_store/{workflow}.md` | Reads | — |
 | `PromptFormatter.get_raw_prompt()` | `agent_config/{workflow}.yml` | Reads | `actions[].prompt` |
 | `PromptPreparationService.prepare_prompt_with_context()` | `agent_config/{workflow}.yml` | Reads | `actions[].context_scope` |
-| `PromptPreparationService._load_seed_data()` | `seed_data/*.json` | Reads | `actions[].context_scope.seed_path` |
+| `PromptPreparationService._load_seed_data()` | `seed_data/*.json` | Reads | `actions[].context_scope.seed` |
 | `PromptUtils.inject_function_outputs_into_prompt()` | `tools/{workflow}/*.py` | Reads | `actions[].prompt` |
 | `render_pipeline_with_templates()` | `agent_config/{workflow}.yml` | Reads | `actions[].prompt`, `actions[].schema_name` |
 | `render_pipeline_with_templates()` | `schema/{workflow}/{action}.yml` | Reads | `actions[].schema_name`, `actions[].schema` |

--- a/agent_actions/prompt/context/scope_builder.py
+++ b/agent_actions/prompt/context/scope_builder.py
@@ -315,7 +315,7 @@ def build_field_context_with_history(
     field_context = {
         "source": {...},        # Original input data
         "{dep_name}": {...},    # Dependency action outputs (FILTERED by context_scope)
-        "seed": {...},          # Static reference data (via static_data)
+        "seed": {...},          # Static reference data (via the seed directive)
         "version": {...},       # Version iteration info (i, idx, length, first, last)
         "workflow": {...},      # Workflow metadata
     }

--- a/agent_actions/prompt/context/static_loader.py
+++ b/agent_actions/prompt/context/static_loader.py
@@ -62,7 +62,7 @@ class StaticDataLoader:
         logger.debug("StaticDataLoader initialized with directory: %s", self.static_data_dir)
 
     def load_static_data(self, static_data_config: dict[str, str]) -> dict[str, Any]:
-        """Load all static data files specified in context_scope.static_data."""
+        """Load all static data files specified in context_scope.seed."""
         if not static_data_config:
             logger.debug("No static data config provided, skipping load")
             return {}

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -541,8 +541,8 @@ class PromptPreparationService:
         agent_config: dict[str, Any], context_scope: dict[str, Any], agent_name: str
     ) -> dict[str, Any]:
         """Load seed data files if configured, returning empty dict otherwise."""
-        seed_path_config = context_scope.get("seed_path") if context_scope else None
-        if not seed_path_config:
+        seed_config = context_scope.get("seed") if context_scope else None
+        if not seed_config:
             return {}
 
         try:
@@ -553,7 +553,7 @@ class PromptPreparationService:
             logger.debug("[SEED_DATA_LOAD] Seed data directory: %s", static_data_dir)
 
             static_data_loader = StaticDataLoader(static_data_dir=static_data_dir)
-            static_data = static_data_loader.load_static_data(seed_path_config)
+            static_data = static_data_loader.load_static_data(seed_config)
 
             logger.debug(
                 "[SEED_DATA_LOAD] Loaded %d seed data files: %s",

--- a/agent_actions/skills/ARCHITECTURE.md
+++ b/agent_actions/skills/ARCHITECTURE.md
@@ -168,7 +168,7 @@ CLI entry point (outside this module):
 
 3. **Bus snapshot rule.** The data model described in `SKILL.md` follows the additive bus pattern: every record's `content` dict only grows. Each action writes its output under a namespace key (`content["action_name"] = {...}`). Nothing is removed. `context_scope.observe` is the selector that controls what each action sees, but the bus carries everything. This is the foundational invariant that all reference docs assume.
 
-4. **`seed.` prefix.** Seed data loaded via `context_scope.seed_path` is available in prompts as `{{ seed.key }}`. The config key is `seed_path:` but the template variable prefix is `seed.` — a naming asymmetry that the debugging guide calls out as a common source of confusion.
+4. **`seed.` prefix.** Seed data declared under `context_scope.seed` is available in prompts as `{{ seed.key }}`. The config key (`seed:`) and the template variable prefix (`seed.`) are the same word — declare it, then reference it.
 
 5. **Skill naming convention.** Skill directories must start with `agac-` by convention (the current skill is `agac-agent-skills`). Discovery does not enforce this — any subdirectory is treated as a skill — but the convention exists for namespace clarity.
 

--- a/agent_actions/skills/agac-agent-skills/SKILL.md
+++ b/agent_actions/skills/agac-agent-skills/SKILL.md
@@ -50,7 +50,7 @@ defaults:
     folder: ./staging
     file_type: [json]
   context_scope:
-    seed_path:
+    seed:
       domain_rules: $file:domain_rules.json
       reference_data: $file:reference_data.json
 ```

--- a/agent_actions/validation/ARCHITECTURE.md
+++ b/agent_actions/validation/ARCHITECTURE.md
@@ -130,7 +130,7 @@ WorkflowStaticAnalyzer.analyze()
              - reserved action name validation
              - template namespace coverage
              - context_scope field references
-             - seed_data/seed_path misuse
+             - seed_data/seed_path/static_data misuse
              - schema structure validation
              - drop directive targeting
              - guard-nullable field detection

--- a/agent_actions/validation/preflight/resolution_service.py
+++ b/agent_actions/validation/preflight/resolution_service.py
@@ -266,14 +266,14 @@ class WorkflowResolutionService:
             context_scope = config.get("context_scope", {})
             if not isinstance(context_scope, dict):
                 continue
-            seed_path_config = context_scope.get("seed_path", {})
-            if not seed_path_config or not isinstance(seed_path_config, dict):
+            seed_config = context_scope.get("seed", {})
+            if not seed_config or not isinstance(seed_config, dict):
                 continue
 
-            action_seed_keys[action_name] = set(seed_path_config.keys())
+            action_seed_keys[action_name] = set(seed_config.keys())
             action_seed_data[action_name] = {}
 
-            for field_name, file_spec in seed_path_config.items():
+            for field_name, file_spec in seed_config.items():
                 if not isinstance(file_spec, str):
                     continue
 
@@ -285,7 +285,7 @@ class WorkflowResolutionService:
                             message=str(e),
                             location=FieldLocation(
                                 agent_name=action_name,
-                                config_field=f"context_scope.seed_path.{field_name}",
+                                config_field=f"context_scope.seed.{field_name}",
                                 raw_reference=file_spec,
                             ),
                             referenced_agent=action_name,
@@ -305,7 +305,7 @@ class WorkflowResolutionService:
                             message=(f"Seed file not found: {file_spec} (resolved to {resolved})"),
                             location=FieldLocation(
                                 agent_name=action_name,
-                                config_field=f"context_scope.seed_path.{field_name}",
+                                config_field=f"context_scope.seed.{field_name}",
                                 raw_reference=file_spec,
                             ),
                             referenced_agent=action_name,
@@ -330,7 +330,7 @@ class WorkflowResolutionService:
                             message=f"Seed file '{file_spec}' failed to parse: {e}",
                             location=FieldLocation(
                                 agent_name=action_name,
-                                config_field=f"context_scope.seed_path.{field_name}",
+                                config_field=f"context_scope.seed.{field_name}",
                                 raw_reference=file_spec,
                             ),
                             referenced_agent=action_name,
@@ -401,14 +401,14 @@ class WorkflowResolutionService:
                     hint = (
                         f"Declared seed keys: {', '.join(sorted(declared_keys))}"
                         if declared_keys
-                        else f"No seed_path entries declared for action '{action_name}'."
+                        else f"No seed entries declared for action '{action_name}'."
                     )
                     errors.append(
                         StaticTypeError(
                             message=(
                                 f"Action '{action_name}' references seed.{seed_key} "
                                 f"but '{seed_key}' is not declared in "
-                                f"context_scope.seed_path"
+                                f"context_scope.seed"
                             ),
                             location=FieldLocation(
                                 agent_name=action_name,

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -116,13 +116,28 @@ class WorkflowStaticAnalyzer:
         # destroy the diagnostic signal.
         context_scope_errors = self._check_context_scope_required()
 
-        # Step 0b: Normalize context_scope using the same function the runtime
-        # pipeline uses. Guarantees all downstream extractors see a dict.
+        # Step 0b: Normalize context_scope (same function the runtime uses) so
+        # extractors see a dict. A removed directive raises here; collect it as a
+        # validation error rather than letting analyze() abort mid-pass.
         for action in self.workflow_config.get("actions", []):
             if isinstance(action, dict):
-                action["context_scope"] = normalize_context_scope(
-                    action.get("context_scope"), version_base_map={}
-                )
+                try:
+                    action["context_scope"] = normalize_context_scope(
+                        action.get("context_scope"), version_base_map={}
+                    )
+                except ConfigurationError as exc:
+                    context_scope_errors.append(
+                        StaticTypeError(
+                            message=str(exc),
+                            location=FieldLocation(
+                                agent_name=action.get("name", "workflow"),
+                                config_field="context_scope",
+                            ),
+                            referenced_agent="",
+                            referenced_field="",
+                        )
+                    )
+                    action["context_scope"] = {}
 
         # Guard-skip observe warnings must be computed before wildcard expansion
         # because expansion turns safe wildcards into specific refs (false positives).

--- a/examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml
+++ b/examples/book_catalog_enrichment/agent_workflow/book_catalog_enrichment/agent_config/book_catalog_enrichment.yml
@@ -23,7 +23,7 @@ defaults:
     folder: ./staging
     file_type: [json]
   context_scope:
-    seed_path:
+    seed:
       book_catalog: $file:book_catalog.json
   retry:
     enabled: true

--- a/examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml
+++ b/examples/contract_reviewer/agent_workflow/contract_reviewer/agent_config/contract_reviewer.yml
@@ -26,7 +26,7 @@ defaults:
   batch_max_workers: 4
 
   context_scope:
-    seed_path:
+    seed:
       risk_criteria: $file:risk_criteria.json
   reprompt:
     on_schema_mismatch: reprompt

--- a/examples/incident_triage/README.md
+++ b/examples/incident_triage/README.md
@@ -277,7 +277,7 @@ Seed data is declared once in `defaults` and made available across all actions:
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       team_roster: $file:team_roster.json
       service_catalog: $file:service_catalog.json
       runbook_catalog: $file:runbook_catalog.json

--- a/examples/incident_triage/agent_workflow/incident_triage/README.md
+++ b/examples/incident_triage/agent_workflow/incident_triage/README.md
@@ -277,7 +277,7 @@ Seed data is declared once in `defaults` and made available across all actions:
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       team_roster: $file:team_roster.json
       service_catalog: $file:service_catalog.json
       runbook_catalog: $file:runbook_catalog.json

--- a/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
+++ b/examples/incident_triage/agent_workflow/incident_triage/agent_config/incident_triage.yml
@@ -26,7 +26,7 @@ defaults:
   api_key: GEMINI_API_KEY
   batch_max_workers: 6
   context_scope:
-    seed_path:
+    seed:
       team_roster: $file:team_roster.json
       service_catalog: $file:service_catalog.json
       runbook_catalog: $file:runbook_catalog.json

--- a/examples/product_listing_enrichment/README.md
+++ b/examples/product_listing_enrichment/README.md
@@ -155,7 +155,7 @@ Seed data provides static reference material that shapes LLM behavior. It's defi
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       brand_voice: $file:brand_voice.json
       marketplace_rules: $file:marketplace_rules.json
 ```

--- a/examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_config/product_listing_enrichment.yml
+++ b/examples/product_listing_enrichment/agent_workflow/product_listing_enrichment/agent_config/product_listing_enrichment.yml
@@ -36,7 +36,7 @@ defaults:
   is_operational: true
 
   context_scope:
-    seed_path:
+    seed:
       brand_voice: $file:brand_voice.json
       marketplace_rules: $file:marketplace_rules.json
   reprompt:

--- a/examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml
+++ b/examples/review_analyzer/agent_workflow/review_analyzer/agent_config/review_analyzer.yml
@@ -36,7 +36,7 @@ defaults:
   api_key: GEMINI_API_KEY
   batch_max_workers: 6
   context_scope:
-    seed_path:
+    seed:
       rubric: $file:evaluation_rubric.json
   retry:
     enabled: true

--- a/examples/support_resolution/README.md
+++ b/examples/support_resolution/README.md
@@ -153,7 +153,7 @@ The `assign_team` action uses seed data -- a static JSON file loaded into the co
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       routing_rules: $file:routing_rules.json
 ```
 

--- a/examples/support_resolution/agent_workflow/support_resolution/README.md
+++ b/examples/support_resolution/agent_workflow/support_resolution/README.md
@@ -153,7 +153,7 @@ The `assign_team` action uses seed data -- a static JSON file loaded into the co
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       routing_rules: $file:routing_rules.json
 ```
 

--- a/examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml
+++ b/examples/support_resolution/agent_workflow/support_resolution/agent_config/support_resolution.yml
@@ -43,7 +43,7 @@ defaults:
     folder: ./staging
     file_type: [json]
   context_scope:
-    seed_path:
+    seed:
       routing_rules: $file:routing_rules.json
 
 actions:

--- a/tests/cli/test_inspect_seed_namespace.py
+++ b/tests/cli/test_inspect_seed_namespace.py
@@ -1,0 +1,15 @@
+"""ContextCommand surfaces the seed.* namespace from the seed directive."""
+
+from agent_actions.cli.inspect import ContextCommand
+
+
+class TestSeedNamespaceKeys:
+    def test_seed_directive_keys_surfaced_in_order(self):
+        ctx = {"seed": {"exam_syllabus": "$file:a.json", "rubric": "$file:b.json"}}
+        assert ContextCommand._seed_namespace_keys(ctx) == ["exam_syllabus", "rubric"]
+
+    def test_no_seed_directive_yields_no_keys(self):
+        assert ContextCommand._seed_namespace_keys({"observe": ["x"]}) == []
+
+    def test_non_dict_seed_yields_no_keys(self):
+        assert ContextCommand._seed_namespace_keys({"seed": None}) == []

--- a/tests/core/parser/test_context_scope_merge.py
+++ b/tests/core/parser/test_context_scope_merge.py
@@ -5,8 +5,8 @@ This test suite verifies that when an action defines its own context_scope,
 it properly merges with (instead of replacing) the defaults.context_scope.
 
 Key scenarios tested:
-1. seed_path from defaults + drop from action
-2. seed_path from defaults + observe from action
+1. seed from defaults + drop from action
+2. seed from defaults + observe from action
 3. observe from both defaults and action (should combine)
 4. All directive combinations
 5. Empty/missing directives
@@ -18,27 +18,27 @@ from agent_actions.output.response.expander import ActionExpander
 class TestContextScopeDeepMerge:
     """Test deep merge helper function for context_scope directives."""
 
-    def test_seed_path_from_defaults_plus_drop_from_action(self):
-        """Action can define drop while inheriting seed_path from defaults."""
-        defaults_scope = {"seed_path": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"}}
+    def test_seed_from_defaults_plus_drop_from_action(self):
+        """Action can define drop while inheriting seed from defaults."""
+        defaults_scope = {"seed": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"}}
         action_scope = {"drop": ["source.syllabus", "source.url"]}
 
         result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
-            "seed_path": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"},
+            "seed": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"},
             "drop": ["source.syllabus", "source.url"],
         }
 
-    def test_seed_path_from_defaults_plus_observe_from_action(self):
-        """Action can define observe while inheriting seed_path from defaults."""
-        defaults_scope = {"seed_path": {"knowledge_base": "$file:kb.json"}}
+    def test_seed_from_defaults_plus_observe_from_action(self):
+        """Action can define observe while inheriting seed from defaults."""
+        defaults_scope = {"seed": {"knowledge_base": "$file:kb.json"}}
         action_scope = {"observe": ["previous_agent.field1", "previous_agent.field2"]}
 
         result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
-            "seed_path": {"knowledge_base": "$file:kb.json"},
+            "seed": {"knowledge_base": "$file:kb.json"},
             "observe": ["previous_agent.field1", "previous_agent.field2"],
         }
 
@@ -72,33 +72,33 @@ class TestContextScopeDeepMerge:
         # Should preserve order and remove duplicates
         assert result == {"observe": ["agent1.field1", "agent2.field2", "agent3.field3"]}
 
-    def test_seed_path_dicts_merge(self):
-        """When both have seed_path, merge the dict contents."""
-        defaults_scope = {"seed_path": {"exam_syllabus": "$file:exam.json"}}
-        action_scope = {"seed_path": {"grading_rubric": "$file:rubric.yaml"}}
+    def test_seed_dicts_merge(self):
+        """When both have seed, merge the dict contents."""
+        defaults_scope = {"seed": {"exam_syllabus": "$file:exam.json"}}
+        action_scope = {"seed": {"grading_rubric": "$file:rubric.yaml"}}
 
         result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
-            "seed_path": {"exam_syllabus": "$file:exam.json", "grading_rubric": "$file:rubric.yaml"}
+            "seed": {"exam_syllabus": "$file:exam.json", "grading_rubric": "$file:rubric.yaml"}
         }
 
-    def test_seed_path_action_overrides_same_key(self):
-        """When both have same seed_path key, action overrides defaults."""
-        defaults_scope = {"seed_path": {"exam_syllabus": "$file:default_exam.json"}}
+    def test_seed_action_overrides_same_key(self):
+        """When both have same seed key, action overrides defaults."""
+        defaults_scope = {"seed": {"exam_syllabus": "$file:default_exam.json"}}
         action_scope = {
-            "seed_path": {
+            "seed": {
                 "exam_syllabus": "$file:custom_exam.json"  # Override
             }
         }
 
         result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
 
-        assert result == {"seed_path": {"exam_syllabus": "$file:custom_exam.json"}}
+        assert result == {"seed": {"exam_syllabus": "$file:custom_exam.json"}}
 
     def test_all_directives_combined(self):
         """Complex scenario with all directive types."""
-        defaults_scope = {"seed_path": {"exam": "$file:exam.json"}, "observe": ["agent1.field1"]}
+        defaults_scope = {"seed": {"exam": "$file:exam.json"}, "observe": ["agent1.field1"]}
         action_scope = {
             "observe": ["agent2.field2"],
             "drop": ["source.api_key"],
@@ -108,7 +108,7 @@ class TestContextScopeDeepMerge:
         result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
-            "seed_path": {"exam": "$file:exam.json"},
+            "seed": {"exam": "$file:exam.json"},
             "observe": ["agent1.field1", "agent2.field2"],
             "drop": ["source.api_key"],
             "passthrough": ["source.metadata"],
@@ -127,15 +127,13 @@ class TestContextScopeDeepMerge:
 class TestContextScopeMergeInActionExpander:
     """Integration tests for context_scope merging in action expansion."""
 
-    def test_action_with_drop_inherits_seed_path_from_defaults(self):
-        """Real-world scenario: action defines drop, inherits seed_path from defaults."""
+    def test_action_with_drop_inherits_seed_from_defaults(self):
+        """Real-world scenario: action defines drop, inherits seed from defaults."""
         defaults = {
             "model_vendor": "openai",
             "model_name": "gpt-4",
             "api_key": "test_key",
-            "context_scope": {
-                "seed_path": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"}
-            },
+            "context_scope": {"seed": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"}},
         }
 
         action = {
@@ -156,10 +154,10 @@ class TestContextScopeMergeInActionExpander:
             template_replacer=template_replacer,
         )
 
-        # Should have both seed_path from defaults AND drop from action
+        # Should have both seed from defaults AND drop from action
         assert "context_scope" in result
         assert result["context_scope"] == {
-            "seed_path": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"},
+            "seed": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"},
             "drop": ["source.syllabus", "source.url"],
         }
 
@@ -169,7 +167,7 @@ class TestContextScopeMergeInActionExpander:
             "model_vendor": "openai",
             "model_name": "gpt-4",
             "api_key": "test_key",
-            "context_scope": {"seed_path": {"knowledge_base": "$file:kb.json"}},
+            "context_scope": {"seed": {"knowledge_base": "$file:kb.json"}},
         }
 
         action = {
@@ -191,15 +189,15 @@ class TestContextScopeMergeInActionExpander:
 
         # Should inherit defaults context_scope
         assert "context_scope" in result
-        assert result["context_scope"] == {"seed_path": {"knowledge_base": "$file:kb.json"}}
+        assert result["context_scope"] == {"seed": {"knowledge_base": "$file:kb.json"}}
 
-    def test_action_with_observe_inherits_seed_path(self):
-        """Action with observe should still inherit seed_path from defaults."""
+    def test_action_with_observe_inherits_seed(self):
+        """Action with observe should still inherit seed from defaults."""
         defaults = {
             "model_vendor": "openai",
             "model_name": "gpt-4",
             "api_key": "test_key",
-            "context_scope": {"seed_path": {"exam": "$file:exam.json"}},
+            "context_scope": {"seed": {"exam": "$file:exam.json"}},
         }
 
         action = {
@@ -224,7 +222,7 @@ class TestContextScopeMergeInActionExpander:
         # Should have both
         assert "context_scope" in result
         assert result["context_scope"] == {
-            "seed_path": {"exam": "$file:exam.json"},
+            "seed": {"exam": "$file:exam.json"},
             "observe": ["generate_summary.summary_content", "score_quality.quality_score"],
         }
 

--- a/tests/integration/test_context_scope_audit.py
+++ b/tests/integration/test_context_scope_audit.py
@@ -1,6 +1,6 @@
 """Comprehensive context_scope audit tests.
 
-Tests every directive (observe, passthrough, drop, seed_path) across:
+Tests every directive (observe, passthrough, drop, seed) across:
 - RECORD vs FILE granularity
 - Wildcard expansion (action.*)
 - Version base expansion
@@ -405,11 +405,11 @@ class TestNormalizerVersionExpansion:
         scope = normalize_context_scope({"passthrough": ["extract.id"]}, version_map)
         assert scope["passthrough"] == ["extract_1.id", "extract_2.id"]
 
-    def test_seed_path_not_expanded(self):
+    def test_seed_not_expanded(self):
         version_map = {"extract": ["extract_1", "extract_2"]}
         seed = {"syllabus": "data/syllabus.json"}
-        scope = normalize_context_scope({"seed_path": seed}, version_map)
-        assert scope["seed_path"] == seed
+        scope = normalize_context_scope({"seed": seed}, version_map)
+        assert scope["seed"] == seed
 
     def test_null_context_scope_returns_empty(self):
         assert normalize_context_scope(None, {}) == {}

--- a/tests/preprocessing/context/test_context_scope_normalizer.py
+++ b/tests/preprocessing/context/test_context_scope_normalizer.py
@@ -8,6 +8,9 @@ Verifies that:
 3. normalize_all_agent_configs normalizes context_scope in-place
 """
 
+import pytest
+
+from agent_actions.errors import ConfigurationError
 from agent_actions.input.context.normalizer import (
     DIRECTIVE_REGISTRY,
     _build_version_base_name_map,
@@ -15,6 +18,24 @@ from agent_actions.input.context.normalizer import (
     normalize_all_agent_configs,
     normalize_context_scope,
 )
+
+
+class TestRemovedDirectives:
+    def test_seed_path_raises_naming_the_replacement(self):
+        """The renamed-away seed_path key raises, naming both the old key and 'seed'."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            normalize_context_scope({"seed_path": {"x": "$file:y.json"}}, {})
+        msg = str(excinfo.value)
+        assert "seed_path" in msg  # names the removed key
+        assert "'seed'" in msg  # points at the replacement
+
+    def test_static_data_raises_naming_the_replacement(self):
+        """The retired static_data key raises with the same guidance."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            normalize_context_scope({"static_data": {"x": "$file:y.json"}}, {})
+        msg = str(excinfo.value)
+        assert "static_data" in msg
+        assert "'seed'" in msg
 
 
 class TestDirectiveRegistry:

--- a/tests/preprocessing/context/test_context_scope_normalizer.py
+++ b/tests/preprocessing/context/test_context_scope_normalizer.py
@@ -4,7 +4,7 @@ Tests for the context_scope_normalizer module.
 Verifies that:
 1. List directives (observe, passthrough, drop, drops) have version base name
    references expanded to concrete versioned references
-2. Dict directives (seed_path) are preserved as-is (never expanded)
+2. Dict directives (seed) are preserved as-is (never expanded)
 3. normalize_all_agent_configs normalizes context_scope in-place
 """
 
@@ -34,8 +34,8 @@ class TestDirectiveRegistry:
         assert DIRECTIVE_REGISTRY["drops"]["expand_versions"] is True
 
     def test_dict_directives_are_not_expanded(self):
-        assert DIRECTIVE_REGISTRY["seed_path"]["type"] == "dict"
-        assert DIRECTIVE_REGISTRY["seed_path"]["expand_versions"] is False
+        assert DIRECTIVE_REGISTRY["seed"]["type"] == "dict"
+        assert DIRECTIVE_REGISTRY["seed"]["expand_versions"] is False
 
 
 class TestNormalizeContextScope:
@@ -57,22 +57,22 @@ class TestNormalizeContextScope:
 
         assert result["observe"] == ["loop_action_1.score", "loop_action_2.score"]
 
-    def test_preserves_seed_path_dict(self):
+    def test_preserves_seed_dict(self):
         context_scope = {
-            "seed_path": {"exam_syllabus": "syllabus.json", "grading_rubric": "rubric.json"}
+            "seed": {"exam_syllabus": "syllabus.json", "grading_rubric": "rubric.json"}
         }
         version_base_map = {"loop_action": ["loop_action_1", "loop_action_2"]}
 
         result = normalize_context_scope(context_scope, version_base_map)
 
-        assert result["seed_path"] == {
+        assert result["seed"] == {
             "exam_syllabus": "syllabus.json",
             "grading_rubric": "rubric.json",
         }
 
     def test_handles_mixed_directives(self):
         context_scope = {
-            "seed_path": {"exam_syllabus": "syllabus.json"},
+            "seed": {"exam_syllabus": "syllabus.json"},
             "observe": ["loop_action.*", "other_action.field1"],
             "passthrough": ["loop_action.*"],
             "drop": ["unwanted_field"],
@@ -81,7 +81,7 @@ class TestNormalizeContextScope:
 
         result = normalize_context_scope(context_scope, version_base_map)
 
-        assert result["seed_path"] == {"exam_syllabus": "syllabus.json"}
+        assert result["seed"] == {"exam_syllabus": "syllabus.json"}
         assert result["observe"] == [
             "loop_action_1.*",
             "loop_action_2.*",
@@ -195,16 +195,14 @@ class TestNormalizeAllAgentConfigs:
                 "version_base_name": "loop",
                 "version_number": 1,
             },
-            "consumer": {
-                "context_scope": {"observe": ["loop.*"], "seed_path": {"key": "value.json"}}
-            },
+            "consumer": {"context_scope": {"observe": ["loop.*"], "seed": {"key": "value.json"}}},
         }
 
         normalize_all_agent_configs(agent_configs)
 
         assert agent_configs["consumer"]["context_scope"] == {
             "observe": ["loop_1.*"],
-            "seed_path": {"key": "value.json"},
+            "seed": {"key": "value.json"},
         }
         assert "context_scope_expanded" not in agent_configs["consumer"]
 
@@ -230,7 +228,7 @@ class TestNormalizeAllAgentConfigs:
 
 
 class TestSeedPathPreservation:
-    def test_seed_path_not_destroyed_by_version_expansion(self):
+    def test_seed_not_destroyed_by_version_expansion(self):
         agent_configs = {
             "extract_1": {
                 "is_versioned_agent": True,
@@ -244,7 +242,7 @@ class TestSeedPathPreservation:
             },
             "consumer": {
                 "context_scope": {
-                    "seed_path": {
+                    "seed": {
                         "exam_syllabus": "syllabus.json",
                         "grading_rubric": "rubric.json",
                     },
@@ -255,7 +253,7 @@ class TestSeedPathPreservation:
 
         normalize_all_agent_configs(agent_configs)
 
-        assert agent_configs["consumer"]["context_scope"]["seed_path"] == {
+        assert agent_configs["consumer"]["context_scope"]["seed"] == {
             "exam_syllabus": "syllabus.json",
             "grading_rubric": "rubric.json",
         }

--- a/tests/unit/prompt/test_seed_directive.py
+++ b/tests/unit/prompt/test_seed_directive.py
@@ -1,0 +1,64 @@
+"""The seed directive: declared under context_scope.seed, loaded under the seed namespace.
+
+The old directive keys (seed_path, static_data) are removed and must fail loud.
+"""
+
+import json
+
+import pytest
+
+from agent_actions.errors import ConfigurationError
+from agent_actions.input.context.normalizer import normalize_context_scope
+from agent_actions.prompt.service import PromptPreparationService
+
+
+def _workflow_with_seed_file(tmp_path, filename="refs.json", content=None):
+    """Build a workflow tree with a seed_data/ folder holding one file; return the config path."""
+    workflow = tmp_path / "workflow"
+    (workflow / "agent_config").mkdir(parents=True)
+    (workflow / "seed_data").mkdir()
+    (workflow / "seed_data" / filename).write_text(
+        json.dumps(content if content is not None else {"a": 1})
+    )
+    return str(workflow / "agent_config" / "wf.yml")
+
+
+class TestSeedDirectiveLoads:
+    def test_seed_directive_loads_under_seed_namespace(self, tmp_path):
+        """context_scope.seed maps alias -> file; the file loads under that alias."""
+        config_path = _workflow_with_seed_file(tmp_path, content={"exam_name": "Q"})
+        agent_config = {"workflow_config_path": config_path}
+        context_scope = {"seed": {"exam_syllabus": "$file:refs.json"}}
+
+        loaded = PromptPreparationService._load_seed_data(agent_config, context_scope, "act")
+
+        assert loaded == {"exam_syllabus": {"exam_name": "Q"}}
+
+    def test_no_seed_directive_loads_nothing(self, tmp_path):
+        """No seed directive -> empty dict, no error."""
+        config_path = _workflow_with_seed_file(tmp_path)
+        agent_config = {"workflow_config_path": config_path}
+
+        assert PromptPreparationService._load_seed_data(agent_config, {"observe": []}, "act") == {}
+
+
+class TestRemovedDirectivesFailLoud:
+    def test_seed_path_directive_is_rejected(self):
+        """The renamed-away seed_path key must fail loud, not silently load nothing."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            normalize_context_scope({"seed_path": {"exam_syllabus": "$file:refs.json"}}, {})
+        assert "seed" in str(excinfo.value)
+
+    def test_static_data_directive_is_rejected(self):
+        """The retired static_data key must fail loud."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            normalize_context_scope({"static_data": {"x": "$file:refs.json"}}, {})
+        assert "seed" in str(excinfo.value)
+
+    def test_seed_directive_is_accepted_and_preserved(self):
+        """The new seed key normalizes without error and is preserved verbatim (dict directive)."""
+        scope = {"seed": {"exam_syllabus": "$file:refs.json"}, "observe": ["source.x"]}
+
+        normalized = normalize_context_scope(scope, {})
+
+        assert normalized["seed"] == {"exam_syllabus": "$file:refs.json"}

--- a/tests/unit/validation/test_resolution_service.py
+++ b/tests/unit/validation/test_resolution_service.py
@@ -153,7 +153,7 @@ class TestSeedFileChecks:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"field1": "$file:missing.json"},
+                        "seed": {"field1": "$file:missing.json"},
                     },
                 },
             },
@@ -180,7 +180,7 @@ class TestSeedFileChecks:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"field1": "$file:data.json"},
+                        "seed": {"field1": "$file:data.json"},
                     },
                 },
             },
@@ -205,7 +205,7 @@ class TestSeedFileChecks:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"field1": "$file:../../etc/passwd"},
+                        "seed": {"field1": "$file:../../etc/passwd"},
                     },
                 },
             },
@@ -216,8 +216,8 @@ class TestSeedFileChecks:
         seed_errors = [e for e in result.errors if "escapes base directory" in e.message]
         assert len(seed_errors) == 1
 
-    def test_no_seed_path_config_no_errors(self):
-        """No seed_path in config produces no errors."""
+    def test_no_seed_config_no_errors(self):
+        """No seed in config produces no errors."""
         svc = WorkflowResolutionService(
             action_configs={
                 "loader": {"context_scope": {}},
@@ -241,7 +241,7 @@ class TestSeedFileChecks:
             action_configs={
                 "broken_action": {
                     "prompt": "{{ unclosed_var",
-                    "context_scope": {"seed_path": {"data": "some_value"}},
+                    "context_scope": {"seed": {"data": "some_value"}},
                 },
             },
             workflow_config_path=workflow_path,
@@ -268,7 +268,7 @@ class TestSeedFileChecks:
             action_configs={
                 "broken_action": {
                     "prompt": "{{ unclosed_var",
-                    "context_scope": {"seed_path": {"data": "v"}},
+                    "context_scope": {"seed": {"data": "v"}},
                 },
                 "good_action": {
                     "prompt": "{{ source.field }}",
@@ -294,7 +294,7 @@ class TestSeedFileChecks:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"field1": "$file:data.json"},
+                        "seed": {"field1": "$file:data.json"},
                     },
                 },
             },

--- a/tests/unit/validation/test_seed_field_validation.py
+++ b/tests/unit/validation/test_seed_field_validation.py
@@ -1,7 +1,7 @@
 """Tests for seed field reference validation in preflight checks.
 
 Covers:
-- Namespace mismatches (error): seed.X where X is not in seed_path
+- Namespace mismatches (error): seed.X where X is not in seed
 - Nested field mismatches (warning): seed.rubric.typo where typo doesn't exist
 - Deeply nested field walks
 - Array boundary handling
@@ -73,17 +73,17 @@ class TestNestedKeyExists:
 
 
 class TestSeedNamespaceValidation:
-    """Referencing seed.X when X is not in seed_path produces a blocking error."""
+    """Referencing seed.X when X is not in seed produces a blocking error."""
 
     def test_undeclared_namespace_from_observe(self, tmp_path):
-        """observe: [seed.missing.field] with no seed_path entry for 'missing'."""
+        """observe: [seed.missing.field] with no seed entry for 'missing'."""
         wf_path = _make_project(tmp_path, {"rubric.json": {"scoring": 1}})
 
         svc = WorkflowResolutionService(
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.missing.field"],
                     },
                 },
@@ -94,11 +94,11 @@ class TestSeedNamespaceValidation:
 
         ns_errors = [e for e in result.errors if "seed.missing" in e.message]
         assert len(ns_errors) == 1
-        assert "not declared in context_scope.seed_path" in ns_errors[0].message
+        assert "not declared in context_scope.seed" in ns_errors[0].message
         assert "rubric" in ns_errors[0].hint  # suggests declared key
 
-    def test_undeclared_namespace_no_seed_path_at_all(self, tmp_path):
-        """Action references seed.X but has no seed_path config."""
+    def test_undeclared_namespace_no_seed_at_all(self, tmp_path):
+        """Action references seed.X but has no seed config."""
         wf_path = _make_project(tmp_path)
 
         svc = WorkflowResolutionService(
@@ -125,7 +125,7 @@ class TestSeedNamespaceValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric"],
                     },
                 },
@@ -157,7 +157,7 @@ class TestSeedFieldValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric.scoring_critera"],  # typo
                     },
                 },
@@ -188,7 +188,7 @@ class TestSeedFieldValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric.scoring_criteria"],
                     },
                 },
@@ -210,7 +210,7 @@ class TestSeedFieldValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": [
                             "seed.rubric.scoring.helpfulness.weight",  # valid
                             "seed.rubric.scoring.helpfulness.typo",  # invalid
@@ -236,7 +236,7 @@ class TestSeedFieldValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric.items"],
                     },
                 },
@@ -258,7 +258,7 @@ class TestSeedFieldValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rules": "$file:rules.json"},
+                        "seed": {"rules": "$file:rules.json"},
                         "observe": ["seed.rules.marketplace_ruls"],  # close typo
                     },
                 },
@@ -281,7 +281,7 @@ class TestSeedFieldValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric.zzz_completely_wrong"],
                     },
                 },
@@ -301,7 +301,7 @@ class TestSeedFieldValidation:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "passthrough": ["seed.rubric.*"],
                     },
                 },
@@ -327,7 +327,7 @@ class TestSeedJsonParseFailure:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"data": "$file:bad.json"},
+                        "seed": {"data": "$file:bad.json"},
                     },
                 },
             },
@@ -357,13 +357,13 @@ class TestMultipleActions:
             action_configs={
                 "action_a": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric.scoring_criteria"],  # valid
                     },
                 },
                 "action_b": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric.typo_field"],  # invalid
                     },
                 },
@@ -376,21 +376,21 @@ class TestMultipleActions:
         assert len(result.warnings) == 1
         assert "action_b" in result.warnings[0].message
 
-    def test_action_without_seed_path_referencing_seed(self, tmp_path):
-        """Action A has seed_path, action B doesn't but references seed."""
+    def test_action_without_seed_referencing_seed(self, tmp_path):
+        """Action A has seed, action B doesn't but references seed."""
         wf_path = _make_project(tmp_path, {"rubric.json": {"a": 1}})
 
         svc = WorkflowResolutionService(
             action_configs={
                 "action_a": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric"],
                     },
                 },
                 "action_b": {
                     "context_scope": {
-                        "observe": ["seed.rubric.field"],  # no seed_path!
+                        "observe": ["seed.rubric.field"],  # no seed!
                     },
                 },
             },
@@ -426,7 +426,7 @@ class TestInlinePromptExtraction:
                     "name": "processor",
                     "prompt": "Score using {{ seed.rubric.scoring_critera }}",
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                     },
                 },
             },
@@ -447,7 +447,7 @@ class TestInlinePromptExtraction:
                     "name": "processor",
                     "prompt": "Use {{ seed.missing_data.field }}",
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                     },
                 },
             },
@@ -475,7 +475,7 @@ class TestExistingChecksUnchanged:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"field1": "$file:missing.json"},
+                        "seed": {"field1": "$file:missing.json"},
                     },
                 },
             },
@@ -494,7 +494,7 @@ class TestExistingChecksUnchanged:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"field1": "$file:../../etc/passwd"},
+                        "seed": {"field1": "$file:../../etc/passwd"},
                     },
                 },
             },
@@ -505,8 +505,8 @@ class TestExistingChecksUnchanged:
         seed_errors = [e for e in result.errors if "escapes base directory" in e.message]
         assert len(seed_errors) == 1
 
-    def test_no_seed_path_no_errors(self):
-        """No seed_path in config produces no errors (existing behavior)."""
+    def test_no_seed_no_errors(self):
+        """No seed in config produces no errors (existing behavior)."""
         svc = WorkflowResolutionService(
             action_configs={"loader": {"context_scope": {}}},
         )
@@ -526,7 +526,7 @@ class TestExistingChecksUnchanged:
             action_configs={
                 "loader": {
                     "context_scope": {
-                        "seed_path": {"field1": "$file:data.json"},
+                        "seed": {"field1": "$file:data.json"},
                     },
                 },
             },
@@ -555,7 +555,7 @@ class TestDeduplication:
             action_configs={
                 "processor": {
                     "context_scope": {
-                        "seed_path": {"rubric": "$file:rubric.json"},
+                        "seed": {"rubric": "$file:rubric.json"},
                         "observe": ["seed.rubric.typo_field"],
                         "passthrough": ["seed.rubric.typo_field"],
                     },

--- a/tests/validation/static_analyzer/test_seed_reference_misuse.py
+++ b/tests/validation/static_analyzer/test_seed_reference_misuse.py
@@ -44,6 +44,44 @@ class TestSeedReferenceMisuse:
         assert len(misuse_errors) == 1
         assert "seed.rubric" in misuse_errors[0].message
 
+    def test_removed_seed_directive_reported_not_crashed(self):
+        """A workflow still using the retired seed_path directive yields a collected
+        validation error (analyze does not raise mid-pass)."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "processor",
+                    "context_scope": {"seed_path": {"rubric": "$file:rubric.json"}},
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        rename_errors = [
+            e for e in result.errors if "seed_path" in e.message and "seed" in e.message
+        ]
+        assert len(rename_errors) >= 1
+
+    def test_static_data_dot_in_observe_triggers_error(self):
+        """Using the retired 'static_data.field' as a reference namespace should error."""
+        workflow_config = {
+            "actions": [
+                {
+                    "name": "processor",
+                    "context_scope": {
+                        "observe": ["static_data.rubric"],
+                    },
+                },
+            ]
+        }
+
+        result = analyze_workflow(workflow_config)
+
+        misuse_errors = [e for e in result.errors if "static_data.rubric" in e.message]
+        assert len(misuse_errors) == 1
+        assert "seed.rubric" in misuse_errors[0].message
+
     def test_seed_dot_in_observe_no_error(self):
         """Using correct 'seed.field' in observe should not trigger a misuse error."""
         workflow_config = {


### PR DESCRIPTION
## Summary

"Static reference data available to prompts" was fragmented across **five** similar names, and the directive key collided with the folder knob — a user set `seed_data_path: seed_path` (conflating the two) and lost a debugging session (the origin of #578).

| Name | Role |
|------|------|
| `seed` | the namespace prompts read — `{{ seed.x }}` |
| `seed_path` | context_scope directive that declares which files to load *(renamed here → `seed`)* |
| `static_data` | a second, half-wired directive for the same thing *(removed here)* |
| `seed_data` | default folder name (+ a flagged misuse token) |
| `seed_data_path` | folder-location config knob *(unchanged)* |

The framework already carried two band-aids for this confusion (an anti-typo linter, and #578's error message). This collapses the declaration to **one** name that matches the reference:

- **Rename** the directive `seed_path` → `seed` (declare `context_scope.seed:`, read `{{ seed.* }}`).
- **Remove** the dead `static_data` directive (was in config types + shown by `agac inspect`, never read by the runtime loader).
- **Fail loud** on the removed keys: `normalize_context_scope` raises a `ConfigurationError` pointing at `seed` instead of silently loading no seed data. This runs on the runtime config-load path (`config/manager.py`) and the validation path — so a leftover `seed_path:` errors clearly rather than silently dropping seeds.
- The old names stay in `SEED_CONFIG_KEYS` so writing `seed_path.x` in a prompt reference is still flagged as misuse.

The folder knob `seed_data_path` and the `seed` namespace are unchanged. **Clean cutover** — no dual-key acceptance, no deprecation shim (per the repo's no-compat-shim rule; one real project migrated).

## Deviations from the spec

- **Chose fail-loud** for the removed keys. The spec left "error vs silently load nothing" as an implementation decision; the no-silent-fallback rule makes erroring (with migration guidance) the correct choice, so the change adds a `REMOVED_DIRECTIVES` guard rather than relying on the prior silent-preserve behavior.
- **Superseded #578 / PR #789** (the error-message band-aid), which is now closed — the `seed_path`-vs-folder collision it patched no longer exists.
- **Left internal `static_data` plumbing** (the loaded-data parameter/variable in `scope_application`/`service`, the `cache_type="static_data"` event label, the `seed_path` `Path` local in `lsp/resolver`). These are internal names, not the directive; renaming them is out of scope and would expand blast radius (event schema, etc.).

## Verification

- **RED → GREEN:** `tests/unit/prompt/test_seed_directive.py` (loads under the new `seed` key; `seed_path`/`static_data` fail loud). Full suite **8070 pass**; `ruff format --check`, `ruff check`, `mypy` clean.
- **Fixture migration is a pure rename** — the gate's reward-hack flag ("22 removed test lines") is a false positive: every removed `assert`/`def` line was a `seed_path`→`seed` rename (confirmed by diff audit and by the anti-gaming reviewer); no assertion was weakened.
- **Review (risk=HIGH → 3 diverse-lens blind reviewers):**
  - Correctness/mechanism → **YES**.
  - Blast-radius → **NO → fixed**: caught stale docs still showing the old directive (`prompt`/`output`/`skills`/`llm` `ARCHITECTURE.md`, `agac-agent-skills/SKILL.md`, `static_loader`/`realtime builder` docstrings/comments) — all updated so copying them can't trigger the new error.
  - Tests/anti-gaming → **YES**; its notes addressed: extracted `ContextCommand._seed_namespace_keys` + a test that `agac inspect` surfaces the `seed` namespace, and strengthened the removed-key tests to assert the error names both the old key and the `seed` replacement.
  - Recorded **YES_WITH_ISSUES** after remediation.
- **Smoke (skipped, offline real-project proof instead):** `scan-project.sh` canary **passed**. On the **migrated qanalabs config**, `agac inspect -a qanalabs_quiz_gen` passes preflight for every action (config normalization + seed resolution succeed under `seed:`; fail-loud guard correctly not tripped), and `agac inspect context` surfaces the `seed` namespace with all 5 keys rendering as `{{ seed.* }}`. The online `agac run` is environmentally blocked on the external LLM (hangs) and adds nothing for the paths this diff touches.
- **Migration:** the qanalabs workflow configs were migrated `seed_path:` → `seed:` (prompts already read `{{ seed.* }}`).

## Pre-existing (not introduced here)
- Verbose-prose flags at `service.py:479`, `static_loader.py:2`, `builder.py:47`, and three test-file module docstrings are pre-existing in files this rename touched.