### PR TITLE
fix(582): preflight warns when kind:tool UDF may not always emit a required schema field

### DIFF
--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -30,6 +30,9 @@ from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
     apply_guard_nullable_schema_fixes,
 )
 from agent_actions.validation.udf_passthrough_validator import find_passthrough_schema_risks
+from agent_actions.validation.udf_required_field_validator import (
+    find_conditional_required_field_risks,
+)
 from agent_actions.workflow.schema_service import WorkflowSchemaService
 
 logger = logging.getLogger(__name__)
@@ -119,6 +122,9 @@ class PreflightService:
         # 7. Cross-check kind:tool passthrough UDFs against strict output schemas
         self._warn_tool_passthrough_risks()
 
+        # 8. Cross-check kind:tool UDFs against their required output-schema fields
+        self._warn_tool_conditional_required_field_risks()
+
     def _collect_prompts(self) -> dict[str, str]:
         """Resolved prompt text per prompt-bearing action, keyed by action name."""
         prompts: dict[str, str] = {}
@@ -185,4 +191,45 @@ class PreflightService:
     def _warn_tool_passthrough_risks(self) -> None:
         """Warn when a kind:tool UDF passes upstream dicts through a strict schema."""
         for finding in find_passthrough_schema_risks(self._collect_tool_passthrough_inputs()):
+            logger.warning("Pre-flight: %s", finding)
+
+    def _collect_tool_required_field_inputs(self) -> dict[str, dict[str, Any]]:
+        """UDF source + compiled required list per kind:tool action.
+
+        Skipped when the UDF is unregistered, its source cannot be read, or
+        the action has no compiled ``json_output_schema`` — the runtime does
+        no output validation without one and cannot reject a missing field.
+        """
+        inputs: dict[str, dict[str, Any]] = {}
+        for name, config in self.action_configs.items():
+            if config.get("kind") != "tool":
+                continue
+            impl = config.get("model_name") or config.get("impl")
+            if not impl:
+                continue
+            schema = config.get("json_output_schema")
+            if not isinstance(schema, dict):
+                # Anthropic-tool compiled schemas are lists; not the tool path,
+                # but be defensive so the check never crashes preflight.
+                continue
+            required = schema.get("required") or []
+            if not required:
+                continue
+            try:
+                source = inspect.getsource(get_udf_metadata(impl)["function"])
+            except (FunctionNotFoundError, OSError, TypeError) as exc:
+                logger.debug("Skipping required-field check for '%s': %s", name, exc)
+                continue
+            inputs[name] = {
+                "source": source,
+                "required": list(required),
+                "additional_properties": bool(schema.get("additionalProperties", False)),
+            }
+        return inputs
+
+    def _warn_tool_conditional_required_field_risks(self) -> None:
+        """Warn when a kind:tool UDF only conditionally emits a required schema field."""
+        for finding in find_conditional_required_field_risks(
+            self._collect_tool_required_field_inputs()
+        ):
             logger.warning("Pre-flight: %s", finding)

--- a/agent_actions/validation/_MANIFEST.md
+++ b/agent_actions/validation/_MANIFEST.md
@@ -36,6 +36,8 @@ decoders to schema validators and preflight checks.
 | `schema_output_validator.py` | Module | Validates output data against JSON schemas. | `validation`, `schema` |
 | `schema_validator.py` | Module | `SchemaValidator`: validates schema files against JSON Schema meta-schema. Fires a single `ValidationStartEvent` via the base class `_prepare_validation()`; the redundant `DataValidationStartedEvent` at the top of `validate()` has been removed. | `validation` |
 | `status_validator.py` | Module | `StatusCommandArgs` definition. | `validation` |
+| `udf_passthrough_validator.py` | Module | `find_passthrough_schema_risks`: static AST scan flagging `kind:tool` UDFs that return bus-derived dicts under a strict output schema. | `validation` |
+| `udf_required_field_validator.py` | Module | `find_conditional_required_field_risks`: static AST scan flagging `kind:tool` UDFs whose required output-schema fields are only produced inside a conditional branch (post-568 required-by-default class). | `validation` |
 | `validate_udfs.py` | Module | Validates that UDFs referenced in configs exist. | `utils.udf_management`, `validation` |
 | `project_validator.py` | Module | `ProjectValidator` for project name, directory, and template validation. | `validation` |
 | `run_validator.py` | Module | `RunCommandArgs` pydantic model and pre-flight gating. | `validation` |

