### PR TITLE
test: deterministic parametrize order for in-flight batch statuses

### DIFF
--- a/tests/unit/test_batch_resubmission_guard.py
+++ b/tests/unit/test_batch_resubmission_guard.py
@@ -86,7 +86,9 @@ class TestCompletedBatchSkipsResubmission:
 class TestInFlightBatchStillBlocks:
     """Existing in-flight guard must continue to work."""
 
-    @pytest.mark.parametrize("status", list(BatchStatus.in_flight_states()))
+    @pytest.mark.parametrize(
+        "status", sorted(BatchStatus.in_flight_states(), key=lambda s: s.value)
+    )
     def test_in_flight_statuses_block_resubmission(self, tmp_path, status):
         """All in-flight statuses block new submission."""
         svc = _make_service()


### PR DESCRIPTION
## Summary
- `tests/unit/test_batch_resubmission_guard.py` parametrized over `list(BatchStatus.in_flight_states())` — a set — so test IDs depended on the hash seed and pytest-xdist workers collected different orders, failing every `pytest -n auto` run with "Different tests were collected". Sorted by status value for a stable order. Only instance of the pattern repo-wide.

## Verification
- Full suite green under `pytest -n auto` (8305 passed) — failed 100% of the time before the fix
- `ruff format --check` / `ruff check` clean