### PR TITLE
fix: classify online prompt-prep failures as FAILED so total failure isn't reported as success

### DIFF
--- a/agent_actions/processing/strategies/online_llm.py
+++ b/agent_actions/processing/strategies/online_llm.py
@@ -137,7 +137,13 @@ def _build_prep_failed_result(
     context: ProcessingContext,
     error_msg: str,
 ) -> ProcessingResult:
-    """Build a tombstone ProcessingResult for a record that failed prompt preparation."""
+    """Build a FAILED ProcessingResult for a record that failed prompt preparation.
+
+    A prep failure is a genuine failure of this action, not upstream
+    cascade-quarantine, so it is classified FAILED (matching the batch path) and
+    counts toward terminal-failure detection. The tombstone preserves lineage so
+    downstream actions still see the record and cascade-skip it.
+    """
     input_record = item if isinstance(item, dict) else None
     source_guid = input_record.get("source_guid") if input_record else None
 
@@ -158,12 +164,14 @@ def _build_prep_failed_result(
             reason=error_msg[:500],
         )
 
-    return ProcessingResult.unprocessed(
-        data=[tombstone],
-        reason=PREP_FAILED,
+    result = ProcessingResult.failed(
+        error=error_msg,
         source_guid=source_guid,
         input_record=input_record,
     )
+    result.data = [tombstone]
+    result.skip_reason = PREP_FAILED
+    return result
 
 
 class OnlineLLMStrategy:

--- a/tests/processing/test_prep_failed_classified_as_failed.py
+++ b/tests/processing/test_prep_failed_classified_as_failed.py
@@ -1,0 +1,55 @@
+"""Online prompt-prep failures are classified FAILED, matching the batch path.
+
+A record whose prompt fails to render is a genuine failure of this action — not
+upstream cascade-quarantine — so it must count toward terminal-failure detection.
+When every record prep-fails, the action must not report success.
+"""
+
+import pytest
+
+from agent_actions.processing.result_collector import CollectionStats
+from agent_actions.processing.strategies.online_llm import _build_prep_failed_result
+from agent_actions.processing.types import ProcessingContext, ProcessingStatus
+from agent_actions.record.reasons import PREP_FAILED
+
+
+def _ctx():
+    return ProcessingContext(agent_config={}, agent_name="vote_quality")
+
+
+def test_prep_failed_result_is_classified_failed():
+    result = _build_prep_failed_result(
+        {"source_guid": "g1"}, _ctx(), "Template references undefined variables: key"
+    )
+    assert result.status == ProcessingStatus.FAILED
+
+
+def test_prep_failed_result_preserves_lineage_tombstone():
+    result = _build_prep_failed_result({"source_guid": "g1"}, _ctx(), "render error")
+    assert result.data, "a tombstone must be preserved so downstream can cascade-skip"
+    assert result.source_guid == "g1"
+    assert result.skip_reason == PREP_FAILED
+
+
+def test_prep_failed_result_without_source_guid_still_failed():
+    # Junk upstream records can lack a source_guid; the prep failure must still
+    # register as a failure rather than vanishing into the unprocessed bucket.
+    result = _build_prep_failed_result({"content": {}}, _ctx(), "render error")
+    assert result.status == ProcessingStatus.FAILED
+
+
+def test_all_prep_failed_trips_terminal_failure_guard():
+    # With prep-failures counted as failed (not unprocessed), an action whose
+    # records all prep-fail has active_input_count > 0 and success == 0, so the
+    # circuit-breaker raises instead of the run silently reporting success.
+    stats = CollectionStats(success=0, failed=3, unprocessed=0)
+    with pytest.raises(RuntimeError, match="0 successful records"):
+        stats.raise_if_terminal_failure("vote_quality", data=[{}, {}, {}], output=[])
+
+
+def test_prep_failures_in_unprocessed_bucket_would_not_trip_guard():
+    # Guards against regressing to the old classification: if prep-failures were
+    # counted as unprocessed, they would be subtracted from active_input_count and
+    # the guard would not fire — the exact bug this fix closes.
+    stats = CollectionStats(success=0, failed=0, unprocessed=3)
+    stats.raise_if_terminal_failure("vote_quality", data=[{}, {}, {}], output=[])  # no raise

--- a/tests/unit/processing/test_online_llm_strategy.py
+++ b/tests/unit/processing/test_online_llm_strategy.py
@@ -581,7 +581,7 @@ class TestInvokeBatchLoop:
         results = strategy.invoke([{"f": "1"}], context)
 
         assert len(results) == 1
-        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].status == ProcessingStatus.FAILED
         assert results[0].data[0]["_state"] == RecordState.FAILED.value
 
     @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")
