### PR TITLE
fix: flag FILE-tool observe collisions at preflight, not just runtime

### DIFF
--- a/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
+++ b/agent_actions/validation/static_analyzer/workflow_static_analyzer.py
@@ -147,6 +147,10 @@ class WorkflowStaticAnalyzer:
         # Guard-filter + fan-in observe hazard: also before wildcard expansion.
         filter_fanin_warnings = self._check_filter_fanin_observe_hazard()
 
+        # FILE-tool observe collision: also before expansion, since two wildcard
+        # namespaces qualify every flat key and expansion would hide that.
+        file_tool_collision_warnings = self._check_file_tool_observe_collision()
+
         # Step 1: Build data flow graph
         self._build_graph()
 
@@ -232,6 +236,9 @@ class WorkflowStaticAnalyzer:
             result.add_warning(warning)
 
         for warning in filter_fanin_warnings:
+            result.add_warning(warning)
+
+        for warning in file_tool_collision_warnings:
             result.add_warning(warning)
 
         # Step 3: Check for unused and missing dependencies (add as warnings)
@@ -1631,6 +1638,68 @@ class WorkflowStaticAnalyzer:
                     )
                 )
 
+        return warnings
+
+    def _check_file_tool_observe_collision(self) -> list[StaticTypeWarning]:
+        """Warn when a FILE-mode tool observes colliding field names across namespaces.
+
+        FILE tools read observed fields as flat top-level keys; when namespaces collide
+        the framework qualifies the keys (``ns.field``) and a bare read returns None.
+        Flags it at preflight instead of at runtime, and reuses the runtime resolver so
+        the two can't drift.
+        """
+        from agent_actions.prompt.context.scope_application import (
+            _resolve_observe_refs_for_flat_keys,
+        )
+
+        warnings: list[StaticTypeWarning] = []
+        for action in self.workflow_config.get("actions", []):
+            if not isinstance(action, dict):
+                continue
+            if action.get("kind") != "tool" and action.get("model_vendor") != "tool":
+                continue
+            if action.get("granularity") != "file":
+                continue
+            context_scope = action.get("context_scope")
+            if not isinstance(context_scope, dict):
+                continue
+            observe_refs = context_scope.get("observe")
+            if not isinstance(observe_refs, list):
+                continue
+
+            resolved, qualify_wildcards = _resolve_observe_refs_for_flat_keys(
+                observe_refs, emit_diagnostics=False
+            )
+            # Match runtime exactly: a specific field is qualified when its bare name
+            # collides; wildcards are qualified only when 2+ distinct namespaces use
+            # one (qualify_wildcards) — not when the same namespace is observed twice.
+            qualified = [out for _, field, out in resolved if field != "*" and out != field]
+            if qualify_wildcards:
+                qualified += [f"{ns}.*" for ns in {ns for ns, field, _ in resolved if field == "*"}]
+            qualified = sorted(qualified)
+            if not qualified:
+                continue
+
+            name = action.get("name", "unknown")
+            warnings.append(
+                StaticTypeWarning(
+                    message=(
+                        f"FILE tool '{name}' observes namespaces with colliding field "
+                        f"names; input keys are delivered namespace-qualified "
+                        f"({', '.join(qualified)}). A tool reading the bare field name "
+                        f"receives None."
+                    ),
+                    location=FieldLocation(
+                        agent_name=name,
+                        config_field="context_scope.observe",
+                        raw_reference=", ".join(r for r in observe_refs if isinstance(r, str)),
+                    ),
+                    referenced_agent="",
+                    referenced_field="",
+                    hint="Read the namespace-qualified keys in the tool, or observe "
+                    "non-colliding fields.",
+                )
+            )
         return warnings
 
     @staticmethod

