### PR TITLE
fix: deep-validate LLM outputs — re-land #816 onto main

### DIFF
--- a/agent_actions/validation/ARCHITECTURE.md
+++ b/agent_actions/validation/ARCHITECTURE.md
@@ -267,6 +267,13 @@ Schema-echo detection:
   -> "Schema-echo detected" error
       |
       v
+_deep_validation_errors()    jsonschema-backed constraint checks
+  Per-element validation of array fields against their items sub-schema
+  (errors name the element index), additionalProperties: false at top
+  level and inside elements, minimum/maximum, enum. Appends to
+  validation_errors and flips is_compliant; None field values tolerated.
+      |
+      v
 Namespace hint:
   If missing_required AND extra_fields are dicts
   -> suggests UDF is passing namespaced input without unwrapping

--- a/agent_actions/validation/schema_output_validator.py
+++ b/agent_actions/validation/schema_output_validator.py
@@ -5,11 +5,15 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+import jsonschema  # type: ignore[import-untyped]
+
 from agent_actions.config.schema_field import field_is_required, top_level_required_ids
 from agent_actions.errors import SchemaValidationError
 from agent_actions.validation.schema_validator import SchemaValidator
 
 logger = logging.getLogger(__name__)
+
+_CONSTRAINT_KEYS = ("minimum", "maximum", "enum")
 
 # Reuse the canonical set of JSON Schema keywords defined in SchemaValidator
 # rather than maintaining a separate list.  When an LLM "echoes" the schema
@@ -179,6 +183,11 @@ def validate_output_against_schema(
             f"Extra fields not allowed in strict mode: {', '.join(extra_fields)}"
         )
 
+    deep_errors = _deep_validation_errors(llm_output, schema, extra_fields)
+    if deep_errors:
+        is_compliant = False
+        validation_errors.extend(deep_errors)
+
     # Detect action-namespaced output: extra keys whose values are dicts
     # suggest the UDF is passing through namespaced input instead of
     # unwrapping it via content.get("action_name", {}).get("field").
