### PR TITLE
fix(hitl): fail the action on non-decision review outcomes

### DIFF
--- a/agent_actions/processing/ARCHITECTURE.md
+++ b/agent_actions/processing/ARCHITECTURE.md
@@ -142,7 +142,7 @@ Input records (from staging or upstream action)
 │  │  1. Call HITL agent with filtered records       │ │
 │  │  2. Receive single decision payload             │ │
 │  │  3. Broadcast decision to all records           │ │
-│  │  4. Detect hitl_status == "timeout" → error     │ │
+│  │  4. Non-decision status (timeout/error) → raise │ │
 │  └─────────────────────────────────────────────────┘ │
 └──────────┬───────────────────────────────────────────┘
            │

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -22,6 +22,9 @@ from agent_actions.workflow.pipeline_file_mode import extract_tool_input
 
 logger = logging.getLogger(__name__)
 
+# The server also emits "timeout" and "error"; those mean no review happened.
+_DECISION_STATUSES = frozenset({"approved", "rejected"})
+
 
 class HITLStrategy:
     """Strategy for FILE-granularity HITL invocation.
@@ -129,6 +132,22 @@ class HITLStrategy:
                     context={
                         "agent_name": context.agent_name,
                         "record_count": len(records),
+                    },
+                )
+
+            # Broadcasting a non-decision would stamp every record reviewed and
+            # let the run succeed while guards discard the whole dataset.
+            status = decision_payload.get("hitl_status")
+            if status not in _DECISION_STATUSES:
+                detail = decision_payload.get("user_comment") or "no detail reported"
+                raise AgentActionsError(
+                    f"HITL review did not produce a decision (hitl_status={status!r}, "
+                    f"detail: {detail}). None of these {len(records)} records were "
+                    "reviewed. Re-run the workflow to review them.",
+                    context={
+                        "agent_name": context.agent_name,
+                        "record_count": len(records),
+                        "hitl_status": status,
                     },
                 )
 

--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -156,6 +156,25 @@ class HITLStrategy:
                 if isinstance(decision_payload.get("record_reviews"), list)
                 else None
             )
+            # Per-record reviews overwrite the broadcast status, so the same
+            # allowlist has to hold here or a non-decision reaches records anyway.
+            for idx, review in enumerate(record_reviews or []):
+                if not isinstance(review, dict):
+                    continue
+                per_record_status = review.get("hitl_status")
+                if per_record_status is not None and per_record_status not in _DECISION_STATUSES:
+                    raise AgentActionsError(
+                        f"HITL review for record {idx} is not a decision "
+                        f"(hitl_status={per_record_status!r}). None of these "
+                        f"{len(records)} records were recorded. Re-run the workflow "
+                        "to review them.",
+                        context={
+                            "agent_name": context.agent_name,
+                            "record_count": len(records),
+                            "record_index": idx,
+                            "hitl_status": per_record_status,
+                        },
+                    )
             # Only propagate HITL decision metadata. Keep source business fields
             # (for example `status`) intact.
             decision_common = {

--- a/docs.agent-actions/docs/guides/human-in-the-loop.md
+++ b/docs.agent-actions/docs/guides/human-in-the-loop.md
@@ -96,7 +96,7 @@ hitl:
 |-------|------|---------|-------------|
 | `port` | int | 3001 | Server port (1024-65535). If busy, tries up to 5 consecutive ports. |
 | `instructions` | str | *(required)* | Instructions displayed in review UI. Be clear and specific. |
-| `timeout` | int | 300 | Seconds before timeout. Server shuts down and workflow continues with `hitl_status: timeout`. |
+| `timeout` | int | 300 | Seconds before timeout. Server shuts down, partial reviews are saved, and the action fails so a re-run can resume. |
 | `require_comment_on_reject` | bool | true | If true, rejecting a record requires a comment explaining why. |
 
 ### Workflow-Level Default Timeout
@@ -185,7 +185,7 @@ HITL actions return decisions in a standardized format:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `hitl_status` | str | `"approved"`, `"rejected"`, or `"timeout"` |
+| `hitl_status` | str | `"approved"` or `"rejected"` — the only values that reach downstream actions |
 | `user_comment` | str | Optional comment from reviewer |
 | `timestamp` | str | ISO-8601 timestamp (UTC) when review was submitted |
 | `record_reviews` | list | (FILE mode only) Per-record decisions |
@@ -223,12 +223,13 @@ guard:
 guard:
   condition: "review_action.hitl_status == 'approved'"
   on_false: skip
-
-# Handle timeout
-guard:
-  condition: "review_action.hitl_status != 'timeout'"
-  on_false: skip
 ```
+
+:::note No guard is needed for timeouts or server failures
+A review that does not complete never produces a record. The HITL action fails
+instead, so `hitl_status` downstream is always `approved` or `rejected` — a
+guard like `hitl_status != 'timeout'` can never fire.
+:::
 
 ## Usage Patterns
 
@@ -439,14 +440,15 @@ hitl:
 
 After timeout:
 - Server shuts down
-- Workflow continues with `hitl_status: "timeout"`
-- Downstream guards can handle this:
+- Decisions you already made are saved to disk
+- **The action fails** — the workflow stops rather than continuing with an
+  unreviewed dataset
+- Re-running the workflow reopens the UI with your earlier decisions restored,
+  so you resume where you left off
 
-```yaml
-guard:
-  condition: "review_action.hitl_status != 'timeout'"
-  on_false: filter
-```
+The same applies when the approval UI cannot start (for example, every port in
+its range is taken). No decision was made, so nothing is written to the records
+and the action fails with the reason. Fix the cause and re-run.
 
 ## Advanced Topics
 

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -341,6 +341,41 @@ def test_file_mode_hitl_unknown_status_is_not_broadcast_as_a_decision():
         HITLStrategy().invoke(input_data, context)
 
 
+def test_file_mode_hitl_per_record_non_decision_status_raises():
+    """The allowlist must hold per record, not only for the file-level status.
+
+    Per-record reviews overwrite the broadcast status, so a non-decision value
+    here reaches records through the same door layer 1 closed one level up.
+    """
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+    ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
+    with (
+        patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=(
+                {
+                    "hitl_status": "approved",
+                    "record_reviews": [
+                        {"hitl_status": "approved", "user_comment": ""},
+                        {"hitl_status": "error", "user_comment": "ui died"},
+                    ],
+                },
+                True,
+            ),
+        ),
+        pytest.raises(AgentActionsError, match="error"),
+    ):
+        HITLStrategy().invoke(input_data, context)
+
+
 def test_file_mode_hitl_rejected_file_decision_still_succeeds():
     """Anchor: real decisions keep flowing through with their shape unchanged."""
     input_data = [

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -285,6 +285,96 @@ def test_file_mode_hitl_timeout_raises_with_record_count():
         HITLStrategy().invoke(input_data, context)
 
 
+def test_file_mode_hitl_server_error_is_not_broadcast_as_a_decision():
+    """A failed approval UI must fail the action, never be applied as a verdict.
+
+    The server emits ``hitl_status="error"`` when it cannot bind a port. Treating
+    that as a decision stamps every record reviewed and lets the run report
+    success while downstream guards silently discard the whole dataset.
+    """
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+    ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
+    with (
+        patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=(
+                {
+                    "hitl_status": "error",
+                    "user_comment": "Server failed to start: [Errno 48] Address already in use",
+                    "timestamp": "2026-02-12T10:00:00Z",
+                },
+                True,
+            ),
+        ),
+        pytest.raises(AgentActionsError, match="error"),
+    ):
+        HITLStrategy().invoke(input_data, context)
+
+
+def test_file_mode_hitl_unknown_status_is_not_broadcast_as_a_decision():
+    """Only approved/rejected are decisions; anything else must fail the action."""
+    input_data = [{"source_guid": "sg-1", "content": {"id": 1}}]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
+    with (
+        patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=(
+                {"hitl_status": "pending", "timestamp": "2026-02-12T10:00:00Z"},
+                True,
+            ),
+        ),
+        pytest.raises(AgentActionsError, match="pending"),
+    ):
+        HITLStrategy().invoke(input_data, context)
+
+
+def test_file_mode_hitl_rejected_file_decision_still_succeeds():
+    """Anchor: real decisions keep flowing through with their shape unchanged."""
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+    ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
+    with patch(
+        "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+        return_value=(
+            {
+                "hitl_status": "rejected",
+                "user_comment": "not usable",
+                "timestamp": "2026-02-12T10:00:00Z",
+            },
+            True,
+        ),
+    ):
+        results = HITLStrategy().invoke(input_data, context)
+
+    assert len(results) == 1
+    assert results[0].status == ProcessingStatus.SUCCESS
+    assert len(results[0].data) == 2
+    for record in results[0].data:
+        assert record["content"]["review_data"]["hitl_status"] == "rejected"
+        assert record["content"]["review_data"]["user_comment"] == "not usable"
+        assert record["content"]["review_data"]["timestamp"] == "2026-02-12T10:00:00Z"
+
+
 def test_file_mode_hitl_observe_filters_and_orders_fields():
     """context_scope.observe should filter fields shown to HITL and preserve order."""
     action_config = {


### PR DESCRIPTION
## Summary
- `HITLStrategy` special-cased only `"timeout"`, so the `"error"` the approval server emits when it cannot bind a port (`hitl/server.py`) fell through the normal path: it was broadcast to every record as a verdict and the result was marked SUCCESS. Downstream guards testing `== 'approved'` then discarded the whole dataset while the run reported green.
- Replaced the single-status check with an allowlist (`approved`/`rejected`), so any future non-decision status fails safe instead of reaching records.
- The allowlist also applies to per-record reviews, which overwrite the broadcast status — otherwise a non-decision reached records through the same door one level down. Not reachable from the shipped server (it normalizes each review and rejects the rest), so this closes a latent hole rather than a live defect.
- Corrected the guide and `processing/ARCHITECTURE.md`. Both described behavior that predates this change: the guide promised `hitl_status: timeout` reaches downstream actions and showed guards filtering on it, but timeout has raised since it was introduced, so those guards could never fire.

**Behavior and record shape are unchanged** for approve/reject: `hitl_status`, `user_comment` and `timestamp` under the action namespace, exactly as before.

## Verification
- RED first, recorded via `gate.sh red`: server-error payload and an unknown status both failed on assertions before the fix.
- Positive anchor (`test_file_mode_hitl_rejected_file_decision_still_succeeds`) pins the unchanged shape, so a fix that raised on real decisions could not have passed.
- `gate.sh green`: **8137 passed**, `ruff format --check`, `ruff check`, and mypy clean.
- `callers.sh HITLStrategy`: 4 production references (`workflow/pipeline.py`, strategies `__init__`) — contained.
- `risk.sh`: LOW.
- **Smoke SKIPPED** — `risk.sh smoke_required=no`, no path in `smoke-surfaces.txt` touched. Compensating live verification instead: ran the real `qanalabs-quiz-maker` `hitl_gate_check` workflow (3 actions, tool+hitl only, no LLM spend) against this branch — full pipeline green, downstream `on_false: filter` guard passed 3/3, and the persisted namespace read straight from SQLite was unchanged.
- Blind fresh-context review: **YES**.