### PR TITLE
fix: context-scope passthrough placement, collision warning, seed double-injection warning

### DIFF
--- a/agent_actions/llm/batch/processing/batch_result_strategy.py
+++ b/agent_actions/llm/batch/processing/batch_result_strategy.py
@@ -32,7 +32,6 @@ from agent_actions.processing.types import (
 )
 from agent_actions.record.envelope import (
     _PERSISTENT_FIELDS,
-    RECORD_FRAMEWORK_FIELDS,
     RecordEnvelope,
 )
 from agent_actions.record.reasons import (
@@ -43,6 +42,7 @@ from agent_actions.record.reasons import (
 from agent_actions.utils.content import get_existing_content, is_version_merge
 from agent_actions.utils.schema_echo import is_schema_echo as _is_schema_echo
 from agent_actions.utils.schema_echo import make_schema_echo_error as _make_schema_echo_error
+from agent_actions.utils.transformation.passthrough import merge_passthrough_namespaces
 
 logger = logging.getLogger(__name__)
 
@@ -326,9 +326,12 @@ class BatchResultStrategy:
         original_row = ctx.reconciler.get_record_by_id(custom_id)
         original_source_guid = ctx.reconciler.get_source_guid(custom_id)
 
+        stored_passthrough: dict[str, Any] = {}
         if ctx.agent_config:
             if custom_id in ctx.context_map:
-                generated_list = self._apply_context_passthrough(ctx, custom_id, generated_list)
+                stored_passthrough = BatchContextMetadata.get_passthrough_fields(
+                    ctx.context_map[custom_id]
+                )
             elif (ctx.agent_config.get("context_scope") or {}).get("passthrough"):
                 logger.warning(
                     "custom_id '%s' not found in context_map, skipping passthrough",
@@ -365,6 +368,8 @@ class BatchResultStrategy:
             else:
                 record = RecordEnvelope.build(action_name, item_dict, envelope_input)
                 record["source_guid"] = original_source_guid  # reconciler is authority for guid
+            if stored_passthrough:
+                merge_passthrough_namespaces(record["content"], stored_passthrough, action_name)
             structured_items.append(record)
 
         # target_id is a per-stage field — not carried by RecordEnvelope.build()
@@ -390,39 +395,6 @@ class BatchResultStrategy:
         processing_result.processing_context = processing_context
         processing_result.is_expansion = len(structured_items) > 1
         return processing_result
-
-    def _apply_context_passthrough(
-        self,
-        ctx: BatchProcessingContext,
-        custom_id: str,
-        generated_list: list[Any],
-    ) -> list[Any]:
-        """Apply stored context_scope.passthrough fields to generated items.
-
-        LLM output wins on key collisions — passthrough only fills gaps.
-        Collisions on user-content fields are logged; framework fields
-        (target_id, _state, etc.) are silently skipped.
-        """
-        stored_passthrough = BatchContextMetadata.get_passthrough_fields(ctx.context_map[custom_id])
-
-        if stored_passthrough:
-            passthrough_keys = set(stored_passthrough.keys())
-            merged: list[Any] = []
-            for item in generated_list:
-                if isinstance(item, dict):
-                    collisions = (passthrough_keys & set(item.keys())) - RECORD_FRAMEWORK_FIELDS
-                    if collisions:
-                        logger.info(
-                            "Passthrough keys overridden by LLM output for %s: %s",
-                            custom_id,
-                            collisions,
-                        )
-                    merged.append({**stored_passthrough, **item})
-                else:
-                    merged.append(item)
-            generated_list = merged
-
-        return generated_list
 
     # -- Error / exhausted / unprocessed builders ------------------------------
 

--- a/agent_actions/processing/enrichment.py
+++ b/agent_actions/processing/enrichment.py
@@ -267,25 +267,27 @@ class PassthroughEnricher(Enricher):
     """Merge passthrough fields into results."""
 
     def enrich(self, result: ProcessingResult, context: ProcessingContext) -> ProcessingResult:
-        """Merge passthrough_fields into the current action's content namespace.
+        """Merge namespaced passthrough_fields into content as sibling namespaces.
 
-        Content is namespaced: ``{"action_a": {...}, "action_b": {...}}``.
-        Passthrough fields are merged into ``content[context.action_name]``,
-        not at the top level.
+        passthrough_fields is ``{namespace: {field: value}}``. Each namespace
+        lands at content level next to the action's own namespace so a
+        downstream ``ns.field`` observe resolves against ``content[ns]``.
+        Idempotent with the transform-time merge: existing namespaces win
+        field-by-field and the action's own output is never touched.
         """
         if not result.passthrough_fields:
             return result
+
+        from agent_actions.utils.transformation.passthrough import (
+            merge_passthrough_namespaces,
+        )
 
         action_name = context.action_name
         for item in result.data:
             content = item.get("content")
             if not isinstance(content, dict):
                 continue
-            ns = content.get(action_name)
-            if isinstance(ns, dict):
-                content[action_name] = {**ns, **result.passthrough_fields}
-            else:
-                content[action_name] = dict(result.passthrough_fields)
+            merge_passthrough_namespaces(content, result.passthrough_fields, action_name)
 
         return result
 

--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -463,6 +463,17 @@ def _resolve_observe_refs_for_flat_keys(
     bare_counts = Counter(field for _, field in valid_pairs)
     collisions = {k for k, v in bare_counts.items() if v > 1}
 
+    if collisions:
+        qualified = sorted(f"{ns}.{field}" for ns, field in valid_pairs if field in collisions)
+        logger.warning(
+            "Action '%s': observe refs share bare field name(s) %s across namespaces. "
+            "Flat keys are namespace-qualified (%s) — a tool reading the bare key "
+            "will not find it; read the qualified key instead.",
+            action_name,
+            sorted(collisions),
+            ", ".join(qualified),
+        )
+
     wildcard_ns: set[str] = set()
     resolved: list[tuple[str, str, str]] = []
     for ns, field in valid_pairs:

--- a/agent_actions/utils/transformation/passthrough.py
+++ b/agent_actions/utils/transformation/passthrough.py
@@ -1,5 +1,7 @@
 """Orchestrator for passthrough transformations using the Strategy Pattern."""
 
+import copy
+
 from agent_actions.record.envelope import RecordEnvelope
 from agent_actions.utils.field_management import FieldManager
 
@@ -12,6 +14,29 @@ from .strategies import (
     PrecomputedUnstructuredStrategy,
 )
 from .strategies.base import ensure_dict_output
+
+
+def merge_passthrough_namespaces(
+    content: dict,
+    passthrough_fields: dict,
+    action_name: str,
+) -> None:
+    """Merge namespaced passthrough fields into *content* in place.
+
+    Passthrough namespaces are siblings of the action namespace, so a
+    downstream ``ns.field`` observe resolves against ``content[ns]``. Existing
+    content wins field-by-field: carry-forward may hold the fuller namespace,
+    and the action's own output must never be overwritten.
+    """
+    for ns, ns_fields in passthrough_fields.items():
+        if ns == action_name or not isinstance(ns_fields, dict):
+            continue
+        existing_ns = content.get(ns)
+        if ns not in content:
+            content[ns] = copy.deepcopy(ns_fields)
+        elif isinstance(existing_ns, dict):
+            for field_name, value in ns_fields.items():
+                existing_ns.setdefault(field_name, copy.deepcopy(value))
 
 
 class PassthroughTransformer:
@@ -108,6 +133,10 @@ class PassthroughTransformer:
             RecordEnvelope.build(action_name, ensure_dict_output(fields), envelope_input)
             for fields in action_outputs
         ]
+
+        if passthrough_fields:
+            for record in output:
+                merge_passthrough_namespaces(record["content"], passthrough_fields, action_name)
 
         return [
             self.field_manager.ensure_required_fields(

--- a/agent_actions/utils/transformation/passthrough.py
+++ b/agent_actions/utils/transformation/passthrough.py
@@ -35,8 +35,11 @@ def merge_passthrough_namespaces(
         if ns not in content:
             content[ns] = copy.deepcopy(ns_fields)
         elif isinstance(existing_ns, dict):
-            for field_name, value in ns_fields.items():
-                existing_ns.setdefault(field_name, copy.deepcopy(value))
+            missing = {k: v for k, v in ns_fields.items() if k not in existing_ns}
+            if missing:
+                # Copy-on-write: namespace dicts may be shared with the input
+                # record's content, so never mutate them in place.
+                content[ns] = {**existing_ns, **copy.deepcopy(missing)}
 
 
 class PassthroughTransformer:

--- a/agent_actions/utils/transformation/strategies/precomputed.py
+++ b/agent_actions/utils/transformation/strategies/precomputed.py
@@ -1,12 +1,16 @@
-"""Passthrough strategies for pre-computed passthrough_fields."""
+"""Passthrough strategies for pre-computed passthrough_fields.
 
-import copy
+These strategies only normalize items to flat action output dicts. The
+namespaced passthrough_fields themselves are merged at content level by
+``PassthroughTransformer`` — never into the action output, which would nest
+the passthrough namespace inside the action's own namespace.
+"""
 
 from .base import IPassthroughTransformStrategy, ensure_dict_output
 
 
 class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
-    """Merge precomputed passthrough fields into structured data items."""
+    """Normalize structured data items when precomputed passthrough fields exist."""
 
     def can_handle(
         self,
@@ -31,24 +35,20 @@ class PrecomputedStructuredStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Merge passthrough fields into content, return flat action output.
-
-        Returns flat action output dicts — RecordEnvelope handles wrapping.
-        """
-        pt = passthrough_fields or {}
+        """Unwrap item content, returning flat action output dicts."""
         result = []
         for item in data:
             if isinstance(item, dict) and "content" in item and isinstance(item["content"], dict):
-                result.append({**item["content"], **copy.deepcopy(pt)})
+                result.append(dict(item["content"]))
             elif isinstance(item, dict):
-                result.append({**item, **copy.deepcopy(pt)})
+                result.append(dict(item))
             else:
                 result.append(ensure_dict_output(item))
         return result
 
 
 class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
-    """Merge precomputed passthrough fields into unstructured data."""
+    """Normalize unstructured data items when precomputed passthrough fields exist."""
 
     def can_handle(
         self,
@@ -73,15 +73,11 @@ class PrecomputedUnstructuredStrategy(IPassthroughTransformStrategy):
         agent_config: dict,
         passthrough_fields: dict | None = None,
     ) -> list:
-        """Merge passthrough fields directly into items, return flat action output.
-
-        Returns flat action output dicts — RecordEnvelope handles wrapping.
-        """
-        pt = passthrough_fields or {}
+        """Return items as flat action output dicts."""
         merged = []
         for item in data:
             if isinstance(item, dict):
-                merged.append({**item, **copy.deepcopy(pt)})
+                merged.append(dict(item))
             else:
                 merged.append(ensure_dict_output(item))
         return merged

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -5,6 +5,7 @@ similar to TypeScript's compile-time type checking.
 """
 
 import logging
+import re
 from typing import Any
 
 from jinja2.exceptions import TemplateSyntaxError
@@ -203,6 +204,10 @@ class WorkflowStaticAnalyzer:
         # Step 2d: Catch seed_data/seed_path misuse in context_scope references
         for error in self._check_seed_reference_misuse():
             result.add_error(error)
+
+        # Step 2d-2: Warn when a seed field is both observed and template-referenced
+        for warning in self._check_seed_template_observe_overlap():
+            result.add_warning(warning)
 
         # Step 2e: Validate schema structures (pre-flight check)
         for error in self._check_schema_structures():
@@ -816,6 +821,89 @@ class WorkflowStaticAnalyzer:
                         )
 
         return errors
+
+    _SEED_TEMPLATE_REF = re.compile(r"\bseed\.([A-Za-z_][A-Za-z0-9_]*)")
+    _JINJA_SPAN = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.S)
+
+    def _check_seed_template_observe_overlap(self) -> list[StaticTypeWarning]:
+        """Warn when a seed field is both observed and referenced in the template.
+
+        Seed data is always available to Jinja templates. Observing the same
+        field additionally injects it into the LLM context message, so the
+        value reaches the model twice.
+        """
+        from agent_actions.prompt.formatter import PromptFormatter
+
+        warnings: list[StaticTypeWarning] = []
+        for action in self.workflow_config.get("actions", []):
+            if not isinstance(action, dict):
+                continue
+
+            name = action.get("name", "unknown")
+            context_scope = action.get("context_scope") or {}
+            if not isinstance(context_scope, dict):
+                continue
+            observe = context_scope.get("observe") or []
+            if not isinstance(observe, list):
+                continue
+
+            observed_seed: set[str] = set()
+            seed_wildcard = False
+            for ref in observe:
+                if not isinstance(ref, str) or "." not in ref:
+                    continue
+                ns, field = ref.split(".", 1)
+                if ns != "seed":
+                    continue
+                if field == "*":
+                    seed_wildcard = True
+                else:
+                    observed_seed.add(field)
+            if not observed_seed and not seed_wildcard:
+                continue
+
+            try:
+                template = PromptFormatter.get_raw_prompt(action)
+            except Exception as exc:
+                logger.debug(
+                    "Cannot load prompt for action '%s', skipping seed overlap check: %s",
+                    name,
+                    exc,
+                )
+                continue
+            if not template:
+                continue
+
+            template_seed: set[str] = set()
+            for span in self._JINJA_SPAN.findall(template):
+                template_seed.update(self._SEED_TEMPLATE_REF.findall(span))
+
+            overlap = template_seed if seed_wildcard else template_seed & observed_seed
+            for field in sorted(overlap):
+                warnings.append(
+                    StaticTypeWarning(
+                        message=(
+                            f"Action '{name}': seed field '{field}' is both in "
+                            f"context_scope.observe and referenced in the prompt "
+                            f"template ({{{{ seed.{field} }}}}). The value is "
+                            f"injected twice — once via the rendered template and "
+                            f"once via the observe context message."
+                        ),
+                        location=FieldLocation(
+                            agent_name=name,
+                            config_field="context_scope.observe",
+                            raw_reference=f"seed.{field}",
+                        ),
+                        referenced_agent="seed",
+                        referenced_field=field,
+                        hint=(
+                            "Remove the observe entry (templates always see seed), "
+                            "or drop the template reference."
+                        ),
+                    )
+                )
+
+        return warnings
 
     def _check_schema_structures(self) -> list[StaticTypeError]:
         """Validate schema definitions for structural correctness.

--- a/tests/unit/llm/batch/test_batch_passthrough_stored.py
+++ b/tests/unit/llm/batch/test_batch_passthrough_stored.py
@@ -1,32 +1,23 @@
-"""Tests for _apply_context_passthrough — stored passthrough merge.
+"""Tests for stored passthrough merge at batch result processing.
 
 Passthrough fields are pre-extracted during batch preparation and stored in
-BatchContextMetadata. At result processing time, stored fields are merged into
-generated items.
+BatchContextMetadata as {namespace: {field: value}}. At result processing
+time, each namespace is merged into the record content as a sibling of the
+action namespace — never inside the action output.
 """
 
 from typing import Any
+from unittest.mock import MagicMock
 
 from agent_actions.llm.batch.core.batch_context_metadata import BatchContextMetadata
 from agent_actions.llm.batch.processing.batch_result_strategy import (
-    BatchProcessingContext,
     BatchResultStrategy,
 )
+from agent_actions.llm.batch.processing.reconciler import BatchResultReconciler
+from agent_actions.llm.providers.batch_base import BatchResult
+from agent_actions.utils.transformation.passthrough import merge_passthrough_namespaces
 
 # ── Helpers ──────────────────────────────────────────────────────────
-
-
-def _make_context(
-    context_map: dict[str, Any],
-    agent_config: dict[str, Any] | None = None,
-) -> BatchProcessingContext:
-    """Build a minimal BatchProcessingContext for passthrough testing."""
-    return BatchProcessingContext(
-        batch_results=[],
-        context_map=context_map,
-        output_directory=None,
-        agent_config=agent_config,
-    )
 
 
 def _make_context_map_entry(**extra) -> dict[str, Any]:
@@ -34,28 +25,47 @@ def _make_context_map_entry(**extra) -> dict[str, Any]:
     base = {
         "target_id": "rec_001",
         "source_guid": "src_001",
+        "content": {"text": "row content"},
     }
     base.update(extra)
     return base
 
 
-# ── Stored passthrough merges into generated items ───────────────────
+def _make_batch_result(custom_id: str, content: dict[str, Any]) -> BatchResult:
+    result = MagicMock(spec=BatchResult)
+    result.custom_id = custom_id
+    result.content = content
+    result.error = None
+    result.success = True
+    result.metadata = {}
+    result.recovery_metadata = None
+    return result
+
+
+def _process(context_map: dict[str, Any], llm_content: dict[str, Any]) -> list:
+    strategy = BatchResultStrategy()
+    return strategy.process(
+        batch_results=[_make_batch_result("rec_001", llm_content)],
+        context_map=context_map,
+        output_directory="/tmp/test",
+        agent_config={"action_name": "summarize"},
+    )
+
+
+# ── Stored passthrough merges at content level ───────────────────────
 
 
 class TestStoredPassthroughMerge:
-    """Stored passthrough fields are merged into every generated item."""
-
-    def test_single_namespace_field(self):
+    def test_single_namespace_lands_at_content_level(self):
         entry = _make_context_map_entry()
         BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
-        ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultStrategy()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "AI overview"}])
+        results = _process({"rec_001": entry}, {"summary": "AI overview"})
 
-        assert len(result) == 1
-        assert result[0]["summary"] == "AI overview"
-        assert result[0]["classify"] == {"category": "tech"}
+        content = results[0].data[0]["content"]
+        assert content["summarize"]["summary"] == "AI overview"
+        assert content["classify"] == {"category": "tech"}
+        assert "classify" not in content["summarize"]
 
     def test_multiple_namespaces(self):
         entry = _make_context_map_entry()
@@ -66,94 +76,92 @@ class TestStoredPassthroughMerge:
                 "extract": {"record_id": "abc"},
             },
         )
-        ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultStrategy()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
+        results = _process({"rec_001": entry}, {"summary": "test"})
 
-        assert result[0]["classify"] == {"category": "tech"}
-        assert result[0]["extract"] == {"record_id": "abc"}
-        assert result[0]["summary"] == "test"
+        content = results[0].data[0]["content"]
+        assert content["classify"] == {"category": "tech"}
+        assert content["extract"] == {"record_id": "abc"}
+        assert content["summarize"]["summary"] == "test"
 
     def test_all_generated_items_receive_passthrough(self):
         entry = _make_context_map_entry()
         BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
-        ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultStrategy()
 
-        result = processor._apply_context_passthrough(
-            ctx, "rec_001", [{"item": 1}, {"item": 2}, {"item": 3}]
-        )
-
-        assert len(result) == 3
-        for item in result:
-            assert item["classify"] == {"category": "tech"}
-
-
-# ── Edge cases ───────────────────────────────────────────────────────
-
-
-class TestStoredPassthroughEdgeCases:
-    """Edge cases: empty passthrough, non-dict items, empty list."""
-
-    def test_empty_stored_passthrough_returns_unchanged(self):
-        """When stored passthrough is empty dict, generated items are unchanged."""
-        entry = _make_context_map_entry()
-        BatchContextMetadata.set_passthrough_fields(entry, {})
-        ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultStrategy()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
-
-        assert result == [{"summary": "test"}]
-
-    def test_no_stored_passthrough_returns_unchanged(self):
-        """When no passthrough was stored at all, generated items are unchanged."""
-        entry = _make_context_map_entry()
-        ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultStrategy()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", [{"summary": "test"}])
-
-        assert result == [{"summary": "test"}]
-
-    def test_non_dict_items_passed_through(self):
-        """Non-dict items in generated_list are passed through unchanged."""
-        entry = _make_context_map_entry()
-        BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
-        ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultStrategy()
-
-        result = processor._apply_context_passthrough(
-            ctx, "rec_001", [{"summary": "test"}, "raw_string", 42]
-        )
-
-        assert result[0]["classify"] == {"category": "tech"}
-        assert result[1] == "raw_string"
-        assert result[2] == 42
-
-    def test_empty_generated_list(self):
-        """Empty generated_list returns empty list."""
-        entry = _make_context_map_entry()
-        BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
-        ctx = _make_context(context_map={"rec_001": entry})
-        processor = BatchResultStrategy()
-
-        result = processor._apply_context_passthrough(ctx, "rec_001", [])
-
-        assert result == []
-
-    def test_passthrough_does_not_fire_without_context_scope_config(self):
-        """Even with agent_config having no context_scope, stored passthrough still applies."""
-        entry = _make_context_map_entry()
-        BatchContextMetadata.set_passthrough_fields(entry, {"source": {"id": "123"}})
-        ctx = _make_context(
+        strategy = BatchResultStrategy()
+        results = strategy.process(
+            batch_results=[_make_batch_result("rec_001", [{"item": 1}, {"item": 2}, {"item": 3}])],
             context_map={"rec_001": entry},
-            agent_config={"action_name": "test"},
+            output_directory="/tmp/test",
+            agent_config={"action_name": "summarize"},
         )
-        processor = BatchResultStrategy()
 
-        result = processor._apply_context_passthrough(ctx, "rec_001", [{"output": "val"}])
+        data = results[0].data
+        assert len(data) == 3
+        for record in data:
+            assert record["content"]["classify"] == {"category": "tech"}
 
-        assert result[0]["source"] == {"id": "123"}
-        assert result[0]["output"] == "val"
+    def test_stored_passthrough_applies_without_context_scope_config(self):
+        """Stored passthrough applies even when agent_config lacks context_scope."""
+        entry = _make_context_map_entry()
+        BatchContextMetadata.set_passthrough_fields(entry, {"source_meta": {"id": "123"}})
+
+        results = _process({"rec_001": entry}, {"output": "val"})
+
+        content = results[0].data[0]["content"]
+        assert content["source_meta"] == {"id": "123"}
+        assert content["summarize"]["output"] == "val"
+
+
+# ── merge_passthrough_namespaces edge cases ──────────────────────────
+
+
+class TestMergePassthroughNamespaces:
+    def test_empty_passthrough_leaves_content_unchanged(self):
+        content = {"summarize": {"summary": "test"}}
+        merge_passthrough_namespaces(content, {}, "summarize")
+        assert content == {"summarize": {"summary": "test"}}
+
+    def test_action_namespace_never_overwritten(self):
+        content = {"summarize": {"summary": "LLM output"}}
+        merge_passthrough_namespaces(content, {"summarize": {"summary": "stale"}}, "summarize")
+        assert content["summarize"]["summary"] == "LLM output"
+
+    def test_existing_namespace_wins_per_field(self):
+        content = {"classify": {"category": "finance"}}
+        merge_passthrough_namespaces(
+            content, {"classify": {"category": "stale", "region": "US"}}, "summarize"
+        )
+        assert content["classify"] == {"category": "finance", "region": "US"}
+
+    def test_non_dict_entries_ignored(self):
+        content = {"summarize": {"summary": "test"}}
+        merge_passthrough_namespaces(
+            content, {"target_id": "rec_001", "flat": "value"}, "summarize"
+        )
+        assert "target_id" not in content
+        assert "flat" not in content
+
+    def test_null_namespace_in_content_left_intact(self):
+        """A guard-skipped (None) namespace must not be replaced by the passthrough copy."""
+        content = {"classify": None}
+        merge_passthrough_namespaces(content, {"classify": {"category": "tech"}}, "summarize")
+        assert content["classify"] is None
+
+
+class TestReconcilerRoundTrip:
+    def test_no_stored_passthrough_content_unchanged(self):
+        entry = _make_context_map_entry()
+
+        results = _process({"rec_001": entry}, {"summary": "test"})
+
+        content = results[0].data[0]["content"]
+        assert content["summarize"]["summary"] == "test"
+        namespaces = set(content.keys()) - {"summarize"}
+        assert not any(isinstance(content.get(ns), dict) and ns == "classify" for ns in namespaces)
+
+    def test_reconciler_still_resolves_guid(self):
+        entry = _make_context_map_entry()
+        BatchContextMetadata.set_passthrough_fields(entry, {"classify": {"category": "tech"}})
+        reconciler = BatchResultReconciler({"rec_001": entry})
+        assert reconciler.get_source_guid("rec_001") == "src_001"

--- a/tests/unit/processing/test_enrichment_namespaced.py
+++ b/tests/unit/processing/test_enrichment_namespaced.py
@@ -46,48 +46,57 @@ def _namespaced_content():
 
 
 class TestPassthroughEnricherNamespaced:
-    """PassthroughEnricher merges passthrough fields into the action namespace."""
+    """PassthroughEnricher places passthrough namespaces at content level."""
 
-    def test_merges_into_existing_action_namespace(self):
-        """Passthrough fields merge INTO content[action_name], not top-level."""
+    def test_passthrough_namespace_lands_at_content_level(self):
         content = {**_namespaced_content(), "action_c": {"llm_field": "llm_output"}}
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=[{"content": content}],
-            passthrough_fields={"pt_field": "preserved"},
+            passthrough_fields={"upstream_hitl": {"hitl_status": "approved"}},
         )
         context = _make_context("action_c")
         enriched = PassthroughEnricher().enrich(result, context)
 
         out = enriched.data[0]["content"]
-        # passthrough field is inside action_c namespace
-        assert out["action_c"]["pt_field"] == "preserved"
-        assert out["action_c"]["llm_field"] == "llm_output"
-        # NOT at top level
-        assert "pt_field" not in out
+        assert out["upstream_hitl"] == {"hitl_status": "approved"}
+        assert out["action_c"] == {"llm_field": "llm_output"}
+        assert "upstream_hitl" not in out["action_c"]
 
-    def test_creates_namespace_when_absent(self):
-        """If action namespace doesn't exist, passthrough fields create it."""
-        content = _namespaced_content()  # no action_c
+    def test_action_namespace_never_overwritten(self):
+        """A passthrough namespace matching the action name is skipped."""
+        content = {**_namespaced_content(), "action_c": {"llm_field": "llm_output"}}
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=[{"content": content}],
-            passthrough_fields={"pt_field": "preserved"},
+            passthrough_fields={"action_c": {"llm_field": "stale"}},
         )
         context = _make_context("action_c")
         enriched = PassthroughEnricher().enrich(result, context)
 
-        out = enriched.data[0]["content"]
-        assert out["action_c"] == {"pt_field": "preserved"}
-        assert "pt_field" not in out
+        assert enriched.data[0]["content"]["action_c"] == {"llm_field": "llm_output"}
 
-    def test_preserves_other_namespaces(self):
-        """Other action namespaces are not modified."""
+    def test_existing_namespace_wins_per_field(self):
+        """Content-level namespaces keep their values; passthrough fills gaps."""
         content = {**_namespaced_content(), "action_c": {"llm_field": "val"}}
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=[{"content": content}],
-            passthrough_fields={"pt_field": "preserved"},
+            passthrough_fields={"action_a": {"field_a": "stale", "field_extra": "new"}},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        out = enriched.data[0]["content"]
+        assert out["action_a"]["field_a"] == "val_a"
+        assert out["action_a"]["field_extra"] == "new"
+
+    def test_preserves_other_namespaces(self):
+        content = {**_namespaced_content(), "action_c": {"llm_field": "val"}}
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            passthrough_fields={"upstream_hitl": {"hitl_status": "approved"}},
         )
         context = _make_context("action_c")
         enriched = PassthroughEnricher().enrich(result, context)
@@ -110,8 +119,26 @@ class TestPassthroughEnricherNamespaced:
 
         assert enriched.data[0]["content"] == content
 
+    def test_idempotent_after_transform_time_merge(self):
+        """Running the enricher on a record that already carries the namespace is a no-op."""
+        content = {
+            **_namespaced_content(),
+            "upstream_hitl": {"hitl_status": "approved"},
+            "action_c": {"llm_field": "val"},
+        }
+        result = ProcessingResult(
+            status=ProcessingStatus.SUCCESS,
+            data=[{"content": content}],
+            passthrough_fields={"upstream_hitl": {"hitl_status": "approved"}},
+        )
+        context = _make_context("action_c")
+        enriched = PassthroughEnricher().enrich(result, context)
+
+        out = enriched.data[0]["content"]
+        assert out["upstream_hitl"] == {"hitl_status": "approved"}
+        assert "upstream_hitl" not in out["action_c"]
+
     def test_multiple_items(self):
-        """Passthrough fields merge into each item's action namespace."""
         items = [
             {"content": {**_namespaced_content(), "action_c": {"idx": 0}}},
             {"content": {**_namespaced_content(), "action_c": {"idx": 1}}},
@@ -119,15 +146,16 @@ class TestPassthroughEnricherNamespaced:
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=items,
-            passthrough_fields={"pt": "val"},
+            passthrough_fields={"upstream_hitl": {"hitl_status": "approved"}},
         )
         context = _make_context("action_c")
         enriched = PassthroughEnricher().enrich(result, context)
 
         for i in range(2):
-            assert enriched.data[i]["content"]["action_c"]["pt"] == "val"
-            assert enriched.data[i]["content"]["action_c"]["idx"] == i
-            assert "pt" not in enriched.data[i]["content"]
+            out = enriched.data[i]["content"]
+            assert out["upstream_hitl"] == {"hitl_status": "approved"}
+            assert out["action_c"]["idx"] == i
+            assert "upstream_hitl" not in out["action_c"]
 
     def test_item_without_content_key_skipped(self):
         """Items with no content dict are skipped without error."""
@@ -142,25 +170,24 @@ class TestPassthroughEnricherNamespaced:
         assert "content" not in enriched.data[0]
         assert "pt" not in enriched.data[0]
 
-    def test_multiple_passthrough_fields(self):
-        """Multiple passthrough fields all merge into action namespace."""
+    def test_multiple_passthrough_namespaces(self):
+        """Multiple passthrough namespaces all land at content level."""
         content = {**_namespaced_content(), "action_c": {"llm_field": "val"}}
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=[{"content": content}],
-            passthrough_fields={"pt_a": "a", "pt_b": "b", "pt_c": "c"},
+            passthrough_fields={"ns_a": {"a": 1}, "ns_b": {"b": 2}},
         )
         context = _make_context("action_c")
         enriched = PassthroughEnricher().enrich(result, context)
 
