### PR TITLE
docs: correct context_scope — passthrough scope and seed directive key

### DIFF
--- a/docs.agent-actions/docs/guides/design-patterns.md
+++ b/docs.agent-actions/docs/guides/design-patterns.md
@@ -145,7 +145,7 @@ defaults:
   model_vendor: openai
   model_name: gpt-4o-mini
   context_scope:
-    seed_path:
+    seed:
       role_requirements: $file:role_requirements.json
       company_values: $file:company_values.json
 
@@ -450,7 +450,7 @@ defaults:
   model_vendor: openai
   model_name: gpt-4o-mini
   context_scope:
-    seed_path:
+    seed:
       brand_guidelines: $file:brand_guidelines.json
 
 actions:
@@ -584,7 +584,7 @@ defaults:
   model_vendor: openai
   model_name: gpt-4o-mini
   context_scope:
-    seed_path:
+    seed:
       glossary: $file:domain_glossary.json
 
 actions:
@@ -704,7 +704,7 @@ defaults:
   model_vendor: openai
   model_name: gpt-4o-mini
   context_scope:
-    seed_path:
+    seed:
       vendor_catalog: $file:vendor_catalog.json
       contract_templates: $file:contract_templates.json
 
@@ -820,7 +820,7 @@ defaults:
   model_vendor: openai
   model_name: gpt-4o-mini
   context_scope:
-    seed_path:
+    seed:
       brand_voice: $file:brand_voice.json
       marketplace_rules: $file:marketplace_rules.json
 

--- a/docs.agent-actions/docs/reference/configuration/defaults.md
+++ b/docs.agent-actions/docs/reference/configuration/defaults.md
@@ -47,7 +47,7 @@ actions:
 | `output_field` | string | Field name for plain-text output when `json_mode: false` (default: `raw_response`) |
 | `granularity` | string | `record` or `file` processing |
 | `run_mode` | string | `batch` or `online` execution |
-| `context_scope` | object | Default context visibility: `observe`, `drop`, `passthrough`, `seed_path` |
+| `context_scope` | object | Default context visibility: `observe`, `drop`, `passthrough`, `seed` |
 | `temperature` | float | LLM temperature (0.0-2.0) |
 | `max_tokens` | integer | Maximum response tokens |
 | `top_p` | float | Top-p (nucleus) sampling (0.0-1.0) |
@@ -130,7 +130,7 @@ Here's where it gets interesting. The `context_scope` in defaults applies to all
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       syllabus: $file:exam_syllabus.json
       rubric: $file:grading_rubric.yaml
 
@@ -146,7 +146,7 @@ actions:
     context_scope:
       observe:
         - extract_facts.facts  # Add action-specific scope
-    # seed_path is merged with defaults
+    # seed is merged with defaults
 ```
 
 ### Context Scope Merging
@@ -156,7 +156,7 @@ You might wonder what happens when an action defines its own context_scope. Acti
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       config: $file:config.json
 
 actions:
@@ -166,7 +166,7 @@ actions:
         - upstream.field
       passthrough:
         - source.id
-    # Result: seed_path from defaults + observe/passthrough from action
+    # Result: seed from defaults + observe/passthrough from action
 ```
 
 ## Overriding Patterns

--- a/docs.agent-actions/docs/reference/configuration/index.md
+++ b/docs.agent-actions/docs/reference/configuration/index.md
@@ -118,7 +118,7 @@ actions:
 | `dependencies` | list | Upstream actions to wait for |
 | `prompt` | string | Inline prompt or `$store.template` reference |
 | `schema` | string | Output validation schema |
-| `context_scope` | object | Control data visibility: `observe`, `drop`, `passthrough`, `seed_path` — see [Context Scope](../context/context-scope.md) |
+| `context_scope` | object | Control data visibility: `observe`, `drop`, `passthrough`, `seed` — see [Context Scope](../context/context-scope.md) |
 | `data_source` | object/string | Optional input source configuration for start-node actions (defaults to `staging/`) |
 
 ### Model Fields

