### PR TITLE
refactor: remove the ActionRunner file-processing facade

### DIFF
--- a/.changes/unreleased/Under the Hood-20260807-214500.yaml
+++ b/.changes/unreleased/Under the Hood-20260807-214500.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove the ActionRunner file-processing facade: nine pure-delegation methods over the runner_file_processing module functions, including two the module itself called back through. Callers and tests now use the module functions directly. No behavior change."
+time: 2026-08-07T21:45:00Z

--- a/agent_actions/workflow/runner.py
+++ b/agent_actions/workflow/runner.py
@@ -18,28 +18,7 @@ from agent_actions.errors import FileSystemError
 from agent_actions.input.loaders.data_source import resolve_start_node_data_source
 from agent_actions.utils.file_handler import FileHandler
 from agent_actions.workflow.runner_file_processing import (
-    collect_files_from_upstream as _collect_files_from_upstream,
-)
-from agent_actions.workflow.runner_file_processing import (
-    is_target_directory as _is_target_directory,
-)
-from agent_actions.workflow.runner_file_processing import (
-    process_directory_files as _process_directory_files,
-)
-from agent_actions.workflow.runner_file_processing import (
     process_files as _process_files,
-)
-from agent_actions.workflow.runner_file_processing import (
-    process_from_storage_backend as _process_from_storage_backend,
-)
-from agent_actions.workflow.runner_file_processing import (
-    process_merged_files as _process_merged_files,
-)
-from agent_actions.workflow.runner_file_processing import (
-    should_skip_item as _should_skip_item,
-)
-from agent_actions.workflow.runner_file_processing import (
-    warn_no_files_found as _warn_no_files_found,
 )
 from agent_actions.workflow.strategies import (
     ActionStrategy,
@@ -306,66 +285,6 @@ class ActionRunner:
             )
         )
 
-    def _should_skip_item(
-        self,
-        item: Path,
-        input_path: Path,
-        processed_paths: set,
-        file_type_filter: set[str] | None = None,
-    ) -> bool:
-        """Check if an item should be skipped during processing."""
-        return _should_skip_item(item, input_path, processed_paths, file_type_filter)
-
-    def _collect_files_from_upstream(self, upstream_data_dirs: list[str]) -> dict[Path, list[Path]]:
-        """Collect files from upstream directories, grouped by relative path."""
-        return _collect_files_from_upstream(upstream_data_dirs)
-
-    def _process_directory_files(
-        self,
-        input_path: Path,
-        output_path: Path,
-        input_directory: str,
-        params: FileProcessParams,
-        processed_paths: set,
-    ) -> tuple[int, int]:
-        """Process all files in a single directory.
-
-        Returns:
-            (files_found, files_processed).
-        """
-        return _process_directory_files(
-            self, input_path, output_path, input_directory, params, processed_paths
-        )
-
-    def _warn_no_files_found(self, params: FileProcessParams) -> None:
-        """Log warning if no files were found in upstream directories."""
-        _warn_no_files_found(params)
-
-    def _process_merged_files(self, params: FileProcessParams) -> tuple[int, int]:
-        """Process files from multiple upstream directories with content merging.
-
-        Returns:
-            (files_found, files_processed).
-        """
-        return _process_merged_files(self, params)
-
-    def _process_from_storage_backend(self, params: FileProcessParams) -> tuple[int, int]:
-        """Process data from storage backend instead of filesystem.
-
-        Returns:
-            (files_found, files_processed) to distinguish "no data" from
-            "data found but processing failed".
-        """
-        return _process_from_storage_backend(self, params)
-
-    def _is_target_directory(self, path: str) -> bool:
-        """Return True if path is a target directory (not staging)."""
-        return _is_target_directory(path)
-
-    def process_files(self, params: FileProcessParams) -> None:
-        """Walk upstream data directories and process each file with the given strategy."""
-        _process_files(self, params)
-
     def process_and_generate_for_action(self, params: ProcessGenerateParams) -> str:
         """Process and generate data for an action using the provided strategy."""
         agent_folder: str = self.get_action_folder(params.action_name)
@@ -388,7 +307,8 @@ class ActionRunner:
             )
             file_type_filter = result.file_type_filter
 
-        self.process_files(
+        _process_files(
+            self,
             FileProcessParams(
                 action_config=params.action_config,
                 action_name=params.action_name,
@@ -397,7 +317,7 @@ class ActionRunner:
                 output_directory=output_directory,
                 idx=params.idx,
                 file_type_filter=file_type_filter,
-            )
+            ),
         )
         return output_directory
 

