### PR TITLE
fix: schema-validate FILE tool output per record, not the result envelope

### DIFF
--- a/agent_actions/validation/schema_output_validator.py
+++ b/agent_actions/validation/schema_output_validator.py
@@ -125,6 +125,14 @@ def validate_output_against_schema(
     """Validate LLM response against expected schema."""
     schema_name = schema.get("name", "unknown")
 
+    # FILE tools return a FileUDFResult envelope (outputs=[{source_index, data}]);
+    # validate each record's business data, not the envelope keys, so a healthy
+    # tool is not reported as an empty object.
+    from agent_actions.utils.udf_management.registry import FileUDFResult
+
+    if isinstance(llm_output, FileUDFResult):
+        llm_output = [out["data"] for out in llm_output.outputs]
+
     # Check for malformed 'properties' before extracting fields
     schema_structure_errors = _check_properties_type(schema)
 

--- a/tests/processing/test_file_tool_output_schema_report.py
+++ b/tests/processing/test_file_tool_output_schema_report.py
@@ -1,0 +1,42 @@
+"""validate_output_against_schema unwraps a FileUDFResult and reports per record."""
+
+from agent_actions.utils.udf_management.registry import FileUDFResult
+from agent_actions.validation.schema_output_validator import validate_output_against_schema
+
+_SCHEMA = {
+    "name": "dedup_by_concept",
+    "properties": {"concept_label": {"type": "string"}, "key": {"type": "string"}},
+    "required": ["concept_label", "key"],
+}
+
+
+def test_conforming_file_udf_result_reports_compliant():
+    result = FileUDFResult(
+        outputs=[
+            {"source_index": 0, "data": {"concept_label": "geometry", "key": "g1"}},
+            {"source_index": 1, "data": {"concept_label": "algebra", "key": "a1"}},
+        ]
+    )
+    report = validate_output_against_schema(result, _SCHEMA, "dedup_by_concept")
+    assert report.is_compliant
+    assert not any("Empty object" in e for e in report.validation_errors)
+    assert report.missing_required == []
+
+
+def test_file_udf_result_records_missing_required_reports_noncompliant():
+    result = FileUDFResult(outputs=[{"source_index": 0, "data": {"concept_label": "geometry"}}])
+    report = validate_output_against_schema(result, _SCHEMA, "dedup_by_concept")
+    assert not report.is_compliant
+    assert "key" in report.missing_required
+
+
+def test_file_udf_result_field_union_across_records():
+    # Fields are drawn from all records, so a field present in any record counts.
+    result = FileUDFResult(
+        outputs=[
+            {"source_index": 0, "data": {"concept_label": "geometry"}},
+            {"source_index": 1, "data": {"key": "g1"}},
+        ]
+    )
+    report = validate_output_against_schema(result, _SCHEMA, "dedup_by_concept")
+    assert {"concept_label", "key"} <= report.actual_fields

--- a/tests/processing/test_file_tool_output_schema_validation.py
+++ b/tests/processing/test_file_tool_output_schema_validation.py
@@ -1,0 +1,65 @@
+"""FILE tool output is schema-validated per record, not as the result envelope.
+
+A FILE tool returns a FileUDFResult envelope (outputs=[{source_index, data}]).
+Schema validation must inspect each record's ``data``, not the envelope keys —
+otherwise every FILE tool with a schema is reported as an empty object.
+"""
+
+import logging
+
+import pytest
+
+from agent_actions.errors import SchemaValidationError
+from agent_actions.processing.helpers import _validate_llm_output_schema
+from agent_actions.utils.udf_management.registry import FileUDFResult
+
+_SCHEMA = {
+    "name": "dedup_by_concept",
+    "properties": {"concept_label": {"type": "string"}, "key": {"type": "string"}},
+}
+
+
+def _tool_config(mode: str) -> dict:
+    return {
+        "agent_type": "dedup_by_concept",
+        "kind": "tool",
+        "schema": _SCHEMA,
+        "reprompt": {"on_schema_mismatch": mode},
+    }
+
+
+def test_conforming_records_do_not_raise_in_reject_mode():
+    result = FileUDFResult(
+        outputs=[
+            {"source_index": 0, "data": {"concept_label": "geometry", "key": "g1"}},
+            {"source_index": 1, "data": {"concept_label": "algebra", "key": "a1"}},
+        ]
+    )
+    # Envelope must be unwrapped: the records conform, so no mismatch is raised.
+    out = _validate_llm_output_schema(result, _tool_config("reject"), "dedup_by_concept")
+    assert out is result
+
+
+def test_conforming_records_emit_no_schema_warning(caplog):
+    result = FileUDFResult(
+        outputs=[{"source_index": 0, "data": {"concept_label": "geometry", "key": "g1"}}]
+    )
+    with caplog.at_level(logging.WARNING, logger="agent_actions.processing.helpers"):
+        _validate_llm_output_schema(result, _tool_config("warn"), "dedup_by_concept")
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "Empty object" not in joined
+    assert "declared fields" not in joined
+
+
+def test_records_missing_required_field_still_flagged():
+    # The guard must still catch genuinely non-conforming records after unwrapping.
+    schema = {**_SCHEMA, "required": ["concept_label", "key"]}
+    config = {
+        "agent_type": "dedup_by_concept",
+        "kind": "tool",
+        "schema": schema,
+        "reprompt": {"on_schema_mismatch": "reject"},
+    }
+    result = FileUDFResult(outputs=[{"source_index": 0, "data": {"concept_label": "geometry"}}])
+    with pytest.raises(SchemaValidationError):
+        _validate_llm_output_schema(result, config, "dedup_by_concept")


### PR DESCRIPTION
## Summary

A FILE-granularity tool returns its records wrapped in a `FileUDFResult` envelope (`outputs=[{source_index, data}]`). The output schema validator `validate_output_against_schema` ran `_extract_output_fields(llm_output)` on the whole envelope. For a `FileUDFResult` object that yields no fields, so the empty-object guard reported **every** FILE tool that declares a schema as an *"Empty object" / "no declared fields"* — a spurious schema-validation warning on healthy tools. It stays warn-only for tools (tool actions strip the inherited `reprompt` block, so it never escalates to reject), but it was noise on every run and, on genuinely broken output, right-for-the-wrong-reason.

The framework's UDF tooling layer (`utils/udf_management/tooling.py:_validate_udf_output`) already unwraps `FileUDFResult.outputs[*].data` and jsonschema-validates each record. The report validator did not.

## Fix

Unwrap the `FileUDFResult` envelope to its per-record `data` list at the top of `validate_output_against_schema`, before field extraction. The guard then inspects real record fields (union across records): silent on conforming tools, still flags genuinely non-conforming output. Non-`FileUDFResult` inputs (dict / list / None) are untouched — the change is behind an `isinstance` guard, so all three callers are unaffected for the LLM path.

## Tests

- `tests/processing/test_file_tool_output_schema_validation.py`: conforming records don't raise in reject mode (the RED failure); records missing a required field still raise; a warn-path no-spurious-warning case.
- `tests/processing/test_file_tool_output_schema_report.py`: report-level assertions (directly observable, not log-dependent) — conforming `FileUDFResult` → `is_compliant`, no "Empty object"; missing-required → non-compliant with the field in `missing_required`; fields drawn as the union across records.

## Verification

- Full suite: **8279 passed**; `ruff check` + `ruff format --check` clean; `mypy agent_actions` clean.
- No circular import: `registry` does not import `validation`; import smoke passes. All three `validate_output_against_schema` callers pass non-`FileUDFResult` inputs through unchanged.
- **Review — please note:** `risk.sh` rated this **LOW** (isinstance-guarded unwrap, 3 files, no chokepoint). The automated blind reviewer could not run — it returned **API 529 (Overloaded)** on two attempts. I performed a documented **author self-review** instead (root cause, caller trace, edge cases, circular-import check — all above). **A fresh-eyes review before merge is recommended**, since the blind pass didn't complete.
- **Smoke: skipped** — `risk.sh` reports `smoke_required=no`; the change is a guarded validator unwrap with no runtime-execution surface, and this clone's smoke env lacks the real `qanalabs_quiz_gen` project (prior-round baseline).
