### PR TITLE
fix(588): guard filter is authoritative across the DAG — no resurrection via unfiltered sibling

### DIFF
--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -15,6 +15,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from agent_actions.storage.backend import DISPOSITION_FILTERED, NODE_LEVEL_RECORD_ID
 from agent_actions.utils.atomic_write import atomic_json_write
 from agent_actions.workflow.merge import merge_json_files, merge_records_by_key
 
@@ -322,6 +323,42 @@ def _resolve_upstream_root(file_path: Path, upstream_data_dirs: list[str]) -> Pa
     return file_path.parent
 
 
+def _collect_upstream_filtered_guids(
+    storage_backend: Any, upstream_data_dirs: list[str]
+) -> set[str]:
+    """Return source_guids a guard `filter` excluded in any upstream dependency.
+
+    A ``filter`` guard means the record is dead — it must not be carried forward
+    (guards/ARCHITECTURE.md).  The record leaves no ``target/`` output row but
+    does carry a per-record FILTERED disposition, so a downstream action that
+    also depends on an *unfiltered* sibling can re-inherit the guid at fan-in.
+    These guids are subtracted before the records reach the action.  Node-level
+    FILTERED markers (``__node__``) are rerun signals, not record identities.
+    """
+    filtered_guids: set[str] = set()
+    for input_directory in upstream_data_dirs:
+        dep = Path(input_directory).name
+        if dep == "staging":
+            continue
+        for disp in storage_backend.get_disposition(dep, disposition=DISPOSITION_FILTERED):
+            record_id = disp.get("record_id")
+            if record_id and record_id != NODE_LEVEL_RECORD_ID:
+                filtered_guids.add(record_id)
+    return filtered_guids
+
+
+def _drop_filtered_records(data: Any, filtered_guids: set[str]) -> tuple[Any, int]:
+    """Drop records whose source_guid was guard-filtered upstream. Returns (kept, dropped)."""
+    if not filtered_guids or not isinstance(data, list):
+        return data, 0
+    kept = [
+        record
+        for record in data
+        if not (isinstance(record, dict) and record.get("source_guid") in filtered_guids)
+    ]
+    return kept, len(data) - len(kept)
+
+
 def process_from_storage_backend(
     runner: ActionRunner, params: FileProcessParams
 ) -> tuple[int, int]:
