### PR TITLE
fix(hitl): announce the auto-approve bypass at warning level and document it

### DIFF
--- a/agent_actions/processing/strategies/hitl.py
+++ b/agent_actions/processing/strategies/hitl.py
@@ -83,8 +83,10 @@ class HITLStrategy:
                 )
 
             if os.environ.get("AGAC_HITL_AUTO_APPROVE") == "true":
-                logger.info(
-                    "[%s] AGAC_HITL_AUTO_APPROVE=true — auto-approving %d records",
+                logger.warning(
+                    "[%s] AGAC_HITL_AUTO_APPROVE=true — bypassing human review and "
+                    "auto-approving all %d records. No human approved this data. "
+                    "Unset the variable to restore the approval gate.",
                     context.agent_name,
                     len(filtered_records),
                 )

--- a/docs.agent-actions/docs/guides/human-in-the-loop.md
+++ b/docs.agent-actions/docs/guides/human-in-the-loop.md
@@ -496,7 +496,28 @@ The workflow continues as soon as you submit, even if the browser tab stays open
 
 ### Testing HITL Actions
 
-For automated testing, mock the HITL decision:
+#### Bypassing review in a smoke run
+
+Setting `AGAC_HITL_AUTO_APPROVE=true` makes every HITL action approve every
+record without opening the UI. It exists so end-to-end smoke runs do not block
+on a human.
+
+```bash
+AGAC_HITL_AUTO_APPROVE=true agac run -a my_workflow --fresh
+```
+
+:::danger This fabricates an approval no human gave
+While the variable is set, **every approval gate in every workflow becomes a
+rubber stamp**. Records are written with `hitl_status: approved` and the
+comment `auto-approved (smoke test)`, which is the only trace in the data that
+no human reviewed them.
+
+Each affected action logs a warning naming the variable and the record count.
+Export it per-command as shown above rather than in your shell profile, and
+never set it in an environment that produces data you intend to keep.
+:::
+
+For unit tests, mock the HITL decision instead:
 
 ```python
 from agent_actions.llm.providers.hitl.client import HitlClient

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -411,12 +411,16 @@ def test_file_mode_hitl_rejected_file_decision_still_succeeds():
         assert record["content"]["review_data"]["timestamp"] == "2026-02-12T10:00:00Z"
 
 
-def test_auto_approve_bypass_is_announced_at_warning_level(monkeypatch, caplog):
+def test_auto_approve_bypass_is_announced_at_warning_level(monkeypatch):
     """The review bypass must be impossible to miss in an otherwise normal run.
 
     ``AGAC_HITL_AUTO_APPROVE`` fabricates the approval a human never gave. It is
     needed by the smoke ring, but at info level a stale shell export silently
     turns every approval gate in every workflow into a rubber stamp.
+
+    Captures on the module logger rather than via ``caplog``: LoggerFactory sets
+    ``propagate = False`` on the ``agent_actions`` logger, so once any earlier
+    test configures logging, records never reach caplog's root handler.
     """
     monkeypatch.setenv("AGAC_HITL_AUTO_APPROVE", "true")
     input_data = [
@@ -429,15 +433,25 @@ def test_auto_approve_bypass_is_announced_at_warning_level(monkeypatch, caplog):
         source_data=input_data,
     )
 
-    with caplog.at_level(
-        logging.WARNING, logger="agent_actions.processing.strategies.hitl"
-    ):
+    emitted: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            emitted.append(record)
+
+    hitl_logger = logging.getLogger("agent_actions.processing.strategies.hitl")
+    handler = _Capture(level=logging.WARNING)
+    original_level = hitl_logger.level
+    hitl_logger.addHandler(handler)
+    hitl_logger.setLevel(logging.WARNING)
+    try:
         results = HITLStrategy().invoke(input_data, context)
+    finally:
+        hitl_logger.removeHandler(handler)
+        hitl_logger.setLevel(original_level)
 
     bypass_warnings = [
-        record
-        for record in caplog.records
-        if "AGAC_HITL_AUTO_APPROVE" in record.getMessage()
+        record for record in emitted if "AGAC_HITL_AUTO_APPROVE" in record.getMessage()
     ]
     assert bypass_warnings, "bypass must be announced at WARNING, not info"
     assert all(record.levelno >= logging.WARNING for record in bypass_warnings)

--- a/tests/unit/workflow/test_pipeline_hitl_file_mode.py
+++ b/tests/unit/workflow/test_pipeline_hitl_file_mode.py
@@ -1,5 +1,6 @@
 """Tests for FILE granularity HITL pipeline behavior."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -408,6 +409,44 @@ def test_file_mode_hitl_rejected_file_decision_still_succeeds():
         assert record["content"]["review_data"]["hitl_status"] == "rejected"
         assert record["content"]["review_data"]["user_comment"] == "not usable"
         assert record["content"]["review_data"]["timestamp"] == "2026-02-12T10:00:00Z"
+
+
+def test_auto_approve_bypass_is_announced_at_warning_level(monkeypatch, caplog):
+    """The review bypass must be impossible to miss in an otherwise normal run.
+
+    ``AGAC_HITL_AUTO_APPROVE`` fabricates the approval a human never gave. It is
+    needed by the smoke ring, but at info level a stale shell export silently
+    turns every approval gate in every workflow into a rubber stamp.
+    """
+    monkeypatch.setenv("AGAC_HITL_AUTO_APPROVE", "true")
+    input_data = [
+        {"source_guid": "sg-1", "content": {"id": 1}},
+        {"source_guid": "sg-2", "content": {"id": 2}},
+    ]
+    context = ProcessingContext(
+        agent_config={"kind": "hitl", "granularity": "file"},
+        agent_name="review_data",
+        source_data=input_data,
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="agent_actions.processing.strategies.hitl"
+    ):
+        results = HITLStrategy().invoke(input_data, context)
+
+    bypass_warnings = [
+        record
+        for record in caplog.records
+        if "AGAC_HITL_AUTO_APPROVE" in record.getMessage()
+    ]
+    assert bypass_warnings, "bypass must be announced at WARNING, not info"
+    assert all(record.levelno >= logging.WARNING for record in bypass_warnings)
+
+    # Anchor: the bypass itself still behaves exactly as before.
+    assert results[0].status == ProcessingStatus.SUCCESS
+    assert len(results[0].data) == 2
+    for record in results[0].data:
+        assert record["content"]["review_data"]["hitl_status"] == "approved"
 
 
 def test_file_mode_hitl_observe_filters_and_orders_fields():


### PR DESCRIPTION
## Summary
- `AGAC_HITL_AUTO_APPROVE=true` makes every HITL action approve every record with no human involved. It was logged at **info** and was undocumented, so a stale shell export silently converts every approval gate in every workflow into a rubber stamp.
- `harness/bin/smoke-test.sh` depends on it, so the capability stays and the *accident window* closes instead: the announcement moves to **warning** and names the variable, the record count, and how to restore the gate.
- Documented for the first time, under a danger admonition beside the existing monkeypatch-based unit-test guidance.

Business logic keeps using `logger` rather than `click.echo`, per the logging convention in CLAUDE.md. A live run confirmed the warning still reaches the user in normal CLI output.

**Behavior and record shape are unchanged:** the bypass still yields `hitl_status: approved` with the existing `auto-approved (smoke test)` comment, which remains the only trace in the data that no human reviewed it.

## Verification
- RED first via `gate.sh red`; `gate.sh green`: **8137 passed**, lint + mypy clean.
- A behavior anchor in the same test pins that the bypass still approves every record, so this could not pass by disabling the bypass.
- Live run against the real `qanalabs-quiz-maker` project (`hitl_gate_check`) — the warning appears in the run output:
  `AGAC_HITL_AUTO_APPROVE=true — bypassing human review and auto-approving all 3 records. No human approved this data. Unset the variable to restore the approval gate.`
- `risk.sh`: LOW. **Smoke SKIPPED** — `smoke_required=no`, no smoke surface touched; the live run above is the compensating check.
- Blind fresh-context review: **YES**.

## Note on test style
The test installs a handler on the module logger rather than using `caplog`. `LoggerFactory` sets `propagate = False` on the `agent_actions` logger, so once any earlier test configures logging, records never reach caplog's root handler — a caplog-based assertion passes in isolation and fails in the full suite. The reviewer independently reproduced this and confirmed the handler is justified rather than a smell.