@@ -628,7 +628,7 @@ class TestInvokeBatchLoop:
         results = strategy.invoke([{"f": "1"}], context)
 
         assert len(results) == 1
-        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].status == ProcessingStatus.FAILED
         assert results[0].data[0]["_state"] == RecordState.FAILED.value
 
     @patch("agent_actions.processing.strategies.online_llm.get_task_preparer")

--- a/tests/unit/processing/test_prep_failure_e2e.py
+++ b/tests/unit/processing/test_prep_failure_e2e.py
@@ -67,8 +67,8 @@ class TestOnlineMultiRecordContinuation:
         results = strategy.invoke(records, context)
 
         assert len(results) == 3
-        # Record 0: tombstone
-        assert results[0].status == ProcessingStatus.UNPROCESSED
+        # Record 0: failed tombstone (a prep failure is this action's own failure)
+        assert results[0].status == ProcessingStatus.FAILED
         assert results[0].data[0]["_state"] == RecordState.FAILED.value
         # Records 1-2: success
         assert results[1].status == ProcessingStatus.SUCCESS
@@ -98,7 +98,7 @@ class TestOnlineMultiRecordContinuation:
         results = strategy.invoke([{"source_guid": "sg_fail"}, {"source_guid": "sg_ok"}], context)
 
         assert len(results) == 2
-        assert results[0].status == ProcessingStatus.UNPROCESSED
+        assert results[0].status == ProcessingStatus.FAILED
         assert results[1].status == ProcessingStatus.SUCCESS
 
 
@@ -154,12 +154,12 @@ class TestCascadePropagation:
         assert "question" in tombstone["_state_history"][0]["reason"]
 
 
-class TestResultCollectorPrepFailedDisposition:
-    """ResultCollector counts prep-failed tombstones correctly."""
+class TestResultCollectorUnprocessedCounting:
+    """ResultCollector counts cascade-unprocessed records separately from success/failure."""
 
     def test_unprocessed_result_counted_separately(self):
-        """Prep-failed results (UNPROCESSED) don't inflate success or failure counts."""
-        from agent_actions.record.reasons import PREP_FAILED
+        """Upstream-quarantined (UNPROCESSED) records don't inflate success or failure counts."""
+        from agent_actions.record.reasons import UPSTREAM_UNPROCESSED
 
         mock_backend = MagicMock()
 
@@ -169,14 +169,8 @@ class TestResultCollectorPrepFailedDisposition:
                 source_guid="sg_1",
             ),
             ProcessingResult.unprocessed(
-                data=[
-                    {
-                        "content": {"test_action": None},
-                        "_state": RecordState.FAILED.value,
-                        "source_guid": "sg_2",
-                    }
-                ],
-                reason=PREP_FAILED,
+                data=[{"content": {"test_action": None}, "source_guid": "sg_2"}],
+                reason=UPSTREAM_UNPROCESSED,
                 source_guid="sg_2",
             ),
         ]

--- a/tests/unit/processing/test_prep_failure_e2e.py
+++ b/tests/unit/processing/test_prep_failure_e2e.py
@@ -7,6 +7,8 @@ downstream UPSTREAM_UNPROCESSED, across both online and batch paths.
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agent_actions.errors import RecordContextError
 from agent_actions.errors.operations import TemplateVariableError
 from agent_actions.processing.prepared_task import GuardStatus, PreparationContext
@@ -184,3 +186,36 @@ class TestResultCollectorUnprocessedCounting:
         )
         assert stats.success > 0
         assert stats.unprocessed > 0
+
+
+class TestResultCollectorPrepFailureCountedAsFailed:
+    """Wired path: prep-failed results flow through the collector into stats.failed."""
+
+    def test_all_prep_failed_counted_as_failed_and_trips_guard(self):
+        from agent_actions.processing.strategies.online_llm import _build_prep_failed_result
+
+        ctx = ProcessingContext(
+            agent_config={"agent_type": "vote_quality"},
+            agent_name="vote_quality",
+            storage_backend=MagicMock(),
+        )
+        records = [{"source_guid": f"sg_{i}"} for i in range(3)]
+        results = [
+            _build_prep_failed_result(r, ctx, "Template references undefined variables: key")
+            for r in records
+        ]
+
+        output, stats = ResultCollector.collect_results(
+            results,
+            agent_config={"agent_type": "vote_quality"},
+            agent_name="vote_quality",
+            is_first_stage=False,
+            storage_backend=MagicMock(),
+        )
+
+        # The prep failures land in the failure bucket, not unprocessed, so the
+        # terminal-failure guard sees a non-zero active denominator and fires.
+        assert stats.failed == 3
+        assert stats.unprocessed == 0
+        with pytest.raises(RuntimeError, match="0 successful records"):
+            stats.raise_if_terminal_failure("vote_quality", data=records, output=output)


