### PR TITLE
fix: fan-in grouping keys on one universal field, not per-record first-present (UAT DP audit)

### DIFF
--- a/agent_actions/workflow/merge.py
+++ b/agent_actions/workflow/merge.py
@@ -180,32 +180,68 @@ def _merge_group_deep(group: list[dict[str, Any]]) -> dict[str, Any]:
     return merged
 
 
+_AUTO_KEY_CANDIDATES = [
+    "version_correlation_id",
+    "source_guid",
+    "root_target_id",
+    "parent_target_id",
+]
+
+
+def _has_correlation_key(record: dict[str, Any], key_name: str) -> bool:
+    if record.get(key_name):
+        return True
+    content = record.get("content")
+    return isinstance(content, dict) and bool(content.get(key_name))
+
+
+def _select_universal_key(records: list[dict[str, Any]]) -> str | None:
+    """First auto candidate present on every record that carries any candidate.
+
+    Grouping must key every record in the pool on the SAME field: branches of
+    one logical record can carry different key sets (a version-merge descendant
+    has ``version_correlation_id``, a plain branch does not), and per-record
+    key selection would place them in disjoint groups — a silent partial merge.
+    Returns None when no candidate is universal (caller falls back to
+    per-record selection).
+    """
+    keyed = [r for r in records if any(_has_correlation_key(r, k) for k in _AUTO_KEY_CANDIDATES)]
+    if not keyed:
+        return None
+    for key_name in _AUTO_KEY_CANDIDATES:
+        if all(_has_correlation_key(r, key_name) for r in keyed):
+            return key_name
+    return None
+
+
 def merge_records_by_key(records: list[Any], reduce_key: str | None = None) -> list[Any]:
     """Merge records sharing the same correlation key.
 
-    For same-source fan-in (no ``reduce_key``), uses ``merge_branch_records``
-    so each branch contributes only its own namespace and upstream is preserved
-    from the base record (first record in the group).  For ``reduce_key``
-    aggregation (different sources grouped together), uses ``deep_merge_record``.
-
-    Note: When using the branch-records path, ``group[0]`` is the canonical
-    upstream source.  Its shared namespaces survive; other records' versions
-    of the same upstream namespaces are ignored.
+    The grouping key is chosen once for the whole pool (first universal
+    candidate, identity keys before lineage keys) so branches carrying
+    different key sets still group by their shared identity; an explicit
+    ``reduce_key`` takes precedence per record.  Same-source fan-in merges
+    via ``merge_branch_records`` with ``group[0]`` as the canonical
+    upstream (its shared namespaces survive); ``reduce_key`` aggregation
+    deep-merges groups instead.
     """
     groups_by_key: dict[str, list[dict[str, Any]]] = {}
     records_without_key: list[Any] = []
 
-    key_candidates: list[str] = []
-    if reduce_key:
-        key_candidates.append(reduce_key)
-    key_candidates.extend(
-        ["version_correlation_id", "root_target_id", "parent_target_id", "source_guid"]
-    )
+    universal_key = _select_universal_key([r for r in records if isinstance(r, dict)])
 
     for record in records:
         if not isinstance(record, dict):
             records_without_key.append(record)
             continue
+
+        key_candidates: list[str] = []
+        if reduce_key:
+            key_candidates.append(reduce_key)
+        if universal_key is not None:
+            key_candidates.append(universal_key)
+        else:
+            key_candidates.extend(_AUTO_KEY_CANDIDATES)
 
         correlation_value = get_correlation_value(record, key_candidates)
         if correlation_value:

