### PR TITLE
refactor: inline the five identical vendor error-wrapping helpers

### DIFF
--- a/.changes/unreleased/Under the Hood-20260807-230000.yaml
+++ b/.changes/unreleased/Under the Hood-20260807-230000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "Inline the five identical per-vendor error-wrapping helpers — each was a one-line pass-through to the shared wrap_vendor_error with the module's own error mapping. No behavior change."
+time: 2026-08-07T23:00:00Z

--- a/agent_actions/llm/providers/anthropic/client.py
+++ b/agent_actions/llm/providers/anthropic/client.py
@@ -44,11 +44,6 @@ _ERROR_MAPPING = VendorErrorMapping(
 )
 
 
-def _wrap_anthropic_error(e: Exception, model_name: str, request_id: str = "") -> Exception:
-    """Wrap Anthropic SDK errors into unified agent-actions error types."""
-    return wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id)
-
-
 class AnthropicClient(BaseClient):
     """Anthropic Claude API client for JSON and non-JSON LLM invocations."""
 
@@ -164,7 +159,7 @@ class AnthropicClient(BaseClient):
         try:
             response = client.messages.create(**api_args)
         except anthropic.APIError as e:
-            raise _wrap_anthropic_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         latency_ms = (time.perf_counter() - start_time) * 1000
 
         ResponseBuilder.record_usage_and_event(

--- a/agent_actions/llm/providers/cohere/client.py
+++ b/agent_actions/llm/providers/cohere/client.py
@@ -44,11 +44,6 @@ _ERROR_MAPPING = VendorErrorMapping(
 )
 
 
-def _wrap_cohere_error(e: Exception, model_name: str, request_id: str = "") -> Exception:
-    """Wrap Cohere SDK errors into unified agent-actions error types."""
-    return wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id)
-
-
 class CohereClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
     """Cohere API client for JSON and non-JSON LLM invocations."""
 
@@ -116,7 +111,7 @@ class CohereClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
         except (RateLimitError, NetworkError, VendorAPIError):
             raise
         except cohere_errors.ApiError as e:
-            raise _wrap_cohere_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         except Exception as e:
             fire_event(
                 LLMErrorEvent(
@@ -185,7 +180,7 @@ class CohereClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
         except (RateLimitError, NetworkError, VendorAPIError):
             raise
         except cohere_errors.ApiError as e:
-            raise _wrap_cohere_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         except Exception as e:
             fire_event(
                 LLMErrorEvent(

--- a/agent_actions/llm/providers/gemini/client.py
+++ b/agent_actions/llm/providers/gemini/client.py
@@ -45,11 +45,6 @@ _ERROR_MAPPING = VendorErrorMapping(
 )
 
 
-def _wrap_gemini_error(e: Exception, model_name: str, request_id: str = "") -> Exception:
-    """Wrap Google Gemini SDK errors into unified agent-actions error types."""
-    return wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id)
-
-
 def _build_client(api_key: str) -> genai.Client:
     """Build a google-genai Client instance."""
     return genai.Client(api_key=api_key)
@@ -104,7 +99,7 @@ class GeminiClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
         except (RateLimitError, NetworkError, VendorAPIError):
             raise
         except genai_errors.APIError as e:
-            raise _wrap_gemini_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         except Exception as e:
             fire_event(
                 LLMErrorEvent(
@@ -163,7 +158,7 @@ class GeminiClient(BaseClient, JSONResponseMixin, GenericErrorHandlerMixin):
         except (RateLimitError, NetworkError, VendorAPIError):
             raise
         except genai_errors.APIError as e:
-            raise _wrap_gemini_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         except Exception as e:
             fire_event(
                 LLMErrorEvent(

--- a/agent_actions/llm/providers/groq/client.py
+++ b/agent_actions/llm/providers/groq/client.py
@@ -50,11 +50,6 @@ _ERROR_MAPPING = VendorErrorMapping(
 )
 
 
-def _wrap_groq_error(e: Exception, model_name: str, request_id: str = "") -> Exception:
-    """Wrap Groq SDK errors into unified agent-actions error types."""
-    return wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id)
-
-
 class GroqClient(BaseClient, JSONResponseMixin):
     """Groq API client for JSON and non-JSON LLM invocations."""
 
@@ -108,7 +103,7 @@ class GroqClient(BaseClient, JSONResponseMixin):
         except (RateLimitError, NetworkError, VendorAPIError):
             raise
         except groq.APIError as e:
-            raise _wrap_groq_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         except Exception as e:
             fire_event(
                 LLMErrorEvent(
@@ -172,7 +167,7 @@ class GroqClient(BaseClient, JSONResponseMixin):
         except (RateLimitError, NetworkError, VendorAPIError):
             raise
         except groq.APIError as e:
-            raise _wrap_groq_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
 
         latency_ms = (time.perf_counter() - start_time) * 1000
 

--- a/agent_actions/llm/providers/openai/client.py
+++ b/agent_actions/llm/providers/openai/client.py
@@ -45,11 +45,6 @@ _ERROR_MAPPING = VendorErrorMapping(
 )
 
 
-def _wrap_openai_error(e: Exception, model_name: str, request_id: str = "") -> Exception:
-    """Wrap OpenAI SDK errors into unified agent-actions error types."""
-    return wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id)
-
-
 class OpenAIClient(BaseClient):
     """OpenAI API client for JSON and non-JSON LLM invocations."""
 
@@ -113,7 +108,7 @@ class OpenAIClient(BaseClient):
         try:
             response = client.chat.completions.create(**completion_kwargs)
         except openai.APIError as e:
-            raise _wrap_openai_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         latency_ms = (time.perf_counter() - start_time) * 1000
 
         ResponseBuilder.record_usage_and_event(
@@ -204,7 +199,7 @@ class OpenAIClient(BaseClient):
         try:
             response = client.chat.completions.create(**completion_kwargs)
         except openai.APIError as e:
-            raise _wrap_openai_error(e, model_name, request_id) from e
+            raise wrap_vendor_error(e, model_name, _ERROR_MAPPING, request_id) from e
         latency_ms = (time.perf_counter() - start_time) * 1000
 
         ResponseBuilder.record_usage_and_event(


### PR DESCRIPTION
## Summary
Stacked on #843. Each of the five provider clients (openai, groq, cohere, anthropic, gemini) defined a private `_wrap_<vendor>_error` that only forwarded to the shared `wrap_vendor_error` with the module's own `_ERROR_MAPPING`. The 9 call sites now call the shared helper directly — which also makes the error mapping visible at the raise site.

## Verification
- Full suite: **8,227 passed**; ruff + mypy clean; zero surface drift (the wrappers were private)
- No test patched the wrappers (verified before inlining)