### PR TITLE
feat: project-level required_by_default in agent_actions.yml

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260806-182000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260806-182000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "Add a top-level required_by_default key to agent_actions.yml to set required-by-default flat-field schema validation project-wide, instead of per schema file. A schema may still override it with its own required_by_default, and explicit per-field required/optional markers win over both."
+time: 2026-08-06T18:20:00Z

--- a/agent_actions/config/path_config.py
+++ b/agent_actions/config/path_config.py
@@ -272,6 +272,27 @@ def get_seed_data_path(project_root: Path) -> str:
     return name
 
 
+def get_required_by_default(project_root: Path) -> bool:
+    """Return the project-wide ``required_by_default`` schema policy.
+
+    Reads the top-level ``required_by_default`` key from ``agent_actions.yml``.
+    When set true, flat schema fields with no explicit ``required``/``optional``
+    marker are treated as required across every schema, without adding the flag
+    to each schema file. Absent config or key defaults to ``False`` (fields
+    optional by default). A schema that declares its own ``required_by_default``
+    overrides this project setting.
+    """
+    try:
+        config = load_project_config(project_root)
+    except (OSError, ConfigValidationError) as exc:
+        logger.debug(
+            "Could not load required_by_default from project config, defaulting to False: %s",
+            exc,
+        )
+        return False
+    return bool(config.get("required_by_default", False))
+
+
 def resolve_seed_data_dir(workflow_config_path: str | None) -> tuple[Path | None, str]:
     """Resolve the seed data directory: workflow root first, then project root.
 

--- a/agent_actions/output/response/loader.py
+++ b/agent_actions/output/response/loader.py
@@ -103,12 +103,16 @@ class SchemaLoader:
         schema is not found.  Duplicate names are logged as warnings
         by ``discover_schema_files``; the first occurrence is used.
         """
-        from agent_actions.config.path_config import get_schema_path, resolve_project_root
+        from agent_actions.config.path_config import (
+            get_required_by_default,
+            get_schema_path,
+            resolve_project_root,
+        )
 
+        effective_root = resolve_project_root(project_root)
         all_schemas = SchemaLoader.discover_schema_files(project_root)
 
         if schema_name not in all_schemas:
-            effective_root = resolve_project_root(project_root)
             sp = get_schema_path(effective_root)
             project_schema_dir = resolve_relative_to(sp, effective_root)
             wf_root = effective_root / "agent_workflow"
@@ -119,7 +123,12 @@ class SchemaLoader:
                 f"{wf_root if wf_root.exists() else effective_root}."
             )
 
-        return SchemaLoader._read_schema_file(schema_name, all_schemas[schema_name])
+        schema_data = SchemaLoader._read_schema_file(schema_name, all_schemas[schema_name])
+        # A schema that does not declare its own policy inherits the project-wide
+        # required_by_default from agent_actions.yml. Per-schema declaration wins.
+        if isinstance(schema_data, dict) and "required_by_default" not in schema_data:
+            schema_data["required_by_default"] = get_required_by_default(effective_root)
+        return schema_data
 
     @staticmethod
     def _read_schema_file(schema_name: str, schema_file: Path) -> dict:

--- a/docs.agent-actions/docs/reference/configuration/index.md
+++ b/docs.agent-actions/docs/reference/configuration/index.md
@@ -35,6 +35,7 @@ default_agent_config:
 schema_path: schema
 tool_path: ["tools"]
 seed_data_path: seed_data
+required_by_default: false
 
 chunk_config:
   chunk_size: 4000
@@ -51,6 +52,7 @@ output_storage:
 | `schema_path` | Directory containing output schemas (default: `schema`) |
 | `tool_path` | Directories to scan for custom tools |
 | `seed_data_path` | Directory for static reference data (default: `seed_data`) |
+| `required_by_default` | When `true`, flat schema fields (`fields:` list) are required unless marked `optional: true`; when `false` (default) they are optional unless marked `required: true`. Applies project-wide; a schema declaring its own `required_by_default` overrides it. |
 | `chunk_config` | Text chunking for large inputs |
 | `output_storage` | Storage backend config: `backend` (`sqlite`), `db_path` (database file location) |
 

