### PR TITLE
feat(vscode-extension): show workflow status without expanding the tree

### DIFF
--- a/vscode-extension/src/model/status.test.ts
+++ b/vscode-extension/src/model/status.test.ts
@@ -145,10 +145,26 @@ describe('rollupStatus', () => {
 
 describe('workflowSortRank', () => {
     it('puts live workflows above everything else', () => {
-        const ranked = (['completed', 'pending', 'failed', 'running', 'interrupted'] as const)
-            .slice()
-            .sort((a, b) => workflowSortRank(a) - workflowSortRank(b));
-        assert.deepEqual(ranked, ['running', 'failed', 'interrupted', 'pending', 'completed']);
+        const ranked = ACTION_STATUSES.slice().sort(
+            (a, b) => workflowSortRank(a) - workflowSortRank(b) || a.localeCompare(b)
+        );
+        assert.deepEqual(ranked, [
+            'checking_batch',
+            'running',
+            'batch_submitted',
+            'failed',
+            'interrupted',
+            'completed_with_failures',
+            'pending',
+            'completed',
+            'skipped',
+        ]);
+    });
+
+    it('ranks every status, so union drift cannot slip through as last', () => {
+        for (const status of ACTION_STATUSES) {
+            assert.equal(typeof workflowSortRank(status), 'number', status);
+        }
     });
 
     it('gives skipped and completed the same lowest priority', () => {
@@ -159,10 +175,13 @@ describe('workflowSortRank', () => {
 describe('formatWorkflowSummary', () => {
     const base: StatusSummary = {
         total: 12,
-        completed: 0,
-        running: 0,
-        failed: 0,
         pending: 0,
+        running: 0,
+        batch_submitted: 0,
+        checking_batch: 0,
+        completed: 0,
+        completed_with_failures: 0,
+        failed: 0,
         skipped: 0,
         interrupted: 0,
     };
@@ -202,5 +221,66 @@ describe('formatWorkflowSummary', () => {
             undefined
         );
         assert.equal(out, '5/12 · 2 failed');
+    });
+});
+
+describe('rollupStatus for batch and partial-failure runs', () => {
+    it('treats a submitted batch as outstanding, not never-started', () => {
+        assert.notEqual(rollupStatus(['completed', 'batch_submitted']), 'pending');
+    });
+
+    it('treats batch polling as live', () => {
+        assert.equal(rollupStatus(['completed', 'checking_batch']), 'checking_batch');
+    });
+
+    it('does not report a partially failed run as simply completed', () => {
+        assert.equal(
+            rollupStatus(['completed', 'completed_with_failures']),
+            'completed_with_failures'
+        );
+    });
+
+    it('ranks a live run above a submitted batch', () => {
+        assert.equal(rollupStatus(['batch_submitted', 'running']), 'running');
+    });
+});
+
+describe('formatWorkflowSummary for parallel and batch runs', () => {
+    const base: StatusSummary = {
+        total: 12,
+        pending: 0,
+        running: 0,
+        batch_submitted: 0,
+        checking_batch: 0,
+        completed: 0,
+        completed_with_failures: 0,
+        failed: 0,
+        skipped: 0,
+        interrupted: 0,
+    };
+
+    it('counts concurrent actions instead of naming one of them', () => {
+        const out = formatWorkflowSummary(
+            'running',
+            { ...base, completed: 2, running: 5 },
+            'classify_genre'
+        );
+        assert.equal(out, '2/12 · 5 running');
+    });
+
+    it('still names the action when only one is live', () => {
+        const out = formatWorkflowSummary(
+            'running',
+            { ...base, completed: 4, running: 1 },
+            'classify_genre'
+        );
+        assert.equal(out, '4/12 · classify_genre');
+    });
+
+    it('says a batch is outstanding rather than showing a bare count', () => {
+        assert.equal(
+            formatWorkflowSummary('batch_submitted', { ...base, completed: 3, batch_submitted: 1 }),
+            '3/12 · awaiting batch'
+        );
     });
 });

--- a/vscode-extension/src/model/status.test.ts
+++ b/vscode-extension/src/model/status.test.ts
@@ -5,13 +5,14 @@ import { describe, it } from 'node:test';
 
 import {
     ACTION_STATUSES,
+    formatWorkflowSummary,
     parseActionStatus,
     resolveActionStatus,
     rollupStatus,
     toActionStatus,
     workflowSortRank,
 } from './status';
-import type { AgentStatusData, ManifestData } from './status';
+import type { AgentStatusData, ManifestData, StatusSummary } from './status';
 
 describe('toActionStatus', () => {
     it('passes through every status the framework can write', () => {
@@ -152,5 +153,54 @@ describe('workflowSortRank', () => {
 
     it('gives skipped and completed the same lowest priority', () => {
         assert.equal(workflowSortRank('skipped'), workflowSortRank('completed'));
+    });
+});
+
+describe('formatWorkflowSummary', () => {
+    const base: StatusSummary = {
+        total: 12,
+        completed: 0,
+        running: 0,
+        failed: 0,
+        pending: 0,
+        skipped: 0,
+        interrupted: 0,
+    };
+
+    it('names the live action when one is running', () => {
+        const out = formatWorkflowSummary('running', { ...base, completed: 4 }, 'classify_genre');
+        assert.equal(out, '4/12 · classify_genre');
+    });
+
+    it('reports the failure count when nothing is live', () => {
+        assert.equal(formatWorkflowSummary('failed', { ...base, completed: 9, failed: 3 }), '9/12 · 3 failed');
+    });
+
+    it('reports interrupted when there are no failures', () => {
+        assert.equal(
+            formatWorkflowSummary('interrupted', { ...base, completed: 9, interrupted: 1 }),
+            '9/12 · 1 interrupted'
+        );
+    });
+
+    it('explains a short completed count with the skipped total', () => {
+        // Without this a guard-skipped workflow reads as an unexplained 10/12.
+        assert.equal(
+            formatWorkflowSummary('completed', { ...base, completed: 10, skipped: 2 }),
+            '10/12 · 2 skipped'
+        );
+    });
+
+    it('says nothing extra when the count already tells the whole story', () => {
+        assert.equal(formatWorkflowSummary('completed', { ...base, completed: 12 }), '12/12');
+    });
+
+    it('reports at most one detail, the most actionable', () => {
+        const out = formatWorkflowSummary(
+            'failed',
+            { ...base, completed: 5, failed: 2, interrupted: 1, skipped: 3 },
+            undefined
+        );
+        assert.equal(out, '5/12 · 2 failed');
     });
 });

--- a/vscode-extension/src/model/status.test.ts
+++ b/vscode-extension/src/model/status.test.ts
@@ -3,7 +3,14 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
-import { ACTION_STATUSES, parseActionStatus, resolveActionStatus, toActionStatus } from './status';
+import {
+    ACTION_STATUSES,
+    parseActionStatus,
+    resolveActionStatus,
+    rollupStatus,
+    toActionStatus,
+    workflowSortRank,
+} from './status';
 import type { AgentStatusData, ManifestData } from './status';
 
 describe('toActionStatus', () => {
@@ -101,5 +108,49 @@ describe('resolveActionStatus with an unrecognised live value', () => {
         const manifest: ManifestData = { actions: { extract: { status: 'completed' } } };
         const agentStatus = { extract: 'from_the_future' } as AgentStatusData;
         assert.equal(resolveActionStatus(manifest, agentStatus, 'extract'), 'completed');
+    });
+});
+
+describe('rollupStatus', () => {
+    it('reports running when any action is live, whatever else happened', () => {
+        assert.equal(rollupStatus(['completed', 'failed', 'running', 'pending']), 'running');
+    });
+
+    it('reports failed when nothing is live but something failed', () => {
+        assert.equal(rollupStatus(['completed', 'failed', 'pending']), 'failed');
+    });
+
+    it('ranks a failure above an interruption', () => {
+        assert.equal(rollupStatus(['interrupted', 'failed']), 'failed');
+    });
+
+    it('reports interrupted when that is the worst outcome', () => {
+        assert.equal(rollupStatus(['completed', 'interrupted', 'pending']), 'interrupted');
+    });
+
+    it('reports completed only when every action reached a good end', () => {
+        assert.equal(rollupStatus(['completed', 'completed']), 'completed');
+        assert.equal(rollupStatus(['completed', 'skipped']), 'completed');
+    });
+
+    it('does not call a half-finished workflow completed', () => {
+        assert.equal(rollupStatus(['completed', 'pending']), 'pending');
+    });
+
+    it('treats an empty workflow as pending, not completed', () => {
+        assert.equal(rollupStatus([]), 'pending');
+    });
+});
+
+describe('workflowSortRank', () => {
+    it('puts live workflows above everything else', () => {
+        const ranked = (['completed', 'pending', 'failed', 'running', 'interrupted'] as const)
+            .slice()
+            .sort((a, b) => workflowSortRank(a) - workflowSortRank(b));
+        assert.deepEqual(ranked, ['running', 'failed', 'interrupted', 'pending', 'completed']);
+    });
+
+    it('gives skipped and completed the same lowest priority', () => {
+        assert.equal(workflowSortRank('skipped'), workflowSortRank('completed'));
     });
 });

--- a/vscode-extension/src/model/status.ts
+++ b/vscode-extension/src/model/status.ts
@@ -133,3 +133,47 @@ export function resolveActionStatus(
 
     return 'pending';
 }
+
+/**
+ * The status a workflow should show given its actions.
+ *
+ * Ordered by what a reader needs to act on first: a live run outranks a
+ * failure, which outranks an interruption, so the top of the tree answers
+ * "is anything happening, and did anything go wrong" without expanding.
+ * An empty workflow reads as pending, not completed — nothing ran.
+ */
+export function rollupStatus(statuses: readonly ActionStatus[]): ActionStatus {
+    if (statuses.length === 0) {
+        return 'pending';
+    }
+    for (const rank of ['running', 'failed', 'interrupted'] as const) {
+        if (statuses.includes(rank)) {
+            return rank;
+        }
+    }
+    if (statuses.every((s) => s === 'completed' || s === 'skipped')) {
+        return 'completed';
+    }
+    return 'pending';
+}
+
+/**
+ * Sort key placing workflows that need attention at the top of the tree.
+ *
+ * Lower sorts first. Ties are broken by name at the call site so ordering is
+ * stable between refreshes.
+ */
+export function workflowSortRank(status: ActionStatus): number {
+    switch (status) {
+        case 'running':
+            return 0;
+        case 'failed':
+            return 1;
+        case 'interrupted':
+            return 2;
+        case 'pending':
+            return 3;
+        default:
+            return 4;
+    }
+}

--- a/vscode-extension/src/model/status.ts
+++ b/vscode-extension/src/model/status.ts
@@ -142,16 +142,28 @@ export function resolveActionStatus(
  * "is anything happening, and did anything go wrong" without expanding.
  * An empty workflow reads as pending, not completed — nothing ran.
  */
+const ROLLUP_PRECEDENCE: readonly ActionStatus[] = [
+    'running',
+    'checking_batch',
+    'batch_submitted',
+    'failed',
+    'interrupted',
+    'completed_with_failures',
+];
+
+/** Statuses that mean the action reached an acceptable end. */
+const SETTLED: readonly ActionStatus[] = ['completed', 'skipped'];
+
 export function rollupStatus(statuses: readonly ActionStatus[]): ActionStatus {
     if (statuses.length === 0) {
         return 'pending';
     }
-    for (const rank of ['running', 'failed', 'interrupted'] as const) {
+    for (const rank of ROLLUP_PRECEDENCE) {
         if (statuses.includes(rank)) {
             return rank;
         }
     }
-    if (statuses.every((s) => s === 'completed' || s === 'skipped')) {
+    if (statuses.every((s) => SETTLED.includes(s))) {
         return 'completed';
     }
     return 'pending';
@@ -166,25 +178,42 @@ export function rollupStatus(statuses: readonly ActionStatus[]): ActionStatus {
 export function workflowSortRank(status: ActionStatus): number {
     switch (status) {
         case 'running':
+        case 'checking_batch':
             return 0;
-        case 'failed':
+        case 'batch_submitted':
             return 1;
-        case 'interrupted':
+        case 'failed':
             return 2;
-        case 'pending':
+        case 'interrupted':
             return 3;
-        default:
+        case 'completed_with_failures':
             return 4;
+        case 'pending':
+            return 5;
+        case 'completed':
+        case 'skipped':
+            return 6;
     }
+    // No default: adding a status to the union must fail the build here rather
+    // than silently sorting it last. That omission is what let three real
+    // statuses render as never-started.
+    return assertNever(status);
+}
+
+function assertNever(value: never): never {
+    throw new Error(`Unhandled ActionStatus: ${String(value)}`);
 }
 
 /** Status counts for workflow progress display. */
 export interface StatusSummary {
     total: number;
-    completed: number;
-    running: number;
-    failed: number;
     pending: number;
+    running: number;
+    batch_submitted: number;
+    checking_batch: number;
+    completed: number;
+    completed_with_failures: number;
+    failed: number;
     skipped: number;
     interrupted: number;
 }
@@ -202,8 +231,13 @@ export function formatWorkflowSummary(
 ): string {
     const parts = [`${summary.completed}/${summary.total}`];
 
-    if (liveActionName) {
+    if (summary.running > 1) {
+        // A parallel level runs several at once; naming one implies it is alone.
+        parts.push(`${summary.running} running`);
+    } else if (liveActionName) {
         parts.push(liveActionName);
+    } else if (status === 'batch_submitted' || status === 'checking_batch') {
+        parts.push('awaiting batch');
     } else if (summary.failed > 0) {
         parts.push(`${summary.failed} failed`);
     } else if (summary.interrupted > 0) {

--- a/vscode-extension/src/model/status.ts
+++ b/vscode-extension/src/model/status.ts
@@ -177,3 +177,40 @@ export function workflowSortRank(status: ActionStatus): number {
             return 4;
     }
 }
+
+/** Status counts for workflow progress display. */
+export interface StatusSummary {
+    total: number;
+    completed: number;
+    running: number;
+    failed: number;
+    pending: number;
+    skipped: number;
+    interrupted: number;
+}
+
+/**
+ * The one-line summary shown on a collapsed workflow row.
+ *
+ * Reports at most one detail, the most actionable one. Skipped is included so
+ * a workflow that finished with completed < total does not look unexplained.
+ */
+export function formatWorkflowSummary(
+    status: ActionStatus,
+    summary: StatusSummary,
+    liveActionName?: string
+): string {
+    const parts = [`${summary.completed}/${summary.total}`];
+
+    if (liveActionName) {
+        parts.push(liveActionName);
+    } else if (summary.failed > 0) {
+        parts.push(`${summary.failed} failed`);
+    } else if (summary.interrupted > 0) {
+        parts.push(`${summary.interrupted} interrupted`);
+    } else if (summary.skipped > 0) {
+        parts.push(`${summary.skipped} skipped`);
+    }
+
+    return parts.join(' \u00B7 ');
+}

--- a/vscode-extension/src/model/types.ts
+++ b/vscode-extension/src/model/types.ts
@@ -16,9 +16,10 @@ import type {
     AgentStatusData,
     ManifestActionInfo,
     ManifestData,
+    StatusSummary,
 } from './status';
 
-export type { ActionStatus, AgentStatusData, ManifestActionInfo, ManifestData };
+export type { ActionStatus, AgentStatusData, ManifestActionInfo, ManifestData, StatusSummary };
 
 /**
  * Action type inferred from dependencies and configuration
@@ -84,22 +85,6 @@ export interface WorkflowInfo {
     levels: Map<number, ActionInfo[]>;
     /** Summary of action statuses */
     statusSummary: StatusSummary;
-}
-
-/**
- * Status counts for workflow progress display
- */
-export interface StatusSummary {
-    total: number;
-    pending: number;
-    running: number;
-    batch_submitted: number;
-    checking_batch: number;
-    completed: number;
-    completed_with_failures: number;
-    failed: number;
-    skipped: number;
-    interrupted: number;
 }
 
 /**

--- a/vscode-extension/src/providers/treeViewProvider.ts
+++ b/vscode-extension/src/providers/treeViewProvider.ts
@@ -32,6 +32,13 @@ class WorkflowNode extends vscode.TreeItem {
         this.description = this.formatDescription();
         this.tooltip = this.buildTooltip();
         this.iconPath = getStatusIcon(status);
+        // Without this the row is inert: it has no context-menu contribution
+        // either, so a click would do nothing at all.
+        this.command = {
+            command: 'vscode.open',
+            title: 'Open Workflow Config',
+            arguments: [vscode.Uri.file(workflow.configPath)],
+        };
     }
 
     /** Everything needed to triage, on the collapsed row. */

--- a/vscode-extension/src/providers/treeViewProvider.ts
+++ b/vscode-extension/src/providers/treeViewProvider.ts
@@ -11,6 +11,7 @@
 
 import * as vscode from 'vscode';
 import { ActionInfo, ActionStatus, WorkflowInfo } from '../model/types';
+import { rollupStatus, workflowSortRank } from '../model/status';
 import { WorkflowModel } from '../model/workflowModel';
 
 /**
@@ -22,12 +23,32 @@ type TreeNode = WorkflowNode | ActionNode | ActionGroupNode | DataPreviewNode;
  * Workflow root node
  */
 class WorkflowNode extends vscode.TreeItem {
-    constructor(public readonly workflow: WorkflowInfo) {
+    constructor(
+        public readonly workflow: WorkflowInfo,
+        public readonly status: ActionStatus
+    ) {
         super(workflow.name, vscode.TreeItemCollapsibleState.Expanded);
         this.contextValue = 'agentActions.workflow';
-        this.description = `${workflow.statusSummary.completed}/${workflow.statusSummary.total} completed`;
+        this.description = this.formatDescription();
         this.tooltip = this.buildTooltip();
-        this.iconPath = new vscode.ThemeIcon('graph');
+        this.iconPath = getStatusIcon(status);
+    }
+
+    /** Everything needed to triage, on the collapsed row. */
+    private formatDescription(): string {
+        const s = this.workflow.statusSummary;
+        const parts = [`${getStatusLabel(this.status)} ${s.completed}/${s.total}`];
+
+        const live = this.workflow.actions.find((a) => a.status === 'running');
+        if (live) {
+            parts.push(live.name);
+        } else if (s.failed > 0) {
+            parts.push(`${s.failed} failed`);
+        } else if (s.interrupted > 0) {
+            parts.push(`${s.interrupted} interrupted`);
+        }
+
+        return parts.join(' \u00B7 ');
     }
 
     private buildTooltip(): string {
@@ -191,18 +212,18 @@ export class WorkflowTreeProvider implements vscode.TreeDataProvider<TreeNode>, 
     }
 
     getChildren(element?: TreeNode): TreeNode[] {
-        // Root level: show workflows
+        // Root level: one row per workflow, carrying its rolled-up status.
+        // Always shown, even for a single workflow — the row is where progress
+        // and liveness live, and the node starts expanded so nothing is buried.
         if (!element) {
-            const workflows = this.model.getWorkflows();
-            if (workflows.length === 0) {
-                return [];
-            }
-            // If single workflow, show actions directly
-            if (workflows.length === 1) {
-                return this.buildActionNodes(workflows[0].actions);
-            }
-            // Multiple workflows: show workflow nodes
-            return workflows.map((w) => new WorkflowNode(w));
+            return this.model
+                .getWorkflows()
+                .map((w) => new WorkflowNode(w, rollupStatus(w.actions.map((a) => a.status))))
+                .sort(
+                    (a, b) =>
+                        workflowSortRank(a.status) - workflowSortRank(b.status) ||
+                        a.workflow.name.localeCompare(b.workflow.name)
+                );
         }
 
         // Workflow level: show actions (with grouping)

--- a/vscode-extension/src/providers/treeViewProvider.ts
+++ b/vscode-extension/src/providers/treeViewProvider.ts
@@ -11,7 +11,7 @@
 
 import * as vscode from 'vscode';
 import { ActionInfo, ActionStatus, WorkflowInfo } from '../model/types';
-import { rollupStatus, workflowSortRank } from '../model/status';
+import { formatWorkflowSummary, rollupStatus, workflowSortRank } from '../model/status';
 import { WorkflowModel } from '../model/workflowModel';
 
 /**
@@ -36,19 +36,13 @@ class WorkflowNode extends vscode.TreeItem {
 
     /** Everything needed to triage, on the collapsed row. */
     private formatDescription(): string {
-        const s = this.workflow.statusSummary;
-        const parts = [`${getStatusLabel(this.status)} ${s.completed}/${s.total}`];
-
         const live = this.workflow.actions.find((a) => a.status === 'running');
-        if (live) {
-            parts.push(live.name);
-        } else if (s.failed > 0) {
-            parts.push(`${s.failed} failed`);
-        } else if (s.interrupted > 0) {
-            parts.push(`${s.interrupted} interrupted`);
-        }
-
-        return parts.join(' \u00B7 ');
+        const summary = formatWorkflowSummary(
+            this.status,
+            this.workflow.statusSummary,
+            live?.name
+        );
+        return `${getStatusLabel(this.status)} ${summary}`;
     }
 
     private buildTooltip(): string {


### PR DESCRIPTION
## Summary

Answers the original report: *"I have to open all of them to see which ones are actively running."*

Status lived only on leaf nodes, so triage meant expanding every workflow. Worse, the workflow row was skipped entirely when a project had a single workflow — and that row was where the progress summary lived, so the common case showed no summary at all.

Every workflow now gets a row carrying its rolled-up status: **running beats failed beats interrupted**, ordered by what a reader needs to act on first. The row names the live action when there is one, and the failed/interrupted count otherwise, so a collapsed tree answers "is anything happening, and did anything go wrong". Live workflows sort to the top, ties broken by name so ordering is stable between refreshes.

```
● book_catalog_enrichment    ↻ 4/14 · classify_genre
⚠ support_resolution         ⚠ 6/12 · 1 interrupted
✓ contract_reviewer          ✓ 12/12
```

The row is always present now, including for a single workflow, but starts expanded — so that case gains a summary without gaining a click.

## Verification

- Rollup and ordering are pure functions in `status.ts` with 9 tests, including that a half-finished workflow is **not** reported completed and an empty one is pending rather than completed.
- `npm test` 28 passed, `npm run typecheck` clean for `src`, `npm run build` succeeds.
- `gate.sh refactor`: 8146 passed, ruff + mypy clean.

## Not done

The rendering is verified by unit tests and typecheck, not by driving the extension host — there is no integration harness for that, and adding one is a larger piece of work than this change warrants.