--- a/agent_actions/workflow/runner_file_processing.py
+++ b/agent_actions/workflow/runner_file_processing.py
@@ -215,7 +215,7 @@ def process_directory_files(
     processing_errors: list[str] = []
     files_seen = 0
     for item in input_path.rglob("*"):
-        if runner._should_skip_item(item, input_path, processed_paths, params.file_type_filter):
+        if should_skip_item(item, input_path, processed_paths, params.file_type_filter):
             continue
 
         relative_path = item.relative_to(input_path)
@@ -254,7 +254,7 @@ def process_merged_files(runner: ActionRunner, params: FileProcessParams) -> tup
         "no files" from "all files failed".
     """
     output_path = Path(params.output_directory)
-    files_by_path = runner._collect_files_from_upstream(params.upstream_data_dirs)
+    files_by_path = collect_files_from_upstream(params.upstream_data_dirs)
     files_processed_count = 0
     processing_errors: list[str] = []
     files_seen = 0

--- a/tests/unit/core/test_runner_merge.py
+++ b/tests/unit/core/test_runner_merge.py
@@ -6,6 +6,7 @@ import pytest
 
 from agent_actions.workflow.merge import merge_records_by_key
 from agent_actions.workflow.runner import ActionRunner
+from agent_actions.workflow.runner_file_processing import process_from_storage_backend
 
 
 class TestMergeRecordsByKey:
@@ -155,7 +156,7 @@ class TestStorageBackendMerge:
         params.idx = 0
 
         # Execute
-        files_found, files_processed = runner._process_from_storage_backend(params)
+        files_found, files_processed = process_from_storage_backend(runner, params)
 
         # Verify merge happened
         assert files_found == 1  # One unique path
@@ -195,7 +196,7 @@ class TestStorageBackendMerge:
         params.strategy = MagicMock()
         params.idx = 0
 
-        files_found, files_processed = runner._process_from_storage_backend(params)
+        files_found, files_processed = process_from_storage_backend(runner, params)
 
         # Two unique files processed
         assert files_found == 2
@@ -228,7 +229,7 @@ class TestStorageBackendMerge:
         params.strategy = MagicMock()
         params.idx = 0
 
-        runner._process_from_storage_backend(params)
+        process_from_storage_backend(runner, params)
 
         # Verify source_relative_path preserves full path without extension
         assert len(captured_params) == 1

--- a/tests/unit/workflow/test_runner_file_processing_merge.py
+++ b/tests/unit/workflow/test_runner_file_processing_merge.py
@@ -24,6 +24,7 @@ def _make_params(upstream_dirs, output_dir, action_config=None):
     params.action_name = "test_action"
     params.strategy = MagicMock()
     params.idx = 0
+    params.file_type_filter = None
     return params
 
 
@@ -196,7 +197,6 @@ class TestProcessDirectoryFilesIsolation:
                 raise RuntimeError("record namespace failure on b.json")
 
         runner = MagicMock()
-        runner._should_skip_item.return_value = False
         runner._process_single_file.side_effect = _process
 
         params = _make_params([str(input_dir)], output_dir)
@@ -219,7 +219,6 @@ class TestProcessDirectoryFilesIsolation:
             (input_dir / name).write_text(json.dumps([{"id": name}]))
 
         runner = MagicMock()
-        runner._should_skip_item.return_value = False
         runner._process_single_file = MagicMock()
 
         params = _make_params([str(input_dir)], output_dir)

--- a/tests/workflow/test_runner.py
+++ b/tests/workflow/test_runner.py
@@ -19,6 +19,16 @@ from agent_actions.workflow.runner import (
     ProcessGenerateParams,
     SingleFileProcessParams,
 )
+from agent_actions.workflow.runner_file_processing import (
+    collect_files_from_upstream,
+    is_target_directory,
+    process_directory_files,
+    process_files,
+    process_from_storage_backend,
+    process_merged_files,
+    should_skip_item,
+    warn_no_files_found,
+)
 from agent_actions.workflow.strategies import InitialStrategy, StandardStrategy
 
 # ---------------------------------------------------------------------------
@@ -257,34 +267,34 @@ class TestShouldSkipItem:
         batch_dir.mkdir()
         item = batch_dir / "file.json"
         item.touch()
-        assert runner._should_skip_item(item, tmp_path, set()) is True
+        assert should_skip_item(item, tmp_path, set()) is True
 
     def test_directory_skipped(self, runner, tmp_path):
         sub = tmp_path / "subdir"
         sub.mkdir()
-        assert runner._should_skip_item(sub, tmp_path, set()) is True
+        assert should_skip_item(sub, tmp_path, set()) is True
 
     def test_dotfile_skipped(self, runner, tmp_path):
         dotfile = tmp_path / ".hidden"
         dotfile.touch()
-        assert runner._should_skip_item(dotfile, tmp_path, set()) is True
+        assert should_skip_item(dotfile, tmp_path, set()) is True
 
     def test_already_processed(self, runner, tmp_path):
         f = _make_file(tmp_path / "data.json")
         processed = {Path("data.json")}
-        assert runner._should_skip_item(f, tmp_path, processed) is True
+        assert should_skip_item(f, tmp_path, processed) is True
 
     def test_file_type_filter_mismatch(self, runner, tmp_path):
         f = _make_file(tmp_path / "data.csv")
-        assert runner._should_skip_item(f, tmp_path, set(), file_type_filter={"json"}) is True
+        assert should_skip_item(f, tmp_path, set(), file_type_filter={"json"}) is True
 
     def test_valid_file_not_skipped(self, runner, tmp_path):
         f = _make_file(tmp_path / "data.json")
-        assert runner._should_skip_item(f, tmp_path, set()) is False
+        assert should_skip_item(f, tmp_path, set()) is False
 
     def test_valid_file_with_matching_filter(self, runner, tmp_path):
         f = _make_file(tmp_path / "data.json")
-        assert runner._should_skip_item(f, tmp_path, set(), file_type_filter={"json"}) is False
+        assert should_skip_item(f, tmp_path, set(), file_type_filter={"json"}) is False
 
 
 # ---------------------------------------------------------------------------
@@ -296,20 +306,20 @@ class TestCollectFilesFromUpstream:
     def test_single_dir_with_files(self, runner, tmp_path):
         _make_file(tmp_path / "a.json")
         _make_file(tmp_path / "sub" / "b.json")
-        result = runner._collect_files_from_upstream([str(tmp_path)])
+        result = collect_files_from_upstream([str(tmp_path)])
         assert len(result) == 2
         assert Path("a.json") in result
         assert Path("sub/b.json") in result
 
     def test_nonexistent_dir_skipped(self, runner, tmp_path):
-        result = runner._collect_files_from_upstream([str(tmp_path / "nope")])
+        result = collect_files_from_upstream([str(tmp_path / "nope")])
         assert result == {}
 
     def test_skips_batch_and_dotfiles(self, runner, tmp_path):
         _make_file(tmp_path / "batch" / "x.json")
         _make_file(tmp_path / ".hidden")
         _make_file(tmp_path / "good.json")
-        result = runner._collect_files_from_upstream([str(tmp_path)])
+        result = collect_files_from_upstream([str(tmp_path)])
         assert len(result) == 1
         assert Path("good.json") in result
 
@@ -318,7 +328,7 @@ class TestCollectFilesFromUpstream:
         dir2 = tmp_path / "dir2"
         _make_file(dir1 / "shared.json", "one")
         _make_file(dir2 / "shared.json", "two")
-        result = runner._collect_files_from_upstream([str(dir1), str(dir2)])
+        result = collect_files_from_upstream([str(dir1), str(dir2)])
         assert len(result) == 1
         assert len(result[Path("shared.json")]) == 2
 
@@ -409,8 +419,8 @@ class TestProcessDirectoryFiles:
             output_directory=str(output_dir),
             idx=0,
         )
-        _found, processed = runner._process_directory_files(
-            input_dir, output_dir, str(input_dir), params, set()
+        _found, processed = process_directory_files(
+            runner, input_dir, output_dir, str(input_dir), params, set()
         )
         assert processed == 2
         assert strategy.execute.call_count == 2
@@ -432,8 +442,8 @@ class TestProcessDirectoryFiles:
             output_directory=str(output_dir),
             idx=0,
         )
-        _found, processed = runner._process_directory_files(
-            input_dir, output_dir, str(input_dir), params, set()
+        _found, processed = process_directory_files(
+            runner, input_dir, output_dir, str(input_dir), params, set()
         )
         assert processed == 1
 
@@ -456,7 +466,7 @@ class TestWarnNoFilesFound:
             output_directory=str(tmp_path / "out"),
             idx=0,
         )
-        runner._warn_no_files_found(params)
+        warn_no_files_found(params)
         mock_logger.debug.assert_called_once()
         assert "No files found" in mock_logger.debug.call_args[0][0]
 
@@ -472,7 +482,7 @@ class TestWarnNoFilesFound:
             output_directory=str(tmp_path / "out"),
             idx=0,
         )
-        runner._warn_no_files_found(params)
+        warn_no_files_found(params)
         mock_logger.warning.assert_not_called()
 
 
@@ -496,7 +506,7 @@ class TestProcessMergedFiles:
             output_directory=str(output),
             idx=0,
         )
-        _found, processed = runner._process_merged_files(params)
+        _found, processed = process_merged_files(runner, params)
         assert processed == 1
         strategy.execute.assert_called_once()
 
@@ -518,7 +528,7 @@ class TestProcessMergedFiles:
             output_directory=str(output),
             idx=0,
         )
-        _found, processed = runner._process_merged_files(params)
+        _found, processed = process_merged_files(runner, params)
         assert processed == 1
         mock_merge.assert_called_once()
         strategy.execute.assert_called_once()
@@ -542,7 +552,7 @@ class TestProcessMergedFiles:
             output_directory=str(output),
             idx=0,
         )
-        runner._process_merged_files(params)
+        process_merged_files(runner, params)
         # Original content should be restored
         assert (dir1 / "data.json").read_text(encoding="utf-8") == original_content
 
@@ -562,7 +572,7 @@ class TestProcessFromStorageBackend:
             output_directory="/out",
             idx=0,
         )
-        assert runner._process_from_storage_backend(params) == (0, 0)
+        assert process_from_storage_backend(runner, params) == (0, 0)
 
     def test_skips_staging_directories(self, runner_with_backend, tmp_path):
         backend = runner_with_backend.storage_backend
@@ -575,7 +585,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        result = runner_with_backend._process_from_storage_backend(params)
+        result = process_from_storage_backend(runner_with_backend, params)
         assert result == (0, 0)
         backend.list_target_files.assert_not_called()
 
@@ -593,7 +603,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        found, processed = runner_with_backend._process_from_storage_backend(params)
+        found, processed = process_from_storage_backend(runner_with_backend, params)
         assert found == 1
         assert processed == 1
         strategy.execute.assert_called_once()
@@ -617,7 +627,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        found, processed = runner_with_backend._process_from_storage_backend(params)
+        found, processed = process_from_storage_backend(runner_with_backend, params)
         assert found == 1
         assert processed == 1
         mock_merge.assert_called_once()
@@ -637,7 +647,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        found, processed = runner_with_backend._process_from_storage_backend(params)
+        found, processed = process_from_storage_backend(runner_with_backend, params)
         assert found == 2
         assert processed == 1
 
@@ -656,7 +666,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        found, processed = runner_with_backend._process_from_storage_backend(params)
+        found, processed = process_from_storage_backend(runner_with_backend, params)
         # good.json was read and processed; bad.json failed to read → only 1 file in data_by_path
         assert found == 1
         assert processed == 1
@@ -673,7 +683,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        found, processed = runner_with_backend._process_from_storage_backend(params)
+        found, processed = process_from_storage_backend(runner_with_backend, params)
         assert found == 0
         assert processed == 0
 
@@ -695,7 +705,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        found, processed = runner_with_backend._process_from_storage_backend(params)
+        found, processed = process_from_storage_backend(runner_with_backend, params)
         assert found == 1
         assert processed == 1
 
@@ -717,7 +727,7 @@ class TestProcessFromStorageBackend:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        found, processed = runner_with_backend._process_from_storage_backend(params)
+        found, processed = process_from_storage_backend(runner_with_backend, params)
         assert found == 1
         assert processed == 1
 
@@ -736,7 +746,7 @@ class TestProcessFromStorageBackend:
             idx=0,
         )
         with pytest.raises(ConfigurationError, match="missing _state"):
-            runner_with_backend._process_from_storage_backend(params)
+            process_from_storage_backend(runner_with_backend, params)
 
     def test_configuration_error_propagates_from_list_target_files(
         self, runner_with_backend, tmp_path
@@ -754,7 +764,7 @@ class TestProcessFromStorageBackend:
             idx=0,
         )
         with pytest.raises(ConfigurationError, match="bad state"):
-            runner_with_backend._process_from_storage_backend(params)
+            process_from_storage_backend(runner_with_backend, params)
 
 
 # ---------------------------------------------------------------------------
@@ -764,13 +774,13 @@ class TestProcessFromStorageBackend:
 
 class TestIsTargetDirectory:
     def test_target_path(self, runner):
-        assert runner._is_target_directory("/project/agent_io/target/dep") is True
+        assert is_target_directory("/project/agent_io/target/dep") is True
 
     def test_staging_path(self, runner):
-        assert runner._is_target_directory("/project/agent_io/staging/data") is False
+        assert is_target_directory("/project/agent_io/staging/data") is False
 
     def test_both_target_and_staging(self, runner):
-        assert runner._is_target_directory("/project/target/staging/dep") is False
+        assert is_target_directory("/project/target/staging/dep") is False
 
 
 # ---------------------------------------------------------------------------
@@ -794,7 +804,7 @@ class TestProcessFiles:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        runner_with_backend.process_files(params)
+        process_files(runner_with_backend, params)
         strategy.execute.assert_called_once()
 
     def test_storage_backend_found_but_not_processed_raises(self, runner_with_backend, tmp_path):
@@ -816,7 +826,7 @@ class TestProcessFiles:
             idx=0,
         )
         with pytest.raises(DependencyError, match="Found .* files but failed to process"):
-            runner_with_backend.process_files(params)
+            process_files(runner_with_backend, params)
 
     def test_storage_backend_no_data_falls_through(self, runner_with_backend, tmp_path):
         """No data in backend → falls through to filesystem."""
@@ -836,7 +846,7 @@ class TestProcessFiles:
             output_directory=str(output_dir),
             idx=0,
         )
-        runner_with_backend.process_files(params)
+        process_files(runner_with_backend, params)
         strategy.execute.assert_called_once()
 
     @patch("agent_actions.workflow.runner_file_processing.merge_json_files")
@@ -857,7 +867,7 @@ class TestProcessFiles:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        runner.process_files(params)
+        process_files(runner, params)
         mock_merge.assert_called_once()
         strategy.execute.assert_called_once()
 
@@ -877,7 +887,7 @@ class TestProcessFiles:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        runner.process_files(params)
+        process_files(runner, params)
         assert strategy.execute.call_count == 2
 
     def test_single_upstream_dir(self, runner, tmp_path):
@@ -895,7 +905,7 @@ class TestProcessFiles:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        runner.process_files(params)
+        process_files(runner, params)
         assert strategy.execute.call_count == 2
 
     @patch("agent_actions.workflow.runner_file_processing.logger")
@@ -913,7 +923,7 @@ class TestProcessFiles:
             output_directory=str(tmp_path / "output"),
             idx=0,
         )
-        runner.process_files(params)
+        process_files(runner, params)
         mock_logger.debug.assert_called()
         assert any("No files found" in str(c) for c in mock_logger.debug.call_args_list)
 
@@ -954,7 +964,7 @@ class TestRunAgent:
 
 
 class TestProcessAndGenerateForAgent:
-    @patch.object(ActionRunner, "process_files")
+    @patch("agent_actions.workflow.runner._process_files")
     @patch.object(ActionRunner, "setup_directories")
     @patch.object(ActionRunner, "get_action_folder")
     def test_orchestrates_correctly(self, mock_folder, mock_setup, mock_process, runner):
@@ -976,7 +986,7 @@ class TestProcessAndGenerateForAgent:
         mock_process.assert_called_once()
 
     @patch("agent_actions.workflow.runner.resolve_start_node_data_source")
-    @patch.object(ActionRunner, "process_files")
+    @patch("agent_actions.workflow.runner._process_files")
     @patch.object(ActionRunner, "setup_directories")
     @patch.object(ActionRunner, "get_action_folder")
     def test_resolves_file_type_filter_for_start_node(
@@ -997,5 +1007,5 @@ class TestProcessAndGenerateForAgent:
         )
         runner.process_and_generate_for_action(params)
         # process_files should receive the file_type_filter
-        file_params = mock_process.call_args[0][0]
+        file_params = mock_process.call_args[0][1]
         assert file_params.file_type_filter == {"pdf", "docx"}


### PR DESCRIPTION
## Summary
Stacked on #835 (this PR's diff shows only its own layer). Removes the `ActionRunner` file-processing façade in `workflow/runner.py`:

- Nine methods (`_should_skip_item`, `_collect_files_from_upstream`, `_process_directory_files`, `_warn_no_files_found`, `_process_merged_files`, `_process_from_storage_backend`, `_is_target_directory`, `process_files`) were pure delegations to the same-named functions in `runner_file_processing.py` — a façade left behind when the file was split. No production callers outside the runner itself.
- Two of those module functions called **back into the façade** (`runner._should_skip_item`, `runner._collect_files_from_upstream`) — a module→class→module round trip, now direct local calls.
- Test files updated to call the module functions; two mock-based tests that stubbed the façade now exercise the real skip logic (mock params pin `file_type_filter=None` explicitly).

## Verification
- Full suite: **8,229 passed** (verified green before final push; two earlier missed-caller test files were caught by the suite and fixed — `tests/unit/core/test_runner_merge.py`, `tests/unit/workflow/test_runner_file_processing_merge.py`); ruff + mypy clean
- API-surface diff vs parent is exactly `~ ActionRunner` (method set shrank)