--- a/tests/unit/output/response/test_project_required_by_default.py
+++ b/tests/unit/output/response/test_project_required_by_default.py
@@ -1,0 +1,102 @@
+"""Project-level ``required_by_default`` in agent_actions.yml.
+
+A project may set ``required_by_default: true`` at the top level of
+``agent_actions.yml`` to make flat schema fields required-by-default across
+every schema, instead of adding the flag to each schema file. A named schema
+loaded through :meth:`SchemaLoader.load_schema` inherits the project setting
+unless the schema file declares its own ``required_by_default`` (per-schema
+override wins). Explicit per-field markers still take precedence over both.
+"""
+
+import textwrap
+
+from agent_actions.output.response.loader import SchemaLoader
+from agent_actions.validation.schema_output_validator import validate_output_against_schema
+
+
+def _project(tmp_path, *, project_flag: str, schema_body: str) -> None:
+    """Write a minimal project: agent_actions.yml + schema/foo.yml."""
+    (tmp_path / "agent_actions.yml").write_text(
+        textwrap.dedent(
+            f"""\
+            schema_path: schema
+            {project_flag}
+            """
+        )
+    )
+    schema_dir = tmp_path / "schema"
+    schema_dir.mkdir()
+    (schema_dir / "foo.yml").write_text(textwrap.dedent(schema_body))
+
+
+_UNMARKED = """\
+    name: foo
+    fields:
+      - id: a
+        type: string
+      - id: b
+        type: string
+"""
+
+
+def test_project_flag_makes_unmarked_field_required(tmp_path):
+    """required_by_default: true in agent_actions.yml → unmarked 'b' is required."""
+    _project(tmp_path, project_flag="required_by_default: true", schema_body=_UNMARKED)
+    loaded = SchemaLoader.load_schema("foo", project_root=tmp_path)
+    report = validate_output_against_schema({"a": "x"}, loaded, "act")
+    assert not report.is_compliant
+    assert "b" in report.missing_required
+
+
+def test_no_project_flag_keeps_unmarked_field_optional(tmp_path):
+    """Absent flag → v0.2.8 behavior preserved: unmarked 'b' stays optional."""
+    _project(tmp_path, project_flag="", schema_body=_UNMARKED)
+    loaded = SchemaLoader.load_schema("foo", project_root=tmp_path)
+    report = validate_output_against_schema({"a": "x"}, loaded, "act")
+    assert report.is_compliant
+    assert "b" in report.missing_optional
+
+
+def test_project_flag_false_keeps_unmarked_field_optional(tmp_path):
+    """required_by_default: false is explicit opt-out; unmarked 'b' stays optional."""
+    _project(tmp_path, project_flag="required_by_default: false", schema_body=_UNMARKED)
+    loaded = SchemaLoader.load_schema("foo", project_root=tmp_path)
+    report = validate_output_against_schema({"a": "x"}, loaded, "act")
+    assert report.is_compliant
+    assert "b" in report.missing_optional
+
+
+def test_schema_file_override_beats_project_flag(tmp_path):
+    """A schema declaring its own required_by_default wins over the project setting."""
+    schema_body = """\
+        name: foo
+        required_by_default: false
+        fields:
+          - id: a
+            type: string
+          - id: b
+            type: string
+    """
+    _project(tmp_path, project_flag="required_by_default: true", schema_body=schema_body)
+    loaded = SchemaLoader.load_schema("foo", project_root=tmp_path)
+    report = validate_output_against_schema({"a": "x"}, loaded, "act")
+    assert report.is_compliant
+    assert "b" in report.missing_optional
+
+
+def test_optional_field_still_opts_out_under_project_flag(tmp_path):
+    """Safety: optional: true keeps a field optional even when the project flag is on."""
+    schema_body = """\
+        name: foo
+        fields:
+          - id: a
+            type: string
+          - id: b
+            type: string
+            optional: true
+    """
+    _project(tmp_path, project_flag="required_by_default: true", schema_body=schema_body)
+    loaded = SchemaLoader.load_schema("foo", project_root=tmp_path)
+    report = validate_output_against_schema({"a": "x"}, loaded, "act")
+    assert report.is_compliant
+    assert "b" in report.missing_optional

--- a/tests/unit/output/response/test_project_required_by_default.py
+++ b/tests/unit/output/response/test_project_required_by_default.py
@@ -11,6 +11,7 @@ override wins). Explicit per-field markers still take precedence over both.
 import textwrap
 
 from agent_actions.output.response.loader import SchemaLoader