-        ns = enriched.data[0]["content"]["action_c"]
-        assert ns["pt_a"] == "a"
-        assert ns["pt_b"] == "b"
-        assert ns["pt_c"] == "c"
-        assert ns["llm_field"] == "val"
+        out = enriched.data[0]["content"]
+        assert out["ns_a"] == {"a": 1}
+        assert out["ns_b"] == {"b": 2}
+        assert out["action_c"] == {"llm_field": "val"}
 
-    def test_passthrough_field_overwrites_llm_field_with_same_key(self):
-        """Passthrough field with same key as LLM output overwrites it."""
+    def test_flat_passthrough_entries_ignored(self):
+        """Non-namespaced (non-dict) passthrough entries are not merged anywhere."""
         content = {**_namespaced_content(), "action_c": {"shared_key": "llm_value"}}
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
@@ -170,44 +197,45 @@ class TestPassthroughEnricherNamespaced:
         context = _make_context("action_c")
         enriched = PassthroughEnricher().enrich(result, context)
 
-        assert enriched.data[0]["content"]["action_c"]["shared_key"] == "passthrough_value"
+        out = enriched.data[0]["content"]
+        assert out["action_c"]["shared_key"] == "llm_value"
+        assert out.get("shared_key") is None
 
     def test_shared_namespace_dict_not_mutated(self):
