### PR TITLE
fix(592): Phase 1 (D) — refuse preflight on conclusive conditional required-field findings

### DIFF
--- a/agent_actions/services/preflight_service.py
+++ b/agent_actions/services/preflight_service.py
@@ -123,7 +123,7 @@ class PreflightService:
         self._warn_tool_passthrough_risks()
 
         # 8. Cross-check kind:tool UDFs against their required output-schema fields
-        self._warn_tool_conditional_required_field_risks()
+        self._check_tool_conditional_required_field_risks()
 
     def _collect_prompts(self) -> dict[str, str]:
         """Resolved prompt text per prompt-bearing action, keyed by action name."""
@@ -227,9 +227,12 @@ class PreflightService:
             }
         return inputs
 
-    def _warn_tool_conditional_required_field_risks(self) -> None:
-        """Warn when a kind:tool UDF only conditionally emits a required schema field."""
-        for finding in find_conditional_required_field_risks(
-            self._collect_tool_required_field_inputs()
-        ):
-            logger.warning("Pre-flight: %s", finding)
+    def _check_tool_conditional_required_field_risks(self) -> None:
+        """Refuse preflight when a kind:tool UDF only conditionally emits a required schema field."""
+        findings = find_conditional_required_field_risks(self._collect_tool_required_field_inputs())
+        if findings:
+            raise PreFlightValidationError(
+                "\n".join(findings),
+                hint="Mark the field optional in the schema, "
+                "or emit it unconditionally in the UDF.",
+            )

--- a/agent_actions/validation/_MANIFEST.md
+++ b/agent_actions/validation/_MANIFEST.md
@@ -37,7 +37,7 @@ decoders to schema validators and preflight checks.
 | `schema_validator.py` | Module | `SchemaValidator`: validates schema files against JSON Schema meta-schema. Fires a single `ValidationStartEvent` via the base class `_prepare_validation()`; the redundant `DataValidationStartedEvent` at the top of `validate()` has been removed. | `validation` |
 | `status_validator.py` | Module | `StatusCommandArgs` definition. | `validation` |
 | `udf_passthrough_validator.py` | Module | `find_passthrough_schema_risks`: static AST scan flagging `kind:tool` UDFs that return bus-derived dicts under a strict output schema. | `validation` |
-| `udf_required_field_validator.py` | Module | `find_conditional_required_field_risks`: static AST scan flagging `kind:tool` UDFs whose required output-schema fields are only produced inside a conditional branch (post-568 required-by-default class). | `validation` |
+| `udf_required_field_validator.py` | Module | `find_conditional_required_field_risks`: static AST scan that refuses preflight when a `kind:tool` UDF's required output-schema fields are only produced inside a conditional branch (post-568 required-by-default class; refusal wired in `PreflightService._check_tool_conditional_required_field_risks`). | `validation` |
 | `validate_udfs.py` | Module | Validates that UDFs referenced in configs exist. | `utils.udf_management`, `validation` |
 | `project_validator.py` | Module | `ProjectValidator` for project name, directory, and template validation. | `validation` |
 | `run_validator.py` | Module | `RunCommandArgs` pydantic model and pre-flight gating. | `validation` |

--- a/tests/validation/test_udf_required_field_wiring.py
+++ b/tests/validation/test_udf_required_field_wiring.py
@@ -1,10 +1,5 @@
-"""Wire-point test for the conditional-required-field preflight refusal.
-
-Anchors on the actual behavioural failure: when a kind:tool UDF only
-conditionally produces a required output-schema field, the runtime will
-crash at `_validate_udf_output`, so preflight must refuse rather than
-merely warn. Proven end-to-end through the public `PreflightService`
-API — no new symbol is imported here."""
+"""Wire-point test for the conditional-required-field preflight refusal, driven
+through the public `PreflightService.validate()` — no new symbol is imported."""
 
 from __future__ import annotations
 

--- a/tests/validation/test_udf_required_field_wiring.py
+++ b/tests/validation/test_udf_required_field_wiring.py
@@ -1,14 +1,16 @@
-"""Wire-point test for the conditional-required-field preflight warning.
+"""Wire-point test for the conditional-required-field preflight refusal.
 
