### PR TITLE
chore: bump version to 0.2.7

### DIFF
--- a/agent_actions/__version__.py
+++ b/agent_actions/__version__.py
@@ -1,3 +1,3 @@
 """Agent Actions version."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-actions"
-version = "0.2.6"
+version = "0.2.7"
 description = "Declarative YAML-based framework for orchestrating agentic workflows"
 authors = [
     {name = "Muizz Kolapo"},


### PR DESCRIPTION
## Summary
- Bump version `0.2.6` → `0.2.7` in the two version files: `pyproject.toml` and `agent_actions/__version__.py`. **Version-only** — no other changes.
- Release notes are published via `gh release` on the `v0.2.7` tag (not changie).

## Verification
- `python -c "import agent_actions; print(agent_actions.__version__)"` → `0.2.7`; ruff clean.