--- a/agent_actions/validation/udf_required_field_validator.py
+++ b/agent_actions/validation/udf_required_field_validator.py
@@ -1,0 +1,165 @@
+"""Static-AST check: a kind:tool UDF must unconditionally produce every
+required output-schema field, or the runtime schema validator will reject a
+subset of records mid-run.
+
+The runtime signal we mirror is `_validate_udf_output` in
+``agent_actions/utils/udf_management/tooling.py``: `jsonschema.validate` on
+each returned item against ``json_output_schema``, which raises
+``SchemaValidationError`` when a `required` property is missing. Post-568
+every flat schema field is required by default, so a UDF that emits a field
+only when a guard passes crashes the workflow whenever the guard misses.
+
+This validator finds the shape statically. It never imports or executes the
+UDF — only its source is inspected. It errs toward silence: any construction
+shape it does not fully recognise is treated as "unknown" and produces no
+warning, so the check contributes zero false positives on tools that do emit
+their required fields unconditionally.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def _has_spread(dict_node: ast.Dict) -> bool:
+    """True if the dict literal has ``**x`` unpacking — content unknowable."""
+    return any(k is None for k in dict_node.keys)
+
+
+def _const_str_keys(dict_node: ast.Dict) -> set[str]:
+    """Constant string keys from a dict literal — spreads and dynamic keys skipped."""
+    keys: set[str] = set()
+    for k in dict_node.keys:
+        if isinstance(k, ast.Constant) and isinstance(k.value, str):
+            keys.add(k.value)
+    return keys
+
+
+def _last_return(func: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.Return | None:
+    """The tail return, chosen by source order — early guard returns must not shadow it.
+
+    ``ast.walk`` yields in BFS order, so we sort by lineno to get the tail
+    return (the return that actually determines the output shape in the happy
+    path). This mirrors how a reader thinks about a function whose top starts
+    with `if not isinstance(data, dict): return data`.
+    """
+    returns = [
+        node for node in ast.walk(func) if isinstance(node, ast.Return) and node.value is not None
+    ]
+    if not returns:
+        return None
+    return max(returns, key=lambda r: r.lineno)
+
+
+def _unconditional_output_keys(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str] | None:
+    """The constant string keys the UDF puts on its returned mapping without any guard.
+
+    Returns None when the returned shape is unrecognisable (list/scalar return,
+    a helper-call initialiser, a ``**spread`` in the returned literal, etc.).
+    None means "decline to decide" — the caller emits no warning."""
+    ret = _last_return(func)
+    if ret is None or ret.value is None:
+        return None
+    # `return {...}` — the literal's constant keys are the unconditional set.
+    if isinstance(ret.value, ast.Dict):
+        if _has_spread(ret.value):
+            return None
+        return _const_str_keys(ret.value)
+    # `return name` — walk the function's TOP-LEVEL body only. Anything nested
+    # in if/for/while/try/with is by definition conditional.
+    if not isinstance(ret.value, ast.Name):
+        return None
+    target = ret.value.id
+    keys: set[str] = set()
+    initial_found = False
+    for stmt in func.body:
+        # target = {...}
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == target
+            and isinstance(stmt.value, ast.Dict)
+        ):
+            if _has_spread(stmt.value):
+                return None
+            keys |= _const_str_keys(stmt.value)
+            initial_found = True
+            continue
+        # target["k"] = ...
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Subscript)
+            and isinstance(stmt.targets[0].value, ast.Name)
+            and stmt.targets[0].value.id == target
+            and isinstance(stmt.targets[0].slice, ast.Constant)
+            and isinstance(stmt.targets[0].slice.value, str)
+        ):
+            keys.add(stmt.targets[0].slice.value)
+            continue
+        # target.update({...})
+        if (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Call)
+            and isinstance(stmt.value.func, ast.Attribute)
+            and stmt.value.func.attr == "update"
+            and isinstance(stmt.value.func.value, ast.Name)
+            and stmt.value.func.value.id == target
+            and stmt.value.args
+            and isinstance(stmt.value.args[0], ast.Dict)
+        ):
+            if _has_spread(stmt.value.args[0]):
+                return None
+            keys |= _const_str_keys(stmt.value.args[0])
+            continue
+    if not initial_found:
+        # No dict-literal initial assignment (e.g. `result = build(data)` or
+        # `result = data.copy()`): we cannot enumerate what the helper puts
+        # in, so declining is safer than flagging every required field.
+        return None
+    return keys
+
+
+def find_conditional_required_field_risks(actions: dict[str, dict]) -> list[str]:
+    """One warning per required schema field a kind:tool UDF cannot statically be
+    shown to emit unconditionally.
+
+    Each action entry provides:
+
+    - ``source``: UDF text (as returned by ``inspect.getsource``).
+    - ``required``: the compiled ``json_output_schema.required`` list.
+    - ``additional_properties``: recorded for parity with the sibling
+      passthrough validator, but does not weaken the check — allowing extra
+      keys does not make a missing required key permissible.
+    """
+    findings: list[str] = []
+    for name, info in actions.items():
+        required = info.get("required") or []
+        source = info.get("source", "")
+        if not required or not source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        emitted: set[str] | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                emitted = _unconditional_output_keys(node)
+                break
+        if emitted is None:
+            continue
+        for field in required:
+            if field not in emitted:
+                findings.append(
+                    f"{name}: output schema requires '{field}' but the UDF does not "
+                    f"unconditionally emit it — the field is only written inside a "
+                    f"conditional / dynamic-key branch. Runtime schema validation "
+                    f"will reject any record whose branch does not fire. Add "
+                    f"`optional: true` to '{field}' in the schema, or emit it "
+                    f"unconditionally in the UDF."
+                )
+    return findings

--- a/agent_actions/validation/udf_required_field_validator.py
+++ b/agent_actions/validation/udf_required_field_validator.py
@@ -1,24 +1,12 @@
-"""Static-AST check: a kind:tool UDF must unconditionally produce every
-required output-schema field, or the runtime schema validator will reject a
-subset of records mid-run.
-
-The runtime signal we mirror is `_validate_udf_output` in
-``agent_actions/utils/udf_management/tooling.py``: `jsonschema.validate` on
-each returned item against ``json_output_schema``, which raises
-``SchemaValidationError`` when a `required` property is missing. Post-568
-every flat schema field is required by default, so a UDF that emits a field
-only when a guard passes crashes the workflow whenever the guard misses.
-
-This validator finds the shape statically. It never imports or executes the
-UDF — only its source is inspected. It errs toward silence: any construction
-shape it does not fully recognise is treated as "unknown" and produces no
-warning, so the check contributes zero false positives on tools that do emit
-their required fields unconditionally.
-"""
+"""Static-AST check: a kind:tool UDF must unconditionally emit every required
+output-schema field, or `_validate_udf_output` crashes mid-run whenever a
+guard misses. Errs toward silence — unrecognised construction shapes yield
+no warning, so unconditionally-emitting tools stay clean."""
 
 from __future__ import annotations
 
 import ast
+from collections.abc import Iterator
 
 
 def _has_spread(dict_node: ast.Dict) -> bool:
@@ -35,17 +23,26 @@ def _const_str_keys(dict_node: ast.Dict) -> set[str]:
     return keys
 
 
-def _last_return(func: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.Return | None:
-    """The tail return, chosen by source order — early guard returns must not shadow it.
+def _iter_own_returns(func: ast.FunctionDef | ast.AsyncFunctionDef) -> Iterator[ast.Return]:
+    """Yield every ``Return`` belonging to ``func`` — never one from a nested function.
 
-    ``ast.walk`` yields in BFS order, so we sort by lineno to get the tail
-    return (the return that actually determines the output shape in the happy
-    path). This mirrors how a reader thinks about a function whose top starts
-    with `if not isinstance(data, dict): return data`.
+    A plain ``ast.walk`` descends into inner ``FunctionDef``/``AsyncFunctionDef``
+    / ``Lambda`` nodes and would pick their returns as candidates for the outer
+    tail return, silently misclassifying the outer's output shape.
     """