--- a/docs.agent-actions/docs/reference/context/context-scope.md
+++ b/docs.agent-actions/docs/reference/context/context-scope.md
@@ -75,14 +75,20 @@ The `passthrough` directive forwards fields directly to the action output **with
       - source.url                          # Preserve for downstream
 ```
 
+:::warning Passthrough preserves output — it does not feed downstream context
+`passthrough` keeps a field in **this action's own output record** (for lineage or export). It does **not** make that field available to later actions _through_ this action. A downstream action that needs the value must `observe` it from its **original producing action** (for example `observe: [source.url]`), not from the action that passed it through.
+
+In particular, `observe: [some_action.*]` expands only to `some_action`'s own output fields — it does **not** pull in fields that `some_action` merely passed through. Relying on an upstream `passthrough` to satisfy a downstream `observe` can make the field resolve **empty at runtime**, silently, because the field is still declared on the consumer's schema.
+:::
+
 ## Seed Data
 
-Static reference data can be loaded via `seed_path`. See [Seed Data](./seed-data.md) for details.
+Static reference data can be loaded via `seed`. See [Seed Data](./seed-data.md) for details.
 
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       exam_syllabus: $file:syllabus.json
   data_source:
     type: local

--- a/docs.agent-actions/docs/reference/context/field-references.md
+++ b/docs.agent-actions/docs/reference/context/field-references.md
@@ -85,12 +85,12 @@ prompt: |
 
 ### seed
 
-The `seed` reference accesses static seed data loaded via `context_scope.seed_path`:
+The `seed` reference accesses static seed data loaded via `context_scope.seed`:
 
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       exam_syllabus: $file:syllabus.json
 
 actions:

--- a/docs.agent-actions/docs/reference/context/index.md
+++ b/docs.agent-actions/docs/reference/context/index.md
@@ -13,7 +13,7 @@ The context system controls how data flows between actions—referencing upstrea
 |---------|---------|--------|
 | **Field References** | Access upstream action outputs | `{{ action.field }}` |
 | **Context Scope** | Control data visibility and flow | `context_scope: {observe, drop, passthrough}` |
-| **Seed Data** | Load static reference data | `seed_path: {name: $file:path}` |
+| **Seed Data** | Load static reference data | `seed: {name: $file:path}` |
 
 ## Learn More
 

--- a/docs.agent-actions/docs/reference/context/seed-data.md
+++ b/docs.agent-actions/docs/reference/context/seed-data.md
@@ -12,7 +12,7 @@ Seed Data loads static reference data (syllabi, rubrics, lookups) into workflow 
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       exam_syllabus: $file:syllabus.json
       grading_rubric: $file:rubric.yaml
 ```
@@ -62,7 +62,7 @@ prompt: |
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       syllabus: $file:exam_syllabus.json
       rubric: $file:grading_rubric.yaml
 ```
@@ -90,7 +90,7 @@ Workflow-level (recommended):
 ```yaml
 defaults:
   context_scope:
-    seed_path:
+    seed:
       syllabus: $file:syllabus.json
 ```
 
@@ -100,6 +100,6 @@ Per-action (merged with defaults):
 actions:
   - name: specialized_action
     context_scope:
-      seed_path:
+      seed:
         special_data: $file:special.json
 ```


### PR DESCRIPTION
## Summary
Two corrections to the `context_scope` reference docs, both surfaced while debugging a silent empty-field failure:

- **Passthrough scope:** clarified that `passthrough` preserves a field in the action's **own output** and does not feed it to downstream actions *through* that action. A consumer must `observe` the field from its original producing action; `observe: [action.*]` does **not** include fields the action merely passed through. Relying on passthrough to satisfy a downstream `observe` makes the field resolve **empty at runtime, silently**, since it is still declared on the consumer schema. Added as a `:::warning` in `context-scope.md`.
- **Seed directive key:** the valid `context_scope` directive is **`seed`**, not `seed_path` — a `seed_path` directive raises a `ConfigurationError` (the directive registry accepts `observe`/`passthrough`/`drop`/`drops`/`seed`). Fixed ~20 occurrences across 7 files. The separate top-level `seed_data_path` directory key is a different, valid setting and is unchanged.

## Verification
- `seed_path` fully eliminated from the docs (0 remaining); `seed_data_path` preserved (no substring overlap, 4 occurrences intact).
- `seed-data.md` shows the corrected `seed:` directive alongside the distinct `seed_data_path:` setting.
- Content-only markdown changes (one well-formed admonition + string renames; no links or JSX touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)