### PR DESCRIPTION
## Summary

An online record whose prompt fails to render — a missing template variable (`TemplateVariableError` with non-empty `missing_variables`) or a `RecordContextError` — was returned as `ProcessingResult.unprocessed(...)`. But the terminal-failure circuit breaker in `CollectionStats.raise_if_terminal_failure` computes:

```python
active_input_count = len(data) - self.unprocessed
if active_input_count > 0 and self.success == 0 and (self.failed + self.exhausted) > 0:
    raise RuntimeError("... produced 0 successful records ...")
```

Because prep-failures were counted as `unprocessed`, an action where **every** record prep-fails got `active_input_count == 0`, the breaker never fired, the action resolved `COMPLETED`, and the run printed **"Successfully completed"** having produced nothing. (Observed in a real workflow: three vote actions reported OK with 67/67 prep failures each; 31 downstream actions were blocked; zero output; run reported success.)

The `unprocessed` status is documented as *"upstream dead/failed/skipped"* (cascade-quarantine). A prep failure is a genuine failure of **this** action's own prompt, not upstream quarantine — and it's already stamped `RecordState.FAILED` and written `DISPOSITION_FAILED`, so the result-level status disagreed with the record's own state.

## Fix

Reclassify online prep-failures as `ProcessingStatus.FAILED` in `_build_prep_failed_result`, mirroring the **already-correct batch path** (`_build_failed_passthrough`, which returns `ProcessingResult.failed(...)` with the tombstone as data). The collector's FAILED branch preserves lineage (`_state = FAILED` is in `CASCADE_BLOCKING_STATES`, exactly like the `CASCADE_SKIPPED` it replaced), so downstream cascade-skip is unchanged; genuine cascade-quarantine (`UPSTREAM_UNPROCESSED`) is untouched and stays out of the breaker denominator.

Single-path change: only `_build_prep_failed_result`. Batch was already correct; this brings online into parity.

## Tests

- New `tests/processing/test_prep_failed_classified_as_failed.py`: prep-failure classified FAILED (with/without `source_guid`), lineage tombstone preserved, all-prep-failed trips the guard, and a fence test proving prep-failures in the *unprocessed* bucket would **not** trip it (blocks the wrong "make the guard count unprocessed" fix).
- New wired test in `test_prep_failure_e2e.py`: prep-failed results flow through `ResultCollector.collect_results` → `stats.failed == 3, stats.unprocessed == 0` → guard raises. Pins the seam end-to-end so a future refactor can't silently reopen the bug.
- **Four existing assertions were updated from `UNPROCESSED` to `FAILED`** (`test_prep_failure_e2e.py`, `test_online_llm_strategy.py`). These are legitimate corrections, not test-weakening: each already asserted the tombstone's `_state == RecordState.FAILED` right alongside the old `status == UNPROCESSED` — i.e. the record was already a genuine failure while the result status said otherwise; that inconsistency **was** the bug. The multi-record-continuation, tombstone, and downstream-cascade assertions are unchanged. One collector test was retargeted from a `PREP_FAILED` input (a shape the producer no longer emits) to `UPSTREAM_UNPROCESSED` (one it genuinely emits).

## Verification

- Full suite: **8279 passed**; `ruff check` + `ruff format --check` clean; `mypy agent_actions` clean.
- **Review: HIGH tier — three diverse-lens blind reviewers (correctness / blast-radius / tests), all VERDICT YES.** Correctness confirmed the breaker fires for total failure while partial failures never halt (`success == 0` gate). Blast-radius traced every `UNPROCESSED`/`FAILED` consumer (circuit breaker, `task_preparer` cascade, dispositions, `agac retry`, enrichment) — all preserved; it also found the change *resolves* a prior `DISPOSITION_FAILED`/`DISPOSITION_UNPROCESSED` double-write divergence rather than introducing one. Tests confirmed the four assertion edits are legitimate and the new tests non-tautological; the wired collector test above was added per that reviewer's coverage recommendation.
- **Smoke: skipped** — `risk.sh` reports no chokepoint (`smoke_required=no`). The change only alters the total-prep-failure path; normal and partial-failure runs are unaffected. This clone's smoke environment lacks the real `qanalabs_quiz_gen` project (established by baseline in a prior round).
