### PR TITLE
fix: cross-type guard comparisons warn at runtime and preflight; union types survive schema validation

### DIFF
--- a/agent_actions/input/preprocessing/filtering/guard_filter.py
+++ b/agent_actions/input/preprocessing/filtering/guard_filter.py
@@ -266,11 +266,14 @@ class GuardFilter:
 
     def clear_cache(self):
         """Clear all caches."""
+        from ..parsing.ast_nodes import _reset_type_mismatch_warnings
+
         self.parser.clear_cache()
         self._cached_parse.cache_clear()
         with self._circuit_lock:
             self._semantic_error_cache.clear()
             self._error_counts.clear()
+        _reset_type_mismatch_warnings()
 
     def shutdown(self):
         """Shutdown the filter service."""

--- a/agent_actions/input/preprocessing/parsing/ast_nodes.py
+++ b/agent_actions/input/preprocessing/parsing/ast_nodes.py
@@ -23,10 +23,11 @@ class MissingFieldError(ValueError):
 class GuardSemanticError(ValueError):
     """Raised when a guard condition has a structural problem.
 
-    Examples: unquoted string literal on comparison RHS, type mismatch
-    in comparison operands. Distinct from MissingFieldError (data-level)
-    because semantic errors are deterministic — they fail for every record,
-    not just records missing a field.
+    Example: unquoted string literal on comparison RHS. Distinct from
+    MissingFieldError (data-level) because semantic errors are
+    deterministic — they fail for every record, not just records missing
+    a field. Operand type mismatches warn instead of raising: the same
+    condition can be valid for one record's data and not another's.
     """
 
     pass

--- a/agent_actions/input/preprocessing/parsing/ast_nodes.py
+++ b/agent_actions/input/preprocessing/parsing/ast_nodes.py
@@ -37,6 +37,91 @@ def _is_null_or_empty_namespace(ns_value: Any) -> bool:
     return is_null_namespace(ns_value) or (isinstance(ns_value, dict) and not ns_value)
 
 
+def value_type_family(value: Any) -> str | None:
+    """Coarse type family used to detect never-comparable operand pairs."""
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int | float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list | tuple):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return None
+
+
+def families_never_comparable(left: str | None, right: str | None) -> bool:
+    """Whether two type families make ==, != and ordering comparisons
+    type-determined rather than data-determined.
+
+    boolean/number stays comparable (``True == 1`` holds), and an unknown
+    family never triggers — this must only fire on certain mismatches.
+    """
+    if left is None or right is None or left == right:
+        return False
+    return {left, right} != {"boolean", "number"}
+
+
+_TYPE_CHECKED_OPERATOR_NAMES = frozenset({"EQ", "NE", "LT", "LE", "GT", "GE"})
+
+_TYPE_MISMATCH_SEEN: set[tuple[str, str, str, str]] = set()
+_TYPE_MISMATCH_SEEN_MAX = 1024
+
+
+def _reset_type_mismatch_warnings() -> None:
+    _TYPE_MISMATCH_SEEN.clear()
+
+
+def _warn_comparison_type_mismatch(
+    node: "ComparisonNode", left_value: Any, right_value: Any
+) -> None:
+    """Warn once per (field, operator, families) when a field/literal comparison
+    can only ever resolve one way because the operand types never compare.
+
+    Silent cross-type comparisons make ``on_false: filter`` guards drop every
+    record with no signal; the result is left untouched (strict, no coercion) —
+    this only adds the missing announcement.
+    """
+    if node.operator.name not in _TYPE_CHECKED_OPERATOR_NAMES:
+        return
+    if isinstance(node.left, FieldNode) and isinstance(node.right, LiteralNode):
+        field_node, field_value, literal_value = node.left, left_value, right_value
+    elif isinstance(node.right, FieldNode) and isinstance(node.left, LiteralNode):
+        field_node, field_value, literal_value = node.right, right_value, left_value
+    else:
+        return
+    if field_value is None or literal_value is None:
+        return
+
+    field_family = value_type_family(field_value)
+    literal_family = value_type_family(literal_value)
+    if not families_never_comparable(field_family, literal_family):
+        return
+
+    key = (field_node.field_path, node.operator.name, str(field_family), str(literal_family))
+    if key in _TYPE_MISMATCH_SEEN or len(_TYPE_MISMATCH_SEEN) >= _TYPE_MISMATCH_SEEN_MAX:
+        return
+    _TYPE_MISMATCH_SEEN.add(key)
+
+    message = (
+        f"Condition '{format_node(node)}': type mismatch — field "
+        f"'{field_node.field_path}' has a {field_family} value ({field_value!r}) "
+        f"but is compared to a {literal_family} literal ({literal_value!r}); "
+        f"the outcome is decided by the types, not the data."
+    )
+    if field_family == "string" and literal_family in ("boolean", "number"):
+        quoted = (
+            str(literal_value).lower() if isinstance(literal_value, bool) else str(literal_value)
+        )
+        message += (
+            f" If the field is stored as a string, quote the literal "
+            f'(e.g. {field_node.field_path} {node.operator.value} "{quoted}").'
+        )
+    logger.warning(message)
+
+
 def _field_exists(data: Any, field_path: str) -> bool:
     """Check if a field path exists in the data (distinguishes None value from missing)."""
     keys = field_path.split(".")