--- a/tests/validation/static_analyzer/test_file_tool_observe_collision.py
+++ b/tests/validation/static_analyzer/test_file_tool_observe_collision.py
@@ -1,0 +1,126 @@
+"""Preflight flags FILE-mode tools whose observe list collides across namespaces."""
+
+from agent_actions.validation.static_analyzer import analyze_workflow
+
+MARKER = "colliding field names"
+
+
+def _collision_warnings(result):
+    return [w for w in result.warnings if MARKER in w.message]
+
+
+def test_file_tool_two_wildcard_observe_flags_collision():
+    workflow_config = {
+        "actions": [
+            {"name": "tag_concept", "kind": "tool"},
+            {"name": "dedup", "kind": "tool"},
+            {
+                "name": "dedup_by_concept",
+                "kind": "tool",
+                "granularity": "file",
+                "depends_on": ["tag_concept", "dedup"],
+                "context_scope": {"observe": ["tag_concept.*", "dedup.*"]},
+            },
+        ]
+    }
+
+    warnings = _collision_warnings(analyze_workflow(workflow_config))
+
+    assert len(warnings) == 1
+    msg = warnings[0].message
+    assert "dedup_by_concept" in msg
+    # Two wildcard namespaces both qualify; the message names both.
+    assert "tag_concept.*" in msg
+    assert "dedup.*" in msg
+
+
+def test_file_tool_specific_field_collision_flags_the_shared_key():
+    workflow_config = {
+        "actions": [
+            {
+                "name": "action_a",
+                "schema": {"type": "object", "properties": {"answer": {"type": "string"}}},
+            },
+            {
+                "name": "action_b",
+                "schema": {"type": "object", "properties": {"answer": {"type": "string"}}},
+            },
+            {
+                "name": "merge_tool",
+                "kind": "tool",
+                "granularity": "file",
+                "depends_on": ["action_a", "action_b"],
+                "context_scope": {"observe": ["action_a.answer", "action_b.answer"]},
+            },
+        ]
+    }
+
+    warnings = _collision_warnings(analyze_workflow(workflow_config))
+
+    assert len(warnings) == 1
+    msg = warnings[0].message
+    assert "merge_tool" in msg
+    assert "action_a.answer" in msg
+    assert "action_b.answer" in msg
+
+
+def test_file_tool_distinct_fields_no_warning():
+    workflow_config = {
+        "actions": [
+            {
+                "name": "action_a",
+                "schema": {"type": "object", "properties": {"foo": {"type": "string"}}},
+            },
+            {
+                "name": "action_b",
+                "schema": {"type": "object", "properties": {"bar": {"type": "string"}}},
+            },
+            {
+                "name": "merge_tool",
+                "kind": "tool",
+                "granularity": "file",
+                "depends_on": ["action_a", "action_b"],
+                "context_scope": {"observe": ["action_a.foo", "action_b.bar"]},
+            },
+        ]
+    }
+
+    assert _collision_warnings(analyze_workflow(workflow_config)) == []
+
+
+def test_record_mode_tool_collision_not_flagged():
+    # Record-granularity tools receive namespaced context, not flat keys — no collision.
+    workflow_config = {
+        "actions": [
+            {"name": "tag_concept", "kind": "tool"},
+            {"name": "dedup", "kind": "tool"},
+            {
+                "name": "dedup_by_concept",
+                "kind": "tool",
+                "granularity": "record",
+                "depends_on": ["tag_concept", "dedup"],
+                "context_scope": {"observe": ["tag_concept.*", "dedup.*"]},
+            },
+        ]
+    }
+
+    assert _collision_warnings(analyze_workflow(workflow_config)) == []
+
+
+def test_llm_action_collision_not_flagged():
+    # Non-tool actions get namespaced Jinja context; the flat-key hazard is tool-only.
+    workflow_config = {
+        "actions": [
+            {"name": "tag_concept", "kind": "tool"},
+            {"name": "dedup", "kind": "tool"},
+            {
+                "name": "writer",
+                "granularity": "file",
+                "depends_on": ["tag_concept", "dedup"],
+                "prompt": "write",
+                "context_scope": {"observe": ["tag_concept.*", "dedup.*"]},
+            },
+        ]
+    }
+
+    assert _collision_warnings(analyze_workflow(workflow_config)) == []

--- a/tests/validation/static_analyzer/test_file_tool_observe_collision_scoping.py
+++ b/tests/validation/static_analyzer/test_file_tool_observe_collision_scoping.py
@@ -1,0 +1,67 @@
+"""Scoping edges for the FILE-tool observe-collision preflight check."""
+
+from agent_actions.validation.static_analyzer import analyze_workflow
+
+MARKER = "colliding field names"
+
+
+def _collision_warnings(result):
+    return [w for w in result.warnings if MARKER in w.message]
+
+
+def test_tool_declared_via_model_vendor_is_flagged():
+    # Tools can be declared with model_vendor: tool instead of kind: tool.
+    workflow_config = {
+        "actions": [
+            {"name": "tag_concept", "kind": "tool"},
+            {"name": "dedup", "kind": "tool"},
+            {
+                "name": "dedup_by_concept",
+                "model_vendor": "tool",
+                "granularity": "file",
+                "depends_on": ["tag_concept", "dedup"],
+                "context_scope": {"observe": ["tag_concept.*", "dedup.*"]},
+            },
+        ]
+    }
+
+    warnings = _collision_warnings(analyze_workflow(workflow_config))
+    assert len(warnings) == 1
+    assert "dedup_by_concept" in warnings[0].message
+
+
+def test_file_tool_without_observe_no_warning():
+    # context_scope present but no observe — the most common legit config.
+    workflow_config = {
+        "actions": [
+            {"name": "producer", "kind": "tool"},
+            {
+                "name": "flatten",
+                "kind": "tool",
+                "granularity": "file",
+                "depends_on": ["producer"],
+                "context_scope": {"drop": ["producer.debug"]},
+            },
+        ]
+    }
+
+    assert _collision_warnings(analyze_workflow(workflow_config)) == []
+
+
+def test_duplicate_wildcard_same_namespace_no_warning():
+    # Same namespace observed twice does NOT qualify at runtime (qualify_wildcards
+    # needs 2+ distinct namespaces), so preflight must not warn on it either.
+    workflow_config = {
+        "actions": [
+            {"name": "producer", "kind": "tool"},
+            {
+                "name": "flatten",
+                "kind": "tool",
+                "granularity": "file",
+                "depends_on": ["producer"],
+                "context_scope": {"observe": ["producer.*", "producer.*"]},
+            },
+        ]
+    }
+
+    assert _collision_warnings(analyze_workflow(workflow_config)) == []