-    returns = [
-        node for node in ast.walk(func) if isinstance(node, ast.Return) and node.value is not None
-    ]
+    stack: list[ast.AST] = list(func.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        if isinstance(node, ast.Return) and node.value is not None:
+            yield node
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _last_return(func: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.Return | None:
+    """The tail return, chosen by source order — early guard returns must not shadow it."""
+    returns = list(_iter_own_returns(func))
     if not returns:
         return None
     return max(returns, key=lambda r: r.lineno)
@@ -124,16 +121,12 @@ def _unconditional_output_keys(
 
 
 def find_conditional_required_field_risks(actions: dict[str, dict]) -> list[str]:
-    """One warning per required schema field a kind:tool UDF cannot statically be
-    shown to emit unconditionally.
+    """One warning per required schema field a kind:tool UDF cannot statically
+    be shown to emit unconditionally.
 
-    Each action entry provides:
-
-    - ``source``: UDF text (as returned by ``inspect.getsource``).
-    - ``required``: the compiled ``json_output_schema.required`` list.
-    - ``additional_properties``: recorded for parity with the sibling
-      passthrough validator, but does not weaken the check — allowing extra
-      keys does not make a missing required key permissible.
+    ``additional_properties`` is accepted for call-site parity with the sibling
+    passthrough validator but does not weaken the check — extra keys allowed
+    does not make a missing required key permissible.
     """
     findings: list[str] = []
     for name, info in actions.items():

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -43,3 +43,11 @@ and either dismiss the reviewer or bounce the diff.
 the doc-parity gap Lens B named. Record `YES_WITH_ISSUES` after addressing, not `NO`, when
 the body is affirmative. Do NOT rerun another reviewer round to "confirm" — that's just
 laundering a soft finding into a stronger vote and burns tokens for no signal.
+
+## 582 — a static "was this key definitely set" scan must skip nested function bodies
+
+**Failure mode:** `_last_return` used `ast.walk(func)` to pick the tail return by lineno. `ast.walk` descends into every child node — including nested `FunctionDef` / `AsyncFunctionDef` / `Lambda` bodies inside the outer function. A helper defined below the outer's tail return (dead code, but valid syntax) provides a return at a higher lineno and gets picked as the outer's tail. If that inner return happens to be a dict literal containing a field the outer only conditionally emits, the field is silently exonerated — the whole detector misses the exact class of bug it exists to catch. A blind correctness reviewer flagged it before merge; unit tests missed it because they were all single-function fixtures.
+
+**Detection signal:** the reviewer traced `_last_return` line by line and asked "does `ast.walk` distinguish between the outer function's returns and a nested helper's returns?" — a direct question about the traversal contract, not something a happy-path unit test surfaces.
+
+**Prevention rule:** when a static-AST check reasons about a function's OWN control flow (returns, top-level statements, "what runs unconditionally"), never use `ast.walk` on the function node — write a bounded walker that starts from `func.body` and stops descending at nested `FunctionDef` / `AsyncFunctionDef` / `Lambda` nodes. Add a regression fixture with a nested helper defined after the outer's tail return; it costs one paragraph and closes the pathological hole a reviewer will otherwise ask about.

--- a/tests/validation/test_udf_required_field_validator.py
+++ b/tests/validation/test_udf_required_field_validator.py
@@ -99,6 +99,19 @@ _SUBSCRIPT_INSIDE_IF = (
     "    return result\n"
 )
 
+# A NESTED helper whose return sits below the outer function's tail return must
+# not be picked as the outer's tail — the outer's conditional-only field would
+# be silently exonerated by the inner's unrelated dict literal otherwise.
+_NESTED_HELPER_AFTER_TAIL_RETURN = (
+    "def build(data):\n"
+    "    result = {'options': []}\n"
+    "    if 'source_quote' in data:\n"
+    "        result['source_quote'] = data['source_quote']\n"
+    "    def _tail_helper():\n"
+    "        return {'source_quote': None}\n"
+    "    return result\n"
+)
+
 
 def _risks(source, required, additional_properties=True):
     return find_conditional_required_field_risks(
@@ -162,6 +175,12 @@ def test_subscript_assign_inside_if_is_not_credited():
     findings = _risks(_SUBSCRIPT_INSIDE_IF, ["options", "answer"])
     assert len(findings) == 1
     assert "answer" in findings[0]
+
+
+def test_nested_helper_return_does_not_shadow_outer_tail():
+    findings = _risks(_NESTED_HELPER_AFTER_TAIL_RETURN, ["options", "source_quote"])
+    assert len(findings) == 1
+    assert "source_quote" in findings[0]
 
 
 def test_additional_properties_true_does_not_suppress_required_check():

--- a/tests/validation/test_udf_required_field_validator.py
+++ b/tests/validation/test_udf_required_field_validator.py
@@ -1,0 +1,212 @@
+"""Unit tests for the conditional-required-field detector.
+
+The validator's contract: given the UDF source + the schema's compiled
+required list + a boolean for additionalProperties, return one warning per
+required field the UDF cannot statically be shown to emit unconditionally.
+"""
+
+from agent_actions.validation.udf_required_field_validator import (
+    find_conditional_required_field_risks,
+)
+
+# The qanalabs reproducer, shrunk: `options`, `answer`, `answer_text` land in
+# the initial dict literal (unconditional), then `source_quote` and `question`
+# are guarded by `if field in flat`.
+_APPLY_EDITED_DISTRACTORS = (
+    "def apply_edited_distractors(data):\n"
+    "    flat = {}\n"
+    "    for key, value in data.items():\n"
+    "        if isinstance(value, dict):\n"
+    "            flat.update(value)\n"
+    "        else:\n"
+    "            flat[key] = value\n"
+    "    result = {\n"
+    "        'options': flat.get('options', []),\n"
+    "        'answer': flat.get('answer', []),\n"
+    "        'answer_text': flat.get('answer_text', []),\n"
+    "    }\n"
+    "    for field in ('source_quote', 'question'):\n"
+    "        if field in flat:\n"
+    "            result[field] = flat[field]\n"
+    "    return result\n"
+)
+
+_UNCONDITIONAL_DICT_LITERAL = (
+    "def build(data):\n    return {'options': [], 'answer': [], 'answer_text': []}\n"
+)
+
+_UNCONDITIONAL_VIA_NAME = (
+    "def build(data):\n"
+    "    result = {'options': [], 'answer': [], 'answer_text': []}\n"
+    "    return result\n"
+)
+
+# Written unconditionally at function top level, just after the initial literal.
+_TOP_LEVEL_SUBSCRIPT_ASSIGN = (
+    "def build(data):\n    result = {'options': []}\n    result['answer'] = []\n    return result\n"
+)
+
+_TOP_LEVEL_UPDATE_LITERAL = (
+    "def build(data):\n"
+    "    result = {'options': []}\n"
+    "    result.update({'answer': []})\n"
+    "    return result\n"
+)
+
+# `source_quote` only ever written inside a for-loop conditional — the runtime
+# will crash whenever the guard misses.
+_CONDITIONAL_ONLY = (
+    "def build(data):\n"
+    "    result = {'options': []}\n"
+    "    for field in ('source_quote',):\n"
+    "        if field in data:\n"
+    "            result[field] = data[field]\n"
+    "    return result\n"
+)
+
+# Name initialised via a helper call, not a dict literal — the helper is
+# opaque, so declining to decide is safer than flagging every field.
+_HELPER_INITIALISATION = "def build(data):\n    result = build_from(data)\n    return result\n"
+
+# `**spread` means the returned literal contains unknown extra keys — skip.
+_SPREAD_LITERAL = "def build(data):\n    return {**data, 'options': []}\n"
+
+# Early guard return (`return data` on wrong type) must not shadow the tail return.
+_EARLY_GUARD_RETURN = (
+    "def build(data):\n"
+    "    if not isinstance(data, dict):\n"
+    "        return data\n"
+    "    result = {'options': [], 'answer': []}\n"
+    "    return result\n"
+)
+
+# List-emitting FILE-mode UDF — not our shape; skip.
+_LIST_RETURN = (
+    "def flatten(data):\n"
+    "    out = []\n"
+    "    for x in data.get('items', []):\n"
+    "        out.append(x)\n"
+    "    return out\n"
+)
+
+# A subscript assign INSIDE an `if` block is not top-level — must not be
+# credited toward the unconditional set.
+_SUBSCRIPT_INSIDE_IF = (
+    "def build(data):\n"
+    "    result = {'options': []}\n"
+    "    if data.get('flag'):\n"
+    "        result['answer'] = []\n"
+    "    return result\n"
+)
+
+
+def _risks(source, required, additional_properties=True):
+    return find_conditional_required_field_risks(
+        {
+            "f": {
+                "source": source,
+                "required": required,
+                "additional_properties": additional_properties,
+            }
+        }
+    )
+
+
+def test_conditional_required_field_is_flagged():
+    findings = _risks(_APPLY_EDITED_DISTRACTORS, ["options", "answer", "source_quote"])
+    assert len(findings) == 1
+    only = findings[0]
+    assert "f" in only
+    assert "source_quote" in only
+
+
+def test_unconditional_dict_literal_return_is_not_flagged():
+    assert _risks(_UNCONDITIONAL_DICT_LITERAL, ["options", "answer", "answer_text"]) == []
+
+
+def test_unconditional_via_name_is_not_flagged():
+    assert _risks(_UNCONDITIONAL_VIA_NAME, ["options", "answer", "answer_text"]) == []
+
+
+def test_top_level_subscript_assign_is_not_flagged():
+    assert _risks(_TOP_LEVEL_SUBSCRIPT_ASSIGN, ["options", "answer"]) == []
+
+
+def test_top_level_update_literal_is_not_flagged():
+    assert _risks(_TOP_LEVEL_UPDATE_LITERAL, ["options", "answer"]) == []
+
+
+def test_conditional_only_field_is_flagged():
+    findings = _risks(_CONDITIONAL_ONLY, ["options", "source_quote"])
+    assert len(findings) == 1
+    assert "source_quote" in findings[0]
+
+
+def test_helper_initialisation_is_not_flagged():
+    assert _risks(_HELPER_INITIALISATION, ["options", "answer"]) == []
+
+
+def test_spread_literal_is_not_flagged():
+    assert _risks(_SPREAD_LITERAL, ["options", "answer"]) == []
+
+
+def test_early_guard_return_does_not_shadow_tail_return():
+    assert _risks(_EARLY_GUARD_RETURN, ["options", "answer"]) == []
+
+
+def test_list_return_is_not_flagged():
+    assert _risks(_LIST_RETURN, ["items"]) == []
+
+
+def test_subscript_assign_inside_if_is_not_credited():
+    findings = _risks(_SUBSCRIPT_INSIDE_IF, ["options", "answer"])
+    assert len(findings) == 1
+    assert "answer" in findings[0]
+
+
+def test_additional_properties_true_does_not_suppress_required_check():
+    # Contrast with the sibling passthrough validator: additionalProperties
+    # only allows extra keys — it does not weaken the required-fields
+    # constraint, so the check must still fire.
+    findings = _risks(_CONDITIONAL_ONLY, ["source_quote"], additional_properties=True)
+    assert findings and "source_quote" in findings[0]
+
+
+def test_no_required_fields_yields_no_findings():
+    assert _risks(_APPLY_EDITED_DISTRACTORS, []) == []
+
+
+def test_missing_source_is_ignored():
+    assert (
+        find_conditional_required_field_risks(
+            {"f": {"required": ["x"], "additional_properties": True}}
+        )
+        == []
+    )
+
+
+def test_syntactically_invalid_source_is_ignored():
+    assert _risks("def f(:\n    bad", ["options"]) == []
+
+
+def test_two_flagged_actions_yield_two_findings():
+    actions = {
+        "safe": {
+            "source": _UNCONDITIONAL_DICT_LITERAL,
+            "required": ["options", "answer", "answer_text"],
+            "additional_properties": False,
+        },
+        "risky_a": {
+            "source": _CONDITIONAL_ONLY,
+            "required": ["options", "source_quote"],
+            "additional_properties": False,
+        },
+        "risky_b": {
+            "source": _APPLY_EDITED_DISTRACTORS,
+            "required": ["options", "source_quote"],
+            "additional_properties": False,
+        },
+    }
+    findings = find_conditional_required_field_risks(actions)
+    flagged = {name for name in ("safe", "risky_a", "risky_b") if any(name in f for f in findings)}
+    assert flagged == {"risky_a", "risky_b"}

--- a/tests/validation/test_udf_required_field_wiring.py
+++ b/tests/validation/test_udf_required_field_wiring.py
@@ -1,0 +1,91 @@
+"""Wire-point test for the conditional-required-field preflight warning.
+
+Anchors RED on the actual behavioural failure (no preflight warning is emitted
+today for a tool UDF that only conditionally produces a required output-schema
+field) so the fix is proven end-to-end through the public `PreflightService`
+API — no new symbol is imported here."""
+
+from __future__ import annotations
+
+import logging
+
+from agent_actions.services.preflight_service import PreflightService
+
+
+# Real module-level UDF so `inspect.getsource` returns its true body: the
+# initial dict literal fixes only `options`; `source_quote` is written only
+# when a runtime guard passes — the exact shape that crashed qanalabs
+# `reconstruct_options` at 39/52 records post-568.
+def _conditional_source_quote_tool(data):
+    flat = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            flat.update(value)
+        else:
+            flat[key] = value
+    result = {"options": flat.get("options", [])}
+    if "source_quote" in flat:
+        result["source_quote"] = flat["source_quote"]
+    return result
+
+
+def _make_service(action_configs: dict) -> PreflightService:
+    return PreflightService(
+        agent_name="wf",
+        action_configs=action_configs,
+        project_root=None,
+        workflow_config_path="wf.yml",
+        verify_keys=False,
+    )
+
+
+def _capture_preflight_warnings(cfgs: dict, caplog) -> list[str]:
+    """Full `validate()` must reach the new check and stay non-fatal.
+
+    The `agent_actions` logger does not propagate by default; caplog needs it
+    on to see the warning."""
+    logger_name = "agent_actions.services.preflight_service"
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger_name):
+            _make_service(cfgs).validate()
+        return [r.getMessage() for r in caplog.records if r.name == logger_name]
+    finally:
+        aa_logger.propagate = original
+
+
+def test_preflight_warns_when_required_field_only_conditionally_emitted(caplog):
+    from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
+
+    clear_registry()
+    udf_tool(_conditional_source_quote_tool)
+    try:
+        cfgs = {
+            "reconstruct_options": {
+                "kind": "tool",
+                "impl": "_conditional_source_quote_tool",
+                "context_scope": {"observe": ["source.*"]},
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "options": {"type": "array", "items": {"type": "string"}},
+                        "source_quote": {"type": "string"},
+                    },
+                },
+                "json_output_schema": {
+                    "type": "object",
+                    "properties": {
+                        "options": {"type": "array", "items": {"type": "string"}},
+                        "source_quote": {"type": "string"},
+                    },
+                    "required": ["options", "source_quote"],
+                    "additionalProperties": True,
+                },
+            }
+        }
+        msgs = _capture_preflight_warnings(cfgs, caplog)
+        assert any("reconstruct_options" in m and "source_quote" in m for m in msgs), msgs
+    finally:
+        clear_registry()


### PR DESCRIPTION
## Summary

Post-568 (flat schema fields required-by-default), a `kind: tool` action's UDF can declare a field required in the compiled output schema but only emit it inside a conditional branch. The runtime crashes mid-pipeline (`_validate_udf_output` → `'X' is a required property`) whenever the guard misses. The qanalabs `reconstruct_options` action hit this at 39/52 records: `source_quote` was required, but `apply_edited_distractors` only writes `result['source_quote'] = flat['source_quote']` inside `if 'source_quote' in flat`.

This PR adds a static-AST preflight warning that names action + field before the run starts. Warning-only; `agac inspect` exit stays 0, consistent with the 566/567/569 preflight family.

## Design

`agent_actions/validation/udf_required_field_validator.py`:
- Bounded intra-function AST scan — never imports or executes the UDF; source only, via `inspect.getsource(function)`.
- Recognises unconditional emit shapes: `return {"k": ...}`, initial `result = {"k": ...}` dict-literal assignment, top-level `result["k"] = ...`, top-level `result.update({"k": ...})`.
- Errs toward silence — any shape it does not fully recognise (helper-call init, `**spread`, list return, mid-function reassignment) yields `None` and no warning. This preserves "0 false positives on tools that unconditionally emit their required fields" (spec's Verification bullet).
- Tail-return search stops at nested `FunctionDef`/`AsyncFunctionDef`/`Lambda` boundaries so a helper defined below the outer's return cannot shadow it.

`agent_actions/services/preflight_service.py` adds `_collect_tool_required_field_inputs` + `_warn_tool_conditional_required_field_risks`, wired as step 8 after the sibling passthrough check. Reads `json_output_schema.required` (the tool path always compiles via the `openai` dialect → dict shape).

Deviations from the spec: the spec listed `PreflightService.validate()` and/or `ValidateUDFsCommand` as wire points. `ValidateUDFsCommand` operates on raw config that has not yet been through schema compilation (no `json_output_schema.required` to compare against), so wiring landed only in `PreflightService`. `agac inspect` and `agac run` both go through `PreflightService`, matching the spec's Success metric.

## Verification story

- **Harness gates:** `gate.sh red` recorded a genuine assertion failure at the `PreflightService.validate()` wire point (no ImportError-based fake-RED). `gate.sh green` re-runs the RED test hash-checked against tampering, then full `pytest` (8136 passed), `ruff format --check`, `ruff check`, `mypy agent_actions`.
- **HIGH-tier review:** 3/3 YES from correctness / blast-radius / tests-anti-gaming blind reviewers. Correctness reviewer flagged a nested-function edge case (a helper defined below the outer's tail return would be picked as the tail via `ast.walk`); fixed in the follow-up commit with a dedicated regression test (`test_nested_helper_return_does_not_shadow_outer_tail`).
- **Smoke:** skipped — `risk.sh` reports `smoke_required=no`; the diff is preflight-only (new validator + wiring), touches no runtime/config-load surface or smoke-registry paths.
- **Real-project verification:** prototype detector run against every `@udf_tool` function in the qanalabs `tools/qanalabs-quiz-gen/` tree during development. On `apply_edited_distractors` the unconditional set is exactly `{options, answer, answer_text}` (matching the initial dict literal); every other required field is correctly flagged. On tools that emit unconditionally via a full dict literal (e.g. `assemble_question`), the emitted set covers every required field and no warning fires.

## Test plan

- [x] Assertion-level wire-point RED (`tests/validation/test_udf_required_field_wiring.py`) proves the warning behavior at the public `PreflightService.validate()` API without importing the new symbol.
- [x] Unit suite (`tests/validation/test_udf_required_field_validator.py`) — 17 cases covering: qanalabs reproducer, unconditional dict literal / via-name / top-level subscript / `.update({...})`, conditional-only, helper init, `**spread`, early guard return, list return, subscript-inside-`if`, `additionalProperties: true` does not suppress the check, no-required-fields no-op, missing source ignored, syntactically-invalid source ignored, multi-action correctness, nested-helper-does-not-shadow-outer-tail.
- [x] Full `pytest` green (8136 passed). `mypy agent_actions` clean. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)