--- a/tests/unit/workflow/test_merge_fanin_key_asymmetry.py
+++ b/tests/unit/workflow/test_merge_fanin_key_asymmetry.py
@@ -1,0 +1,94 @@
+"""Fan-in grouping when branches carry asymmetric correlation keys."""
+
+from agent_actions.workflow.merge import merge_records_by_key
+
+
+def _branch_record(namespace: str, guid: str, vc: str | None = None, **top: object) -> dict:
+    record = {
+        "source_guid": guid,
+        "target_id": f"tid-{namespace}-{guid}",
+        "content": {namespace: {"value": namespace}},
+        **top,
+    }
+    if vc is not None:
+        record["version_correlation_id"] = vc
+    return record
+
+
+class TestFanInKeyAsymmetry:
+    """Branches of the same logical record must group despite different key sets."""
+
+    def test_vc_branch_merges_with_plain_branch(self):
+        """A version-merge descendant and a plain branch of the same record merge."""
+        records = [
+            _branch_record("branch_a", "guid-1", vc="corr_aaa"),
+            _branch_record("branch_b", "guid-1"),
+            _branch_record("branch_a", "guid-2", vc="corr_bbb"),
+            _branch_record("branch_b", "guid-2"),
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 2
+        by_guid = {r["source_guid"]: r for r in result}
+        for guid in ("guid-1", "guid-2"):
+            content = by_guid[guid]["content"]
+            assert set(content) == {"branch_a", "branch_b"}
+
+    def test_uniform_vc_pool_groups_by_vc(self):
+        """When every record carries a vc id, grouping keys on it as before."""
+        records = [
+            _branch_record("branch_a", "guid-1", vc="corr_aaa"),
+            _branch_record("branch_b", "guid-1", vc="corr_aaa"),
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+        assert set(result[0]["content"]) == {"branch_a", "branch_b"}
+
+    def test_same_guid_different_vc_stays_separate(self):
+        """Records sharing a guid but carrying distinct vc ids never merge."""
+        records = [
+            _branch_record("branch_a", "guid-1", vc="corr_aaa"),
+            _branch_record("branch_b", "guid-1", vc="corr_zzz"),
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 2
+
+    def test_expansion_siblings_with_shared_parent_not_collapsed(self):
+        """Expanded siblings share a parent id but are distinct records."""
+        records = [
+            _branch_record("flat", "guid-1", parent_target_id="parent-1"),
+            _branch_record("flat", "guid-2", parent_target_id="parent-1"),
+            _branch_record("flat", "guid-3", parent_target_id="parent-1"),
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 3
+        assert {r["source_guid"] for r in result} == {"guid-1", "guid-2", "guid-3"}
+
+    def test_parent_key_still_groups_records_without_guid(self):
+        """Records with only a parent id keep grouping by it."""
+        records = [
+            {"parent_target_id": "parent-1", "content": {"branch_a": {"value": 1}}},
+            {"parent_target_id": "parent-1", "content": {"branch_b": {"value": 2}}},
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 1
+
+    def test_disjoint_key_spaces_stay_separate(self):
+        """With no key shared by all records, per-record grouping still applies."""
+        records = [
+            {"version_correlation_id": "corr_aaa", "content": {"branch_a": {"value": 1}}},
+            {"parent_target_id": "parent-1", "content": {"branch_b": {"value": 2}}},
+        ]
+
+        result = merge_records_by_key(records)
+
+        assert len(result) == 2


### PR DESCRIPTION
## Summary
- **Fixes silent partial fan-in merges** (UAT DP audit, DP-06 — pre-marked known bug): `merge_records_by_key` selected the correlation key independently per record (first present of `version_correlation_id` / `root_target_id` / `parent_target_id` / `source_guid`). Branches of the same logical record carrying different key sets could never group — a version-merge-descendant branch keyed on its correlation id while a plain sibling branch keyed on its source guid — so the fan-in consumer received duplicate half-records, each missing the other branch's namespace, with no error. A second instance of the same class: expansion siblings sharing `parent_target_id` (no vc id) all keyed on the shared parent and silently collapsed into one record.
- **Fix:** the grouping key is chosen once for the whole pool — the first candidate present on every keyed record — with identity keys (`version_correlation_id`, `source_guid`) ranked before lineage keys (`root_target_id`, `parent_target_id`). Explicit `reduce_key` keeps its per-record precedence. Per-record selection remains the fallback when no candidate is universal, so disjoint-key pools behave as before.
- **Root-cause deviation from the audit doc:** DP-06 attributed the failure to *unequal branch depths*. Verified against the real project store: depth is a red herring — the actual trigger is key-space asymmetry between branches. An unequal-depth diamond with symmetric keys (e.g. `select_best_code_snippet`: draft depth-1 + three versioned generators depth-2) merged correctly in the real June-23 run because every branch carried an aligned inherited `version_correlation_id`.

## Verification
- RED (`tests/unit/workflow/test_merge_fanin_key_asymmetry.py`): asymmetric branches split into 4 half-records (expected 2); expansion siblings collapsed 3→1. Both genuine failures recorded by the gate before the fix.
- GREEN: full suite **8250 passed**, ruff clean, mypy clean. All 61 existing merge tests unchanged and green (including `reduce_key` precedence, parent-only grouping, keyless/non-dict passthrough).
- **Real-data replay** (qana_quiz June-23 store, `consolidate_quality_review`'s 4-branch fan-in, 20 records):
  - Unmodified pool: 5 merged records × 4 namespaces — byte-identical grouping before/after the fix (no regression on real shapes).
  - Asymmetric pool (one branch stripped of its vc id, simulating a branch that never crossed a version merge): **main → 10 records (5×3-namespace + 5×1-namespace halves); fixed → 5 records × 4 namespaces.**
- Blind fresh-context review (LOW tier, diff + bug statement only): see review verdict in the harness record.
- Smoke: skipped per `risk.sh` (`smoke_required=no` — no registered project surface touched; the change is exercised by the suite's runner/merge/data-bus integration tests).

## DP audit classification (context for this PR)
- DP-01 dependency wait, DP-02 skip propagation, DP-03 filter cascade (incl. sibling-branch re-entry guard), DP-04 multi-dep fan-in delivery, DP-05 cycle detection: all verified on current main — evidence in `coordination/status.md`.
- DP-06: fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
