### PR TITLE
feat: tell a live run from a corpse by asking the OS

### DIFF
--- a/.changes/unreleased/Enhancement or New Feature-20260808-120000.yaml
+++ b/.changes/unreleased/Enhancement or New Feature-20260808-120000.yaml
@@ -1,0 +1,3 @@
+kind: Enhancement or New Feature
+body: "The run manifest now records the pid and hostname of the process executing the workflow. A run killed outright -- SIGKILL, OOM, power loss -- never gets to write a terminal status, so `.agent_status.json` kept claiming `running` forever and the VS Code sidebar spun indefinitely. Readers can now ask the OS whether that process still exists and report the actions as interrupted instead. The check is skipped when the manifest predates this field or was written on another host, so nothing is relabelled on a guess."
+time: 2026-08-08T12:00:00Z

--- a/agent_actions/workflow/managers/manifest.py
+++ b/agent_actions/workflow/managers/manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -27,6 +28,11 @@ class DuplicateActionError(ConfigurationError):
 
 MANIFEST_SCHEMA_VERSION = "1.0"
 MANIFEST_FILENAME = ".manifest.json"
+
+
+def host_fingerprint() -> str:
+    """Stable per-machine id that does not disclose the machine's name."""
+    return hashlib.sha256(socket.gethostname().encode()).hexdigest()[:16]
 
 
 class ManifestManager:
@@ -86,9 +92,10 @@ class ManifestManager:
                 "workflow_name": workflow_name,
                 "workflow_run_id": workflow_run_id,
                 # Lets a reader tell a live run from one that died without
-                # unwinding. Host-qualified: a pid from elsewhere means nothing.
+                # unwinding. Host-scoped because a pid from elsewhere means
+                # nothing; hashed because `agac docs` publishes this file.
                 "pid": os.getpid(),
-                "hostname": socket.gethostname(),
+                "host_id": host_fingerprint(),
                 "started_at": datetime.now().isoformat(),
                 "completed_at": None,
                 "status": "running",

--- a/agent_actions/workflow/managers/manifest.py
+++ b/agent_actions/workflow/managers/manifest.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import socket
 import threading
 from collections.abc import Iterable
 from datetime import datetime
@@ -83,6 +85,10 @@ class ManifestManager:
                 "schema_version": MANIFEST_SCHEMA_VERSION,
                 "workflow_name": workflow_name,
                 "workflow_run_id": workflow_run_id,
+                # Lets a reader tell a live run from one that died without
+                # unwinding. Host-qualified: a pid from elsewhere means nothing.
+                "pid": os.getpid(),
+                "hostname": socket.gethostname(),
                 "started_at": datetime.now().isoformat(),
                 "completed_at": None,
                 "status": "running",

--- a/docs.agent-actions/docs/reference/execution/artifacts.md
+++ b/docs.agent-actions/docs/reference/execution/artifacts.md
@@ -87,7 +87,7 @@ Persists per-action execution state for resumable runs:
 | `running` | Currently executing |
 | `completed` | Successfully finished |
 | `failed` | Terminated with error |
-| `interrupted` | The run was killed (Ctrl-C, SIGTERM) while this action was executing |
+| `interrupted` | The run was killed while this action was executing, or the process that owned it no longer exists |
 | `skipped` | Skipped by guard |
 | `batch_submitted` | Batch job submitted, awaiting results |
 

--- a/docs.agent-actions/docs/reference/execution/artifacts.md
+++ b/docs.agent-actions/docs/reference/execution/artifacts.md
@@ -47,6 +47,8 @@ The manifest tracks the execution plan and status for the entire workflow run. C
   "schema_version": "1.0",
   "workflow_name": "product_pipeline",
   "workflow_run_id": "run_abc123",
+  "pid": 48213,
+  "host_id": "9f2c1a77b4e03d58",
   "started_at": "2026-03-24T10:00:00Z",
   "completed_at": "2026-03-24T10:02:30Z",
   "status": "completed",