-Anchors RED on the actual behavioural failure (no preflight warning is emitted
-today for a tool UDF that only conditionally produces a required output-schema
-field) so the fix is proven end-to-end through the public `PreflightService`
+Anchors on the actual behavioural failure: when a kind:tool UDF only
+conditionally produces a required output-schema field, the runtime will
+crash at `_validate_udf_output`, so preflight must refuse rather than
+merely warn. Proven end-to-end through the public `PreflightService`
 API — no new symbol is imported here."""
 
 from __future__ import annotations
 
-import logging
+import pytest
 
+from agent_actions.errors.preflight import PreFlightValidationError
 from agent_actions.services.preflight_service import PreflightService
 
 
@@ -39,24 +41,7 @@ def _make_service(action_configs: dict) -> PreflightService:
     )
 
 
-def _capture_preflight_warnings(cfgs: dict, caplog) -> list[str]:
-    """Full `validate()` must reach the new check and stay non-fatal.
-
-    The `agent_actions` logger does not propagate by default; caplog needs it
-    on to see the warning."""
-    logger_name = "agent_actions.services.preflight_service"
-    aa_logger = logging.getLogger("agent_actions")
-    original = aa_logger.propagate
-    aa_logger.propagate = True
-    try:
-        with caplog.at_level(logging.WARNING, logger=logger_name):
-            _make_service(cfgs).validate()
-        return [r.getMessage() for r in caplog.records if r.name == logger_name]
-    finally:
-        aa_logger.propagate = original
-
-
-def test_preflight_warns_when_required_field_only_conditionally_emitted(caplog):
+def test_preflight_refuses_when_required_field_only_conditionally_emitted():
     from agent_actions.utils.udf_management.registry import clear_registry, udf_tool
 
     clear_registry()
@@ -85,7 +70,10 @@ def test_preflight_warns_when_required_field_only_conditionally_emitted(caplog):
                 },
             }
         }
-        msgs = _capture_preflight_warnings(cfgs, caplog)
-        assert any("reconstruct_options" in m and "source_quote" in m for m in msgs), msgs
+        with pytest.raises(PreFlightValidationError) as excinfo:
+            _make_service(cfgs).validate()
+        message = str(excinfo.value)
+        assert "reconstruct_options" in message, message
+        assert "source_quote" in message, message
     finally:
         clear_registry()


### PR DESCRIPTION
## Summary

Phase 1 of spec `specs/active/592-dag-schema-fit-at-preflight.md`. Flips the sink of `find_conditional_required_field_risks` from `logger.warning` to `raise PreFlightValidationError`. When the scanner conclusively identifies a `kind:tool` UDF that only conditionally emits a required output-schema field, the runtime is guaranteed to reject records whose emission branch does not fire. A warning that runs alongside a certain future crash is a missed refusal, not an advisory.

- `_warn_tool_conditional_required_field_risks` → `_check_tool_conditional_required_field_risks` (matches its new sink contract; docstring trimmed to a one-liner after review feedback on referencing internal symbols).
- `PreFlightValidationError` raised with a hint pointing at the two workflow-level fixes: mark the field optional, or emit it unconditionally in the UDF.
- Manifest entry for `udf_required_field_validator.py` updated to describe refusal, not flagging.

## Scope discipline

Phase 1 only. Does **not** extend the AST scanner to new return shapes (list returns, `AnnAssign` initialisers, comprehension returns — all left in the `err toward silence` bucket). Those shapes are the reason `cc_flatten_code` failed at runtime in the incident that filed spec 592, and they are addressed by Phase 2 (F — DAG schema-fit), which is gated by Task 1 on the spec and not touched here.

## Verification story

- `harness/bin/gate.sh red tests/validation/test_udf_required_field_wiring.py::test_preflight_refuses_when_required_field_only_conditionally_emitted` recorded on a genuine assertion failure (`pytest.raises(PreFlightValidationError)` fires under the old warn sink).
- `harness/bin/gate.sh green` — full pytest `8167 passed`, ruff format + check clean, mypy clean.
- `harness/bin/risk.sh` → tier=LOW, smoke_required=no (no chokepoint touched, 3 files, 161 lines).
- Blind self-review: verdict YES. One INFO on the manifest wording, applied in commit `cc4601f7`.
- `harness/bin/gate.sh review YES LOW` recorded at `cc4601f7`.
- `harness/bin/gate.sh smoke --skip` recorded: risk.sh classified LOW with smoke_required=no; diff is preflight-service internal sink flip + wire-point test retarget + one manifest wording fix; no chokepoint or smoke surface touched.

## Reward-hack disclosure

The wire-point test at `tests/validation/test_udf_required_field_wiring.py` was retargeted from asserting a `caplog` warning to asserting `pytest.raises(PreFlightValidationError)`. Two assert/def-test lines were removed in the process — this is a retargeting of the wire point to the Phase 1 sink, not a test-weakening. The old test would fail after Phase 1 by design.

## Test plan

- [ ] `pytest tests/validation/test_udf_required_field_wiring.py` passes on this branch.
- [ ] Full `pytest` on this branch passes (verified locally at 8167).
- [ ] `ruff format --check` and `ruff check` clean.
- [ ] Confirm no user workflow in the org is silently relying on the warn-then-crash behavior. If a workflow hits the refusal, resolve at the workflow level (mark field optional or emit unconditionally) — do not weaken this check.

## Follow-ups (out of scope for this PR)

- Phase 2 (F) — DAG schema-fit at preflight. Task 1 answers needed on default posture (implicit vs explicit `input_required`) and `defaults:` syntax before implementation begins. See spec 592.
- The `cc_flatten_code` runtime crash that filed this spec is **not** fixed by Phase 1 (the UDF returns a list; the scanner declines on that shape). Workflow-level workaround options are in the spec's pass paths section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)