-        """PassthroughEnricher must not mutate shared namespace dict objects in-place."""
+        """Filling gaps in an existing namespace must not mutate the shared dict in place."""
         shared_ns = {"llm_field": "original"}
-        item_a = {"content": {"action_c": shared_ns}}
+        item_a = {"content": {"upstream": shared_ns, "action_c": {"out": 1}}}
 
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=[item_a],
-            passthrough_fields={"pt_from_a": "a_value"},
+            passthrough_fields={"upstream": {"extra_field": "a_value"}},
         )
         context = _make_context("action_c")
         PassthroughEnricher().enrich(result, context)
 
-        assert item_a["content"]["action_c"]["pt_from_a"] == "a_value"
+        assert item_a["content"]["upstream"]["extra_field"] == "a_value"
+        assert item_a["content"]["upstream"]["llm_field"] == "original"
         assert shared_ns == {"llm_field": "original"}
 
     def test_shared_namespace_multiple_records_in_same_result(self):
-        """Multiple items in the same result sharing a namespace dict stay isolated."""
-        shared_ns = {"base": "value"}
+        """Inserted passthrough namespaces are independent copies per record."""
         items = [
-            {"content": {"action_c": shared_ns}},
-            {"content": {"action_c": shared_ns}},
+            {"content": {"action_c": {"idx": 0}}},
+            {"content": {"action_c": {"idx": 1}}},
         ]
         result = ProcessingResult(
             status=ProcessingStatus.SUCCESS,
             data=items,
-            passthrough_fields={"injected": "pt"},
+            passthrough_fields={"upstream": {"base": "value"}},
         )
         context = _make_context("action_c")
         enriched = PassthroughEnricher().enrich(result, context)
 
