### PR TITLE
fix: preflight seed checks share the runtime's directory resolution (UAT SD audit)

### DIFF
--- a/agent_actions/config/path_config.py
+++ b/agent_actions/config/path_config.py
@@ -270,3 +270,54 @@ def get_seed_data_path(project_root: Path) -> str:
         )
         return "seed_data"
     return name
+
+
+def resolve_seed_data_dir(workflow_config_path: str | None) -> tuple[Path | None, str]:
+    """Resolve the seed data directory: workflow root first, then project root.
+
+    Single authority for seed directory resolution — the runtime loader and
+    the preflight seed checks must agree on which folder is consulted.
+    Returns ``(directory, seed_dir_name)``; directory is ``None`` when
+    neither the workflow-level nor the project-level folder exists.
+    """
+    from agent_actions.config.paths import PathManager, ProjectRootNotFoundError
+
+    seed_dir_name = "seed_data"
+    try:
+        pm = PathManager()
+        start_path = Path(workflow_config_path).parent if workflow_config_path else None
+        if start_path is not None:
+            try:
+                project_root = pm.get_project_root(start_path=start_path)
+                seed_dir_name = get_seed_data_path(project_root)
+            except ProjectRootNotFoundError:
+                logger.debug("No project root found from %s", start_path)
+
+        if workflow_config_path:
+            current = Path(workflow_config_path).resolve().parent
+            workflow_root = None
+            search_up = current
+            while search_up != search_up.parent:
+                if (search_up / "agent_config").exists():
+                    workflow_root = search_up
+                    break
+                if search_up.name == "agent_config":
+                    workflow_root = search_up.parent
+                    break
+                search_up = search_up.parent
+            if workflow_root is None:
+                workflow_root = current
+
+            workflow_seed_dir = workflow_root / seed_dir_name
+            if workflow_seed_dir.is_dir():
+                logger.debug("Found workflow-level seed data: %s", workflow_seed_dir)
+                return workflow_seed_dir, seed_dir_name
+
+        project_seed_dir = pm.get_project_root() / seed_dir_name
+        if project_seed_dir.is_dir():
+            logger.debug("Found project-level seed data: %s", project_seed_dir)
+            return project_seed_dir, seed_dir_name
+    except Exception as e:
+        logger.warning("Error during seed data resolution: %s", e, exc_info=True)
+
+    return None, seed_dir_name

--- a/agent_actions/prompt/service.py
+++ b/agent_actions/prompt/service.py
@@ -662,78 +662,17 @@ class PromptPreparationService:
 
     @staticmethod
     def _determine_static_data_dir(workflow_config_path: str | None) -> Path:
-        """
-        Determine seed data directory using unified PathManager.
-
-        Resolution order:
-        1. ``seed_data_path`` from ``agent_actions.yml`` (user-configurable)
-        2. Workflow-level directory (sibling of ``agent_config/``)
-        3. Project-level directory via ``PathManager``
-
-        The directory name defaults to ``seed_data`` but can be overridden
-        by setting ``seed_data_path`` in the project config.
+        """Resolve the seed data directory (workflow root first, then project root).
 
         Raises:
