### PR TITLE
fix: FILE tool input qualifies colliding observed fields (UAT VR audit)

### DIFF
--- a/agent_actions/prompt/context/scope_application.py
+++ b/agent_actions/prompt/context/scope_application.py
@@ -435,13 +435,15 @@ def _resolve_source_content(
 def _resolve_observe_refs_for_flat_keys(
     observe_refs: list[str],
     action_name: str = "unknown",
+    *,
+    emit_diagnostics: bool = True,
 ) -> tuple[list[tuple[str, str, str]], bool]:
     """Parse observe refs and detect bare-key collisions for FILE mode flat key injection.
 
-    Returns (resolved, qualify_wildcards) where resolved is a list of
-    (namespace, field_name, output_key) triples. output_key is
-    namespace-qualified when bare-key collisions are detected.
-    qualify_wildcards is True when multiple wildcard namespaces exist.
+    Returns (resolved, qualify_wildcards): (namespace, field_name, output_key)
+    triples with output_key namespace-qualified on collision, and whether
+    multiple wildcard namespaces exist. ``emit_diagnostics=False`` is for
+    per-record callers re-resolving refs the enrichment pass already diagnosed.
     """
     valid_pairs: list[tuple[str, str]] = []
 
@@ -450,20 +452,21 @@ def _resolve_observe_refs_for_flat_keys(
             ns, field = parse_field_reference(ref)
             valid_pairs.append((ns, field))
         except ValueError as e:
-            fire_event(
-                ContextFieldSkippedEvent(
-                    action_name=action_name,
-                    field_ref=ref,
-                    reason=str(e),
-                    directive="resolve_observe_refs",
+            if emit_diagnostics:
+                fire_event(
+                    ContextFieldSkippedEvent(
+                        action_name=action_name,
+                        field_ref=ref,
+                        reason=str(e),
+                        directive="resolve_observe_refs",
+                    )
                 )
-            )
             continue
 
     bare_counts = Counter(field for _, field in valid_pairs)
     collisions = {k for k, v in bare_counts.items() if v > 1}
 
-    if collisions:
+    if collisions and emit_diagnostics:
         qualified = sorted(f"{ns}.{field}" for ns, field in valid_pairs if field in collisions)
         logger.warning(
             "Action '%s': observe refs share bare field name(s) %s across namespaces. "

--- a/agent_actions/workflow/pipeline_file_mode.py
+++ b/agent_actions/workflow/pipeline_file_mode.py
@@ -132,13 +132,15 @@ def _resolve_input_record(
 def extract_tool_input(record: dict, context_scope: Mapping[str, Any]) -> dict:
     """Extract observed business fields from an enriched record for tool input.
 
-    Reads from enriched content where drops have already been applied by
-    ``apply_context_scope_for_records()``.  Uses ``parse_field_reference()``
-    for validated ref parsing instead of the former ``str.split()`` shadow.
-
+    Reads post-drop enriched content. Bare field names colliding across
+    observed namespaces are delivered namespace-qualified (``ns.field``),
+    matching the flat keys enrichment injects; qualification follows the
+    declared refs, not namespace presence, so tools see stable key shapes.
     When no observe is configured, flattens all content namespaces.
     """
-    from agent_actions.prompt.context.scope_parsing import parse_field_reference
+    from agent_actions.prompt.context.scope_application import (
+        _resolve_observe_refs_for_flat_keys,
+    )
 
     content = record.get("content")
     if not isinstance(content, dict):
@@ -155,20 +157,21 @@ def extract_tool_input(record: dict, context_scope: Mapping[str, Any]) -> dict:
         return business
 
     # Extract observed fields from post-drop enriched content.
-    # Drops were already applied by apply_context_scope_for_records().
+    # Drops and collision diagnostics were already handled by
+    # apply_context_scope_for_records().
+    resolved, qualify_wildcards = _resolve_observe_refs_for_flat_keys(
+        observe_refs, emit_diagnostics=False
+    )
     business = {}
-    for ref in observe_refs:
-        try:
-            ns, field = parse_field_reference(ref)
-        except ValueError:
-            continue  # Bad ref — already logged by scope application
+    for ns, field, output_key in resolved:
         ns_data = content.get(ns)
         if not isinstance(ns_data, dict):
             continue
         if field == "*":
-            business.update(ns_data)
+            for f, v in ns_data.items():
+                business[f"{ns}.{f}" if qualify_wildcards else f] = v
         elif field in ns_data:
-            business[field] = ns_data[field]
+            business[output_key] = ns_data[field]
 
     return business
 

--- a/tests/unit/workflow/test_file_tool_observe_collisions.py
+++ b/tests/unit/workflow/test_file_tool_observe_collisions.py
@@ -1,0 +1,80 @@
+"""A FILE-granularity tool observing fields that collide across namespaces must
+receive namespace-qualified keys — never a silent last-writer-wins flatten.
+
+Enrichment already warns on collision and promises qualified keys; the tool
+input must honor that promise so every observed namespace's value is delivered.
+"""
+
+from agent_actions.prompt.context.scope_application import (
+    apply_context_scope_for_records,
+)
+from agent_actions.workflow.pipeline_file_mode import extract_tool_input
+
+
+def _enriched(record, context_scope):
+    enriched, skipped = apply_context_scope_for_records(
+        records=[record], context_scope=context_scope, action_name="agg"
+    )
+    assert not skipped
+    return enriched[0]
+
+
+class TestCollidingNamespacesQualify:
+    def test_multi_wildcard_delivers_every_namespace(self):
+        record = {
+            "source_guid": "sg-1",
+            "content": {
+                "gen_code_1": {"code": "V1", "language": "python"},
+                "gen_code_2": {"code": "V2", "language": "js"},
+                "gen_code_3": {"code": "V3", "language": "rust"},
+            },
+        }
+        cs = {"observe": ["gen_code_1.*", "gen_code_2.*", "gen_code_3.*"]}
+
+        business = extract_tool_input(_enriched(record, cs), cs)
+
+        assert business["gen_code_1.code"] == "V1"
+        assert business["gen_code_2.code"] == "V2"
+        assert business["gen_code_3.code"] == "V3"
+        assert business["gen_code_1.language"] == "python"
+        assert business["gen_code_3.language"] == "rust"
+        assert "code" not in business  # a bare key would hide two of three values
+
+    def test_specific_colliding_refs_qualify(self):
+        record = {"content": {"review_a": {"title": "A"}, "review_b": {"title": "B"}}}
+        cs = {"observe": ["review_a.title", "review_b.title"]}
+
+        business = extract_tool_input(_enriched(record, cs), cs)
+
+        assert business == {"review_a.title": "A", "review_b.title": "B"}
+
+    def test_declared_but_absent_wildcard_namespace_still_qualifies(self):
+        """Qualification follows the declared refs, not which upstreams produced
+        output — tool code must be able to rely on stable key shapes."""
+        record = {"content": {"gen_code_1": {"code": "V1"}}}
+        cs = {"observe": ["gen_code_1.*", "gen_code_2.*"]}
+
+        business = extract_tool_input(_enriched(record, cs), cs)
+
+        assert business == {"gen_code_1.code": "V1"}
+
+
+class TestNonCollidingStayBare:
+    def test_single_wildcard_namespace_bare_keys(self):
+        record = {"content": {"extract": {"q": "Q1", "a": "A1"}}}
+        cs = {"observe": ["extract.*"]}
+
+        assert extract_tool_input(_enriched(record, cs), cs) == {"q": "Q1", "a": "A1"}
+
+    def test_cross_namespace_distinct_fields_stay_bare(self):
+        record = {"content": {"extract": {"q": "Q1"}, "classify": {"category": "FAQ", "x": 1}}}
+        cs = {"observe": ["extract.*", "classify.category"]}
+
+        business = extract_tool_input(_enriched(record, cs), cs)
+
+        assert business == {"q": "Q1", "category": "FAQ"}
+
+    def test_no_observe_flattens_all_namespaces(self):
+        record = {"content": {"extract": {"q": "Q1"}, "classify": {"category": "FAQ"}}}
+
+        assert extract_tool_input(record, {}) == {"q": "Q1", "category": "FAQ"}


### PR DESCRIPTION
## Summary

UAT validation-checks audit, VR category (Version Fan-out & Merge, VR-01..VR-09): verify-first over the version subsystem found one real framework defect; the other eight checks are verified working on current main or are project-side findings.

**The fix — FILE tool input qualifies colliding observed fields.** A FILE-granularity tool observing the same bare field name across multiple namespaces (the version fan-in shape, e.g. `observe: [gen_code_1.*, gen_code_2.*, gen_code_3.*]`) received a last-writer-wins flatten: all but one namespace's values silently vanished from the tool input, with no error. The enrichment pass already detects this collision, warns "read the qualified key instead", and injects namespace-qualified flat keys into record content — a contract the tool-input builder never honored. `extract_tool_input` now resolves observe refs through the same collision resolver enrichment uses (`_resolve_observe_refs_for_flat_keys`), delivering `ns.field` keys on collision and keeping bare keys for the non-colliding majority. Qualification follows the declared refs (not namespace presence) so tools read stable key shapes. The resolver gains `emit_diagnostics=False` so per-record re-resolution does not repeat the warnings enrichment already emitted once. The HITL strategy shares `extract_tool_input` and inherits the same contract.

**Verification of the other checks (no code change needed):**
- VR-01/02 (fan-out count, param injection): expansion produces exactly one agent per `range` value; `${param}` replacement + `{{ version.* }}` Jinja context inject distinct per-version values. Real-project trace data: 15 prompt traces = 3 versions × 5 records; `extract_raw_qa_1/2/3` compiled prompts differ exactly at the `{{ version.iteration }}` branch. Project-side note: `filter_learning_quality`'s template never references its `voter_id` param, so its three prompts are identical by authoring choice (vote independence rests on sampling alone).
- VR-03/04: version outputs live in distinct per-version namespaces with correlation IDs; the correlator enforces an own-namespace invariant and merges all versions into one record. Record-granularity consumers (LLM and tool) receive every version namespace: the context normalizer expands base-name observe refs (`filter_learning_quality.*` → `_1/_2/_3`) at config load, and a probe through the real `normalize_all_agent_configs` → `TaskPreparer.prepare` chain delivers all three namespaces single-nested.
- VR-05: a reprompt-exhausted version writes its own namespace + correlation ID (merge includes it); a fully-absent version yields `_missing_iterations` and the merge proceeds with the survivors; the version-correlation path does not apply the all-or-nothing cascade taint. Existing partial-merge tests cover this.
- VR-08 (claimed: version_consumption unreliable with tool actions): **stale project memory** for the record path — current main delivers correctly (see VR-04). The residual true defect was the FILE-path collision flatten fixed here.
- VR-06/07/09: project-side. VR-06 confirmed verbatim (`final_decision = "filter" if keep_count == 0 else "keep"` — 1/3 keep = keep, anti-conservative) in the project's `aggregate_votes.py`; newer `ql_*` workflows already use true majority (`keeps >= 2`). VR-07 verified live: the 2026-07-26 `agac run -a ql_code_centered` exercised named-sibling fan-in through tool aggregators on current main. VR-09 confirmed: `aggregate_answer_verification.py` silently returns `answer_matches=False` when both source namespaces are absent — the tool can distinguish (absent namespaces arrive as None) but chooses not to; project fix suggested.

**Known boundary (pre-existing, unchanged):** the shared collision detector compares declared ref field names, so a single wildcard ref plus a specific ref that expand to the same key are not treated as a collision — identical behavior at the enrichment layer; flagged for a future contract tightening.

## Verification

- RED→GREEN under the harness: 3 failing tests recorded (last-writer-wins pinned), fix landed, `gate.sh green` — full suite **8244 passed**, ruff format/check clean, mypy clean.
- New tests (`tests/unit/workflow/test_file_tool_observe_collisions.py`) run through the real enrichment pass (`apply_context_scope_for_records`) before `extract_tool_input`: multi-wildcard delivers every namespace qualified; specific colliding refs qualify; declared-but-absent wildcard namespace still qualifies (stable key shapes); single-namespace and non-colliding shapes keep bare keys; no-observe flatten unchanged.
- Blind fresh-context review (risk tier LOW → 1 reviewer): **VERDICT YES** — confirmed the two layers now share one resolver by construction, both callers (`file_tool.py`, `hitl.py`) safe, reconciliation never depends on input key shapes.
- Smoke: `smoke-test.sh online` exits 1 **identically on main and branch** (`baseline.sh` verdict: pre-existing/environmental — this clone's project copy lacks the `agent_workflow/qanalabs_quiz_gen` config dir). Compensating evidence: `scan-project.sh` canary PASS; branch-code preflight on the intact shared project copy — `ql_code_centered` inspect fully green; `qana_quiz` fails only on the known project-side `seed_path` → `seed` staleness already tracked in coordination status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
