### PR TITLE
docs: correct what actually publishes a release

### DIFF
--- a/.changes/unreleased/Under the Hood-20260808-203000.yaml
+++ b/.changes/unreleased/Under the Hood-20260808-203000.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: "RELEASING.md said pushing a v* tag publishes to PyPI. It does not — publish.yml triggers on `release: published`, so a tag alone reaches nothing. Corrected, and documented the release-PR changelog entry the CI job requires, the pre-tag version check, and the manual VS Code extension publish."
+time: 2026-08-08T20:30:00Z

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,26 +30,80 @@ task changelog:merge
 
 This updates the version in both `pyproject.toml` and `agent_actions/__version__.py` (configured via `.changie.yaml` replacements), and merges entries into `CHANGELOG.md`.
 
-Commit and push:
+`changie batch` empties `.changes/unreleased/`, but the **Changelog Entry** CI job
+fails any PR whose `.changes/unreleased/` is empty. So the release PR carries one
+entry announcing itself:
+
+```bash
+cat > ".changes/unreleased/Under the Hood-$(date -u +%Y%m%d-%H%M%S).yaml" <<EOF
+kind: Under the Hood
+body: "Release vX.Y.Z — batch changie entries, bump version"
+time: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+```
+
+That entry is not consumed by this release, so it appears in the *next* one's notes.
+
+Commit and open a PR:
 
 ```bash
 git add pyproject.toml agent_actions/__version__.py CHANGELOG.md .changes/
 git commit -m "chore: release vX.Y.Z"
-git push origin main
+git push -u origin chore/release-X.Y.Z
+gh pr create --base main --title "chore: release vX.Y.Z"
 ```
+
+Base the release PR on `main`, not on another branch. Squash-merging a branch
+below it rewrites the base out from under it, and the release merges somewhere
+that never reaches `main` — leaving a half-released `main` and a tag that would
+point at the wrong version.
 
 ### 3. Tag the release
 
+After the PR merges, confirm the version actually landed before tagging. A tag
+cannot be moved once published, and PyPI will not accept a replacement:
+
 ```bash
+git checkout main && git pull
+git show origin/main:pyproject.toml | grep '^version'   # must read X.Y.Z
+
 git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-Pushing a `v*` tag triggers the `publish.yml` workflow, which builds and publishes to PyPI via OIDC trusted publishing.
+The tag on its own publishes nothing. It exists so the GitHub Release in the
+next step has something to point at.
 
-### 4. Create a GitHub Release
+### 4. Create a GitHub Release — this is what publishes
 
-Go to **Releases → Draft a new release**, select the tag, and publish. Add a summary of changes.
+`publish.yml` triggers on `release: published`, not on the tag push, so nothing
+reaches PyPI until the release exists:
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --notes-file <(sed -n '/^## X.Y.Z/,/^## /p' CHANGELOG.md | sed '1d;$d')
+```
+
+Or draft it from **Releases → Draft a new release**, select the tag, and publish.
+
+Confirm it ran:
+
+```bash
+gh run list --workflow=publish.yml --limit 1
+```
+
+### 5. The VS Code extension
+
+The extension is versioned separately in `vscode-extension/package.json` and is
+not published by any workflow. Build and upload it by hand:
+
+```bash
+cd vscode-extension
+npm run package                                          # produces agent-actions-X.Y.Z.vsix
+npx vsce publish --packagePath agent-actions-X.Y.Z.vsix  # needs a Marketplace PAT
+```
+
+Prefer `--packagePath` over a bare `vsce publish`: it ships the artefact you
+verified rather than rebuilding on the publishing machine.
 
 ---
 


### PR DESCRIPTION
## The wrong claim

`RELEASING.md` step 3 said:

> Pushing a `v*` tag triggers the `publish.yml` workflow, which builds and publishes to PyPI via OIDC trusted publishing.

It does not. `publish.yml` is:

```yaml
on:
  release:
    types: [published]
```

The tag alone reaches nothing. Following the doc literally leaves you believing you have shipped when you have not — which is exactly what happened during v0.3.0: the tag went up, `publish.yml` never fired, and PyPI only received the package once the GitHub Release was created.

Step 4 already said to create a release, but as a documentation nicety rather than the publishing step. Now labelled as what it is.

## Four other gaps, all hit during v0.3.0

**The release PR needs a changelog entry.** `changie batch` empties `.changes/unreleased/`, but the **Changelog Entry** CI job fails any PR whose unreleased set is empty. Release PRs therefore carry an entry announcing themselves — already the convention (v0.2.8 did it in `6c467af7`) but written down nowhere, so I removed the previous one as litter and had to put it back. Documented, including that it surfaces in the *next* release's notes.

**The doc pushed straight to `main`.** Releases go through a PR, and that PR must be based on `main`. Basing it on another branch and squash-merging the one beneath rewrites the base out from under it, and the release lands somewhere that never reaches `main`. That happened here — `main` briefly had the extension bumped and the package not.

**Added a version check before tagging.** A tag cannot be moved once published and PyPI refuses a replacement, so tagging a half-merged `main` is unrecoverable. One `git show origin/main:pyproject.toml` catches it.

**The VS Code extension.** Versioned separately, published by no workflow. That step existed only in people's heads.

## Verification

Every claim checked against the source rather than restated:

- trigger: `.github/workflows/publish.yml` lines 3-5
- CI check: `.github/workflows/ci.yml:43-50`
- version replacements: `.changie.yaml:26-32`
- extension publish: no workflow references `vsce`

Docs only — no code paths touched.