### PR TITLE
fix(vscode-extension): read the manifest from where the framework writes it

### DIFF
--- a/docs.agent-actions/docs/guides/editor-setup.md
+++ b/docs.agent-actions/docs/guides/editor-setup.md
@@ -135,7 +135,7 @@ flowchart TB
 
     subgraph "Data Sources"
         CONFIG["agent_config/*.yml"]
-        MANIFEST["agent_io/target/.manifest.json"]
+        MANIFEST["agent_io/logs/.manifest.json"]
         RUNTIME["agent_io/.agent_status.json"]
     end
 
@@ -324,7 +324,7 @@ The Workflow Navigator reads from three sources:
 | File | Purpose | When Updated |
 |------|---------|--------------|
 | `agent_config/*.yml` | Workflow structure, action definitions, dependencies | When you edit the workflow |
-| `agent_io/target/.manifest.json` | Execution plan, action levels, output directories | When workflow starts |
+| `agent_io/logs/.manifest.json` | Execution plan, action levels, output directories | When workflow starts |
 | `agent_io/.agent_status.json` | Live runtime status for each action | During workflow execution |
 
 File watchers automatically refresh the UI when these files change. For more responsive updates during execution, enable polling with `agentActions.refreshInterval`.
@@ -490,7 +490,7 @@ Ensure your project has:
 
 If workflow status isn't refreshing:
 
-1. Check that `agent_io/target/.manifest.json` exists
+1. Check that `agent_io/logs/.manifest.json` exists
 2. Try `Cmd+Shift+R` to manually refresh
 3. Enable polling: `"agentActions.refreshInterval": 2000`
 

--- a/vscode-extension/src/model/manifestReader.ts
+++ b/vscode-extension/src/model/manifestReader.ts
@@ -2,8 +2,8 @@
  * Manifest and Agent Status Reader
  *
  * Reads runtime status from:
- * - agent_io/target/.manifest.json (execution plan and status)
- * - agent_io/.agent_status.json (live runtime status from PR #823)
+ * - the run manifest (execution plan and status) — see paths.ts for where
+ * - agent_io/.agent_status.json (live per-action status)
  */
 
 import * as vscode from 'vscode';

--- a/vscode-extension/src/model/paths.test.ts
+++ b/vscode-extension/src/model/paths.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+    AGENT_STATUS_GLOB,
+    MANIFEST_GLOB,
+    agentStatusPath,
+    manifestCandidatePaths,
+} from './paths';
+
+const AGENT_IO = path.join('proj', 'agent_workflow', 'wf', 'agent_io');
+
+describe('manifestCandidatePaths', () => {
+    it('looks in logs/ first, where the framework writes', () => {
+        assert.equal(
+            manifestCandidatePaths(AGENT_IO)[0],
+            path.join(AGENT_IO, 'logs', '.manifest.json')
+        );
+    });
+
+    it('keeps target/ as a fallback for projects last run before the move', () => {
+        assert.equal(
+            manifestCandidatePaths(AGENT_IO)[1],
+            path.join(AGENT_IO, 'target', '.manifest.json')
+        );
+    });
+
+    it('offers exactly the two known locations', () => {
+        assert.equal(manifestCandidatePaths(AGENT_IO).length, 2);
+    });
+
+    it('never looks for the manifest directly under agent_io', () => {
+        // The bug this replaces: a single hardcoded path that no longer exists.
+        const stray = path.join(AGENT_IO, '.manifest.json');
+        assert.ok(!manifestCandidatePaths(AGENT_IO).includes(stray));
+    });
+});
+
+describe('agentStatusPath', () => {
+    it('resolves directly under agent_io', () => {
+        assert.equal(agentStatusPath(AGENT_IO), path.join(AGENT_IO, '.agent_status.json'));
+    });
+});
+
+describe('watch globs', () => {
+    it('covers both manifest locations so the fallback still refreshes', () => {
+        assert.match(MANIFEST_GLOB, /logs/);
+        assert.match(MANIFEST_GLOB, /target/);
+    });
+
+    it('watches the status file where the framework writes it', () => {
+        assert.equal(AGENT_STATUS_GLOB, '**/agent_io/.agent_status.json');
+    });
+});

