### PR TITLE
fix(556): gate schema-echo dicts at the persistence boundary

### DIFF
--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from agent_actions.config.defaults import StorageDefaults
 from agent_actions.record.lifecycle_read import reset_for_downstream, validate_lifecycle_batch
+from agent_actions.record.reasons import PARSE_ERROR
+from agent_actions.utils.schema_echo import is_schema_echo, make_schema_echo_error
 
 logger = logging.getLogger(__name__)
 
@@ -125,10 +127,8 @@ class StorageBackend(ABC):
         for ``make_schema_echo_error``) and gets a FAILED/PARSE_ERROR disposition so
         the failure stays queryable rather than being silently dropped.
         """
-        from agent_actions.record.reasons import PARSE_ERROR
-        from agent_actions.utils.schema_echo import is_schema_echo, make_schema_echo_error
-
         gated: list[dict[str, Any]] = []
+        failed_rows: list[DispositionRow] = []
         for record in delta_records:
             content = record.get("content")
             if not isinstance(content, dict) or action_name not in content:
@@ -152,16 +152,20 @@ class StorageBackend(ABC):
             )
 
             if source_guid:
-                try:
-                    self.set_disposition(
-                        action_name, source_guid, DISPOSITION_FAILED, reason=PARSE_ERROR
-                    )
-                except NotImplementedError:
-                    logger.warning(
-                        "[%s] Disposition write skipped for %s — backend has no set_disposition",
-                        action_name,
-                        source_guid,
-                    )
+                failed_rows.append(
+                    (action_name, source_guid, DISPOSITION_FAILED, PARSE_ERROR, None, None, None)
+                )
+
+        if failed_rows:
+            try:
+                self.set_dispositions_batch(failed_rows)
+            except NotImplementedError:
+                logger.warning(
+                    "[%s] Disposition write skipped for %d record(s) — "
+                    "backend has no set_dispositions_batch",
+                    action_name,
+                    len(failed_rows),
+                )
         return gated
 
     def write_target(

--- a/agent_actions/storage/backend.py
+++ b/agent_actions/storage/backend.py
@@ -111,6 +111,59 @@ class StorageBackend(ABC):
         """Create tables, indexes, and other infrastructure required by the backend."""
         ...
 
+    def _gate_schema_echo_deltas(
+        self,
+        action_name: str,
+        delta_records: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Replace schema-echo namespaces with a parse-error sentinel before persistence.
+
+        A namespace shaped like the compiled JSON Schema means an upstream path
+        handed us the schema instead of LLM output. The live-LLM flow catches this
+        in ``_reject_schema_echo_items``; this gate catches the resume / carry-forward
+        path that never invokes the LLM. The record keeps flowing (namespace swapped
+        for ``make_schema_echo_error``) and gets a FAILED/PARSE_ERROR disposition so
+        the failure stays queryable rather than being silently dropped.
+        """
+        from agent_actions.record.reasons import PARSE_ERROR
+        from agent_actions.utils.schema_echo import is_schema_echo, make_schema_echo_error
+
+        gated: list[dict[str, Any]] = []
+        for record in delta_records:
+            content = record.get("content")
+            if not isinstance(content, dict) or action_name not in content:
+                gated.append(record)
+                continue
+            ns_value = content[action_name]
+            if not is_schema_echo(ns_value):
+                gated.append(record)
+                continue
+
+            source_guid = record.get("source_guid")
+            logger.warning(
+                "[%s] Schema-echo in delta for source_guid=%s (keys: %s) — "
+                "replacing with parse-error sentinel",
+                action_name,
+                source_guid,
+                sorted(ns_value.keys()),
+            )
+            gated.append(
+                {**record, "content": {**content, action_name: make_schema_echo_error(ns_value)}}
+            )
+
+            if source_guid:
+                try:
+                    self.set_disposition(
+                        action_name, source_guid, DISPOSITION_FAILED, reason=PARSE_ERROR
+                    )
+                except NotImplementedError:
+                    logger.warning(
+                        "[%s] Disposition write skipped for %s — backend has no set_disposition",
+                        action_name,
+                        source_guid,
+                    )
+        return gated
+
     def write_target(
         self,
         action_name: str,
@@ -136,6 +189,10 @@ class StorageBackend(ABC):
                     delta_records.append(
                         self._extract_delta(record, action_name, is_first_action=is_first_action)
                     )
+
+        # Refuse to persist namespaces that are the compiled JSON Schema instead of
+        # LLM output — the carry-forward / resume path bypasses the live-LLM guard.
+        delta_records = self._gate_schema_echo_deltas(action_name, delta_records)
 
         if not self._format_version_written:
             self.save_metadata("storage_format_version", str(self._STORAGE_FORMAT_VERSION))

--- a/tests/unit/storage/test_schema_echo_gate.py
+++ b/tests/unit/storage/test_schema_echo_gate.py
@@ -1,0 +1,121 @@
+"""write_target refuses to persist schema-echo dicts as record namespaces.
+
+A resume / carry-forward record can reach the storage boundary with its action
+namespace set to the compiled JSON Schema (the Ollama ``format`` shape) instead
+of LLM output, bypassing the in-flight ``_reject_schema_echo_items`` guard. The
+persistence gate replaces such a namespace with the parse-error sentinel and
+records FAILED/PARSE_ERROR so the failure is queryable on the next read.
+"""
+
+import pytest
+
+from agent_actions.storage.backends.sqlite_backend import SQLiteBackend
+
+SCHEMA_ECHO = {
+    "title": "InlineSchema",
+    "type": "object",
+    "properties": {"distractor_explanation_1": {"type": "string"}},
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+def _record(source_guid, namespace_value, action="explain_distractor_1"):
+    return {
+        "_state": "processed",
+        "target_id": f"t-{source_guid}",
+        "source_guid": source_guid,
+        "content": {action: namespace_value},
+    }
+
+
+class TestSchemaEchoGate:
+    @pytest.fixture
+    def backend(self, tmp_path):
+        db_path = tmp_path / "agent_io" / "test.db"
+        b = SQLiteBackend(str(db_path), "test_workflow")
+        b.initialize()
+        yield b
+        b.close()
+
+    def test_clean_record_passes_through_unchanged(self, backend):
+        """Non-echo namespace is written verbatim — the gate is a no-op for it."""
+        clean = {"distractor_explanation_1": "the real explanation"}
+        backend.write_target("explain_distractor_1", "f.json", [_record("sg-clean", clean)])
+
+        rows = backend._read_target_raw("explain_distractor_1", "f.json")
+        assert rows[0]["content"]["explain_distractor_1"] == clean
+        assert backend.get_disposition("explain_distractor_1", record_id="sg-clean") == []
+
+    def test_schema_echo_replaced_with_parse_error_sentinel(self, backend):
+        """A namespace matching is_schema_echo is replaced before it reaches storage."""
+        backend.write_target("explain_distractor_1", "f.json", [_record("sg-echo", SCHEMA_ECHO)])
+
+        ns = backend._read_target_raw("explain_distractor_1", "f.json")[0]["content"][
+            "explain_distractor_1"
+        ]
+        assert "_parse_error" in ns  # converted to a typed failure
+        assert "raw_response" in ns  # mirrors helpers._reject_schema_echo_items
+        assert "title" not in ns and "properties" not in ns  # the schema dict is gone
+
+    def test_schema_echo_writes_failed_parse_error_disposition(self, backend):
+        """The gated record gets DISPOSITION_FAILED with reason=PARSE_ERROR."""
+        backend.write_target("explain_distractor_1", "f.json", [_record("sg-echo", SCHEMA_ECHO)])
+
+        disps = backend.get_disposition("explain_distractor_1", record_id="sg-echo")
+        assert any(d["disposition"] == "failed" and d["reason"] == "parse_error" for d in disps)
+
+    def test_schema_echo_without_source_guid_is_still_gated(self, backend):
+        """Echo namespace is replaced even with no source_guid; disposition write is skipped."""
+        rec = {"_state": "processed", "content": {"explain_distractor_1": SCHEMA_ECHO}}
+        backend.write_target("explain_distractor_1", "f.json", [rec])
+
+        ns = backend._read_target_raw("explain_distractor_1", "f.json")[0]["content"][
+            "explain_distractor_1"
+        ]
+        assert "_parse_error" in ns
+        assert backend.get_disposition("explain_distractor_1") == []  # nothing to key it on
+
+    def test_full_mode_record_without_action_namespace_is_ignored(self, backend):
+        """A record whose content lacks the action namespace passes through untouched."""
+        rec = {
+            "_state": "processed",
+            "source_guid": "sg-other",
+            "content": {"some_other_action": {"x": 1}},
+        }
+        backend.write_target("explain_distractor_1", "f.json", [rec])
+
+        rows = backend._read_target_raw("explain_distractor_1", "f.json")
+        assert rows[0]["content"] == {"some_other_action": {"x": 1}}
+        assert backend.get_disposition("explain_distractor_1", record_id="sg-other") == []
+
+    def test_echo_after_prior_success_ends_failed_parse_error(self, backend):
+        """A stale prior SUCCESS is cleared when the gate writes FAILED/PARSE_ERROR.
+
+        set_disposition deletes any prior disposition for (action, record), so the
+        record ends unambiguously failed — a downstream reader never sees the stale
+        success alongside the new failure.
+        """
+        backend.set_disposition("explain_distractor_1", "sg-echo", "success")
+        backend.write_target("explain_distractor_1", "f.json", [_record("sg-echo", SCHEMA_ECHO)])
+
+        disps = backend.get_disposition("explain_distractor_1", record_id="sg-echo")
+        kinds = {(d["disposition"], d["reason"]) for d in disps}
+        assert ("failed", "parse_error") in kinds  # the gate's disposition
+        assert ("success", None) not in kinds  # the stale success was cleared
+
+    def test_gate_fires_for_any_action_name(self, backend):
+        """The gate keys off content shape, not a hardcoded action name — a schema-echo
+        under a different action is gated identically (kills a hardcoded-name cheat)."""
+        backend.write_target(
+            "some_other_action",
+            "f.json",
+            [_record("sg-other", SCHEMA_ECHO, action="some_other_action")],
+        )
+
+        ns = backend._read_target_raw("some_other_action", "f.json")[0]["content"][
+            "some_other_action"
+        ]
+        assert "_parse_error" in ns
+        disps = backend.get_disposition("some_other_action", record_id="sg-other")
+        assert any(d["disposition"] == "failed" and d["reason"] == "parse_error" for d in disps)


### PR DESCRIPTION
## Summary
`StorageBackend.write_target` now refuses to persist a record whose action namespace is the compiled JSON Schema (the Ollama `format` shape: `{"title","type":"object","properties",...}`) instead of LLM output. A resume / carry-forward record reaches `write_target` without an LLM call, so the in-flight `_reject_schema_echo_items` guard never runs and the schema dict was written verbatim into `target_data`.

The new `_gate_schema_echo_deltas` runs after delta extraction and before `_write_target_raw`: a namespace matching `is_schema_echo` is replaced with the `make_schema_echo_error` sentinel and the record gets a `FAILED`/`PARSE_ERROR` disposition, so the failure surfaces on the next read exactly like the live-LLM parse-error path. It lives on the abstract base, so every backend inherits the invariant. Reuses `is_schema_echo` / `make_schema_echo_error` / `PARSE_ERROR` as-is — no new constants, no collector change.

## Verification
- **RED**: 5 of 7 tests fail on `main` (echo persisted verbatim, no disposition), including a varied-action-name test so a hardcoded-name gate can't pass.
- **GREEN**: full suite **8126 passed**; `ruff` + `mypy` clean.
- **Review (HIGH tier, 3 blind lenses)**:
  - *Correctness*: YES — gate at the right chokepoint (covers `force_full` + delta branches), guards mirror `_extract_delta`, replacement reaches `_write_target_raw`, `NotImplementedError` caught.
  - *Blast radius*: YES — sqlite `RLock` is re-entrant (calling `set_disposition` from inside `write_target` is deadlock-safe); every `write_target` caller checked for false-positives (none carry `title`+`type:object`+`properties`); no SUCCESS-write race.
  - *Tests/anti-gaming*: flagged that all tests used one action name → **fixed** by adding `test_gate_fires_for_any_action_name` (recorded in RED). Real SQLite round-trip, non-tautological assertions, collector untouched.
- **Smoke**: skipped — `scan-project` canary divergence is pre-existing (`baseline.sh` confirms it fails on `main` too; stale project action registry, unrelated to storage). The gate is a no-op on clean data; the real `write_target`→`_write_target_raw`→`_read_target_raw` round trip + disposition writes are covered by the 7 unit tests.

## Deviations from the spec (verify-first)
- **`set_disposition` clears priors.** The spec assumed a prior SUCCESS and the gate's FAILED would coexist (`UNIQUE(action,record,disposition)`). Current `set_disposition` (sqlite_backend.py) `DELETE`s all prior dispositions for `(action, record)` first, so the gate's FAILED **replaces** a stale SUCCESS — the record ends unambiguously failed (better). Test asserts the real behavior.
- **Test path** is `tests/unit/storage/` (spec said `tests/storage/`).
- **Real-DB before-count is now 0** (spec cited 11 rows on 2026-06-17). Those rows were cleaned since; the gate is a forward-looking invariant — RED proves `write_target` still persists a schema-echo namespace verbatim on `main`, i.e. the hole is open.

## Out of scope (follow-up)
The upstream planter that stamps `compile_unified_schema` output as record content on the resume/checkpoint path — suspect sites `processing/strategies/online_llm.py:_checkpoint_record` and `llm/batch/services/processing_recovery.py`. This gate is the safety net regardless of which path is wrong.