-            StaticDataLoadError: If seed data folder doesn't exist.
+            StaticDataLoadError: If no seed data folder exists at either level.
         """
-        from agent_actions.config.path_config import get_seed_data_path
-        from agent_actions.config.paths import (
-            PathManager,
-            ProjectRootNotFoundError,
-        )
+        from agent_actions.config.path_config import resolve_seed_data_dir
 
-        workflow_seed_dir = None
-        seed_dir_name = "seed_data"
-        try:
-            pm = PathManager()
-            start_path = Path(workflow_config_path).parent if workflow_config_path else None
-            if start_path:
-                try:
-                    project_root = pm.get_project_root(start_path=start_path)
-                    seed_dir_name = get_seed_data_path(project_root)
-                except ProjectRootNotFoundError:
-                    logger.debug("No project root found from %s", start_path)
+        seed_dir, seed_dir_name = resolve_seed_data_dir(workflow_config_path)
+        if seed_dir is not None:
+            return seed_dir
 
-            if workflow_config_path:
-                file_path_obj = Path(workflow_config_path).resolve()
-                current = file_path_obj.parent
-                workflow_root = None
-
-                search_up = current
-                while search_up != search_up.parent:
-                    if (search_up / "agent_config").exists():
-                        workflow_root = search_up
-                        break
-                    if search_up.name == "agent_config":  # In case we are inside it
-                        workflow_root = search_up.parent
-                        break
-                    search_up = search_up.parent
-
-                if not workflow_root:
-                    workflow_root = current
-
-                workflow_seed_dir = workflow_root / seed_dir_name
-                if workflow_seed_dir.exists() and workflow_seed_dir.is_dir():
-                    logger.debug("Found workflow-level seed data: %s", workflow_seed_dir)
-                    return workflow_seed_dir
-
-            project_seed_dir = pm.get_project_root() / seed_dir_name
-
-            if project_seed_dir.exists() and project_seed_dir.is_dir():
-                logger.debug("Found project-level seed data via PathManager: %s", project_seed_dir)
-                return project_seed_dir
-
-            logger.warning(
-                "Could not find seed data at workflow level (%s) or project level (%s)",
-                workflow_seed_dir if workflow_seed_dir is not None else "unknown",
-                project_seed_dir,
-            )
-
-        except Exception as e:
-            logger.warning("Error during seed data resolution: %s", e, exc_info=True)
-            # Fall through to error raising
-
-        # Not found - raise error
         raise StaticDataLoadError(
             f"Seed data directory not found. Create '{seed_dir_name}' folder "
             "at workflow root (same level as agent_config/, schema/, prompt_store/) "

--- a/agent_actions/validation/preflight/resolution_service.py
+++ b/agent_actions/validation/preflight/resolution_service.py
@@ -254,8 +254,32 @@ class WorkflowResolutionService:
         errors: list[StaticTypeError] = []
         warnings: list[StaticTypeWarning] = []
 
-        seed_data_dir = self._resolve_seed_data_dir()
+        seed_data_dir, seed_dir_name = self._resolve_seed_data_dir()
         if seed_data_dir is None:
+            # No seed directory anywhere — an error for any action that
+            # declares seed refs (the runtime loader would fail per record).
+            for action_name, action_config in self.action_configs.items():
+                context_scope = action_config.get("context_scope") or {}
+                seed_config = context_scope.get("seed", {})
+                if seed_config and isinstance(seed_config, dict):
+                    errors.append(
+                        StaticTypeError(
+                            message=(
+                                f"Seed data directory not found: create '{seed_dir_name}' at "
+                                "the workflow root (same level as agent_config/) or at the "
+                                "project root"
+                            ),
+                            location=FieldLocation(
+                                agent_name=action_name,
+                                config_field="context_scope.seed",
+                                raw_reference=seed_dir_name,
+                            ),
+                            referenced_agent=action_name,
+                            referenced_field="seed",
+                            hint=f"Declared seed fields: {', '.join(sorted(seed_config))}",
+                        )
+                    )
+                    break
             return errors, warnings
 
         # Phase 1: validate file existence and load seed data
@@ -530,32 +554,15 @@ class WorkflowResolutionService:
 
     # ── Helpers ────────────────────────────────────────────────────────
 
-    def _resolve_seed_data_dir(self) -> Path | None:
-        """Resolve the seed data directory from workflow config path.
+    def _resolve_seed_data_dir(self) -> tuple[Path | None, str]:
+        """Resolve the seed data directory via the shared runtime resolver.
 
-        Uses the ``seed_data_path`` setting from ``agent_actions.yml``
-        when available, falling back to ``"seed_data"``.
+        Preflight must consult the same folder the runtime loader will use
+        (workflow root first, then project root).
         """
         if not self.workflow_config_path:
-            return None
+            return None, "seed_data"
 
-        from agent_actions.config.path_config import find_project_root_dir, get_seed_data_path
+        from agent_actions.config.path_config import resolve_seed_data_dir
 
-        seed_dir_name = "seed_data"
-        config_start = Path(self.workflow_config_path).parent
-        project_root = find_project_root_dir(config_start)
-        if project_root is not None:
-            seed_dir_name = get_seed_data_path(project_root)
-
-        config_path = Path(self.workflow_config_path).resolve()
-        current = config_path.parent
-        while current != current.parent:
-            if (current / "agent_config").exists():
-                seed_dir = current / seed_dir_name
-                return seed_dir if seed_dir.exists() else None
-            if current.name == "agent_config":
-                seed_dir = current.parent / seed_dir_name
-                return seed_dir if seed_dir.exists() else None
-            current = current.parent
-
-        return None
+        return resolve_seed_data_dir(self.workflow_config_path)

--- a/tests/unit/validation/test_resolution_service.py
+++ b/tests/unit/validation/test_resolution_service.py
@@ -281,8 +281,8 @@ class TestSeedFileChecks:
         good_action_errors = [e for e in result.errors if e.location.agent_name == "good_action"]
         assert len(good_action_errors) == 0
 
-    def test_seed_data_dir_missing_graceful_skip(self, tmp_path):
-        """When seed_data directory doesn't exist, gracefully skip (no errors)."""
+    def test_seed_data_dir_missing_with_seed_refs_errors(self, tmp_path):
+        """Declared seed refs with no seed directory anywhere is a blocking error."""
         project = tmp_path / "project"
         agent_config = project / "agent_config"
         agent_config.mkdir(parents=True)