@@ -255,6 +340,7 @@ def evaluate_node(
                     ) from e
                 raise
 
+        _warn_comparison_type_mismatch(node, left_value, right_value)
         try:
             return op_fn(left_value, right_value)
         except (TypeError, ValueError):

--- a/agent_actions/validation/static_analyzer/schema_structure_validator.py
+++ b/agent_actions/validation/static_analyzer/schema_structure_validator.py
@@ -14,6 +14,16 @@ class SchemaStructureValidator:
     # Valid JSON Schema types
     VALID_TYPES = {"string", "number", "integer", "boolean", "array", "object", "null"}
 
+    def _is_valid_type_declaration(self, type_value: Any) -> bool:
+        """A known type name, or a non-empty union list of known names."""
+        if isinstance(type_value, str):
+            return type_value in self.VALID_TYPES
+        if isinstance(type_value, list):
+            return bool(type_value) and all(
+                isinstance(t, str) and t in self.VALID_TYPES for t in type_value
+            )
+        return False
+
     def validate_schema(
         self,
         schema: dict[str, Any],
@@ -169,8 +179,12 @@ class SchemaStructureValidator:
                     hint="Add 'type' key: string, number, integer, boolean, array, or object",
                 )
             )
-        elif field_type not in self.VALID_TYPES:
-            if not (field_type.startswith("array[") and field_type.endswith("]")):
+        elif not self._is_valid_type_declaration(field_type):
+            if not (
+                isinstance(field_type, str)
+                and field_type.startswith("array[")
+                and field_type.endswith("]")
+            ):
                 errors.append(
                     StaticTypeError(
                         message=f"Field '{field_id}' has invalid type '{field_type}'",
@@ -310,7 +324,7 @@ class SchemaStructureValidator:
                         hint="Add type: string, number, integer, boolean, array, or object",
                     )
                 )
