### PR TITLE
refactor: remove the ActionExpander delegate facade

### DIFF
--- a/.changes/unreleased/Under the Hood-20260807-203000.yaml
+++ b/.changes/unreleased/Under the Hood-20260807-203000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove the ActionExpander delegate façade: 13 static pass-through wrappers (9 with no callers at all) and an empty __init__, self-described as 'thin wrappers, no logic'. Tests now call the real module functions directly. No behavior change."
+time: 2026-08-07T20:30:00Z

--- a/agent_actions/output/response/expander.py
+++ b/agent_actions/output/response/expander.py
@@ -15,7 +15,6 @@ Implementation details are split across focused submodules:
 import logging
 from typing import Any
 
-from agent_actions.config.types import RunMode
 from agent_actions.errors import ConfigurationError, ConfigValidationError
 from agent_actions.utils.constants import DEFAULT_ACTION_KIND, HITL_FILE_GRANULARITY_ERROR
 
@@ -25,15 +24,9 @@ from .expander_action_types import (
     process_hitl_action,
     process_tool_action,
 )
-from .expander_guard_validation import (
-    build_schema_registry,
-    validate_agent_guards,
-    validate_guard_references,
-)
 from .expander_merge import (
     deep_merge_context_scope,
     initialize_optional_fields,
-    merge_directive_value,
     process_chunk_config,
 )
 from .expander_schema import (
@@ -55,83 +48,6 @@ class ActionExpander:
 
     Supports loop expansion for iterative action processing.
     """
-
-    def __init__(self):
-        """Initialize the ActionExpander."""
-        # This class uses static methods for utility functions
-
-    # ------------------------------------------------------------------
-    # Backward-compatible delegates (thin wrappers, no logic)
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _validate_vendor_exists(vendor: str | None, action_name: str) -> None:
-        return validate_vendor_exists(vendor, action_name)
-
-    @staticmethod
-    def _validate_action_name(action_name: str | None) -> None:
-        return validate_action_name(action_name)
-
-    @staticmethod
-    def _validate_required_fields(agent: dict[str, Any], action_name: str) -> None:
-        return validate_required_fields(agent, action_name)
-
-    @staticmethod
-    def _merge_directive_value(existing: Any, new_value: Any) -> Any:
-        return merge_directive_value(existing, new_value)
-
-    @staticmethod
-    def _deep_merge_context_scope(
-        defaults_scope: dict[str, Any] | None, action_scope: dict[str, Any] | None
-    ) -> dict[str, Any]:
-        return deep_merge_context_scope(defaults_scope, action_scope)
-
-    @staticmethod
-    def _process_schema_config(
-        agent: dict[str, Any], action: dict[str, Any], template_replacer
-    ) -> None:
-        return process_schema_config(agent, action, template_replacer)
-
-    @staticmethod
-    def _process_guard_config(agent: dict[str, Any], action: dict[str, Any]) -> None:
-        return process_guard_config(agent, action)
-
-    @staticmethod
-    def _process_tool_action(
-        agent: dict[str, Any], action: dict[str, Any], run_mode: RunMode
-    ) -> None:
-        return process_tool_action(agent, action, run_mode)
-
-    @staticmethod
-    def _compile_output_schema(agent: dict[str, Any], action: dict[str, Any]) -> None:
-        return compile_output_schema(agent, action)
-
-    @staticmethod
-    def _process_chunk_config(
-        agent: dict[str, Any], action: dict[str, Any], defaults: dict[str, Any]
-    ) -> None:
-        return process_chunk_config(agent, action, defaults)
-
-    @staticmethod
-    def _initialize_optional_fields(agent: dict[str, Any]) -> None:
-        return initialize_optional_fields(agent)
-
-    @staticmethod
-    def _build_schema_registry(agents: list[dict[str, Any]]) -> dict[str, Any]:
-        return build_schema_registry(agents)
-
-    @staticmethod
-    def _validate_agent_guards(
-        agent: dict[str, Any],
-        validator,
-        agent_indices: dict[str, int],
-        action_schemas: dict[str, Any],
-    ) -> list[str]:
-        return validate_agent_guards(agent, validator, agent_indices, action_schemas)
-
-    # ------------------------------------------------------------------
-    # Orchestration methods (real logic stays here)
-    # ------------------------------------------------------------------
 
     @staticmethod
     def _create_template_replacer(param_name: str, current_val, idx: int, values):
@@ -430,10 +346,6 @@ class ActionExpander:
                 agents.append(created_agent)
 
         return {workflow_name: agents}
-
-    @staticmethod
-    def validate_guard_references(agents: list[dict[str, Any]], strict: bool = True) -> list[str]:
-        return validate_guard_references(agents, strict)
 
 
 __all__ = ["ActionExpander"]

--- a/agent_actions/output/response/expander_guard_validation.py
+++ b/agent_actions/output/response/expander_guard_validation.py
@@ -112,7 +112,7 @@ def validate_guard_references(agents: list[dict[str, Any]], strict: bool = True)
         agents = result['my_workflow']
 
         # Validate guard references
-        errors = ActionExpander.validate_guard_references(agents, strict=False)
+        errors = validate_guard_references(agents, strict=False)
         if errors:
             for error in errors:
                 logger.warning(error)

--- a/tests/core/parser/test_context_scope_merge.py
+++ b/tests/core/parser/test_context_scope_merge.py
@@ -13,6 +13,7 @@ Key scenarios tested:
 """
 
 from agent_actions.output.response.expander import ActionExpander
+from agent_actions.output.response.expander_merge import deep_merge_context_scope
 
 
 class TestContextScopeDeepMerge:
@@ -23,7 +24,7 @@ class TestContextScopeDeepMerge:
         defaults_scope = {"seed": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"}}
         action_scope = {"drop": ["source.syllabus", "source.url"]}
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
             "seed": {"exam_syllabus": "$file:azure_ds_associate_syllabus.json"},
@@ -35,7 +36,7 @@ class TestContextScopeDeepMerge:
         defaults_scope = {"seed": {"knowledge_base": "$file:kb.json"}}
         action_scope = {"observe": ["previous_agent.field1", "previous_agent.field2"]}
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
             "seed": {"knowledge_base": "$file:kb.json"},
@@ -47,7 +48,7 @@ class TestContextScopeDeepMerge:
         defaults_scope = {"observe": ["agent1.field1"]}
         action_scope = {"observe": ["agent2.field2", "agent3.field3"]}
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {"observe": ["agent1.field1", "agent2.field2", "agent3.field3"]}
 
@@ -56,7 +57,7 @@ class TestContextScopeDeepMerge:
         defaults_scope = {"drop": ["source.internal_id"]}
         action_scope = {"drop": ["source.api_key", "source.credentials"]}
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {"drop": ["source.internal_id", "source.api_key", "source.credentials"]}
 
@@ -67,7 +68,7 @@ class TestContextScopeDeepMerge:
             "observe": ["agent2.field2", "agent3.field3"]  # agent2.field2 is duplicate
         }
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         # Should preserve order and remove duplicates
         assert result == {"observe": ["agent1.field1", "agent2.field2", "agent3.field3"]}
@@ -77,7 +78,7 @@ class TestContextScopeDeepMerge:
         defaults_scope = {"seed": {"exam_syllabus": "$file:exam.json"}}
         action_scope = {"seed": {"grading_rubric": "$file:rubric.yaml"}}
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
             "seed": {"exam_syllabus": "$file:exam.json", "grading_rubric": "$file:rubric.yaml"}
@@ -92,7 +93,7 @@ class TestContextScopeDeepMerge:
             }
         }
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {"seed": {"exam_syllabus": "$file:custom_exam.json"}}
 