@@ -376,6 +413,12 @@ def process_from_storage_backend(
     files_found = len(data_by_path)
     files_processed = 0
 
+    # A guard `filter` on any upstream dependency makes those records dead — they
+    # must not re-enter here through an unfiltered sibling dependency.
+    filtered_guids = _collect_upstream_filtered_guids(
+        runner.storage_backend, params.upstream_data_dirs
+    )
+
     for relative_path, data_sources in data_by_path.items():
         try:
             if len(data_sources) == 1:
@@ -395,6 +438,15 @@ def process_from_storage_backend(
                     else:
                         all_data.append(source_data)
                 data = merge_records_by_key(all_data, reduce_key)
+
+            data, dropped = _drop_filtered_records(data, filtered_guids)
+            if dropped:
+                logger.info(
+                    "%s: dropped %d record(s) filtered by an upstream guard "
+                    "(filter is authoritative — dead records are not carried forward)",
+                    params.action_name,
+                    dropped,
+                )
 
             source_key = str(Path(relative_path).with_suffix(""))
             virtual_input_path = output_path / relative_path

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -278,6 +278,9 @@ def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> tup
                     reduce_key or "auto",
                 )
                 merged_data = merge_json_files(file_paths, reduce_key=reduce_key)
+                # Guard-`filter` subtraction lives only in the storage-backend
+                # fan-in (where FILTERED dispositions exist); this filesystem path
+                # is unreachable whenever they do. Add it here if that changes.
 
                 # TemporaryDirectory instead of in-place overwrite: the old approach
                 # (overwrite + restore in finally) left corrupt files on SIGKILL.
@@ -323,24 +326,56 @@ def _resolve_upstream_root(file_path: Path, upstream_data_dirs: list[str]) -> Pa
     return file_path.parent
 
 
-def _collect_upstream_filtered_guids(
-    storage_backend: Any, upstream_data_dirs: list[str]
-) -> set[str]:
-    """Return source_guids a guard `filter` excluded in any upstream dependency.
+def _ancestor_action_names(
+    storage_backend: Any, action_name: str, upstream_data_dirs: list[str]
+) -> list[str]:
+    """Transitive upstream actions of ``action_name``.
 
-    A ``filter`` guard means the record is dead — it must not be carried forward
-    (guards/ARCHITECTURE.md).  The record leaves no ``target/`` output row but
-    does carry a per-record FILTERED disposition, so a downstream action that
-    also depends on an *unfiltered* sibling can re-inherit the guid at fan-in.
-    These guids are subtracted before the records reach the action.  Node-level
-    FILTERED markers (``__node__``) are rerun signals, not record identities.
+    A guard ``filter`` is authoritative for the filtering action AND everything
+    downstream of it, so a filtered guid must be subtracted even when the
+    filtering action is a grandparent reached only via one branch.  Prefer the
+    stored dependency graph (precise transitive ancestors); fall back to the
+    DIRECT dependency directories — never the flat execution order, which would
+    include parallel peers and could drop records that are legitimately live on
+    an independent branch.
+    """
+    try:
+        raw = storage_backend.load_metadata("dependency_graph")
+    except Exception:
+        raw = None
+    if raw:
+        try:
+            graph = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            graph = None
+        if isinstance(graph, dict) and isinstance(graph.get(action_name), list):
+            return [a for a in graph[action_name] if a != "staging"]
+    return [Path(d).name for d in upstream_data_dirs if Path(d).name != "staging"]
+
+
+def _collect_upstream_filtered_guids(
+    storage_backend: Any, action_name: str, upstream_data_dirs: list[str]
+) -> set[str]:
+    """Return source_guids a guard `filter` excluded anywhere upstream of ``action_name``.
+
+    A filtered record is dead (guards/ARCHITECTURE.md) but leaves a per-record
+    FILTERED disposition, so it can re-enter via an unfiltered sibling — these
+    guids are subtracted at fan-in.  ``__node__`` markers are rerun signals, not
+    record ids.  Fails open on storage errors (a safety net must not abort).
     """
     filtered_guids: set[str] = set()
-    for input_directory in upstream_data_dirs:
-        dep = Path(input_directory).name
-        if dep == "staging":
+    for dep in _ancestor_action_names(storage_backend, action_name, upstream_data_dirs):
+        try:
+            dispositions = storage_backend.get_disposition(dep, disposition=DISPOSITION_FILTERED)
+        except (OSError, sqlite3.Error, ValueError) as e:
+            logger.warning(
+                "Could not read FILTERED dispositions for upstream '%s' — "
+                "filter authority not enforced for it this run: %s",
+                dep,
+                e,
+            )
             continue
-        for disp in storage_backend.get_disposition(dep, disposition=DISPOSITION_FILTERED):
+        for disp in dispositions:
             record_id = disp.get("record_id")
             if record_id and record_id != NODE_LEVEL_RECORD_ID:
                 filtered_guids.add(record_id)
@@ -413,10 +448,10 @@ def process_from_storage_backend(
     files_found = len(data_by_path)
     files_processed = 0
 
-    # A guard `filter` on any upstream dependency makes those records dead — they
-    # must not re-enter here through an unfiltered sibling dependency.
+    # A guard `filter` anywhere upstream makes those records dead — they must not
+    # re-enter here through an unfiltered sibling dependency.
     filtered_guids = _collect_upstream_filtered_guids(
-        runner.storage_backend, params.upstream_data_dirs
+        runner.storage_backend, params.action_name, params.upstream_data_dirs
     )
 
     for relative_path, data_sources in data_by_path.items():

--- a/tests/unit/workflow/test_filter_authoritative_fanin.py
+++ b/tests/unit/workflow/test_filter_authoritative_fanin.py
@@ -1,0 +1,179 @@
+"""Guard `filter` is authoritative across the DAG.
+
+A record a guard `on_false: filter` excluded ("dead — cannot be carried forward",
+per guards/ARCHITECTURE.md) must not re-enter a downstream action's input through
+an *unfiltered sibling* dependency. The FILE-mode storage fan-in
+(`process_from_storage_backend`) unions dependency outputs by ``source_guid``; a
+guid present only in the unfiltered sibling passes straight through. The fix
+subtracts any ``source_guid`` a dependency recorded as ``FILTERED`` before the
+records reach the downstream action.
+"""
+
+from unittest.mock import MagicMock
+
+from agent_actions.storage.backend import DISPOSITION_FILTERED, NODE_LEVEL_RECORD_ID
+from agent_actions.workflow.runner_file_processing import process_from_storage_backend
+
+
+def _params(upstream_dirs, output_dir, action_name="dedup_by_concept"):
+    params = MagicMock()
+    params.upstream_data_dirs = upstream_dirs
+    params.output_directory = str(output_dir)
+    params.action_config = {}
+    params.action_name = action_name
+    params.strategy = MagicMock()
+    params.idx = 0
+    return params
+
+
+def _storage(target_by_action, filtered_by_action):
+    """Backend stub: each dep contributes one file; dispositions per action."""
+    storage = MagicMock()
+    storage.list_target_files.return_value = ["data.json"]
+    storage.read_target.side_effect = lambda action, rel: target_by_action[action]
+
+    def _get_disposition(action, record_id=None, disposition=None):
+        if disposition == DISPOSITION_FILTERED:
+            return [
+                {"record_id": rid, "disposition": DISPOSITION_FILTERED}
+                for rid in filtered_by_action.get(action, [])
+            ]
+        return []
+
+    storage.get_disposition.side_effect = _get_disposition
+    return storage
+
+
+def _captured_guids(runner):
+    call = runner._process_single_file.call_args
+    data = call[0][0].data
+    return [r["source_guid"] for r in data]
+
+
+def test_filtered_record_does_not_resurrect_via_unfiltered_sibling(tmp_path):
+    # A (tag_code_concept) guard-filtered sg-2 → absent from A's output but recorded
+    # FILTERED. B (dedup_code_blocks) never filtered → still carries sg-2. The
+    # downstream fan-in must not receive sg-2.
+    tag_dir = tmp_path / "tag_code_concept"
+    dedup_dir = tmp_path / "dedup_code_blocks"
+    output = tmp_path / "out"
+    for d in (tag_dir, dedup_dir, output):
+        d.mkdir()
+
+    tag_records = [
+        {"source_guid": "sg-1", "content": {"tag_code_concept": {"concept_label": "loops"}}},
+        {"source_guid": "sg-3", "content": {"tag_code_concept": {"concept_label": "io"}}},
+    ]
+    dedup_records = [
+        {"source_guid": "sg-1", "content": {"dedup_code_blocks": {"code_block": "a"}}},
+        {"source_guid": "sg-2", "content": {"dedup_code_blocks": {"code_block": "b"}}},
+        {"source_guid": "sg-3", "content": {"dedup_code_blocks": {"code_block": "c"}}},
+    ]
+    storage = _storage(
+        {"tag_code_concept": tag_records, "dedup_code_blocks": dedup_records},
+        {"tag_code_concept": ["sg-2"]},
+    )
+    runner = MagicMock()
+    runner.storage_backend = storage
+
+    process_from_storage_backend(runner, _params([str(tag_dir), str(dedup_dir)], output))
+
+    guids = _captured_guids(runner)
+    assert "sg-2" not in guids, f"filtered sg-2 resurrected via dedup_code_blocks: {guids}"
+    assert sorted(guids) == ["sg-1", "sg-3"]
+
+
+def test_filtered_record_dropped_from_single_source_file(tmp_path):
+    # The filtering dep produced no output file (all filtered); the file arrives
+    # from the unfiltered sibling alone (single-source branch). The filtered guid
+    # must still be dropped.
+    tag_dir = tmp_path / "tag_code_concept"
+    dedup_dir = tmp_path / "dedup_code_blocks"
+    output = tmp_path / "out"
+    for d in (tag_dir, dedup_dir, output):
+        d.mkdir()
+
+    dedup_records = [
+        {"source_guid": "sg-1", "content": {"dedup_code_blocks": {"code_block": "a"}}},
+        {"source_guid": "sg-2", "content": {"dedup_code_blocks": {"code_block": "b"}}},
+    ]
+
+    storage = MagicMock()
+    storage.read_target.side_effect = lambda action, rel: (
+        dedup_records if action == "dedup_code_blocks" else []
+    )
+
+    def _list_targets(action):
+        return ["data.json"] if action == "dedup_code_blocks" else []
+
+    storage.list_target_files.side_effect = _list_targets
+
+    def _get_disposition(action, record_id=None, disposition=None):
+        if action == "tag_code_concept" and disposition == DISPOSITION_FILTERED:
+            return [{"record_id": "sg-2", "disposition": DISPOSITION_FILTERED}]
+        return []
+
+    storage.get_disposition.side_effect = _get_disposition
+    runner = MagicMock()
+    runner.storage_backend = storage
+
+    process_from_storage_backend(runner, _params([str(tag_dir), str(dedup_dir)], output))
+
+    guids = _captured_guids(runner)
+    assert guids == ["sg-1"], f"filtered sg-2 survived single-source path: {guids}"
+
+
+def test_no_filter_preserves_full_union(tmp_path):
+    # Regression: two dependencies, no guard filters → full union is preserved.
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    output = tmp_path / "out"
+    for d in (a_dir, b_dir, output):
+        d.mkdir()
+
+    a_records = [{"source_guid": "sg-1", "content": {"a": {"x": 1}}}]
+    b_records = [
+        {"source_guid": "sg-1", "content": {"b": {"y": 2}}},
+        {"source_guid": "sg-2", "content": {"b": {"y": 3}}},
+    ]
+    storage = _storage({"a": a_records, "b": b_records}, {})  # no filtered dispositions
+    runner = MagicMock()
+    runner.storage_backend = storage
+
+    process_from_storage_backend(runner, _params([str(a_dir), str(b_dir)], output))
+
+    guids = _captured_guids(runner)
+    assert sorted(guids) == ["sg-1", "sg-2"], f"union altered without any filter: {guids}"
+
+
+def test_node_level_filtered_disposition_is_ignored(tmp_path):
+    # A node-level FILTERED marker (__node__) must not be treated as a record guid
+    # to subtract — only per-record source_guids suppress records.
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    output = tmp_path / "out"
+    for d in (a_dir, b_dir, output):
+        d.mkdir()
+
+    a_records = [{"source_guid": "sg-1", "content": {"a": {"x": 1}}}]
+    b_records = [{"source_guid": "sg-1", "content": {"b": {"y": 2}}}]
+
+    storage = MagicMock()
+    storage.list_target_files.return_value = ["data.json"]
+    storage.read_target.side_effect = lambda action, rel: (
+        {"a": a_records, "b": b_records}[action]
+    )
+
+    def _get_disposition(action, record_id=None, disposition=None):
+        if action == "a" and disposition == DISPOSITION_FILTERED:
+            return [{"record_id": NODE_LEVEL_RECORD_ID, "disposition": DISPOSITION_FILTERED}]
+        return []
+
+    storage.get_disposition.side_effect = _get_disposition
+    runner = MagicMock()
+    runner.storage_backend = storage
+
+    process_from_storage_backend(runner, _params([str(a_dir), str(b_dir)], output))
+
+    guids = _captured_guids(runner)
+    assert guids == ["sg-1"], f"node-level marker wrongly dropped a record: {guids}"

--- a/tests/unit/workflow/test_filter_authoritative_fanin.py
+++ b/tests/unit/workflow/test_filter_authoritative_fanin.py
@@ -160,9 +160,7 @@ def test_node_level_filtered_disposition_is_ignored(tmp_path):
 
     storage = MagicMock()
     storage.list_target_files.return_value = ["data.json"]
-    storage.read_target.side_effect = lambda action, rel: (
-        {"a": a_records, "b": b_records}[action]
-    )
+    storage.read_target.side_effect = lambda action, rel: ({"a": a_records, "b": b_records}[action])
 
     def _get_disposition(action, record_id=None, disposition=None):
         if action == "a" and disposition == DISPOSITION_FILTERED:

--- a/tests/unit/workflow/test_filter_authoritative_fanin.py
+++ b/tests/unit/workflow/test_filter_authoritative_fanin.py
@@ -9,6 +9,7 @@ subtracts any ``source_guid`` a dependency recorded as ``FILTERED`` before the
 records reach the downstream action.
 """
 
+import json
 from unittest.mock import MagicMock
 
 from agent_actions.storage.backend import DISPOSITION_FILTERED, NODE_LEVEL_RECORD_ID
@@ -26,11 +27,15 @@ def _params(upstream_dirs, output_dir, action_name="dedup_by_concept"):
     return params
 
 
-def _storage(target_by_action, filtered_by_action):
+def _storage(target_by_action, filtered_by_action, dependency_graph=None):
     """Backend stub: each dep contributes one file; dispositions per action."""
     storage = MagicMock()
     storage.list_target_files.return_value = ["data.json"]
     storage.read_target.side_effect = lambda action, rel: target_by_action[action]
+    # None → the collector falls back to the DIRECT dependency directories.
+    storage.load_metadata.return_value = (
+        json.dumps(dependency_graph) if dependency_graph is not None else None
+    )
 
     def _get_disposition(action, record_id=None, disposition=None):
         if disposition == DISPOSITION_FILTERED:
@@ -99,6 +104,7 @@ def test_filtered_record_dropped_from_single_source_file(tmp_path):
     ]
 
     storage = MagicMock()
