### PR TITLE
docs: soft reset re-drives the workflow, not "from scratch" (CK audit)

### DIFF
--- a/agent_actions/skills/agac-agent-skills/scripts/reset_workflow.py
+++ b/agent_actions/skills/agac-agent-skills/scripts/reset_workflow.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Reset workflow state.
 
-Default (soft reset): removes .agent_status.json so the next run starts from
-scratch while keeping source data and the SQLite store intact.
+Default (soft reset): removes .agent_status.json so the next run re-drives the
+workflow, while keeping source data and the SQLite store intact. Records already
+completed in the store are carried forward, not regenerated — use --full for a
+true from-scratch rebuild.
 
 --full: wipes source/, store/, target/, and .agent_status.json, then
 recreates target/.
@@ -58,7 +60,10 @@ def main() -> None:
     else:
         print(f"Soft reset: clearing {status} (keeps DB and source)")
         remove(status)
-        print(f"Done. Run `agac run -a {args.workflow} -u tools` to re-run from scratch.")
+        print(
+            f"Done. Run `agac run -a {args.workflow} -u tools` to re-drive the workflow "
+            "(completed records carry forward; use --full to regenerate everything)."
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

First of the **CK→EX→EC remaining-framework UAT sweep**. The CK (Checkpoint & Resume) audit — CK-01..CK-05 — is a **verification round: no framework defect found** (like the earlier TL round). All five checks are sound on current main; the only actionable item is a documentation-accuracy fix, which is this diff.

**The fix:** `scripts/reset_workflow.py`'s soft reset removes `.agent_status.json` but keeps the SQLite store, so on the next run records already completed are **carried forward, not regenerated**. The prior wording ("starts from scratch" / "re-run from scratch") implied fresh output and could mislead an operator into thinking a soft reset regenerates everything. Corrected the module docstring and the CLI hint; `--full` remains the true from-scratch path. Doc-only, so no RED/GREEN applies.

**CK checks — all verified working (evidence):**
- **CK-01 / CK-04** (rerun-skip; resume-identical output): two-gate skip — node-level `_check_prior_output` (`executor.py:270`, gated on `is_completed` + non-empty `list_target_files`) and per-record `DispositionGate` (`disposition_gate.py:44`) which sends only non-terminal records to the LLM and carries terminals forward from `target_data` (→ `checkpoint_output` fallback). A 2-of-3-done action re-sends only the 3rd record.
- **CK-02** (stale disposition after `.agent_status.json` reset → silent zero-record success): **already closed by #804** — `_clear_stale_node_disposition` wipes `SKIPPED@__node__` before `_resolve_completion_status` reads it; per-record `skipped` never feeds that resolver (it drives logged carry-forward, not silent loss). This audit finding is what the docstring fix addresses.
- **CK-03** (SIGKILL mid-LLM): a record's durable state is committed strictly **after** schema validation (WAL + single per-record commit); a kill leaves no terminal disposition, or at worst disposition-without-output, which the carry-forward `missing` path reprocesses. No partial-complete record is ever skipped.
- **CK-05** (`checkpoint_output` currency): `UNIQUE(action_name, relative_path, source_guid)` + `INSERT OR REPLACE` = exactly one latest row per record; it's an auxiliary fallback while `record_disposition` is the resume authority.

**Sweep spillover verified the same run (no change needed):**
- **EC-09** — the batch→online `run_mode` boundary is per-action and storage-mediated (`pipeline.py:537-557`); no in-memory batch context spans the handoff, so records aren't lost at the mode switch.
- **EC-03** — `optional: true` is respected (= LW-11, fixed in #815); 61 tests pass.

**Not framework (documented, not fixed here):** EX (8 checks) and the remaining EC (8) are project-side qanalabs UDF/config quality — export tools, dedup, `record_limit`, guard presence — which belong on the project track, not this framework harness.

## Verification

- 4 blind verify-first agents traced each CK check against current code; ~250 targeted pinning tests pass across them (idempotency, checkpoint-resume, stale-node-disposition, disposition-atomicity).
- Full suite: **8298 passed** (0:01:12), exit 0.
- `ruff format --check` + `ruff check` clean on the changed file.
- Risk LOW (doc-only). Smoke skipped: `reset_workflow.py` is not a smoke surface.