@@ -105,7 +106,7 @@ class TestContextScopeDeepMerge:
             "passthrough": ["source.metadata"],
         }
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {
             "seed": {"exam": "$file:exam.json"},
@@ -119,7 +120,7 @@ class TestContextScopeDeepMerge:
         defaults_scope = {"passthrough": ["source.id", "source.timestamp"]}
         action_scope = {"passthrough": ["source.metadata"]}
 
-        result = ActionExpander._deep_merge_context_scope(defaults_scope, action_scope)
+        result = deep_merge_context_scope(defaults_scope, action_scope)
 
         assert result == {"passthrough": ["source.id", "source.timestamp", "source.metadata"]}
 

--- a/tests/core/test_config_validation_errors.py
+++ b/tests/core/test_config_validation_errors.py
@@ -6,7 +6,10 @@ import pytest
 
 from agent_actions.errors import ConfigurationError, ConfigValidationError
 from agent_actions.llm.providers.client_base import BaseClient
-from agent_actions.output.response.expander import ActionExpander
+from agent_actions.output.response.expander_validation import (
+    validate_action_name,
+    validate_required_fields,
+)
 
 
 class TestConfigValidationErrorMessages:
@@ -21,7 +24,7 @@ class TestConfigValidationErrorMessages:
             "api_key": "TEST_KEY",
         }
         with pytest.raises(ConfigValidationError) as exc_info:
-            ActionExpander._validate_required_fields(agent, "test_action")
+            validate_required_fields(agent, "test_action")
         error = exc_info.value
         assert error.context is not None
         assert error.context["action_name"] == "test_action"
@@ -35,7 +38,7 @@ class TestConfigValidationErrorMessages:
         """Verify error lists all missing fields."""
         agent = {"agent_type": "test_action", "name": "test_action"}
         with pytest.raises(ConfigValidationError) as exc_info:
-            ActionExpander._validate_required_fields(agent, "test_action")
+            validate_required_fields(agent, "test_action")
         error = exc_info.value
         missing = error.context["missing_fields"]
         assert "model_vendor" in missing
@@ -59,7 +62,7 @@ class TestConfigValidationErrorMessages:
     def test_reserved_action_name_error_lists_reserved_names(self):
         """Verify reserved action name validation includes reserved list."""
         with pytest.raises(ConfigValidationError) as exc_info:
-            ActionExpander._validate_action_name("prompt")
+            validate_action_name("prompt")
         error = exc_info.value
         assert "prompt" in str(error)
         assert "reserved_names" in error.context

