### PR TITLE
refactor: remove backward-compat re-export shims

### DIFF
--- a/.changes/unreleased/Under the Hood-20260807-223000.yaml
+++ b/.changes/unreleased/Under the Hood-20260807-223000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Remove backward-compat re-export shims: retry.py no longer re-exports retry_polling/retry_serialization names (callers import the real modules; the serialize/deserialize static-method facade is gone) and disposition_gate no longer aliases the storage TERMINAL_DISPOSITIONS set. No behavior change."
+time: 2026-08-07T22:30:00Z

--- a/agent_actions/llm/batch/services/processing.py
+++ b/agent_actions/llm/batch/services/processing.py
@@ -52,6 +52,9 @@ from agent_actions.llm.batch.services.processing_recovery import (
     register_recovery_batch,
 )
 from agent_actions.llm.batch.services.retry import BatchRetryService
+from agent_actions.llm.batch.services.retry_serialization import (
+    serialize_results,
+)
 from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.output.writer import FileWriter
@@ -538,7 +541,7 @@ class BatchProcessingService:
                         retry_max_attempts=max_attempts,
                         missing_ids=list(missing_ids),
                         record_failure_counts=record_failure_counts,
-                        accumulated_results=BatchRetryService.serialize_results(batch_results),
+                        accumulated_results=serialize_results(batch_results),
                     )
                     from agent_actions.processing.recovery.reprompt import parse_reprompt_config
 