@@ -302,8 +302,9 @@ class TestSeedFileChecks:
         )
         result = svc.resolve_all()
 
-        seed_errors = [e for e in result.errors if "seed" in e.message.lower()]
-        assert len(seed_errors) == 0
+        dir_errors = [e for e in result.errors if "Seed data directory not found" in e.message]
+        assert len(dir_errors) == 1
+        assert "field1" in (dir_errors[0].hint or "")
 
 
 class TestVendorRunModeCompatibility:

--- a/tests/unit/validation/test_seed_dir_preflight_fallback.py
+++ b/tests/unit/validation/test_seed_dir_preflight_fallback.py
@@ -1,0 +1,89 @@
+"""Preflight seed checks must use the same directory resolution as the runtime."""
+
+from agent_actions.validation.preflight.resolution_service import WorkflowResolutionService
+
+
+def _make_service(workflow_path: str, seed_config: dict) -> WorkflowResolutionService:
+    return WorkflowResolutionService(
+        action_configs={
+            "loader": {
+                "context_scope": {"seed": seed_config},
+            },
+        },
+        workflow_config_path=workflow_path,
+    )
+
+
+class TestProjectLevelSeedFallback:
+    """The runtime falls back to the project-level seed dir; preflight must too."""
+
+    def _project_layout(self, tmp_path, *, workflow_seed: bool, project_seed: bool):
+        project = tmp_path / "proj"
+        (project / "agent_workflow" / "wf" / "agent_config").mkdir(parents=True)
+        (project / "agent_actions.yml").write_text("schema_path: schema\n")
+        if project_seed:
+            seed = project / "seed_data"
+            seed.mkdir()
+            (seed / "existing.json").write_text("{}")
+        if workflow_seed:
+            wf_seed = project / "agent_workflow" / "wf" / "seed_data"
+            wf_seed.mkdir()
+            (wf_seed / "data.json").write_text("{}")
+        return str(project / "agent_workflow" / "wf" / "agent_config" / "wf.yml")
+
+    def test_project_level_seed_dir_is_validated(self, tmp_path):
+        """A missing ref is reported when seeds live only at the project level."""
+        wf_path = self._project_layout(tmp_path, workflow_seed=False, project_seed=True)
+
+        svc = _make_service(wf_path, {"field1": "$file:missing.json"})
+        result = svc.resolve_all()
+
+        seed_errors = [e for e in result.errors if "Seed file not found" in e.message]
+        assert len(seed_errors) == 1
+        assert "existing.json" in seed_errors[0].hint
+
+    def test_project_level_seed_dir_valid_ref_passes(self, tmp_path):
+        """A valid project-level ref passes instead of being skipped."""
+        wf_path = self._project_layout(tmp_path, workflow_seed=False, project_seed=True)
+
+        svc = _make_service(wf_path, {"field1": "$file:existing.json"})
+        result = svc.resolve_all()
+
+        seed_errors = [e for e in result.errors if "seed" in e.message.lower()]
+        assert seed_errors == []
+
+    def test_workflow_level_seed_dir_still_preferred(self, tmp_path):
+        """When both levels exist, the workflow-level directory wins."""
+        wf_path = self._project_layout(tmp_path, workflow_seed=True, project_seed=True)
+
+        svc = _make_service(wf_path, {"field1": "$file:data.json"})
+        result = svc.resolve_all()
+
+        seed_errors = [e for e in result.errors if "seed" in e.message.lower()]
+        assert seed_errors == []
+
+    def test_seed_directives_with_no_seed_dir_anywhere_error(self, tmp_path):
+        """Declared seed refs with no seed directory must error, not skip silently."""
+        wf_path = self._project_layout(tmp_path, workflow_seed=False, project_seed=False)
+
+        svc = _make_service(wf_path, {"field1": "$file:anything.json"})
+        result = svc.resolve_all()
+
+        dir_errors = [e for e in result.errors if "Seed data directory not found" in e.message]
+        assert len(dir_errors) == 1
+
+    def test_no_seed_directives_no_seed_dir_stays_silent(self, tmp_path):
+        """Workflows that declare no seeds are unaffected by a missing directory."""
+        project = tmp_path / "proj"
+        (project / "agent_workflow" / "wf" / "agent_config").mkdir(parents=True)
+        (project / "agent_actions.yml").write_text("schema_path: schema\n")
+        wf_path = str(project / "agent_workflow" / "wf" / "agent_config" / "wf.yml")
+
+        svc = WorkflowResolutionService(
+            action_configs={"loader": {"context_scope": {}}},
+            workflow_config_path=wf_path,
+        )
+        result = svc.resolve_all()
+
+        seed_errors = [e for e in result.errors if "seed" in e.message.lower()]
+        assert seed_errors == []