--- a/tests/unit/output/response/test_expander_schema.py
+++ b/tests/unit/output/response/test_expander_schema.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from agent_actions.output.response.expander import ActionExpander
+from agent_actions.output.response.expander_schema import compile_output_schema
 
 LOGGER_NAME = "agent_actions.output.response.expander"
 
@@ -32,7 +32,7 @@ class TestCompileOutputSchemaWarning:
         agent = {"agent_type": "test_action", "schema": "unexpected_string_value"}
 
         with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
-            ActionExpander._compile_output_schema(agent, {})
+            compile_output_schema(agent, {})
 
         assert any("unsupported type" in msg.lower() for msg in caplog.messages)
         assert any("str" in msg for msg in caplog.messages)
@@ -44,7 +44,7 @@ class TestCompileOutputSchemaWarning:
         agent = {"agent_type": "test_action", "schema": 42}
 
         with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
-            ActionExpander._compile_output_schema(agent, {})
+            compile_output_schema(agent, {})
 
         assert any("unsupported type" in msg.lower() for msg in caplog.messages)
         assert any("int" in msg for msg in caplog.messages)
@@ -61,7 +61,7 @@ class TestCompileOutputSchemaWarning:
         }
 
         with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
-            ActionExpander._compile_output_schema(agent, {})
+            compile_output_schema(agent, {})
 
         assert not any("unsupported type" in msg.lower() for msg in caplog.messages)
 
@@ -73,7 +73,7 @@ class TestCompileOutputSchemaWarning:
         }
 
         with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
-            ActionExpander._compile_output_schema(agent, {})
+            compile_output_schema(agent, {})
 
         assert not any("unsupported type" in msg.lower() for msg in caplog.messages)
 
@@ -85,7 +85,7 @@ class TestCompileOutputSchemaWarning:
             "schema": "should_be_ignored",
         }
 
-        ActionExpander._compile_output_schema(agent, {})
+        compile_output_schema(agent, {})
 
         # Original json_output_schema preserved
         assert agent["json_output_schema"] == {"type": "object"}

--- a/tests/unit/workflow/test_pipeline_file_mode_tool.py
+++ b/tests/unit/workflow/test_pipeline_file_mode_tool.py
@@ -703,7 +703,7 @@ def test_validate_udf_output_rejects_invalid_items_in_list():
 
 # --- Array schema: json_output_schema is per-item at compile time ---
 
-# For `schema: {type: array, items: {…}}`, _compile_output_schema stores
+# For `schema: {type: array, items: {…}}`, compile_output_schema stores
 # the items schema directly as json_output_schema (no wrapper).
 _ARRAY_ITEM_SCHEMA = {
     "type": "object",
@@ -734,8 +734,8 @@ def test_validate_udf_output_array_schema_rejects_invalid_item():
 
 
 def test_compile_output_schema_extracts_array_items():
-    """_compile_output_schema should store items schema for array-type schemas."""
-    from agent_actions.output.response.expander import ActionExpander
+    """compile_output_schema should store items schema for array-type schemas."""
+    from agent_actions.output.response.expander_schema import compile_output_schema
 
     agent = {"agent_type": "my_tool"}
     agent["schema"] = {
@@ -747,7 +747,7 @@ def test_compile_output_schema_extracts_array_items():
         },
     }
 
-    ActionExpander._compile_output_schema(agent, {})
+    compile_output_schema(agent, {})
 
     # json_output_schema is the per-item schema with additionalProperties enforced
     assert agent["json_output_schema"] == {
@@ -760,14 +760,14 @@ def test_compile_output_schema_extracts_array_items():
 
 def test_compile_output_schema_non_array_unchanged():
     """Non-array schemas compile through the standard path."""
-    from agent_actions.output.response.expander import ActionExpander
+    from agent_actions.output.response.expander_schema import compile_output_schema
 
     agent = {"agent_type": "my_tool"}
     agent["schema"] = [
         {"id": "name", "type": "string", "required": True},
     ]
 
-    ActionExpander._compile_output_schema(agent, {})
+    compile_output_schema(agent, {})
 
     # Standard compilation: top-level object with properties
     assert agent["json_output_schema"]["type"] == "object"


### PR DESCRIPTION
## Summary
Stacked on #831 (this PR's diff shows only its own layer). Removes the `ActionExpander` delegate façade in `output/response/expander.py`:

- **13 static pass-through wrappers** — self-labeled *"Backward-compatible delegates (thin wrappers, no logic)"* — plus an empty `__init__`. Nine had zero callers anywhere; the other four were called only by tests.
- The class-level `validate_guard_references` delegate, whose sole reference was a docstring example (updated to the module function).
- Tests now import the real module functions (`expander_merge.deep_merge_context_scope`, `expander_validation.validate_*`, `expander_schema.compile_output_schema`) — the class keeps only its real orchestration methods.

## Verification
- Full suite: **8,246 passed**; ruff + mypy clean
- API-surface diff vs the parent branch is exactly `~ ActionExpander` (method set shrank) — nothing else moved
- Affected test files (289 tests) pass individually