### PR DESCRIPTION
## Summary

A FILE-granularity tool reads its observed fields as flat top-level input keys. When two observed namespaces share a bare field name — or two wildcard refs (`[A.*, B.*]`) flatten into one key space — the framework namespace-qualifies those flat keys (`ns.field`) so one namespace can't shadow another, and a tool that reads the bare field name then silently receives `None`. This was previously surfaced **only at runtime**, as a `logger.warning` at the tool action itself (`scope_application.py`), after upstream LLM stages had already spent tokens. A real workflow zeroed out all downstream output this way before anyone saw the warning.

This adds a preflight static-analysis check, `WorkflowStaticAnalyzer._check_file_tool_observe_collision()`, that derives the same collision from config alone (action `kind`/`model_vendor`, `granularity`, `observe`) and emits a `StaticTypeWarning` at `analyze()` time — before the run starts.

Key design points:
- **Cannot drift from runtime.** The check imports and calls the same resolver the runtime uses (`_resolve_observe_refs_for_flat_keys`, already imported cross-module by `pipeline_file_mode.py`). Detection is defined by the exact qualification decision the runtime makes, not a re-implementation.
- **Runs before wildcard expansion** (like the sibling `_check_guard_skipped_observe_refs` / `_check_filter_fanin_observe_hazard` checks), since expansion rewrites `A.*` into concrete fields and would hide the two-wildcard collision.
- **Matches runtime exactly on both cases:** a specific field is flagged when its bare name collides; wildcards are flagged only when 2+ *distinct* namespaces use one (`qualify_wildcards`) — so a degenerate `[A.*, A.*]` (same namespace twice), which the runtime does not qualify, is not warned on either.

## Scope decision (deferred, deliberate)

The runtime flat-key path is gated on `is_tool_action OR is_hitl_action`, and FILE-mode HITL also calls `extract_tool_input` (`hitl.py`). This check is scoped to **tools only**. The `bare-key read → None → silent junk output` failure mode is tool-specific: for HITL, `extract_tool_input`'s result becomes the *human review payload*, qualification preserves the data (it doesn't lose it), and the empty-observe case is already warned separately (`hitl.py`). The warning text ("a tool reading the bare field name receives None") would be untrue for HITL, so broadening would add an inaccurate warning rather than close a gap.

## Verification

- **RED → GREEN (mechanical gate):** RED recorded two genuine assertion failures (the two-wildcard and specific-field positive cases produced no warning on `main`); GREEN re-ran the frozen RED target + full suite.
- **Tests:** 5 RED tests (`test_file_tool_observe_collision.py`) — two-wildcard, specific-field, distinct-fields (no warning), record-granularity (no warning), LLM action (no warning). 3 scoping tests (`test_file_tool_observe_collision_scoping.py`) — `model_vendor: tool` detection, `context_scope` present but no `observe` (no warning), duplicate wildcard same namespace (no warning).
- **Suite:** `8281 passed`; `ruff check` + `ruff format --check` clean; `mypy agent_actions` clean.
- **Blind review:** one LOW-tier fresh-context reviewer (diff + bug statement only). Verdict **YES** — confirmed the fix targets root cause, reuses the runtime resolver so the two can't drift, is scoped to the right actions, runs before expansion, and breaks no existing behavior (202 static-analyzer tests pass, no spurious warnings on the existing corpus). Its three non-blocking notes (the `model_vendor` test gap, the no-observe test gap, and the `[A.*, A.*]` over-warn) are all addressed in this diff.
- **Smoke:** skipped — `risk.sh` reports no chokepoint touched (`smoke_required=no`). This is a preflight/static-analysis warning addition only; no runtime execution path, provider, storage, CLI, or config-loading surface changed.