--- a/agent_actions/llm/batch/services/processing_recovery.py
+++ b/agent_actions/llm/batch/services/processing_recovery.py
@@ -26,7 +26,10 @@ from agent_actions.llm.batch.infrastructure.recovery_state import (
 from agent_actions.llm.batch.infrastructure.registry import (
     BatchRegistryManager,
 )
-from agent_actions.llm.batch.services.retry import BatchRetryService
+from agent_actions.llm.batch.services.retry_serialization import (
+    deserialize_results,
+    serialize_results,
+)
 from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BatchResult
 from agent_actions.logging.core.manager import fire_event
@@ -119,7 +122,7 @@ def process_recovery_batch(
         file_name=file_name,
     )
 
-    accumulated = BatchRetryService.deserialize_results(state.accumulated_results)
+    accumulated = deserialize_results(state.accumulated_results)
 
     if entry.recovery_type == RecoveryType.RETRY:
         return handle_retry_recovery(
@@ -188,7 +191,7 @@ def handle_retry_recovery(
             state.retry_attempt = next_attempt
             state.missing_ids = list(still_missing)
             state.record_failure_counts = updated_counts
-            state.accumulated_results = BatchRetryService.serialize_results(merged)
+            state.accumulated_results = serialize_results(merged)
             RecoveryStateManager.save(
                 context.service._storage_backend,
                 context.service._resolve_action_name(context.action_name),
@@ -251,7 +254,7 @@ def handle_reprompt_recovery(
     )
     if setup is None:
         # Merge prior graduated results with current cycle before finalizing.
-        final_results = BatchRetryService.deserialize_results(state.graduated_results)
+        final_results = deserialize_results(state.graduated_results)
         final_results.extend(recovery_results)
         return _finalize_and_cleanup(
             context,
@@ -265,7 +268,7 @@ def handle_reprompt_recovery(
     validation_name = strategy.name
     graduated, still_failing, failure_types = loop.split(recovery_results)
     loop.tag_graduated(graduated)
-    state.graduated_results.extend(BatchRetryService.serialize_results(graduated))
+    state.graduated_results.extend(serialize_results(graduated))
     state.evaluation_strategy_name = validation_name
 
     accumulate_failure_types(state.failure_type_counts, failure_types)
@@ -325,7 +328,7 @@ def handle_reprompt_recovery(
             failure_type_counts=state.failure_type_counts or None,
         )
 
-    final_results = BatchRetryService.deserialize_results(state.graduated_results)
+    final_results = deserialize_results(state.graduated_results)
     if still_failing:
         final_results.extend(still_failing)
 
@@ -449,7 +452,7 @@ def check_and_submit_reprompt(
         on_exhausted=on_exhausted,
         evaluation_strategy_name=strategy.name,
         graduated_results=(list(recovery_state.graduated_results) if recovery_state else [])
-        + BatchRetryService.serialize_results(graduated),
+        + serialize_results(graduated),
         reprompt_attempts_per_record=(
             dict(recovery_state.reprompt_attempts_per_record) if recovery_state else {}
         ),

--- a/agent_actions/llm/batch/services/retry.py
+++ b/agent_actions/llm/batch/services/retry.py
@@ -15,18 +15,7 @@ from typing import TYPE_CHECKING, Any, Optional
 # Import operation modules for delegation
 from agent_actions.llm.batch.services import reprompt_ops as _reprompt
 from agent_actions.llm.batch.services import retry_ops as _retry
-
-# Re-export module-level functions for backward compatibility.
-# Tests and callers patch/import these from "agent_actions.llm.batch.services.retry".
-from agent_actions.llm.batch.services.retry_polling import (
-    import_validation_module as _import_validation_module,  # noqa: F401
-)
-from agent_actions.llm.batch.services.retry_polling import wait_for_batch_completion  # noqa: F401
-from agent_actions.llm.batch.services.retry_serialization import (  # noqa: F401
-    deserialize_results,
-    serialize_results,
-)
-from agent_actions.llm.batch.services.shared import retrieve_and_reconcile  # noqa: F401
+from agent_actions.llm.batch.services.shared import retrieve_and_reconcile
 from agent_actions.llm.providers.batch_base import BaseBatchClient, BatchResult
 from agent_actions.processing.types import RecoveryMetadata
 
@@ -343,17 +332,3 @@ class BatchRetryService:
             per_record_attempts=per_record_attempts,
             failure_type_counts=failure_type_counts,
         )
-
-    # =========================================================================
-    # SERIALIZATION (delegated to retry_serialization)
-    # =========================================================================
-
-    @staticmethod
-    def serialize_results(results: list[BatchResult]) -> list[dict[str, Any]]:
-        """Serialize BatchResult objects for JSON persistence."""
-        return serialize_results(results)
-
-    @staticmethod
-    def deserialize_results(data: list[dict[str, Any]]) -> list[BatchResult]:
-        """Deserialize BatchResult objects from JSON."""
-        return deserialize_results(data)

--- a/agent_actions/processing/ARCHITECTURE.md
+++ b/agent_actions/processing/ARCHITECTURE.md
@@ -331,7 +331,7 @@ Every path that resets action state also clears checkpoint records:
 ## Disposition Gate — What Gets Reprocessed
 
 ```
-GATE_TERMINAL_DISPOSITIONS (not reprocessed on re-run):
+TERMINAL_DISPOSITIONS (not reprocessed on re-run):
   ✓ SUCCESS
   ✓ FILTERED
   ✓ SKIPPED

--- a/agent_actions/processing/disposition_gate.py
+++ b/agent_actions/processing/disposition_gate.py
@@ -16,10 +16,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from agent_actions.storage.backend import (
-    TERMINAL_DISPOSITIONS as GATE_TERMINAL_DISPOSITIONS,  # noqa: F401
-)
-
 if TYPE_CHECKING:
     from agent_actions.storage.backend import StorageBackend
 

--- a/agent_actions/storage/ARCHITECTURE.md
+++ b/agent_actions/storage/ARCHITECTURE.md
@@ -165,7 +165,7 @@ UNPROCESSED        Cascade casualty — upstream failure prevented processing
 Three frozen sets partition dispositions by how the system treats them:
 
 ```
-GATE_TERMINAL_DISPOSITIONS (not reprocessed on re-run):
+TERMINAL_DISPOSITIONS (not reprocessed on re-run):
   SUCCESS, FILTERED, SKIPPED, PASSTHROUGH, EXHAUSTED
 
   These records are "done" from the disposition gate's perspective.
@@ -371,7 +371,7 @@ This is defense-in-depth. All SQL uses parameterized queries, so injection is no
 
 9. **Threading model is single-process only.** The `RLock` serializes access within one Python process. Multiple processes writing to the same database rely on SQLite's file-level locking (with the 30-second timeout). The framework does not currently use multi-process writes, but the lock timeout is the safety net if it ever does.
 
-10. **get_terminal_record_ids imports from processing at call time.** The method does `from agent_actions.processing.disposition_gate import GATE_TERMINAL_DISPOSITIONS` inside the method body to avoid a circular import. This means the set of terminal dispositions is defined in the processing module, not in storage.
+10. **The terminal-disposition set lives in storage.** `TERMINAL_DISPOSITIONS` is defined in `storage/backend.py` next to `get_terminal_record_ids`, which reads it directly — the disposition gate in processing consumes the storage-defined set, not the other way around.
 
 11. **source_data deduplication is by source_guid only within a path.** The UNIQUE constraint is `(relative_path, source_guid)`. The same `source_guid` can exist under different `relative_path` values without conflict. A record without a `source_guid` is an upstream invariant violation: `write_source` raises `DataValidationError` (fail-loud) rather than silently dropping it. `save_checkpoint_records` takes the same posture — its `checkpoint_output` table is `UNIQUE(action_name, relative_path, source_guid)` with `INSERT OR REPLACE`, so a blank `source_guid` would collapse distinct records via silent overwrite.
 

--- a/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
+++ b/tests/unit/llm/batch/test_reprompt_selective_resubmit.py
@@ -11,6 +11,9 @@ import contextlib
 from unittest.mock import MagicMock, patch
 
 from agent_actions.llm.batch.core.batch_models import BatchIdentity, RecoveryContext
+from agent_actions.llm.batch.services.retry_serialization import (
+    serialize_results,
+)
 from agent_actions.llm.providers.batch_base import BatchResult
 
 # ---------------------------------------------------------------------------
@@ -270,7 +273,6 @@ class TestSelectiveRepromptResubmission:
         from agent_actions.llm.batch.services.processing_recovery import (
             handle_reprompt_recovery,
         )
-        from agent_actions.llm.batch.services.retry import BatchRetryService
 
         accumulated = _make_results(10, fail_ids=set())
         rec_003_ok = BatchResult(custom_id="rec_003", content={"answer": "now_ok"}, success=True)
@@ -285,7 +287,7 @@ class TestSelectiveRepromptResubmission:
             reprompt_max_attempts=3,
             validation_name="check_it",
             on_exhausted="return_last",
-            accumulated_results=BatchRetryService.serialize_results(accumulated),
+            accumulated_results=serialize_results(accumulated),
             reprompt_attempts_per_record={"rec_003": 1, "rec_007": 1},
         )
 

--- a/tests/unit/processing/test_disposition_gate.py
+++ b/tests/unit/processing/test_disposition_gate.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from agent_actions.processing.disposition_gate import (
-    GATE_TERMINAL_DISPOSITIONS,
     DispositionGate,
     build_carry_forward,
 )
+from agent_actions.storage.backend import TERMINAL_DISPOSITIONS
 
 
 def _make_record(guid: str | None = None, **extra: object) -> dict:
@@ -109,18 +109,18 @@ class TestRecordsWithoutGuid:
 class TestTerminalSetCorrectness:
     def test_deferred_is_not_terminal(self):
         """Spec test 7: DEFERRED records must be reprocessed."""
-        assert "deferred" not in GATE_TERMINAL_DISPOSITIONS
+        assert "deferred" not in TERMINAL_DISPOSITIONS
 
     def test_failed_is_not_terminal(self):
         """Spec test 8: FAILED records must be reprocessed."""
-        assert "failed" not in GATE_TERMINAL_DISPOSITIONS
+        assert "failed" not in TERMINAL_DISPOSITIONS
 
     def test_exhausted_is_terminal(self):
         """Spec test 9: EXHAUSTED is gate-terminal."""
-        assert "exhausted" in GATE_TERMINAL_DISPOSITIONS
+        assert "exhausted" in TERMINAL_DISPOSITIONS
 
     def test_all_expected_terminals_present(self):
-        assert GATE_TERMINAL_DISPOSITIONS == frozenset(
+        assert TERMINAL_DISPOSITIONS == frozenset(
             {
                 "success",
                 "filtered",

--- a/tests/unit/test_batch_submission_utc.py
+++ b/tests/unit/test_batch_submission_utc.py
@@ -270,61 +270,25 @@ class TestImportValidationModuleRaisesOnImportError:
     """E-6 — ImportError from load_module_from_path surfaces as ConfigurationError."""
 
     def test_import_error_raises_configuration_error(self):
-        from agent_actions.llm.batch.services.retry import _import_validation_module
+        from agent_actions.llm.batch.services.retry_polling import import_validation_module
 
         with patch(
             "agent_actions.llm.batch.services.retry_polling.load_module_from_path",
             side_effect=ImportError("No module named 'my_validator'"),
         ):
             with pytest.raises(ConfigurationError, match="my_validator"):
-                _import_validation_module("my_validator", "/some/path")
+                import_validation_module("my_validator", "/some/path")
 
     def test_other_exception_logs_warning_not_raises(self):
         """Non-ImportError exceptions are still suppressed to a warning."""
-        from agent_actions.llm.batch.services.retry import _import_validation_module
+        from agent_actions.llm.batch.services.retry_polling import import_validation_module
 
         with patch(
             "agent_actions.llm.batch.services.retry_polling.load_module_from_path",
             side_effect=RuntimeError("disk error"),
         ):
             # Should not raise — other exceptions are downgraded to warning
-            _import_validation_module("my_validator", None)
-
-
-# ---------------------------------------------------------------------------
-# E-7  ·  retry.py — backward-compat re-export of wait_for_batch_completion
-# ---------------------------------------------------------------------------
-
-
-class TestBackwardCompatReExports:
-    """E-7 — Ensure facade re-exports don't silently break."""
-
-    def test_wait_for_batch_completion_importable_from_retry(self):
-        """wait_for_batch_completion should be importable from the facade."""
-        from agent_actions.llm.batch.services.retry import wait_for_batch_completion  # noqa: F401
-
-        # Must be the same function object as the canonical location
-        from agent_actions.llm.batch.services.retry_polling import (
-            wait_for_batch_completion as canonical,
-        )
-
-        assert wait_for_batch_completion is canonical
-
-    def test_serialize_deserialize_importable_from_retry(self):
-        """serialize/deserialize_results should be importable from the facade."""
-        from agent_actions.llm.batch.services.retry import (  # noqa: F401
-            deserialize_results,
-            serialize_results,
-        )
-        from agent_actions.llm.batch.services.retry_serialization import (
-            deserialize_results as canonical_de,
-        )
-        from agent_actions.llm.batch.services.retry_serialization import (
-            serialize_results as canonical_se,
-        )
-
-        assert serialize_results is canonical_se
-        assert deserialize_results is canonical_de
+            import_validation_module("my_validator", None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Stacked on #841. Removes the two backward-compat re-export shims found via the dead-code baseline (shims are merge-blocking per RULES.md):

- `llm/batch/services/retry.py` no longer re-exports `retry_polling`/`retry_serialization`/`shared` names "for backward compatibility"; the serialize/deserialize **static-method façade** on `BatchRetryService` is gone too (8 callers now use `retry_serialization` directly). `retrieve_and_reconcile` stays — it's a real dependency whose unused-import suppression was stale
- `processing/disposition_gate.py` no longer aliases the storage `TERMINAL_DISPOSITIONS` set (`GATE_TERMINAL_DISPOSITIONS` had zero importers)
- The test class that existed solely to pin the re-exports is deleted with them; the E-6 tests now exercise `import_validation_module` at its canonical location; three stale architecture-doc claims corrected (the terminal set lives in storage, not processing)

## Verification
- Full suite: **8,227 passed** (delta = exactly the 2 shim-pinning tests); ruff + mypy clean
- Surface diff vs parent: `~ BatchRetryService`, `- GATE_TERMINAL_DISPOSITIONS` — nothing else