### PR TITLE
fix: HITL timeout response carries the partial review snapshot (UAT HT audit)

### DIFF
--- a/agent_actions/llm/providers/hitl/server.py
+++ b/agent_actions/llm/providers/hitl/server.py
@@ -381,6 +381,14 @@ class HitlServer:
         with self._lock:
             if self.response_event.is_set():
                 return  # Another thread already set the response
+            if (
+                status == "timeout"
+                and record_reviews is None
+                and any(r is not None for r in self.record_reviews)
+            ):
+                # Timeout callers have no payload to pass; attach the recorded
+                # reviews so the caller can report how many were completed.
+                record_reviews = list(self.record_reviews)
             self.response = {
                 "hitl_status": status,
                 "user_comment": comment,

--- a/tests/unit/test_hitl_timeout_review_snapshot.py
+++ b/tests/unit/test_hitl_timeout_review_snapshot.py
@@ -1,0 +1,60 @@
+"""Timeout responses must carry the partial per-record review snapshot."""
+
+from agent_actions.llm.providers.hitl.server import HitlServer
+
+
+def _server():
+    return HitlServer(
+        port=3097,
+        instructions="Review output",
+        context_data=[{"id": 1}, {"id": 2}, {"id": 3}],
+        timeout=1,
+    )
+
+
+def test_start_and_wait_timeout_includes_partial_reviews():
+    server = _server()
+    client = server.app.test_client()
+    resp = client.post("/api/review-record", json={"index": 0, "hitl_status": "approved"})
+    assert resp.status_code == 200
+
+    result = server.start_and_wait()
+
+    assert result["hitl_status"] == "timeout"
+    reviews = result.get("record_reviews")
+    assert isinstance(reviews, list)
+    assert len(reviews) == 3
+    assert reviews[0] == {"hitl_status": "approved", "user_comment": ""}
+    assert reviews[1] is None
+    assert reviews[2] is None
+
+
+def test_shutdown_timeout_includes_partial_reviews():
+    server = _server()
+    client = server.app.test_client()
+    resp = client.post(
+        "/api/review-record",
+        json={"index": 1, "hitl_status": "rejected", "user_comment": "not accurate"},
+    )
+    assert resp.status_code == 200
+
+    resp = client.post("/api/shutdown")
+    assert resp.status_code == 200
+
+    assert server.response["hitl_status"] == "timeout"
+    reviews = server.response.get("record_reviews")
+    assert isinstance(reviews, list)
+    assert len(reviews) == 3
+    assert reviews[1]["hitl_status"] == "rejected"
+    assert reviews[1]["user_comment"] == "not accurate"
+    assert reviews[0] is None
+    assert reviews[2] is None
+
+
+def test_timeout_with_no_reviews_omits_snapshot():
+    server = _server()
+
+    result = server.start_and_wait()
+
+    assert result["hitl_status"] == "timeout"
+    assert "record_reviews" not in result

--- a/tests/unit/test_hitl_timeout_seam.py
+++ b/tests/unit/test_hitl_timeout_seam.py
@@ -1,0 +1,60 @@
+"""The server's timeout response and the strategy's timeout report agree."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_actions.errors import AgentActionsError
+from agent_actions.llm.providers.hitl.server import HitlServer
+from agent_actions.processing.strategies.hitl import HITLStrategy
+from agent_actions.processing.types import ProcessingContext
+
+
+def _server():
+    return HitlServer(
+        port=3096,
+        instructions="Review output",
+        context_data=[{"id": 1}, {"id": 2}, {"id": 3}],
+        timeout=1,
+    )
+
+
+def test_timed_out_server_response_drives_reviewed_count_in_error():
+    server = _server()
+    client = server.app.test_client()
+    resp = client.post("/api/review-record", json={"index": 0, "hitl_status": "approved"})
+    assert resp.status_code == 200
+
+    response = server.start_and_wait()
+
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+        {"source_guid": "sg-3", "content": {"id": 3}},
+    ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
+    with (
+        patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=(response, True),
+        ),
+        pytest.raises(AgentActionsError, match="1/3 records reviewed"),
+    ):
+        HITLStrategy().invoke(input_data, context)
+
+
+def test_non_timeout_terminal_response_keeps_explicit_payload_only():
+    server = _server()
+    client = server.app.test_client()
+    resp = client.post("/api/review-record", json={"index": 0, "hitl_status": "approved"})
+    assert resp.status_code == 200
+
+    server._make_terminal_response("error", "server failed")
+
+    assert server.response["hitl_status"] == "error"
+    assert "record_reviews" not in server.response


### PR DESCRIPTION
## Summary
- UAT HT (HITL) audit round, checks HT-01..HT-06. One framework defect found and fixed; five checks verified with real-store and live end-to-end evidence.
- **Defect:** the HITL server's terminal timeout response (idle timeout and UI shutdown) was built without the per-record review snapshot, so the workflow error always reported "0/N records reviewed" even when the reviewer had decided records and those decisions were persisted for resume. Found by a live probe: reviewed 1 of 3 records, let the session time out — error said 0/3 while the resume state file correctly held 1/3.
- **Fix:** `_make_terminal_response` attaches a snapshot of the recorded reviews on the timeout paths only (under the existing lock, only when no explicit payload was passed and at least one review exists). Approve/reject/submit responses are built from their explicit payloads and are unchanged; the strategy raises on timeout before applying reviews, so no downstream decision behavior changes — the count in the error message becomes correct.
- Root-cause note: the strategy-side pin (`test_file_mode_hitl_timeout_raises_with_record_count`) feeds a timeout payload *with* `record_reviews` — a shape the real server never produced. Cross-layer contract divergence; the new tests pin the server side of the seam.

## Verification
- RED: `tests/unit/test_hitl_timeout_review_snapshot.py` — 2 genuine assertion failures on main (timeout via `start_and_wait` and via `/api/shutdown` both lacked the snapshot), plus an edge pin (no reviews → no `record_reviews` key).
- GREEN: full suite green; ruff format/check clean; mypy clean.
- Review: HIGH tier (provider chokepoint) — three blind diverse-lens reviewers (correctness, blast radius, tests/anti-gaming): 3/3 YES. The tests lens asked for two hardening tests — the timeout-only gate pinned in isolation, and a server-to-strategy seam test (real timed-out server response fed into the strategy, asserting the "1/3 records reviewed" message) — both added in `tests/unit/test_hitl_timeout_seam.py`; recorded as YES_WITH_ISSUES. Suite after additions: 8278 passed.
- Live end-to-end (real project, branch code, real HITL server driven over HTTP):
  - One review session served all 3 file records in a single batch (HT-02).
  - Per-record decisions approve/reject/approve → `hitl_status` stored under the action namespace per record (HT-03); the rejected record was guard-filtered downstream with a `disposition=filtered, reason=guard_filter` audit row and absent from the export output (HT-04).
  - Timeout run terminated in 26s (no hang), downstream skipped with a named upstream-failure reason, partial review persisted; re-run resumed the session with the prior decision intact and completed (HT-05).
- Real qana store: HITL-gated action skipped via `guard_prefilter_skip` tombstones for all records with a non-"review" recommendation while downstream `normalize_review_decision` ran and produced `approved=True` (HT-01); `approve_final_question.hitl_status="approved"` read by the `assign_batch_name` guard (HT-03/GD linkage).
- HT-06 (pre-marked bug): confirmed project-side — ISSUE-004 auto-approve tools return `{"hitl_status": "approved"}` unconditionally in all ql_* workflows; framework HITL works when configured (proven by the live probes above).

## Deviations from check wording
- HT-01 expects "no entry in target_data" for the skipped HITL action; the framework writes a null tombstone plus an `unprocessed/guard_prefilter_skip` disposition (same semantics, deliberate audit trail — consistent with the GD round's findings).
- HT-05 expects a `disposition="timeout"` row and a completing run; the design is fail-loud + resume: the action fails with a named error carrying the (now correct) review count, partial reviews persist, and a re-run resumes the session. This is stronger than a silent timeout disposition and is pinned by existing tests.

## Smoke
- `smoke-test.sh online` fails identically on main (baseline verdict: pre-existing — its config targets a `qanalabs_quiz_gen` workflow absent from the project); recorded as a justified skip.
- Compensating canaries on branch code: registry scan canary PASS after a justified `--refresh` (two intentional probe tools added to the sample project for the live HITL runs), plus the three live `agac run` executions above (gate run, timeout run, resume run) using the branch-installed framework against the real project.

## Follow-ups filed (out of scope)
- Pre-existing narrow race in `_handle_review_record`: the terminal-state check happens before the lock is taken, so a review POSTed at the exact moment of timeout can be silently dropped from both the count and the resume state (reviewer finding; orthogonal to this fix).
- ISSUE-004 (project-side): all ql_* workflows bypass HITL via unconditional auto-approve tools; the framework gate works when configured, so restoring real HITL is a project config/tools change.
