### PR TITLE
fix(hitl): keep source_data aligned so reviews land on the right records

### DIFF
--- a/agent_actions/processing/ARCHITECTURE.md
+++ b/agent_actions/processing/ARCHITECTURE.md
@@ -543,9 +543,13 @@ This is intentional. FILE mode workflows depend on sequential accumulation
 (record N can reference record N-1's output). Do not unify without
 verifying FILE-mode workflows that depend on positional ordering.
 
-Also: FILE mode prunes context.source_data after cascade filter (line 176-183)
-to maintain positional alignment with processable records. If you skip this
-pruning, FileToolStrategy.reconcile_outputs() matches records by wrong indices.
+Also: FILE mode rebuilds context.source_data from `processable` after the
+disposition gate and cascade filter, replaying both onto it so index i still
+names the record the strategy receives at index i. It is rebuilt rather than
+pruned by guid because the gate re-queues un-carryable records at the END of
+the work list, which pruning alone would leave misaligned. If you skip this,
+FileToolStrategy.reconcile_outputs() matches records by wrong indices and
+HITLStrategy attributes each reviewer decision to the wrong record.
 ```
 
 ---

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -163,6 +163,16 @@ class UnifiedProcessor:
                     to_process = passing
             passing = to_process
 
+            # FILE mode: carried records are served from prior output, so drop
+            # them here too or the positional broadcast below shifts onto them.
+            if raw_records is not None and carry_results:
+                carried_guids = {r.source_guid for r in carry_results if r.source_guid is not None}
+                context.source_data = [
+                    s
+                    for s in (context.source_data or [])
+                    if s.get("source_guid") not in carried_guids
+                ]
+
         # Cascade filter — quarantine upstream-failed records before strategy
         # sees them.  Strategies only receive processable records.
         processable, quarantined_results = partition_cascade_records(

--- a/agent_actions/processing/unified.py
+++ b/agent_actions/processing/unified.py
@@ -119,8 +119,15 @@ class UnifiedProcessor:
                 records, context, raw_records
             )
             context.source_data = original_passing
+            # prefilter_by_guard returns these index-aligned. Keep the pairing so
+            # any later filtering or reordering of `passing` can be replayed onto
+            # source_data, which FILE-mode strategies index by position.
+            source_by_record = {
+                id(rec): original for rec, original in zip(passing, original_passing, strict=True)
+            }
         else:
             passing, guard_results = self._guard_filter(records, context)
+            source_by_record = {}
 
         carry_results: list[ProcessingResult] = []
         if self._disposition_gate is not None and passing:
@@ -163,33 +170,16 @@ class UnifiedProcessor:
                     to_process = passing
             passing = to_process
 
-            # FILE mode: carried records are served from prior output, so drop
-            # them here too or the positional broadcast below shifts onto them.
-            if raw_records is not None and carry_results:
-                carried_guids = {r.source_guid for r in carry_results if r.source_guid is not None}
-                context.source_data = [
-                    s
-                    for s in (context.source_data or [])
-                    if s.get("source_guid") not in carried_guids
-                ]
-
         # Cascade filter — quarantine upstream-failed records before strategy
         # sees them.  Strategies only receive processable records.
         processable, quarantined_results = partition_cascade_records(
             passing, action_name=context.agent_name
         )
 
-        # FILE mode: filter context.source_data to maintain positional alignment
-        # with processable records (used by reconcile_outputs / HITL broadcast).
-        if raw_records is not None and quarantined_results:
-            quarantined_guids = {
-                r.source_guid for r in quarantined_results if r.source_guid is not None
-            }
-            context.source_data = [
-                s
-                for s in (context.source_data or [])
-                if s.get("source_guid") not in quarantined_guids
-            ]
+        # Rebuilt from `processable`, not by subtracting guid sets: the gate
+        # re-queues un-carryable records at the END of the work list.
+        if raw_records is not None:
+            context.source_data = [source_by_record[id(rec)] for rec in processable]
 
         invocation_results = strategy.invoke(processable, context) if processable else []
 

--- a/tests/unit/processing/test_hitl_cascade_mixed.py
+++ b/tests/unit/processing/test_hitl_cascade_mixed.py
@@ -317,3 +317,55 @@ class TestHITLCarryForwardAlignment:
         r1_out = [r for r in output if r.get("source_guid") == "r1"]
         assert len(r1_out) == 1
         assert r1_out[0]["content"]["hitl_review"]["user_comment"] == "prior"
+
+    def test_reviews_stay_aligned_when_a_terminal_record_is_missing_from_prior_output(self):
+        """R1 and R3 are terminal, but prior output holds only R3.
+
+        R1 cannot be carried, so it is re-queued for processing — appended at the
+        END of the work list while it still sits FIRST in source_data. Reviews
+        must follow the records the reviewer saw, not the stale ordering.
+        """
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "active")
+        r3 = _record("r3", "active")
+        r4 = _record("r4", "active")
+
+        mock_backend = MagicMock()
+        mock_backend.get_terminal_record_ids.return_value = {"r1", "r3"}
+        mock_backend.read_target.return_value = [
+            {
+                "source_guid": "r3",
+                "content": {"hitl_review": {"hitl_status": "approved", "user_comment": "prior"}},
+            }
+        ]
+
+        context = _make_context()
+        context.source_data = [r1, r2, r3, r4]
+        context.storage_backend = mock_backend
+        context.file_path = "test.json"
+
+        captured: dict[str, list] = {}
+
+        def _capture(**kwargs):
+            # The reviewer sees observe-filtered records; `val` carries the
+            # record identity that source_guid is stripped of.
+            captured["records"] = list(kwargs.get("context") or [])
+            reviews = [
+                {"hitl_status": "approved", "user_comment": f"review for {r.get('val')}"}
+                for r in captured["records"]
+            ]
+            return ([{"hitl_status": "approved", "record_reviews": reviews}], True)
+
+        with patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            side_effect=_capture,
+        ):
+            processor = UnifiedProcessor(disposition_gate=DispositionGate(mock_backend))
+            output, _stats = processor.process(
+                [r1, r2, r3, r4], context, HITLStrategy(), raw_records=[r1, r2, r3, r4]
+            )
+
+        for guid in ("r1", "r2", "r4"):
+            out = [r for r in output if r.get("source_guid") == guid]
+            assert len(out) == 1, f"{guid} must appear exactly once"
+            assert out[0]["content"]["hitl_review"]["user_comment"] == f"review for {guid}"

--- a/tests/unit/processing/test_hitl_cascade_mixed.py
+++ b/tests/unit/processing/test_hitl_cascade_mixed.py
@@ -255,3 +255,65 @@ class TestGateCascadeInteraction:
         assert spy.received[0].get("source_guid") == "r1"
 
         assert stats.unprocessed == 1
+
+
+class TestHITLCarryForwardAlignment:
+    """FILE-mode HITL reviews must stay aligned when the gate carries records.
+
+    UnifiedProcessor re-filters ``context.source_data`` for cascade-quarantined
+    records so HITL's positional broadcast stays aligned, but not for records
+    the disposition gate carries forward — the sibling case, one block earlier.
+    """
+
+    def test_reviews_not_misattributed_when_gate_carries_a_record(self):
+        """R1 already reviewed on a prior run; R2 and R3 are new.
+
+        HITL is shown [R2, R3] and returns reviews in that order. Each review
+        must land on the record the reviewer saw it against.
+        """
+        r1 = _record("r1", "active")
+        r2 = _record("r2", "active")
+        r3 = _record("r3", "active")
+
+        mock_backend = MagicMock()
+        mock_backend.get_terminal_record_ids.return_value = {"r1"}
+        mock_backend.read_target.return_value = [
+            {
+                "source_guid": "r1",
+                "content": {"hitl_review": {"hitl_status": "approved", "user_comment": "prior"}},
+            }
+        ]
+
+        context = _make_context()
+        context.source_data = [r1, r2, r3]
+        context.storage_backend = mock_backend
+        context.file_path = "test.json"
+
+        hitl_response = {
+            "hitl_status": "approved",
+            "record_reviews": [
+                {"hitl_status": "approved", "user_comment": "R2 looks good"},
+                {"hitl_status": "rejected", "user_comment": "R3 needs work"},
+            ],
+        }
+
+        with patch(
+            "agent_actions.processing.strategies.hitl.run_dynamic_agent",
+            return_value=([hitl_response], True),
+        ):
+            processor = UnifiedProcessor(disposition_gate=DispositionGate(mock_backend))
+            output, _stats = processor.process(
+                [r1, r2, r3], context, HITLStrategy(), raw_records=[r1, r2, r3]
+            )
+
+        r2_out = [r for r in output if r.get("source_guid") == "r2"]
+        r3_out = [r for r in output if r.get("source_guid") == "r3"]
+        assert len(r2_out) == 1
+        assert len(r3_out) == 1
+        assert r2_out[0]["content"]["hitl_review"]["user_comment"] == "R2 looks good"
+        assert r3_out[0]["content"]["hitl_review"]["user_comment"] == "R3 needs work"
+
+        # The carried record must appear exactly once, from prior output only.
+        r1_out = [r for r in output if r.get("source_guid") == "r1"]
+        assert len(r1_out) == 1
+        assert r1_out[0]["content"]["hitl_review"]["user_comment"] == "prior"


### PR DESCRIPTION
## Summary
FILE-mode strategies broadcast decisions **by position** against `context.source_data`. The cascade filter re-filtered that list to preserve the alignment; the disposition gate one block earlier did not. On an incremental re-run where part of a file is already terminal, `source_data` was longer than the record set the reviewer actually saw, so **every decision shifted onto the wrong record** and each carried record was emitted twice.

Review surfaced a second, adjacent case the first fix missed: when a record is terminal in the disposition DB but absent from prior output it cannot be carried, so the gate re-queues it at the **end** of the work list. Subtracting carried guids leaves that reordering intact and reviews still land wrong.

The fix therefore replaces **both** ad-hoc filters (carry and cascade) with a single replay: pair `passing` with `original_passing` while `prefilter_by_guard` still guarantees they are index-aligned, then rebuild `source_data` from `processable`. Keying on record identity rather than `source_guid` also covers records that have no guid — which the guid-set filters silently kept in place, shifting every later index.

`zip(..., strict=True)` makes a broken alignment invariant fail loudly rather than silently misattributing a reviewer's decision. It sits downstream of `prefilter_by_guard`'s existing `len(original_data) != len(data)` guard, so it is a tripwire, not a new failure mode.

**Sibling:** `strategies/file_tool.py` consumes `source_data` through the index-keyed mapping from `reconcile_outputs`, so it had the identical latent bug. Both sit downstream of this one filter and are fixed by the same change.

## Verification
- RED first, twice — each proving the bug in its plainest form:
  - gate carry: `assert 'R3 needs work' == 'R2 looks good'`
  - re-queue reordering: `assert 'review for r2' == 'review for r1'`

  Each is a reviewer's decision recorded against the wrong record.
- `gate.sh green`: **8153 passed**, `ruff format --check`, `ruff check`, mypy clean.
- `processing/ARCHITECTURE.md` updated — it documented the old prune, including a now-wrong line reference.
- `risk.sh`: LOW. **Smoke SKIPPED** — `smoke_required=no`, no path in `smoke-surfaces.txt` touched. Compensating live verification: the real `qanalabs-quiz-maker` `hitl_gate_check` workflow ran green end to end against this branch.
- Blind fresh-context review: **YES**. The reviewer specifically confirmed no `KeyError` risk in the identity map, that `strict=True` is safe on every path into the FILE-mode branch, and that dropping guid-less records is a correctness improvement rather than a regression.