-            elif prop_type not in self.VALID_TYPES:
+            elif not self._is_valid_type_declaration(prop_type):
                 errors.append(
                     StaticTypeError(
                         message=f"Property '{prop_name}' has invalid type '{prop_type}'",

--- a/agent_actions/validation/static_analyzer/schema_structure_validator.py
+++ b/agent_actions/validation/static_analyzer/schema_structure_validator.py
@@ -217,7 +217,7 @@ class SchemaStructureValidator:
         errors: list[StaticTypeError] = []
 
         schema_type = schema.get("type")
-        if schema_type not in self.VALID_TYPES:
+        if not self._is_valid_type_declaration(schema_type):
             errors.append(
                 StaticTypeError(
                     message=f"Invalid schema type '{schema_type}'",

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -997,7 +997,9 @@ class WorkflowStaticAnalyzer:
                 if not producer_schema:
                     continue
                 declared = self._extract_field_types_from_schema(producer_schema).get(field_name)
-                declared_family = self._JSON_TYPE_FAMILIES.get(declared or "")
+                if not isinstance(declared, str):
+                    continue  # union types like ["string", "null"] stay unchecked
+                declared_family = self._JSON_TYPE_FAMILIES.get(declared)
                 literal_family = value_type_family(literal_node.value)
                 if not families_never_comparable(declared_family, literal_family):
                     continue

--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -224,6 +224,10 @@ class WorkflowStaticAnalyzer:
         for warning in self._check_guard_nullable_fields():
             result.add_warning(warning)
 
+        # Step 2h: Guard literals whose type can never match the field's schema type
+        for warning in self._check_guard_literal_type_mismatch():
+            result.add_warning(warning)
+
         for warning in guard_skip_observe_warnings:
             result.add_warning(warning)
 
@@ -900,6 +904,138 @@ class WorkflowStaticAnalyzer:
                             "Remove the observe entry (templates always see seed), "
                             "or drop the template reference."
                         ),
+                    )
+                )
+
+        return warnings
+
+    _GUARD_TYPE_CHECKED_OPERATORS = frozenset({"EQ", "NE", "LT", "LE", "GT", "GE"})
+
+    _JSON_TYPE_FAMILIES = {
+        "string": "string",
+        "boolean": "boolean",
+        "integer": "number",
+        "number": "number",
+        "array": "array",
+        "object": "object",
+    }
+
+    def _check_guard_literal_type_mismatch(self) -> list[StaticTypeWarning]:
+        """Warn when a guard comparison literal can never match the referenced
+        field's declared schema type.
+
+        ``producer.approved == true`` with ``approved`` declared ``string``
+        evaluates false for every record regardless of data — with
+        ``on_false: filter`` the whole dataset silently disappears. The
+        runtime warns per record; this surfaces the same mismatch before any
+        record is processed.
+        """
+        from agent_actions.input.preprocessing.parsing.ast_nodes import (
+            ComparisonNode,
+            FieldNode,
+            LiteralNode,
+            LogicalNode,
+            families_never_comparable,
+            format_node,
+            value_type_family,
+        )
+        from agent_actions.input.preprocessing.parsing.parser import WhereClauseParser
+
+        def iter_field_literal_comparisons(node):
+            if isinstance(node, LogicalNode):
+                yield from iter_field_literal_comparisons(node.left)
+                if node.right is not None:
+                    yield from iter_field_literal_comparisons(node.right)
+            elif isinstance(node, ComparisonNode):
+                if isinstance(node.left, FieldNode) and isinstance(node.right, LiteralNode):
+                    yield node, node.left, node.right
+                elif isinstance(node.left, LiteralNode) and isinstance(node.right, FieldNode):
+                    yield node, node.right, node.left
+
+        warnings: list[StaticTypeWarning] = []
+        parser: WhereClauseParser | None = None
+
+        for action in self.workflow_config.get("actions", []):
+            if not isinstance(action, dict):
+                continue
+            consumer_name = action.get("name", "unknown")
+            guard = action.get("guard")
+            if isinstance(guard, dict):
+                condition = guard.get("condition")
+            elif isinstance(guard, str):
+                condition = guard
+            else:
+                condition = None
+            if not condition or not isinstance(condition, str):
+                continue
+            if condition.strip().startswith("udf:"):
+                continue
+
+            if parser is None:
+                parser = WhereClauseParser()
+            parse_result = parser.parse(condition)
+            if not parse_result.success or parse_result.ast is None:
+                continue  # unparseable conditions are surfaced at evaluation time
+
+            for comparison, field_node, literal_node in iter_field_literal_comparisons(
+                parse_result.ast.root
+            ):
+                if comparison.operator.name not in self._GUARD_TYPE_CHECKED_OPERATORS:
+                    continue
+                if literal_node.value is None:
+                    continue
+                path = field_node.field_path
+                if "." not in path:
+                    continue
+                producer_name, field_name = path.split(".", 1)
+                if "." in field_name:
+                    continue  # schema types are tracked per top-level field
+                producer_node = self.graph.get_node(producer_name)
+                if not producer_node:
+                    continue
+                producer_schema = producer_node.output_schema.json_schema
+                if not producer_schema:
+                    continue
+                declared = self._extract_field_types_from_schema(producer_schema).get(field_name)
+                declared_family = self._JSON_TYPE_FAMILIES.get(declared or "")
+                literal_family = value_type_family(literal_node.value)
+                if not families_never_comparable(declared_family, literal_family):
+                    continue
+
+                message = (
+                    f"Guard on action '{consumer_name}': type mismatch in "
+                    f"'{format_node(comparison)}' — '{path}' is declared "
+                    f"'{declared}' in the schema of '{producer_name}' but the "
+                    f"literal is {literal_family} ({literal_node.value!r}); the "
+                    f"comparison outcome is decided by the types, not the data."
+                )
+                if declared_family == "string" and literal_family in ("boolean", "number"):
+                    literal_value = literal_node.value
+                    quoted = (
+                        str(literal_value).lower()
+                        if isinstance(literal_value, bool)
+                        else str(literal_value)
+                    )
+                    hint = (
+                        f"Quote the literal (e.g. {path} "
+                        f'{comparison.operator.value} "{quoted}"), or change the '
+                        f"schema type."
+                    )
+                elif declared_family == "boolean" and literal_family == "string":
+                    hint = "Compare against true/false without quotes, or change the schema type."
+                else:
+                    hint = "Align the literal with the field's declared schema type."
+                warnings.append(
+                    StaticTypeWarning(
+                        message=message,
+                        location=FieldLocation(
+                            agent_name=consumer_name,
+                            config_field="guard",
+                            raw_reference=path,
+                        ),
+                        referenced_agent=producer_name,
+                        referenced_field=field_name,
+                        hint=hint,
                     )
                 )
 

--- a/tests/unit/input/preprocessing/test_condition_type_mismatch_warning.py
+++ b/tests/unit/input/preprocessing/test_condition_type_mismatch_warning.py
@@ -1,0 +1,150 @@
+"""Cross-type guard comparisons must warn, not silently evaluate to not-matched.
+
+``field == true`` against a string ``"true"`` (or ``score > 3`` against ``"5"``)
+is decided by the type mismatch, not the data — every such record silently
+takes the false branch. The evaluation result must stay unchanged (strict,
+no coercion), but the mismatch must be announced.
+"""
+
+import logging
+
+import pytest
+
+from agent_actions.input.preprocessing.filtering.evaluator import GuardEvaluator
+from agent_actions.input.preprocessing.filtering.guard_filter import GuardFilter
+
+
+@pytest.fixture()
+def _enable_log_propagation():
+    """Ensure the agent_actions logger propagates to root so caplog captures records."""
+    aa_logger = logging.getLogger("agent_actions")
+    original = aa_logger.propagate
+    aa_logger.propagate = True
+    yield
+    aa_logger.propagate = original
+
+
+@pytest.fixture()
+def _reset_mismatch_dedup():
+    """Clear the warn-once state so each test observes its own warning."""
+    from agent_actions.input.preprocessing.parsing import ast_nodes
+
+    reset = getattr(ast_nodes, "_reset_type_mismatch_warnings", None)
+    if reset:
+        reset()
+    yield
+    if reset:
+        reset()
+
+
+def _evaluate(item, clause, behavior="filter"):
+    evaluator = GuardEvaluator(GuardFilter(enable_metrics=False))
+    return evaluator.evaluate(item, {"scope": "item", "clause": clause, "behavior": behavior})
+
+
+def _mismatch_warnings(caplog):
+    return [r for r in caplog.records if "type mismatch" in r.message]
+
+
+@pytest.mark.usefixtures("_enable_log_propagation", "_reset_mismatch_dedup")
+class TestEqualityTypeMismatchWarns:
+    def test_string_value_vs_boolean_literal_warns_and_stays_unmatched(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _evaluate(
+                {"content": {"review": {"approved": "true"}}},
+                "review.approved == true",
+            )
+
+        assert result.should_execute is False  # behavior unchanged: still filtered
+        warnings = _mismatch_warnings(caplog)
+        assert len(warnings) == 1
+        message = warnings[0].message
+        assert "review.approved" in message
+        assert "string" in message
+        assert "boolean" in message
+
+    def test_string_field_hint_suggests_quoting_the_literal(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _evaluate(
+                {"content": {"review": {"approved": "true"}}},
+                "review.approved == true",
+            )
+
+        message = _mismatch_warnings(caplog)[0].message
+        assert '"true"' in message
+
+    def test_string_value_vs_array_literal_warns(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _evaluate(
+                {"content": {"assemble": {"options": "a, b"}}},
+                "assemble.options != []",
+            )
+
+        warnings = _mismatch_warnings(caplog)
+        assert len(warnings) == 1
+        assert "assemble.options" in warnings[0].message
+
+
+@pytest.mark.usefixtures("_enable_log_propagation", "_reset_mismatch_dedup")
+class TestRelationalTypeMismatchWarns:
+    def test_string_value_vs_number_literal_warns_and_stays_unmatched(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _evaluate(
+                {"content": {"vote": {"score": "5"}}},
+                "vote.score > 3",
+            )
+
+        assert result.should_execute is False
+        warnings = _mismatch_warnings(caplog)
+        assert len(warnings) == 1
+        assert "vote.score" in warnings[0].message
+
+
+@pytest.mark.usefixtures("_enable_log_propagation", "_reset_mismatch_dedup")
+class TestCompatibleComparisonsStaySilent:
+    def test_boolean_value_vs_boolean_literal_no_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _evaluate(
+                {"content": {"review": {"approved": True}}},
+                "review.approved == true",
+            )
+
+        assert result.should_execute is True
+        assert _mismatch_warnings(caplog) == []
+
+    def test_none_value_no_warning(self, caplog):
+        """None fields come from skipped upstreams — a mismatch warning would fire
+        on every legitimately skipped record."""
+        with caplog.at_level(logging.WARNING):
+            result = _evaluate(
+                {"content": {"review": {"approved": None}}},
+                "review.approved == true",
+            )
+
+        assert result.should_execute is False
+        assert _mismatch_warnings(caplog) == []
+
+    def test_boolean_value_vs_number_literal_no_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _evaluate({"content": {"review": {"flag": True}}}, "review.flag == 1")
+
+        assert _mismatch_warnings(caplog) == []
+
+    def test_number_value_vs_number_literal_no_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _evaluate({"content": {"vote": {"score": 5}}}, "vote.score > 3")
+
+        assert result.should_execute is True
+        assert _mismatch_warnings(caplog) == []
+
+
+@pytest.mark.usefixtures("_enable_log_propagation", "_reset_mismatch_dedup")
+class TestWarningDeduplication:
+    def test_same_mismatch_across_records_warns_once(self, caplog):
+        evaluator = GuardEvaluator(GuardFilter(enable_metrics=False))
+        guard = {"scope": "item", "clause": "review.approved == true", "behavior": "filter"}
+        with caplog.at_level(logging.WARNING):
+            for value in ("true", "false", "true"):
+                evaluator.evaluate({"content": {"review": {"approved": value}}}, guard)
+
+        assert len(_mismatch_warnings(caplog)) == 1

--- a/tests/unit/input/preprocessing/test_condition_type_mismatch_warning.py
+++ b/tests/unit/input/preprocessing/test_condition_type_mismatch_warning.py
@@ -139,6 +139,32 @@ class TestCompatibleComparisonsStaySilent:
 
 
 @pytest.mark.usefixtures("_enable_log_propagation", "_reset_mismatch_dedup")
+class TestOperandOrderAndOperatorScope:
+    def test_literal_on_left_field_on_right_warns(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _evaluate(
+                {"content": {"review": {"approved": "true"}}},
+                "true == review.approved",
+            )
+
+        warnings = _mismatch_warnings(caplog)
+        assert len(warnings) == 1
+        assert "review.approved" in warnings[0].message
+
+    def test_in_operator_stays_exempt(self, caplog):
+        """IN compares a scalar against an array-shaped literal by design —
+        a family check would flag every legitimate membership test."""
+        with caplog.at_level(logging.WARNING):
+            result = _evaluate(
+                {"content": {"page": {"density": "high"}}},
+                'page.density IN ["high", "medium"]',
+            )
+
+        assert result.should_execute is True
+        assert _mismatch_warnings(caplog) == []
+
+
+@pytest.mark.usefixtures("_enable_log_propagation", "_reset_mismatch_dedup")
 class TestWarningDeduplication:
     def test_same_mismatch_across_records_warns_once(self, caplog):
         evaluator = GuardEvaluator(GuardFilter(enable_metrics=False))

--- a/tests/unit/validation/test_guard_literal_type_check.py
+++ b/tests/unit/validation/test_guard_literal_type_check.py
@@ -103,3 +103,8 @@ class TestCompatibleGuardLiteralsStaySilent:
     def test_null_literal_no_warning(self):
         wf = _workflow({"approved": "string"}, "producer.approved != null")
         assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []
+
+    def test_nullable_union_type_no_warning_and_no_crash(self):
+        wf = _workflow({"status": "string"}, 'producer.status == "approved"')
+        wf["actions"][0]["schema"]["properties"]["status"] = {"type": ["string", "null"]}
+        assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []

--- a/tests/unit/validation/test_guard_literal_type_check.py
+++ b/tests/unit/validation/test_guard_literal_type_check.py
@@ -1,0 +1,105 @@
+"""Preflight: a guard literal whose type can never match the referenced field's
+declared schema type must be flagged before any record is processed.
+
+``producer.approved == true`` with ``approved`` declared ``string`` filters every
+record at runtime regardless of data — the analyzer must surface it statically.
+"""
+
+from agent_actions.validation.static_analyzer.workflow_static_analyzer import (
+    WorkflowStaticAnalyzer,
+)
+
+
+def _workflow(producer_schema_types, guard_condition, on_false="filter"):
+    return {
+        "name": "wf",
+        "actions": [
+            {
+                "name": "producer",
+                "prompt": "P: {{ source.text }}",
+                "schema": {
+                    "type": "object",
+                    "properties": {f: {"type": t} for f, t in producer_schema_types.items()},
+                },
+                "context_scope": {"observe": ["source.text"]},
+            },
+            {
+                "name": "consumer",
+                "dependencies": ["producer"],
+                "prompt": "C: {{ source.text }}",
+                "schema": {
+                    "type": "object",
+                    "properties": {"out": {"type": "string"}},
+                },
+                "guard": {"condition": guard_condition, "on_false": on_false},
+                "context_scope": {"observe": ["source.text", "producer.*"]},
+            },
+        ],
+    }
+
+
+def _type_warnings(result):
+    return [w.message for w in result.warnings if "type mismatch" in w.message]
+
+
+class TestGuardLiteralTypeMismatchWarns:
+    def test_boolean_literal_vs_string_field_warns(self):
+        wf = _workflow({"approved": "string"}, "producer.approved == true")
+        warnings = _type_warnings(WorkflowStaticAnalyzer(wf).analyze())
+
+        assert len(warnings) == 1
+        message = warnings[0]
+        assert "producer.approved" in message
+        assert "string" in message
+        assert "boolean" in message
+
+    def test_string_literal_vs_boolean_field_warns(self):
+        wf = _workflow({"approved": "boolean"}, 'producer.approved == "true"')
+        warnings = _type_warnings(WorkflowStaticAnalyzer(wf).analyze())
+
+        assert len(warnings) == 1
+        assert "producer.approved" in warnings[0]
+
+    def test_number_literal_vs_string_field_relational_warns(self):
+        wf = _workflow({"score": "string"}, "producer.score > 3")
+        warnings = _type_warnings(WorkflowStaticAnalyzer(wf).analyze())
+
+        assert len(warnings) == 1
+        assert "producer.score" in warnings[0]
+
+    def test_compound_condition_flags_only_the_mismatched_side(self):
+        wf = _workflow(
+            {"approved": "string", "status": "string"},
+            'producer.approved == true or producer.status == "ok"',
+        )
+        warnings = _type_warnings(WorkflowStaticAnalyzer(wf).analyze())
+
+        assert len(warnings) == 1
+        assert "producer.approved" in warnings[0]
+        assert "producer.status" not in warnings[0]
+
+
+class TestCompatibleGuardLiteralsStaySilent:
+    def test_boolean_literal_vs_boolean_field_no_warning(self):
+        wf = _workflow({"approved": "boolean"}, "producer.approved == true")
+        assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []
+
+    def test_string_literal_vs_string_field_no_warning(self):
+        wf = _workflow({"status": "string"}, 'producer.status == "approved"')
+        assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []
+
+    def test_number_literal_vs_integer_field_no_warning(self):
+        wf = _workflow({"score": "integer"}, "producer.score >= 3")
+        assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []
+
+    def test_undeclared_field_no_warning(self):
+        wf = _workflow({"other": "string"}, "producer.approved == true")
+        assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []
+
+    def test_udf_guard_no_warning(self):
+        wf = _workflow({"approved": "string"}, "udf:tools.check_approved")
+        assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []
+
+    def test_null_literal_no_warning(self):
+        wf = _workflow({"approved": "string"}, "producer.approved != null")
+        assert _type_warnings(WorkflowStaticAnalyzer(wf).analyze()) == []

--- a/tests/unit/validation/test_schema_structure_union_types.py
+++ b/tests/unit/validation/test_schema_structure_union_types.py
@@ -1,0 +1,45 @@
+"""Union type declarations (``type: ["string", "null"]``) are legal JSON Schema
+and must validate member-wise — at the top level, in properties, and in
+list-style fields — instead of crashing an unhashable membership check.
+"""
+
+from agent_actions.validation.static_analyzer.schema_structure_validator import (
+    SchemaStructureValidator,
+)
+
+
+def _validate(schema):
+    return SchemaStructureValidator().validate_schema(schema, "producer", "schema")
+
+
+class TestUnionTypesAccepted:
+    def test_top_level_union_type_no_error(self):
+        schema = {"type": ["object", "null"], "properties": {"status": {"type": "string"}}}
+        assert _validate(schema) == []
+
+    def test_property_union_type_no_error(self):
+        schema = {"type": "object", "properties": {"status": {"type": ["string", "null"]}}}
+        assert _validate(schema) == []
+
+    def test_fields_style_union_type_no_error(self):
+        schema = {"fields": [{"id": "status", "type": ["string", "null"]}]}
+        assert _validate(schema) == []
+
+
+class TestInvalidTypesStillRejected:
+    def test_union_with_unknown_member_is_error(self):
+        schema = {"type": "object", "properties": {"status": {"type": ["string", "bogus"]}}}
+        errors = _validate(schema)
+        assert len(errors) == 1
+        assert "status" in errors[0].message
+
+    def test_top_level_union_with_unknown_member_is_error(self):
+        schema = {"type": ["object", "bogus"], "properties": {"status": {"type": "string"}}}
+        errors = _validate(schema)
+        assert len(errors) == 1
+
+    def test_non_string_non_list_type_is_error(self):
+        schema = {"type": "object", "properties": {"status": {"type": 42}}}
+        errors = _validate(schema)
+        assert len(errors) == 1
+        assert "status" in errors[0].message


### PR DESCRIPTION
## Summary

GD (Guard Conditions) run over UAT checks GD-01..GD-10: verified filter/skip behavior, expression evaluation, namespace resolution, dispositions, and the skipped-namespace crash against framework code and the real project's stored data. Nine of ten checks verified working on current main; the one live defect is fixed here.

**The defect (GD-06 class):** a guard comparison whose operand types can never compare — `review.approved == true` against a string `"true"`, or `vote.score > 3` against `"5"` — silently evaluates to not-matched for every record. With `on_false: filter` the whole dataset disappears with zero signal. Real workflows use `== true` guards heavily (87 guarded actions across the canary project's 10 workflows).

**Fix (strict + loud, no coercion):**
- **Runtime** (`ast_nodes.py`): `evaluate_node` warns once per (field, operator, type-family pair) when a field/literal comparison crosses never-comparable families. Evaluation results are byte-for-byte unchanged — the fix only adds the missing announcement. boolean/number stays exempt (`True == 1` is meaningful); `None` never triggers (skipped upstreams resolve fields to None and must stay quiet).
- **Preflight** (`workflow_static_analyzer.py`): new step 2h `_check_guard_literal_type_mismatch` parses each guard condition into the WHERE-clause AST and warns when a comparison literal can never match the referenced field's declared schema type, with a quote/unquote hint. Catches the misconfiguration before any record is processed.

**Deviation from the check's literal wording:** GD-06's expected line reads as asking for coercion ("if stored as string 'true', the condition must still evaluate correctly"). Coercion would be a silent fallback masking a producer-side schema violation — write-path validation now enforces declared types (#815/#816). This PR keeps comparisons strict and makes the mismatch loud at both layers instead.

**Verified, no fix needed (evidence in run journal):**
- GD-01/02: TRUE executes; FALSE+filter absent from all downstream actions (probe + real data: the one real filtered record is absent from every later action).
- GD-03: skip writes a `{action: None}` tombstone; downstream still runs; passthrough dispositions present in real DBs.
- GD-04: dotted guard paths read the aggregated namespace, not per-version fields.
- GD-05: filtered dispositions are written by current code (UnifiedProcessor probe + existing tests). The real store's missing `filtered` row for a 2026-07-08 run predates the disposition fixes in the then-installed framework copy — historical, not current.
- GD-07: string equality is exactly case- and whitespace-sensitive.
- GD-08: `!= []` parses (empty array literal) and evaluates correctly.
- GD-09: commented-out guards are pure no-ops (never reach config).
- GD-10: the observe-a-skipped-namespace crash is fixed by the NullNamespace sentinel; observe/guard/prompt paths resolve skipped fields to None without crashing.

## Verification

- RED→GREEN through harness gates: 9 genuine assertion failures recorded, then full suite **8229 passed**, ruff format/check + mypy clean.
- 19 new tests across two files: runtime warning (mismatch warns + result unchanged; None/bool-number/matched-type stay silent; warn-once dedup) and analyzer check (bool-vs-string both directions, relational, compound conditions flag only the mismatched side; udf/null/undeclared-field stay silent).
- Real-project canary: analyzed all 10 workflows (87 guarded actions) with the new preflight check — **0 warnings** on a working project (no false positives).
- Blind review: HIGH tier, 3 diverse-lens reviewers (correctness / blast radius / tests-anti-gaming): B and C YES; A NO with a real finding — a nullable union type (`"type": ["string","null"]`, the exact shape the guard-nullable auto-fixer produces) crashed the new check with `unhashable type: 'list'`. Fixing it exposed that the pattern was **pre-existing in three places** in `schema_structure_validator` (list-style fields, properties, and — caught by lens A's delta re-verification — the top-level type gate); all three now route through a member-wise `_is_valid_type_declaration`, with union coverage for each site. Lens A re-verified twice, final VERDICT YES; recorded YES_WITH_ISSUES.
- Review-driven additions: explicit tests for literal-on-left operand order and IN-operator exemption; `GuardFilter.clear_cache()` resets the warn-once set; `GuardSemanticError` docstring corrected (type mismatches warn, not raise). Final suite **8238 passed**, ruff + mypy clean.
- Follow-up noted by lens A (non-blocking, pre-existing shape): a top-level union type skips the nested `properties`/`items` structural walk (`schema_type == "object"` never matches a list) — a coverage gap, strictly better than the prior crash.
- Smoke: skipped per risk.sh (`smoke_required=no` — parsing/validation layers, no smoke surface); the analyzer canary above exercises the real project.