--- a/tests/unit/validation/test_seed_field_validation.py
+++ b/tests/unit/validation/test_seed_field_validation.py
@@ -515,8 +515,8 @@ class TestExistingChecksUnchanged:
         seed_errors = [e for e in result.errors if "seed" in e.message.lower()]
         assert len(seed_errors) == 0
 
-    def test_seed_data_dir_missing_graceful_skip(self, tmp_path):
-        """No seed_data directory → graceful skip (existing behavior)."""
+    def test_seed_data_dir_missing_with_seed_refs_errors(self, tmp_path):
+        """No seed directory anywhere with declared seed refs is a blocking error."""
         project = tmp_path / "project"
         agent_config = project / "agent_config"
         agent_config.mkdir(parents=True)
@@ -534,8 +534,8 @@ class TestExistingChecksUnchanged:
         )
         result = svc.resolve_all()
 
-        assert len(result.errors) == 0
-        assert len(result.warnings) == 0
+        dir_errors = [e for e in result.errors if "Seed data directory not found" in e.message]
+        assert len(dir_errors) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Fixes a preflight/runtime divergence in seed-directory resolution** (UAT SD audit): the preflight seed-reference validator resolved the seed directory with its own logic — workflow root only, silently returning `None` when that folder was absent, and skipping ALL seed validation on `None`. The runtime loader documents and implements a project-root fallback. Consequences: projects keeping seeds at the project level got zero preflight validation (missing files failed per-record at prompt preparation instead of at startup), and a workflow declaring seed refs with no seed directory anywhere passed preflight silently.
- **Fix (single authority):** one shared `resolve_seed_data_dir(workflow_config_path) -> (Path | None, seed_dir_name)` in `config/path_config.py` — workflow root first, then project root, honoring the `seed_data_path` setting — now used by both the runtime loader (which raises the same `StaticDataLoadError` on `None`) and the preflight check. When actions declare seed refs and no directory exists at either level, preflight emits a blocking `StaticTypeError` naming the expected folder and the declared seed fields.
- **Disclosed test updates (green-gate reward-hack check):** two existing tests asserted the silent skip as intended ("graceful skip"); both now assert the blocking error — a behavior-change strengthening, confirmed legitimate by the blind reviewer.

## SD audit classification (context for this PR)
- **SD-01** (pre-marked known bug): the historical `StaticDataLoadError` path failure is fixed in current code — runtime prefers the workflow root exactly as expected, with a clear error naming the location; the residual preflight-side divergence is what this PR closes. **SD-02** verified on real traces: seeded actions embed the syllabus exactly once in every prompt including the first (`extract_raw_qa_*` 1/1, `filter_learning_quality_*` 5/5). **SD-03** verified: blocking preflight error naming the missing file + available files, zero LLM calls; runtime `StaticDataLoadError` as backstop — this PR extends the startup guarantee to project-level layouts. **SD-04** verified: store scan found no seed keys inside any action output namespace. **SD-05** verified project-side: every workflow's declared refs exist, incl. each ql_* workflow's specific examples file; the run-half is blocked by the known project-side `seed_path:`→`seed:` migration (fails loud via the removed-directive guard). **SD-06** verified: no double-injection (content-marker count = 1 in all prompts); no action observes seed keys; framework contract (LLM auto-inject, tools need observe) confirmed in prior rounds.

## Deviations / follow-ups
- `tooling/lsp/resolver.py:166` has a third, independently-ordered seed resolution (project-first — opposite priority) — editor go-to-definition only, not a validation gate; deferred as a follow-up (filed in coordination status).
- The missing-directory preflight error anchors to the first seed-declaring action only — the root cause is singular; fixing the directory clears all actions.
- Environment note: the shared project's `qana_quiz/seed_data/*.json` are unpulled git-lfs pointers in this checkout; the framework would fail loudly on them (invalid JSON) — the June-23 run machine had real content (verified from stored prompts).

## Verification
- RED (`tests/unit/validation/test_seed_dir_preflight_fallback.py`): project-level layout with a missing ref produced zero preflight errors (silent skip), and declared refs with no directory anywhere passed silently — both genuine failures recorded by the gate pre-fix. Guards: workflow-level preference and no-seed silence pinned.
- GREEN: full suite **8273 passed** + ruff + mypy. Blind fresh-context review (LOW tier, diff + bug statement only): **YES** (2 minor non-blocking notes, above).
- Smoke: `smoke-test.sh online` fails identically on main (baseline verdict: pre-existing/environmental — the smoke config targets a `qanalabs_quiz_gen` workflow absent from the project checkout). Compensating: `scan-project.sh` canary passes after a justified `--refresh` (divergence = the user-requested `map_reduce_fanin_check` sample tools, unrelated to this diff); real-project preflight canary with branch code — `agac inspect -a ql_code_centered` (workflow-level seed layout, 6 real seed files) — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