+from agent_actions.output.response.vendor_compilation import compile_unified_schema
 from agent_actions.validation.schema_output_validator import validate_output_against_schema
 
 
@@ -82,6 +83,22 @@ def test_schema_file_override_beats_project_flag(tmp_path):
     report = validate_output_against_schema({"a": "x"}, loaded, "act")
     assert report.is_compliant
     assert "b" in report.missing_optional
+
+
+def test_project_flag_reaches_vendor_compiler(tmp_path):
+    """The injected flag survives into the compiled vendor schema's required list."""
+    _project(tmp_path, project_flag="required_by_default: true", schema_body=_UNMARKED)
+    loaded = SchemaLoader.load_schema("foo", project_root=tmp_path)
+    compiled = compile_unified_schema(loaded, "openai")
+    assert set(compiled["schema"]["required"]) == {"a", "b"}
+
+
+def test_no_flag_leaves_vendor_compiler_required_empty(tmp_path):
+    """Without the project flag, unmarked fields stay out of the compiled required list."""
+    _project(tmp_path, project_flag="", schema_body=_UNMARKED)
+    loaded = SchemaLoader.load_schema("foo", project_root=tmp_path)
+    compiled = compile_unified_schema(loaded, "openai")
+    assert compiled["schema"]["required"] == []
 
 
 def test_optional_field_still_opts_out_under_project_flag(tmp_path):


### PR DESCRIPTION
## Summary
v0.2.8 (#815) made flat schema fields **optional-by-default**; restoring the prior required-by-default behavior meant adding `required_by_default: true` to every schema file. This adds a **top-level `required_by_default` key to `agent_actions.yml`** that applies the policy project-wide.

`SchemaLoader.load_schema` stamps the project value onto any loaded schema that does not declare its own, so all downstream consumers — preflight prompt validation, runtime output validation, and vendor schema compilation — honor it. Precedence is unchanged and layered:

`explicit per-field required` → `top-level required: [...]` → `per-field optional` → **schema's own `required_by_default`** → **project `required_by_default`** → `false`.

A schema declaring its own `required_by_default` overrides the project setting; explicit per-field markers win over both. Default is `false` (no behavior change unless a project opts in).

## Why load-time injection is the right single source
`required_by_default` is only meaningful for **named file `fields:` schemas** — inline shorthand (`{field: type!}`) always sets an explicit per-field `required`, and HITL output is a fixed constant. Every named-schema consumer resolves through `SchemaLoader.load_schema`, so stamping there reaches preflight, runtime validation, and vendor compilation without threading a parameter through each site.

## Verification
- **RED → GREEN**, full suite **8305 passed**, `ruff` + `mypy` clean.
- New test matrix (`tests/unit/output/response/test_project_required_by_default.py`): flag on/off/explicit-false, per-schema override beats project flag, `optional: true` still opts out under the flag, and the value reaching the **vendor compiler** (guards against normalization dropping the stamped key).
- **Real project** (`qanalabs-quiz-maker`, `agac inspect -a ql_multi_choice`): with the flag, prompt-guarantee warnings dropped **46 → 0**. Registry canary (`scan-project.sh`) green.
- Blind fresh-context review: **YES**, no blocking issues.

### Behavioral note for adopters
The flag restores *strictness*, not just silence: making fields required-by-default also makes the preflight DAG-fit check stricter, so `dag-fit` warnings rose **3 → 30** on `ql_multi_choice` — these correctly surface genuine cases where a producer does not emit a field a consumer now requires (project-schema mismatches, identical to what v0.2.7's required-by-default default would have shown). That is project-config cleanup, separate from this framework option.

## Smoke
Skipped the online LLM ring with justification: the schema-loading surface was exercised directly on the real project via `agac inspect` (the delta above), the registry canary is green, the change is additive with `default=false`, and the full suite + mypy + ruff pass. An online workflow adds no coverage the inspect + canary don't already give.

## Known, pre-existing (not introduced here)
The new accessor mirrors `get_seed_data_path`. Like every sibling accessor it shares two pre-existing edge behaviors: a quoted YAML `"false"` is truthy (`bool(str)`), and a non-dict top-level config would `AttributeError`. Left consistent with the siblings rather than diverging for one key.