-        assert enriched.data[0]["content"]["action_c"]["injected"] == "pt"
-        assert enriched.data[1]["content"]["action_c"]["injected"] == "pt"
-        enriched.data[0]["content"]["action_c"]["extra"] = "only_in_0"
-        assert "extra" not in enriched.data[1]["content"]["action_c"]
-        assert shared_ns == {"base": "value"}
+        assert enriched.data[0]["content"]["upstream"] == {"base": "value"}
+        assert enriched.data[1]["content"]["upstream"] == {"base": "value"}
+        enriched.data[0]["content"]["upstream"]["extra"] = "only_in_0"
+        assert "extra" not in enriched.data[1]["content"]["upstream"]
 
 
 # ---------------------------------------------------------------------------
@@ -270,7 +298,7 @@ class TestEnrichmentPipelineNamespaced:
     """Full enrichment pipeline with namespaced content."""
 
     def test_full_pipeline_passthrough_in_correct_namespace(self):
-        """All enrichers run in sequence — passthrough in action namespace, others at record level."""
+        """All enrichers run in sequence — passthrough at content level, others at record level."""
         content = {
             "action_a": {"field_a": "val_a"},
             "action_b": {"field_b": "val_b"},
@@ -280,7 +308,7 @@ class TestEnrichmentPipelineNamespaced:
             status=ProcessingStatus.SUCCESS,
             data=[{"content": content, "source_guid": "sg-1"}],
             source_guid="sg-1",
-            passthrough_fields={"pt_field": "preserved_value"},
+            passthrough_fields={"upstream_hitl": {"hitl_status": "approved"}},
             pre_extracted_metadata={"model": "gpt-4"},
             recovery_metadata=RecoveryMetadata(
                 retry=RetryMetadata(attempts=2, failures=1, succeeded=True, reason="timeout")
@@ -292,10 +320,10 @@ class TestEnrichmentPipelineNamespaced:
 
         item = enriched.data[0]
 
-        # Passthrough fields merged into action_c namespace
-        assert item["content"]["action_c"]["pt_field"] == "preserved_value"
-        assert item["content"]["action_c"]["llm_field"] == "llm_output"
-        assert "pt_field" not in item["content"]
+        # Passthrough namespace is a sibling of the action namespace
+        assert item["content"]["upstream_hitl"] == {"hitl_status": "approved"}
+        assert item["content"]["action_c"] == {"llm_field": "llm_output"}
+        assert "upstream_hitl" not in item["content"]["action_c"]
 
         # Other namespaces preserved
         assert item["content"]["action_a"] == {"field_a": "val_a"}

--- a/tests/unit/processing/test_enrichment_namespaced.py
+++ b/tests/unit/processing/test_enrichment_namespaced.py
@@ -1,7 +1,8 @@
 """Tests for enrichment pipeline with namespaced content.
 
 Content is namespaced: {"action_a": {...}, "action_b": {...}}.
-PassthroughEnricher must merge into content[action_name], not top-level.
+PassthroughEnricher places passthrough namespaces at content level, as
+siblings of the action namespace — never inside content[action_name].
 Other enrichers must NOT modify content internals — they work at record level.
 """
 

--- a/tests/unit/prompt/context/test_file_mode_collision_warning.py
+++ b/tests/unit/prompt/context/test_file_mode_collision_warning.py
@@ -7,9 +7,21 @@ so the qualification must be announced, not silent.
 
 import logging
 
+import pytest
+
 from agent_actions.prompt.context.scope_application import (
     apply_context_scope_for_records,
 )
+
+
+@pytest.fixture()
+def _enable_log_propagation():
+    """Ensure the agent_actions logger propagates to root so caplog captures records."""
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = original
 
 
 def _records():
@@ -21,6 +33,7 @@ def _records():
     ]
 
 
+@pytest.mark.usefixtures("_enable_log_propagation")
 class TestCollisionQualificationWarning:
     def test_collision_emits_warning_naming_qualified_keys(self, caplog):
         with caplog.at_level(logging.WARNING):
@@ -32,8 +45,7 @@ class TestCollisionQualificationWarning:
 
         messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
         assert any(
-            "ns1.answer" in m and "ns2.answer" in m and "merge_answers" in m
-            for m in messages
+            "ns1.answer" in m and "ns2.answer" in m and "merge_answers" in m for m in messages
         )
 
     def test_no_collision_emits_no_warning(self, caplog):

--- a/tests/unit/prompt/context/test_file_mode_collision_warning.py
+++ b/tests/unit/prompt/context/test_file_mode_collision_warning.py
@@ -1,0 +1,73 @@
+"""FILE-mode observe refs that collide on a bare field name must warn loudly.
+
+When two namespaces share a field name, flat injected keys become
+namespace-qualified (``ns.field``). A tool reading the bare key gets nothing,
+so the qualification must be announced, not silent.
+"""
+
+import logging
+
+from agent_actions.prompt.context.scope_application import (
+    apply_context_scope_for_records,
+)
+
+
+def _records():
+    return [
+        {
+            "source_guid": "g1",
+            "content": {"ns1": {"answer": "a", "score": 1}, "ns2": {"answer": "b"}},
+        }
+    ]
+
+
+class TestCollisionQualificationWarning:
+    def test_collision_emits_warning_naming_qualified_keys(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            apply_context_scope_for_records(
+                _records(),
+                {"observe": ["ns1.answer", "ns2.answer"]},
+                action_name="merge_answers",
+            )
+
+        messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any(
+            "ns1.answer" in m and "ns2.answer" in m and "merge_answers" in m
+            for m in messages
+        )
+
+    def test_no_collision_emits_no_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            apply_context_scope_for_records(
+                _records(),
+                {"observe": ["ns1.answer", "ns2.answer"]},
+                action_name="merge_answers",
+            )
+        baseline = [r.getMessage() for r in caplog.records]
+        caplog.clear()
+
+        with caplog.at_level(logging.WARNING):
+            apply_context_scope_for_records(
+                _records(),
+                {"observe": ["ns1.answer", "ns1.score"]},
+                action_name="merge_answers",
+            )
+
+        messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert baseline, "collision case must produce a warning to compare against"
+        assert not any("qualified" in m or "collision" in m for m in messages)
+
+    def test_enriched_records_still_carry_qualified_keys(self, caplog):
+        """The warning is advisory — qualified delivery itself must not change."""
+        with caplog.at_level(logging.WARNING):
+            enriched, skipped = apply_context_scope_for_records(
+                _records(),
+                {"observe": ["ns1.answer", "ns2.answer"]},
+                action_name="merge_answers",
+            )
+
+        assert skipped == []
+        content = enriched[0]["content"]
+        assert content.get("ns1.answer") == "a"
+        assert content.get("ns2.answer") == "b"
+        assert "answer" not in content

--- a/tests/unit/unification/test_phase3_batch_retrieve.py
+++ b/tests/unit/unification/test_phase3_batch_retrieve.py
@@ -99,16 +99,17 @@ def _make_ctx(
 
 
 class TestMergeOrder:
-    """U-2.A: LLM output must win over passthrough on key collision."""
+    """U-2.A: passthrough lands at content level; the action namespace is never overwritten."""
 
-    def test_llm_wins_on_passthrough_collision(self, strategy: BatchResultStrategy) -> None:
-        """When passthrough and LLM have same key, LLM value is kept."""
-        # Passthrough has "summary" — same key the LLM will produce.
+    def test_action_namespace_never_overwritten_by_passthrough(
+        self, strategy: BatchResultStrategy
+    ) -> None:
+        """A passthrough namespace colliding with the action name is skipped."""
         context_map = {
             "t-001": _build_context_map_row(
                 "t-001",
                 filter_status=FilterStatus.INCLUDED,
-                passthrough_fields={"summary": "Original passthrough value", "extra_field": "kept"},
+                passthrough_fields={"test_action": {"summary": "Original passthrough value"}},
             ),
         }
         llm_result = _make_batch_result("t-001", {"summary": "LLM generated this", "score": 0.95})
@@ -125,25 +126,21 @@ class TestMergeOrder:
         result = results[0]
         assert result.status == ProcessingStatus.SUCCESS
 
-        # Data items are {source_guid, content: {<existing>, <action_name>: {<merged>}}, target_id}.
-        # The passthrough merge happens BEFORE version_merge wraps output under action_name.
-        # So the merged fields live inside content[action_name].
-        data_item = result.data[0]
-        action_ns = data_item["content"]["test_action"]
-
-        # LLM value must win on collision
+        action_ns = result.data[0]["content"]["test_action"]
         assert action_ns["summary"] == "LLM generated this", (
-            f"LLM value should win on collision, got action_ns={action_ns}"
+            f"LLM output must win over a same-named passthrough namespace, got {action_ns}"
         )
         assert action_ns["score"] == 0.95
 
-    def test_passthrough_fills_gaps(self, strategy: BatchResultStrategy) -> None:
-        """Passthrough fields that don't collide with LLM output are preserved."""
+    def test_passthrough_namespaces_land_at_content_level(
+        self, strategy: BatchResultStrategy
+    ) -> None:
+        """Namespaced passthrough fields become siblings of the action namespace."""
         context_map = {
             "t-001": _build_context_map_row(
                 "t-001",
                 filter_status=FilterStatus.INCLUDED,
-                passthrough_fields={"category": "finance", "region": "US"},
+                passthrough_fields={"classify": {"category": "finance", "region": "US"}},
             ),
         }
         llm_result = _make_batch_result("t-001", {"summary": "LLM output", "score": 0.8})
@@ -157,64 +154,68 @@ class TestMergeOrder:
         )
 
         assert len(results) == 1
-        data_item = results[0].data[0]
-        action_ns = data_item["content"]["test_action"]
-
-        # Non-colliding passthrough fields should be present in the action namespace
-        assert action_ns.get("category") == "finance", (
-            f"Non-colliding passthrough field missing: action_ns={action_ns}"
+        content = results[0].data[0]["content"]
+        assert content.get("classify") == {"category": "finance", "region": "US"}, (
+            f"Passthrough namespace missing at content level: {content}"
         )
-        assert action_ns.get("region") == "US"
+        assert "classify" not in content["test_action"], (
+            "Passthrough namespace must not be nested inside the action output"
+        )
+        assert content["test_action"]["summary"] == "LLM output"
 
-    def test_collision_logged(
-        self, strategy: BatchResultStrategy, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Key collisions between passthrough and LLM output are logged."""
+    def test_existing_content_namespace_wins_per_field(self, strategy: BatchResultStrategy) -> None:
+        """A namespace already in record content keeps its values; passthrough fills gaps."""
         context_map = {
             "t-001": _build_context_map_row(
                 "t-001",
                 filter_status=FilterStatus.INCLUDED,
-                passthrough_fields={"summary": "will collide"},
+                passthrough_fields={"classify": {"category": "stale", "region": "US"}},
+                content={"classify": {"category": "finance"}},
             ),
         }
-        llm_result = _make_batch_result("t-001", {"summary": "LLM wins"})
+        llm_result = _make_batch_result("t-001", {"summary": "LLM output"})
 
         ctx = _make_ctx([llm_result], context_map)
-        with caplog.at_level(logging.DEBUG):
-            strategy.process(
-                batch_results=ctx.batch_results,
-                context_map=ctx.context_map,
-                output_directory=ctx.output_directory,
-                agent_config=ctx.agent_config,
-            )
-
-        collision_logged = any("summary" in r.getMessage() for r in caplog.records)
-        assert collision_logged, (
-            f"Collision between passthrough and LLM key 'summary' should be logged. "
-            f"Records: {[(r.name, r.getMessage()) for r in caplog.records]}"
+        results = strategy.process(
+            batch_results=ctx.batch_results,
+            context_map=ctx.context_map,
+            output_directory=ctx.output_directory,
+            agent_config=ctx.agent_config,
         )
 
-    def test_framework_fields_not_logged_as_collision(
+        content = results[0].data[0]["content"]
+        assert content["classify"]["category"] == "finance", (
+            "Existing content value must win over the passthrough copy"
+        )
+        assert content["classify"]["region"] == "US", (
+            "Passthrough must fill fields missing from the existing namespace"
+        )
+
+    def test_non_dict_passthrough_entries_ignored(
         self, strategy: BatchResultStrategy, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Framework fields (target_id, _state, etc.) should not be logged as collisions."""
+        """Framework fields (target_id, _state, etc.) are non-namespaced and are not merged."""
         context_map = {
             "t-001": _build_context_map_row(
                 "t-001",
                 filter_status=FilterStatus.INCLUDED,
-                passthrough_fields={"target_id": "t-001", "summary": "will collide"},
+                passthrough_fields={"target_id": "t-001", "summary": "flat entry"},
             ),
         }
         llm_result = _make_batch_result("t-001", {"summary": "LLM wins", "target_id": "t-001"})
 
         ctx = _make_ctx([llm_result], context_map)
         with caplog.at_level(logging.INFO):
-            strategy.process(
+            results = strategy.process(
                 batch_results=ctx.batch_results,
                 context_map=ctx.context_map,
                 output_directory=ctx.output_directory,
                 agent_config=ctx.agent_config,
             )
+
+        content = results[0].data[0]["content"]
+        assert content["test_action"]["summary"] == "LLM wins"
+        assert "summary" not in content, "Flat passthrough entries must not leak to content level"
 
         # target_id is a framework field — should NOT be logged as collision
         for record in caplog.records:

--- a/tests/unit/utils/test_passthrough_namespaced_placement.py
+++ b/tests/unit/utils/test_passthrough_namespaced_placement.py
@@ -1,0 +1,139 @@
+"""Namespaced passthrough fields must land at content level, not inside the action output.
+
+context_scope.passthrough produces {namespace: {field: value}} dicts. The output
+record must carry each namespace as a sibling of the action's own namespace so
+downstream observe refs like ``ns.field`` resolve against ``content[ns]``.
+"""
+
+from agent_actions.prompt.context.scope_application import apply_context_scope
+from agent_actions.utils.transformation.passthrough import PassthroughTransformer
+
+
+def _config(passthrough_refs):
+    return {"context_scope": {"passthrough": passthrough_refs}}
+
+
+class TestNamespacedPassthroughPlacement:
+    def test_unstructured_output_places_namespace_at_content_level(self):
+        transformer = PassthroughTransformer()
+        llm_output = [{"batch_name": "batch_A"}]
+        passthrough = {"approve_final_question": {"hitl_status": "approved"}}
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="g1",
+            agent_config=_config(["approve_final_question.*"]),
+            action_name="assign_batch_name",
+            passthrough_fields=passthrough,
+        )
+
+        content = result[0]["content"]
+        assert content.get("approve_final_question") == {"hitl_status": "approved"}
+        assert content.get("assign_batch_name") == {"batch_name": "batch_A"}
+
+    def test_action_namespace_not_polluted_with_passthrough(self):
+        transformer = PassthroughTransformer()
+        llm_output = [{"batch_name": "batch_A"}]
+        passthrough = {"approve_final_question": {"hitl_status": "approved"}}
+
+        result = transformer.transform_with_passthrough(
+            data=llm_output,
+            context_data={},
+            source_guid="g1",
+            agent_config=_config(["approve_final_question.*"]),
+            action_name="assign_batch_name",
+            passthrough_fields=passthrough,
+        )
+
+        action_output = result[0]["content"]["assign_batch_name"]
+        assert "approve_final_question" not in action_output
+
+    def test_structured_output_places_namespace_at_content_level(self):
+        transformer = PassthroughTransformer()
+        data = [{"source_guid": "g1", "content": {"batch_name": "batch_A"}}]
+        passthrough = {"approve_final_question": {"hitl_status": "approved"}}
+
+        result = transformer.transform_with_passthrough(
+            data=data,
+            context_data={},
+            source_guid="g1",
+            agent_config=_config(["approve_final_question.*"]),
+            action_name="assign_batch_name",
+            passthrough_fields=passthrough,
+        )
+
+        content = result[0]["content"]
+        assert content.get("approve_final_question") == {"hitl_status": "approved"}
+        assert content.get("assign_batch_name") == {"batch_name": "batch_A"}
+        assert "approve_final_question" not in content["assign_batch_name"]
+
+    def test_existing_richer_namespace_not_clobbered(self):
+        """Carry-forward already holds the full namespace; the passthrough subset
+        must not shrink it."""
+        transformer = PassthroughTransformer()
+        existing = {
+            "approve_final_question": {"hitl_status": "approved", "reviewer": "ann"},
+        }
+        passthrough = {"approve_final_question": {"hitl_status": "approved"}}
+
+        result = transformer.transform_with_passthrough(
+            data=[{"batch_name": "batch_A"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=_config(["approve_final_question.hitl_status"]),
+            action_name="assign_batch_name",
+            passthrough_fields=passthrough,
+            existing_content=existing,
+        )
+
+        content = result[0]["content"]
+        assert content["approve_final_question"]["hitl_status"] == "approved"
+        assert content["approve_final_question"]["reviewer"] == "ann"
+        assert "approve_final_question" not in content["assign_batch_name"]
+
+    def test_multiple_passthrough_namespaces_all_at_content_level(self):
+        transformer = PassthroughTransformer()
+        passthrough = {
+            "approve_final_question": {"hitl_status": "approved"},
+            "review_consolidated_answers": {"decision": "pass"},
+        }
+
+        result = transformer.transform_with_passthrough(
+            data=[{"batch_name": "batch_A"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=_config(
+                ["approve_final_question.*", "review_consolidated_answers.*"]
+            ),
+            action_name="assign_batch_name",
+            passthrough_fields=passthrough,
+        )
+
+        content = result[0]["content"]
+        assert content.get("approve_final_question") == {"hitl_status": "approved"}
+        assert content.get("review_consolidated_answers") == {"decision": "pass"}
+        assert "approve_final_question" not in content["assign_batch_name"]
+        assert "review_consolidated_answers" not in content["assign_batch_name"]
+
+    def test_downstream_observe_resolves_passthrough_namespace(self):
+        """The stored shape must satisfy a downstream observe of the passthrough field."""
+        transformer = PassthroughTransformer()
+        passthrough = {"approve_final_question": {"hitl_status": "approved"}}
+
+        result = transformer.transform_with_passthrough(
+            data=[{"batch_name": "batch_A"}],
+            context_data={},
+            source_guid="g1",
+            agent_config=_config(["approve_final_question.*"]),
+            action_name="assign_batch_name",
+            passthrough_fields=passthrough,
+        )
+
+        content = result[0]["content"]
+        _, llm_context, _ = apply_context_scope(
+            content,
+            {"observe": ["approve_final_question.hitl_status"]},
+            action_name="downstream",
+        )
+        assert llm_context.get("approve_final_question", {}).get("hitl_status") == "approved"

--- a/tests/unit/utils/test_passthrough_namespaced_placement.py
+++ b/tests/unit/utils/test_passthrough_namespaced_placement.py
@@ -103,9 +103,7 @@ class TestNamespacedPassthroughPlacement:
             data=[{"batch_name": "batch_A"}],
             context_data={},
             source_guid="g1",
-            agent_config=_config(
-                ["approve_final_question.*", "review_consolidated_answers.*"]
-            ),
+            agent_config=_config(["approve_final_question.*", "review_consolidated_answers.*"]),
             action_name="assign_batch_name",
             passthrough_fields=passthrough,
         )

--- a/tests/unit/utils/test_passthrough_strategies.py
+++ b/tests/unit/utils/test_passthrough_strategies.py
@@ -197,18 +197,18 @@ class TestContextScopeUnstructuredStrategy:
 
 
 class TestPrecomputedStructuredStrategy:
-    """PrecomputedStructuredStrategy merges passthrough, returns flat."""
+    """PrecomputedStructuredStrategy normalizes items; passthrough placement is
+    the transformer's job (content level), never the flat action output."""
 
-    def test_merges_passthrough_returns_flat(self):
+    def test_returns_flat_without_passthrough_merge(self):
         strategy = PrecomputedStructuredStrategy()
         data = [{"source_guid": "g1", "content": {"vote": "keep"}}]
-        passthrough = {"extra": "value"}
+        passthrough = {"upstream": {"extra": "value"}}
 
         result = strategy.transform(data, {}, "g1", _agent_config(), passthrough)
 
         assert len(result) == 1
-        assert result[0]["vote"] == "keep"
-        assert result[0]["extra"] == "value"
+        assert result[0] == {"vote": "keep"}
         assert "source_guid" not in result[0]
         assert "content" not in result[0]
 
@@ -216,24 +216,22 @@ class TestPrecomputedStructuredStrategy:
         """Output should not be wrapped under action namespace."""
         strategy = PrecomputedStructuredStrategy()
         data = [{"source_guid": "g1", "content": {"x": 1}}]
-        passthrough = {"y": 2}
+        passthrough = {"upstream": {"y": 2}}
 
         result = strategy.transform(data, {}, "g1", _agent_config("act"), passthrough)
 
-        # Flat — no action namespace wrapping
         assert "act" not in result[0]
-        assert result[0]["x"] == 1
-        assert result[0]["y"] == 2
+        assert result[0] == {"x": 1}
 
     def test_item_without_content_key(self):
         strategy = PrecomputedStructuredStrategy()
         data = [{"source_guid": "g1", "content": {"x": 1}}, {"other": "val"}]
-        passthrough = {"y": 2}
+        passthrough = {"upstream": {"y": 2}}
 
         result = strategy.transform(data, {}, "g1", _agent_config(), passthrough)
 
-        assert result[0] == {"x": 1, "y": 2}
-        assert result[1] == {"other": "val", "y": 2}
+        assert result[0] == {"x": 1}
+        assert result[1] == {"other": "val"}
 
 
 # ---------------------------------------------------------------------------
@@ -242,22 +240,23 @@ class TestPrecomputedStructuredStrategy:
 
 
 class TestPrecomputedUnstructuredStrategy:
-    """PrecomputedUnstructuredStrategy merges passthrough, returns flat."""
+    """PrecomputedUnstructuredStrategy normalizes items; passthrough placement is
+    the transformer's job (content level), never the flat action output."""
 
-    def test_merges_passthrough_returns_flat(self):
+    def test_returns_flat_without_passthrough_merge(self):
         strategy = PrecomputedUnstructuredStrategy()
         data = [{"vote": "keep"}]
-        passthrough = {"extra": "value"}
+        passthrough = {"upstream": {"extra": "value"}}
 
         result = strategy.transform(data, {}, "g1", _agent_config(), passthrough)
 
         assert len(result) == 1
-        assert result[0] == {"vote": "keep", "extra": "value"}
+        assert result[0] == {"vote": "keep"}
         assert "source_guid" not in result[0]
 
     def test_non_dict_items_normalized(self):
         strategy = PrecomputedUnstructuredStrategy()
-        result = strategy.transform(["text"], {}, "g1", _agent_config(), {"k": "v"})
+        result = strategy.transform(["text"], {}, "g1", _agent_config(), {"ns": {"k": "v"}})
         assert result[0] == {"value": "text"}
 
 

--- a/tests/unit/validation/test_seed_observe_template_overlap.py
+++ b/tests/unit/validation/test_seed_observe_template_overlap.py
@@ -1,0 +1,84 @@
+"""Warn when a seed field is both observed and referenced in the prompt template.
+
+Seed data is always available to Jinja templates. Observing the same seed field
+additionally injects it into the LLM context message, so the blob reaches the
+model twice. The static analyzer must surface the overlap.
+"""
+
+from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+    WorkflowStaticAnalyzer,
+)
+
+
+def _workflow(prompt, observe):
+    return {
+        "name": "wf",
+        "actions": [
+            {
+                "name": "author",
+                "prompt": prompt,
+                "schema": {
+                    "type": "object",
+                    "properties": {"out": {"type": "string"}},
+                },
+                "context_scope": {"observe": observe},
+            }
+        ],
+    }
+
+
+def _overlap_warnings(result):
+    return [
+        w.message
+        for w in result.warnings
+        if "seed" in w.message and "twice" in w.message
+    ]
+
+
+class TestSeedObserveTemplateOverlap:
+    def test_observed_and_templated_seed_field_warns(self):
+        wf = _workflow(
+            "Rules: {{ seed.rules }}\nText: {{ source.text }}",
+            ["source.text", "seed.rules"],
+        )
+        result = WorkflowStaticAnalyzer(wf).analyze()
+
+        warnings = _overlap_warnings(result)
+        assert len(warnings) == 1
+        assert "rules" in warnings[0]
+        assert "author" in warnings[0]
+
+    def test_observe_only_no_warning(self):
+        wf = _workflow(
+            "Text: {{ source.text }}",
+            ["source.text", "seed.rules"],
+        )
+        result = WorkflowStaticAnalyzer(wf).analyze()
+        assert _overlap_warnings(result) == []
+
+    def test_template_only_no_warning(self):
+        wf = _workflow(
+            "Rules: {{ seed.rules }}\nText: {{ source.text }}",
+            ["source.text"],
+        )
+        result = WorkflowStaticAnalyzer(wf).analyze()
+        assert _overlap_warnings(result) == []
+
+    def test_wildcard_seed_observe_with_template_ref_warns(self):
+        wf = _workflow(
+            "Rules: {{ seed.rules }}\nText: {{ source.text }}",
+            ["source.text", "seed.*"],
+        )
+        result = WorkflowStaticAnalyzer(wf).analyze()
+
+        warnings = _overlap_warnings(result)
+        assert len(warnings) == 1
+        assert "rules" in warnings[0]
+
+    def test_distinct_seed_fields_no_warning(self):
+        wf = _workflow(
+            "Rules: {{ seed.rules }}",
+            ["source.text", "seed.examples"],
+        )
+        result = WorkflowStaticAnalyzer(wf).analyze()
+        assert _overlap_warnings(result) == []

--- a/tests/unit/validation/test_seed_observe_template_overlap.py
+++ b/tests/unit/validation/test_seed_observe_template_overlap.py
@@ -28,11 +28,7 @@ def _workflow(prompt, observe):
 
 
 def _overlap_warnings(result):
-    return [
-        w.message
-        for w in result.warnings
-        if "seed" in w.message and "twice" in w.message
-    ]
+    return [w.message for w in result.warnings if "seed" in w.message and "twice" in w.message]
 
 
 class TestSeedObserveTemplateOverlap:


### PR DESCRIPTION
## Summary

Fixes the three real defects found by the UAT context-scope (CS) audit of how `source.field` / `action.field` resolve into prompt and tool context. The other seven CS checks were verified working against real `prompt_trace` data and code (resolution, wildcards, version-merge expansion, drop, typo detection) — no changes needed there.

**1. Passthrough namespaces were nested inside the action's output (CS-06).**
`apply_context_scope` emits `passthrough_fields` as `{namespace: {field: value}}`, but all three merge sites folded that dict into the flat action output before `RecordEnvelope.build` wrapped it — producing `content[action][ns][field]` instead of `content[ns][field]`. A downstream `observe: [ns.field]` could not resolve the passthrough copy, and the action namespace carried keys not in its schema. Fixed at all three sites through one shared helper (`merge_passthrough_namespaces`):
- `PrecomputedStructuredStrategy` / `PrecomputedUnstructuredStrategy` (online record path)
- `batch_result_strategy.py` stored-passthrough merge (batch path)
- `PassthroughEnricher` (enrichment pipeline — found by blind review after the first fix; it re-polluted the action namespace right after the corrected placement)

The helper places namespaces at content level as siblings of the action namespace, never overwrites the action's own output, lets existing content win field-by-field, and is copy-on-write (never mutates a namespace dict shared with the input record's content). It is idempotent, so the transform-time merge followed by the enricher merge is safe.

**2. FILE-mode flat-key collisions were silently namespace-qualified (CS-09).**
When observe refs share a bare field name across namespaces, injected flat keys become `ns.field` — a tool reading the bare key gets nothing, with zero signal. `_resolve_observe_refs_for_flat_keys` now logs a warning naming the qualified keys. Delivery behavior is unchanged.

**3. Seed fields observed AND template-referenced reach the model twice (CS-10).**
Seed is always available to Jinja; observing the same field additionally injects it via the observe context message (verified empirically: the blob lands twice). The static analyzer now emits a warn-level finding (`_check_seed_template_observe_overlap`) when an action's template references `{{ seed.K }}` and its observe lists `seed.K` (or `seed.*`).

## Existing-test rewrites (flagged by the gate — intentional)

The gate's reward-hack check flags 63 removed assert/def-test lines from existing tests. Those tests encoded the buggy contract with flat toy fixtures (`passthrough_fields={"pt": "val"}`) that don't match the real namespaced shape the producer emits. They were rewritten — not deleted — to assert content-level placement with realistic namespaced fixtures:
- `tests/unit/utils/test_passthrough_strategies.py`
- `tests/unit/llm/batch/test_batch_passthrough_stored.py` (tested a now-removed private method; rewritten end-to-end through `strategy.process`)
- `tests/unit/unification/test_phase3_batch_retrieve.py` (merge-order tests re-specified: action namespace never overwritten, content-level placement, per-field precedence)
- `tests/unit/processing/test_enrichment_namespaced.py`

New test files: `test_passthrough_namespaced_placement.py` (placement + downstream observe round-trip), `test_file_mode_collision_warning.py`, `test_seed_observe_template_overlap.py`.

## Verification

- RED recorded before any source change (`gate.sh red`): 6 genuine assertion failures on the placement tests; the collision/seed tests failed alongside.
- GREEN (`gate.sh green`): RED target passes, full suite green (8,195+ passed), `ruff check` and `ruff format --check` clean.
- Blind review, HIGH tier (3 diverse lenses): all three verdicts YES at the final HEAD. Lenses A and B independently found the `PassthroughEnricher` sibling — fixed in a follow-up commit and re-verified with executed repros; lens C independently confirmed the same sibling and its fix, judged the existing-test rewrites legitimate re-specification (not weakening), and flagged one stale test-file docstring (fixed).
- Real-project check: the branch static analyzer ran over all 10 workflows in the qanalabs canary project — 0 crashes, 0 false-positive seed-overlap warnings.

## Smoke skip (recorded via gate.sh smoke --skip)

`smoke-test.sh` targets workflow `qanalabs_quiz_gen`, which no longer exists in the canary project (it evolved to the `ql_*` family). `baseline.sh` verdict: fails on main too — pre-existing/environmental, not a branch effect. The `scan-project.sh` canary was refreshed with justification: the project gained the `to_qanalabs_*` converter UDFs since the manifest snapshot (also present on main). The real-project analyzer sweep above stands in for the canary's zero-false-positive signal.

## Out of scope (documented follow-ups)

- `ContextScopeStructuredStrategy` / `ContextScopeUnstructuredStrategy` merge bare context fields into the action output via a separate mechanism gated on empty precomputed passthrough; blind review confirmed it is a genuinely different path and not part of this defect. Follow-up filed in coordination status.
- The harness smoke script needs re-targeting to an existing canary workflow.
