### PR TITLE
fix(585): validate context_scope directives against the closed registry

### DIFF
--- a/agent_actions/config/types.py
+++ b/agent_actions/config/types.py
@@ -42,7 +42,7 @@ class ContextScopeDict(TypedDict, total=False):
     observe: list[str]
     passthrough: list[str]
     drop: list[str]
-    keep: list[str]
+    drops: list[str]
     seed: dict[str, Any]
 
 

--- a/agent_actions/input/context/normalizer.py
+++ b/agent_actions/input/context/normalizer.py
@@ -18,9 +18,6 @@ DIRECTIVE_REGISTRY = {
     "seed": {"type": "dict", "expand_versions": False},
 }
 
-# Directive keys that were removed, mapped to their replacement (for a loud error).
-REMOVED_DIRECTIVES = {"seed_path": "seed", "static_data": "seed"}
-
 # Namespaces users write in prompt references when they mean the 'seed' namespace.
 SEED_CONFIG_KEYS = frozenset({"seed_data", "seed_path", "static_data"})
 
@@ -53,17 +50,16 @@ def normalize_context_scope(
     expanded_scope = {}
 
     for directive_name, directive_value in context_scope.items():
-        if directive_name in REMOVED_DIRECTIVES:
-            replacement = REMOVED_DIRECTIVES[directive_name]
+        if directive_name not in DIRECTIVE_REGISTRY:
             raise ConfigurationError(
-                f"context_scope.{directive_name} is no longer a valid directive; "
-                f"it was renamed to '{replacement}'. Rename '{directive_name}:' to "
-                f"'{replacement}:' under context_scope.",
-                context={"directive": directive_name, "replacement": replacement},
+                f"context_scope.{directive_name} is not a valid directive. "
+                f"Valid directives: {', '.join(sorted(DIRECTIVE_REGISTRY))}.",
+                context={
+                    "directive": directive_name,
+                    "valid_directives": sorted(DIRECTIVE_REGISTRY),
+                },
             )
-        directive_info = DIRECTIVE_REGISTRY.get(
-            directive_name, {"type": "unknown", "expand_versions": False}
-        )
+        directive_info = DIRECTIVE_REGISTRY[directive_name]
 
         if directive_info["type"] == "list" and directive_info["expand_versions"]:
             if isinstance(directive_value, list):

--- a/agent_actions/tooling/docs/parser.py
+++ b/agent_actions/tooling/docs/parser.py
@@ -270,10 +270,6 @@ class WorkflowParser:
         if "passthrough" in context_scope and isinstance(context_scope["passthrough"], list):
             inputs.extend(context_scope["passthrough"])
 
-        # Extract from 'keep' (legacy/alternative pattern)
-        if "keep" in context_scope and isinstance(context_scope["keep"], list):
-            inputs.extend(context_scope["keep"])
-
         # Remove duplicates while preserving order
         seen = set()
         unique_inputs = []

--- a/tests/preprocessing/context/test_context_scope_normalizer.py
+++ b/tests/preprocessing/context/test_context_scope_normalizer.py
@@ -21,21 +21,28 @@ from agent_actions.input.context.normalizer import (
 
 
 class TestRemovedDirectives:
-    def test_seed_path_raises_naming_the_replacement(self):
-        """The renamed-away seed_path key raises, naming both the old key and 'seed'."""
+    """Removed names fail the SAME generic way as any other invalid directive —
+    they name the offending key and list the valid set, with no rename narrative."""
+
+    def test_seed_path_raises_generic_invalid_directive(self):
         with pytest.raises(ConfigurationError) as excinfo:
             normalize_context_scope({"seed_path": {"x": "$file:y.json"}}, {})
         msg = str(excinfo.value)
-        assert "seed_path" in msg  # names the removed key
-        assert "'seed'" in msg  # points at the replacement
+        assert "seed_path" in msg  # names the offending key
+        assert "renamed" not in msg.lower()  # no migration story
+        assert "no longer" not in msg.lower()
+        for valid in DIRECTIVE_REGISTRY:  # lists the valid set, derived from the registry
+            assert valid in msg
 
-    def test_static_data_raises_naming_the_replacement(self):
-        """The retired static_data key raises with the same guidance."""
+    def test_static_data_raises_generic_invalid_directive(self):
         with pytest.raises(ConfigurationError) as excinfo:
             normalize_context_scope({"static_data": {"x": "$file:y.json"}}, {})
         msg = str(excinfo.value)
         assert "static_data" in msg
-        assert "'seed'" in msg
+        assert "renamed" not in msg.lower()
+        assert "no longer" not in msg.lower()
+        for valid in DIRECTIVE_REGISTRY:
+            assert valid in msg
 
 
 class TestDirectiveRegistry:
@@ -127,13 +134,23 @@ class TestNormalizeContextScope:
 
         assert result["observe"] == ["regular_action.field1"]
 
-    def test_handles_unknown_directives(self):
-        context_scope = {"unknown_directive": {"foo": "bar"}}
-        version_base_map = {"loop_action": ["loop_action_1"]}
+    def test_unknown_directive_raises_not_silently_inert(self):
+        """An unrecognized directive fails loudly (was silently copied through, doing nothing)."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            normalize_context_scope({"unknown_directive": {"foo": "bar"}}, {})
+        msg = str(excinfo.value)
+        assert "unknown_directive" in msg  # names the offending key
+        for valid in DIRECTIVE_REGISTRY:  # lists the valid set
+            assert valid in msg
 
-        result = normalize_context_scope(context_scope, version_base_map)
-
-        assert result["unknown_directive"] == {"foo": "bar"}
+    def test_typo_directive_raises_naming_valid_set(self):
+        """A near-miss typo (observ) errors instead of silently scoping nothing."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            normalize_context_scope({"observ": ["source.*"]}, {})
+        msg = str(excinfo.value)
+        assert "observ" in msg
+        assert "observe" in msg  # the valid set names the intended directive
+        assert "renamed" not in msg.lower()  # generic message, no rename story
 
 
 class TestExpandListDirective:


### PR DESCRIPTION
## Summary
`normalize_context_scope` silently accepted any unrecognized `context_scope` directive: it copied the value into the normalized scope, where no downstream consumer ever reads an unknown key (consumers only read `observe`/`passthrough`/`drop`/`drops`/`seed`). So a typo like `observ:` scoped nothing and raised no error — a silent-config-typo class. A hardcoded `REMOVED_DIRECTIVES = {"seed_path": "seed", "static_data": "seed"}` map loudly caught two specific removed names with a rename-migration message, while every other typo stayed silent.

Both are replaced with **one closed-set guard**: a directive name not in `DIRECTIVE_REGISTRY` raises `ConfigurationError` naming the key and listing the valid set (derived from the registry). Typos, removed names, and unknown keys now fail the same loud, uniform way — no per-name rename narrative, nothing project-specific in the framework.

**Single authority for the valid set:** `ContextScopeDict` carried a dead `keep` (no runtime consumer, no YAML uses it as a directive — only as a field ref like `aggregate_votes.keep`) and lacked `drops`. Aligned it to the registry and removed the dead `keep` read in the docs parser.

### Design decisions
- **Message tells you what to use, not what changed.** The old rename map only ever helped the one project with unmigrated `seed_path:` configs — a backward-compat shim. Every wrong name now gets the same generic "not a valid directive. Valid directives: …" line.
- **Single-authority** reconciliation (`DIRECTIVE_REGISTRY` is the truth), not registry-only, so the type stops lying.

## Verification
- **RED**: 4 tests fail on main — 2 inverted (`test_handles_unknown_directives` asserted the silent pass-through; `TestRemovedDirectives` asserted the rename hint) + 2 new (`observ` typo, unknown key). Genuine assertion failures.
- **GREEN**: full suite **8113 passed**; `ruff` + `mypy` clean.
- **Blind review** (fresh context, diff + bug only): **YES** — root cause fixed, all five valid directives still accept, `keep` field-refs untouched, valid-set can't drift (it *is* `sorted(DIRECTIVE_REGISTRY)`), and `workflow_static_analyzer.py` already catches the `ConfigurationError` and maps it to `StaticTypeError`.
- **Real project** (`agac inspect -a ql_domc` through the actual loader, not a unit dict):
  ```
  Error: Configuration Error: Invalid configuration in agent 'ql_domc'
    Problem: context_scope.seed_path is not a valid directive. Valid directives: drop, drops, observe, passthrough, seed.
  ```
  Loud, lists the valid set, no rename story, exit 1.
- **Smoke**: skipped — `scan-project` canary divergence is pre-existing (`baseline.sh` confirms it fails on main too; stale project action registry, unrelated to directive validation). Filed as a separate follow-up.

## Notes
- **Test inversion (not test-weakening):** the 7 removed test-assert lines are the two tests that encoded the old behavior (silent pass-through + rename hint), flipped to assert the loud generic error.
- **Consequence, not a hint:** the qanalabs workflows using `seed_path:` (8+) now get the generic error — they already failed on main via the old map. Migrating them `seed_path:`→`seed:` is a separate change in the qanalabs repo; the framework carries no per-user migration text.