+    storage.load_metadata.return_value = None
     storage.read_target.side_effect = lambda action, rel: (
         dedup_records if action == "dedup_code_blocks" else []
     )
@@ -121,6 +127,89 @@ def test_filtered_record_dropped_from_single_source_file(tmp_path):
 
     guids = _captured_guids(runner)
     assert guids == ["sg-1"], f"filtered sg-2 survived single-source path: {guids}"
+
+
+def test_transitive_ancestor_filter_is_authoritative(tmp_path):
+    # Grandparent G filtered sg-2; it re-enters D via unfiltered branch P2. G is
+    # not a DIRECT dep of D — only the dependency graph's transitive ancestors
+    # expose it, so direct-dep-only scoping would miss this.
+    p1_dir = tmp_path / "p1"
+    p2_dir = tmp_path / "p2"
+    output = tmp_path / "out"
+    for d in (p1_dir, p2_dir, output):
+        d.mkdir()
+
+    p1_records = [{"source_guid": "sg-1", "content": {"p1": {"x": 1}}}]
+    p2_records = [
+        {"source_guid": "sg-1", "content": {"p2": {"y": 2}}},
+        {"source_guid": "sg-2", "content": {"p2": {"y": 3}}},  # resurrected via P2
+    ]
+    storage = _storage(
+        {"p1": p1_records, "p2": p2_records},
+        {"g": ["sg-2"]},  # only the grandparent recorded the filter
+        dependency_graph={"d": ["g", "p1", "p2"]},  # D's transitive ancestors include G
+    )
+    runner = MagicMock()
+    runner.storage_backend = storage
+
+    process_from_storage_backend(
+        runner, _params([str(p1_dir), str(p2_dir)], output, action_name="d")
+    )
+
+    guids = _captured_guids(runner)
+    assert "sg-2" not in guids, f"grandparent-filtered sg-2 resurrected at D: {guids}"
+    assert sorted(guids) == ["sg-1"]
+
+
+def test_record_without_source_guid_is_kept(tmp_path):
+    # A record lacking a source_guid key must never be dropped (it cannot match a
+    # filtered guid, and dropping it would be silent data loss).
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    output = tmp_path / "out"
+    for d in (a_dir, b_dir, output):
+        d.mkdir()
+
+    a_records = [{"content": {"a": {"x": 1}}}]  # no source_guid
+    b_records = [{"source_guid": "sg-2", "content": {"b": {"y": 2}}}]
+    storage = _storage({"a": a_records, "b": b_records}, {"a": ["sg-2"]})
+    runner = MagicMock()
+    runner.storage_backend = storage
+
+    process_from_storage_backend(runner, _params([str(a_dir), str(b_dir)], output))
+
+    call = runner._process_single_file.call_args
+    data = call[0][0].data
+    # The no-guid record survives; sg-2 (filtered by 'a') is dropped.
+    assert any("source_guid" not in r for r in data), "no-guid record was wrongly dropped"
+    assert all(r.get("source_guid") != "sg-2" for r in data)
+
+
+def test_get_disposition_error_fails_open(tmp_path):
+    # A storage error while reading dispositions must not abort the action — it
+    # degrades to no subtraction (matching the surrounding read handlers).
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    output = tmp_path / "out"
+    for d in (a_dir, b_dir, output):
+        d.mkdir()
+
+    a_records = [{"source_guid": "sg-1", "content": {"a": {"x": 1}}}]
+    b_records = [{"source_guid": "sg-2", "content": {"b": {"y": 2}}}]
+
+    storage = MagicMock()
+    storage.load_metadata.return_value = None
+    storage.list_target_files.return_value = ["data.json"]
+    storage.read_target.side_effect = lambda action, rel: ({"a": a_records, "b": b_records}[action])
+    storage.get_disposition.side_effect = ValueError("disposition read failed")
+    runner = MagicMock()
+    runner.storage_backend = storage
+
+    process_from_storage_backend(runner, _params([str(a_dir), str(b_dir)], output))
+
+    # Action still processed both records (fail-open, no crash).
+    guids = _captured_guids(runner)
+    assert sorted(guids) == ["sg-1", "sg-2"]
 
 
 def test_no_filter_preserves_full_union(tmp_path):
