### PR TITLE
fix(586): prevent kind:tool actions from entering the reprompt loop

### DIFF
--- a/agent_actions/output/response/expander.py
+++ b/agent_actions/output/response/expander.py
@@ -270,6 +270,12 @@ class ActionExpander:
         if action_kind in {"tool", "hitl"} and action.get("run_mode") is None:
             agent["run_mode"] = get_default("run_mode")
 
+        # reprompt is an LLM-recovery directive; a defaults-level reprompt must not
+        # bleed onto deterministic tool/hitl actions. An explicit action-level
+        # reprompt is still honoured.
+        if action_kind in {"tool", "hitl"} and "reprompt" not in action:
+            agent["reprompt"] = get_default("reprompt")
+
         # Validate configuration
         validate_vendor_exists(agent["model_vendor"], action.get("name", "unknown"))
         if action_kind not in {"tool", "hitl"}:

--- a/agent_actions/output/response/expander.py
+++ b/agent_actions/output/response/expander.py
@@ -275,14 +275,15 @@ class ActionExpander:
         # a reprompt inherited from workflow defaults is stripped.
         if action_kind in {"tool", "hitl"}:
             if "reprompt" in action:
+                kind_label = getattr(action_kind, "value", action_kind)
                 raise ConfigValidationError(
                     "reprompt",
-                    f"{action_kind} action '{action.get('name', 'unknown')}' cannot declare "
+                    f"{kind_label} action '{action.get('name', 'unknown')}' cannot declare "
                     "'reprompt' — reprompt is an LLM-recovery directive and has no effect on "
                     "deterministic tools or HITL steps.",
                     context={
                         "action": action.get("name", "unknown"),
-                        "kind": action_kind,
+                        "kind": kind_label,
                         "hint": "Remove the reprompt block from this action.",
                     },
                 )

--- a/agent_actions/output/response/expander.py
+++ b/agent_actions/output/response/expander.py
@@ -16,7 +16,7 @@ import logging
 from typing import Any
 
 from agent_actions.config.types import RunMode
-from agent_actions.errors import ConfigurationError
+from agent_actions.errors import ConfigurationError, ConfigValidationError
 from agent_actions.utils.constants import DEFAULT_ACTION_KIND, HITL_FILE_GRANULARITY_ERROR
 
 from .config_fields import get_default, inherit_simple_fields
@@ -270,10 +270,22 @@ class ActionExpander:
         if action_kind in {"tool", "hitl"} and action.get("run_mode") is None:
             agent["run_mode"] = get_default("run_mode")
 
-        # reprompt is an LLM-recovery directive; a defaults-level reprompt must not
-        # bleed onto deterministic tool/hitl actions. An explicit action-level
-        # reprompt is still honoured.
-        if action_kind in {"tool", "hitl"} and "reprompt" not in action:
+        # reprompt is an LLM-recovery directive and is inert for deterministic
+        # tool/hitl actions. An explicit reprompt is a config error (fail fast);
+        # a reprompt inherited from workflow defaults is stripped.
+        if action_kind in {"tool", "hitl"}:
+            if "reprompt" in action:
+                raise ConfigValidationError(
+                    "reprompt",
+                    f"{action_kind} action '{action.get('name', 'unknown')}' cannot declare "
+                    "'reprompt' — reprompt is an LLM-recovery directive and has no effect on "
+                    "deterministic tools or HITL steps.",
+                    context={
+                        "action": action.get("name", "unknown"),
+                        "kind": action_kind,
+                        "hint": "Remove the reprompt block from this action.",
+                    },
+                )
             agent["reprompt"] = get_default("reprompt")
 
         # Validate configuration

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -76,12 +76,15 @@ def run_dynamic_agent(
         additional_context=None,
     )
 
-    if agent_config.get("kind") != "tool":
-        response = _validate_llm_output_schema(
-            response, agent_config, agent_name, skip_schema_validation=skip_schema_validation
-        )
+    response = _validate_llm_output_schema(
+        response, agent_config, agent_name, skip_schema_validation=skip_schema_validation
+    )
 
     return (response, True)