@@ -313,6 +322,96 @@ def _extract_schema_fields(schema: dict[str, Any]) -> tuple[set[str], set[str], 
                 field_types[k] = v
 
     return all_fields, required_fields, field_types
+
+
+def _deep_validation_errors(
+    llm_output: Any,
+    schema: dict[str, Any],
+    extra_fields: list[str],
+) -> list[str]:
+    """Constraint checks the flat pass skips: per-element items, additionalProperties, bounds, enum."""
+    errors: list[str] = []
+
+    if schema.get("additionalProperties") is False and extra_fields:
+        errors.append(
+            f"Extra fields not allowed (additionalProperties: false): {', '.join(extra_fields)}"
+        )
+
+    if "fields" in schema:
+        for field_def in schema.get("fields", []):
+            if not isinstance(field_def, dict):
+                continue
+            field_id = field_def.get("id") or field_def.get("name")
+            if field_id:
+                errors.extend(_field_value_errors(llm_output, field_id, field_def))
+    elif "properties" in schema and isinstance(schema["properties"], dict):
+        for prop_name, prop_def in schema["properties"].items():
+            if isinstance(prop_def, dict):
+                errors.extend(_field_value_errors(llm_output, prop_name, prop_def))
+    elif "schema" in schema and isinstance(schema["schema"], dict):
+        errors.extend(_deep_validation_errors(llm_output, schema["schema"], extra_fields))
+    elif (
+        schema.get("type") == "array"
+        and isinstance(schema.get("items"), dict)
+        and isinstance(llm_output, list)
+    ):
+        errors.extend(_element_errors(llm_output, schema["items"], field_name=None))
+
+    return errors
+
+
+def _field_value_errors(llm_output: Any, field_name: str, field_def: dict[str, Any]) -> list[str]:
+    """Deep errors for one output field: per-element items validation plus value constraints."""
+    if not isinstance(llm_output, dict) or field_name not in llm_output:
+        return []
+    value = llm_output[field_name]
+    if value is None:
+        return []
+
+    errors: list[str] = []
+    items = field_def.get("items")
+    if field_def.get("type") == "array" and isinstance(items, dict) and isinstance(value, list):
+        errors.extend(_element_errors(value, items, field_name=field_name))
+    errors.extend(_constraint_errors(value, field_name, field_def))
+    return errors
+
+
+def _element_errors(
+    elements: list[Any],
+    items_schema: dict[str, Any],
+    field_name: str | None,
+) -> list[str]:
+    """Validate each array element against the items sub-schema, naming the element index."""
+    location = f"'items' for field '{field_name}'" if field_name else "'items'"
+    try:
+        jsonschema.Draft202012Validator.check_schema(items_schema)
+    except jsonschema.exceptions.SchemaError as e:
+        return [f"Invalid {location} sub-schema: {e.message}"]
+
+    validator = jsonschema.Draft202012Validator(items_schema)
+    prefix = f"Field '{field_name}' element" if field_name else "Element"
+    errors: list[str] = []
+    for idx, element in enumerate(elements):
+        for message in sorted(err.message for err in validator.iter_errors(element)):
+            errors.append(f"{prefix} {idx}: {message}")
+    return errors
+
+
+def _constraint_errors(value: Any, field_name: str, field_def: dict[str, Any]) -> list[str]:
+    """Validate a field value against its declared minimum/maximum/enum constraints."""
+    constraints = {k: field_def[k] for k in _CONSTRAINT_KEYS if k in field_def}
+    if not constraints:
+        return []
+    try:
+        jsonschema.Draft202012Validator.check_schema(constraints)
+    except jsonschema.exceptions.SchemaError as e:
+        return [f"Invalid constraints for field '{field_name}': {e.message}"]
+
+    validator = jsonschema.Draft202012Validator(constraints)
+    return [
+        f"Field '{field_name}': {message}"
+        for message in sorted(err.message for err in validator.iter_errors(value))
+    ]
 
 
 def _extract_output_fields(llm_output: Any) -> set[str]:

--- a/tests/unit/validation/test_deep_schema_validation.py
+++ b/tests/unit/validation/test_deep_schema_validation.py
@@ -1,0 +1,311 @@
+"""Deep schema checks: per-element items, additionalProperties, bounds, enum."""
+
+from agent_actions.validation.schema_output_validator import validate_output_against_schema
+
+
+class TestArrayFieldItemsRequiredPerElement:
+    """items.required is enforced per element, not against the union of keys."""
+
+    def _schema(self):
+        return {
+            "name": "review_findings",
+            "properties": {
+                "findings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "summary": {"type": "string"},
+                            "severity": {"type": "string"},
+                        },
+                        "required": ["summary", "severity"],
+                    },
+                }
+            },
+            "required": ["findings"],
+        }
+
+    def test_one_incomplete_element_among_complete_ones_is_non_compliant(self):
+        output = {
+            "findings": [
+                {"summary": "first", "severity": "low"},
+                {"summary": "second"},
+                {"summary": "third", "severity": "high"},
+            ]
+        }
+        report = validate_output_against_schema(output, self._schema(), "review_action")
+        assert not report.is_compliant
+        assert any(
+            "'findings' element 1" in e and "'severity' is a required property" in e
+            for e in report.validation_errors
+        )
+
+    def test_complete_elements_produce_no_element_errors(self):
+        output = {
+            "findings": [
+                {"summary": "first", "severity": "low"},
+                {"summary": "second"},
+            ]
+        }
+        report = validate_output_against_schema(output, self._schema(), "review_action")
+        assert not any("element 0" in e for e in report.validation_errors)
+        assert any("element 1" in e for e in report.validation_errors)
+
+
+class TestArrayFieldItemsAdditionalProperties:
+    """items.additionalProperties: false rejects extra keys inside elements."""
+
+    def test_extra_key_in_element_is_non_compliant(self):
+        schema = {
+            "name": "qa_pairs",
+            "properties": {
+                "pairs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"question": {"type": "string"}},
+                        "required": ["question"],
+                        "additionalProperties": False,
+                    },
+                }
+            },
+            "required": ["pairs"],
+        }
+        output = {
+            "pairs": [
+                {"question": "fine"},
+                {"question": "fine", "rogue": "nope"},
+            ]
+        }
+        report = validate_output_against_schema(output, schema, "qa_action")
+        assert not report.is_compliant
+        assert any(
+            "'pairs' element 1" in e and "rogue" in e and "Additional properties" in e
+            for e in report.validation_errors
+        )
+        assert not any("element 0" in e for e in report.validation_errors)
+
+
+class TestTopLevelAdditionalProperties:
+    """Top-level additionalProperties: false applies without strict_mode."""
+
+    def test_extra_top_level_field_is_non_compliant_in_non_strict_mode(self):
+        schema = {
+            "name": "strict_top",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+        output = {"answer": "yes", "surprise": "extra"}
+        report = validate_output_against_schema(output, schema, "strict_action", strict_mode=False)
+        assert not report.is_compliant
+        assert any(
+            "additionalProperties" in e and "surprise" in e for e in report.validation_errors
+        )
+
+    def test_no_extra_fields_stays_compliant(self):
+        schema = {
+            "name": "strict_top",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+        report = validate_output_against_schema({"answer": "yes"}, schema, "strict_action")
+        assert report.is_compliant
+        assert report.validation_errors == []
+
+
+class TestNumericBounds:
+    """minimum/maximum on a field are enforced."""
+
+    def _schema(self):
+        return {
+            "name": "scored",
+            "properties": {"score": {"type": "integer", "minimum": 0, "maximum": 10}},
+            "required": ["score"],
+        }
+
+    def test_above_maximum_is_non_compliant(self):
+        report = validate_output_against_schema({"score": 15}, self._schema(), "score_action")
+        assert not report.is_compliant
+        assert any(
+            "'score'" in e and "greater than the maximum of 10" in e
+            for e in report.validation_errors
+        )
+
+    def test_below_minimum_is_non_compliant(self):
+        report = validate_output_against_schema({"score": -3}, self._schema(), "score_action")
+        assert not report.is_compliant
+        assert any(
+            "'score'" in e and "less than the minimum of 0" in e for e in report.validation_errors
+        )
+
+    def test_in_range_is_compliant(self):
+        report = validate_output_against_schema({"score": 7}, self._schema(), "score_action")
+        assert report.is_compliant
+        assert report.validation_errors == []
+
+    def test_bounds_on_fields_format_field(self):
+        schema = {
+            "name": "scored",
+            "fields": [{"id": "score", "type": "integer", "minimum": 0, "maximum": 10}],
+        }
+        report = validate_output_against_schema({"score": 15}, schema, "score_action")
+        assert not report.is_compliant
+        assert any(
+            "'score'" in e and "greater than the maximum of 10" in e
+            for e in report.validation_errors
+        )
+
+
+class TestEnum:
+    """enum membership is enforced."""
+
+    def test_value_outside_enum_is_non_compliant(self):
+        schema = {
+            "name": "status_schema",
+            "properties": {"status": {"type": "string", "enum": ["open", "closed"]}},
+            "required": ["status"],
+        }
+        report = validate_output_against_schema({"status": "pending"}, schema, "status_action")
+        assert not report.is_compliant
+        assert any("'status'" in e and "is not one of" in e for e in report.validation_errors)
+
+    def test_enum_on_fields_format_field(self):
+        schema = {
+            "name": "status_schema",
+            "fields": [{"id": "status", "type": "string", "enum": ["open", "closed"]}],
+        }
+        report = validate_output_against_schema({"status": "pending"}, schema, "status_action")
+        assert not report.is_compliant
+        assert any("'status'" in e and "is not one of" in e for e in report.validation_errors)
+
+    def test_enum_member_is_compliant(self):
+        schema = {
+            "name": "status_schema",
+            "properties": {"status": {"type": "string", "enum": ["open", "closed"]}},
+            "required": ["status"],
+        }
+        report = validate_output_against_schema({"status": "open"}, schema, "status_action")
+        assert report.is_compliant
+        assert report.validation_errors == []
+
+
+class TestAllValidNoRegression:
+    """Fully valid outputs against a constrained schema stay compliant."""
+
+    def test_deep_schema_all_valid(self):
+        schema = {
+            "name": "everything",
+            "properties": {
+                "score": {"type": "integer", "minimum": 0, "maximum": 10},
+                "status": {"type": "string", "enum": ["open", "closed"]},
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"label": {"type": "string"}},
+                        "required": ["label"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["score", "status", "entries"],
+        }
+        output = {
+            "score": 5,
+            "status": "open",
+            "entries": [{"label": "a"}, {"label": "b"}],
+        }
+        report = validate_output_against_schema(output, schema, "everything_action")
+        assert report.is_compliant
+        assert report.validation_errors == []
+
+    def test_none_value_skips_constraint_checks(self):
+        schema = {
+            "name": "status_schema",
+            "properties": {"status": {"type": "string", "enum": ["open", "closed"]}},
+        }
+        report = validate_output_against_schema({"status": None}, schema, "status_action")
+        assert report.is_compliant
+
+
+class TestFieldsFormatItemsSubSchema:
+    """fields-format array field with an items sub-schema is validated per element."""
+
+    def _schema(self):
+        return {
+            "name": "canonicalize_qa",
+            "fields": [
+                {
+                    "id": "canonical_questions",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"question_text": {"type": "string"}},
+                        "required": ["question_text"],
+                        "additionalProperties": True,
+                    },
+                }
+            ],
+        }
+
+    def test_element_missing_items_required_is_non_compliant(self):
+        output = {
+            "canonical_questions": [
+                {"question_text": "What is X?"},
+                {"source": "no question here"},
+            ]
+        }
+        report = validate_output_against_schema(output, self._schema(), "canonicalize_qa")
+        assert not report.is_compliant
+        assert any(
+            "'canonical_questions' element 1" in e and "'question_text' is a required property" in e
+            for e in report.validation_errors
+        )
+
+    def test_all_elements_valid_is_compliant(self):
+        output = {
+            "canonical_questions": [
+                {"question_text": "What is X?", "source": "doc1"},
+                {"question_text": "What is Y?"},
+            ]
+        }
+        report = validate_output_against_schema(output, self._schema(), "canonicalize_qa")
+        assert report.is_compliant
+        assert report.validation_errors == []
+
+    def test_non_object_element_is_non_compliant(self):
+        output = {"canonical_questions": [{"question_text": "ok"}, "just a string"]}
+        report = validate_output_against_schema(output, self._schema(), "canonicalize_qa")
+        assert not report.is_compliant
+        assert any(
+            "'canonical_questions' element 1" in e and "is not of type 'object'" in e
+            for e in report.validation_errors
+        )
+
+
+class TestTopLevelArraySchemaPerElement:
+    """Top-level array schema validates each element instead of the key union."""
+
+    def test_one_incomplete_element_is_non_compliant(self):
+        schema = {
+            "name": "item_list",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}, "body": {"type": "string"}},
+                "required": ["title", "body"],
+            },
+        }
+        output = [
+            {"title": "t1", "body": "b1"},
+            {"title": "t2"},
+        ]
+        report = validate_output_against_schema(output, schema, "list_action")
+        assert not report.is_compliant
+        assert any(
+            "Element 1" in e and "'body' is a required property" in e
+            for e in report.validation_errors
+        )
+        assert not any("Element 0" in e for e in report.validation_errors)


### PR DESCRIPTION
## Summary
- Re-lands #816 unchanged. #816 was a stacked PR based on `fix/schema-required-opt-in`; #815 merged into main *without deleting its branch*, so GitHub never retargeted #816 — it merged into the stale base branch 13 seconds later and its commits never reached main.
- This branch cherry-picks the exact three commits of #816's delta onto current main. The resulting tree is **byte-identical** to #816's reviewed head (`git diff fb1bec11 HEAD` is empty).
- Content: LLM output validation now enforces deep schema constraints — per-element array `items` (required + type, errors name the element index), `additionalProperties: false`, `minimum`/`maximum`, and `enum` — via `jsonschema.Draft202012Validator`, appended to `SchemaValidationReport` so warn/reprompt/reject modes all inherit.

## Verification
- `git diff fb1bec11 HEAD` empty — identical tree to the head that passed #816's HIGH-tier 3-reviewer verdict (3/3 YES).
- Full suite on this branch: 8228 passed. `ruff check` + `ruff format --check` clean.
- Real-data canary from #816 still applies: all 342 stored LLM outputs across the canary project's workflow DBs re-validated with the new checks — 0 newly non-compliant.