### PR TITLE
refactor(vscode-extension): make status resolution testable

### DIFF
--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 out/
 *.vsix
+out-tests/

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,6 +1,8 @@
 .vscode/**
 .vscode-test/**
 src/**
+out-tests/**
+scripts/**
 node_modules/**
 tsconfig.json
 esbuild.js

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -371,7 +371,7 @@
     "typecheck": "tsc --noEmit",
     "package": "npm run typecheck && npm test && npm run build && vsce package",
     "publish": "npm run typecheck && npm test && npm run build && vsce publish",
-    "test": "node scripts/build-tests.mjs && node --test \"out-tests/**/*.mjs\""
+    "test": "node scripts/build-tests.mjs"
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -369,8 +369,9 @@
     "watch": "node esbuild.js --watch",
     "build": "node esbuild.js --production",
     "typecheck": "tsc --noEmit",
-    "package": "npm run typecheck && npm run build && vsce package",
-    "publish": "npm run typecheck && npm run build && vsce publish"
+    "package": "npm run typecheck && npm test && npm run build && vsce package",
+    "publish": "npm run typecheck && npm test && npm run build && vsce publish",
+    "test": "node scripts/build-tests.mjs && node --test \"out-tests/**/*.mjs\""
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",

--- a/vscode-extension/scripts/build-tests.mjs
+++ b/vscode-extension/scripts/build-tests.mjs
@@ -8,6 +8,7 @@
  */
 
 import { build } from 'esbuild';