+
+
+def _is_tool_action(agent_config: dict[str, Any]) -> bool:
+    return agent_config.get("kind") == "tool" or agent_config.get("model_vendor") == "tool"
 
 
 def _resolve_schema_mismatch_mode(agent_config: dict[str, Any]) -> str:
@@ -89,10 +92,22 @@ def _resolve_schema_mismatch_mode(agent_config: dict[str, Any]) -> str:
 
     Returns ``"reject"``, ``"reprompt"``, or ``"warn"`` (internal signal for
     no enforcement).
+
+    For deterministic tool actions, ``"reprompt"`` is coerced to ``"reject"``
+    because re-running the same UDF on the same input always yields the same
+    output — reprompt is inert and would only burn futile attempts.
     """
     reprompt = agent_config.get("reprompt")
     if isinstance(reprompt, dict) and reprompt.get("on_schema_mismatch"):
-        return str(reprompt["on_schema_mismatch"])
+        mode = str(reprompt["on_schema_mismatch"])
+        if mode == "reprompt" and _is_tool_action(agent_config):
+            logger.warning(
+                "Action '%s': on_schema_mismatch=reprompt is inert for deterministic tools "
+                "— treating as reject.",
+                agent_config.get("name", "unknown"),
+            )
+            return "reject"
+        return mode
     return "warn"
 
 

--- a/agent_actions/processing/helpers.py
+++ b/agent_actions/processing/helpers.py
@@ -151,6 +151,20 @@ def _reject_schema_echo_items(response: Any, agent_name: str) -> Any:
     return result
 
 
+def _is_empty_output(response: Any) -> bool:
+    """Check if a tool/LLM response is effectively empty."""
+    if response is None:
+        return True
+    if isinstance(response, dict) and len(response) == 0:
+        return True
+    if isinstance(response, list):
+        if len(response) == 0:
+            return True
+        if all(isinstance(item, dict) and len(item) == 0 for item in response):
+            return True
+    return False
+
+
 def _validate_llm_output_schema(
     response: Any,
     agent_config: dict[str, Any],
@@ -183,6 +197,12 @@ def _validate_llm_output_schema(
                 agent_name,
                 mismatch_mode,
             )
+        return response
+
+    # Empty output is the on_empty handler's domain, not schema validation's:
+    # an empty response has no fields to check, so rejecting it here would
+    # pre-empt the on_empty policy (skip/warn/error) with a hard failure.
+    if _is_empty_output(response):
         return response
 
     mismatch_mode = _resolve_schema_mismatch_mode(agent_config)

--- a/agent_actions/processing/invocation/factory.py
+++ b/agent_actions/processing/invocation/factory.py
@@ -39,6 +39,7 @@ class InvocationStrategyFactory:
     @staticmethod
     def _create_online_strategy(agent_config: dict[str, Any]) -> OnlineStrategy:
         """Create OnlineStrategy with configured recovery services."""
+        from agent_actions.processing.helpers import _is_tool_action
         from agent_actions.processing.recovery.reprompt import (
             create_reprompt_service_from_config,
         )
@@ -51,6 +52,15 @@ class InvocationStrategyFactory:
 
         validator = InvocationStrategyFactory._build_validator(agent_config)
 
+        retry_service = create_retry_service_from_config(retry_config)
+
+        # Reprompt is meaningless for deterministic tools — re-running the same UDF yields the same output.
+        if _is_tool_action(agent_config):
+            return OnlineStrategy(
+                retry_service=retry_service,
+                reprompt_service=None,
+            )
+
         critique_fn = None
         if reprompt_config and reprompt_config.get("use_llm_critique"):
             from agent_actions.processing.recovery.critique import invoke_critique
@@ -58,7 +68,6 @@ class InvocationStrategyFactory:
             def critique_fn(response: Any, errors: str) -> str:
                 return invoke_critique(agent_config, response, errors)
 
-        retry_service = create_retry_service_from_config(retry_config)
         reprompt_service = create_reprompt_service_from_config(
             reprompt_config, validator=validator, critique_fn=critique_fn
         )

--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -27,6 +27,7 @@ from agent_actions.logging.events.data_pipeline_events import (
 )
 from agent_actions.logging.events.llm_events import TemplateRenderingFailedEvent
 from agent_actions.processing.exhausted_builder import ExhaustedRecordBuilder
+from agent_actions.processing.helpers import _is_empty_output
 from agent_actions.processing.invocation import InvocationStrategy, InvocationStrategyFactory
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
 from agent_actions.processing.record_helpers import (
@@ -59,20 +60,6 @@ from agent_actions.storage.backend import DISPOSITION_FAILED, DISPOSITION_SUCCES
 from agent_actions.utils.content import get_existing_content
 
 logger = logging.getLogger(__name__)
-
-
-def _is_empty_output(response: Any) -> bool:
-    """Check if a tool/LLM response is effectively empty."""
-    if response is None:
-        return True
-    if isinstance(response, dict) and len(response) == 0:
-        return True
-    if isinstance(response, list):
-        if len(response) == 0:
-            return True
-        if all(isinstance(item, dict) and len(item) == 0 for item in response):
-            return True
-    return False
 
 
 def _empty_warn_reason(

--- a/tests/processing/test_empty_output_detection.py
+++ b/tests/processing/test_empty_output_detection.py
@@ -8,7 +8,7 @@ from agent_actions.config.schema import ActionConfig
 from agent_actions.errors import EmptyOutputError
 from agent_actions.logging.events.data_pipeline_events import RecordEmptyOutputEvent
 from agent_actions.logging.events.handlers.run_results import ActionResult, RunResultsCollector
-from agent_actions.processing.strategies.online_llm import _is_empty_output
+from agent_actions.processing.helpers import _is_empty_output
 
 # =============================================================================
 # _is_empty_output helper tests

--- a/tests/unit/core/test_schema_mismatch_reprompt.py
+++ b/tests/unit/core/test_schema_mismatch_reprompt.py
@@ -402,3 +402,47 @@ class TestToolKindNoReprompt:
         """kind: llm (or no kind) with reprompt must still return reprompt — no regression."""
         config = {"reprompt": {"on_schema_mismatch": "reprompt"}}
         assert _resolve_schema_mismatch_mode(config) == "reprompt"
+
+
+# ---------------------------------------------------------------------------
+# Empty output is on_empty's domain, never a schema-reject failure
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyOutputExemptFromSchemaReject:
+    """Empty output routes via the on_empty handler — it must never be rejected.
+
+    An empty response has no fields to validate against a schema; raising a hard
+    SchemaValidationError here would pre-empt the on_empty policy (skip/warn/error).
+    """
+
+    def _reject_config(self):
+        return {
+            "schema": {
+                "fields": [
+                    {"name": "title", "type": "string", "required": True},
+                    {"name": "score", "type": "number", "required": True},
+                ]
+            },
+            "reprompt": {"on_schema_mismatch": "reject"},
+            "name": "t",
+        }
+
+    def test_empty_list_not_rejected(self):
+        assert _validate_llm_output_schema([], self._reject_config(), "t") == []
+
+    def test_empty_dict_not_rejected(self):
+        assert _validate_llm_output_schema({}, self._reject_config(), "t") == {}
+
+    def test_list_of_empty_dicts_not_rejected(self):
+        assert _validate_llm_output_schema([{}, {}], self._reject_config(), "t") == [{}, {}]
+
+    def test_none_not_rejected(self):
+        assert _validate_llm_output_schema(None, self._reject_config(), "t") is None
+
+    def test_nonempty_invalid_still_rejected(self):
+        """P2 only exempts empty — genuinely-wrong non-empty output still hard-fails."""
+        from agent_actions.errors import SchemaValidationError
+
+        with pytest.raises(SchemaValidationError):
+            _validate_llm_output_schema({"wrong": "x"}, self._reject_config(), "t")

--- a/tests/unit/core/test_schema_mismatch_reprompt.py
+++ b/tests/unit/core/test_schema_mismatch_reprompt.py
@@ -346,3 +346,61 @@ class TestBuildValidatorUnregisteredUdf:
         config = {"reprompt": {"validation": "nonexistent_udf"}}
         with pytest.raises(ConfigurationError, match="not found"):
             InvocationStrategyFactory._build_validator(config)
+
+
+# ---------------------------------------------------------------------------
+# Tool-kind: reprompt must not be wired
+# ---------------------------------------------------------------------------
+
+
+class TestToolKindNoReprompt:
+    """kind: tool actions must not get a reprompt service or schema-reprompt validator."""
+
+    def _make_tool_config(self):
+        return {
+            "kind": "tool",
+            "schema": {
+                "fields": [
+                    {"name": "code_block", "type": "string", "required": True},
+                    {"name": "description", "type": "string", "required": True},
+                ]
+            },
+            "reprompt": {"on_schema_mismatch": "reprompt", "max_attempts": 3},
+            "name": "flatten_code",
+        }
+
+    def test_tool_kind_with_schema_reprompt_yields_no_validator(self):
+        """_build_validator must return None for kind: tool — reprompt is inert on tools."""
+        result = InvocationStrategyFactory._build_validator(self._make_tool_config())
+        assert result is None
+
+    def test_tool_kind_online_strategy_has_no_reprompt_service(self):
+        """_create_online_strategy must not wire a reprompt_service for kind: tool."""
+        strategy = InvocationStrategyFactory._create_online_strategy(self._make_tool_config())
+        assert strategy._reprompt_service is None
+
+    def test_model_vendor_tool_also_yields_no_validator(self):
+        """model_vendor: tool (legacy signal) also triggers the no-reprompt path."""
+        config = {
+            "model_vendor": "tool",
+            "schema": {
+                "fields": [{"name": "result", "type": "string", "required": True}]
+            },
+            "reprompt": {"on_schema_mismatch": "reprompt", "max_attempts": 2},
+            "name": "some_tool",
+        }
+        assert InvocationStrategyFactory._build_validator(config) is None
+
+    def test_resolve_schema_mode_coerces_reprompt_to_reject_for_tools(self):
+        """For kind: tool with on_schema_mismatch: reprompt, mode is coerced to reject."""
+        config = {
+            "kind": "tool",
+            "reprompt": {"on_schema_mismatch": "reprompt"},
+            "name": "my_tool",
+        }
+        assert _resolve_schema_mismatch_mode(config) == "reject"
+
+    def test_resolve_schema_mode_llm_reprompt_unchanged(self):
+        """kind: llm (or no kind) with reprompt must still return reprompt — no regression."""
+        config = {"reprompt": {"on_schema_mismatch": "reprompt"}}
+        assert _resolve_schema_mismatch_mode(config) == "reprompt"

--- a/tests/unit/core/test_schema_mismatch_reprompt.py
+++ b/tests/unit/core/test_schema_mismatch_reprompt.py
@@ -383,9 +383,7 @@ class TestToolKindNoReprompt:
         """model_vendor: tool (legacy signal) also triggers the no-reprompt path."""
         config = {
             "model_vendor": "tool",
-            "schema": {
-                "fields": [{"name": "result", "type": "string", "required": True}]
-            },
+            "schema": {"fields": [{"name": "result", "type": "string", "required": True}]},
             "reprompt": {"on_schema_mismatch": "reprompt", "max_attempts": 2},
             "name": "some_tool",
         }

--- a/tests/unit/output/response/test_config_fields.py
+++ b/tests/unit/output/response/test_config_fields.py
@@ -289,6 +289,19 @@ class TestRepromptPrecedenceForToolHitl:
         with pytest.raises(ConfigValidationError, match="reprompt"):
             ActionExpander._create_agent_from_action(action, self._DEFAULTS, agent, lambda x: x)
 
+    def test_reprompt_error_renders_kind_value_not_enum_repr(self):
+        """When kind is the ActionKind enum, the error must say 'tool', not 'ActionKind.TOOL'."""
+        from agent_actions.config.schema import ActionKind
+        from agent_actions.errors import ConfigValidationError
+
+        action = {**self._tool_action(), "kind": ActionKind.TOOL, "reprompt": {"validation": "f"}}
+        agent = {"agent_type": "my_tool", "name": "my_tool"}
+        with pytest.raises(ConfigValidationError) as exc:
+            ActionExpander._create_agent_from_action(action, self._DEFAULTS, agent, lambda x: x)
+        message = str(exc.value)
+        assert "tool action 'my_tool'" in message
+        assert "ActionKind" not in message
+
 
 class TestVendorCompatibilityValidatorRunModeCoercion:
     """Verify VendorCompatibilityValidator coerces raw run_mode strings to RunMode."""

--- a/tests/unit/output/response/test_config_fields.py
+++ b/tests/unit/output/response/test_config_fields.py
@@ -216,6 +216,66 @@ class TestIsOperationalFromConfig:
         assert result["is_operational"] is False
 
 
+class TestRepromptPrecedenceForToolHitl:
+    """Tool/hitl actions must not inherit reprompt from workflow defaults.
+
+    reprompt is an LLM-recovery directive: re-running a deterministic UDF (or a
+    HITL step) on the same input can't change the outcome, so a defaults-level
+    reprompt must not bleed onto tool/hitl actions. An explicit action-level
+    reprompt is still honoured.
+    """
+
+    _DEFAULTS = {"reprompt": {"on_schema_mismatch": "reprompt", "max_attempts": 3}}
+
+    def _tool_action(self):
+        return {
+            "name": "my_tool",
+            "kind": "tool",
+            "impl": "pkg.some_fn",
+            "schema": {"fields": [{"name": "x", "type": "string"}]},
+        }
+
+    def test_tool_does_not_inherit_reprompt_from_defaults(self):
+        agent = {"agent_type": "my_tool", "name": "my_tool"}
+        result = ActionExpander._create_agent_from_action(
+            self._tool_action(), self._DEFAULTS, agent, lambda x: x
+        )
+        assert result["reprompt"] is False
+
+    def test_hitl_does_not_inherit_reprompt_from_defaults(self):
+        action = {
+            "name": "review",
+            "kind": "hitl",
+            "hitl": {"instructions": "Review the batch"},
+        }
+        agent = {"agent_type": "review", "name": "review"}
+        result = ActionExpander._create_agent_from_action(
+            action, self._DEFAULTS, agent, lambda x: x
+        )
+        assert result["reprompt"] is False
+
+    def test_llm_still_inherits_reprompt_from_defaults(self):
+        action = {
+            "name": "gen",
+            "model_vendor": "openai",
+            "model_name": "gpt-4o",
+            "api_key": "k",
+        }
+        agent = {"agent_type": "gen", "name": "gen"}
+        result = ActionExpander._create_agent_from_action(
+            action, self._DEFAULTS, agent, lambda x: x
+        )
+        assert result["reprompt"] == {"on_schema_mismatch": "reprompt", "max_attempts": 3}
+
+    def test_tool_explicit_reprompt_is_preserved(self):
+        action = {**self._tool_action(), "reprompt": {"on_schema_mismatch": "reject"}}
+        agent = {"agent_type": "my_tool", "name": "my_tool"}
+        result = ActionExpander._create_agent_from_action(
+            action, self._DEFAULTS, agent, lambda x: x
+        )
+        assert result["reprompt"] == {"on_schema_mismatch": "reject"}
+
+
 class TestVendorCompatibilityValidatorRunModeCoercion:
     """Verify VendorCompatibilityValidator coerces raw run_mode strings to RunMode."""
 

--- a/tests/unit/output/response/test_config_fields.py
+++ b/tests/unit/output/response/test_config_fields.py
@@ -267,13 +267,27 @@ class TestRepromptPrecedenceForToolHitl:
         )
         assert result["reprompt"] == {"on_schema_mismatch": "reprompt", "max_attempts": 3}
 
-    def test_tool_explicit_reprompt_is_preserved(self):
+    def test_tool_explicit_reprompt_raises(self):
+        """An explicit reprompt on a tool is a config error, not a silent accept."""
+        from agent_actions.errors import ConfigValidationError
+
         action = {**self._tool_action(), "reprompt": {"on_schema_mismatch": "reject"}}
         agent = {"agent_type": "my_tool", "name": "my_tool"}
-        result = ActionExpander._create_agent_from_action(
-            action, self._DEFAULTS, agent, lambda x: x
-        )
-        assert result["reprompt"] == {"on_schema_mismatch": "reject"}
+        with pytest.raises(ConfigValidationError, match="reprompt"):
+            ActionExpander._create_agent_from_action(action, self._DEFAULTS, agent, lambda x: x)
+
+    def test_hitl_explicit_reprompt_raises(self):
+        from agent_actions.errors import ConfigValidationError
+
+        action = {
+            "name": "review",
+            "kind": "hitl",
+            "hitl": {"instructions": "Review the batch"},
+            "reprompt": {"on_schema_mismatch": "reprompt"},
+        }
+        agent = {"agent_type": "review", "name": "review"}
+        with pytest.raises(ConfigValidationError, match="reprompt"):
+            ActionExpander._create_agent_from_action(action, self._DEFAULTS, agent, lambda x: x)
 
 
 class TestVendorCompatibilityValidatorRunModeCoercion:


### PR DESCRIPTION
## Summary

Deterministic `kind: tool` (and `kind: hitl`) actions must not participate in the LLM reprompt loop, and empty tool output must route via `on_empty` instead of crashing. This PR lands the original fix plus three follow-ups surfaced by real workflow runs.

### Original (586)
- `InvocationStrategyFactory` no longer wires a `RepromptService`/`SchemaValidator` for `kind: tool` — re-running a deterministic UDF on the same input can't change the outcome, so reprompt is inert.

### P1 — reprompt precedence for tool/hitl
`defaults.reprompt` was inherited by **every** action, including tools/hitl, firing a per-record "reprompt is inert for tools" coercion warning (25× for a 25-record action). `_create_agent_from_action` now strips **inherited** reprompt for tool/hitl.

### P2 — empty output routes via `on_empty`, never schema-reject
A tool that legitimately returned **empty** output (`[]`) raised a hard `SchemaValidationError` mid-pipeline instead of reaching its `on_empty` policy. `_validate_llm_output_schema` now exempts empty output (`None`/`{}`/`[]`/list-of-empty-dicts) for **all** action types; genuinely-wrong **non-empty** output still hard-fails in reject mode. `_is_empty_output` moved from the online strategy down into the shared processing helpers (correct import direction; no re-export shim).

### P3 — explicit reprompt on tool/hitl is a config error (fail fast)
An **explicit** `reprompt` block on a `kind: tool` or `kind: hitl` action was silently accepted (coerced at runtime) instead of rejected. It now raises `ConfigValidationError` at expansion — before the workflow runs — mirroring the existing tool `impl`/`schema` validation. Inherited `defaults.reprompt` is still stripped (not an error); LLM actions still inherit it. The error renders the action kind by value (`tool`), not the enum repr.

## Verification
- **RED → GREEN**: full suite green — **8105 passed**, ruff + mypy clean. Each increment recorded a genuine RED first (empty+reject crash; explicit-reprompt-not-rejected; enum-repr in message).
- **New tests**: `TestRepromptPrecedenceForToolHitl` (tool + hitl stripped/rejected, LLM retains, enum-label regression); `TestEmptyOutputExemptFromSchemaReject` (empty exempt across None/`{}`/`[]`/`[{}]`, non-empty-invalid still rejects).
- **Blind review**: LOW tier, fresh-context reviewers — **YES** on both the P1/P2 and P3 diffs (bug real, discriminator correct, no shims/fallbacks/circular import, no masking).
- **Smoke**: harness canary is environmentally unprovisioned in this clone (`baseline.sh` confirms it fails on `main` too). Direct real-project smoke instead: `agac inspect -a ql_code_centered` with an explicit tool-level reprompt now **fails fast** with `tool action 'flatten_code' cannot declare 'reprompt'`; a `WorkflowInspector` expansion assertion confirms tool/hitl actions get `reprompt=False` while LLM actions retain the inherited reprompt (no false-positive).

## Out of scope
The `flatten_code` empty output in the original field run traces to upstream `code_extractor` producing no usable `candidate_code_list` (project data/prompt), not the framework. This PR ensures the framework routes that empty cleanly via `on_empty` rather than crashing.