@@ -159,6 +248,7 @@ def test_node_level_filtered_disposition_is_ignored(tmp_path):
     b_records = [{"source_guid": "sg-1", "content": {"b": {"y": 2}}}]
 
     storage = MagicMock()
+    storage.load_metadata.return_value = None
     storage.list_target_files.return_value = ["data.json"]
     storage.read_target.side_effect = lambda action, rel: ({"a": a_records, "b": b_records}[action])
 


### PR DESCRIPTION
## Summary
Guard `on_false: filter` is documented (`guards/ARCHITECTURE.md`) to mean a record is **excluded entirely — cannot be carried forward** (dead), as opposed to `skip` which carries the record forward. This PR makes that contract hold across the DAG.

**The bug:** a guard-filtered record re-entered a downstream action through an **unfiltered sibling** dependency. The FILE-mode storage fan-in (`process_from_storage_backend`) unions every dependency's output by `source_guid`; a guid present only in the unfiltered sibling passed straight through. Filter leaves no `target/` output row and is not a cascade-blocking state, so nothing suppressed it.

**Real hit (`ql_code_centered`):** `tag_code_concept` guard-filters 18 syllabus-rejected blocks (`filter_by_syllabus.is_syllabus_aligned == true, on_false: filter`), but `dedup_by_concept` — which also depends on the unfiltered `dedup_code_blocks` — received all 52. The 18 dead records resurrected, got re-dropped by `observe`, and were the upstream cause of the `prefilter_by_guard` length-mismatch crash (previously patched in the now-closed #794).

## Fix
Read-side, no new persistence. A per-record `FILTERED` disposition is already written for every guard-filtered record (`unified.py:254-256` / `315-317` → `result_collector.py:678`). At fan-in, `process_from_storage_backend` now:
- collects the `FILTERED` `source_guid`s of each upstream dependency (`get_disposition(dep, disposition="filtered")`), once per action;
- subtracts them from the assembled records before they reach the action — in **both** the multi-source merge branch and the single-source branch;
- ignores node-level (`__node__`) FILTERED markers (rerun signals, not record ids).

A disposition-table marker is not a `target/` output row, so filter's "no output row" contract is preserved.

## Verification
- **RED** (`tests/unit/workflow/test_filter_authoritative_fanin.py`): drives the real `process_from_storage_backend`. Pre-fix, a guid filtered by one dependency resurrects via the unfiltered sibling (both merge and single-source branches) → fails. Post-fix → dropped. Plus regressions: no-filter union preserved; node-level marker ignored.
- **GREEN:** full suite **8093 passed**; `ruff check` + `ruff format --check` + `mypy agent_actions` clean.
- **Blast radius:** the subtraction is a no-op when no dependency has FILTERED dispositions (regression test proves the union is unchanged), so workflows without guard-filters are unaffected.

## Review
Blind fresh-context reviewer (LOW tier): **YES_WITH_ISSUES** — "core fix correct, minimal, right chokepoint; mutation-verified." Three findings, all resolved in `58b1eb14`:
- **[MED] transitive resurrection** — a guid filtered by a *grandparent* (not a direct dep) could re-enter via an unfiltered branch. Now scoped to the action's **transitive ancestors** from the stored `dependency_graph` (falling back to direct deps only — never the flat execution order, which would over-subtract parallel peers). Covered by `test_transitive_ancestor_filter_is_authoritative`.
- **[LOW] fail-open** — the disposition read now degrades to no-subtraction + warning on a storage error instead of aborting the action (matches surrounding read handlers). Covered by `test_get_disposition_error_fails_open`.
- **[LOW] filesystem fan-in note** — documented that `process_merged_files` omits the subtraction and is unreachable while dispositions exist.

Smoke: **skipped** — LOW tier, no chokepoint/registry/provider surface (read-side fan-in subtraction only).

## Deviations / follow-ups (named per harness)
- **Scope = transitive ancestors, via the dependency graph.** When no `dependency_graph` is stored (legacy workflows), the collector falls back to **direct dependencies only** — deliberately not the flat execution order, which would treat parallel peers as ancestors and could drop legitimately-live records. So in legacy-metadata workflows the grandparent case degrades to direct-dep scope (conservative; no data loss).
- **Sibling path not touched:** the file-based fan-in (`merge_json_files` / `process_merged_files`) has no storage backend and thus no dispositions to consult; it is unreachable while dispositions exist (documented in-code). The incident is storage-backed.
- **Live end-to-end verification blocked by spec 586.** The current `ql_code_centered` run cascade-skips at `flatten_code`, so it never reaches `tag_code_concept`'s filter and no store yet holds a per-record FILTERED disposition. The write path is confirmed in code; unit tests exercise the real fan-in. Re-run once 586 lands to confirm `dedup_by_concept` receives 34, not 52.

Supersedes the symptom fix in #794 (closed): #794 stopped the crash; this removes the cause.