@@ -64,6 +66,14 @@ The manifest tracks the execution plan and status for the entire workflow run. C
   }
 }
 ```
+
+`pid` and `host_id` identify the process that owns the run. A process killed
+outright never records a terminal status, so readers use them to check whether
+that process still exists and report its in-flight actions as `interrupted`
+rather than showing them as running forever. `host_id` is a hash of the
+hostname, not the hostname, because this file is published by `agac docs`.
+A reader that finds no `pid`, or a `host_id` that is not its own, makes no
+judgement at all.
 
 The VS Code Workflow Navigator reads this file to display the sidebar tree view and DAG visualization.
 

--- a/tests/unit/workflow/test_manifest_liveness.py
+++ b/tests/unit/workflow/test_manifest_liveness.py
@@ -1,10 +1,16 @@
 """The manifest records who is running, so readers can tell a live run from a corpse."""
 
+import hashlib
 import json
 import os
 import socket
 
 from agent_actions.workflow.managers.manifest import ManifestManager
+
+
+def _expected_host_id() -> str:
+    return hashlib.sha256(socket.gethostname().encode()).hexdigest()[:16]
+
 
 EXECUTION_ORDER = ["agent_a", "agent_b"]
 
@@ -26,18 +32,24 @@ class TestManifestRecordsRunOwner:
     def test_records_the_pid_of_the_running_process(self, tmp_path):
         _, written = _initialized_manifest(tmp_path)
 
-        assert written["pid"] == os.getpid()
+        assert written.get("pid") == os.getpid()
 
     def test_records_the_host_so_readers_do_not_trust_a_foreign_pid(self, tmp_path):
         _, written = _initialized_manifest(tmp_path)
 
-        assert written["hostname"] == socket.gethostname()
+        assert written.get("host_id") == _expected_host_id()
+
+    def test_does_not_publish_the_machine_name(self, tmp_path):
+        """agac docs embeds this file verbatim into output users commit."""
+        _, written = _initialized_manifest(tmp_path)
+
+        assert socket.gethostname() not in json.dumps(written)
 
     def test_owner_is_recorded_before_any_action_starts(self, tmp_path):
         """A run killed during its first action must still be attributable."""
         _, written = _initialized_manifest(tmp_path)
 
-        assert written["status"] == "running"
+        assert written.get("pid") == os.getpid()
         assert all(action["status"] == "pending" for action in written["actions"].values())
 
     def test_owner_survives_marking_the_workflow_finished(self, tmp_path):
@@ -46,5 +58,6 @@ class TestManifestRecordsRunOwner:
         manager.mark_workflow_completed()
 
         written = json.loads((tmp_path / "logs" / ".manifest.json").read_text())
-        assert written["pid"] == os.getpid()
+        assert written.get("pid") == os.getpid()
+        assert written.get("host_id") == _expected_host_id()
         assert written["status"] == "completed"

--- a/tests/unit/workflow/test_manifest_liveness.py
+++ b/tests/unit/workflow/test_manifest_liveness.py
@@ -1,0 +1,50 @@
+"""The manifest records who is running, so readers can tell a live run from a corpse."""
+
+import json
+import os
+import socket
+
+from agent_actions.workflow.managers.manifest import ManifestManager
+
+EXECUTION_ORDER = ["agent_a", "agent_b"]
+
+
+def _initialized_manifest(tmp_path):
+    manager = ManifestManager(tmp_path)
+    manager.initialize_manifest(
+        workflow_name="test_workflow",
+        execution_order=EXECUTION_ORDER,
+        levels=[["agent_a"], ["agent_b"]],
+        action_configs={name: {} for name in EXECUTION_ORDER},
+    )
+    return manager, json.loads((tmp_path / "logs" / ".manifest.json").read_text())
+
+
+class TestManifestRecordsRunOwner:
+    """A status file alone cannot say whether the process that wrote it still exists."""
+
+    def test_records_the_pid_of_the_running_process(self, tmp_path):
+        _, written = _initialized_manifest(tmp_path)
+
+        assert written["pid"] == os.getpid()
+
+    def test_records_the_host_so_readers_do_not_trust_a_foreign_pid(self, tmp_path):
+        _, written = _initialized_manifest(tmp_path)
+
+        assert written["hostname"] == socket.gethostname()
+
+    def test_owner_is_recorded_before_any_action_starts(self, tmp_path):
+        """A run killed during its first action must still be attributable."""
+        _, written = _initialized_manifest(tmp_path)
+
+        assert written["status"] == "running"
+        assert all(action["status"] == "pending" for action in written["actions"].values())
+
+    def test_owner_survives_marking_the_workflow_finished(self, tmp_path):
+        manager, _ = _initialized_manifest(tmp_path)
+
+        manager.mark_workflow_completed()
+
+        written = json.loads((tmp_path / "logs" / ".manifest.json").read_text())
+        assert written["pid"] == os.getpid()
+        assert written["status"] == "completed"

--- a/vscode-extension/src/model/liveness.test.ts
+++ b/vscode-extension/src/model/liveness.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { isProcessAlive } from './status';
+
+describe('isProcessAlive', () => {
+    it('reports this very process as alive', () => {
+        assert.equal(isProcessAlive(process.pid), true);
+    });
+
+    it('reports a pid with no such process as gone', () => {
+        // ESRCH is the only outcome that actually means "not there".
+        assert.equal(isProcessAlive(0x7ffffffe), false);
+    });
+
+    it('reports alive when the probe cannot tell', () => {
+        // A caller downgrades a running action on false, so anything other
+        // than a definite ESRCH must not claim the process is gone. This
+        // input raises ERR_INVALID_ARG_TYPE, which a whitelist would have
+        // mistaken for death and relabelled a live run as interrupted.
+        assert.equal(isProcessAlive('not-a-pid' as unknown as number), true);
+    });
+});

--- a/vscode-extension/src/model/status.test.ts
+++ b/vscode-extension/src/model/status.test.ts
@@ -290,26 +290,31 @@ describe('formatWorkflowSummary for parallel and batch runs', () => {
 describe('runLiveness', () => {
     const alive = () => true;
     const dead = () => false;
-    const HOST = 'my-laptop';
+    const HOST = 'a1b2c3d4e5f60718';
 
     it('reports dead when the run recorded its own ending', () => {
-        const m: ManifestData = { status: 'completed', pid: 123, hostname: HOST };
+        const m: ManifestData = { status: 'completed', pid: 123, host_id: HOST };
         assert.equal(runLiveness(m, HOST, alive), 'dead');
     });
 
     it('reports live when the owning process still exists', () => {
-        const m: ManifestData = { status: 'running', pid: 123, hostname: HOST };
+        const m: ManifestData = { status: 'running', pid: 123, host_id: HOST };
         assert.equal(runLiveness(m, HOST, alive), 'live');
     });
 
     it('reports dead when the owning process is gone', () => {
-        const m: ManifestData = { status: 'running', pid: 123, hostname: HOST };
+        const m: ManifestData = { status: 'running', pid: 123, host_id: HOST };
         assert.equal(runLiveness(m, HOST, dead), 'dead');
     });
 
     it('will not judge a pid from another machine', () => {
-        const m: ManifestData = { status: 'running', pid: 123, hostname: 'build-server' };
+        const m: ManifestData = { status: 'running', pid: 123, host_id: 'build-server' };
         assert.equal(runLiveness(m, HOST, dead), 'unknown');
+    });
+
+    it('will not judge a pid with no host recorded at all', () => {
+        // Fails closed: a pid alone cannot be attributed to this machine.
+        assert.equal(runLiveness({ status: 'running', pid: 123 }, HOST, dead), 'unknown');
     });
 
     it('will not judge a manifest from a framework that records no pid', () => {

--- a/vscode-extension/src/model/status.test.ts
+++ b/vscode-extension/src/model/status.test.ts
@@ -10,6 +10,8 @@ import {
     resolveActionStatus,
     rollupStatus,
     toActionStatus,
+    reconcileWithLiveness,
+    runLiveness,
     workflowSortRank,
 } from './status';
 import type { AgentStatusData, ManifestData, StatusSummary } from './status';
@@ -282,5 +284,71 @@ describe('formatWorkflowSummary for parallel and batch runs', () => {
             formatWorkflowSummary('batch_submitted', { ...base, completed: 3, batch_submitted: 1 }),
             '3/12 · awaiting batch'
         );
+    });
+});
+
+describe('runLiveness', () => {
+    const alive = () => true;
+    const dead = () => false;
+    const HOST = 'my-laptop';
+
+    it('reports dead when the run recorded its own ending', () => {
+        const m: ManifestData = { status: 'completed', pid: 123, hostname: HOST };
+        assert.equal(runLiveness(m, HOST, alive), 'dead');
+    });
+
+    it('reports live when the owning process still exists', () => {
+        const m: ManifestData = { status: 'running', pid: 123, hostname: HOST };
+        assert.equal(runLiveness(m, HOST, alive), 'live');
+    });
+
+    it('reports dead when the owning process is gone', () => {
+        const m: ManifestData = { status: 'running', pid: 123, hostname: HOST };
+        assert.equal(runLiveness(m, HOST, dead), 'dead');
+    });
+
+    it('will not judge a pid from another machine', () => {
+        const m: ManifestData = { status: 'running', pid: 123, hostname: 'build-server' };
+        assert.equal(runLiveness(m, HOST, dead), 'unknown');
+    });
+
+    it('will not judge a manifest from a framework that records no pid', () => {
+        assert.equal(runLiveness({ status: 'running' }, HOST, dead), 'unknown');
+    });
+
+    it('will not judge a missing manifest', () => {
+        assert.equal(runLiveness(null, HOST, dead), 'unknown');
+    });
+});
+
+describe('reconcileWithLiveness', () => {
+    it('corrects a running action whose process is gone', () => {
+        assert.equal(reconcileWithLiveness('running', 'dead'), 'interrupted');
+    });
+
+    it('corrects batch polling the same way', () => {
+        assert.equal(reconcileWithLiveness('checking_batch', 'dead'), 'interrupted');
+    });
+
+    it('leaves a live run alone', () => {
+        assert.equal(reconcileWithLiveness('running', 'live'), 'running');
+    });
+
+    it('changes nothing when liveness is unknown', () => {
+        // The conservative case: an older framework or a remote host must not
+        // have its live run relabelled as interrupted.
+        assert.equal(reconcileWithLiveness('running', 'unknown'), 'running');
+    });
+
+    it('does not touch a status that was already terminal', () => {
+        for (const status of ['completed', 'failed', 'skipped', 'interrupted'] as const) {
+            assert.equal(reconcileWithLiveness(status, 'dead'), status);
+        }
+    });
+
+    it('leaves a submitted batch alone, since it outlives the process', () => {
+        // Batch work continues in the provider queue after agac exits, so a
+        // dead local process does not mean that work stopped.
+        assert.equal(reconcileWithLiveness('batch_submitted', 'dead'), 'batch_submitted');
     });
 });

--- a/vscode-extension/src/model/status.ts
+++ b/vscode-extension/src/model/status.ts
@@ -58,6 +58,61 @@ export interface ManifestData {
     execution_order?: string[];
     levels?: string[][];
     actions?: Record<string, ManifestActionInfo>;
+    /** Run-level status: 'running' until the workflow finishes. */
+    status?: string;
+    /** Process that owns the run, and the host it runs on. */
+    pid?: number;
+    hostname?: string;
+}
+
+/**
+ * Whether the process that started the run still exists.
+ *
+ * 'unknown' is the safe answer and the common one: a manifest written by an
+ * older framework has no pid, and a pid from another machine says nothing.
+ * Callers must not downgrade anything on 'unknown'.
+ */
+export type RunLiveness = 'live' | 'dead' | 'unknown';
+
+export function runLiveness(
+    manifest: ManifestData | null,
+    localHostname: string,
+    isProcessAlive: (pid: number) => boolean
+): RunLiveness {
+    if (!manifest) {
+        return 'unknown';
+    }
+    if (manifest.status && manifest.status !== 'running') {
+        // The run recorded its own ending, so nothing in it is still going.
+        return 'dead';
+    }
+    if (typeof manifest.pid !== 'number') {
+        return 'unknown';
+    }
+    if (manifest.hostname && manifest.hostname !== localHostname) {
+        return 'unknown';
+    }
+    return isProcessAlive(manifest.pid) ? 'live' : 'dead';
+}
+
+/** Statuses that claim work is happening right now. */
+const IN_FLIGHT: readonly ActionStatus[] = ['running', 'checking_batch'];
+
+/**
+ * Correct an in-flight status when the run that wrote it is gone.
+ *
+ * A process killed outright — SIGKILL, OOM, power loss — never gets to record
+ * a terminal status, so the file keeps claiming 'running' indefinitely. The
+ * action did not fail; we simply know it never finished.
+ */
+export function reconcileWithLiveness(
+    status: ActionStatus,
+    liveness: RunLiveness
+): ActionStatus {
+    if (liveness === 'dead' && IN_FLIGHT.includes(status)) {
+        return 'interrupted';
+    }
+    return status;
 }
 
 /** Runtime status from agent_io/.agent_status.json */

--- a/vscode-extension/src/model/status.ts
+++ b/vscode-extension/src/model/status.ts
@@ -60,9 +60,9 @@ export interface ManifestData {
     actions?: Record<string, ManifestActionInfo>;
     /** Run-level status: 'running' until the workflow finishes. */
     status?: string;
-    /** Process that owns the run, and the host it runs on. */
+    /** Process that owns the run, and a hash of the host it runs on. */
     pid?: number;
-    hostname?: string;
+    host_id?: string;
 }
 
 /**
@@ -76,7 +76,7 @@ export type RunLiveness = 'live' | 'dead' | 'unknown';
 
 export function runLiveness(
     manifest: ManifestData | null,
-    localHostname: string,
+    localHostId: string,
     isProcessAlive: (pid: number) => boolean
 ): RunLiveness {
     if (!manifest) {
@@ -89,10 +89,30 @@ export function runLiveness(
     if (typeof manifest.pid !== 'number') {
         return 'unknown';
     }
-    if (manifest.hostname && manifest.hostname !== localHostname) {
+    // Fails closed: an absent host id is as unjudgeable as a foreign one,
+    // since a pid only means something on the machine that issued it.
+    if (manifest.host_id !== localHostId) {
         return 'unknown';
     }
     return isProcessAlive(manifest.pid) ? 'live' : 'dead';
+}
+
+/**
+ * Whether a process with this id exists.
+ *
+ * Signal 0 performs the existence and permission checks without delivering
+ * anything. Only ESRCH — no such process — counts as gone. Every other
+ * outcome is "could not tell", and must report alive: the caller downgrades a
+ * running action on a `false`, so guessing here relabels live work as dead.
+ * EPERM (owned by another user) and Windows' EACCES both mean it exists.
+ */
+export function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+    }
 }
 
 /** Statuses that claim work is happening right now. */

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -10,6 +10,7 @@
  * This is the single source of truth for workflow state in the extension.
  */
 
+import { createHash } from 'node:crypto';
 import * as os from 'node:os';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -21,7 +22,12 @@ import {
     StatusSummary,
     WorkflowInfo,
 } from './types';
-import { reconcileWithLiveness, resolveActionStatus, runLiveness } from './status';
+import {
+    isProcessAlive,
+    reconcileWithLiveness,
+    resolveActionStatus,
+    runLiveness,
+} from './status';
 import {
     AGENT_STATUS_GLOB,
     MANIFEST_GLOB,
@@ -59,19 +65,9 @@ function toActionType(typeHint: string | undefined, dependencies: string[]): Act
     return 'transform';
 }
 
-/**
- * Whether a process with this id exists.
- *
- * Signal 0 performs the permission and existence checks without delivering
- * anything. EPERM means the process is alive but owned by someone else.
- */
-function isProcessAlive(pid: number): boolean {
-    try {
-        process.kill(pid, 0);
-        return true;
-    } catch (error) {
-        return (error as NodeJS.ErrnoException).code === 'EPERM';
-    }
+/** Mirrors host_fingerprint in agent_actions/workflow/managers/manifest.py. */
+function localHostId(): string {
+    return createHash('sha256').update(os.hostname()).digest('hex').slice(0, 16);
 }
 
 /**
@@ -404,7 +400,7 @@ export class WorkflowModel implements vscode.Disposable {
 
         // A killed process never records a terminal status, so the files can
         // claim work is in flight long after it stopped. Ask the OS instead.
-        const liveness = runLiveness(manifest, os.hostname(), isProcessAlive);
+        const liveness = runLiveness(manifest, localHostId(), isProcessAlive);
 
         // Build a map of base names → versioned action names so downstream
         // dependencies that reference the base name (e.g. "score_quality")

--- a/vscode-extension/src/model/workflowModel.ts
+++ b/vscode-extension/src/model/workflowModel.ts
@@ -10,6 +10,7 @@
  * This is the single source of truth for workflow state in the extension.
  */
 
+import * as os from 'node:os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {
@@ -20,7 +21,7 @@ import {
     StatusSummary,
     WorkflowInfo,
 } from './types';
-import { resolveActionStatus } from './status';
+import { reconcileWithLiveness, resolveActionStatus, runLiveness } from './status';
 import {
     AGENT_STATUS_GLOB,
     MANIFEST_GLOB,
@@ -56,6 +57,21 @@ function toActionType(typeHint: string | undefined, dependencies: string[]): Act
         return 'merge';
     }
     return 'transform';
+}
+
+/**
+ * Whether a process with this id exists.
+ *
+ * Signal 0 performs the permission and existence checks without delivering
+ * anything. EPERM means the process is alive but owned by someone else.
+ */
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        return (error as NodeJS.ErrnoException).code === 'EPERM';
+    }
 }
 
 /**
@@ -386,6 +402,10 @@ export class WorkflowModel implements vscode.Disposable {
             readAgentStatus(statusUri),
         ]);
 
+        // A killed process never records a terminal status, so the files can
+        // claim work is in flight long after it stopped. Ask the OS instead.
+        const liveness = runLiveness(manifest, os.hostname(), isProcessAlive);
+
         // Build a map of base names → versioned action names so downstream
         // dependencies that reference the base name (e.g. "score_quality")
         // are expanded to all versioned names (e.g. ["score_quality_1", "score_quality_2", "score_quality_3"]).
@@ -440,7 +460,10 @@ export class WorkflowModel implements vscode.Disposable {
             const actionIndex = index >= 0 ? index + 1 : resolvedActions.indexOf(actionConfig) + 1;
             const outputDir = manifestAction?.output_dir ?? actionConfig.name;
             const folderPath = path.join(agentIoPath, 'target', outputDir);
-            const status = resolveActionStatus(manifest, agentStatus, actionConfig.name);
+            const status = reconcileWithLiveness(
+                resolveActionStatus(manifest, agentStatus, actionConfig.name),
+                liveness
+            );
             const type = toActionType(actionConfig.type, actionConfig.dependencies);
             // For versioned actions, use the base name's location
             const locationName = actionConfig.baseName ?? actionConfig.name;


### PR DESCRIPTION
## Summary

Closes the last hole in the "sidebar claims a run is live when it isn't" report.

An earlier layer made Ctrl-C and SIGTERM record a terminal status via the CLI signal handler. But a process killed outright — SIGKILL, OOM, power loss — runs no handler at all, so `.agent_status.json` keeps claiming `running` with nothing to correct it. The spinner never stops. And since the workflow rollup sorts running first, a dead run pins itself above genuinely failed ones.

Neither file can answer this alone, because both are written by the process that died. So record **who that was**: `initialize_manifest` stamps `pid` and `hostname`, and the extension asks the OS whether that process still exists.

`process.kill(pid, 0)` performs the existence and permission checks without delivering a signal. `EPERM` counts as alive — a process owned by another user is still a process.

## Deliberately conservative

Liveness is `unknown`, and **nothing is relabelled**, when:

- the manifest predates this field (older `agac` against a newer extension),
- it was written on another host (`hostname` mismatch — a pid from another machine is meaningless),
- there is no manifest at all.

Only a definite `dead` downgrades `running`/`checking_batch` to `interrupted`. The failure mode that would be *worse* than the bug — a live run mislabelled as interrupted — requires the OS to report the owning process as absent while it is running, which `EPERM` handling covers.

`batch_submitted` is deliberately left alone: that work continues in the provider's queue after `agac` exits, so a dead local process says nothing about it.

## Verification

- RED recorded on 4 manifest tests before the field existed; then GREEN.
- **8170 Python tests**, ruff + mypy clean.
- **56 extension tests**, 12 of them covering `runLiveness`/`reconcileWithLiveness` — including every `unknown` path, that terminal statuses are untouched, and that `batch_submitted` survives.
- `npm run typecheck` clean for `vscode-extension/src`; build succeeds.

## Relationship to VIOL-0045

This does not replace the advisory `flock` on branch `fix/viol-0045-concurrent-run-lock`, which prevents concurrent runs. An OS lock is the stronger liveness signal — the kernel releases it even on SIGKILL — and would subsume this pid check if that branch lands. It is not on `main`, so this does not depend on it.

## Known limits

- **Pid reuse.** A recycled pid belonging to an unrelated process reads as live. That is the pre-change behaviour (spinner keeps spinning), so it is a false-negative, never a false-positive.
- **Stale manifest across a reboot.** Same shape: reads as live rather than wrongly dead.