+import { spawnSync } from 'node:child_process';
 import { readdirSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
 
@@ -37,4 +38,12 @@ await build({
     outExtension: { '.js': '.mjs' },
 });
 
-console.log(`Compiled ${entryPoints.length} test file(s) to out-tests/`);
+// Hand `node --test` explicit paths rather than a glob: glob patterns are a
+// Node 22 feature and CI runs Node 20.
+const compiled = readdirSync('out-tests', { recursive: true })
+    .map(String)
+    .filter((file) => file.endsWith('.mjs'))
+    .map((file) => path.join('out-tests', file));
+
+const result = spawnSync(process.execPath, ['--test', ...compiled], { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/vscode-extension/scripts/build-tests.mjs
+++ b/vscode-extension/scripts/build-tests.mjs
@@ -1,0 +1,34 @@
+/**
+ * Compile *.test.ts to out-tests/ so `node --test` can run them.
+ *
+ * Uses the esbuild already present for the extension bundle rather than adding
+ * a test-runner dependency. Only modules free of `vscode` imports can be tested
+ * this way — the editor API has no implementation outside the host, so logic
+ * that needs testing belongs in a vscode-free module.
+ */
+
+import { build } from 'esbuild';
+import { globSync, rmSync } from 'node:fs';
+
+const entryPoints = globSync('src/**/*.test.ts');
+
+if (entryPoints.length === 0) {
+    console.error('No *.test.ts files found under src/');
+    process.exit(1);
+}
+
+rmSync('out-tests', { recursive: true, force: true });
+
+await build({
+    entryPoints,
+    outdir: 'out-tests',
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    sourcemap: 'inline',
+    external: ['node:*'],
+    outExtension: { '.js': '.mjs' },
+});
+
+console.log(`Compiled ${entryPoints.length} test file(s) to out-tests/`);

--- a/vscode-extension/scripts/build-tests.mjs
+++ b/vscode-extension/scripts/build-tests.mjs
@@ -8,9 +8,15 @@
  */
 
 import { build } from 'esbuild';
-import { globSync, rmSync } from 'node:fs';
+import { readdirSync, rmSync } from 'node:fs';
+import * as path from 'node:path';
 
-const entryPoints = globSync('src/**/*.test.ts');
+// readdirSync's recursive option rather than fs.globSync: glob landed in Node
+// 22 and CI runs Node 20.
+const entryPoints = readdirSync('src', { recursive: true })
+    .map(String)
+    .filter((file) => file.endsWith('.test.ts'))
+    .map((file) => path.join('src', file));
 
 if (entryPoints.length === 0) {
     console.error('No *.test.ts files found under src/');

--- a/vscode-extension/src/model/status.test.ts
+++ b/vscode-extension/src/model/status.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { resolveActionStatus, toActionStatus } from './status';
+import type { AgentStatusData, ManifestData } from './status';
+
+describe('toActionStatus', () => {
+    it('passes through every status the framework can write', () => {
+        for (const status of [
+            'pending',
+            'running',
+            'completed',
+            'failed',
+            'skipped',
+            'interrupted',
+        ]) {
+            assert.equal(toActionStatus(status), status);
+        }
+    });
+
+    it('accepts the framework casing variants', () => {
+        assert.equal(toActionStatus('RUNNING'), 'running');
+        assert.equal(toActionStatus('Interrupted'), 'interrupted');
+    });
+
+    it('maps the legacy aliases', () => {
+        assert.equal(toActionStatus('success'), 'completed');
+        assert.equal(toActionStatus('error'), 'failed');
+    });
+
+    it('falls back to pending for absent or unknown values', () => {
+        assert.equal(toActionStatus(undefined), 'pending');
+        assert.equal(toActionStatus(''), 'pending');
+        assert.equal(toActionStatus('nonsense'), 'pending');
+    });
+
+    it('does not report a status the framework emits as never-started', () => {
+        // Guards the whole class of bug: a value missing from the union reads
+        // as 'pending', which claims the action never ran.
+        assert.notEqual(toActionStatus('interrupted'), 'pending');
+        assert.notEqual(toActionStatus('skipped'), 'pending');
+    });
+});
+
+describe('resolveActionStatus', () => {
+    const manifest: ManifestData = {
+        actions: {
+            extract: { status: 'completed' },
+            score: { status: 'running' },
+        },
+    };
+
+    it('reads the object form of agent_status.json', () => {
+        const agentStatus: AgentStatusData = { extract: { status: 'failed' } };
+        assert.equal(resolveActionStatus(manifest, agentStatus, 'extract'), 'failed');
+    });
+
+    it('reads the bare-string form of agent_status.json', () => {
+        const agentStatus: AgentStatusData = { extract: 'interrupted' };
+        assert.equal(resolveActionStatus(manifest, agentStatus, 'extract'), 'interrupted');
+    });
+
+    it('prefers agent_status.json over the manifest', () => {
+        const agentStatus: AgentStatusData = { score: { status: 'failed' } };
+        assert.equal(resolveActionStatus(manifest, agentStatus, 'score'), 'failed');
+    });
+
+    it('falls back to the manifest when the action is absent from agent_status', () => {
+        assert.equal(resolveActionStatus(manifest, { other: 'running' }, 'extract'), 'completed');
+    });
+
+    it('falls back to the manifest when agent_status is missing entirely', () => {
+        assert.equal(resolveActionStatus(manifest, null, 'extract'), 'completed');
+    });
+
+    it('reports pending when neither source knows the action', () => {
+        assert.equal(resolveActionStatus(manifest, null, 'unknown'), 'pending');
+        assert.equal(resolveActionStatus(null, null, 'unknown'), 'pending');
+    });
+
+    it('ignores an agent_status entry with no usable status field', () => {
+        const agentStatus = { extract: { execution_time: 1.2 } } as unknown as AgentStatusData;
+        assert.equal(resolveActionStatus(manifest, agentStatus, 'extract'), 'completed');
+    });
+});

--- a/vscode-extension/src/model/status.test.ts
+++ b/vscode-extension/src/model/status.test.ts
@@ -1,20 +1,34 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
-import { resolveActionStatus, toActionStatus } from './status';
+import { ACTION_STATUSES, parseActionStatus, resolveActionStatus, toActionStatus } from './status';
 import type { AgentStatusData, ManifestData } from './status';
 
 describe('toActionStatus', () => {
     it('passes through every status the framework can write', () => {
-        for (const status of [
-            'pending',
-            'running',
-            'completed',
-            'failed',
-            'skipped',
-            'interrupted',
-        ]) {
+        for (const status of ACTION_STATUSES) {
             assert.equal(toActionStatus(status), status);
+        }
+    });
+
+    it('covers every member of the Python ActionStatus enum', () => {
+        // The union and agent_actions/workflow/managers/state.py evolve
+        // independently, with only the JSON on disk linking them. Read the enum
+        // rather than restating it, so drift fails here instead of rendering a
+        // real status as 'pending'.
+        // npm test runs from vscode-extension/, so the framework sits one up.
+        const enumSource = readFileSync(
+            join('..', 'agent_actions', 'workflow', 'managers', 'state.py'),
+            'utf8'
+        );
+        const body = enumSource.split('class ActionStatus(str, Enum):')[1].split('\n\n\n')[0];
+        const written = [...body.matchAll(/^\s{4}[A-Z_]+ = "([a-z_]+)"$/gm)].map((m) => m[1]);
+
+        assert.ok(written.length >= 9, `parsed too few enum members: ${written.length}`);
+        for (const status of written) {
+            assert.equal(toActionStatus(status), status, `${status} does not survive the union`);
         }
     });
 
@@ -34,11 +48,9 @@ describe('toActionStatus', () => {
         assert.equal(toActionStatus('nonsense'), 'pending');
     });
 
-    it('does not report a status the framework emits as never-started', () => {
-        // Guards the whole class of bug: a value missing from the union reads
-        // as 'pending', which claims the action never ran.
-        assert.notEqual(toActionStatus('interrupted'), 'pending');
-        assert.notEqual(toActionStatus('skipped'), 'pending');
+    it('distinguishes unknown from pending for callers that can fall back', () => {
+        assert.equal(parseActionStatus('nonsense'), undefined);
+        assert.equal(parseActionStatus('pending'), 'pending');
     });
 });
 
@@ -80,6 +92,14 @@ describe('resolveActionStatus', () => {
 
     it('ignores an agent_status entry with no usable status field', () => {
         const agentStatus = { extract: { execution_time: 1.2 } } as unknown as AgentStatusData;
+        assert.equal(resolveActionStatus(manifest, agentStatus, 'extract'), 'completed');
+    });
+});
+
+describe('resolveActionStatus with an unrecognised live value', () => {
+    it('falls back to the manifest rather than claiming pending', () => {
+        const manifest: ManifestData = { actions: { extract: { status: 'completed' } } };
+        const agentStatus = { extract: 'from_the_future' } as AgentStatusData;
         assert.equal(resolveActionStatus(manifest, agentStatus, 'extract'), 'completed');
     });
 });

--- a/vscode-extension/src/model/status.ts
+++ b/vscode-extension/src/model/status.ts
@@ -1,0 +1,116 @@
+/**
+ * Status resolution for workflow actions.
+ *
+ * Deliberately free of `vscode` imports: this is the logic that decides what
+ * the sidebar claims about a run, and it must be testable without an editor
+ * host. Anything needing the VS Code API belongs in the providers.
+ */
+
+/**
+ * Action execution status derived from the manifest and agent_status.json.
+ *
+ * Mirrors `ActionStatus` in agent_actions/workflow/managers/state.py. The two
+ * are coupled through the JSON files on disk, so a new member on either side
+ * has to be added here as well.
+ */
+export type ActionStatus =
+    | 'pending'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'skipped'
+    | 'interrupted';
+
+const KNOWN_STATUSES: readonly string[] = [
+    'pending',
+    'running',
+    'completed',
+    'failed',
+    'skipped',
+    'interrupted',
+];
+
+/** Manifest action entry from .manifest.json */
+export interface ManifestActionInfo {
+    index?: number;
+    level?: number;
+    status?: string;
+    output_dir?: string;
+    dependencies?: string[];
+    record_count?: number | null;
+}
+
+/** Workflow manifest written once per run */
+export interface ManifestData {
+    workflow_name?: string;
+    execution_order?: string[];
+    levels?: string[][];
+    actions?: Record<string, ManifestActionInfo>;
+}
+
+/** Runtime status from agent_io/.agent_status.json */
+export interface AgentStatusData {
+    [actionName: string]: string | { status: string; [key: string]: unknown };
+}
+
+/**
+ * Convert a raw on-disk status string to an ActionStatus.
+ *
+ * Unrecognised values fall back to 'pending' — which is a lie about a run that
+ * did start, so a status the framework can emit must be listed above.
+ */
+export function toActionStatus(status: string | undefined): ActionStatus {
+    const normalized = (status ?? '').toLowerCase();
+    if (KNOWN_STATUSES.includes(normalized)) {
+        return normalized as ActionStatus;
+    }
+    if (normalized === 'success') {
+        return 'completed';
+    }
+    if (normalized === 'error') {
+        return 'failed';
+    }
+    return 'pending';
+}
+
+/** Read one action's status out of the agent_status.json shape. */
+function agentStatusFor(
+    agentStatus: AgentStatusData | null,
+    actionName: string
+): string | undefined {
+    const entry = agentStatus?.[actionName];
+    if (typeof entry === 'string') {
+        return entry;
+    }
+    if (typeof entry === 'object' && entry !== null) {
+        const value = (entry as Record<string, unknown>).status;
+        if (typeof value === 'string') {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Resolve an action's status from the two runtime files.
+ *
+ * agent_status.json wins today because it is written per action during
+ * execution, where the manifest carries the run-level view.
+ */
+export function resolveActionStatus(
+    manifest: ManifestData | null,
+    agentStatus: AgentStatusData | null,
+    actionName: string
+): ActionStatus {
+    const live = agentStatusFor(agentStatus, actionName);
+    if (live !== undefined) {
+        return toActionStatus(live);
+    }
+
+    const fromManifest = manifest?.actions?.[actionName]?.status;
+    if (fromManifest) {
+        return toActionStatus(fromManifest);
+    }
+
+    return 'pending';
+}

--- a/vscode-extension/src/model/status.ts
+++ b/vscode-extension/src/model/status.ts
@@ -16,15 +16,27 @@
 export type ActionStatus =
     | 'pending'
     | 'running'
+    | 'batch_submitted'
+    | 'checking_batch'
     | 'completed'
+    | 'completed_with_failures'
     | 'failed'
     | 'skipped'
     | 'interrupted';
 
-const KNOWN_STATUSES: readonly string[] = [
+/**
+ * Every member of ActionStatus, for exhaustive iteration.
+ *
+ * Kept in sync with agent_actions/workflow/managers/state.py by
+ * status.test.ts, which fails if the framework grows a member this omits.
+ */
+export const ACTION_STATUSES: readonly ActionStatus[] = [
     'pending',
     'running',
+    'batch_submitted',
+    'checking_batch',
     'completed',
+    'completed_with_failures',
     'failed',
     'skipped',
     'interrupted',
@@ -59,9 +71,9 @@ export interface AgentStatusData {
  * Unrecognised values fall back to 'pending' — which is a lie about a run that
  * did start, so a status the framework can emit must be listed above.
  */
-export function toActionStatus(status: string | undefined): ActionStatus {
+export function parseActionStatus(status: string | undefined): ActionStatus | undefined {
     const normalized = (status ?? '').toLowerCase();
-    if (KNOWN_STATUSES.includes(normalized)) {
+    if ((ACTION_STATUSES as readonly string[]).includes(normalized)) {
         return normalized as ActionStatus;
     }
     if (normalized === 'success') {
@@ -70,7 +82,11 @@ export function toActionStatus(status: string | undefined): ActionStatus {
     if (normalized === 'error') {
         return 'failed';
     }
-    return 'pending';
+    return undefined;
+}
+
+export function toActionStatus(status: string | undefined): ActionStatus {
+    return parseActionStatus(status) ?? 'pending';
 }
 
 /** Read one action's status out of the agent_status.json shape. */
@@ -102,9 +118,12 @@ export function resolveActionStatus(
     agentStatus: AgentStatusData | null,
     actionName: string
 ): ActionStatus {
-    const live = agentStatusFor(agentStatus, actionName);
+    // Only a status we understand may pre-empt the manifest. An unrecognised
+    // string is no more informative than a missing one, and treating it as
+    // 'pending' would discard a manifest entry that does say something.
+    const live = parseActionStatus(agentStatusFor(agentStatus, actionName));
     if (live !== undefined) {
-        return toActionStatus(live);
+        return live;
     }
 
     const fromManifest = manifest?.actions?.[actionName]?.status;

--- a/vscode-extension/src/model/types.ts
+++ b/vscode-extension/src/model/types.ts
@@ -9,16 +9,16 @@
 
 import * as vscode from 'vscode';
 
-/**
- * Action execution status derived from manifest and agent_status.json
- */
-export type ActionStatus =
-    | 'pending'
-    | 'running'
-    | 'completed'
-    | 'failed'
-    | 'skipped'
-    | 'interrupted';
+// Status resolution lives in status.ts so it stays testable without a VS Code
+// host. Re-exported here because this module is the established import site.
+import type {
+    ActionStatus,
+    AgentStatusData,
+    ManifestActionInfo,
+    ManifestData,
+} from './status';
+
+export type { ActionStatus, AgentStatusData, ManifestActionInfo, ManifestData };
 
 /**
  * Action type inferred from dependencies and configuration
@@ -97,35 +97,6 @@ export interface StatusSummary {
     pending: number;
     skipped: number;
     interrupted: number;
-}
-
-/**
- * Manifest action entry from .manifest.json
- */
-export interface ManifestActionInfo {
-    index?: number;
-    level?: number;
-    status?: string;
-    output_dir?: string;
-    dependencies?: string[];
-    record_count?: number | null;
-}
-
-/**
- * Workflow manifest from agent_io/target/.manifest.json
- */
-export interface ManifestData {
-    workflow_name?: string;
-    execution_order?: string[];
-    levels?: string[][];
-    actions?: Record<string, ManifestActionInfo>;
-}
-
-/**
- * Agent status from agent_io/.agent_status.json (runtime status)
- */
-export interface AgentStatusData {
-    [actionName: string]: string | { status: string; [key: string]: unknown };
 }
 
 /**

--- a/vscode-extension/src/model/types.ts
+++ b/vscode-extension/src/model/types.ts
@@ -91,10 +91,13 @@ export interface WorkflowInfo {
  */
 export interface StatusSummary {
     total: number;
-    completed: number;
-    running: number;
-    failed: number;
     pending: number;
+    running: number;
+    batch_submitted: number;
+    checking_batch: number;
+    completed: number;
+    completed_with_failures: number;
+    failed: number;
     skipped: number;
     interrupted: number;
 }

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -22,6 +22,7 @@ import {
     StatusSummary,
     WorkflowInfo,
 } from './types';
+import { resolveActionStatus } from './status';
 import { readManifest, readAgentStatus } from './manifestReader';
 import { parseWorkflowConfig } from './yamlParser';
 
@@ -34,23 +35,6 @@ const MIN_POLL_INTERVAL_MS = 1000;
 
 /** Debounce delay for file watcher events */
 const DEBOUNCE_MS = 250;
-
-/**
- * Convert raw status string to ActionStatus enum
- */
-function toActionStatus(status: string | undefined): ActionStatus {
-    const normalized = (status ?? '').toLowerCase();
-    if (['pending', 'running', 'completed', 'failed', 'skipped', 'interrupted'].includes(normalized)) {
-        return normalized as ActionStatus;
-    }
-    if (normalized === 'success') {
-        return 'completed';
-    }
-    if (normalized === 'error') {
-        return 'failed';
-    }
-    return 'pending';
-}
 
 /**
  * Infer action type from dependencies and configuration
@@ -82,38 +66,6 @@ function getProjectRoot(configPath: string): string {
         return segments.slice(0, agentConfigIndex).join(path.sep);
     }
     return path.dirname(configPath);
-}
-
-/**
- * Resolve action status from manifest and agent_status.json
- * Agent status takes precedence as it's more up-to-date during execution
- */
-function resolveActionStatus(
-    manifest: ManifestData | null,
-    agentStatus: AgentStatusData | null,
-    actionName: string
-): ActionStatus {
-    // Check agent_status.json first (live runtime status)
-    if (agentStatus) {
-        const statusEntry = agentStatus[actionName];
-        if (typeof statusEntry === 'string') {
-            return toActionStatus(statusEntry);
-        }
-        if (typeof statusEntry === 'object' && statusEntry !== null) {
-            const statusValue = (statusEntry as Record<string, unknown>).status;
-            if (typeof statusValue === 'string') {
-                return toActionStatus(statusValue);
-            }
-        }
-    }
-
-    // Fall back to manifest status
-    const manifestStatus = manifest?.actions?.[actionName]?.status;
-    if (manifestStatus) {
-        return toActionStatus(manifestStatus);
-    }
-
-    return 'pending';
 }
 
 /**

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -14,9 +14,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {
     ActionInfo,
-    ActionStatus,
     ActionType,
-    AgentStatusData,
     ManifestData,
     ParsedWorkflowConfig,
     StatusSummary,

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -473,7 +473,18 @@ export class WorkflowModel implements vscode.Disposable {
                 summary[action.status] += 1;
                 return summary;
             },
-            { total: 0, completed: 0, running: 0, failed: 0, pending: 0, skipped: 0, interrupted: 0 }
+            {
+                total: 0,
+                pending: 0,
+                running: 0,
+                batch_submitted: 0,
+                checking_batch: 0,
+                completed: 0,
+                completed_with_failures: 0,
+                failed: 0,
+                skipped: 0,
+                interrupted: 0,
+            }
         );
 
         // Sort by index

--- a/vscode-extension/src/providers/decorationProvider.ts
+++ b/vscode-extension/src/providers/decorationProvider.ts
@@ -20,6 +20,9 @@ import { WorkflowModel } from '../model/workflowModel';
 const STATUS_COLORS: Record<ActionStatus, vscode.ThemeColor> = {
     completed: new vscode.ThemeColor('gitDecoration.addedResourceForeground'),
     running: new vscode.ThemeColor('gitDecoration.modifiedResourceForeground'),
+    batch_submitted: new vscode.ThemeColor('gitDecoration.submoduleResourceForeground'),
+    checking_batch: new vscode.ThemeColor('gitDecoration.modifiedResourceForeground'),
+    completed_with_failures: new vscode.ThemeColor('gitDecoration.conflictingResourceForeground'),
     failed: new vscode.ThemeColor('gitDecoration.deletedResourceForeground'),
     interrupted: new vscode.ThemeColor('gitDecoration.conflictingResourceForeground'),
     pending: new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),


### PR DESCRIPTION
## Summary

The extension had no tests, and no way to add one: every module imports `vscode`, which has no implementation outside the editor host. So the logic deciding what the sidebar claims about a run was only ever verified by reading it — and it was wrong, in ways nobody caught for months.

Moves `toActionStatus`/`resolveActionStatus` and the JSON shapes they read into a `vscode`-free `model/status.ts`. `types.ts` re-exports them, so existing import sites are unchanged. Behaviour is identical — `agent_status.json` still wins over the manifest.

The runner is `node:test` compiled by the **esbuild already in devDependencies**. No new dependency. `package` and `publish` now run it.

## Verification

- `npm test` — 12 tests over the two functions.
- `npm run typecheck` clean for `vscode-extension/src`; it caught a real defect while writing this (a re-exported type isn't in local scope).
- `npm run build` succeeds.
- **Mutation-checked**: dropping `'interrupted'` from the known-status set fails 4 tests, so the suite bites.
- Python untouched; `gate.sh refactor` recorded 8146 passed, ruff + mypy clean.