--- a/vscode-extension/src/model/paths.test.ts
+++ b/vscode-extension/src/model/paths.test.ts
@@ -30,10 +30,11 @@ describe('manifestCandidatePaths', () => {
         assert.equal(manifestCandidatePaths(AGENT_IO).length, 2);
     });
 
-    it('never looks for the manifest directly under agent_io', () => {
-        // The bug this replaces: a single hardcoded path that no longer exists.
-        const stray = path.join(AGENT_IO, '.manifest.json');
-        assert.ok(!manifestCandidatePaths(AGENT_IO).includes(stray));
+    it('puts the framework-written location ahead of the legacy one', () => {
+        // Order is the whole point: reversing it would serve a pre-migration
+        // manifest in preference to the current run's.
+        const dirs = manifestCandidatePaths(AGENT_IO).map((p) => path.basename(path.dirname(p)));
+        assert.deepEqual(dirs, ['logs', 'target']);
     });
 });
 
@@ -44,9 +45,12 @@ describe('agentStatusPath', () => {
 });
 
 describe('watch globs', () => {
-    it('covers both manifest locations so the fallback still refreshes', () => {
-        assert.match(MANIFEST_GLOB, /logs/);
-        assert.match(MANIFEST_GLOB, /target/);
+    it('covers every location the reader will look in', () => {
+        // Substring checks would pass for a glob that watches nothing, so
+        // derive the expectation from the candidate list itself.
+        const dirs = manifestCandidatePaths(AGENT_IO).map((p) => path.basename(path.dirname(p)));
+        assert.deepEqual(dirs.sort(), ['logs', 'target']);
+        assert.equal(MANIFEST_GLOB, '**/agent_io/{logs,target}/.manifest.json');
     });
 
     it('watches the status file where the framework writes it', () => {

--- a/vscode-extension/src/model/paths.ts
+++ b/vscode-extension/src/model/paths.ts
@@ -1,0 +1,36 @@
+/**
+ * Where the framework writes the runtime files the sidebar reads.
+ *
+ * Free of `vscode` imports so the location rules stay testable — getting one
+ * of these wrong makes the extension silently fall back to guessing, which is
+ * hard to notice and was the state of things before this module existed.
+ */
+
+import * as path from 'node:path';
+
+export const MANIFEST_FILENAME = '.manifest.json';
+export const AGENT_STATUS_FILENAME = '.agent_status.json';
+
+/**
+ * Manifest locations in preference order.
+ *
+ * The framework writes to `agent_io/logs/`. `agent_io/target/` is the
+ * pre-migration location, retained for projects whose last run predates that
+ * move — the same fallback `scan_runs` applies in
+ * agent_actions/tooling/docs/scanner/data_scanners.py.
+ */
+export function manifestCandidatePaths(agentIoPath: string): string[] {
+    return [
+        path.join(agentIoPath, 'logs', MANIFEST_FILENAME),
+        path.join(agentIoPath, 'target', MANIFEST_FILENAME),
+    ];
+}
+
+/** The live per-action status file, written directly under agent_io/. */
+export function agentStatusPath(agentIoPath: string): string {
+    return path.join(agentIoPath, AGENT_STATUS_FILENAME);
+}
+
+/** Watch both manifest locations so the fallback still triggers a refresh. */
+export const MANIFEST_GLOB = '**/agent_io/{logs,target}/.manifest.json';
+export const AGENT_STATUS_GLOB = '**/agent_io/.agent_status.json';

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -21,12 +21,16 @@ import {
     WorkflowInfo,
 } from './types';
 import { resolveActionStatus } from './status';
+import {
+    AGENT_STATUS_GLOB,
+    MANIFEST_GLOB,
+    agentStatusPath,
+    manifestCandidatePaths,
+} from './paths';
 import { readManifest, readAgentStatus } from './manifestReader';
 import { parseWorkflowConfig } from './yamlParser';
 
 const CONFIG_GLOB = '**/agent_config/**/*.{yml,yaml}';
-const MANIFEST_GLOB = '**/agent_io/target/.manifest.json';
-const AGENT_STATUS_GLOB = '**/agent_io/.agent_status.json';
 
 /** Minimum polling interval to prevent excessive refreshes */
 const MIN_POLL_INTERVAL_MS = 1000;
@@ -342,6 +346,22 @@ export class WorkflowModel implements vscode.Disposable {
     }
 
     /**
+     * Read the manifest from the first location that has one.
+     *
+     * Absence of both is normal: a workflow that has never run has no manifest,
+     * and the model falls back to computing execution order from the config.
+     */
+    private async readFirstManifest(agentIoPath: string): Promise<ManifestData | null> {
+        for (const candidate of manifestCandidatePaths(agentIoPath)) {
+            const manifest = await readManifest(vscode.Uri.file(candidate));
+            if (manifest) {
+                return manifest;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Build a WorkflowInfo from parsed config and runtime data
      */
     private async buildWorkflow(
@@ -353,11 +373,10 @@ export class WorkflowModel implements vscode.Disposable {
         const agentIoPath = path.join(rootPath, 'agent_io');
 
         // Read runtime status files
-        const manifestUri = vscode.Uri.file(path.join(agentIoPath, 'target', '.manifest.json'));
-        const statusUri = vscode.Uri.file(path.join(agentIoPath, '.agent_status.json'));
+        const statusUri = vscode.Uri.file(agentStatusPath(agentIoPath));
 
         const [manifest, agentStatus] = await Promise.all([
-            readManifest(manifestUri),
+            this.readFirstManifest(agentIoPath),
             readAgentStatus(statusUri),
         ]);
 

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -348,15 +348,21 @@ export class WorkflowModel implements vscode.Disposable {
     /**
      * Read the manifest from the first location that has one.
      *
-     * Absence of both is normal: a workflow that has never run has no manifest,
-     * and the model falls back to computing execution order from the config.
+     * Absence of all candidates is normal: a workflow that has never run has no
+     * manifest, and the model falls back to computing execution order from the
+     * config. The fallback is keyed on the file being absent rather than on the
+     * read succeeding, so a corrupt current manifest surfaces as no manifest
+     * instead of quietly substituting an older run's from the legacy location.
      */
     private async readFirstManifest(agentIoPath: string): Promise<ManifestData | null> {
         for (const candidate of manifestCandidatePaths(agentIoPath)) {
-            const manifest = await readManifest(vscode.Uri.file(candidate));
-            if (manifest) {
-                return manifest;
+            const uri = vscode.Uri.file(candidate);
+            try {
+                await vscode.workspace.fs.stat(uri);
+            } catch {
+                continue;
             }
+            return await readManifest(uri);
         }
         return null;
     }


### PR DESCRIPTION
## Summary

The extension looked for `agent_io/target/.manifest.json`. The storage refactor (#682, `e4176c17`) moved it to `agent_io/logs/` and stopped writing `target/` at all — there is not one `target/` directory left in the example projects. The manifest has silently never loaded since.

Nothing looked broken, because every read of it is optional: no `execution_order` means fall back to a locally computed topo-sort; no per-action entry means `record_count` stays null and `level` is guessed. The sidebar kept rendering, just from worse data than it had.

Reads `logs/` first, keeping `target/` as a fallback for projects whose last run predates the move — the same fallback `scan_runs` applies in `agent_actions/tooling/docs/scanner/data_scanners.py:194-196`. The file watcher globs both, or the fallback would never trigger a refresh.

## Verification

- Locations live in a `vscode`-free `paths.ts` with 7 tests — this survived precisely because it was only verifiable by reading.
- `npm test` 19 passed, `npm run typecheck` clean for `src`, `npm run build` succeeds.
- `gate.sh refactor`: 8146 passed, ruff + mypy clean.