### PR TITLE
fix(589): reject XML first-stage with a clear error (unsupported)

### DIFF
--- a/agent_actions/input/preprocessing/staging/initial_pipeline.py
+++ b/agent_actions/input/preprocessing/staging/initial_pipeline.py
@@ -426,10 +426,8 @@ def _prepare_batch_data(ctx: DataPreparationContext):
     local_batch_id = f"batch_{uuid.uuid4().hex}"
     node_id = f"node_{ctx.idx}_{uuid.uuid4()}"
     from agent_actions.input.loaders.tabular import TabularLoader
-    from agent_actions.input.loaders.xml import XmlLoader
 
     tabular_loader = TabularLoader(ctx.agent_config, ctx.agent_name)
-    xml_loader = XmlLoader(ctx.agent_config, ctx.agent_name)
 
     data_chunk: list[dict[str, Any]]
     src_text: list[dict[str, Any]]
@@ -461,19 +459,14 @@ def _prepare_batch_data(ctx: DataPreparationContext):
         src_text = []
 
     elif ctx.file_type == ".xml":
-        # XML: let XmlLoader read the file itself (FileReader returns (tree, root) tuple, not str)
-        xml_result: Any = xml_loader.process(content=None, file_path=ctx.file_path)
-        if isinstance(xml_result, list):
-            data_chunk = _add_batch_metadata(xml_result, local_batch_id, node_id)
-        else:
-            data_chunk = [
-                {
-                    "content": xml_result,
-                    "batch_id": local_batch_id,
-                    "batch_uuid": f"{local_batch_id}_0",
-                }
-            ]
-        src_text = []
+        raise AgentActionsError(
+            "XML first-stage input is not supported; convert to CSV or JSON.",
+            context={
+                "file_type": ctx.file_type,
+                "file_path": ctx.file_path,
+                "agent_name": ctx.agent_name,
+            },
+        )
 
     else:
         supported = [
@@ -486,7 +479,6 @@ def _prepare_batch_data(ctx: DataPreparationContext):
             ".csv",
             ".tsv",
             ".xlsx",
-            ".xml",
         ]
         raise AgentActionsError(
             "Unsupported file type in staging loader",
@@ -514,11 +506,9 @@ def _prepare_online_data(ctx: DataPreparationContext):
     """Prepare data for online mode processing using direct loaders."""
     from agent_actions.input.loaders.json import JsonLoader
     from agent_actions.input.loaders.tabular import TabularLoader
-    from agent_actions.input.loaders.xml import XmlLoader
 
     json_loader = JsonLoader(ctx.agent_config, ctx.agent_name)
     tabular_loader = TabularLoader(ctx.agent_config, ctx.agent_name)
-    xml_loader = XmlLoader(ctx.agent_config, ctx.agent_name)
 
     data_chunk: Any
     src_text: Any
@@ -555,8 +545,14 @@ def _prepare_online_data(ctx: DataPreparationContext):
         data_chunk = src_text = _wrap_online_rows(rows)
 
     elif ctx.file_type == ".xml":
-        data_chunk = xml_loader.process(content=None, file_path=ctx.file_path)
-        src_text = data_chunk
+        raise AgentActionsError(
+            "XML first-stage input is not supported; convert to CSV or JSON.",
+            context={
+                "file_type": ctx.file_type,
+                "file_path": ctx.file_path,
+                "agent_name": ctx.agent_name,
+            },
+        )
 
     else:
         supported = [
@@ -569,7 +565,6 @@ def _prepare_online_data(ctx: DataPreparationContext):
             ".csv",
             ".tsv",
             ".xlsx",
-            ".xml",
         ]
         raise AgentActionsError(
             "Unsupported file type in staging loader",

--- a/tests/unit/input/test_xml_first_stage_rejected.py
+++ b/tests/unit/input/test_xml_first_stage_rejected.py
@@ -1,0 +1,42 @@
+"""XML first-stage input is rejected with a clear error, not a broken record.
+
+XmlLoader.process returns an ET.Element (the parse tree), not rows, so batch XML fell to a
+{content: <ET.Element>} fallback (unwrapped, unstamped) and online XML emitted an element that
+failed cryptically at the storage boundary. XML first-stage is unused and has no validated row
+shape, so both branches fail loud with an actionable message instead of a broken record.
+"""
+
+from pathlib import Path
+
+import pytest
+
+# Pre-load the workflow package to break a pre-existing import-order cycle.
+import agent_actions.workflow.coordinator  # noqa: F401
+from agent_actions.errors import AgentActionsError
+from agent_actions.input.preprocessing.staging.initial_pipeline import (
+    DataPreparationContext,
+    _prepare_batch_data,
+    _prepare_online_data,
+)
+
+
+def _xml_ctx(tmp_path: Path) -> DataPreparationContext:
+    p = tmp_path / "d.xml"
+    p.write_text("<root><item>hello</item><item>world</item></root>", encoding="utf-8")
+    return DataPreparationContext(
+        content=None,
+        file_type=".xml",
+        agent_config={},
+        file_path=str(p),
+        agent_name="a",
+    )
+
+
+def test_batch_xml_is_rejected_with_clear_error(tmp_path):
+    with pytest.raises(AgentActionsError, match="not supported"):
+        _prepare_batch_data(_xml_ctx(tmp_path))
+
+
+def test_online_xml_is_rejected_with_clear_error(tmp_path):
+    with pytest.raises(AgentActionsError, match="not supported"):
+        _prepare_online_data(_xml_ctx(tmp_path))


### PR DESCRIPTION
## Summary

`XmlLoader.process` returns an `ET.Element` (the parse tree), not rows like every other loader (`TabularLoader`/`JsonLoader` → `list[dict]`). So first-stage XML was broken on both paths:
- **Batch** fell to a `{content: <ET.Element>}` fallback — unwrapped, unstamped, an XML element where the user payload should be.
- **Online** (post-#798) emitted the element and failed cryptically at `write_source` (no `source_guid`).

**Task 1 decision — fail loud, don't guess a row shape.** XML first-stage is unused: no `.xml` fixtures, no workflow references it, and the only XML test pins the current (broken) `process → ET.Element` contract. There is no validated definition of "what is a row in an XML document," and guessing one (children-of-root vs repeated-tag) would silently mis-row every downstream action. So both `_prepare_batch_data` and `_prepare_online_data` `.xml` branches now raise a clear `AgentActionsError("XML first-stage input is not supported; convert to CSV or JSON.")`, deleting the silent-wrong batch fallback. The unused `XmlLoader` import/instantiation is removed from both functions, and `.xml` is dropped from the `supported` lists.

This is the follow-up split out of #798 (579), which unified the first-stage envelope and deferred XML because XML's problem was never enveloping — it was that XML produced no rows to envelope.

## Deviations / scope notes
- **Not implementing a row shape** — the spec (589) offered A/B/C row-derivation options *or* WONTFIX-with-fail-loud if unused. Verified unused → chose fail-loud (confirmed with the maintainer). `XmlLoader` itself is untouched (still exported, still parses, its contract test is unchanged) — it's simply no longer used for first-stage row ingestion.
- **`XmlLoader.supports_filetype` still returns `True` for `.xml`** — harmless; it's read only by the AST-based doc scanner, not runtime routing (reviewer-confirmed). Left as-is to keep the change minimal.

## Verification
- **RED → GREEN**: new `test_xml_first_stage_rejected.py` — both batch and online `.xml` now raise `AgentActionsError` matching "not supported" (previously returned a broken record / element).
- **Full suite: 8157 pass**; ruff + mypy clean.
- **Full-pipeline ordering checked**: `FileReader._read_xml` returns a `(tree, root)` tuple, `validate_staging_field_names`/`_validate_staged_data` no-op on it, then the staging branch raises — so a real `.xml` file surfaces the clear "convert to CSV/JSON" message, not a cryptic crash.
- **No missed callers**: nothing ingests `.xml` through `_prepare_batch_data`/`_prepare_online_data` expecting rows; `XmlLoader.process` (returns `ET.Element`) and its test are unchanged.
- **Blind review (LOW tier): YES**, no issues.
- **Smoke skipped** — no smoke surface touched (`input/preprocessing/staging/`, `XmlLoader`/`FileReader` unchanged); behavior is fully unit-covered.